### PR TITLE
fix: handle Windows OSError in _check_stale_instance() (#121)

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -60,6 +60,11 @@ def _check_stale_instance() -> bool:
         return True
     except PermissionError:
         return False  # Process exists but we can't signal it
+    except OSError:
+        # Windows: os.kill(pid, 0) raises OSError (WinError 87)
+        # since signal 0 is not supported. Treat as stale.
+        _cleanup_pid_file()
+        return True
 
 
 app = typer.Typer(


### PR DESCRIPTION
## Summary

- `os.kill(pid, 0)` in `_check_stale_instance()` is POSIX-only — on Windows it raises `OSError (WinError 87)` instead of `ProcessLookupError`, crashing MCP server startup when a stale PID file exists.
- Added a fallback `except OSError` clause that treats the error as "process not found" and cleans up the stale PID file, consistent with the existing `ProcessLookupError` handling.

## Test plan

- [x] `uv run pytest tests/unit/cli/ -x -q` — 154 passed
- [x] `uv run pytest tests/ --ignore=tests/unit/mcp --ignore=tests/integration/mcp --ignore=tests/e2e -x -q` — 2314 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)