### PR TITLE
fix: clarify false convergence gate message (#114)

### DIFF
--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -142,18 +142,18 @@ class ConvergenceCriteria:
                         failed_acs=regressed,
                     )
 
-            # False convergence gate: block if ontology never actually evolved.
+            # Evolution gate: withhold convergence if ontology never actually evolved.
             # When ontology never changes, either Reflect is conservatively
-            # preserving a well-performing ontology, or Wonder→Reflect encountered
-            # errors. Either way, defer convergence until genuine evolution occurs.
+            # preserving a well-performing ontology, or Wonder/Reflect encountered
+            # errors. Either way, withhold convergence until genuine evolution occurs.
             evolved_count = self._count_evolved_generations(lineage)
             if evolved_count == 0:
                 return ConvergenceSignal(
                     converged=False,
                     reason=(
-                        f"Convergence deferred: similarity {latest_sim:.3f} "
+                        f"Convergence withheld: similarity {latest_sim:.3f} "
                         f"but ontology unchanged across {num_gens} generations "
-                        f"(Reflect may be conservatively stable — not necessarily an error)"
+                        f"(evolution required before convergence is accepted)"
                     ),
                     ontology_similarity=latest_sim,
                     generation=current_gen,
@@ -224,11 +224,11 @@ class ConvergenceCriteria:
         return delta.similarity
 
     def _count_evolved_generations(self, lineage: OntologyLineage) -> int:
-        """Count how many consecutive generation pairs show actual ontology evolution.
+        """Count how many generation pairs show actual ontology evolution.
 
         Returns the number of transitions where similarity < convergence_threshold,
         indicating Wonder→Reflect successfully mutated the ontology.
-        A return of 0 means the ontology never changed — either because Reflect
+        A return of 0 means the ontology never changed -- either because Reflect
         conservatively preserved a well-performing ontology, or because
         Wonder/Reflect encountered errors preventing mutation.
         """

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -262,7 +262,7 @@ class TestConvergenceGating:
 
         Gen 1→2: B→A = genuine evolution (similarity < threshold).
         Gen 2→3: A→A = stable (similarity = 1.0).
-        This passes the false-convergence gate because evolution DID occur.
+        This passes the evolution gate because evolution DID occur.
         """
         return _lineage_with_schemas(SCHEMA_B, SCHEMA_A, SCHEMA_A)
 
@@ -403,15 +403,15 @@ class TestConvergenceGating:
         assert "unsatisfactory" in signal.reason
 
 
-class TestFalseConvergenceDetection:
-    """Tests for false convergence detection (P1-5).
+class TestEvolutionGateDetection:
+    """Tests for evolution gate detection (P1-5).
 
     When the ontology never changes across generations, the system should
     block convergence — whether due to conservative Reflect or errors.
     """
 
     def test_blocks_when_ontology_never_evolved(self) -> None:
-        """Identical ontology across all generations -> false convergence blocked."""
+        """Identical ontology across all generations -> convergence withheld."""
         lineage = _lineage_with_schemas(SCHEMA_A, SCHEMA_A, SCHEMA_A)
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
@@ -420,7 +420,7 @@ class TestFalseConvergenceDetection:
         )
         signal = criteria.evaluate(lineage)
         assert not signal.converged
-        assert "Convergence deferred" in signal.reason
+        assert "Convergence withheld" in signal.reason
 
     def test_allows_when_ontology_evolved_at_least_once(self) -> None:
         """Ontology evolved once then stabilized -> genuine convergence."""
@@ -444,10 +444,10 @@ class TestFalseConvergenceDetection:
         )
         signal = criteria.evaluate(lineage)
         assert not signal.converged
-        assert "Convergence deferred" in signal.reason
+        assert "Convergence withheld" in signal.reason
 
-    def test_max_generations_overrides_false_convergence(self) -> None:
-        """Hard cap still terminates even with false convergence."""
+    def test_max_generations_overrides_withheld_convergence(self) -> None:
+        """Hard cap still terminates even with withheld convergence."""
         lineage = _lineage_with_schemas(SCHEMA_A, SCHEMA_A, SCHEMA_A)
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,


### PR DESCRIPTION
## Summary
- **"Convergence deferred" -> "Convergence withheld"** -- active verb (system is preventing, not postponing)
- **Remove "not necessarily an error"** -> replaced with actionable "evolution required before convergence is accepted"
- **Replace Unicode em dash (U+2014) with ASCII `--`** in persisted reason strings and docstrings
- **Fix "consecutive" docstring bug** -- `_count_evolved_generations` counts all pairs, not consecutive ones
- **Unify terminology**: "false convergence" -> "evolution gate" in comments, test class names, and docstrings
- **Rename `Wonder→Reflect`** to `Wonder/Reflect` in comments (arrow implied causality)

## Test plan
- [x] All 20 tests in `test_convergence.py` pass
- [x] Grepped for stale strings ("False convergence", "false_convergence", "Convergence deferred") -- no remnants in src/ or tests/

Closes #114