### PR TITLE
fix(mcp): resolve job_wait polling cursor stall during AC decomposition

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -241,7 +241,11 @@ class JobManager:
                 sub_name = sub_data.get("content") or sub_data.get("sub_task_id") or ""
                 sub_status = sub_data.get("status") or ""
                 if sub_name:
-                    return f"Working | {sub_name} ({sub_status})" if sub_status else f"Working | {sub_name}"
+                    return (
+                        f"Working | {sub_name} ({sub_status})"
+                        if sub_status
+                        else f"Working | {sub_name}"
+                    )
 
         if snapshot.links.session_id:
             repo = SessionRepository(self._event_store)


### PR DESCRIPTION
## Summary

- **Root cause fixed** — `_derive_status_message()` only checked `workflow.progress.updated` events, ignoring `execution.subtask.updated` events on the same aggregate. During AC decomposition, the message string stayed identical, so `_monitor_job()` never emitted `mcp.job.updated` and the polling cursor stalled.
- **Targeted queries** — replaced single `query_events(limit=20)` with two `event_type`-filtered queries (`limit=1` each) for `workflow.progress.updated` and `execution.subtask.updated`. Self-documenting and immune to window-size issues.
- **Subtask enrichment** — status messages now include subtask `content` and `status` fields (e.g., `"Executing | user-auth validation (delivering) | 1/16 ACs"`), producing natural string variation during decomposition phases.
- **Heartbeat safety net** — added 60-second heartbeat in `_monitor_job()` to guarantee cursor advancement during genuinely quiet phases (long LLM inference with no subtask events).

1 file changed (`job_manager.py`), 2 methods modified (`_derive_status_message`, `_monitor_job`). No execution logic touched.

## Design Decision

Chose to enrich the existing monitor bridge (`_derive_status_message`) rather than modifying `wait_for_change()` to poll execution-level events directly. This preserves the clean aggregate boundary separation (job vs execution) while fixing the observer gap. The heartbeat is a defensive safety net, not the primary fix — subtask message enrichment alone resolves the stall for the common case.

Alternatives considered and rejected:
- **Modify `wait_for_change()` to poll execution aggregate** — breaks aggregate separation
- **Emit more `workflow.progress.updated` from parallel executor** — invasive change to execution domain
- **Heartbeat-only (no enrichment)** — masks the real problem with semantically empty events

Accepted trade-off: `_derive_status_message` now has read-coupling to `execution.subtask.updated` event schema (`content`, `sub_task_id`, `status` fields). This is bounded and documented. If coupling grows beyond 3 event types, a generic progress event contract should be introduced.

## Test Plan

- [x] `pytest -k job` — 9 passed
- [x] `pytest -k "monitor or event_store"` — 39 passed
- [x] `pytest -k mcp` — 350 passed
- [x] Verified field names match `parallel_executor.py:1037-1042` (`content`, `sub_task_id`, `status`)
- [x] Verified `event_type` parameter exists in `EventStore.query_events()` signature
- [x] Edge cases verified: empty subtask list, both events None, empty status string — all handled correctly

Closes #148