### PR TITLE
fix(lint): resolve ruff errors from #63 merge

### DIFF
--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -24,7 +24,6 @@ from ouroboros.providers.base import (
     MessageRole,
 )
 
-
 log = structlog.get_logger()
 
 # Interview round constants

--- a/src/ouroboros/core/file_lock.py
+++ b/src/ouroboros/core/file_lock.py
@@ -18,7 +18,7 @@ from filelock import FileLock
 
 
 @contextmanager
-def file_lock(file_path: Path, exclusive: bool = True) -> Iterator[None]:
+def file_lock(file_path: Path, exclusive: bool = True) -> Iterator[None]:  # noqa: ARG001
     """Context manager for cross-platform file locking.
 
     Creates a .lock file alongside the target file. Both shared and exclusive


### PR DESCRIPTION
## Summary
- Fix import sorting in `interview.py` (ruff I001)
- Suppress `ARG001` for `file_lock()` `exclusive` param — kept for API compatibility with existing call sites

Follows up on #63 squash merge which introduced 2 ruff lint failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)