### PR TITLE
Fix Codex model routing setup and eval timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ npm install -g @openai/codex      # Codex CLI (if not installed)
 curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/release/0.26.0-beta/scripts/install.sh | bash
 ```
 
-Installs Ouroboros, registers Codex skills/rules and MCP server in one step.
+Installs Ouroboros, runs `ouroboros setup --runtime codex`, writes `~/.ouroboros/config.yaml`, installs managed Codex rules/skills, and registers the Ouroboros MCP server in `~/.codex/config.toml`.
+
+Set Codex role-specific model overrides such as `clarification.default_model`, `llm.qa_model`, `evaluation.semantic_model`, and `consensus.*` in `~/.ouroboros/config.yaml`. Keep `~/.codex/config.toml` for MCP/env hookup only.
 
 ```bash
 ouroboros init start "I want to build a task management CLI"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,8 +92,12 @@ ouroboros setup --non-interactive
 - Prompts you to select a runtime if multiple are found (or auto-selects if only one)
 - Writes `orchestrator.runtime_backend` to `~/.ouroboros/config.yaml`
 - For Claude Code: registers the MCP server in `~/.claude/mcp.json`
-- For Codex CLI: sets `orchestrator.codex_cli_path` in config
-- For Codex CLI: does **not** currently install global `~/.codex/` rules or skills
+- For Codex CLI: sets `orchestrator.codex_cli_path` and `llm.backend: codex` in `~/.ouroboros/config.yaml`
+- For Codex CLI: installs managed Ouroboros rules into `~/.codex/rules/`
+- For Codex CLI: installs managed Ouroboros skills into `~/.codex/skills/`
+- For Codex CLI: registers the Ouroboros MCP/env block in `~/.codex/config.toml`
+
+> **Codex config split:** put persistent Ouroboros per-role model overrides in `~/.ouroboros/config.yaml` (`clarification.default_model`, `llm.qa_model`, `evaluation.semantic_model`, `consensus.models`, `consensus.advocate_model`, `consensus.devil_model`, `consensus.judge_model`). `~/.codex/config.toml` is only the Codex MCP/env hookup file used by setup.
 
 > **`opencode` caveat:** `setup` detects the `opencode` binary in PATH but cannot configure it — if `opencode` is your only installed runtime, `setup` exits with `Error: Unsupported runtime: opencode`. The `opencode` runtime backend is **not yet implemented** (`runtime_factory.py` raises `NotImplementedError`). It is planned for a future release.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -29,6 +29,28 @@ Complete reference for `~/.ouroboros/config.yaml` and all related environment va
 
 ---
 
+## Codex CLI Users
+
+For Codex-backed Ouroboros workflows:
+
+- Put persistent Ouroboros role overrides in `~/.ouroboros/config.yaml`.
+- Use `~/.codex/config.toml` only for the Codex MCP/env hookup written by `ouroboros setup --runtime codex`.
+- The Codex-aware loader does **not** hardcode a mini model when these keys are left at their shipped defaults. It resolves Codex-backed lookups to Codex's `default` sentinel unless you set an explicit model string.
+
+### Codex Role Override Map
+
+| Role | `config.yaml` key |
+|------|-------------------|
+| Clarification / interview | `clarification.default_model` |
+| QA verdict | `llm.qa_model` |
+| Semantic evaluation | `evaluation.semantic_model` |
+| Consensus simple voting | `consensus.models` |
+| Consensus deliberative roles | `consensus.advocate_model`, `consensus.devil_model`, `consensus.judge_model` |
+
+> **Recommended documented baseline:** use GPT-5.4 with medium reasoning effort in Codex CLI, then pin specific Ouroboros roles in `config.yaml` when you want deterministic per-role model selection.
+
+---
+
 ## Top-Level Sections
 
 | Section | Class | Purpose |
@@ -299,12 +321,12 @@ consensus:
 | `min_models` | `int >= 2` | `3` | Minimum number of models required for a consensus vote. |
 | `threshold` | `float [0.0, 1.0]` | `0.67` | Fraction of models that must agree for consensus to pass (e.g., `0.67` = 2/3 majority). |
 | `diversity_required` | `bool` | `true` | When `true`, consensus requires models from at least two different providers. |
