### PR TITLE
fix(seed): robust extraction prompt with retry logic

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -32,20 +32,42 @@ If the `ouroboros_interview` MCP tool is available, use it for persistent, struc
    ```
    The tool returns a session ID and the first question.
 
-2. **Continue the interview** — relay the user's answer back:
+2. **Present the question using AskUserQuestion**:
+   After receiving a question from the tool, present it via `AskUserQuestion` with contextually relevant suggested answers:
+   ```json
+   {
+     "questions": [{
+       "question": "<question from MCP tool>",
+       "header": "Q<N>",
+       "options": [
+         {"label": "<option 1>", "description": "<brief explanation>"},
+         {"label": "<option 2>", "description": "<brief explanation>"}
+       ],
+       "multiSelect": false
+     }]
+   }
+   ```
+
+   **Generating options** — analyze the question and suggest 2-3 likely answers:
+   - Binary questions (greenfield/brownfield, yes/no): use the natural choices
+   - Technology choices: suggest common options for the context
+   - Open-ended questions: suggest representative answer categories
+   - The user can always type a custom response via "Other"
+
+3. **Relay the answer back**:
    ```
    Tool: ouroboros_interview
    Arguments:
      session_id: <session ID from step 1>
-     answer: <user's response>
+     answer: <user's selected option or custom text>
    ```
    The tool records the answer, generates the next question, and returns it.
 
-3. **Repeat step 2** until the user says "done" or requirements are clear.
+4. **Repeat steps 2-3** until the user says "done" or requirements are clear.
 
-4. After completion, suggest `ooo seed` to generate the Seed specification.
+5. After completion, suggest `ooo seed` to generate the Seed specification.
 
-**Advantages of MCP mode**: State persists to disk (survives session restarts), ambiguity scoring, direct integration with `ooo seed` via session ID.
+**Advantages of MCP mode**: State persists to disk (survives session restarts), ambiguity scoring, direct integration with `ooo seed` via session ID, structured input with AskUserQuestion.
 
 ### Path B: Plugin Fallback (No MCP Server)
 
@@ -53,9 +75,10 @@ If the MCP tool is NOT available, fall back to agent-based interview:
 
 1. Read `agents/socratic-interviewer.md` and adopt that role
 2. Ask clarifying questions based on the user's topic
-3. Use Read, Glob, Grep, WebFetch to explore context if needed
-4. Continue until the user says "done"
-5. Interview results live in conversation context (not persisted)
+3. **Present each question using AskUserQuestion** with contextually relevant suggested answers (same format as Path A step 2)
+4. Use Read, Glob, Grep, WebFetch to explore context if needed
+5. Continue until the user says "done"
+6. Interview results live in conversation context (not persisted)
 
 ## Interviewer Behavior (Both Modes)
 

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -13,6 +13,7 @@ The SeedGenerator:
 
 from dataclasses import dataclass, field
 from pathlib import Path
+import re
 from typing import Any
 
 import structlog
@@ -39,6 +40,7 @@ log = structlog.get_logger()
 # Default model moved to config.models.ClarificationConfig.default_model
 _FALLBACK_MODEL = "claude-opus-4-6"
 EXTRACTION_TEMPERATURE = 0.2
+_MAX_EXTRACTION_RETRIES = 1
 
 
 @dataclass
@@ -290,6 +292,8 @@ class SeedGenerator:
     ) -> Result[dict[str, Any], ProviderError]:
         """Extract structured requirements from interview using LLM.
 
+        Retries once with a clarified prompt on parse failure.
+
         Args:
             state: The interview state.
 
@@ -311,33 +315,94 @@ class SeedGenerator:
             max_tokens=self.max_tokens,
         )
 
-        result = await self.llm_adapter.complete(messages, config)
+        last_error = ""
+        last_response = ""
 
-        if result.is_err:
-            log.warning(
-                "seed.extraction.failed",
-                interview_id=state.interview_id,
-                error=str(result.error),
-            )
-            return Result.err(result.error)
+        for attempt in range(_MAX_EXTRACTION_RETRIES + 1):
+            result = await self.llm_adapter.complete(messages, config)
 
-        # Parse the response
-        try:
-            requirements = self._parse_extraction_response(result.value.content)
-            return Result.ok(requirements)
-        except (ValueError, KeyError) as e:
-            log.warning(
-                "seed.extraction.parse_failed",
-                interview_id=state.interview_id,
-                error=str(e),
-                response=result.value.content[:500],
-            )
-            return Result.err(
-                ProviderError(
-                    f"Failed to parse extraction response: {e}",
-                    details={"response_preview": result.value.content[:200]},
+            if result.is_err:
+                log.warning(
+                    "seed.extraction.failed",
+                    interview_id=state.interview_id,
+                    error=str(result.error),
+                    attempt=attempt + 1,
                 )
+                return Result.err(result.error)
+
+            last_response = result.value.content
+
+            try:
+                requirements = self._parse_extraction_response(last_response)
+                if attempt > 0:
+                    log.info(
+                        "seed.extraction.retry_succeeded",
+                        interview_id=state.interview_id,
+                        attempt=attempt + 1,
+                    )
+                return Result.ok(requirements)
+            except (ValueError, KeyError) as e:
+                last_error = str(e)
+                log.warning(
+                    "seed.extraction.parse_failed",
+                    interview_id=state.interview_id,
+                    error=last_error,
+                    response=last_response[:500],
+                    attempt=attempt + 1,
+                )
+
+                if attempt < _MAX_EXTRACTION_RETRIES:
+                    # Retry with clarified prompt
+                    messages = [
+                        Message(role=MessageRole.SYSTEM, content=system_prompt),
+                        Message(
+                            role=MessageRole.USER,
+                            content=self._build_retry_prompt(context, last_response, last_error),
+                        ),
+                    ]
+
+        return Result.err(
+            ProviderError(
+                f"Failed to parse extraction response after "
+                f"{_MAX_EXTRACTION_RETRIES + 1} attempts: {last_error}",
+                details={"response_preview": last_response[:200]},
             )
+        )
+
+    def _build_retry_prompt(self, context: str, failed_response: str, error: str) -> str:
+        """Build a retry prompt after extraction parse failure.
+
+        Args:
+            context: Original interview context.
+            failed_response: The response that failed to parse.
+            error: The parse error message.
+
+        Returns:
+            Retry prompt string.
+        """
+        return f"""Your previous response could not be parsed. Error: {error}
+
+Your response was:
+---
+{failed_response[:1000]}
+---
+
+Please try again. Extract requirements from this interview:
+---
+{context}
+---
+
+You MUST respond with ONLY the following format, one field per line, no other text:
+
+GOAL: <clear goal statement>
+CONSTRAINTS: <constraint 1> | <constraint 2> | ...
+ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2> | ...
+ONTOLOGY_NAME: <name>
+ONTOLOGY_DESCRIPTION: <description>
+ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
+EVALUATION_PRINCIPLES: <name>:<description>:<weight> | ...
+EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
+PROJECT_TYPE: greenfield"""
 
     def _build_interview_context(self, state: InterviewState) -> str:
         """Build context string from interview state.
@@ -376,13 +441,65 @@ class SeedGenerator:
         Returns:
             User prompt string.
         """
-        return f"""Please extract structured requirements from the following interview conversation:
+        return f"""Extract structured requirements from the following interview conversation.
 
 ---
 {context}
 ---
 
-Extract all components and provide them in the specified format."""
+Respond ONLY with the structured format below. Do NOT add explanations, questions, commentary, or prose. Do NOT wrap in markdown code blocks.
+
+GOAL: <clear goal statement>
+CONSTRAINTS: <constraint 1> | <constraint 2> | ...
+ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2> | ...
+ONTOLOGY_NAME: <name>
+ONTOLOGY_DESCRIPTION: <description>
+ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
+EVALUATION_PRINCIPLES: <name>:<description>:<weight> | ...
+EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
+PROJECT_TYPE: greenfield"""
+
+    _KNOWN_PREFIXES = (
+        "GOAL:",
+        "CONSTRAINTS:",
+        "ACCEPTANCE_CRITERIA:",
+        "ONTOLOGY_NAME:",
+        "ONTOLOGY_DESCRIPTION:",
+        "ONTOLOGY_FIELDS:",
+        "EVALUATION_PRINCIPLES:",
+        "EXIT_CONDITIONS:",
+        "PROJECT_TYPE:",
+        "CONTEXT_REFERENCES:",
+        "EXISTING_PATTERNS:",
+        "EXISTING_DEPENDENCIES:",
+    )
+
+    def _preprocess_response(self, response: str) -> str:
+        """Strip markdown code blocks and conversational preamble.
+
+        Args:
+            response: Raw LLM response text.
+
+        Returns:
+            Cleaned response starting from first recognized prefix.
+        """
+        text = response.strip()
+
+        # Strip markdown code block markers
+        code_block_match = re.search(r"```(?:\w*)\n(.*?)```", text, re.DOTALL)
+        if code_block_match:
+            text = code_block_match.group(1).strip()
+
+        # Find first recognized prefix and discard preamble
+        lines = text.split("\n")
+        start_idx = 0
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if any(stripped.startswith(p) for p in self._KNOWN_PREFIXES):
+                start_idx = i
+                break
+
+        return "\n".join(lines[start_idx:])
 
     def _parse_extraction_response(self, response: str) -> dict[str, Any]:
         """Parse LLM response into requirements dictionary.
@@ -396,7 +513,8 @@ Extract all components and provide them in the specified format."""
         Raises:
             ValueError: If response cannot be parsed.
         """
-        lines = response.strip().split("\n")
+        cleaned = self._preprocess_response(response)
+        lines = cleaned.strip().split("\n")
         requirements: dict[str, Any] = {}
 
         for line in lines:
@@ -404,20 +522,7 @@ Extract all components and provide them in the specified format."""
             if not line:
                 continue
 
-            for prefix in [
-                "GOAL:",
-                "CONSTRAINTS:",
-                "ACCEPTANCE_CRITERIA:",
-                "ONTOLOGY_NAME:",
-                "ONTOLOGY_DESCRIPTION:",
-                "ONTOLOGY_FIELDS:",
-                "EVALUATION_PRINCIPLES:",
-                "EXIT_CONDITIONS:",
-                "PROJECT_TYPE:",
-                "CONTEXT_REFERENCES:",
-                "EXISTING_PATTERNS:",
-                "EXISTING_DEPENDENCIES:",
-            ]:
+            for prefix in self._KNOWN_PREFIXES:
                 if line.startswith(prefix):
                     key = prefix[:-1].lower()  # Remove colon and lowercase
                     value = line[len(prefix) :].strip()
@@ -433,7 +538,11 @@ Extract all components and provide them in the specified format."""
 
         for field_name in required_fields:
             if field_name not in requirements:
-                raise ValueError(f"Missing required field: {field_name}")
+                raise ValueError(
+                    f"Missing required field: {field_name}. "
+                    f"Found: {list(requirements.keys())}. "
+                    f"Response preview: {response[:200]}"
+                )
 
         return requirements
 

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -477,15 +477,14 @@ class TestSeedGeneratorErrorHandling:
 
     @pytest.mark.asyncio
     async def test_generate_handles_malformed_response(self) -> None:
-        """SeedGenerator returns error for malformed LLM response."""
+        """SeedGenerator returns error for malformed LLM response after retries."""
         mock_adapter = AsyncMock()
         state = create_interview_state_with_rounds()
         low_ambiguity = create_low_ambiguity_score()
 
-        # Missing required fields
-        mock_adapter.complete = AsyncMock(
-            return_value=Result.ok(create_mock_completion_response("INVALID: missing fields"))
-        )
+        # Missing required fields — both initial and retry return bad data
+        bad_response = Result.ok(create_mock_completion_response("INVALID: missing fields"))
+        mock_adapter.complete = AsyncMock(side_effect=[bad_response, bad_response])
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             generator = SeedGenerator(
@@ -496,6 +495,114 @@ class TestSeedGeneratorErrorHandling:
             result = await generator.generate(state, low_ambiguity)
 
             assert result.is_err
+            assert mock_adapter.complete.call_count == 2
+
+
+class TestSeedGeneratorRobustParsing:
+    """Test SeedGenerator handles non-ideal LLM responses."""
+
+    @pytest.mark.asyncio
+    async def test_parse_response_with_conversational_preamble(self) -> None:
+        """Parser handles LLM response with prose before structured output."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        response_with_preamble = (
+            "Based on the interview, here are the extracted requirements:\n\n"
+            + create_valid_extraction_response()
+        )
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(response_with_preamble))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert result.value.goal == "Build a CLI task manager with project grouping"
+
+    @pytest.mark.asyncio
+    async def test_parse_response_with_markdown_code_block(self) -> None:
+        """Parser handles structured output wrapped in markdown code blocks."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        response_with_markdown = (
+            "Here are the extracted requirements:\n\n```\n"
+            + create_valid_extraction_response()
+            + "\n```"
+        )
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(response_with_markdown))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert result.value.goal == "Build a CLI task manager with project grouping"
+
+    @pytest.mark.asyncio
+    async def test_extraction_retries_on_parse_failure(self) -> None:
+        """Extraction retries once with clarification prompt on parse failure."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        conversational = Result.ok(
+            create_mock_completion_response(
+                "Let me explore the codebase to provide accurate context."
+            )
+        )
+        valid = Result.ok(create_mock_completion_response(create_valid_extraction_response()))
+        mock_adapter.complete = AsyncMock(side_effect=[conversational, valid])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert mock_adapter.complete.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_extraction_fails_after_max_retries(self) -> None:
+        """Extraction fails gracefully after all retry attempts exhausted."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        bad = Result.ok(
+            create_mock_completion_response("I'd be happy to help! Let me think about this...")
+        )
+        mock_adapter.complete = AsyncMock(side_effect=[bad, bad])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_err
+            assert "after 2 attempts" in str(result.error)
+            assert mock_adapter.complete.call_count == 2
 
 
 class TestSeedGeneratorSaveAndLoad:


### PR DESCRIPTION
## Summary

- **Fix seed extraction failure** (#53): The bundled Claude CLI responded with conversational text (`"Let me explore the codebase..."`) instead of structured output, causing `Missing required field: goal`
- **Strengthen extraction prompt**: Inline format template + explicit "no prose" instructions in user message
- **Add response preprocessing**: Strip markdown code blocks and skip conversational preamble before parsing
- **Add retry logic**: 1 retry with clarified correction prompt on parse failure
- **Add AskUserQuestion to interview skill**: Structured input collection with contextual suggested answers

## Test plan

- [x] All 28 seed generator tests pass (including 4 new robust parsing tests)
- [x] Full suite: 2382 passed, 0 failed
- [ ] Manual: run `ooo interview` → `ooo seed` end-to-end with MCP server

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)