### PR TITLE
feat(providers): add custom CLI path support to ClaudeCodeAdapter

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -98,10 +98,11 @@ class ClaudeCodeAdapter:
             cli_path: Explicit CLI path from constructor.
 
         Returns:
-            Resolved Path if set and exists, None otherwise.
+            Resolved Path if set and exists, None otherwise (falls back to SDK default).
         """
         # Priority: explicit parameter > environment variable > None (SDK default)
-        path_str = cli_path or os.environ.get("OUROBOROS_CLI_PATH")
+        path_str = str(cli_path) if cli_path else os.environ.get("OUROBOROS_CLI_PATH", "")
+        path_str = path_str.strip()
 
         if not path_str:
             return None
@@ -112,6 +113,7 @@ class ClaudeCodeAdapter:
             log.warning(
                 "claude_code_adapter.cli_path_not_found",
                 cli_path=str(resolved),
+                fallback="using SDK bundled CLI",
             )
             return None
 
@@ -119,6 +121,15 @@ class ClaudeCodeAdapter:
             log.warning(
                 "claude_code_adapter.cli_path_not_file",
                 cli_path=str(resolved),
+                fallback="using SDK bundled CLI",
+            )
+            return None
+
+        if not os.access(resolved, os.X_OK):
+            log.warning(
+                "claude_code_adapter.cli_not_executable",
+                cli_path=str(resolved),
+                fallback="using SDK bundled CLI",
             )
             return None
 


### PR DESCRIPTION
## Summary

- Add `cli_path` parameter to `ClaudeCodeAdapter` constructor
- Add `OUROBOROS_CLI_PATH` environment variable support
- Enable using custom/instrumented CLI wrappers instead of SDK's bundled CLI

## Motivation

The Claude Agent SDK bundles its own CLI binary and uses it by default, bypassing any system CLI. This is problematic when users want to use instrumented CLI wrappers (e.g., for OTEL tracing, monitoring, etc.).

**Example use case**: When using a monitoring tool that provides an instrumented `claude` wrapper at `~/.tool/bin/claude`, the SDK would bypass it and use its bundled CLI instead.

## Configuration

```python
# Option 1: Constructor parameter
adapter = ClaudeCodeAdapter(cli_path="/path/to/claude")

# Option 2: Environment variable
export OUROBOROS_CLI_PATH=/path/to/claude
```

**Priority**: explicit parameter > environment variable > SDK bundled CLI

## Test plan

- [x] Lint check passes
- [x] Type check passes
- [ ] Manual test with custom CLI path

🤖 Generated with [Claude Code](https://claude.com/claude-code)