### PR TITLE
Persist interview ambiguity snapshots for seed generation

### DIFF
--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -88,6 +88,8 @@ class InterviewState(BaseModel):
     codebase_paths: list[dict[str, str]] = Field(default_factory=list)
     codebase_context: str = ""
     explore_completed: bool = False
+    ambiguity_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    ambiguity_breakdown: dict[str, Any] | None = None
 
     @property
     def current_round_number(self) -> int:
@@ -102,6 +104,26 @@ class InterviewState(BaseModel):
     def mark_updated(self) -> None:
         """Update the updated_at timestamp."""
         self.updated_at = datetime.now(UTC)
+
+    def store_ambiguity(
+        self,
+        *,
+        score: float,
+        breakdown: dict[str, Any],
+    ) -> None:
+        """Persist the latest ambiguity evaluation on the interview state."""
+        self.ambiguity_score = score
+        self.ambiguity_breakdown = breakdown
+        self.mark_updated()
+
+    def clear_stored_ambiguity(self) -> None:
+        """Invalidate any persisted ambiguity snapshot after interview changes."""
+        if self.ambiguity_score is None and self.ambiguity_breakdown is None:
+            return
+
+        self.ambiguity_score = None
+        self.ambiguity_breakdown = None
+        self.mark_updated()
 
 
 @dataclass

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -23,7 +23,12 @@ from rich.console import Console
 import structlog
 import yaml
 
-from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
+from ouroboros.bigbang.ambiguity import (
+    AmbiguityScore,
+    AmbiguityScorer,
+    ComponentScore,
+    ScoreBreakdown,
+)
 from ouroboros.bigbang.interview import InterviewEngine, InterviewState
 from ouroboros.bigbang.seed_generator import SeedGenerator
 from ouroboros.core.errors import ValidationError
@@ -622,6 +627,54 @@ class GenerateSeedHandler:
     seed_generator: SeedGenerator | None = field(default=None, repr=False)
     llm_adapter: ClaudeCodeAdapter | None = field(default=None, repr=False)
 
+    def _build_ambiguity_score_from_value(self, ambiguity_score_value: float) -> AmbiguityScore:
+        """Build an ambiguity score object from an explicit numeric override."""
+        breakdown = ScoreBreakdown(
+            goal_clarity=ComponentScore(
+                name="goal_clarity",
+                clarity_score=1.0 - ambiguity_score_value,
+                weight=0.40,
+                justification="Provided as input parameter",
+            ),
+            constraint_clarity=ComponentScore(
+                name="constraint_clarity",
+                clarity_score=1.0 - ambiguity_score_value,
+                weight=0.30,
+                justification="Provided as input parameter",
+            ),
+            success_criteria_clarity=ComponentScore(
+                name="success_criteria_clarity",
+                clarity_score=1.0 - ambiguity_score_value,
+                weight=0.30,
+                justification="Provided as input parameter",
+            ),
+        )
+        return AmbiguityScore(
+            overall_score=ambiguity_score_value,
+            breakdown=breakdown,
+        )
+
+    def _load_stored_ambiguity_score(self, state: InterviewState) -> AmbiguityScore | None:
+        """Load a persisted ambiguity score snapshot from interview state."""
+        if state.ambiguity_score is None:
+            return None
+
+        if isinstance(state.ambiguity_breakdown, dict):
+            try:
+                breakdown = ScoreBreakdown.model_validate(state.ambiguity_breakdown)
+            except PydanticValidationError:
+                log.warning(
+                    "mcp.tool.generate_seed.invalid_stored_ambiguity_breakdown",
+                    session_id=state.interview_id,
+                )
+            else:
+                return AmbiguityScore(
+                    overall_score=state.ambiguity_score,
+                    breakdown=breakdown,
+                )
+
+        return self._build_ambiguity_score_from_value(state.ambiguity_score)
+
     @property
     def definition(self) -> MCPToolDefinition:
         """Return the tool definition."""
