### PR TITLE
Fix concurrent session execution with WAL mode and state namespacing

### DIFF
--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -138,16 +138,27 @@ class InterviewEngine:
     Note:
         The model can be configured via OuroborosConfig.clarification.default_model
         or passed directly to the constructor.
+
+        For concurrent session isolation, pass a session_id to scope state
+        files under ~/.ouroboros/sessions/{session_id}/data/.
     """
 
     llm_adapter: LLMAdapter
     state_dir: Path = field(default_factory=lambda: Path.home() / ".ouroboros" / "data")
+    session_id: str | None = None
     model: str = _FALLBACK_MODEL
     temperature: float = 0.7
     max_tokens: int = 2048
 
     def __post_init__(self) -> None:
-        """Ensure state directory exists."""
+        """Ensure state directory exists.
+
+        If session_id is set and state_dir is the default, scopes state
+        under ~/.ouroboros/sessions/{session_id}/data/ for isolation.
+        """
+        default_dir = Path.home() / ".ouroboros" / "data"
+        if self.session_id and self.state_dir == default_dir:
+            self.state_dir = Path.home() / ".ouroboros" / "sessions" / self.session_id / "data"
         self.state_dir.mkdir(parents=True, exist_ok=True)
 
     def _state_file_path(self, interview_id: str) -> Path:

--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -149,15 +149,22 @@ class CheckpointStore:
 
     MAX_ROLLBACK_DEPTH = 3
 
-    def __init__(self, base_path: Path | None = None) -> None:
+    def __init__(self, base_path: Path | None = None, session_id: str | None = None) -> None:
         """Initialize checkpoint store.
 
         Args:
             base_path: Base directory for checkpoints.
                       Defaults to ~/.ouroboros/data/checkpoints/
+            session_id: Optional session ID for namespace isolation.
+                       When provided, checkpoints are stored under
+                       ~/.ouroboros/sessions/{session_id}/checkpoints/
+                       to prevent collisions between concurrent sessions.
         """
         if base_path is None:
-            base_path = Path.home() / ".ouroboros" / "data" / "checkpoints"
+            if session_id:
+                base_path = Path.home() / ".ouroboros" / "sessions" / session_id / "checkpoints"
+            else:
+                base_path = Path.home() / ".ouroboros" / "data" / "checkpoints"
         self._base_path = base_path
 
     def initialize(self) -> None:

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -21,7 +21,7 @@ class EventStore:
     All operations are transactional for atomicity.
 
     Usage:
-        store = EventStore("sqlite+aiosqlite:///ouroboros.db")
+        store = EventStore()  # defaults to ~/.ouroboros/ouroboros.db
         await store.initialize()
 
         # Append event
@@ -57,6 +57,10 @@ class EventStore:
         For aiosqlite, uses StaticPool (default) which maintains a single
         connection. This avoids connection accumulation while supporting
         :memory: databases in tests.
+
+        Enables WAL journal mode and busy timeout for concurrent session
+        support. WAL allows concurrent readers with a single writer,
+        eliminating 'database is locked' errors in multi-session scenarios.
         """
         if self._engine is None:
             self._engine = create_async_engine(
@@ -67,6 +71,15 @@ class EventStore:
         # Create all tables defined in metadata
         async with self._engine.begin() as conn:
             await conn.run_sync(metadata.create_all)
+
+        # Enable WAL mode and busy timeout for concurrent access.
+        # WAL (Write-Ahead Logging) allows multiple readers + one writer
+        # without blocking. busy_timeout makes SQLite retry on lock
+        # contention instead of immediately raising SQLITE_BUSY.
+        if "sqlite" in self._database_url:
+            async with self._engine.begin() as conn:
+                await conn.execute(text("PRAGMA journal_mode=WAL"))
+                await conn.execute(text("PRAGMA busy_timeout=5000"))
 
     async def append(self, event: BaseEvent) -> None:
         """Append an event to the store.

--- a/src/ouroboros/secondary/scheduler.py
+++ b/src/ouroboros/secondary/scheduler.py
@@ -14,7 +14,7 @@ Usage:
     from ouroboros.secondary import SecondaryLoopScheduler, TodoRegistry
     from ouroboros.persistence import EventStore
 
-    store = EventStore("sqlite+aiosqlite:///ouroboros.db")
+    store = EventStore()  # defaults to ~/.ouroboros/ouroboros.db
     registry = TodoRegistry(store)
     scheduler = SecondaryLoopScheduler(registry)
 

--- a/src/ouroboros/secondary/todo_registry.py
+++ b/src/ouroboros/secondary/todo_registry.py
@@ -13,7 +13,7 @@ Usage:
     from ouroboros.secondary import TodoRegistry, Todo, Priority, TodoStatus
     from ouroboros.persistence import EventStore
 
-    store = EventStore("sqlite+aiosqlite:///ouroboros.db")
+    store = EventStore()  # defaults to ~/.ouroboros/ouroboros.db
     await store.initialize()
 
     registry = TodoRegistry(store)


### PR DESCRIPTION
## Summary

- Enable SQLite WAL journal mode and `busy_timeout` in `EventStore.initialize()` to eliminate `database is locked` errors during concurrent multi-session usage
- Add `session_id` parameter to `CheckpointStore` and `InterviewEngine` for per-session state isolation under `~/.ouroboros/sessions/{session_id}/`
- Fix docstring examples in `scheduler.py` and `todo_registry.py` to use centralized default DB path instead of hardcoded relative paths

Fixes #124

## Test plan

### Automated
- [x] All existing tests pass (87 session/interview, 19 event store, 40 checkpoint/UoW — 146 total)

### Manual testing steps

**1. Install this branch as the MCP server:**
```bash
uv tool install --force --python 3.14 \
  "ouroboros-ai @ git+https://github.com/shawndowns/ouroboros.git@ooo/run/seed_3545c4224005"
```

**2. Open two terminal windows** with the same project (or different projects) and run concurrent sessions:
- **Terminal 1**: `claude` → `ooo interview "Build a REST API"`
- **Terminal 2**: `claude` → `ooo interview "Build a CLI tool"`

**3. Verify:**
- [ ] Neither session gets `database is locked` errors
- [ ] Both interviews save/load state independently
- [ ] WAL mode is active: `sqlite3 ~/.ouroboros/ouroboros.db "PRAGMA journal_mode;"` returns `wal`

**4. Restore released version after testing:**
```bash
uv tool install --force --python 3.14 ouroboros-ai
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)