### PR TITLE
fix(providers): omit allowed_tools when unset so SDK enables read-only tools

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -359,7 +359,6 @@ class ClaudeCodeAdapter:
             disallowed = dangerous_tools
 
         options_kwargs: dict = {
-            "allowed_tools": self._allowed_tools if self._allowed_tools else [],
             "disallowed_tools": disallowed,
             "max_turns": self._max_turns,
             # Allow MCP and other ~/.claude/ settings to be inherited
@@ -367,6 +366,13 @@ class ClaudeCodeAdapter:
             "cwd": os.getcwd(),
             "cli_path": self._cli_path,
         }
+        # Only set allowed_tools when explicitly specified (strict mode).
+        # An empty list tells the SDK "allow nothing", which silently blocks
+        # all tools — including Read/Glob/Grep that the interviewer prompt
+        # claims are available.  Omitting the key lets the SDK fall back to
+        # its default behaviour: allow every tool not in disallowed_tools.
+        if self._allowed_tools:
+            options_kwargs["allowed_tools"] = self._allowed_tools
         # Pass model from CompletionConfig if specified
         # "default" is not a valid SDK model — treat it as None (use SDK default)
         if config.model and config.model != "default":

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -1,0 +1,123 @@
+"""Unit tests for ouroboros.providers.claude_code_adapter module.
+
+Focused on verifying that allowed_tools / disallowed_tools are passed
+correctly to the Claude Agent SDK.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
+
+
+class TestClaudeCodeAdapterToolPermissions:
+    """Verify that tool permission options are built correctly."""
+
+    def _build_options_kwargs(self, adapter: ClaudeCodeAdapter) -> dict:
+        """Extract the options_kwargs dict that _execute_single_request would build.
+
+        We replicate just the tool-permission logic so we can assert on
+        the dictionary without actually calling the SDK.
+        """
+        import os
+
+        dangerous_tools = ["Write", "Edit", "Bash", "Task", "NotebookEdit"]
+
+        if adapter._allowed_tools:
+            all_tools = [
+                "Read", "Write", "Edit", "Bash", "WebFetch", "WebSearch",
+                "Glob", "Grep", "Task", "NotebookEdit", "TodoRead",
+                "TodoWrite", "LS",
+            ]
+            disallowed = [t for t in all_tools if t not in adapter._allowed_tools]
+        else:
+            disallowed = dangerous_tools
+
+        options_kwargs: dict = {
+            "disallowed_tools": disallowed,
+            "max_turns": adapter._max_turns,
+            "permission_mode": adapter._permission_mode,
+            "cwd": os.getcwd(),
+            "cli_path": adapter._cli_path,
+        }
+        if adapter._allowed_tools:
+            options_kwargs["allowed_tools"] = adapter._allowed_tools
+
+        return options_kwargs
+
+    def test_permissive_mode_omits_allowed_tools(self) -> None:
+        """When no allowed_tools specified, the key is omitted entirely.
+
+        An empty list would tell the SDK 'allow nothing', silently blocking
+        Read/Glob/Grep that the interviewer prompt claims are available.
+        """
+        adapter = ClaudeCodeAdapter(max_turns=3)
+
+        opts = self._build_options_kwargs(adapter)
+
+        assert "allowed_tools" not in opts
+        assert "Write" in opts["disallowed_tools"]
+        assert "Bash" in opts["disallowed_tools"]
+        # Read-only tools should NOT be disallowed
+        assert "Read" not in opts["disallowed_tools"]
+        assert "Glob" not in opts["disallowed_tools"]
+        assert "Grep" not in opts["disallowed_tools"]
+
+    def test_strict_mode_sets_allowed_tools(self) -> None:
+        """When allowed_tools is specified, it is included in options."""
+        adapter = ClaudeCodeAdapter(
+            max_turns=3,
+            allowed_tools=["Read", "Glob", "Grep"],
+        )
+
+        opts = self._build_options_kwargs(adapter)
+
+        assert opts["allowed_tools"] == ["Read", "Glob", "Grep"]
+        # Disallowed should be everything NOT in allowed_tools
+        assert "Write" in opts["disallowed_tools"]
+        assert "Bash" in opts["disallowed_tools"]
+        assert "Read" not in opts["disallowed_tools"]
+        assert "Glob" not in opts["disallowed_tools"]
+        assert "Grep" not in opts["disallowed_tools"]
+
+    @pytest.mark.asyncio
+    async def test_execute_request_omits_allowed_tools_in_permissive_mode(self) -> None:
+        """Integration: _execute_single_request does not pass allowed_tools=[] to SDK."""
+        adapter = ClaudeCodeAdapter(max_turns=1)
+
+        # Mock the SDK imports and query function
+        mock_result_msg = MagicMock()
+        type(mock_result_msg).__name__ = "ResultMessage"
+        mock_result_msg.result = "What framework are you using?"
+        mock_result_msg.is_error = False
+
+        mock_options_cls = MagicMock()
+        captured_kwargs: dict = {}
+
+        def capture_options(**kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock()
+
+        mock_options_cls.side_effect = capture_options
+
+        async def mock_query_gen(**kwargs):
+            yield mock_result_msg
+
+        with patch.dict("sys.modules", {
+            "claude_agent_sdk": MagicMock(
+                ClaudeAgentOptions=mock_options_cls,
+                query=mock_query_gen,
+            ),
+            "claude_agent_sdk._errors": MagicMock(
+                MessageParseError=type("MessageParseError", (Exception,), {}),
+            ),
+        }):
+            from ouroboros.providers.base import CompletionConfig
+
+            config = CompletionConfig(model="claude-opus-4-6")
+            await adapter._execute_single_request("test prompt", config)
+
+            # The key assertion: allowed_tools should NOT be in the kwargs
+            assert "allowed_tools" not in captured_kwargs
+            assert "disallowed_tools" in captured_kwargs


### PR DESCRIPTION
## Problem

When `ClaudeCodeAdapter` is created without explicit `allowed_tools` (the default for interview question generation), the options dict passes `allowed_tools=[]` to `ClaudeAgentOptions`. The SDK interprets an empty list as **"allow nothing"**, which silently blocks `Read`/`Glob`/`Grep` — the exact tools the `socratic-interviewer` prompt claims are available.

The sub-Claude then outputs text like *"Let me look at the gold standard pages and the pages that need updating before asking my first question."* instead of an actual question. That text gets stored as the interview "question", breaking the flow completely.

### Reproduction

1. Run `ooo interview` with a brownfield project context that references specific file paths
2. The MCP tool returns a "question" that starts with "Let me look at..." or "Let me first examine..."
3. The interview never produces actual questions

### Root cause

```python
# definitions.py line ~1074
engine = InterviewEngine(
    llm_adapter=ClaudeCodeAdapter(max_turns=3),  # no allowed_tools → defaults to []
    ...
)

# claude_code_adapter.py line ~362 (before fix)
options_kwargs = {
    "allowed_tools": self._allowed_tools if self._allowed_tools else [],  # [] = "allow nothing"
    ...
}
```

The comment above this code says *"Block dangerous tools explicitly, allow everything else"* — but `allowed_tools=[]` does the opposite.

## Fix

Only include `allowed_tools` in `options_kwargs` when the caller explicitly specifies them (strict mode). When omitted, the SDK falls back to its default: allow every tool not in `disallowed_tools`.

```python
# After fix — permissive mode doesn't set allowed_tools at all
options_kwargs: dict = {
    "disallowed_tools": disallowed,
    ...
}
if self._allowed_tools:
    options_kwargs["allowed_tools"] = self._allowed_tools
```

## Changes

- `src/ouroboros/providers/claude_code_adapter.py` — Remove `allowed_tools=[]` from options dict; only set when explicitly specified
- `tests/unit/providers/test_claude_code_adapter.py` — New test file: 3 tests covering permissive mode (omits key), strict mode (sets key), and integration with `_execute_single_request`

## Test plan

- [x] `pytest tests/unit/providers/test_claude_code_adapter.py` — 3 pass
- [x] `pytest tests/unit/bigbang/test_interview.py tests/unit/mcp/tools/test_definitions.py` — 74 pass (no regressions)
- [x] `ruff check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)