### PR TITLE
fix(interview): gate completion on ambiguity score to prevent deadlock

### DIFF
--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -143,10 +143,28 @@ class InterviewState(BaseModel):
         """Get the current round number (1-based)."""
         return len(self.rounds) + 1
 
+    # Mirrors AMBIGUITY_THRESHOLD from ambiguity.py to avoid circular import.
+    _SEED_READY_THRESHOLD: float = 0.2
+
     @property
     def is_complete(self) -> bool:
         """Check if interview is marked complete (user-controlled)."""
         return self.status == InterviewStatus.COMPLETED
+
+    @property
+    def can_reopen(self) -> bool:
+        """True when a completed interview should be reopenable.
+
+        A completed interview is reopenable only when its stored ambiguity
+        score exceeds the seed-generation threshold — i.e. it was completed
+        prematurely and is now in a deadlock (can't generate seed, can't
+        resume).
+        """
+        return (
+            self.is_complete
+            and self.ambiguity_score is not None
+            and self.ambiguity_score > self._SEED_READY_THRESHOLD
+        )
 
     def mark_updated(self) -> None:
         """Update the updated_at timestamp."""
@@ -361,12 +379,20 @@ class InterviewEngine:
             return Result.err(ValidationError(error_msg, field="user_response"))
 
         if state.is_complete:
-            return Result.err(
-                ValidationError(
-                    "Cannot record response - interview is complete",
-                    field="status",
-                    value=state.status,
+            if not state.can_reopen:
+                return Result.err(
+                    ValidationError(
+                        "Cannot record response - interview is complete",
+                        field="status",
+                        value=state.status,
+                    )
                 )
+            # Deadlock recovery: reopen when completed prematurely
+            state.status = InterviewStatus.IN_PROGRESS
+            log.info(
+                "interview.reopened_for_ambiguity",
+                interview_id=state.interview_id,
+                ambiguity_score=state.ambiguity_score,
             )
 
         # Create new round
@@ -546,7 +572,9 @@ class InterviewEngine:
         _OVERHEAD = 20  # newlines, ellipsis, separators
 
         # Budget for base_prompt after accounting for other sections
-        base_budget = _MAX_SYSTEM_PROMPT_CHARS - len(dynamic_header) - len(perspective_panel) - _OVERHEAD
+        base_budget = (
+            _MAX_SYSTEM_PROMPT_CHARS - len(dynamic_header) - len(perspective_panel) - _OVERHEAD
+        )
         if base_budget < 0:
             # Header + panel already exceed budget — truncate both proportionally
             total = len(dynamic_header) + len(perspective_panel)

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -479,6 +479,36 @@ class InterviewHandler:
         )
         return score
 
+    @staticmethod
+    def _ambiguity_gate_response(
+        session_id: str,
+        score: AmbiguityScore | None,
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Build an MCP response refusing premature interview completion."""
+        score_display = f"{score.overall_score:.2f}" if score is not None else "unknown"
+        return Result.ok(
+            MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text=(
+                            f"Cannot complete yet — ambiguity score "
+                            f"{score_display} exceeds threshold "
+                            f"{AMBIGUITY_THRESHOLD}. "
+                            f"Please answer a few more questions to "
+                            f"clarify remaining areas."
+                        ),
+                    ),
+                ),
+                is_error=False,
+                meta={
+                    "session_id": session_id,
+                    "ambiguity_score": (score.overall_score if score is not None else None),
+                    "seed_ready": False,
+                },
+            )
+        )
+
     async def _complete_interview_response(
         self,
         engine: InterviewEngine,
@@ -769,12 +799,21 @@ class InterviewHandler:
                     if _is_interview_completion_signal(answer):
                         if state.rounds and state.rounds[-1].user_response is None:
                             state.rounds.pop()
-                        state.clear_stored_ambiguity()
-                        return await self._complete_interview_response(
-                            engine,
-                            state,
-                            session_id,
-                        )
+                        # Gate: check ambiguity before completing.
+                        # Stored score first; live scoring as fallback.
+                        exit_score = _load_state_ambiguity_score(state)
+                        if exit_score is None or not exit_score.is_ready_for_seed:
+                            exit_score = await self._score_interview_state(llm_adapter, state)
+                        if exit_score is not None and exit_score.is_ready_for_seed:
+                            return await self._complete_interview_response(
+                                engine,
+                                state,
+                                session_id,
+                                exit_score,
+                            )
+                        # Ambiguity too high — refuse completion
+                        await engine.save_state(state)
+                        return self._ambiguity_gate_response(session_id, exit_score)
 
                     if not state.rounds:
                         return Result.err(

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1485,8 +1485,8 @@ class TestInterviewHandlerCwd:
         assert result.is_ok
         assert state.status == InterviewStatus.COMPLETED
         assert state.rounds == []
-        assert state.ambiguity_score is None
-        assert state.ambiguity_breakdown is None
+        # Score is preserved (not cleared) since completion now gates on it
+        assert state.ambiguity_score == 0.14
         mock_engine.ask_next_question.assert_not_called()
         assert result.value.meta["completed"] is True
 


### PR DESCRIPTION
## Summary
- **Prevention**: Interview completion signal ("done") now checks ambiguity score first. If > 0.2 threshold, refuses completion and prompts for more clarification.
- **Recovery**: Added `InterviewState.can_reopen` property — completed interviews with ambiguity > 0.2 can be automatically reopened via `record_response()`, breaking the deadlock.
- **Refactor**: Extracted `_ambiguity_gate_response()` static method for clean separation of the refusal response.

## Problem
When a user explicitly completed an interview (e.g. "done", "wrap up"), the handler marked it as `COMPLETED` **without checking ambiguity**. If the LLM-scored ambiguity was > 0.2:
- `generate_seed` rejected it (score too high)
- `interview` rejected resuming (already completed)
- **Deadlock** — no way forward or backward

## Checks passed
- [x] ruff lint
- [x] ruff format (auto-fixed 2 files)
- [x] mypy — 0 issues
- [x] pytest — 253 passed

## Test plan
- Existing test updated: `test_interview_handle_done_completes_without_new_question` — now verifies score is preserved on completion
- All 11 interview handler tests pass
- All 102 bigbang (interview + ambiguity + seed) tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)