-| `models` | `list[string]` | (see above) | Model roster for Stage 3 simple voting. Specify as `provider/model` or `openrouter/provider/model`. Overridable via `OUROBOROS_CONSENSUS_MODELS` (comma-separated). |
-| `advocate_model` | `string` | `"openrouter/anthropic/claude-opus-4-6"` | Model that argues in favor of the proposed solution in deliberative consensus. Overridable via `OUROBOROS_CONSENSUS_ADVOCATE_MODEL`. |
-| `devil_model` | `string` | `"openrouter/openai/gpt-4o"` | Model that argues against (devil's advocate) in deliberative consensus. Overridable via `OUROBOROS_CONSENSUS_DEVIL_MODEL`. |
-| `judge_model` | `string` | `"openrouter/google/gemini-2.5-pro"` | Model that renders a final verdict after deliberation. Overridable via `OUROBOROS_CONSENSUS_JUDGE_MODEL`. |
+| `models` | `list[string]` | (see above) | Model roster for Stage 3 simple voting. With `llm.backend: litellm`, use `provider/model` or `openrouter/provider/model`. With `llm.backend: codex`, use Codex/OpenAI model IDs such as `gpt-5.4`. Overridable via `OUROBOROS_CONSENSUS_MODELS` (comma-separated). |
+| `advocate_model` | `string` | `"openrouter/anthropic/claude-opus-4-6"` | Model that argues in favor of the proposed solution in deliberative consensus. With `llm.backend: codex`, this can be a Codex/OpenAI model ID such as `gpt-5.4`. Overridable via `OUROBOROS_CONSENSUS_ADVOCATE_MODEL`. |
+| `devil_model` | `string` | `"openrouter/openai/gpt-4o"` | Model that argues against (devil's advocate) in deliberative consensus. With `llm.backend: codex`, this can be a Codex/OpenAI model ID such as `gpt-5.4`. Overridable via `OUROBOROS_CONSENSUS_DEVIL_MODEL`. |
+| `judge_model` | `string` | `"openrouter/google/gemini-2.5-pro"` | Model that renders a final verdict after deliberation. With `llm.backend: codex`, this can be a Codex/OpenAI model ID such as `gpt-5.4`. Overridable via `OUROBOROS_CONSENSUS_JUDGE_MODEL`. |
 
-> **Note:** Consensus models are accessed via OpenRouter. Ensure `OPENROUTER_API_KEY` is set in `credentials.yaml` or as an environment variable when `stage3_enabled: true`.
+> **Backend note:** With `llm.backend: litellm`, consensus models typically go through OpenRouter/LiteLLM and require the corresponding provider credentials (commonly `OPENROUTER_API_KEY`). With `llm.backend: codex`, the configured model strings are sent through Codex CLI instead.
 
 ---
 
@@ -484,9 +506,38 @@ orchestrator:
   runtime_backend: codex
   codex_cli_path: /usr/local/bin/codex   # omit if codex is already on PATH
 
+llm:
+  backend: codex
+
 logging:
   level: info
 ```
+
+### Codex CLI Runtime With Explicit Role Overrides
+
+```yaml
+# ~/.ouroboros/config.yaml
+orchestrator:
+  runtime_backend: codex
+  codex_cli_path: /usr/local/bin/codex
+
+llm:
+  backend: codex
+  qa_model: gpt-5.4
+
+clarification:
+  default_model: gpt-5.4
+
+evaluation:
+  semantic_model: gpt-5.4
+
+consensus:
+  advocate_model: gpt-5.4
+  devil_model: gpt-5.4
+  judge_model: gpt-5.4
+```
+
+This is the recommended Ouroboros-side pattern for Codex users. Keep `~/.codex/config.toml` limited to the MCP/env block created by setup.
 
 ### Full Config Skeleton
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,7 +112,7 @@ uv run ouroboros --version            # verify CLI
 |------|-------------|
 | Claude Code (`ooo`) | Claude Code with plugin support |
 | Standalone CLI (`ouroboros`) | Python >= 3.12, API key (Anthropic or OpenAI) |
-| Codex CLI backend | Python >= 3.12, `npm install -g @openai/codex`, OpenAI API key |
+| Codex CLI backend | Python >= 3.12, `npm install -g @openai/codex`, OpenAI API key with access to GPT-5.4 |
 
 ---
 
@@ -144,6 +144,32 @@ llm:
 logging:
   level: info
 ```
+
+For Codex CLI, the recommended documented baseline is GPT-5.4 with medium reasoning effort. Put Ouroboros per-role overrides in `~/.ouroboros/config.yaml`, not in `~/.codex/config.toml`:
+
+```yaml
+# ~/.ouroboros/config.yaml
+orchestrator:
+  runtime_backend: codex
+  codex_cli_path: /usr/local/bin/codex
+
+llm:
+  backend: codex
+  qa_model: gpt-5.4
+
+clarification:
+  default_model: gpt-5.4
+
+evaluation:
+  semantic_model: gpt-5.4
+
+consensus:
+  advocate_model: gpt-5.4
+  devil_model: gpt-5.4
+  judge_model: gpt-5.4
+```
+
+`ouroboros setup --runtime codex` uses `~/.codex/config.toml` only for the Codex MCP/env hookup and installs managed Ouroboros rules/skills into `~/.codex/`.
 
 ### Environment Variables
 
@@ -272,10 +298,10 @@ Ouroboros delegates code execution to a pluggable runtime backend. Two ship out 
 |---|---|---|
 | **Best for** | Claude Code users; subscription billing | OpenAI ecosystem; pay-per-token billing |
 | **Install** | `pip install ouroboros-ai[claude]` | `pip install ouroboros-ai` + `npm install -g @openai/codex` |
-| **Skill shortcuts** | `ooo` inside Claude Code | Use `ouroboros` CLI |
+| **Skill shortcuts** | `ooo` inside Claude Code | `ooo` after `ouroboros setup --runtime codex` installs managed Codex skills |
 | **Config value** | `claude` | `codex` |
 
-Both backends run the same core workflow engine (seed execution, TUI). However, user-facing commands differ: Claude Code offers `ooo` skill shortcuts and the full MCP tool suite (evaluate, evolve, unstuck, ralph), while Codex CLI uses `ouroboros` command equivalents — some advanced operations are MCP/Claude-only.
+Both backends run the same core workflow engine (seed execution, TUI). However, user-facing commands still differ: Claude Code has native in-session `ooo` workflows, while Codex CLI relies on `ouroboros setup --runtime codex` to install managed rules/skills plus the MCP hookup. The `ouroboros` CLI remains the most universal terminal path, and some advanced operations are still MCP/Claude-only.
 
 For backend-specific configuration:
 - [Claude Code runtime guide](runtime-guides/claude-code.md)

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -63,7 +63,7 @@ These capabilities depend on the runtime backend's native features and execution
 | Aspect | Claude Code | Codex CLI |
 |--------|-------------|-----------|
 | **Primary UX** | In-session skills and MCP server | Session-oriented Ouroboros runtime over Codex CLI transport |
-| **Skill shortcuts (`ooo`)** | Yes -- skills loaded into Claude Code session | **Not yet available.** Codex skill artifacts exist in the repository but automatic installation into `~/.codex/` is not yet implemented. Use `ouroboros` CLI commands instead (see [Codex runtime guide](runtime-guides/codex.md#ooo-skill-availability-on-codex) for the full equivalence table). `ooo setup` is not supported on Codex — use `ouroboros setup --runtime codex` from the terminal |
+| **Skill shortcuts (`ooo`)** | Yes -- skills loaded into Claude Code session | Yes -- after `ouroboros setup --runtime codex` installs managed skills into `~/.codex/skills/`, rules into `~/.codex/rules/`, and the MCP/env hookup into `~/.codex/config.toml`. Keep role-specific Ouroboros model overrides in `~/.ouroboros/config.yaml` |
 | **MCP integration** | Native MCP server support | Deterministic skill/MCP dispatch through the Ouroboros Codex adapter |
 | **Session context** | Shares Claude Code session context | Preserved via runtime handles, native session IDs, and resume support |
 | **Install extras** | `ouroboros-ai[claude]` | `ouroboros-ai` (base package) + `codex` on PATH |

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -11,7 +11,7 @@ Ouroboros can use **OpenAI Codex CLI** as a runtime backend. [Codex CLI](https:/
 
 No additional Python SDK is required beyond the base `ouroboros-ai` package.
 
-> **Model recommendation:** Use **GPT-5.4** (or later) for best results with Codex CLI. GPT-5.4 provides strong coding, multi-step reasoning, and agentic task execution that pairs well with the Ouroboros specification-first workflow harness.
+> **Model recommendation:** Use **GPT-5.4** with **medium** reasoning effort for the documented Codex setup. GPT-5.4 provides strong coding, multi-step reasoning, and agentic task execution that pairs well with the Ouroboros specification-first workflow harness.
 
 ## Prerequisites
 
@@ -66,21 +66,55 @@ Or pass the backend on the command line:
 uv run ouroboros run workflow --runtime codex ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
 ```
 
+### Where Codex users configure what
+
+Use `~/.ouroboros/config.yaml` for Ouroboros runtime settings and per-role model overrides.
+
+Use `~/.codex/config.toml` only for the Codex MCP/env hookup written by `ouroboros setup --runtime codex`.
+
+If you want Codex-backed Ouroboros roles to use explicit models instead of inheriting Codex CLI's active default/profile, set the existing `config.yaml` keys directly:
+
+```yaml
+# ~/.ouroboros/config.yaml
+orchestrator:
+  runtime_backend: codex
+  codex_cli_path: /usr/local/bin/codex   # omit if codex is already on PATH
+
+llm:
+  backend: codex
+  qa_model: gpt-5.4
+
+clarification:
+  default_model: gpt-5.4
+
+evaluation:
+  semantic_model: gpt-5.4
+
+consensus:
+  advocate_model: gpt-5.4
+  devil_model: gpt-5.4
+  judge_model: gpt-5.4
+  # Optional: the simple-voting roster also lives here as `consensus.models`
+```
+
+When these keys are left at their shipped defaults, the Codex-aware loader resolves them to Codex's `default` sentinel rather than hardcoding a mini model. In practice, Codex then uses its active global default/profile. Explicit `config.yaml` values always win.
+
 ## Command Surface
 
 From the user's perspective, the Codex integration behaves like a **session-oriented Ouroboros runtime** — the same specification-first workflow harness that drives the Claude runtime.
 
 Under the hood, `CodexCliRuntime` still talks to the local `codex` executable, but it preserves native session IDs and resume handles, and the Codex command dispatcher can route `ooo`-style skill commands through the in-process Ouroboros MCP server.
 
-Today, the most reliable documented entrypoint is still the `ouroboros` CLI while Codex artifact installation is being finalized.
-
 `ouroboros setup --runtime codex` currently:
 
 - Detects the `codex` binary on your `PATH`
-- Writes `orchestrator.runtime_backend: codex` to `~/.ouroboros/config.yaml`
+- Writes `orchestrator.runtime_backend: codex` and `llm.backend: codex` to `~/.ouroboros/config.yaml`
 - Records `orchestrator.codex_cli_path` when available
+- Installs managed Ouroboros rules into `~/.codex/rules/`
+- Installs managed Ouroboros skills into `~/.codex/skills/`
+- Registers the Ouroboros MCP/env hookup in `~/.codex/config.toml`
 
-Running `ouroboros setup --runtime codex` automatically installs Codex rule and skill assets into `~/.codex/rules/` and `~/.codex/skills/`. Once installed, Codex can route `ooo`-style skill commands through the Ouroboros MCP server.
+`~/.codex/config.toml` is not where Ouroboros per-role model overrides belong. Keep `clarification`, `qa`, `semantic`, and `consensus` model settings in `~/.ouroboros/config.yaml`.
 
 ### `ooo` Skill Availability on Codex
 
@@ -141,7 +175,7 @@ The `CodexCliRuntime` adapter launches `codex` (or `codex-cli`) as its transport
 ## Codex CLI Strengths
 
 - **Session-aware Codex runtime** -- Ouroboros preserves Codex session handles and resume state across workflow steps
-- **Strong coding and reasoning** -- GPT-5.4 provides robust code generation and multi-file editing across languages
+- **Strong coding and reasoning** -- GPT-5.4 with medium reasoning effort provides robust code generation and multi-file editing across languages
 - **Agentic task execution** -- effective at decomposing complex tasks into sequential steps and iterating autonomously
 - **Open-source** -- Codex CLI is open-source (Apache 2.0), allowing inspection and contribution
 - **Ouroboros harness** -- the specification-first workflow engine adds structured acceptance criteria, evaluation principles, and deterministic exit conditions on top of Codex CLI's capabilities
@@ -154,7 +188,7 @@ Codex CLI and Claude Code are independent runtime backends with different tool s
 |--------|-----------|-------------|
 | What it is | Ouroboros session runtime backed by Codex CLI transport | Anthropic's agentic coding tool |
 | Authentication | OpenAI API key | Max Plan subscription |
-| Model | GPT-5.4 (recommended) | Claude (via claude-agent-sdk) |
+| Model | GPT-5.4 with medium reasoning effort (recommended) | Claude (via claude-agent-sdk) |
 | Sandbox | Codex CLI's own sandbox model | Claude Code's permission system |
 | Tool surface | Codex-native tools (file I/O, shell) | Read, Write, Edit, Bash, Glob, Grep |
 | Session model | Session-aware via runtime handles, resume IDs, and skill dispatch | Native Claude session context |
@@ -233,7 +267,7 @@ The database will be created automatically at `~/.ouroboros/ouroboros.db`.
 
 Using Codex CLI as the runtime backend requires an OpenAI API key and incurs standard OpenAI API usage charges. Costs depend on:
 
-- Model used (GPT-5.4 recommended)
+- Model used (GPT-5.4 with medium reasoning effort recommended)
 - Task complexity and token usage
 - Number of tool calls and iterations
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -32,21 +32,95 @@ def _detect_runtimes() -> dict[str, str | None]:
     return runtimes
 
 
-_CODEX_MCP_SECTION = """\
+_CODEX_MCP_SECTION = """# Ouroboros MCP hookup for Codex CLI.
+# Keep Ouroboros runtime settings and per-role model overrides in
+# ~/.ouroboros/config.yaml (for example: clarification.default_model,
+# llm.qa_model, evaluation.semantic_model, consensus.*).
+# This file is only for the Codex MCP/env registration block.
 
 [mcp_servers.ouroboros]
 command = "uvx"
 args = ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"]
-tool_timeout_sec = 600
 
 [mcp_servers.ouroboros.env]
 OUROBOROS_AGENT_RUNTIME = "codex"
 OUROBOROS_LLM_BACKEND = "codex"
 """
 
+_CODEX_MCP_COMMENT_LINES = (
+    "# Ouroboros MCP hookup for Codex CLI.",
+    "# Keep Ouroboros runtime settings and per-role model overrides in",
+    "# ~/.ouroboros/config.yaml (for example: clarification.default_model,",
+    "# llm.qa_model, evaluation.semantic_model, consensus.*).",
+    "# This file is only for the Codex MCP/env registration block.",
+)
+
+
+def _is_codex_ouroboros_table_header(line: str) -> bool:
+    """Return True when the line starts the managed Codex MCP table."""
+    return line == "[mcp_servers.ouroboros]" or line.startswith("[mcp_servers.ouroboros.")
+
+
+def _trim_managed_codex_comments(lines: list[str]) -> None:
+    """Remove the managed Codex comment block immediately before a table."""
+    while lines and not lines[-1].strip():
+        lines.pop()
+
+    comment_index = len(lines)
+    for expected in reversed(_CODEX_MCP_COMMENT_LINES):
+        if comment_index == 0 or lines[comment_index - 1] != expected:
+            return
+        comment_index -= 1
+
+    del lines[comment_index:]
+
+
+def _upsert_codex_mcp_section(raw: str) -> tuple[str, bool]:
+    """Insert or replace the managed Codex MCP block.
+
+    Returns:
+        Tuple of (updated_contents, existed_before).
+    """
+    section_lines = _CODEX_MCP_SECTION.strip("\n").splitlines()
+    input_lines = raw.splitlines()
+    output_lines: list[str] = []
+    index = 0
+    existed_before = False
+    inserted = False
+
+    while index < len(input_lines):
+        stripped = input_lines[index].strip()
+        if _is_codex_ouroboros_table_header(stripped):
+            existed_before = True
+            if not inserted:
+                _trim_managed_codex_comments(output_lines)
+                if output_lines and output_lines[-1].strip():
+                    output_lines.append("")
+                output_lines.extend(section_lines)
+                inserted = True
+
+            index += 1
+            while index < len(input_lines):
+                next_stripped = input_lines[index].strip()
+                is_table_header = next_stripped.startswith("[") and next_stripped.endswith("]")
+                if is_table_header and not _is_codex_ouroboros_table_header(next_stripped):
+                    break
+                index += 1
+            continue
+
+        output_lines.append(input_lines[index])
+        index += 1
+
+    if not inserted:
+        if output_lines and output_lines[-1].strip():
+            output_lines.append("")
+        output_lines.extend(section_lines)
+
+    return "\n".join(output_lines).rstrip() + "\n", existed_before
+
 
 def _register_codex_mcp_server() -> None:
-    """Register Ouroboros MCP server in ~/.codex/config.toml."""
+    """Register the Ouroboros MCP/env hookup in ~/.codex/config.toml."""
     import tomllib
 
     codex_config = Path.home() / ".codex" / "config.toml"
@@ -55,21 +129,35 @@ def _register_codex_mcp_server() -> None:
     if codex_config.exists():
         raw = codex_config.read_text(encoding="utf-8")
         try:
-            parsed = tomllib.loads(raw)
+            tomllib.loads(raw)
         except tomllib.TOMLDecodeError:
             print_error(f"Could not parse {codex_config} — skipping MCP registration.")
             return
 
-        if "ouroboros" in parsed.get("mcp_servers", {}):
-            print_info("Codex MCP server already registered.")
+        updated_raw, existed_before = _upsert_codex_mcp_section(raw)
+        if updated_raw == raw:
+            print_info("Codex MCP server already up to date.")
             return
 
-        # Append section to existing file
-        codex_config.write_text(raw.rstrip("\n") + "\n" + _CODEX_MCP_SECTION, encoding="utf-8")
+        codex_config.write_text(updated_raw, encoding="utf-8")
+        if existed_before:
+            print_success(f"Updated Ouroboros MCP server in {codex_config}")
+        else:
+            print_success(f"Registered Ouroboros MCP server in {codex_config}")
     else:
         codex_config.write_text(_CODEX_MCP_SECTION.lstrip("\n"), encoding="utf-8")
+        print_success(f"Registered Ouroboros MCP server in {codex_config}")
 
-    print_success(f"Registered Ouroboros MCP server in {codex_config}")
+
+def _print_codex_config_guidance(config_path: Path) -> None:
+    """Explain where Codex users should configure Ouroboros vs. Codex settings."""
+    print_info(
+        "Configure Ouroboros runtime and per-role model overrides in "
+        f"{config_path}."
+    )
+    print_info(
+        "Use ~/.codex/config.toml only for the Codex MCP/env hookup written by setup."
+    )
 
 
 def _install_codex_artifacts() -> None:
@@ -123,6 +211,7 @@ def _setup_codex(codex_path: str) -> None:
 
     # Register MCP server in Codex config (~/.codex/config.toml)
     _register_codex_mcp_server()
+    _print_codex_config_guidance(config_path)
 
     # Also register MCP server for Codex users who also have Claude Code
     mcp_config_path = Path.home() / ".claude" / "mcp.json"
@@ -140,13 +229,16 @@ def _setup_codex(codex_path: str) -> None:
                 "command": "uvx",
                 "args": ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"],
             }
-        entry["timeout"] = 600
+        removed_timeout = entry.pop("timeout", None) is not None
         mcp_data["mcpServers"]["ouroboros"] = entry
 
         with mcp_config_path.open("w") as f:
             json.dump(mcp_data, f, indent=2)
 
-        print_info("Updated Claude MCP server config with timeout.")
+        if removed_timeout:
+            print_info("Removed legacy Claude MCP timeout override.")
+        else:
+            print_info("Updated Claude MCP server config.")
 
 
 def _setup_claude(claude_path: str) -> None:
@@ -186,19 +278,17 @@ def _setup_claude(claude_path: str) -> None:
         mcp_data["mcpServers"]["ouroboros"] = {
             "command": "uvx",
             "args": ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"],
-            "timeout": 600,
         }
         with mcp_config_path.open("w") as f:
             json.dump(mcp_data, f, indent=2)
         print_success("Registered MCP server in ~/.claude/mcp.json")
     else:
-        # Ensure existing entries have timeout
         entry = mcp_data["mcpServers"]["ouroboros"]
-        if "timeout" not in entry:
-            entry["timeout"] = 600
+        if "timeout" in entry:
+            del entry["timeout"]
             with mcp_config_path.open("w") as f:
                 json.dump(mcp_data, f, indent=2)
-            print_info("Updated MCP server config with timeout.")
+            print_info("Removed legacy MCP timeout override.")
         else:
             print_info("MCP server already registered.")
 

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -242,6 +242,7 @@ class EvaluateHandler:
     event_store: EventStore | None = field(default=None, repr=False)
     llm_adapter: LLMAdapter | None = field(default=None, repr=False)
     llm_backend: str | None = field(default=None, repr=False)
+    TIMEOUT_SECONDS: int = 0  # No server-side timeout; client/runtime decides.
 
     @property
     def definition(self) -> MCPToolDefinition:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1,84 +1,256 @@
-"""Tests for CLI setup command — config persistence."""
+"""Unit tests for the setup command."""
 
-from __future__ import annotations
-
+import json
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 import yaml
 
-
-@pytest.fixture
-def tmp_config_env(tmp_path: Path):
-    """Provide isolated config dir + home for setup tests."""
-    config_dir = tmp_path / ".ouroboros"
-    config_dir.mkdir()
-    home_dir = tmp_path / "home"
-    home_dir.mkdir()
-    claude_dir = home_dir / ".claude"
-    claude_dir.mkdir()
-    return config_dir, home_dir
+import ouroboros.cli.commands.setup as setup_cmd
 
 
-def _run_setup_claude(config_dir: Path, home_dir: Path, claude_path: str):
-    """Run _setup_claude with mocked paths."""
-    from ouroboros.cli.commands.setup import _setup_claude
+class TestCodexSetup:
+    """Tests for Codex-specific setup behavior."""
 
-    with (
-        patch(
-            "ouroboros.config.loader.ensure_config_dir",
-            return_value=config_dir,
-        ),
-        patch("ouroboros.config.loader.create_default_config"),
-        patch("pathlib.Path.home", return_value=home_dir),
-    ):
-        _setup_claude(claude_path)
+    def test_register_codex_mcp_server_writes_guidance_comment(self, tmp_path: Path) -> None:
+        """The generated Codex config should explain the config file split."""
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            setup_cmd._register_codex_mcp_server()
 
+        config_path = tmp_path / ".codex" / "config.toml"
+        contents = config_path.read_text(encoding="utf-8")
 
-class TestSetupClaude:
-    """Tests for _setup_claude() config persistence (review findings #2, #3)."""
+        assert "Keep Ouroboros runtime settings and per-role model overrides in" in contents
+        assert "~/.ouroboros/config.yaml" in contents
+        assert "This file is only for the Codex MCP/env registration block." in contents
+        assert "[mcp_servers.ouroboros]" in contents
+        assert 'OUROBOROS_AGENT_RUNTIME = "codex"' in contents
+        assert 'OUROBOROS_LLM_BACKEND = "codex"' in contents
+        assert "tool_timeout_sec" not in contents
 
-    def test_setup_claude_persists_runtime_backend(self, tmp_config_env: tuple):
-        config_dir, home_dir = tmp_config_env
-        config_path = config_dir / "config.yaml"
-        config_path.write_text(yaml.dump({}))
-
-        _run_setup_claude(config_dir, home_dir, "/usr/local/bin/claude")
-
-        saved = yaml.safe_load(config_path.read_text())
-        assert saved["orchestrator"]["runtime_backend"] == "claude"
-        assert saved["llm"]["backend"] == "claude"
-
-    def test_setup_claude_persists_claude_path(self, tmp_config_env: tuple):
-        config_dir, home_dir = tmp_config_env
-        config_path = config_dir / "config.yaml"
-        config_path.write_text(yaml.dump({}))
-
-        _run_setup_claude(config_dir, home_dir, "/opt/custom/bin/claude")
-
-        saved = yaml.safe_load(config_path.read_text())
-        assert saved["orchestrator"]["cli_path"] == "/opt/custom/bin/claude"
-
-    def test_switch_codex_to_claude_overwrites_backend(self, tmp_config_env: tuple):
-        """Switching from codex to claude must rewrite runtime_backend and llm.backend."""
-        config_dir, home_dir = tmp_config_env
-        config_path = config_dir / "config.yaml"
-        config_path.write_text(
-            yaml.dump(
-                {
-                    "orchestrator": {
-                        "runtime_backend": "codex",
-                        "codex_cli_path": "/usr/bin/codex",
-                    },
-                    "llm": {"backend": "codex"},
-                }
+    def test_register_codex_mcp_server_rewrites_existing_block_without_timeout(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Re-running setup should replace legacy Codex blocks instead of skipping them."""
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        codex_config.write_text(
+            "\n".join(
+                [
+                    "[mcp_servers.other]",
+                    'command = "custom"',
+                    "",
+                    "# Ouroboros MCP hookup for Codex CLI.",
+                    "[mcp_servers.ouroboros]",
+                    'command = "uvx"',
+                    'args = ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"]',
+                    "tool_timeout_sec = 600",
+                    "",
+                    "[mcp_servers.ouroboros.env]",
+                    'OUROBOROS_AGENT_RUNTIME = "claude"',
+                    "",
+                ]
             )
+            + "\n",
+            encoding="utf-8",
         )
 
-        _run_setup_claude(config_dir, home_dir, "/usr/local/bin/claude")
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            setup_cmd._register_codex_mcp_server()
 
-        saved = yaml.safe_load(config_path.read_text())
-        assert saved["orchestrator"]["runtime_backend"] == "claude"
-        assert saved["llm"]["backend"] == "claude"
-        assert saved["orchestrator"]["cli_path"] == "/usr/local/bin/claude"
+        contents = codex_config.read_text(encoding="utf-8")
+
+        assert "[mcp_servers.other]" in contents
+        assert contents.count("[mcp_servers.ouroboros]") == 1
+        assert contents.count("[mcp_servers.ouroboros.env]") == 1
+        assert 'OUROBOROS_AGENT_RUNTIME = "codex"' in contents
+        assert 'OUROBOROS_LLM_BACKEND = "codex"' in contents
+        assert "tool_timeout_sec" not in contents
+
+    def test_install_codex_artifacts_installs_rules_and_skills(self, tmp_path: Path) -> None:
+        """Codex setup should install both managed rules and managed skills."""
+        rules_path = tmp_path / ".codex" / "rules"
+        skill_paths = [tmp_path / ".codex" / "skills" / "evaluate"]
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.codex.install_codex_rules", return_value=rules_path) as mock_rules,
+            patch("ouroboros.codex.install_codex_skills", return_value=skill_paths) as mock_skills,
+            patch("ouroboros.cli.commands.setup.print_success") as mock_success,
+        ):
+            setup_cmd._install_codex_artifacts()
+
+        mock_rules.assert_called_once()
+        mock_skills.assert_called_once()
+        success_messages = [call.args[0] for call in mock_success.call_args_list]
+        assert any("Installed Codex rules" in message for message in success_messages)
+        assert any("Installed 1 Codex skills" in message for message in success_messages)
+
+    def test_setup_codex_updates_config_and_prints_config_split_guidance(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Codex setup should configure config.yaml and explain where settings belong."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("orchestrator:\n  runtime_backend: claude\n", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._install_codex_artifacts") as mock_install,
+            patch("ouroboros.cli.commands.setup._register_codex_mcp_server") as mock_register,
+            patch("ouroboros.cli.commands.setup.print_info") as mock_info,
+        ):
+            setup_cmd._setup_codex("/usr/local/bin/codex")
+
+        config_dict = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert config_dict["orchestrator"]["runtime_backend"] == "codex"
+        assert config_dict["orchestrator"]["codex_cli_path"] == "/usr/local/bin/codex"
+        assert config_dict["llm"]["backend"] == "codex"
+        mock_install.assert_called_once_with()
+        mock_register.assert_called_once_with()
+
+        info_messages = [call.args[0] for call in mock_info.call_args_list]
+        assert any("Config saved to" in message for message in info_messages)
+        assert any("Configure Ouroboros runtime" in message for message in info_messages)
+        assert any("Codex MCP/env hookup" in message for message in info_messages)
+
+    def test_setup_codex_preserves_existing_role_overrides(self, tmp_path: Path) -> None:
+        """Re-running Codex setup should not wipe role-specific model overrides."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "orchestrator": {
+                        "runtime_backend": "claude",
+                        "default_max_turns": 15,
+                    },
+                    "llm": {
+                        "backend": "litellm",
+                        "qa_model": "gpt-5.4",
+                    },
+                    "clarification": {
+                        "default_model": "gpt-5.4",
+                    },
+                    "evaluation": {
+                        "semantic_model": "gpt-5.4",
+                    },
+                    "consensus": {
+                        "advocate_model": "gpt-5.4",
+                        "devil_model": "gpt-5.4",
+                        "judge_model": "gpt-5.4",
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._install_codex_artifacts"),
+            patch("ouroboros.cli.commands.setup._register_codex_mcp_server"),
+        ):
+            setup_cmd._setup_codex("/usr/local/bin/codex")
+
+        config_dict = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert config_dict["orchestrator"]["runtime_backend"] == "codex"
+        assert config_dict["orchestrator"]["codex_cli_path"] == "/usr/local/bin/codex"
+        assert config_dict["orchestrator"]["default_max_turns"] == 15
+        assert config_dict["llm"]["backend"] == "codex"
+        assert config_dict["llm"]["qa_model"] == "gpt-5.4"
+        assert config_dict["clarification"]["default_model"] == "gpt-5.4"
+        assert config_dict["evaluation"]["semantic_model"] == "gpt-5.4"
+        assert config_dict["consensus"]["advocate_model"] == "gpt-5.4"
+        assert config_dict["consensus"]["devil_model"] == "gpt-5.4"
+        assert config_dict["consensus"]["judge_model"] == "gpt-5.4"
+
+    def test_setup_codex_removes_legacy_claude_timeout_override(self, tmp_path: Path) -> None:
+        """Codex setup should clear the legacy 600s Claude MCP timeout override."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        claude_config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "ouroboros": {
+                            "command": "uvx",
+                            "args": ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"],
+                            "timeout": 600,
+                        },
+                        "other": {
+                            "command": "node",
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._install_codex_artifacts"),
+            patch("ouroboros.cli.commands.setup._register_codex_mcp_server"),
+        ):
+            setup_cmd._setup_codex("/usr/local/bin/codex")
+
+        claude_mcp = json.loads(claude_config.read_text(encoding="utf-8"))
+        assert "timeout" not in claude_mcp["mcpServers"]["ouroboros"]
+        assert claude_mcp["mcpServers"]["other"]["command"] == "node"
+
+
+class TestClaudeSetup:
+    """Tests for Claude-specific setup behavior."""
+
+    def test_setup_claude_removes_legacy_timeout_override(self, tmp_path: Path) -> None:
+        """Claude setup should no longer persist the legacy 600s MCP timeout."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        claude_config = claude_dir / "mcp.json"
+        claude_config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "ouroboros": {
+                            "command": "uvx",
+                            "args": ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"],
+                            "timeout": 600,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+        ):
+            setup_cmd._setup_claude("/usr/local/bin/claude")
+
+        claude_mcp = json.loads(claude_config.read_text(encoding="utf-8"))
+        config_dict = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert "timeout" not in claude_mcp["mcpServers"]["ouroboros"]
+        assert config_dict["orchestrator"]["runtime_backend"] == "claude"
+        assert config_dict["llm"]["backend"] == "claude"

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1050,6 +1050,11 @@ class TestEvaluateHandler:
         handler = EvaluateHandler()
         assert handler.definition.name == "ouroboros_evaluate"
 
+    def test_handler_has_no_server_side_timeout(self) -> None:
+        """Long-running evaluation should not inherit a fixed server timeout."""
+        handler = EvaluateHandler()
+        assert handler.TIMEOUT_SECONDS == 0
+
     def test_definition_requires_session_id_and_artifact(self) -> None:
         """EvaluateHandler requires session_id and artifact parameters."""
         handler = EvaluateHandler()


### PR DESCRIPTION
## Summary
- document that Codex users should keep per-role model overrides in `~/.ouroboros/config.yaml`, while `~/.codex/config.toml` is only the MCP/env hookup
- update Codex setup to install managed rules/skills, rewrite existing Codex MCP config, and remove legacy `600s` timeout overrides from both Codex and Claude MCP config
- make `ouroboros_evaluate` explicitly non-time-limited on the server side and add regression coverage for the setup/evaluation paths

## Testing
- `uv run pytest tests/unit/cli/test_setup.py tests/unit/mcp/tools/test_definitions.py tests/unit/evaluation/test_mechanical.py tests/unit/evaluation/test_semantic.py -q`
