### PR TITLE
fix(interview): add marketplace refresh step

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -45,13 +45,14 @@ Compare the result with the current version in `.claude-plugin/plugin.json`.
   }
   ```
   - If "Update now":
-    1. Run `claude plugin update ouroboros` via Bash (update plugin/skills). If this fails, inform the user and stop — do NOT proceed to step 2.
-    2. Detect the user's Python package manager and upgrade the MCP server:
+    1. Run `claude plugin marketplace update ouroboros` via Bash (refresh marketplace index). If this fails, tell the user "⚠️ Marketplace refresh failed, continuing…" and proceed.
+    2. Run `claude plugin update ouroboros@ouroboros` via Bash (update plugin/skills). If this fails, inform the user and stop — do NOT proceed to step 3.
+    3. Detect the user's Python package manager and upgrade the MCP server:
        - Check which tool installed `ouroboros-ai` by running these in order:
          - `uv tool list 2>/dev/null | grep "^ouroboros-ai "` → if found, use `uv tool upgrade ouroboros-ai`
          - `pipx list 2>/dev/null | grep "^  ouroboros-ai "` → if found, use `pipx upgrade ouroboros-ai`
          - Otherwise, print: "Also upgrade the MCP server: `pip install --upgrade ouroboros-ai`" (do NOT run pip automatically)
-    3. Tell the user: "Updated! Restart Claude Code to apply, then run `ooo interview` again."
+    4. Tell the user: "Updated! Restart Claude Code to apply, then run `ooo interview` again."
   - If "Skip": proceed immediately.
 - If versions match, the check fails (network error, timeout, rate limit 403/429), or parsing fails/returns empty: **silently skip** and proceed.
 


### PR DESCRIPTION
### Summary
- Add marketplace index refresh step (`claude plugin marketplace update ouroboros`) before plugin update in interview skill's update flow
- Fix plugin update command to `claude plugin update ouroboros@ouroboros`

### Testing
- `uv run pytest tests/unit/bigbang/test_interview.py tests/unit/mcp/tools/test_definitions.py`
  ```
  ❯ uv run pytest tests/unit/bigbang/test_interview.py 
        Built ouroboros-ai @ file:///home/jleem/projects/ouroboros
  Installed 103 packages in 64ms
  ============================================== test session starts ==============================================
  platform linux -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
  rootdir: /home/jleem/projects/ouroboros
  configfile: pyproject.toml
  plugins: asyncio-1.3.0, anyio-4.12.1, cov-7.0.0
  asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
  collected 43 items                                                                                              
  
  tests/unit/bigbang/test_interview.py ...........................................                          [100%]
  
  ============================================== 43 passed in 3.70s ===============================================
  ```
- Manual skill run
  
  <img width="926" height="514" alt="image" src="https://github.com/user-attachments/assets/a3ca8094-98a2-4895-8619-631b3ec4d954" />
