### PR TITLE
feat: workflow resumption after Ctrl+C interruption (#50)

### DIFF
--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: resume
+description: "Resume an interrupted workflow session from checkpoint"
+---
+
+# /ouroboros:resume
+
+Resume an interrupted workflow session from its last checkpoint.
+
+## Usage
+
+```
+ooo resume [session_id]
+/ouroboros:resume [session_id]
+```
+
+**Trigger keywords:** "resume", "continue session", "pick up where I left off"
+
+## How It Works
+
+When a workflow is interrupted (Ctrl+C), Ouroboros saves a checkpoint with:
+- Which acceptance criteria were completed
+- Which are still pending
+- The seed specification and goal
+- Progress metadata (messages, duration)
+
+Resuming injects this context so the agent continues from the last completed AC.
+
+## Instructions
+
+When the user invokes this skill:
+
+1. **Find interrupted sessions**:
+   - If `session_id` provided: use it directly
+   - If no session_id: check for the most recently interrupted session
+   - If multiple found: present options via AskUserQuestion
+
+2. **Load checkpoint context**:
+   - Call `ouroboros workflow resume <session_id>` CLI or reconstruct from events
+   - Build a summary of completed vs remaining ACs
+
+3. **Resume execution**:
+   - Call `ouroboros_execute_seed` MCP tool with:
+     ```
+     Tool: ouroboros_execute_seed
+     Arguments:
+       seed_content: <original seed YAML>
+       session_id: <interrupted session ID>
+     ```
+   - The resumed session continues from the last checkpoint
+
+4. **Present progress**:
+   - Show which ACs were already completed (from previous session)
+   - Show which ACs are being worked on now
+   - Track new progress normally
+
+## Fallback (No MCP Server)
+
+If the MCP server is not available:
+
+1. Run `ouroboros workflow list --interrupted` to find sessions
+2. Run `ouroboros workflow resume <session_id>` to get the context summary
+3. Use the context summary to manually guide the agent on what remains
+
+## Example
+
+```
+User: ooo resume
+
+Resuming session sess-abc-123
+Goal: Build a CLI task manager
+Previous progress: 3/5 ACs completed
+
+Completed:
+  [x] Tasks can be created
+  [x] Tasks can be listed
+  [x] Tasks support tags
+
+Remaining:
+  [ ] Tasks can be marked complete
+  [ ] Tasks persist across restarts
+
+Continuing execution from AC 4...
+```
+
+## Next Steps (Always Display)
+
+After resumption completes, show the same next steps as `ooo run`:
+
+**On success:**
+```
+📍 Next: `ooo evaluate <session_id>` to verify against acceptance criteria
+```
+
+**On failure:**
+```
+📍 Next steps:
+  - Fix the issues identified above, then `ooo resume` to continue
+  - `ooo unstuck` if you're blocked on how to fix it
+```

--- a/src/ouroboros/cli/commands/workflow.py
+++ b/src/ouroboros/cli/commands/workflow.py
@@ -1,0 +1,274 @@
+"""Workflow management commands for Ouroboros.
+
+List interrupted sessions and resume workflows from checkpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from rich.console import Console
+from rich.table import Table
+import typer
+
+from ouroboros.cli.formatters.panels import print_error, print_info, print_success
+
+app = typer.Typer(
+    name="workflow",
+    help="Manage workflow sessions (list, resume).",
+    no_args_is_help=True,
+)
+
+console = Console()
+
+
+def _load_interrupted_sessions() -> list[dict]:
+    """Load interrupted/paused sessions from the event store.
+
+    Returns:
+        List of session dicts with id, goal, progress, and timestamp.
+    """
+    import asyncio
+
+    from ouroboros.persistence.event_store import EventStore
+
+    async def _query() -> list[dict]:
+        store = EventStore()
+        await store.initialize()
+
+        # Get all sessions and filter for paused/interrupted ones
+        sessions = await store.get_all_sessions()
+        interrupted = []
+
+        for session in sessions:
+            payload = session.get("payload", {})
+            # Check if session was interrupted (look for interruption events)
+            session_id = payload.get("session_id", "")
+            if not session_id:
+                continue
+
+            # Replay session events to find status
+            events = await store.replay("orchestrator", session_id)
+            status = "unknown"
+            goal = payload.get("seed_goal", "Unknown")
+            messages = 0
+            timestamp = session.get("timestamp", "")
+
+            for event in events:
+                ep = event.get("payload", {})
+                etype = event.get("event_type", "")
+                if "completed" in etype:
+                    status = "completed"
+                elif "failed" in etype:
+                    error_type = ep.get("error_type", "")
+                    if error_type == "KeyboardInterrupt":
+                        status = "interrupted"
+                    else:
+                        status = "failed"
+                    messages = ep.get("messages_processed", 0)
+
+            if status == "interrupted":
+                interrupted.append({
+                    "session_id": session_id,
+                    "goal": goal,
+                    "messages": messages,
+                    "timestamp": timestamp,
+                })
+
+        return interrupted
+
+    return asyncio.run(_query())
+
+
+def _build_resume_context(session_id: str) -> str | None:
+    """Build context summary for resuming an interrupted session.
+
+    Reconstructs what was completed before interruption for prompt injection.
+
+    Args:
+        session_id: The session to build context for.
+
+    Returns:
+        Context summary string, or None if session not found.
+    """
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    store = CheckpointStore()
+
+    # Try to load checkpoint for this session's seed
+    # Checkpoints are keyed by seed_id, so we need to find the right one
+    import asyncio
+
+    from ouroboros.persistence.event_store import EventStore
+
+    async def _find_seed_id() -> str | None:
+        es = EventStore()
+        await es.initialize()
+        events = await es.replay("orchestrator", session_id)
+        for event in events:
+            payload = event.get("payload", {})
+            if "seed_id" in payload:
+                return payload["seed_id"]
+        return None
+
+    seed_id = asyncio.run(_find_seed_id())
+    if not seed_id:
+        return None
+
+    checkpoint_result = store.load(seed_id)
+    if checkpoint_result.is_err or checkpoint_result.value is None:
+        return None
+
+    checkpoint = checkpoint_result.value
+    state = checkpoint.state
+
+    # Build human-readable context summary
+    goal = state.get("seed_goal", "Unknown")
+    acs = state.get("acceptance_criteria", [])
+    workflow = state.get("workflow_state", {})
+    completed_acs = []
+    pending_acs = []
+
+    ac_list = workflow.get("acceptance_criteria", [])
+    for ac in ac_list:
+        if ac.get("status") == "completed":
+            completed_acs.append(ac.get("content", ""))
+        else:
+            pending_acs.append(ac.get("content", ""))
+
+    # Fallback if workflow_state doesn't have AC details
+    if not completed_acs and not pending_acs and acs:
+        completed_count = workflow.get("completed_count", 0)
+        completed_acs = acs[:completed_count]
+        pending_acs = acs[completed_count:]
+
+    messages = state.get("messages_processed", 0)
+    duration = state.get("duration_seconds", 0)
+
+    lines = [
+        f"## Resuming Interrupted Session: {session_id}",
+        f"**Goal**: {goal}",
+        f"**Progress before interruption**: {messages} messages, {duration:.0f}s",
+        "",
+    ]
+
+    if completed_acs:
+        lines.append("### Completed Acceptance Criteria")
+        for ac in completed_acs:
+            lines.append(f"- [x] {ac}")
+        lines.append("")
+
+    if pending_acs:
+        lines.append("### Remaining Acceptance Criteria (resume from here)")
+        for ac in pending_acs:
+            lines.append(f"- [ ] {ac}")
+        lines.append("")
+
+    lines.append("**Instructions**: Continue from where the previous session left off.")
+    lines.append("Do NOT redo completed ACs. Start with the first remaining AC.")
+
+    return "\n".join(lines)
+
+
+@app.command("list")
+def list_sessions(
+    interrupted: Annotated[
+        bool,
+        typer.Option(
+            "--interrupted",
+            help="Show only interrupted sessions.",
+        ),
+    ] = False,
+) -> None:
+    """List workflow sessions.
+
+    Examples:
+        ouroboros workflow list --interrupted
+    """
+    try:
+        sessions = _load_interrupted_sessions()
+    except Exception as e:
+        print_error(f"Failed to load sessions: {e}")
+        raise typer.Exit(1) from e
+
+    if not sessions:
+        print_info("No interrupted sessions found.")
+        return
+
+    table = Table(title="Interrupted Sessions")
+    table.add_column("Session ID", style="cyan")
+    table.add_column("Goal", style="white", max_width=50)
+    table.add_column("Messages", style="yellow", justify="right")
+    table.add_column("Interrupted At", style="dim")
+
+    for s in sessions:
+        table.add_row(
+            s["session_id"],
+            s["goal"][:50],
+            str(s["messages"]),
+            s["timestamp"][:19] if s["timestamp"] else "",
+        )
+
+    console.print(table)
+    console.print(f"\n[blue]Resume with: ouroboros workflow resume <session_id>[/blue]")
+
+
+@app.command()
+def resume(
+    session_id: Annotated[
+        str,
+        typer.Argument(help="Session ID to resume (or 'latest')."),
+    ] = "latest",
+) -> None:
+    """Resume an interrupted workflow session.
+
+    Examples:
+        ouroboros workflow resume latest
+        ouroboros workflow resume sess-abc-123
+    """
+    try:
+        sessions = _load_interrupted_sessions()
+    except Exception as e:
+        print_error(f"Failed to load sessions: {e}")
+        raise typer.Exit(1) from e
+
+    if not sessions:
+        print_info("No interrupted sessions to resume.")
+        return
+
+    # Resolve 'latest'
+    target_id = session_id
+    if target_id == "latest":
+        target_id = sessions[0]["session_id"]
+        print_info(f"Resuming latest interrupted session: {target_id}")
+
+    # Find the session
+    target = next((s for s in sessions if s["session_id"] == target_id), None)
+    if not target:
+        print_error(f"Session not found: {target_id}")
+        print_info("Use 'ouroboros workflow list --interrupted' to see available sessions.")
+        raise typer.Exit(1)
+
+    # Build resume context
+    context = _build_resume_context(target_id)
+    if not context:
+        print_error(f"Could not build resume context for session {target_id}")
+        print_info("The checkpoint may have been lost. Try re-running with 'ooo run'.")
+        raise typer.Exit(1)
+
+    # Display resume info
+    print_success(f"Session {target_id} ready to resume")
+    console.print(f"  Goal: {target['goal'][:80]}")
+    console.print(f"  Messages processed: {target['messages']}")
+    console.print()
+
+    # Output the context summary for use in prompts
+    console.print("[bold]Resume Context (inject into next execution):[/bold]")
+    console.print(context)
+    console.print()
+    console.print("[blue]📍 Next: Run 'ooo run' with this session's seed to continue[/blue]")
+    console.print(f"[blue]   Pass session_id={target_id} to resume from checkpoint[/blue]")
+
+
+__all__ = ["app"]

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -14,7 +14,7 @@ from typing import Annotated
 import typer
 
 from ouroboros import __version__
-from ouroboros.cli.commands import config, init, mcp, run, status, tui
+from ouroboros.cli.commands import config, init, mcp, run, status, tui, workflow
 from ouroboros.cli.formatters import console
 
 # Create the main Typer app
@@ -32,6 +32,7 @@ app.add_typer(config.app, name="config")
 app.add_typer(status.app, name="status")
 app.add_typer(mcp.app, name="mcp")
 app.add_typer(tui.app, name="tui")
+app.add_typer(workflow.app, name="workflow")
 
 
 # Top-level convenience aliases

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -639,6 +639,77 @@ class OrchestratorRunner:
                 )
             )
 
+        except KeyboardInterrupt:
+            # Ctrl+C: save checkpoint before exiting so session can be resumed
+            duration = (datetime.now(UTC) - start_time).total_seconds()
+            log.info(
+                "orchestrator.runner.interrupted",
+                execution_id=exec_id,
+                session_id=tracker.session_id,
+                messages_processed=messages_processed,
+            )
+
+            # Save interruption checkpoint with current AC progress
+            checkpoint_state = {
+                "session_id": tracker.session_id,
+                "execution_id": exec_id,
+                "seed_id": seed.metadata.seed_id,
+                "seed_goal": seed.goal,
+                "acceptance_criteria": seed.acceptance_criteria,
+                "messages_processed": messages_processed,
+                "duration_seconds": duration,
+                "interrupted_at": datetime.now(UTC).isoformat(),
+                "workflow_state": state_tracker.state.to_dict(),
+            }
+
+            try:
+                from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+                checkpoint = CheckpointData.create(
+                    seed_id=seed.metadata.seed_id,
+                    phase="interrupted",
+                    state=checkpoint_state,
+                )
+                store = CheckpointStore()
+                store.save(checkpoint)
+            except Exception:
+                log.warning("orchestrator.runner.checkpoint_save_failed_on_interrupt")
+
+            # Emit interruption event
+            failed_event = create_session_failed_event(
+                session_id=tracker.session_id,
+                error_message="Interrupted by user (Ctrl+C)",
+                error_type="KeyboardInterrupt",
+                messages_processed=messages_processed,
+            )
+            await self._event_store.append(failed_event)
+
+            self._console.print(
+                f"\n[yellow]⚠ Execution interrupted. "
+                f"Progress saved ({messages_processed} messages, "
+                f"{state_tracker.state.completed_count}/{state_tracker.state.total_count} ACs).[/yellow]"
+            )
+            self._console.print(
+                f"[blue]📍 Resume with: ouroboros workflow resume {tracker.session_id}[/blue]"
+            )
+
+            return Result.ok(
+                OrchestratorResult(
+                    success=False,
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    summary={
+                        "goal": seed.goal,
+                        "interrupted": True,
+                        "completed_acs": state_tracker.state.completed_count,
+                        "total_acs": state_tracker.state.total_count,
+                    },
+                    messages_processed=messages_processed,
+                    final_message="Interrupted by user (Ctrl+C). Session saved for resumption.",
+                    duration_seconds=duration,
+                )
+            )
+
         except Exception as e:
             log.exception(
                 "orchestrator.runner.execute_failed",


### PR DESCRIPTION
## Summary

Adds the ability to resume workflow sessions interrupted by Ctrl+C, addressing the three gaps identified in #50:

- **Progress state preservation**: `OrchestratorRunner.execute_seed()` now catches `KeyboardInterrupt` separately from general exceptions. On interrupt, it saves a `CheckpointData` with full AC progress (completed count, workflow state, seed info) before exiting.

- **Context injection on resume**: `_build_resume_context()` reconstructs a summary from checkpoint data showing completed vs remaining ACs, formatted for prompt injection so the agent knows exactly where to continue.

- **CLI interface**: New `ouroboros workflow` command group:
  - `workflow list --interrupted` — queries EventStore for sessions with `KeyboardInterrupt` error type
  - `workflow resume <session_id|latest>` — loads checkpoint, displays resume context

- **Resume skill**: New `skills/resume/SKILL.md` for plugin-based workflow (`ooo resume`)

## Changes

| File | Change |
|------|--------|
| `src/ouroboros/orchestrator/runner.py` | KeyboardInterrupt handler with checkpoint save |
| `src/ouroboros/cli/commands/workflow.py` | **New** — list + resume CLI commands |
| `src/ouroboros/cli/main.py` | Register workflow command group |
| `skills/resume/SKILL.md` | **New** — resume skill instructions |

## Design Decisions

- **Checkpoint on interrupt, not periodic**: The existing `PeriodicCheckpointer` handles background saves. This adds explicit save on Ctrl+C to guarantee state is captured at interruption.
- **Event-based session discovery**: Uses EventStore events with `error_type=KeyboardInterrupt` to identify interrupted sessions rather than a separate registry.
- **Context summary over full replay**: Token-efficient approach — summarizes completed ACs rather than replaying full conversation history.

## Test plan

- [ ] Ctrl+C during `ouroboros run` saves checkpoint and shows resume message
- [ ] `ouroboros workflow list --interrupted` shows the interrupted session
- [ ] `ouroboros workflow resume latest` loads checkpoint and displays context
- [ ] Context summary correctly shows completed vs remaining ACs
- [ ] Resuming with `session_id` passes through to `ouroboros_execute_seed`

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>