### PR TITLE
fix(tui): narrow bare except clauses to specific exceptions

### DIFF
--- a/src/ouroboros/tui/components/agents_panel.py
+++ b/src/ouroboros/tui/components/agents_panel.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import DataTable, Static
@@ -260,7 +261,7 @@ class AgentsPanel(Widget):
                     "---",
                     f"[bold]{metrics.utilization_percent:.0f}%[/]",
                 )
-        except Exception:
+        except NoMatches:
             pass
 
     def _format_tokens(self, tokens: int) -> str:

--- a/src/ouroboros/tui/components/event_log.py
+++ b/src/ouroboros/tui/components/event_log.py
@@ -15,6 +15,7 @@ from enum import Enum
 from typing import Any
 
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Input, RichLog, Static
@@ -213,7 +214,7 @@ class EventLog(Widget):
         """Update log display based on filter and search."""
         try:
             log = self.query_one("#log-display", RichLog)
-        except Exception:
+        except NoMatches:
             return
 
         # Clear and repopulate
@@ -276,7 +277,7 @@ class EventLog(Widget):
             stats = self.query_one("#stats-row", Static)
             total = len(self.entries)
             stats.update(f"Showing {count} of {total} entries")
-        except Exception:
+        except NoMatches:
             pass
 
     def watch_entries(self, _: list[LogEntry]) -> None:
@@ -311,7 +312,7 @@ class EventLog(Widget):
                     btn.add_class("active")
                 else:
                     btn.remove_class("active")
-            except Exception:
+            except NoMatches:
                 pass
 
     def update_from_state(self, state: TUIState) -> None:
@@ -346,7 +347,7 @@ class EventLog(Widget):
                 timestamp = datetime.fromisoformat(
                     log_entry.get("timestamp", datetime.now().isoformat())
                 )
