### PR TITLE
fix(tui): SLT binary CI build + TUI bug fixes (v0.23.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Self-improving AI workflow system. Crystallize requirements before execution with Socratic interview, ambiguity scoring, and 3-stage evaluation.",
   "author": {
     "name": "Q00",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,60 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-tui:
+    name: Build TUI (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+          - runner: macos-13
+            target: x86_64-apple-darwin
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --manifest-path crates/ouroboros-tui/Cargo.toml --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: |
+          cp crates/ouroboros-tui/target/${{ matrix.target }}/release/ouroboros-tui ouroboros-tui-${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ouroboros-tui-${{ matrix.target }}
+          path: ouroboros-tui-${{ matrix.target }}
+
+  attach-tui-binaries:
+    name: Attach TUI Binaries to Release
+    runs-on: ubuntu-latest
+    needs: [release, build-tui]
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ouroboros-tui-*
+          merge-multiple: true
+
+      - name: Attach binaries to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ouroboros-tui-*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ When the user types any of these commands, read the corresponding SKILL.md file 
 Custom agents are in `agents/`. When a skill references an agent (e.g., `ouroboros:socratic-interviewer`), read its definition from `agents/{name}.md` and adopt that role.
 
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.23.0 -->
+<!-- ooo:VERSION:0.23.1 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.

--- a/crates/ouroboros-tui/src/db.rs
+++ b/crates/ouroboros-tui/src/db.rs
@@ -61,28 +61,24 @@ impl OuroborosDb {
     }
 
     pub fn read_new_events(&mut self) -> Vec<EventRow> {
-        let query = match &self.last_seen_id {
-            Some(last_id) => {
-                let ts_query = format!(
-                    "SELECT id, aggregate_type, aggregate_id, event_type, payload, timestamp \
-                     FROM events WHERE timestamp > (SELECT timestamp FROM events WHERE id = '{}') \
-                     ORDER BY timestamp ASC",
-                    last_id.replace('\'', "''")
-                );
-                ts_query
-            }
+        let last_id = match &self.last_seen_id {
+            Some(id) => id.clone(),
             None => {
                 return self.read_all_events();
             }
         };
 
-        let mut stmt = match self.conn.prepare(&query) {
+        let mut stmt = match self.conn.prepare(
+            "SELECT id, aggregate_type, aggregate_id, event_type, payload, timestamp \
+             FROM events WHERE timestamp > (SELECT timestamp FROM events WHERE id = ?1) \
+             ORDER BY timestamp ASC",
+        ) {
             Ok(s) => s,
             Err(_) => return Vec::new(),
         };
 
         let rows: Vec<EventRow> = stmt
-            .query_map([], |row| {
+            .query_map([&last_id], |row| {
                 let payload_str: String = row.get(4)?;
                 let payload: Value = serde_json::from_str(&payload_str).unwrap_or(Value::Null);
                 Ok(EventRow {
@@ -108,6 +104,38 @@ impl OuroborosDb {
         self.conn
             .query_row("SELECT count(*) FROM events", [], |row| row.get(0))
             .unwrap_or(0)
+    }
+
+    pub fn read_events_for_session(&mut self, aggregate_id: &str) -> Vec<EventRow> {
+        let mut stmt = match self.conn.prepare(
+            "SELECT id, aggregate_type, aggregate_id, event_type, payload, timestamp \
+             FROM events WHERE aggregate_id = ?1 ORDER BY timestamp ASC",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+
+        let rows: Vec<EventRow> = stmt
+            .query_map([aggregate_id], |row| {
+                let payload_str: String = row.get(4)?;
+                let payload: Value = serde_json::from_str(&payload_str).unwrap_or(Value::Null);
+                Ok(EventRow {
+                    id: row.get(0)?,
+                    aggregate_type: row.get(1)?,
+                    aggregate_id: row.get(2)?,
+                    event_type: row.get(3)?,
+                    payload,
+                    timestamp: row.get(5)?,
+                })
+            })
+            .ok()
+            .map(|iter| iter.filter_map(|r| r.ok()).collect())
+            .unwrap_or_default();
+
+        if let Some(last) = rows.last() {
+            self.last_seen_id = Some(last.id.clone());
+        }
+        rows
     }
 
     pub fn distinct_sessions(&self) -> Vec<(String, String, String, usize)> {
@@ -154,6 +182,9 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
                 .and_then(|v| v.as_str())
                 .map(String::from),
         });
+        if state.execution_events.len() > 500 {
+            state.execution_events.drain(..state.execution_events.len() - 500);
+        }
 
         let log_level = if ev.event_type.contains("fail") || ev.event_type.contains("error") {
             LogLevel::Error
@@ -353,8 +384,126 @@ pub fn populate_state_from_events(state: &mut AppState, events: &[EventRow]) {
                     state.iteration = round as u32;
                 }
             }
+            "lineage.created" => {
+                let goal = ev
+                    .payload
+                    .get("goal")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                state.lineages.push(Lineage {
+                    id: ev.aggregate_id.clone(),
+                    seed_goal: goal,
+                    generations: Vec::new(),
+                    current_gen: 0,
+                    converged: false,
+                });
+            }
+            "lineage.generation.started" => {
+                if let Some(lin) = state.lineages.iter_mut().find(|l| l.id == ev.aggregate_id) {
+                    let gen_num = ev
+                        .payload
+                        .get("generation_number")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(1) as u32;
+                    lin.current_gen = gen_num;
+                    lin.generations.push(LineageGeneration {
+                        number: gen_num,
+                        status: ACStatus::Executing,
+                        score: 0.0,
+                        ac_pass_count: 0,
+                        ac_total: 0,
+                        summary: ev
+                            .payload
+                            .get("phase")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("executing")
+                            .to_string(),
+                    });
+                }
+            }
+            "lineage.generation.completed" => {
+                if let Some(lin) = state.lineages.iter_mut().find(|l| l.id == ev.aggregate_id) {
+                    let gen_num = ev
+                        .payload
+                        .get("generation_number")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(1) as u32;
+                    if let Some(gen) = lin.generations.iter_mut().find(|g| g.number == gen_num) {
+                        gen.status = ACStatus::Completed;
+                        if let Some(eval) = ev.payload.get("evaluation_summary") {
+                            gen.score = eval
+                                .get("score")
+                                .and_then(|v| v.as_f64())
+                                .unwrap_or(0.0) as f32;
+                            gen.summary = eval
+                                .get("failure_reason")
+                                .and_then(|v| v.as_str())
+                                .or_else(|| {
+                                    if eval
+                                        .get("final_approved")
+                                        .and_then(|v| v.as_bool())
+                                        .unwrap_or(false)
+                                    {
+                                        Some("Approved")
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .unwrap_or("Completed")
+                                .to_string();
+                        }
+                    }
+                }
+            }
+            "lineage.generation.failed" => {
+                if let Some(lin) = state.lineages.iter_mut().find(|l| l.id == ev.aggregate_id) {
+                    let gen_num = ev
+                        .payload
+                        .get("generation_number")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(1) as u32;
+                    if let Some(gen) = lin.generations.iter_mut().find(|g| g.number == gen_num) {
+                        gen.status = ACStatus::Failed;
+                        gen.summary = ev
+                            .payload
+                            .get("error")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Failed")
+                            .to_string();
+                    }
+                }
+            }
+            "lineage.converged" => {
+                if let Some(lin) = state.lineages.iter_mut().find(|l| l.id == ev.aggregate_id) {
+                    lin.converged = true;
+                }
+            }
+            "lineage.stagnated" | "lineage.rewound" | "lineage.ontology.evolved" => {
+                // tracked via logs, no state update needed
+            }
             _ => {}
         }
+    }
+
+    // Rebuild lineage list state
+    if !state.lineages.is_empty() {
+        state.lineage_list = slt::ListState::new(
+            state
+                .lineages
+                .iter()
+                .map(|l| {
+                    format!(
+                        "{} — {} (gen {}{})",
+                        l.id,
+                        crate::state::truncate(&l.seed_goal, 40),
+                        l.current_gen,
+                        if l.converged { " ✓" } else { "" }
+                    )
+                })
+                .collect::<Vec<_>>(),
+        );
     }
 
     state.rebuild_tree_state();

--- a/crates/ouroboros-tui/src/main.rs
+++ b/crates/ouroboros-tui/src/main.rs
@@ -167,7 +167,43 @@ fn main() -> std::io::Result<()> {
                     Screen::Logs => views::logs::render(ui, &mut state),
                     Screen::Debug => views::debug::render(ui, &mut state),
                     Screen::Lineage => views::lineage::render(ui, &mut state),
-                    Screen::SessionSelector => views::session_selector::render(ui, &mut state),
+                    Screen::SessionSelector => {
+                        if let Some(idx) = views::session_selector::render(ui, &mut state) {
+                            if let Some(session) = state.sessions.get(idx) {
+                                let agg_id = session.aggregate_id.clone();
+                                if let Some(ref mut conn) = ouro_db {
+                                    // Reset state for new session
+                                    let mut new_state = AppState::new();
+                                    // Preserve sessions list
+                                    new_state.sessions = state.sessions.clone();
+                                    new_state.session_list = slt::ListState::new(
+                                        new_state
+                                            .sessions
+                                            .iter()
+                                            .map(|s| {
+                                                format!(
+                                                    "{} — {} ({} events)",
+                                                    s.aggregate_type,
+                                                    s.aggregate_id,
+                                                    s.event_count
+                                                )
+                                            })
+                                            .collect::<Vec<_>>(),
+                                    );
+                                    let events = conn.read_events_for_session(&agg_id);
+                                    db::populate_state_from_events(&mut new_state, &events);
+                                    new_state.add_log(
+                                        LogLevel::Info,
+                                        "tui",
+                                        &format!("Loaded session: {agg_id}"),
+                                    );
+                                    state = new_state;
+                                }
+                                state.screen = Screen::Dashboard;
+                                state.tabs.selected = 0;
+                            }
+                        }
+                    }
                 });
 
                 render_footer(ui);
@@ -231,7 +267,7 @@ fn handle_global_keys(ui: &mut Context, state: &mut AppState) {
     if ui.key('e') && !on_logs {
         state.tabs.selected = 4;
     }
-    if ui.key('s') && !state.command_palette.open {
+    if ui.key('s') && !state.command_palette.open && !on_logs {
         state.screen = Screen::SessionSelector;
     }
 }
@@ -252,8 +288,8 @@ fn render_header(ui: &mut Context, state: &AppState) {
             ui.spacer();
 
             if !state.session_id.is_empty() {
-                ui.text(&state.session_id[..14.min(state.session_id.len())])
-                    .fg(secondary);
+                let sid: String = state.session_id.chars().take(14).collect();
+                ui.text(&sid).fg(secondary);
                 ui.text("  ").fg(dim);
             }
 
@@ -309,14 +345,16 @@ fn render_tab_bar(ui: &mut Context, state: &mut AppState) {
         ui.spacer();
     });
 
-    state.screen = match state.tabs.selected {
-        0 => Screen::Dashboard,
-        1 => Screen::Execution,
-        2 => Screen::Logs,
-        3 => Screen::Debug,
-        4 => Screen::Lineage,
-        _ => Screen::Dashboard,
-    };
+    if state.screen != Screen::SessionSelector {
+        state.screen = match state.tabs.selected {
+            0 => Screen::Dashboard,
+            1 => Screen::Execution,
+            2 => Screen::Logs,
+            3 => Screen::Debug,
+            4 => Screen::Lineage,
+            _ => Screen::Dashboard,
+        };
+    }
 }
 
 fn render_footer(ui: &mut Context) {

--- a/crates/ouroboros-tui/src/state.rs
+++ b/crates/ouroboros-tui/src/state.rs
@@ -288,6 +288,7 @@ pub struct AppState {
     // Execution
     pub execution_events: Vec<ExecutionEvent>,
     pub execution_scroll: ScrollState,
+    pub event_timeline_scroll: ScrollState,
     pub phase_outputs: HashMap<String, Vec<String>>,
     pub log_table: TableState,
 
@@ -368,6 +369,7 @@ impl AppState {
 
             execution_events: Vec::new(),
             execution_scroll: ScrollState::new(),
+            event_timeline_scroll: ScrollState::new(),
             phase_outputs: HashMap::new(),
             log_table: TableState::new(
                 vec!["Time", "Level", "Source", "Message"],

--- a/crates/ouroboros-tui/src/views/execution.rs
+++ b/crates/ouroboros-tui/src/views/execution.rs
@@ -114,7 +114,7 @@ pub fn render(ui: &mut Context, state: &mut AppState) {
                         ui.text("No events yet").fg(dim);
                     });
                 } else {
-                    ui.scrollable(&mut state.detail_scroll).grow(1).col(|ui| {
+                    ui.scrollable(&mut state.event_timeline_scroll).grow(1).col(|ui| {
                         let events: Vec<ExecutionEvent> = if state.execution_events.is_empty() {
                             state
                                 .raw_events

--- a/crates/ouroboros-tui/src/views/session_selector.rs
+++ b/crates/ouroboros-tui/src/views/session_selector.rs
@@ -1,8 +1,9 @@
-use slt::{Border, Context};
+use slt::{Border, Context, KeyCode};
 
 use crate::state::*;
 
-pub fn render(ui: &mut Context, state: &mut AppState) {
+/// Returns Some(selected_index) when Enter is pressed, None otherwise.
+pub fn render(ui: &mut Context, state: &mut AppState) -> Option<usize> {
     let dim = ui.theme().text_dim;
     let surface = ui.theme().surface;
     let surface_hover = ui.theme().surface_hover;
@@ -10,13 +11,29 @@ pub fn render(ui: &mut Context, state: &mut AppState) {
     let secondary = ui.theme().secondary;
     let accent = ui.theme().accent;
 
+    // Esc returns to previous screen
+    if ui.key_code(KeyCode::Esc) {
+        state.screen = Screen::Dashboard;
+        state.tabs.selected = 0;
+    }
+
+    let mut selected = None;
+
+    // Enter selects session
+    if ui.key_code(KeyCode::Enter) && !state.sessions.is_empty() {
+        selected = Some(state.session_list.selected);
+    }
+
     ui.container().grow(1).gap(1).col(|ui| {
         ui.container().bg(surface_hover).px(3).py(1).col(|ui| {
             ui.text("Session Selector").fg(text).bold();
-            ui.text(
-                "Select a session to monitor. Sessions are loaded from the EventStore database.",
-            )
-            .fg(dim);
+            ui.row(|ui| {
+                ui.text("Select a session to monitor. ").fg(dim);
+                ui.text("Enter").fg(accent);
+                ui.text(" select  ").fg(dim);
+                ui.text("Esc").fg(accent);
+                ui.text(" back").fg(dim);
+            });
         });
 
         ui.container()
@@ -53,4 +70,6 @@ pub fn render(ui: &mut Context, state: &mut AppState) {
             }
         }
     });
+
+    selected
 }

--- a/src/ouroboros/__init__.py
+++ b/src/ouroboros/__init__.py
@@ -13,7 +13,7 @@ Example:
     from ouroboros.bigbang import InterviewEngine
 """
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"
 
 __all__ = ["__version__", "main"]
 

--- a/src/ouroboros/cli/commands/tui.py
+++ b/src/ouroboros/cli/commands/tui.py
@@ -90,21 +90,21 @@ def main(
 
 def _run_slt_backend(db_path: Path) -> None:
     import shutil
-    import subprocess
-    import sys
 
     bin_path = shutil.which("ouroboros-tui")
     if bin_path is None:
         print_error(
             "ouroboros-tui not found.\n\n"
             "Install options:\n"
-            "  cargo install --path crates/ouroboros-tui   (from source)\n"
-            "  Download binary from GitHub Releases        (pre-built)",
+            "  Download pre-built binary:\n"
+            "    https://github.com/Q00/ouroboros/releases/latest\n\n"
+            "  Build from source (requires Rust):\n"
+            "    cargo install --path crates/ouroboros-tui",
         )
         raise typer.Exit(1)
 
     args = [bin_path, "monitor", "--db-path", str(db_path)]
-    sys.exit(subprocess.call(args))
+    os.execv(bin_path, args)
 
 
 __all__ = ["app"]

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -37,9 +37,17 @@ app.add_typer(tui.app, name="tui")
 
 # Top-level convenience aliases
 @app.command(hidden=True)
-def monitor() -> None:
+def monitor(
+    backend: Annotated[
+        str,
+        typer.Option(
+            "--backend",
+            help="TUI backend to use: 'python' (default) or 'slt' (native binary).",
+        ),
+    ] = "python",
+) -> None:
     """Launch the TUI monitor (shorthand for 'ouroboros tui monitor')."""
-    tui.monitor_command()
+    tui.monitor_command(backend=backend)
 
 
 def version_callback(value: bool) -> None:


### PR DESCRIPTION
## Summary

v0.23.0 shipped `--backend slt` option but had no pre-built binaries and the Rust TUI had several functional bugs.

- Add Rust binary CI build to `release.yml` (macOS ARM/Intel, Linux x64 matrix)
- Fix SLT not-found error message with actual download URL
- Forward `--backend` through `ouroboros monitor` shorthand
- Use `os.execv` for proper TUI signal handling
- Fix session selector unreachable (`render_tab_bar` overwrote screen every frame)
- Implement `lineage.*` event parsing (was completely missing)
- Cap `execution_events` at 500 to prevent OOM on 60K+ event DBs
- Fix shared scroll state between Dashboard and Execution views
- Fix SQL injection in `read_new_events` (parameterized query)
- Fix `s` key missing `!on_logs` guard
- Fix `session_id` byte slicing panic risk

## Test plan

- [x] `uv run ruff format && ruff check` — pass
- [x] `uv run pytest` — 2336 passed
- [x] `ouroboros monitor --help` — shows `--backend` option
- [x] `cargo build --release` — compiles successfully
- [x] `ouroboros-tui` — loads 60K events from real DB without crash
- [ ] Tag v0.23.1, verify CI builds all 3 binaries and attaches to release

🤖 Generated with [Claude Code](https://claude.com/claude-code)