### PR TITLE
feat(eval): add Java Maven language preset

### DIFF
--- a/docs/guides/language-support.md
+++ b/docs/guides/language-support.md
@@ -11,6 +11,7 @@ Ouroboros Stage 1 (Mechanical Verification) auto-detects your project's language
 | Zig | `build.zig` | — | `zig build` | `zig build test` | — | — |
 | Rust | `Cargo.toml` | `cargo clippy` | `cargo build` | `cargo test` | — | — |
 | Go | `go.mod` | `go vet ./...` | `go build ./...` | `go test ./...` | — | `go test -cover ./...` |
+| Java (Maven) | `pom.xml` | — | `mvn clean compile` | `mvn test` | — | — |
 | Node (npm) | `package-lock.json` | `npm run lint` | `npm run build` | `npm test` | — | — |
 | Node (pnpm) | `pnpm-lock.yaml` | `pnpm lint` | `pnpm build` | `pnpm test` | — | — |
 | Node (bun) | `bun.lockb` | `bun lint` | `bun run build` | `bun test` | — | — |
@@ -70,6 +71,15 @@ test = "zig build test -Doptimize=Debug"
 build = "cmake --build build"
 test = "ctest --test-dir build"
 lint = "clang-tidy src/*.cpp"
+```
+
+**Java Maven project with additional checks:**
+```toml
+build = "mvn clean compile"
+test = "mvn test"
+lint = "mvn checkstyle:check"
+static = "mvn spotbugs:check"
+coverage = "mvn verify -Pcoverage"
 ```
 
 **Haskell project:**

--- a/src/ouroboros/evaluation/languages.py
+++ b/src/ouroboros/evaluation/languages.py
@@ -96,6 +96,11 @@ LANGUAGE_PRESETS: dict[str, LanguagePreset] = {
         test_command=("go", "test", "./..."),
         coverage_command=("go", "test", "-cover", "./..."),
     ),
+    "java-maven": LanguagePreset(
+        name="java-maven",
+        build_command=("mvn", "clean", "compile"),
+        test_command=("mvn", "test"),
+    ),
     "node-npm": LanguagePreset(
         name="node-npm",
         lint_command=("npm", "run", "lint"),
@@ -133,6 +138,8 @@ _DETECTION_RULES: list[tuple[str, str]] = [
     ("Cargo.toml", "rust"),
     # Go
     ("go.mod", "go"),
+    # Java (Maven)
+    ("pom.xml", "java-maven"),
     # Node.js package managers (check lockfiles before generic package.json)
     ("bun.lockb", "node-bun"),
     ("bun.lock", "node-bun"),

--- a/tests/unit/evaluation/test_languages.py
+++ b/tests/unit/evaluation/test_languages.py
@@ -49,6 +49,12 @@ class TestDetectLanguage:
         assert preset is not None
         assert preset.name == "python"
 
+    def test_detect_java_maven(self, tmp_path: Path) -> None:
+        (tmp_path / "pom.xml").touch()
+        preset = detect_language(tmp_path)
+        assert preset is not None
+        assert preset.name == "java-maven"
+
     def test_detect_node_npm(self, tmp_path: Path) -> None:
         (tmp_path / "package.json").touch()
         (tmp_path / "package-lock.json").touch()
@@ -88,6 +94,33 @@ class TestDetectLanguage:
         """Empty directory returns None."""
         preset = detect_language(tmp_path)
         assert preset is None
+
+    def test_pom_xml_detected_before_package_json(self, tmp_path: Path) -> None:
+        """pom.xml takes priority over package.json (Maven before Node)."""
+        (tmp_path / "pom.xml").touch()
+        (tmp_path / "package.json").touch()
+        preset = detect_language(tmp_path)
+        assert preset is not None
+        assert preset.name == "java-maven"
+
+    def test_pom_xml_detected_before_node_lockfiles(self, tmp_path: Path) -> None:
+        """pom.xml takes priority over Node lockfiles (Maven before Node)."""
+        for lockfile in ("package-lock.json", "pnpm-lock.yaml", "yarn.lock", "bun.lockb"):
+            d = tmp_path / lockfile.replace(".", "_")
+            d.mkdir()
+            (d / "pom.xml").touch()
+            (d / lockfile).touch()
+            preset = detect_language(d)
+            assert preset is not None, f"Failed for {lockfile}"
+            assert preset.name == "java-maven", f"Expected java-maven over {lockfile}"
+
+    def test_go_mod_detected_before_pom_xml(self, tmp_path: Path) -> None:
+        """go.mod takes priority over pom.xml (Go before Maven)."""
+        (tmp_path / "go.mod").touch()
+        (tmp_path / "pom.xml").touch()
+        preset = detect_language(tmp_path)
+        assert preset is not None
+        assert preset.name == "go"
 
     def test_uv_takes_priority_over_pyproject(self, tmp_path: Path) -> None:
         """uv.lock is checked before pyproject.toml."""
@@ -209,6 +242,16 @@ class TestBuildMechanicalConfig:
         assert config.test_command == ("make", "test")
         assert config.lint_command is None
 
+    def test_auto_detect_java_maven(self, tmp_path: Path) -> None:
+        (tmp_path / "pom.xml").touch()
+        config = build_mechanical_config(tmp_path)
+        assert config.build_command == ("mvn", "clean", "compile")
+        assert config.test_command == ("mvn", "test")
+        assert config.lint_command is None
+        assert config.static_command is None
+        assert config.coverage_command is None
+        assert config.working_dir == tmp_path
+
     def test_no_toml_file_no_error(self, tmp_path: Path) -> None:
         """Missing .ouroboros/mechanical.toml is not an error."""
         (tmp_path / "build.zig").touch()
@@ -246,3 +289,34 @@ class TestLanguagePresetCommands:
         assert preset.build_command is not None
         assert preset.test_command is not None
         assert preset.coverage_command is not None
+
+    def test_java_maven_preset_has_build_and_test_only(self) -> None:
+        from ouroboros.evaluation.languages import LANGUAGE_PRESETS
+
+        preset = LANGUAGE_PRESETS["java-maven"]
+        assert preset.name == "java-maven"
+        assert preset.build_command == ("mvn", "clean", "compile")
+        assert preset.test_command == ("mvn", "test")
+        assert preset.lint_command is None
+        assert preset.static_command is None
+        assert preset.coverage_command is None
+
+    def test_java_maven_preset_no_quiet_flags(self) -> None:
+        """Maven commands must not include quiet flags (-q or --quiet)."""
+        from ouroboros.evaluation.languages import LANGUAGE_PRESETS
+
+        preset = LANGUAGE_PRESETS["java-maven"]
+        for cmd in (preset.build_command, preset.test_command):
+            assert cmd is not None
+            assert "-q" not in cmd
+            assert "--quiet" not in cmd
+
+    def test_java_maven_preset_is_frozen(self) -> None:
+        """java-maven preset is immutable (frozen dataclass)."""
+        from ouroboros.evaluation.languages import LANGUAGE_PRESETS
+
+        preset = LANGUAGE_PRESETS["java-maven"]
+        import pytest
+
+        with pytest.raises(AttributeError):
+            preset.name = "modified"  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- Add `java-maven` language preset with `mvn clean compile` (build) and `mvn test` (test)
- Lint/static/coverage set to None — users opt-in via `.ouroboros/mechanical.toml`
- Detection via `pom.xml` marker file, placed after Go and before Node in priority order
- Docs updated with Maven example and toml override example

## Design Decision
Followed Zig's minimal pattern (build + test only) because Maven's checkstyle/spotbugs require explicit pom.xml plugin config unlike Rust's `cargo clippy` or Go's `go vet` which work out of the box. Validated by contrarian + architect agent review.

## Test Plan
- [x] `test_detect_java_maven` — pom.xml detection
- [x] `test_pom_xml_detected_before_package_json` — Maven > Node priority
- [x] `test_pom_xml_detected_before_node_lockfiles` — Maven > Node lockfiles
- [x] `test_go_mod_detected_before_pom_xml` — Go > Maven priority
- [x] `test_auto_detect_java_maven` — config building with all commands verified
- [x] `test_java_maven_preset_has_build_and_test_only` — preset values
- [x] `test_java_maven_preset_no_quiet_flags` — no -q flags
- [x] `test_java_maven_preset_is_frozen` — immutability
- [x] All 40 language tests pass

Closes #135