@@ -700,42 +753,36 @@ class GenerateSeedHandler:
 
             state: InterviewState = state_result.value
 
-            # Use provided ambiguity score or check if state has it
+            # Use provided ambiguity score, a persisted snapshot, or compute on demand.
             if ambiguity_score_value is not None:
-                # Create a valid ScoreBreakdown with placeholder component scores
-                breakdown = ScoreBreakdown(
-                    goal_clarity=ComponentScore(
-                        name="goal_clarity",
-                        clarity_score=1.0 - ambiguity_score_value,
-                        weight=0.40,
-                        justification="Provided as input parameter",
-                    ),
-                    constraint_clarity=ComponentScore(
-                        name="constraint_clarity",
-                        clarity_score=1.0 - ambiguity_score_value,
-                        weight=0.30,
-                        justification="Provided as input parameter",
-                    ),
-                    success_criteria_clarity=ComponentScore(
-                        name="success_criteria_clarity",
-                        clarity_score=1.0 - ambiguity_score_value,
-                        weight=0.30,
-                        justification="Provided as input parameter",
-                    ),
-                )
-                ambiguity_score = AmbiguityScore(
-                    overall_score=ambiguity_score_value,
-                    breakdown=breakdown,
-                )
+                ambiguity_score = self._build_ambiguity_score_from_value(ambiguity_score_value)
             else:
-                # TODO: Check if state has embedded ambiguity score
-                # For now, require explicit score if not in state
-                return Result.err(
-                    MCPToolError(
-                        "ambiguity_score is required (interview didn't calculate it)",
-                        tool_name="ouroboros_generate_seed",
+                ambiguity_score = self._load_stored_ambiguity_score(state)
+                if ambiguity_score is None:
+                    scorer = AmbiguityScorer(
+                        llm_adapter=llm_adapter,
                     )
-                )
+                    score_result = await scorer.score(state)
+                    if score_result.is_err:
+                        return Result.err(
+                            MCPToolError(
+                                f"Failed to calculate ambiguity: {score_result.error}",
+                                tool_name="ouroboros_generate_seed",
+                            )
+                        )
+
+                    ambiguity_score = score_result.value
+                    state.store_ambiguity(
+                        score=ambiguity_score.overall_score,
+                        breakdown=ambiguity_score.breakdown.model_dump(mode="json"),
+                    )
+                    save_result = await interview_engine.save_state(state)
+                    if save_result.is_err:
+                        log.warning(
+                            "mcp.tool.generate_seed.persist_ambiguity_failed",
+                            session_id=session_id,
+                            error=str(save_result.error),
+                        )
 
             # Use injected or create seed generator
             generator = self.seed_generator or SeedGenerator(llm_adapter=llm_adapter)
@@ -1226,6 +1273,7 @@ class InterviewHandler:
                             )
                         )
                     state = record_result.value
+                    state.clear_stored_ambiguity()
 
                     # Emit response recorded event
                     from ouroboros.events.interview import interview_response_recorded

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -123,6 +123,27 @@ class TestInterviewState:
             interview_id="test_001",
             initial_context="Build a CLI tool",
             status=InterviewStatus.IN_PROGRESS,
