### PR TITLE
fix(ci): prevent test hang from QA invoking real Claude CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -722,6 +722,7 @@ class TestEvolveStepHandler:
             {
                 "lineage_id": "lin_handler_test",
                 "seed_content": yaml.dump(seed.to_dict()),
+                "skip_qa": True,
             }
         )
 
@@ -754,6 +755,7 @@ class TestEvolveStepHandler:
                 "lineage_id": "lin_handler_project_dir",
                 "seed_content": yaml.dump(seed.to_dict()),
                 "project_dir": "/tmp/test-project",
+                "skip_qa": True,
             }
         )
 


### PR DESCRIPTION
## Summary

- `TestEvolveStepHandler` unit tests called `handle()` without `skip_qa`, triggering `QAHandler` → `ClaudeCodeAdapter` → bundled Claude CLI subprocess
- On CI runners without API credentials, this causes **indefinite hangs** (6h+ on all Python versions)
- Root cause surfaced by #75 (dependency upgrade `claude-agent-sdk 0.1.22 → 0.1.48`), but the underlying issue exists on `main` too — it just happened to fail fast due to SDK version differences

## Changes

- Add `skip_qa=True` to `TestEvolveStepHandler` test calls (unit tests should not invoke real Claude CLI)
- Add `timeout-minutes: 15` to test workflow as safety net

## Test plan

- [x] All 2661 tests pass locally (26s)
- [x] `TestEvolveStepHandler` runs in 1.2s instead of 20-30s
- [ ] CI passes on this PR
- [ ] After merge, re-run #75 CI to verify fix

Ref: #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)