### PR TITLE
fix(providers): exclude top_p for Anthropic models

### DIFF
--- a/src/ouroboros/providers/litellm_adapter.py
+++ b/src/ouroboros/providers/litellm_adapter.py
@@ -122,9 +122,14 @@ class LiteLLMAdapter:
             "messages": [m.to_dict() for m in messages],
             "temperature": config.temperature,
             "max_tokens": config.max_tokens,
-            "top_p": config.top_p,
             "timeout": self._timeout,
         }
+
+        # Anthropic models don't accept both temperature and top_p together
+        # Other providers (OpenAI, OpenRouter) support both
+        model_lower = config.model.lower()
+        if not ("anthropic" in model_lower or "claude" in model_lower):
+            kwargs["top_p"] = config.top_p
 
         if config.stop:
             kwargs["stop"] = config.stop

--- a/tests/unit/providers/test_litellm_adapter.py
+++ b/tests/unit/providers/test_litellm_adapter.py
@@ -179,6 +179,34 @@ class TestLiteLLMAdapterBuildCompletionKwargs:
 
         assert kwargs["api_key"] == "test-key"
 
+    def test_excludes_top_p_for_anthropic_models(self) -> None:
+        """Excludes top_p for Anthropic models (API rejects temperature + top_p together)."""
+        adapter = LiteLLMAdapter()
+        messages = [Message(role=MessageRole.USER, content="Hello")]
+
+        anthropic_models = [
+            "claude-sonnet-4-5",
+            "claude-opus-4-6",
+            "anthropic/claude-sonnet-4-5",
+        ]
+        for model in anthropic_models:
+            config = CompletionConfig(model=model)
+            with patch.dict("os.environ", {}, clear=True):
+                kwargs = adapter._build_completion_kwargs(messages, config)
+            assert "top_p" not in kwargs, f"top_p should be excluded for {model}"
+
+    def test_includes_top_p_for_non_anthropic_models(self) -> None:
+        """Includes top_p for non-Anthropic models (OpenAI, OpenRouter, etc.)."""
+        adapter = LiteLLMAdapter()
+        messages = [Message(role=MessageRole.USER, content="Hello")]
+
+        non_anthropic_models = ["gpt-4", "openrouter/openai/gpt-4", "gemini-pro"]
+        for model in non_anthropic_models:
+            config = CompletionConfig(model=model)
+            with patch.dict("os.environ", {}, clear=True):
+                kwargs = adapter._build_completion_kwargs(messages, config)
+            assert kwargs["top_p"] == 1.0, f"top_p should be included for {model}"
+
     def test_includes_api_base_when_set(self) -> None:
         """Includes api_base when set in constructor."""
         adapter = LiteLLMAdapter(api_base="https://custom.api")


### PR DESCRIPTION
## Problem

Anthropic's API rejects requests that include both `temperature` and `top_p` simultaneously, throwing a 400 error. The current implementation always passes `top_p`, which breaks any Anthropic/Claude model.

## Solution

Conditionally omit `top_p` from the kwargs when the model name contains `anthropic` or `claude`. All other providers (OpenAI, OpenRouter, Gemini, etc.) continue to receive `top_p` as before.

## Changes

- `src/ouroboros/providers/litellm_adapter.py`: Conditional `top_p` inclusion based on provider
- `tests/unit/providers/test_litellm_adapter.py`: 2 new tests covering Anthropic exclusion and non-Anthropic inclusion

## Tests

```
test_excludes_top_p_for_anthropic_models  ✅
test_includes_top_p_for_non_anthropic_models  ✅
```

---

*Note: This fix was originally included in #66 (OpenClaw integration). Splitting it out per reviewer feedback so it can merge independently.*