### PR TITLE
fix(mcp): pass host/port to FastMCP constructor for SSE transport

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -101,9 +101,16 @@ async def _run_mcp_server(
         transport: Transport type (stdio or sse).
         db_path: Optional path to EventStore database.
     """
-    from ouroboros.mcp.server.adapter import create_ouroboros_server
+    from ouroboros.mcp.server.adapter import create_ouroboros_server, validate_transport
     from ouroboros.orchestrator.session import SessionRepository
     from ouroboros.persistence.event_store import EventStore
+
+    # Validate transport early, before any expensive startup work
+    try:
+        transport = validate_transport(transport)
+    except ValueError:
+        print_error(f"Invalid transport {transport!r}. Must be 'stdio' or 'sse'.")
+        raise typer.Exit(code=1)
 
     # Create EventStore with custom path if provided
     if db_path:
@@ -137,8 +144,6 @@ async def _run_mcp_server(
 
     tool_count = len(server.info.tools)
 
-    transport = transport.lower()
-
     if transport == "stdio":
         # In stdio mode, stdout is the JSON-RPC channel.
         # All human-readable output must go to stderr.
@@ -146,14 +151,11 @@ async def _run_mcp_server(
         _stderr_console.print(f"[blue]Registered {tool_count} tools[/blue]")
         _stderr_console.print("[blue]Reading from stdin, writing to stdout[/blue]")
         _stderr_console.print("[blue]Press Ctrl+C to stop[/blue]")
-    elif transport == "sse":
+    else:
         print_success(f"MCP Server starting on {transport}...")
         print_info(f"Registered {tool_count} tools")
         print_info(f"Listening on {host}:{port}")
         print_info("Press Ctrl+C to stop")
-    else:
-        print_error(f"Invalid transport {transport!r}. Must be 'stdio' or 'sse'.")
-        raise typer.Exit(code=1)
 
     # Manage PID file for stale instance detection
     if _check_stale_instance():

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -35,6 +35,21 @@ from ouroboros.mcp.types import (
 
 log = structlog.get_logger(__name__)
 
+VALID_TRANSPORTS: frozenset[str] = frozenset({"stdio", "sse"})
+
+
+def validate_transport(transport: str) -> str:
+    """Normalize and validate a transport string.
+
+    Returns the lowercased transport if valid, raises ValueError otherwise.
+    """
+    transport = transport.lower()
+    if transport not in VALID_TRANSPORTS:
+        msg = f"Invalid transport {transport!r}. Must be one of: {', '.join(sorted(VALID_TRANSPORTS))}"
+        raise ValueError(msg)
+    return transport
+
+
 # Map MCPToolParameter types to Python annotations for FastMCP schema inference.
 _TOOL_TYPE_MAP: dict[ToolInputType, type] = {
     ToolInputType.STRING: str,
@@ -403,8 +418,6 @@ class MCPServerAdapter:
                 )
             )
 
-    _VALID_TRANSPORTS = {"stdio", "sse"}
-
     async def serve(
         self,
         transport: str = "stdio",
@@ -421,10 +434,7 @@ class MCPServerAdapter:
             host: Host to bind to (SSE only). Defaults to "localhost".
             port: Port to bind to (SSE only). Defaults to 8080.
         """
-        transport = transport.lower()
-        if transport not in self._VALID_TRANSPORTS:
-            msg = f"Invalid transport {transport!r}. Must be one of: {', '.join(sorted(self._VALID_TRANSPORTS))}"
-            raise ValueError(msg)
+        transport = validate_transport(transport)
 
         try:
             from mcp.server.fastmcp import FastMCP

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -4,12 +4,16 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
+
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPResourceNotFoundError, MCPServerError
 from ouroboros.mcp.server.adapter import (
+    VALID_TRANSPORTS,
     MCPServerAdapter,
     _project_dir_from_artifact,
     _project_dir_from_seed,
+    validate_transport,
 )
 from ouroboros.mcp.types import (
     ContentType,
@@ -247,3 +251,102 @@ class TestMCPServerAdapterInfo:
         tool_names = {t.name for t in info.tools}
         assert "tool1" in tool_names
         assert "tool2" in tool_names
+
+
+# ── Transport validation ────────────────────────────────────────────
+
+
+class TestValidateTransport:
+    """Tests for validate_transport()."""
+
+    def test_valid_lowercase(self):
+        assert validate_transport("stdio") == "stdio"
+        assert validate_transport("sse") == "sse"
+
+    def test_case_insensitive(self):
+        assert validate_transport("SSE") == "sse"
+        assert validate_transport("Stdio") == "stdio"
+        assert validate_transport("sSe") == "sse"
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid transport"):
+            validate_transport("http")
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="Invalid transport"):
+            validate_transport("")
+
+    def test_valid_transports_constant(self):
+        assert "stdio" in VALID_TRANSPORTS
+        assert "sse" in VALID_TRANSPORTS
+
+
+class TestServeTransport:
+    """Tests for MCPServerAdapter.serve() transport handling."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_transport_raises(self):
+        adapter = MCPServerAdapter()
+        with pytest.raises(ValueError, match="Invalid transport"):
+            await adapter.serve(transport="bogus")
+
+    @pytest.mark.asyncio
+    async def test_sse_passes_host_port_to_fastmcp(self):
+        """Verify host/port are forwarded to FastMCP constructor."""
+        from unittest.mock import MagicMock, patch
+
+        mock_fastmcp_cls = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.tool = MagicMock(return_value=lambda f: f)
+        mock_instance.resource = MagicMock(return_value=lambda f: f)
+        mock_instance.run_sse_async = AsyncMock()
+        mock_fastmcp_cls.return_value = mock_instance
+
+        adapter = MCPServerAdapter()
+
+        with (
+            patch(
+                "ouroboros.mcp.server.adapter.FastMCP",
+                mock_fastmcp_cls,
+                create=True,
+            ),
+            patch.dict(
+                "sys.modules",
+                {"mcp.server.fastmcp": MagicMock(FastMCP=mock_fastmcp_cls)},
+            ),
+        ):
+            await adapter.serve(transport="sse", host="0.0.0.0", port=9000)
+
+        mock_fastmcp_cls.assert_called_once()
+        call_kwargs = mock_fastmcp_cls.call_args
+        assert call_kwargs.kwargs["host"] == "0.0.0.0"
+        assert call_kwargs.kwargs["port"] == 9000
+
+    @pytest.mark.asyncio
+    async def test_sse_ephemeral_port_zero(self):
+        """port=0 must reach FastMCP without being rewritten."""
+        from unittest.mock import MagicMock, patch
+
+        mock_fastmcp_cls = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.tool = MagicMock(return_value=lambda f: f)
+        mock_instance.resource = MagicMock(return_value=lambda f: f)
+        mock_instance.run_sse_async = AsyncMock()
+        mock_fastmcp_cls.return_value = mock_instance
+
+        adapter = MCPServerAdapter()
+
+        with (
+            patch(
+                "ouroboros.mcp.server.adapter.FastMCP",
+                mock_fastmcp_cls,
+                create=True,
+            ),
+            patch.dict(
+                "sys.modules",
+                {"mcp.server.fastmcp": MagicMock(FastMCP=mock_fastmcp_cls)},
+            ),
+        ):
+            await adapter.serve(transport="sse", host="localhost", port=0)
+
+        assert mock_fastmcp_cls.call_args.kwargs["port"] == 0


### PR DESCRIPTION
## Summary
- FastMCP reads host/port from internal settings set at construction time
- Previously, host/port were only passed to `run_sse_async()` which silently ignored them
- Server would bind to default address (0.0.0.0:8000) instead of user-specified host/port
- Now passes host/port to `FastMCP()` constructor and removes redundant args from `run_sse_async()`

## Test plan
- [ ] Start MCP server with `--transport sse --port 9000` and verify it binds to port 9000
- [ ] Verify stdio transport is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)