+            ambiguity_score=0.18,
+            ambiguity_breakdown={
+                "goal_clarity": {
+                    "name": "goal_clarity",
+                    "clarity_score": 0.9,
+                    "weight": 0.4,
+                    "justification": "Clear goal",
+                },
+                "constraint_clarity": {
+                    "name": "constraint_clarity",
+                    "clarity_score": 0.8,
+                    "weight": 0.3,
+                    "justification": "Mostly clear constraints",
+                },
+                "success_criteria_clarity": {
+                    "name": "success_criteria_clarity",
+                    "clarity_score": 0.75,
+                    "weight": 0.3,
+                    "justification": "Success criteria are measurable",
+                },
+            },
         )
         state.rounds.append(
             InterviewRound(
@@ -144,6 +165,21 @@ class TestInterviewState:
         assert len(restored.rounds) == 1
         assert restored.rounds[0].question == "What problem does it solve?"
         assert restored.rounds[0].user_response == "Task management"
+        assert restored.ambiguity_score == 0.18
+        assert restored.ambiguity_breakdown == state.ambiguity_breakdown
+
+    def test_clear_stored_ambiguity(self) -> None:
+        """Stored ambiguity snapshots can be invalidated after interview changes."""
+        state = InterviewState(
+            interview_id="test_001",
+            ambiguity_score=0.12,
+            ambiguity_breakdown={"goal_clarity": {"name": "goal_clarity"}},
+        )
+
+        state.clear_stored_ambiguity()
+
+        assert state.ambiguity_score is None
+        assert state.ambiguity_breakdown is None
 
 
 class TestInterviewRound:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from ouroboros.bigbang.interview import InterviewRound, InterviewState
+from ouroboros.core.types import Result
 from ouroboros.mcp.tools.definitions import (
     OUROBOROS_TOOLS,
     CancelExecutionHandler,
@@ -656,6 +658,171 @@ class TestInterviewHandlerCwd:
         mock_engine.start_interview.assert_awaited_once()
         call_kwargs = mock_engine.start_interview.call_args
         assert call_kwargs[1]["cwd"] == str(tmp_path)
+
+    async def test_interview_handle_clears_stored_ambiguity_after_new_answer(self) -> None:
+        """Interview answers should invalidate any persisted ambiguity snapshot."""
+        handler = InterviewHandler()
+        state = InterviewState(
+            interview_id="sess-123",
+            ambiguity_score=0.14,
+            ambiguity_breakdown={"goal_clarity": {"name": "goal_clarity"}},
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question="What should it do?",
+                    user_response=None,
+                )
+            ],
+        )
+        mock_engine = MagicMock()
+        mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+        mock_engine.record_response = AsyncMock(return_value=Result.ok(state))
+        mock_engine.ask_next_question = AsyncMock(
+            return_value=MagicMock(is_ok=True, is_err=False, value="Next question?"),
+        )
+        mock_engine.save_state = AsyncMock(return_value=MagicMock(is_ok=True, is_err=False))
+
+        with patch(
+            "ouroboros.mcp.tools.definitions.InterviewEngine",
+            return_value=mock_engine,
+        ):
+            result = await handler.handle({"session_id": "sess-123", "answer": "Manage tasks"})
+
+        assert result.is_ok
+        assert state.ambiguity_score is None
+        assert state.ambiguity_breakdown is None
+
+
+class TestGenerateSeedHandlerAmbiguity:
+    """Test ambiguity persistence behavior in GenerateSeedHandler."""
+
+    async def test_generate_seed_handler_calculates_and_persists_ambiguity_when_missing(
+        self,
+    ) -> None:
+        """GenerateSeedHandler should score the interview and persist the snapshot when absent."""
+        state = InterviewState(
+            interview_id="sess-123",
+            initial_context="Build a tool",
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question="What should it do?",
+                    user_response="Manage tasks",
+                )
+            ],
+        )
+        mock_adapter = MagicMock()
+        mock_interview_engine = MagicMock()
+        mock_interview_engine.load_state = AsyncMock(return_value=Result.ok(state))
+        mock_interview_engine.save_state = AsyncMock(
+            return_value=MagicMock(is_ok=True, is_err=False),
+        )
+        mock_seed_generator = MagicMock()
+        mock_seed_generator.generate = AsyncMock(return_value=Result.err(RuntimeError("boom")))
+        mock_score = MagicMock(
+            overall_score=0.12,
+            breakdown=MagicMock(
+                model_dump=MagicMock(
+                    return_value={
+                        "goal_clarity": {
+                            "name": "goal_clarity",
+                            "clarity_score": 0.9,
+                            "weight": 0.4,
+                            "justification": "Clear goal",
+                        },
+                        "constraint_clarity": {
+                            "name": "constraint_clarity",
+                            "clarity_score": 0.9,
+                            "weight": 0.3,
+                            "justification": "Clear constraints",
+                        },
+                        "success_criteria_clarity": {
+                            "name": "success_criteria_clarity",
+                            "clarity_score": 0.85,
+                            "weight": 0.3,
+                            "justification": "Measurable success",
+                        },
+                    }
+                )
+            ),
+        )
+        mock_scorer = MagicMock()
+        mock_scorer.score = AsyncMock(return_value=Result.ok(mock_score))
+        handler = GenerateSeedHandler(
+            llm_adapter=mock_adapter,
+            interview_engine=mock_interview_engine,
+            seed_generator=mock_seed_generator,
+        )
+
+        with (
+            patch(
+                "ouroboros.mcp.tools.definitions.AmbiguityScorer",
+                return_value=mock_scorer,
+            ) as mock_scorer_cls,
+        ):
+            await handler.handle({"session_id": "sess-123"})
+
+        mock_scorer_cls.assert_called_once()
+        mock_scorer.score.assert_awaited_once_with(state)
+        mock_interview_engine.save_state.assert_awaited_once_with(state)
+        assert state.ambiguity_score == 0.12
+        assert state.ambiguity_breakdown is not None
+        generate_call = mock_seed_generator.generate.await_args
+        assert generate_call.args[0] == state
+        assert generate_call.args[1].overall_score == 0.12
+
+    async def test_generate_seed_handler_reuses_stored_ambiguity_snapshot(self) -> None:
+        """GenerateSeedHandler should not rescore when the interview state already has a snapshot."""
+        state = InterviewState(
+            interview_id="sess-123",
+            initial_context="Build a tool",
+            ambiguity_score=0.11,
+            ambiguity_breakdown={
+                "goal_clarity": {
+                    "name": "goal_clarity",
+                    "clarity_score": 0.92,
+                    "weight": 0.4,
+                    "justification": "Clear goal",
+                },
+                "constraint_clarity": {
+                    "name": "constraint_clarity",
+                    "clarity_score": 0.88,
+                    "weight": 0.3,
+                    "justification": "Clear constraints",
+                },
+                "success_criteria_clarity": {
+                    "name": "success_criteria_clarity",
+                    "clarity_score": 0.87,
+                    "weight": 0.3,
+                    "justification": "Clear success criteria",
+                },
+            },
+        )
+        mock_adapter = MagicMock()
+        mock_interview_engine = MagicMock()
+        mock_interview_engine.load_state = AsyncMock(return_value=Result.ok(state))
+        mock_interview_engine.save_state = AsyncMock(
+            return_value=MagicMock(is_ok=True, is_err=False),
+        )
+        mock_seed_generator = MagicMock()
+        mock_seed_generator.generate = AsyncMock(return_value=Result.err(RuntimeError("boom")))
+        handler = GenerateSeedHandler(
+            llm_adapter=mock_adapter,
+            interview_engine=mock_interview_engine,
+            seed_generator=mock_seed_generator,
+        )
+
+        with (
+            patch(
+                "ouroboros.mcp.tools.definitions.AmbiguityScorer",
+            ) as mock_scorer_cls,
+        ):
+            await handler.handle({"session_id": "sess-123"})
+
+        mock_scorer_cls.assert_not_called()
+        assert mock_interview_engine.save_state.await_count == 0
+        generate_call = mock_seed_generator.generate.await_args
+        assert generate_call.args[1].overall_score == 0.11
 
 
 class TestCancelExecutionHandler:


### PR DESCRIPTION
## Summary
- persist ambiguity snapshots on interview state so MCP seed generation can reuse them
- calculate and save ambiguity on demand when generate_seed runs without an explicit score
- invalidate stored ambiguity whenever new interview answers arrive to avoid stale seed generation

## Testing
- uv run pytest tests/unit/bigbang/test_interview.py tests/unit/mcp/tools/test_definitions.py