### PR TITLE
fix(runner): replace Unicode emoji with ASCII for Windows cp1252 consoles

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -166,6 +166,19 @@ class ParallelACExecutor:
             except (OSError, ValueError):
                 pass
 
+    def _safe_console_text(self, text: str) -> str:
+        """Return console-safe text for the active output encoding."""
+        console_file = getattr(self._console, "file", None)
+        encoding = getattr(console_file, "encoding", None)
+        if not isinstance(encoding, str) or not encoding:
+            return text
+
+        try:
+            text.encode(encoding)
+        except UnicodeEncodeError:
+            return text.encode(encoding, errors="replace").decode(encoding)
+        return text
+
     async def execute_parallel(
         self,
         seed: Seed,
@@ -565,7 +578,9 @@ class ParallelACExecutor:
             if sub_acs and len(sub_acs) >= MIN_SUB_ACS:
                 # Decomposition successful - execute Sub-ACs in parallel
                 self._console.print(
-                    f"  [cyan]AC {ac_index + 1} → Decomposed into {len(sub_acs)} Sub-ACs (parallel)[/cyan]"
+                    self._safe_console_text(
+                        f"  [cyan]AC {ac_index + 1} -> Decomposed into {len(sub_acs)} Sub-ACs (parallel)[/cyan]"
+                    )
                 )
                 self._flush_console()
 
@@ -929,7 +944,11 @@ When complete, explicitly state: [TASK_COMPLETE]
                 if message.tool_name:
                     tool_input = message.data.get("tool_input", {})
                     tool_detail = self._format_tool_detail(message.tool_name, tool_input)
-                    self._console.print(f"{indent}[yellow]{label} → {tool_detail}[/yellow]")
+                    self._console.print(
+                        self._safe_console_text(
+                            f"{indent}[yellow]{label} -> {tool_detail}[/yellow]"
+                        )
+                    )
                     self._flush_console()
 
                     # Emit tool started event for TUI

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -363,6 +363,24 @@ class OrchestratorRunner:
         """
         self._active_sessions[execution_id] = session_id
 
+    def _safe_console_text(self, text: str) -> str:
+        """Return console-safe text for the active output encoding.
+
+        Rich on Windows may target a legacy cp1252 console. Agent output can
+        contain emoji or other Unicode characters that would otherwise crash the
+        runner while printing progress or final summaries.
+        """
+        console_file = getattr(self._console, "file", None)
+        encoding = getattr(console_file, "encoding", None)
+        if not isinstance(encoding, str) or not encoding:
+            return text
+
+        try:
+            text.encode(encoding)
+        except UnicodeEncodeError:
+            return text.encode(encoding, errors="replace").decode(encoding)
+        return text
+
     def _unregister_session(self, execution_id: str, session_id: str) -> None:
         """Unregister a session after execution completes.
 
@@ -912,21 +930,23 @@ class OrchestratorRunner:
                     # Print log-style output for tool calls and agent messages
                     if message.tool_name and message.tool_name != last_tool:
                         status.stop()
-                        self._console.print(f"  [yellow]🔧 {message.tool_name}[/yellow]")
+                        self._console.print(f"  [yellow][tool] {message.tool_name}[/yellow]")
                         status.start()
                         last_tool = message.tool_name
                     elif message.type == "assistant" and message.content and not message.tool_name:
                         # Show agent thinking/reasoning
                         content = message.content.strip()
                         status.stop()
-                        self._console.print(f"  [dim]💭 {content}[/dim]")
+                        self._console.print(
+                            f"  [dim][thought] {self._safe_console_text(content)}[/dim]"
+                        )
                         status.start()
 
                     # Print when AC is completed
                     current_completed = state_tracker.state.completed_count
                     if current_completed > last_completed_count:
                         status.stop()
-                        self._console.print(f"  [green]✓ AC {current_completed} completed[/green]")
+                        self._console.print(f"  [green][done] AC {current_completed} completed[/green]")
                         status.start()
                         last_completed_count = current_completed
 
@@ -1022,7 +1042,7 @@ class OrchestratorRunner:
                 # Display success
                 self._console.print(
                     Panel(
-                        Text(final_message[:1000], style="green"),
+                        Text(self._safe_console_text(final_message[:1000]), style="green"),
                         title="[green]Execution Completed[/green]",
                         border_style="green",
                     )
@@ -1042,7 +1062,7 @@ class OrchestratorRunner:
                 # Display failure
                 self._console.print(
                     Panel(
-                        Text(final_message[:1000], style="red"),
+                        Text(self._safe_console_text(final_message[:1000]), style="red"),
                         title="[red]Execution Failed[/red]",
                         border_style="red",
                     )
@@ -1267,7 +1287,7 @@ class OrchestratorRunner:
 
             self._console.print(
                 Panel(
-                    Text(final_message, style="green"),
+                    Text(self._safe_console_text(final_message), style="green"),
                     title="[green]Parallel Execution Completed[/green]",
                     border_style="green",
                 )
@@ -1286,7 +1306,7 @@ class OrchestratorRunner:
 
             self._console.print(
                 Panel(
-                    Text(final_message, style="yellow"),
+                    Text(self._safe_console_text(final_message), style="yellow"),
                     title="[yellow]Partial Success[/yellow]",
                     border_style="yellow",
                 )
@@ -1480,21 +1500,23 @@ Note: This is a resumed session. Please continue from where execution was interr
                     # Print log-style output for tool calls and agent messages
                     if message.tool_name and message.tool_name != last_tool:
                         status.stop()
-                        self._console.print(f"  [yellow]🔧 {message.tool_name}[/yellow]")
+                        self._console.print(f"  [yellow][tool] {message.tool_name}[/yellow]")
                         status.start()
                         last_tool = message.tool_name
                     elif message.type == "assistant" and message.content and not message.tool_name:
                         # Show agent thinking/reasoning
                         content = message.content.strip()
                         status.stop()
-                        self._console.print(f"  [dim]💭 {content}[/dim]")
+                        self._console.print(
+                            f"  [dim][thought] {self._safe_console_text(content)}[/dim]"
+                        )
                         status.start()
 
                     # Print when AC is completed
                     current_completed = state_tracker.state.completed_count
                     if current_completed > last_completed_count:
                         status.stop()
-                        self._console.print(f"  [green]✓ AC {current_completed} completed[/green]")
+                        self._console.print(f"  [green][done] AC {current_completed} completed[/green]")
                         status.start()
                         last_completed_count = current_completed
 
@@ -1560,7 +1582,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                 )
                 self._console.print(
                     Panel(
-                        Text(final_message[:1000], style="green"),
+                        Text(self._safe_console_text(final_message[:1000]), style="green"),
                         title="[green]Resumed Execution Completed[/green]",
                         border_style="green",
                     )
@@ -1569,7 +1591,7 @@ Note: This is a resumed session. Please continue from where execution was interr
                 await self._session_repo.mark_failed(session_id, final_message)
                 self._console.print(
                     Panel(
-                        Text(final_message[:1000], style="red"),
+                        Text(self._safe_console_text(final_message[:1000]), style="red"),
                         title="[red]Resumed Execution Failed[/red]",
                         border_style="red",
                     )

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1,0 +1,119 @@
+"""Unit tests for ParallelACExecutor."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelACExecutor
+
+
+class _MockAdapter:
+    """Minimal adapter stub for ParallelACExecutor tests."""
+
+    def __init__(self, messages: list[AgentMessage]) -> None:
+        self._messages = messages
+
+    async def execute_task(self, *args, **kwargs) -> AsyncIterator[AgentMessage]:
+        for message in self._messages:
+            yield message
+
+
+@pytest.mark.asyncio
+async def test_execute_atomic_ac_uses_ascii_safe_tool_output() -> None:
+    """Tool progress logs should avoid Unicode markers that break cp1252 consoles."""
+    adapter = _MockAdapter(
+        [
+            AgentMessage(
+                type="assistant",
+                content="Calling tool: Write: foo.txt",
+                tool_name="Write",
+                data={"tool_input": {"file_path": "foo.txt"}},
+            ),
+            AgentMessage(
+                type="result",
+                content="[TASK_COMPLETE]",
+                data={"subtype": "success"},
+            ),
+        ]
+    )
+    console = MagicMock()
+    event_store = AsyncMock()
+    event_store.append = AsyncMock()
+
+    executor = ParallelACExecutor(adapter=adapter, event_store=event_store, console=console)
+
+    result = await executor._execute_atomic_ac(
+        ac_index=0,
+        ac_content="Write the output file",
+        session_id="sess_123",
+        tools=["Write"],
+        system_prompt="System prompt",
+        seed_goal="Seed goal",
+        depth=0,
+        start_time=__import__("datetime").datetime.now(__import__("datetime").UTC),
+    )
+
+    assert result.success is True
+    printed = "\n".join(str(call.args[0]) for call in console.print.call_args_list if call.args)
+    assert "->" in printed
+    assert "→" not in printed
+
+
+@pytest.mark.asyncio
+async def test_execute_single_ac_decomposition_uses_ascii_safe_output() -> None:
+    """Decomposition status logs should avoid Unicode markers that break cp1252 consoles."""
+    adapter = _MockAdapter([])
+    console = MagicMock()
+    event_store = AsyncMock()
+    event_store.append = AsyncMock()
+
+    executor = ParallelACExecutor(adapter=adapter, event_store=event_store, console=console)
+
+    sub_results = [
+        ACExecutionResult(ac_index=100, ac_content="Sub task 1", success=True),
+        ACExecutionResult(ac_index=101, ac_content="Sub task 2", success=True),
+    ]
+
+    with (
+        patch.object(executor, "_try_decompose_ac", AsyncMock(return_value=["Sub task 1", "Sub task 2"])),
+        patch.object(executor, "_execute_sub_acs_parallel", AsyncMock(return_value=sub_results)),
+    ):
+        result = await executor._execute_single_ac(
+            ac_index=0,
+            ac_content="Complex task",
+            session_id="sess_123",
+            tools=["Write"],
+            system_prompt="System prompt",
+            seed_goal="Seed goal",
+            depth=0,
+            execution_id="exec_123",
+        )
+
+    assert result.success is True
+    printed = "\n".join(str(call.args[0]) for call in console.print.call_args_list if call.args)
+    assert "-> Decomposed into 2 Sub-ACs" in printed
+    assert "→" not in printed
+
+
+def test_safe_console_text_replaces_unencodable_characters() -> None:
+    """Console sanitization should protect Windows cp1252 output."""
+
+    class _Cp1252File:
+        encoding = "cp1252"
+
+        def flush(self) -> None:
+            return None
+
+    console = MagicMock()
+    console.file = _Cp1252File()
+    event_store = AsyncMock()
+    event_store.append = AsyncMock()
+    executor = ParallelACExecutor(adapter=_MockAdapter([]), event_store=event_store, console=console)
+
+    safe = executor._safe_console_text("✅ done")
+
+    assert safe == "? done"

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -381,6 +381,27 @@ class TestOrchestratorRunner:
         assert result.is_ok
         assert captured_kwargs["resume_handle"] == runtime_handle
 
+    def test_safe_console_text_replaces_unencodable_characters(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Console sanitization should protect Windows cp1252 output."""
+
+        class _Cp1252File:
+            encoding = "cp1252"
+
+            def flush(self) -> None:
+                return None
+
+        console = MagicMock()
+        console.file = _Cp1252File()
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, console)
+
+        safe = runner._safe_console_text("✅ done")
+
+        assert safe == "? done"
+
 
 class TestOrchestratorError:
     """Tests for OrchestratorError."""


### PR DESCRIPTION
## Summary

- Add `_safe_console_text()` to `OrchestratorRunner` and `ParallelACExecutor` that detects console encoding and replaces unencodable characters with `?`
- Replace Unicode emoji in console output: `→` → `->`, `🔧` → `[tool]`, `💭` → `[thought]`, `✓` → `[done]`
- Wrap all `Panel(Text(...))` outputs through the safety method, including execute, parallel, and resume paths

### Problem

Rich on Windows may target a legacy cp1252 console. Agent output containing emoji crashes the runner while printing progress or final summaries with `UnicodeEncodeError`.

### Approach

Rather than forcing UTF-8 on Windows (which has side effects), the fix:
1. Probes `console.file.encoding` at render time
2. Attempts `text.encode(encoding)` — short-circuits if text is already safe
3. Falls back to `errors="replace"` which substitutes `?` for unencodable codepoints

## Test plan

- [x] 4 new unit tests covering cp1252 encoding replacement
- [x] Integration tests verify `->` replaces `→` in tool/decomposition output
- [x] 48 orchestrator tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)