-            except Exception:
+            except ValueError:
                 timestamp = datetime.now()
 
             new_entries.append(

--- a/src/ouroboros/tui/components/progress.py
+++ b/src/ouroboros/tui/components/progress.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from enum import Enum
 
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import ProgressBar, Static
@@ -301,7 +302,7 @@ class ProgressTracker(Widget):
         try:
             bar = self.query_one("#overall-bar", ProgressBar)
             bar.progress = overall.total_percent
-        except Exception:
+        except NoMatches:
             pass
 
         # Update overall stats
@@ -315,7 +316,7 @@ class ProgressTracker(Widget):
             if overall.eta_display:
                 parts.append(f"[dim]{overall.eta_display} remaining[/]")
             stats.update(" | ".join(parts))
-        except Exception:
+        except NoMatches:
             pass
 
         # Update phase bars
@@ -330,7 +331,7 @@ class ProgressTracker(Widget):
 
                 percent = self.query_one(f"#phase-percent-{phase.value}", Static)
                 percent.update(f"{phase_progress.percent_complete:.0f}%")
-            except Exception:
+            except NoMatches:
                 pass
 
         # Update current activity
@@ -344,7 +345,7 @@ class ProgressTracker(Widget):
             else:
                 activity_text.update("Idle")
                 activity_label.update("Status:")
-        except Exception:
+        except NoMatches:
             pass
 
         # Update milestones
@@ -381,7 +382,7 @@ class ProgressTracker(Widget):
             else:
                 container.update("[dim]No milestones yet[/]")
 
-        except Exception:
+        except NoMatches:
             pass
 
     def watch_overall(self, _: OverallProgress) -> None:

--- a/src/ouroboros/tui/components/token_tracker.py
+++ b/src/ouroboros/tui/components/token_tracker.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import ProgressBar, Static
@@ -294,7 +295,7 @@ class TokenTracker(Widget):
             self.query_one("#summary-output", Static).update(
                 f"[value]{self._format_tokens(summary.total_output_tokens)}[/] [label]Output[/]"
             )
-        except Exception:
+        except NoMatches:
             pass
 
         # Update tier breakdown
@@ -308,7 +309,7 @@ class TokenTracker(Widget):
             self.query_one("#tier-opus", Static).update(
                 f"[tier-value]{self._format_tokens(summary.opus_tokens)}[/] [tier-label]Opus[/]"
             )
-        except Exception:
+        except NoMatches:
             pass
 
         # Update budget bar
@@ -349,7 +350,7 @@ class TokenTracker(Widget):
                 else:
                     status_widget.update(f"{progress:.0f}% of ${self.budget_usd:.2f} budget used")
 
-            except Exception:
+            except NoMatches:
                 pass
 
     def _format_tokens(self, tokens: int) -> str:

--- a/src/ouroboros/tui/screens/dashboard.py
+++ b/src/ouroboros/tui/screens/dashboard.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import Footer, Header, Label, Static
@@ -226,7 +227,7 @@ class StatusPanel(Static):
                 # Update CSS class for color
                 elem.remove_class(old_status)
                 elem.add_class(status)
-            except Exception:
+            except NoMatches:
                 pass
 
         if current_ac is not None and current_ac != self.current_ac:
@@ -234,7 +235,7 @@ class StatusPanel(Static):
             try:
                 elem = self.query_one("#ac-value", Static)
                 elem.update(self._truncate_ac(current_ac) or "[dim]None[/dim]")
-            except Exception:
+            except NoMatches:
                 pass
 
         if activity is not None and activity != self.activity:
@@ -242,7 +243,7 @@ class StatusPanel(Static):
             try:
                 elem = self.query_one("#activity-value", Static)
                 elem.update(activity or "[dim]Idle[/dim]")
-            except Exception:
+            except NoMatches:
                 pass
 
 

--- a/src/ouroboros/tui/screens/dashboard_v2.py
+++ b/src/ouroboros/tui/screens/dashboard_v2.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import Footer, Label, Static
@@ -282,7 +283,7 @@ class ActivityBar(Static):
             if self.elapsed:
                 stats_parts.append(f"[dim]Time: {self.elapsed}[/]")
             stats_elem.update(" │ ".join(stats_parts) if stats_parts else "")
-        except Exception:
+        except NoMatches:
             pass
 
 
@@ -487,7 +488,7 @@ class DashboardScreenV2(Screen[None]):
             try:
                 status_widget = self._command_bar.query_one("#mini-status", MiniStatusIndicator)
                 status_widget.status = message.status
-            except Exception:
+            except NoMatches:
                 pass
 
     def on_phase_changed(self, message: PhaseChanged) -> None:
@@ -496,7 +497,7 @@ class DashboardScreenV2(Screen[None]):
             try:
                 phase_widget = self._command_bar.query_one("#mini-phase", MiniPhaseIndicator)
                 phase_widget.phase = message.current_phase
-            except Exception:
+            except NoMatches:
                 pass
 
     def on_drift_updated(self, message: DriftUpdated) -> None:
@@ -505,7 +506,7 @@ class DashboardScreenV2(Screen[None]):
             try:
                 drift_widget = self._command_bar.query_one("#mini-drift", MiniDriftIndicator)
                 drift_widget.drift = message.combined_drift
-            except Exception:
+            except NoMatches:
                 pass
 
     def on_cost_updated(self, message: CostUpdated) -> None:
@@ -515,7 +516,7 @@ class DashboardScreenV2(Screen[None]):
                 cost_widget = self._command_bar.query_one("#mini-cost", MiniCostIndicator)
                 cost_widget.tokens = message.total_tokens
                 cost_widget.cost_usd = message.total_cost_usd
-            except Exception:
+            except NoMatches:
                 pass
 
     def on_ac_updated(self, message: ACUpdated) -> None:
@@ -559,7 +560,7 @@ class DashboardScreenV2(Screen[None]):
                 cost_widget = self._command_bar.query_one("#mini-cost", MiniCostIndicator)
                 cost_widget.tokens = message.estimated_tokens
                 cost_widget.cost_usd = message.estimated_cost_usd
-            except Exception:
+            except NoMatches:
                 pass
 
         # Update activity bar
@@ -673,7 +674,7 @@ class DashboardScreenV2(Screen[None]):
                 cost_widget = self._command_bar.query_one("#mini-cost", MiniCostIndicator)
                 cost_widget.tokens = state.total_tokens
                 cost_widget.cost_usd = state.total_cost_usd
-            except Exception:
+            except NoMatches:
                 pass
 
         if self._enhanced_tree:

--- a/src/ouroboros/tui/screens/dashboard_v3.py
+++ b/src/ouroboros/tui/screens/dashboard_v3.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
 from textual.screen import Screen
@@ -416,7 +417,7 @@ class SelectableACTree(Static):
     def _rebuild_tree(self) -> None:
         try:
             tree = self.query_one("#ac-tree", Tree)
-        except Exception:
+        except NoMatches:
             return
 
         tree.clear()
@@ -791,7 +792,7 @@ class DashboardScreenV3(Screen[None]):
             try:
                 tree_widget = self._tree.query_one("#ac-tree", Tree)
                 tree_widget.focus()
-            except Exception:
+            except NoMatches:
                 pass
 
     def action_logs(self) -> None:

--- a/src/ouroboros/tui/screens/hud_dashboard.py
+++ b/src/ouroboros/tui/screens/hud_dashboard.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import Footer, Tree
@@ -224,7 +225,7 @@ class HUDDashboardScreen(Screen[None]):
                 hud_row.remove_class("hidden")
             else:
                 hud_row.add_class("hidden")
-        except Exception:
+        except NoMatches:
             pass
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -452,7 +453,7 @@ class HUDDashboardScreen(Screen[None]):
             try:
                 tree_widget = self._tree.query_one("#ac-tree", Tree)
                 tree_widget.focus()
-            except Exception:
+            except NoMatches:
                 pass
 
     def action_toggle_hud(self) -> None:

--- a/src/ouroboros/tui/screens/logs.py
+++ b/src/ouroboros/tui/screens/logs.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, VerticalScroll
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import Footer, Input, Label, Static
@@ -335,7 +336,7 @@ class LogsScreen(Screen[None]):
         """Refresh log display after filter change or new log."""
         try:
             container = self.query_one("#log-container", VerticalScroll)
-        except Exception:
+        except NoMatches:
             return
 
         # Remove all children and re-add filtered logs

--- a/src/ouroboros/tui/widgets/agent_activity.py
+++ b/src/ouroboros/tui/widgets/agent_activity.py
@@ -9,6 +9,7 @@ Displays current subAgent activity including:
 from __future__ import annotations
 
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
@@ -135,7 +136,7 @@ class AgentActivityWidget(Widget):
             self.query_one("#tool-line", Static).update(self._format_tool_line())
             self.query_one("#file-line", Static).update(self._format_file_line())
             self.query_one("#thinking-line", Static).update(self._format_thinking_line())
-        except Exception:
+        except NoMatches:
             pass
 
     def watch_current_tool(self, _new_value: str) -> None:

--- a/src/ouroboros/tui/widgets/lineage_tree.py
+++ b/src/ouroboros/tui/widgets/lineage_tree.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
@@ -134,7 +135,7 @@ class LineageTreeWidget(Widget):
 
         try:
             tree = self.query_one("#lineage-tree", Tree)
-        except Exception:
+        except NoMatches:
             return
 
         tree.clear()


### PR DESCRIPTION
## Summary

Replace 30 overly broad `except Exception: pass` with precise exception types across 11 TUI files.

- **29× `except NoMatches:`** for `query_one()` calls that may fail when widgets are not yet mounted or have been removed from the DOM
- **1× `except ValueError:`** for `datetime.fromisoformat()` parsing in `event_log.py`

### Why this matters

Bare `except Exception` silently swallows real bugs — `TypeError`, `KeyError`, `AttributeError` all get hidden behind `pass`. This makes debugging TUI issues unnecessarily difficult, since genuine errors disappear without a trace.

`query_one()` only raises `NoMatches` when the CSS selector finds no widget. The other exception it can raise — `TooManyMatches` — is intentionally **not** caught, because duplicate widget IDs indicate a real bug that should surface immediately.

### Files changed

**Components (4 files, 13 changes):**
- `agents_panel.py` — 1× `NoMatches` (DataTable query)
- `event_log.py` — 3× `NoMatches` + 1× `ValueError` (datetime parsing)
- `progress.py` — 5× `NoMatches` (progress display updates)
- `token_tracker.py` — 3× `NoMatches` (summary/tier/budget widgets)

**Screens (5 files, 15 changes):**
- `dashboard.py` — 3× `NoMatches` (status widgets)
- `dashboard_v2.py` — 7× `NoMatches` (mini-status widgets)
- `dashboard_v3.py` — 2× `NoMatches` (Tree widget)
- `hud_dashboard.py` — 2× `NoMatches` (HUD row / Tree widget)
- `logs.py` — 1× `NoMatches` (VerticalScroll container)

**Widgets (2 files, 2 changes):**
- `agent_activity.py` — 1× `NoMatches` (activity display)
- `lineage_tree.py` — 1× `NoMatches` (Tree widget)

### What was intentionally left unchanged

- **`app.py`** (11 instances) — wraps polling, file I/O, and state updates, not `query_one()`
- **`screens/debug.py`** (2 instances) — uses `except Exception as e:` with logging; intentional broad catch
- **`screens/lineage_detail.py`** (5 instances) — mixed patterns including git operations and `as e` logging
- **`screens/session_selector.py`, `lineage_selector.py`** — `as e` patterns with error handling

These require case-by-case analysis and are better suited for a follow-up PR.

## Test plan

- [x] `ruff check` — all checks passed (no lint issues)
- [x] `pytest tests/` — 2516 passed
- [x] Full `grep -rn "except Exception" src/ouroboros/tui/` audit — all remaining instances verified as intentional

🤖 Generated with [Claude Code](https://claude.com/claude-code)