### PR TITLE
feat(update): sync CLAUDE.md version marker after upgrade

### DIFF
--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -70,30 +70,21 @@ When the user invokes this skill:
    claude plugin update ouroboros@ouroboros
    ```
 
-   c. **Verify**:
+   c. **Verify and update CLAUDE.md version marker**:
    ```bash
-   python3 -c "import ouroboros; print(ouroboros.__version__)"
+   NEW_VERSION=$(python3 -c "import ouroboros; print(ouroboros.__version__)" 2>/dev/null)
+   echo "Installed: v$NEW_VERSION"
+
+   if [ -n "$NEW_VERSION" ] && grep -q "ooo:VERSION" CLAUDE.md 2>/dev/null; then
+     OLD_VERSION=$(grep "ooo:VERSION" CLAUDE.md | sed 's/.*ooo:VERSION:\(.*\) -->/\1/' | tr -d ' ')
+     if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+       sed -i.bak "s/<!-- ooo:VERSION:.*-->/<!-- ooo:VERSION:$NEW_VERSION -->/" CLAUDE.md && rm -f CLAUDE.md.bak
+       echo "CLAUDE.md version marker updated: v$OLD_VERSION → v$NEW_VERSION"
+     else
+       echo "CLAUDE.md version marker already up to date (v$NEW_VERSION)"
+     fi
+   fi
    ```
-
-   d. **Update CLAUDE.md version marker** (if present):
-
-   Check if the current working directory has a `CLAUDE.md` with an Ouroboros block:
-   ```bash
-   grep -q "ooo:VERSION" CLAUDE.md 2>/dev/null && echo "HAS_BLOCK" || echo "NO_BLOCK"
-   ```
-
-   If `HAS_BLOCK`:
-   1. Extract the old version from the marker:
-      ```bash
-      grep "ooo:VERSION" CLAUDE.md | sed 's/.*ooo:VERSION:\(.*\) -->/\1/'
-      ```
-   2. If the old version differs from the newly installed version, replace the marker:
-      ```bash
-      sed -i.bak "s/<!-- ooo:VERSION:.*-->/<!-- ooo:VERSION:$NEW_VERSION -->/" CLAUDE.md
-      ```
-   3. Report: `CLAUDE.md version marker updated: v{old} → v{new}`
-
-   If `NO_BLOCK`, skip silently.
 
    > **Note**: This only updates the version marker. If the block content itself
    > changed between versions, the user should run `ooo setup` to regenerate it.


### PR DESCRIPTION
## Summary

- After `ooo update` upgrades the PyPI package and plugin, it now checks if the current project's `CLAUDE.md` has an Ouroboros block (`<!-- ooo:VERSION:X.Y.Z -->`) with a stale version marker
- If found, it updates the marker to match the newly installed version
- Adds guidance in post-update output to run `ooo setup` if block content changed between versions

## Problem

When a user runs `ooo update`, the PyPI package and Claude Code plugin are upgraded, but the `<!-- ooo:VERSION:X.Y.Z -->` marker in project-level `CLAUDE.md` files remains on the old version. This creates version drift that must be fixed manually.

## Changes

**`skills/update/SKILL.md`** — Added step 4d:
1. Checks if `CLAUDE.md` in the current directory has an `<!-- ooo:VERSION:... -->` marker
2. If the marker version differs from the newly installed version, updates it via `sed`
3. Skips silently if no Ouroboros block is present
4. Notes that full block content regeneration requires `ooo setup`

Also updated step 5 (post-update guidance) to mention `ooo setup` for content changes.

## Test plan

- [ ] Run `ooo update` in a project with an existing CLAUDE.md Ouroboros block — verify version marker is updated
- [ ] Run `ooo update` in a project without CLAUDE.md — verify no errors
- [ ] Run `ooo update` in a project with CLAUDE.md but no Ouroboros block — verify skipped silently