### PR TITLE
feat(evolution): add TerminationReason enum, Gate Guard, and opt-in convergence quality gates

### DIFF
--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -280,6 +280,12 @@ class SeedGenerator:
                 )
             elif action == "remove" and mutation.field_name in fields_by_name:
                 del fields_by_name[mutation.field_name]
+            else:
+                log.warning(
+                    "seed_generator.unhandled_mutation",
+                    action=action,
+                    field_name=mutation.field_name,
+                )
 
         return OntologySchema(
             name=schema.name,

--- a/src/ouroboros/core/errors.py
+++ b/src/ouroboros/core/errors.py
@@ -9,6 +9,7 @@ Exception Hierarchy:
     ├── ProviderError     - LLM provider failures (rate limits, API errors)
     ├── ConfigError       - Configuration and credentials issues
     ├── PersistenceError  - Database and storage issues
+    ├── TransitionError   - Invalid state transitions in event sourcing
     └── ValidationError   - Schema and data validation failures
 """
 
@@ -160,6 +161,29 @@ class PersistenceError(OuroborosError):
         super().__init__(message, details)
         self.operation = operation
         self.table = table
+
+
+class TransitionError(OuroborosError):
+    """Error from invalid state transitions in event sourcing.
+
+    Raised when a lineage event is not allowed in the current lineage status.
+
+    Attributes:
+        current_status: The lineage status at the time of the attempted transition.
+        event_type: The event type that was rejected.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        current_status: str,
+        event_type: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message, details)
+        self.current_status = current_status
+        self.event_type = event_type
 
 
 class ValidationError(OuroborosError):

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -214,6 +214,7 @@ class OntologyLineage(BaseModel, frozen=True):
     generations: tuple[GenerationRecord, ...] = Field(default_factory=tuple)
     rewind_history: tuple[RewindRecord, ...] = Field(default_factory=tuple)
     status: LineageStatus = LineageStatus.ACTIVE
+    termination_reason: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     @property
@@ -230,9 +231,14 @@ class OntologyLineage(BaseModel, frozen=True):
         """Return new lineage with appended generation."""
         return self.model_copy(update={"generations": self.generations + (record,)})
 
-    def with_status(self, status: LineageStatus) -> OntologyLineage:
-        """Return new lineage with updated status."""
-        return self.model_copy(update={"status": status})
+    def with_status(
+        self, status: LineageStatus, termination_reason: str | None = None
+    ) -> OntologyLineage:
+        """Return new lineage with updated status and optional termination reason."""
+        updates: dict = {"status": status}
+        if termination_reason is not None:
+            updates["termination_reason"] = termination_reason
+        return self.model_copy(update=updates)
 
     def rewind_to(self, generation_number: int) -> OntologyLineage:
         """Return lineage truncated to the given generation.

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -29,6 +29,21 @@ class LineageStatus(StrEnum):
     ABORTED = "aborted"
 
 
+class TerminationReason(StrEnum):
+    """Why the evolutionary loop terminated.
+
+    Categorizes the termination cause (not the final status). Multiple
+    reasons can map to the same LineageStatus — e.g., STAGNATED, OSCILLATED,
+    and REPETITIVE all result in LineageStatus.CONVERGED.
+    """
+
+    CONVERGED = "converged"  # ontology stable: similarity >= threshold
+    STAGNATED = "stagnated"  # ontology unchanged for N consecutive generations
+    OSCILLATED = "oscillated"  # ontology cycling between similar states (A→B→A→B)
+    EXHAUSTED = "exhausted"  # max_generations reached
+    REPETITIVE = "repetitive"  # wonder questions repeating across generations
+
+
 class GenerationPhase(StrEnum):
     """Lifecycle phase of a single generation (for error recovery)."""
 
@@ -214,7 +229,7 @@ class OntologyLineage(BaseModel, frozen=True):
     generations: tuple[GenerationRecord, ...] = Field(default_factory=tuple)
     rewind_history: tuple[RewindRecord, ...] = Field(default_factory=tuple)
     status: LineageStatus = LineageStatus.ACTIVE
-    termination_reason: str | None = None
+    termination_reason: TerminationReason | str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     @property
@@ -232,7 +247,9 @@ class OntologyLineage(BaseModel, frozen=True):
         return self.model_copy(update={"generations": self.generations + (record,)})
 
     def with_status(
-        self, status: LineageStatus, termination_reason: str | None = None
+        self,
+        status: LineageStatus,
+        termination_reason: TerminationReason | str | None = None,
     ) -> OntologyLineage:
         """Return new lineage with updated status and optional termination reason."""
         updates: dict = {"status": status}

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -251,10 +251,12 @@ class OntologyLineage(BaseModel, frozen=True):
         status: LineageStatus,
         termination_reason: TerminationReason | str | None = None,
     ) -> OntologyLineage:
-        """Return new lineage with updated status and optional termination reason."""
-        updates: dict = {"status": status}
-        if termination_reason is not None:
-            updates["termination_reason"] = termination_reason
+        """Return new lineage with updated status and optional termination reason.
+
+        When transitioning to a non-terminal status (e.g. ACTIVE after rewind),
+        termination_reason is cleared to None to avoid stale metadata.
+        """
+        updates: dict = {"status": status, "termination_reason": termination_reason}
         return self.model_copy(update=updates)
 
     def rewind_to(self, generation_number: int) -> OntologyLineage:
@@ -284,5 +286,6 @@ class OntologyLineage(BaseModel, frozen=True):
             update={
                 "generations": truncated,
                 "status": LineageStatus.ACTIVE,
+                "termination_reason": None,
             }
         )

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -229,7 +229,7 @@ class OntologyLineage(BaseModel, frozen=True):
     generations: tuple[GenerationRecord, ...] = Field(default_factory=tuple)
     rewind_history: tuple[RewindRecord, ...] = Field(default_factory=tuple)
     status: LineageStatus = LineageStatus.ACTIVE
-    termination_reason: TerminationReason | str | None = None
+    termination_reason: TerminationReason | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     @property
@@ -249,7 +249,7 @@ class OntologyLineage(BaseModel, frozen=True):
     def with_status(
         self,
         status: LineageStatus,
-        termination_reason: TerminationReason | str | None = None,
+        termination_reason: TerminationReason | None = None,
     ) -> OntologyLineage:
         """Return new lineage with updated status and optional termination reason.
 

--- a/src/ouroboros/events/lineage.py
+++ b/src/ouroboros/events/lineage.py
@@ -129,17 +129,21 @@ def lineage_converged(
     generation_number: int,
     reason: str,
     similarity: float,
+    termination_reason: str | None = None,
 ) -> BaseEvent:
     """Create event when convergence is detected."""
+    data: dict = {
+        "generation_number": generation_number,
+        "reason": reason,
+        "similarity": similarity,
+    }
+    if termination_reason is not None:
+        data["termination_reason"] = str(termination_reason)
     return BaseEvent(
         type="lineage.converged",
         aggregate_type="lineage",
         aggregate_id=lineage_id,
-        data={
-            "generation_number": generation_number,
-            "reason": reason,
-            "similarity": similarity,
-        },
+        data=data,
     )
 
 
@@ -147,16 +151,20 @@ def lineage_exhausted(
     lineage_id: str,
     generation_number: int,
     max_generations: int,
+    termination_reason: str | None = None,
 ) -> BaseEvent:
     """Create event when max generations is reached."""
+    data: dict = {
+        "generation_number": generation_number,
+        "max_generations": max_generations,
+    }
+    if termination_reason is not None:
+        data["termination_reason"] = str(termination_reason)
     return BaseEvent(
         type="lineage.exhausted",
         aggregate_type="lineage",
         aggregate_id=lineage_id,
-        data={
-            "generation_number": generation_number,
-            "max_generations": max_generations,
-        },
+        data=data,
     )
 
 
@@ -199,15 +207,19 @@ def lineage_stagnated(
     generation_number: int,
     reason: str,
     window: int,
+    termination_reason: str | None = None,
 ) -> BaseEvent:
     """Create event when stagnation is detected (repeated feedback/unchanged ontology)."""
+    data: dict = {
+        "generation_number": generation_number,
+        "reason": reason,
+        "stagnation_window": window,
+    }
+    if termination_reason is not None:
+        data["termination_reason"] = str(termination_reason)
     return BaseEvent(
         type="lineage.stagnated",
         aggregate_type="lineage",
         aggregate_id=lineage_id,
-        data={
-            "generation_number": generation_number,
-            "reason": reason,
-            "stagnation_window": window,
-        },
+        data=data,
     )

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -429,8 +429,11 @@ class ConvergenceCriteria:
         if not latest_wonder.questions:
             return None
 
+        # Exclude the latest generation — its questions are the ones being
+        # evaluated via latest_wonder, so including them would make every
+        # question appear "already seen" and the gate would never block.
         prev_questions: set[str] = set()
-        for gen in lineage.generations:
+        for gen in lineage.generations[:-1]:
             prev_questions.update(gen.wonder_questions)
 
         novel = [q for q in latest_wonder.questions if q not in prev_questions]

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -41,9 +41,7 @@ class ConvergenceSignal:
 
     def __post_init__(self) -> None:
         if self.converged and self.termination_reason is None:
-            raise ValueError(
-                "converged=True requires termination_reason to be set"
-            )
+            raise ValueError("converged=True requires termination_reason to be set")
 
 
 @dataclass
@@ -403,8 +401,7 @@ class ConvergenceCriteria:
         scores = [
             g.evaluation_summary.drift_score
             for g in recent
-            if g.evaluation_summary is not None
-            and g.evaluation_summary.drift_score is not None
+            if g.evaluation_summary is not None and g.evaluation_summary.drift_score is not None
         ]
 
         if len(scores) < 2:

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -68,8 +68,8 @@ class ConvergenceCriteria:
     eval_min_score: float = 0.7
     ac_gate_mode: str = "all"  # "all" | "ratio" | "off"
     ac_min_pass_ratio: float = 1.0  # for "ratio" mode
-    regression_gate_enabled: bool = True
-    validation_gate_enabled: bool = True
+    regression_gate_enabled: bool = False
+    validation_gate_enabled: bool = False
     ontology_completeness_gate_enabled: bool = False
     ontology_min_fields: int = 3
     wonder_gate_enabled: bool = False

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -70,6 +70,8 @@ class ConvergenceCriteria:
     ac_min_pass_ratio: float = 1.0  # for "ratio" mode
     regression_gate_enabled: bool = True
     validation_gate_enabled: bool = True
+    ontology_completeness_gate_enabled: bool = False
+    ontology_min_fields: int = 3
 
     def evaluate(
         self,
@@ -114,6 +116,23 @@ class ConvergenceCriteria:
         # Signal 1: Ontology stability (latest two generations)
         latest_sim = self._latest_similarity(lineage)
         if latest_sim >= self.convergence_threshold:
+            # Safety: if ontology has been stable for stagnation_window consecutive
+            # generations but gates keep blocking, force stagnation termination.
+            # Without this, gates (e.g., completeness) can block indefinitely
+            # since the stagnation check below only runs when similarity < threshold.
+            if self._check_stagnation(lineage):
+                return ConvergenceSignal(
+                    converged=True,
+                    reason=(
+                        f"Stagnation detected: ontology unchanged for "
+                        f"{self.stagnation_window} consecutive generations "
+                        f"(convergence gates could not be satisfied)"
+                    ),
+                    ontology_similarity=latest_sim,
+                    generation=current_gen,
+                    termination_reason=TerminationReason.STAGNATED,
+                )
+
             # Eval gate: block convergence if evaluation is unsatisfactory
             if self.eval_gate_enabled and latest_evaluation is not None:
                 eval_blocks = not latest_evaluation.final_approved or (
@@ -183,6 +202,17 @@ class ConvergenceCriteria:
                     ontology_similarity=latest_sim,
                     generation=current_gen,
                 )
+
+            # Ontology completeness gate: block convergence if ontology is structurally thin
+            if self.ontology_completeness_gate_enabled:
+                completeness_block = self._check_ontology_completeness(lineage)
+                if completeness_block is not None:
+                    return ConvergenceSignal(
+                        converged=False,
+                        reason=completeness_block,
+                        ontology_similarity=latest_sim,
+                        generation=current_gen,
+                    )
 
             # Validation gate: block convergence if validation was skipped or failed
             if self.validation_gate_enabled and validation_output:
@@ -325,6 +355,40 @@ class ConvergenceCriteria:
                 return failed, (
                     f"Per-AC gate (mode=ratio): pass ratio {ratio:.2f} "
                     f"< required {self.ac_min_pass_ratio:.2f}"
+                )
+
+        return None
+
+    def _check_ontology_completeness(self, lineage: OntologyLineage) -> str | None:
+        """Check if ontology meets minimum structural completeness.
+
+        Returns blocking reason if incomplete, None if OK.
+        Checks: (1) minimum field count, (2) description quality.
+        """
+        if not lineage.generations:
+            return None
+
+        ontology = lineage.generations[-1].ontology_snapshot
+
+        # Check 1: Minimum field count
+        if self.ontology_min_fields > 0 and len(ontology.fields) < self.ontology_min_fields:
+            return (
+                f"Ontology completeness gate: {len(ontology.fields)} fields "
+                f"(minimum {self.ontology_min_fields} required)"
+            )
+
+        # Check 2: Trivially short or name-echoing descriptions
+        if ontology.fields:
+            trivial_count = sum(
+                1
+                for f in ontology.fields
+                if len(f.description.strip()) < 10
+                or f.description.strip().lower() == f.name.strip().lower()
+            )
+            if trivial_count > len(ontology.fields) // 2:
+                return (
+                    f"Ontology completeness gate: {trivial_count}/{len(ontology.fields)} "
+                    f"fields have trivial descriptions"
                 )
 
         return None

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -74,6 +74,8 @@ class ConvergenceCriteria:
     ontology_min_fields: int = 3
     wonder_gate_enabled: bool = False
     wonder_novelty_threshold: float = 0.5
+    drift_trend_gate_enabled: bool = False
+    drift_trend_window: int = 3
 
     def evaluate(
         self,
@@ -227,6 +229,17 @@ class ConvergenceCriteria:
                         generation=current_gen,
                     )
 
+            # Drift trend gate: block if drift_score is monotonically increasing
+            if self.drift_trend_gate_enabled:
+                drift_block = self._check_drift_trend_gate(lineage)
+                if drift_block is not None:
+                    return ConvergenceSignal(
+                        converged=False,
+                        reason=drift_block,
+                        ontology_similarity=latest_sim,
+                        generation=current_gen,
+                    )
+
             # Validation gate: block convergence if validation was skipped or failed
             if self.validation_gate_enabled and validation_output:
                 # Use explicit bool flag when available; fall back to string matching
@@ -369,6 +382,40 @@ class ConvergenceCriteria:
                     f"Per-AC gate (mode=ratio): pass ratio {ratio:.2f} "
                     f"< required {self.ac_min_pass_ratio:.2f}"
                 )
+
+        return None
+
+    def _check_drift_trend_gate(self, lineage: OntologyLineage) -> str | None:
+        """Block convergence if drift_score shows monotonic increase.
+
+        Checks if drift_score has increased in every consecutive pair within
+        the recent window. This indicates the ontology is consistently moving
+        away from the goal.
+
+        Generations with missing evaluation or drift_score (None) are skipped.
+        If fewer than 2 valid scores remain, the gate passes.
+        """
+        gens = lineage.generations
+        if len(gens) < self.drift_trend_window:
+            return None
+
+        recent = gens[-self.drift_trend_window :]
+        scores = [
+            g.evaluation_summary.drift_score
+            for g in recent
+            if g.evaluation_summary is not None
+            and g.evaluation_summary.drift_score is not None
+        ]
+
+        if len(scores) < 2:
+            return None
+
+        increases = sum(1 for i in range(1, len(scores)) if scores[i] > scores[i - 1])
+        if increases >= len(scores) - 1:
+            return (
+                f"Drift trend gate: drift_score monotonically increasing over "
+                f"{len(scores)} generations ({scores[0]:.3f} → {scores[-1]:.3f})"
+            )
 
         return None
 

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -18,6 +18,7 @@ from ouroboros.core.lineage import (
     GenerationRecord,
     OntologyDelta,
     OntologyLineage,
+    TerminationReason,
 )
 from ouroboros.evolution.regression import RegressionDetector
 from ouroboros.evolution.wonder import WonderOutput
@@ -25,13 +26,24 @@ from ouroboros.evolution.wonder import WonderOutput
 
 @dataclass(frozen=True, slots=True)
 class ConvergenceSignal:
-    """Result of convergence evaluation."""
+    """Result of convergence evaluation.
+
+    When converged=True, termination_reason must be set to indicate why.
+    When converged=False, termination_reason is None (loop continues).
+    """
 
     converged: bool
     reason: str
     ontology_similarity: float
     generation: int
     failed_acs: tuple[int, ...] = ()
+    termination_reason: TerminationReason | None = None
+
+    def __post_init__(self) -> None:
+        if self.converged and self.termination_reason is None:
+            raise ValueError(
+                "converged=True requires termination_reason to be set"
+            )
 
 
 @dataclass
@@ -87,6 +99,7 @@ class ConvergenceCriteria:
                 reason=f"Max generations reached ({self.max_generations})",
                 ontology_similarity=self._latest_similarity(lineage),
                 generation=current_gen,
+                termination_reason=TerminationReason.EXHAUSTED,
             )
 
         # Need at least min_generations completed before checking other signals
@@ -197,6 +210,7 @@ class ConvergenceCriteria:
                 ),
                 ontology_similarity=latest_sim,
                 generation=current_gen,
+                termination_reason=TerminationReason.CONVERGED,
             )
 
         # Signal 2: Stagnation (unchanged for N consecutive gens)
@@ -211,6 +225,7 @@ class ConvergenceCriteria:
                     ),
                     ontology_similarity=latest_sim,
                     generation=current_gen,
+                    termination_reason=TerminationReason.STAGNATED,
                 )
 
         # Signal 2.5: Oscillation detection (A→B→A→B cycling)
@@ -219,9 +234,10 @@ class ConvergenceCriteria:
             if oscillating:
                 return ConvergenceSignal(
                     converged=True,
-                    reason=("Oscillation detected: ontology is cycling between similar states"),
+                    reason="Oscillation detected: ontology is cycling between similar states",
                     ontology_similarity=latest_sim,
                     generation=current_gen,
+                    termination_reason=TerminationReason.OSCILLATED,
                 )
 
         # Signal 3: Repetitive wonder questions
@@ -233,6 +249,7 @@ class ConvergenceCriteria:
                     reason="Repetitive feedback: wonder questions are repeating across generations",
                     ontology_similarity=latest_sim,
                     generation=current_gen,
+                    termination_reason=TerminationReason.REPETITIVE,
                 )
 
         # Not converged

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -30,6 +30,10 @@ class ConvergenceSignal:
 
     When converged=True, termination_reason must be set to indicate why.
     When converged=False, termination_reason is None (loop continues).
+
+    Note: ``converged`` means "the loop should terminate", NOT "the ontology
+    has converged". EXHAUSTED, STAGNATED, OSCILLATED and REPETITIVE all
+    set converged=True despite not representing true ontological convergence.
     """
 
     converged: bool
@@ -38,6 +42,7 @@ class ConvergenceSignal:
     generation: int
     failed_acs: tuple[int, ...] = ()
     termination_reason: TerminationReason | None = None
+    blocking_gate: str | None = None
 
     def __post_init__(self) -> None:
         if self.converged and self.termination_reason is None:
@@ -150,6 +155,7 @@ class ConvergenceCriteria:
                         ),
                         ontology_similarity=latest_sim,
                         generation=current_gen,
+                        blocking_gate="eval",
                     )
 
             # Per-AC gate: block convergence if individual ACs are failing
@@ -168,6 +174,7 @@ class ConvergenceCriteria:
                         ontology_similarity=latest_sim,
                         generation=current_gen,
                         failed_acs=failed_indices,
+                        blocking_gate="ac",
                     )
 
             # Signal 5: Regression gate — block convergence if ACs regressed
@@ -186,6 +193,7 @@ class ConvergenceCriteria:
                         ontology_similarity=latest_sim,
                         generation=current_gen,
                         failed_acs=regressed,
+                        blocking_gate="regression",
                     )
 
             # Evolution gate: withhold convergence if ontology never actually evolved.
@@ -203,6 +211,7 @@ class ConvergenceCriteria:
                     ),
                     ontology_similarity=latest_sim,
                     generation=current_gen,
+                    blocking_gate="evolution",
                 )
 
             # Ontology completeness gate: block convergence if ontology is structurally thin
@@ -214,9 +223,24 @@ class ConvergenceCriteria:
                         reason=completeness_block,
                         ontology_similarity=latest_sim,
                         generation=current_gen,
+                        blocking_gate="completeness",
                     )
 
-            # Wonder gate: block convergence if Wonder found significant novel questions
+            # Wonder gate: block convergence if Wonder found significant novel questions.
+            # When wonder_gate is enabled but no wonder output is available, block
+            # convergence — "unable to generate questions" is not the same as
+            # "no questions remain" (Ouroboros principle: questions must be answered).
+            if self.wonder_gate_enabled and latest_wonder is None:
+                return ConvergenceSignal(
+                    converged=False,
+                    reason=(
+                        "Wonder gate: wonder output unavailable — cannot confirm "
+                        "no questions remain (wonder_gate_enabled=True)"
+                    ),
+                    ontology_similarity=latest_sim,
+                    generation=current_gen,
+                    blocking_gate="wonder",
+                )
             if self.wonder_gate_enabled and latest_wonder is not None:
                 wonder_block = self._check_wonder_gate(lineage, latest_wonder)
                 if wonder_block is not None:
@@ -225,6 +249,7 @@ class ConvergenceCriteria:
                         reason=wonder_block,
                         ontology_similarity=latest_sim,
                         generation=current_gen,
+                        blocking_gate="wonder",
                     )
 
             # Drift trend gate: block if drift_score is monotonically increasing
@@ -236,6 +261,7 @@ class ConvergenceCriteria:
                         reason=drift_block,
                         ontology_similarity=latest_sim,
                         generation=current_gen,
+                        blocking_gate="drift_trend",
                     )
 
             # Validation gate: block convergence if validation was skipped or failed
@@ -254,6 +280,7 @@ class ConvergenceCriteria:
                         reason=(f"Validation gate blocked: {validation_output}"),
                         ontology_similarity=latest_sim,
                         generation=current_gen,
+                        blocking_gate="validation",
                     )
 
             return ConvergenceSignal(
@@ -393,7 +420,7 @@ class ConvergenceCriteria:
         Generations with missing evaluation or drift_score (None) are skipped.
         If fewer than 2 valid scores remain, the gate passes.
         """
-        gens = lineage.generations
+        gens = self._completed_generations(lineage)
         if len(gens) < self.drift_trend_window:
             return None
 

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -65,6 +65,7 @@ class ConvergenceCriteria:
         latest_wonder: WonderOutput | None = None,
         latest_evaluation: EvaluationSummary | None = None,
         validation_output: str | None = None,
+        validation_passed: bool | None = None,
     ) -> ConvergenceSignal:
         """Check if the loop should terminate.
 
@@ -172,7 +173,15 @@ class ConvergenceCriteria:
 
             # Validation gate: block convergence if validation was skipped or failed
             if self.validation_gate_enabled and validation_output:
-                if "skipped" in validation_output.lower() or "error" in validation_output.lower():
+                # Use explicit bool flag when available; fall back to string matching
+                if validation_passed is not None:
+                    gate_blocked = not validation_passed
+                else:
+                    gate_blocked = (
+                        "skipped" in validation_output.lower()
+                        or "error" in validation_output.lower()
+                    )
+                if gate_blocked:
                     return ConvergenceSignal(
                         converged=False,
                         reason=(f"Validation gate blocked: {validation_output}"),

--- a/src/ouroboros/evolution/convergence.py
+++ b/src/ouroboros/evolution/convergence.py
@@ -72,6 +72,8 @@ class ConvergenceCriteria:
     validation_gate_enabled: bool = True
     ontology_completeness_gate_enabled: bool = False
     ontology_min_fields: int = 3
+    wonder_gate_enabled: bool = False
+    wonder_novelty_threshold: float = 0.5
 
     def evaluate(
         self,
@@ -210,6 +212,17 @@ class ConvergenceCriteria:
                     return ConvergenceSignal(
                         converged=False,
                         reason=completeness_block,
+                        ontology_similarity=latest_sim,
+                        generation=current_gen,
+                    )
+
+            # Wonder gate: block convergence if Wonder found significant novel questions
+            if self.wonder_gate_enabled and latest_wonder is not None:
+                wonder_block = self._check_wonder_gate(lineage, latest_wonder)
+                if wonder_block is not None:
+                    return ConvergenceSignal(
+                        converged=False,
+                        reason=wonder_block,
                         ontology_similarity=latest_sim,
                         generation=current_gen,
                     )
@@ -356,6 +369,36 @@ class ConvergenceCriteria:
                     f"Per-AC gate (mode=ratio): pass ratio {ratio:.2f} "
                     f"< required {self.ac_min_pass_ratio:.2f}"
                 )
+
+        return None
+
+    def _check_wonder_gate(
+        self, lineage: OntologyLineage, latest_wonder: WonderOutput
+    ) -> str | None:
+        """Block convergence if Wonder found significant novel questions.
+
+        Compares latest wonder questions against all previous generations.
+        If novelty ratio >= threshold, ontology may still benefit from evolution.
+
+        Returns blocking reason if novel questions exceed threshold, None if OK.
+        """
+        if not latest_wonder.questions:
+            return None
+
+        prev_questions: set[str] = set()
+        for gen in lineage.generations:
+            prev_questions.update(gen.wonder_questions)
+
+        novel = [q for q in latest_wonder.questions if q not in prev_questions]
+        if not latest_wonder.questions:
+            return None
+        novelty_ratio = len(novel) / len(latest_wonder.questions)
+
+        if novelty_ratio >= self.wonder_novelty_threshold:
+            return (
+                f"Wonder gate: {len(novel)}/{len(latest_wonder.questions)} novel questions "
+                f"(novelty {novelty_ratio:.0%} >= {self.wonder_novelty_threshold:.0%} threshold)"
+            )
 
         return None
 

--- a/src/ouroboros/evolution/guard.py
+++ b/src/ouroboros/evolution/guard.py
@@ -1,0 +1,70 @@
+"""LineageGuard — validates state transitions before event persistence.
+
+Wraps EventStore.append() with transition matrix validation. Only lineage
+events (aggregate_type == "lineage") are validated; all other events pass
+through unconditionally.
+
+Note: append_batch() is not covered by this guard. Lineage events currently
+do not use batch append.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ouroboros.core.errors import TransitionError
+from ouroboros.core.lineage import LineageStatus
+from ouroboros.events.base import BaseEvent
+from ouroboros.evolution.projector import LineageProjector
+from ouroboros.evolution.transitions import is_transition_allowed
+from ouroboros.persistence.event_store import EventStore
+
+logger = logging.getLogger(__name__)
+
+
+class LineageGuard:
+    """Validates lineage event transitions before persisting to EventStore.
+
+    Usage:
+        guard = LineageGuard(event_store)
+        await guard.gated_append(event)  # validates, then appends
+    """
+
+    def __init__(self, event_store: EventStore) -> None:
+        self._event_store = event_store
+
+    async def gated_append(self, event: BaseEvent) -> None:
+        """Validate and append an event to the EventStore.
+
+        Non-lineage events (aggregate_type != "lineage") pass through
+        without validation. lineage.created always passes (initial event).
+        All other lineage events are checked against the transition matrix.
+
+        Args:
+            event: The event to validate and append.
+
+        Raises:
+            TransitionError: If the event is not allowed in the current
+                lineage status.
+            PersistenceError: If the underlying append fails.
+        """
+        if event.aggregate_type != "lineage":
+            await self._event_store.append(event)
+            return
+
+        if event.type == "lineage.created":
+            await self._event_store.append(event)
+            return
+
+        # Determine current status from event stream (single source of truth)
+        events = await self._event_store.replay_lineage(event.aggregate_id)
+        current_status = LineageProjector.resolve_status(events)
+
+        if not is_transition_allowed(current_status, event.type):
+            raise TransitionError(
+                f"Event '{event.type}' not allowed in status '{current_status.value}'",
+                current_status=current_status.value,
+                event_type=event.type,
+            )
+
+        await self._event_store.append(event)

--- a/src/ouroboros/evolution/guard.py
+++ b/src/ouroboros/evolution/guard.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import logging
 
 from ouroboros.core.errors import TransitionError
-from ouroboros.core.lineage import LineageStatus
 from ouroboros.events.base import BaseEvent
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.transitions import is_transition_allowed

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -30,6 +30,7 @@ from ouroboros.core.lineage import (
     LineageStatus,
     OntologyDelta,
     OntologyLineage,
+    TerminationReason,
 )
 from ouroboros.core.seed import Seed
 from ouroboros.core.types import Result
@@ -46,6 +47,7 @@ from ouroboros.events.lineage import (
     lineage_wonder_degraded,
 )
 from ouroboros.evolution.convergence import ConvergenceCriteria, ConvergenceSignal
+from ouroboros.evolution.guard import LineageGuard
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ReflectEngine, ReflectOutput
 from ouroboros.evolution.wonder import WonderEngine, WonderOutput
@@ -150,6 +152,7 @@ class EvolutionaryLoop:
         validator: Any | None = None,
     ) -> None:
         self.event_store = event_store
+        self._guard = LineageGuard(event_store)
         self.config = config or EvolutionaryLoopConfig()
         self.wonder_engine = wonder_engine
         self.reflect_engine = reflect_engine
@@ -207,7 +210,7 @@ class EvolutionaryLoop:
         )
 
         # Emit lineage created event
-        await self.event_store.append(lineage_created(lineage.lineage_id, lineage.goal))
+        await self._guard.gated_append(lineage_created(lineage.lineage_id, lineage.goal))
 
         generation_results: list[GenerationResult] = []
         current_seed = initial_seed
@@ -244,7 +247,7 @@ class EvolutionaryLoop:
                         "timeout": self.config.generation_timeout_seconds,
                     },
                 )
-                await self.event_store.append(
+                await self._guard.gated_append(
                     lineage_generation_failed(
                         lineage.lineage_id,
                         generation_number,
@@ -282,7 +285,7 @@ class EvolutionaryLoop:
             lineage = lineage.with_generation(record)
 
             # Emit generation completed event (with seed_json for cross-session reconstruction)
-            await self.event_store.append(
+            await self._guard.gated_append(
                 lineage_generation_completed(
                     lineage.lineage_id,
                     generation_number,
@@ -299,7 +302,7 @@ class EvolutionaryLoop:
 
             # Emit ontology evolved event if delta exists
             if result.ontology_delta and result.ontology_delta.similarity < 1.0:
-                await self.event_store.append(
+                await self._guard.gated_append(
                     lineage_ontology_evolved(
                         lineage.lineage_id,
                         generation_number,
@@ -324,40 +327,13 @@ class EvolutionaryLoop:
                         "generation": generation_number,
                         "reason": signal.reason,
                         "similarity": signal.ontology_similarity,
+                        "termination_reason": str(signal.termination_reason),
                     },
                 )
 
-                # Emit appropriate termination event
-                if generation_number >= self.config.max_generations:
-                    await self.event_store.append(
-                        lineage_exhausted(
-                            lineage.lineage_id,
-                            generation_number,
-                            self.config.max_generations,
-                        )
-                    )
-                    lineage = lineage.with_status(LineageStatus.EXHAUSTED)
-                elif "Stagnation" in signal.reason or "Oscillation" in signal.reason:
-                    await self.event_store.append(
-                        lineage_stagnated(
-                            lineage.lineage_id,
-                            generation_number,
-                            signal.reason,
-                            self.config.stagnation_window,
-                        )
-                    )
-                    lineage = lineage.with_status(LineageStatus.CONVERGED)
-                else:
-                    await self.event_store.append(
-                        lineage_converged(
-                            lineage.lineage_id,
-                            generation_number,
-                            signal.reason,
-                            signal.ontology_similarity,
-                        )
-                    )
-                    lineage = lineage.with_status(LineageStatus.CONVERGED)
-
+                lineage = await self._emit_termination(
+                    signal, lineage, generation_number
+                )
                 break
 
             # Prepare for next generation
@@ -419,7 +395,7 @@ class EvolutionaryLoop:
                 lineage_id=lineage_id,
                 goal=initial_seed.goal,
             )
-            await self.event_store.append(lineage_created(lineage.lineage_id, lineage.goal))
+            await self._guard.gated_append(lineage_created(lineage.lineage_id, lineage.goal))
             generation_number = 1
             current_seed = initial_seed
 
@@ -524,7 +500,7 @@ class EvolutionaryLoop:
         if gen_result.is_err:
             # Emit generation.failed event so the event store reflects the failure.
             # Without this, only generation.started is recorded, leaving an orphan.
-            await self.event_store.append(
+            await self._guard.gated_append(
                 lineage_generation_failed(
                     lineage.lineage_id,
                     generation_number,
@@ -570,7 +546,7 @@ class EvolutionaryLoop:
         )
         lineage = lineage.with_generation(record)
 
-        await self.event_store.append(
+        await self._guard.gated_append(
             lineage_generation_completed(
                 lineage.lineage_id,
                 generation_number,
@@ -587,7 +563,7 @@ class EvolutionaryLoop:
 
         # Emit ontology evolved event if delta exists
         if result.ontology_delta and result.ontology_delta.similarity < 1.0:
-            await self.event_store.append(
+            await self._guard.gated_append(
                 lineage_ontology_evolved(
                     lineage.lineage_id,
                     generation_number,
@@ -605,38 +581,9 @@ class EvolutionaryLoop:
 
         action = StepAction.CONTINUE
         if signal.converged:
-            if generation_number >= self.config.max_generations:
-                await self.event_store.append(
-                    lineage_exhausted(
-                        lineage.lineage_id,
-                        generation_number,
-                        self.config.max_generations,
-                    )
-                )
-                lineage = lineage.with_status(LineageStatus.EXHAUSTED)
-                action = StepAction.EXHAUSTED
-            elif "Stagnation" in signal.reason or "Oscillation" in signal.reason:
-                await self.event_store.append(
-                    lineage_stagnated(
-                        lineage.lineage_id,
-                        generation_number,
-                        signal.reason,
-                        self.config.stagnation_window,
-                    )
-                )
-                lineage = lineage.with_status(LineageStatus.CONVERGED)
-                action = StepAction.STAGNATED
-            else:
-                await self.event_store.append(
-                    lineage_converged(
-                        lineage.lineage_id,
-                        generation_number,
-                        signal.reason,
-                        signal.ontology_similarity,
-                    )
-                )
-                lineage = lineage.with_status(LineageStatus.CONVERGED)
-                action = StepAction.CONVERGED
+            lineage, action = await self._emit_termination_step(
+                signal, lineage, generation_number
+            )
 
         return Result.ok(
             StepResult(
@@ -647,6 +594,74 @@ class EvolutionaryLoop:
                 next_generation=generation_number + 1,
             )
         )
+
+    async def _emit_termination(
+        self,
+        signal: ConvergenceSignal,
+        lineage: OntologyLineage,
+        generation_number: int,
+    ) -> OntologyLineage:
+        """Emit termination event and update lineage status. Used by run()."""
+        tr = signal.termination_reason
+
+        if tr == TerminationReason.EXHAUSTED:
+            await self._guard.gated_append(
+                lineage_exhausted(
+                    lineage.lineage_id,
+                    generation_number,
+                    self.config.max_generations,
+                    termination_reason=str(tr),
+                )
+            )
+            return lineage.with_status(LineageStatus.EXHAUSTED, termination_reason=tr)
+
+        if tr in (
+            TerminationReason.STAGNATED,
+            TerminationReason.OSCILLATED,
+            TerminationReason.REPETITIVE,
+        ):
+            await self._guard.gated_append(
+                lineage_stagnated(
+                    lineage.lineage_id,
+                    generation_number,
+                    signal.reason,
+                    self.config.stagnation_window,
+                    termination_reason=str(tr),
+                )
+            )
+            return lineage.with_status(LineageStatus.CONVERGED, termination_reason=tr)
+
+        # Default: CONVERGED (ontology stable)
+        await self._guard.gated_append(
+            lineage_converged(
+                lineage.lineage_id,
+                generation_number,
+                signal.reason,
+                signal.ontology_similarity,
+                termination_reason=str(tr),
+            )
+        )
+        return lineage.with_status(LineageStatus.CONVERGED, termination_reason=tr)
+
+    async def _emit_termination_step(
+        self,
+        signal: ConvergenceSignal,
+        lineage: OntologyLineage,
+        generation_number: int,
+    ) -> tuple[OntologyLineage, StepAction]:
+        """Emit termination event and return (lineage, action). Used by evolve_step()."""
+        tr = signal.termination_reason
+        lineage = await self._emit_termination(signal, lineage, generation_number)
+
+        if tr == TerminationReason.EXHAUSTED:
+            return lineage, StepAction.EXHAUSTED
+        if tr in (
+            TerminationReason.STAGNATED,
+            TerminationReason.OSCILLATED,
+            TerminationReason.REPETITIVE,
+        ):
+            return lineage, StepAction.STAGNATED
+        return lineage, StepAction.CONVERGED
 
     async def _run_generation(
         self,
@@ -680,7 +695,7 @@ class EvolutionaryLoop:
                 },
             )
             try:
-                await self.event_store.append(
+                await self._guard.gated_append(
                     lineage_generation_failed(
                         lineage.lineage_id,
                         generation_number,
@@ -714,7 +729,7 @@ class EvolutionaryLoop:
             prev_gen = lineage.generations[-1]
 
             # Emit generation started
-            await self.event_store.append(
+            await self._guard.gated_append(
                 lineage_generation_started(
                     lineage.lineage_id,
                     generation_number,
@@ -758,7 +773,7 @@ class EvolutionaryLoop:
                         )
                 else:
                     # Wonder degraded - emit event but continue
-                    await self.event_store.append(
+                    await self._guard.gated_append(
                         lineage_wonder_degraded(
                             lineage.lineage_id,
                             generation_number,
@@ -767,7 +782,7 @@ class EvolutionaryLoop:
                     )
 
             # Phase transition: wondering → reflecting
-            await self.event_store.append(
+            await self._guard.gated_append(
                 lineage_generation_phase_changed(
                     lineage.lineage_id,
                     generation_number,
@@ -800,7 +815,7 @@ class EvolutionaryLoop:
                             },
                         )
                     else:
-                        await self.event_store.append(
+                        await self._guard.gated_append(
                             lineage_generation_failed(
                                 lineage.lineage_id,
                                 generation_number,
@@ -827,7 +842,7 @@ class EvolutionaryLoop:
                     )
 
                 # Phase transition: reflecting → seeding
-                await self.event_store.append(
+                await self._guard.gated_append(
                     lineage_generation_phase_changed(
                         lineage.lineage_id,
                         generation_number,
@@ -842,7 +857,7 @@ class EvolutionaryLoop:
                         reflect_output,
                     )
                     if seed_result.is_err:
-                        await self.event_store.append(
+                        await self._guard.gated_append(
                             lineage_generation_failed(
                                 lineage.lineage_id,
                                 generation_number,
@@ -865,7 +880,7 @@ class EvolutionaryLoop:
 
         else:
             # Gen 1: just emit started event
-            await self.event_store.append(
+            await self._guard.gated_append(
                 lineage_generation_started(
                     lineage.lineage_id,
                     generation_number,
@@ -875,7 +890,7 @@ class EvolutionaryLoop:
             )
 
         # Phase transition: → executing
-        await self.event_store.append(
+        await self._guard.gated_append(
             lineage_generation_phase_changed(
                 lineage.lineage_id,
                 generation_number,
@@ -902,7 +917,7 @@ class EvolutionaryLoop:
                         },
                     )
                 elif hasattr(exec_result, "is_ok"):
-                    await self.event_store.append(
+                    await self._guard.gated_append(
                         lineage_generation_failed(
                             lineage.lineage_id,
                             generation_number,
@@ -914,7 +929,7 @@ class EvolutionaryLoop:
                 else:
                     execution_output = str(exec_result)
             except Exception as e:
-                await self.event_store.append(
+                await self._guard.gated_append(
                     lineage_generation_failed(
                         lineage.lineage_id,
                         generation_number,
@@ -963,7 +978,7 @@ class EvolutionaryLoop:
                 validation_passed = False
 
         # Phase transition: → evaluating
-        await self.event_store.append(
+        await self._guard.gated_append(
             lineage_generation_phase_changed(
                 lineage.lineage_id,
                 generation_number,
@@ -1002,7 +1017,7 @@ class EvolutionaryLoop:
                     iteration=generation_number,
                     metrics=drift_metrics,
                 )
-                await self.event_store.append(drift_event)
+                await self._guard.gated_append(drift_event)
             except Exception as e:
                 logger.warning(
                     "evolution.drift.measurement_failed",
@@ -1047,7 +1062,7 @@ class EvolutionaryLoop:
 
             from ouroboros.events.lineage import lineage_rewound
 
-            await self.event_store.append(
+            await self._guard.gated_append(
                 lineage_rewound(
                     lineage.lineage_id,
                     from_gen,

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -77,6 +77,8 @@ class EvolutionaryLoopConfig:
     validation_gate_enabled: bool = True
     ontology_completeness_gate_enabled: bool = False
     ontology_min_fields: int = 3
+    wonder_gate_enabled: bool = False
+    wonder_novelty_threshold: float = 0.5
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,6 +186,8 @@ class EvolutionaryLoop:
             validation_gate_enabled=self.config.validation_gate_enabled,
             ontology_completeness_gate_enabled=self.config.ontology_completeness_gate_enabled,
             ontology_min_fields=self.config.ontology_min_fields,
+            wonder_gate_enabled=self.config.wonder_gate_enabled,
+            wonder_novelty_threshold=self.config.wonder_novelty_threshold,
         )
 
     def set_project_dir(self, project_dir: str | None) -> Token[str | None]:

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -83,6 +83,7 @@ class GenerationResult:
     reflect_output: ReflectOutput | None = None
     ontology_delta: OntologyDelta | None = None
     validation_output: str | None = None
+    validation_passed: bool | None = None
     phase: GenerationPhase = GenerationPhase.COMPLETED
     success: bool = True
 
@@ -312,6 +313,7 @@ class EvolutionaryLoop:
                 result.wonder_output,
                 latest_evaluation=result.evaluation_summary,
                 validation_output=result.validation_output,
+                validation_passed=result.validation_passed,
             )
 
             if signal.converged:
@@ -924,19 +926,25 @@ class EvolutionaryLoop:
 
         # Validate phase - reconcile parallel execution artifacts
         validation_output: str | None = None
+        validation_passed: bool | None = None
         if execute and execution_output and self.validator:
             try:
                 validation_result = await self.validator(current_seed, execution_output)
                 if isinstance(validation_result, str):
                     validation_output = validation_result
+                    validation_passed = True
                 elif hasattr(validation_result, "is_ok"):
                     if validation_result.is_ok:
                         validation_output = str(validation_result.value)
+                        validation_passed = True
                     else:
                         validation_output = f"Validation error: {validation_result.error}"
+                        validation_passed = False
                 else:
                     validation_output = str(validation_result)
+                    validation_passed = True
                 if validation_output and "skipped" in validation_output.lower():
+                    validation_passed = False
                     logger.warning(
                         "evolution.generation.validation_skipped",
                         extra={"generation": generation_number, "output": validation_output},
@@ -952,6 +960,7 @@ class EvolutionaryLoop:
                     extra={"error": str(e), "generation": generation_number},
                 )
                 validation_output = f"Validation skipped: {e}"
+                validation_passed = False
 
         # Phase transition: → evaluating
         await self.event_store.append(
@@ -1010,6 +1019,7 @@ class EvolutionaryLoop:
                 reflect_output=reflect_output,
                 ontology_delta=ontology_delta,
                 validation_output=validation_output,
+                validation_passed=validation_passed,
                 phase=GenerationPhase.COMPLETED,
                 success=True,
             )

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -79,6 +79,8 @@ class EvolutionaryLoopConfig:
     ontology_min_fields: int = 3
     wonder_gate_enabled: bool = False
     wonder_novelty_threshold: float = 0.5
+    drift_trend_gate_enabled: bool = False
+    drift_trend_window: int = 3
 
 
 @dataclass(frozen=True, slots=True)
@@ -188,6 +190,8 @@ class EvolutionaryLoop:
             ontology_min_fields=self.config.ontology_min_fields,
             wonder_gate_enabled=self.config.wonder_gate_enabled,
             wonder_novelty_threshold=self.config.wonder_novelty_threshold,
+            drift_trend_gate_enabled=self.config.drift_trend_gate_enabled,
+            drift_trend_window=self.config.drift_trend_window,
         )
 
     def set_project_dir(self, project_dir: str | None) -> Token[str | None]:
@@ -593,6 +597,7 @@ class EvolutionaryLoop:
             result.wonder_output,
             latest_evaluation=result.evaluation_summary,
             validation_output=result.validation_output,
+            validation_passed=result.validation_passed,
         )
 
         action = StepAction.CONTINUE

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -351,9 +351,7 @@ class EvolutionaryLoop:
                     },
                 )
 
-                lineage = await self._emit_termination(
-                    signal, lineage, generation_number
-                )
+                lineage = await self._emit_termination(signal, lineage, generation_number)
                 break
 
             # Prepare for next generation
@@ -602,9 +600,7 @@ class EvolutionaryLoop:
 
         action = StepAction.CONTINUE
         if signal.converged:
-            lineage, action = await self._emit_termination_step(
-                signal, lineage, generation_number
-            )
+            lineage, action = await self._emit_termination_step(signal, lineage, generation_number)
 
         return Result.ok(
             StepResult(

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -631,7 +631,27 @@ class EvolutionaryLoop:
             )
             return lineage.with_status(LineageStatus.CONVERGED, termination_reason=tr)
 
-        # Default: CONVERGED (ontology stable)
+        if tr == TerminationReason.CONVERGED:
+            await self._guard.gated_append(
+                lineage_converged(
+                    lineage.lineage_id,
+                    generation_number,
+                    signal.reason,
+                    signal.ontology_similarity,
+                    termination_reason=str(tr),
+                )
+            )
+            return lineage.with_status(LineageStatus.CONVERGED, termination_reason=tr)
+
+        # Defensive: unknown TerminationReason falls back to CONVERGED with warning
+        logger.warning(
+            "evolution.termination.unknown_reason",
+            extra={
+                "termination_reason": str(tr),
+                "lineage_id": lineage.lineage_id,
+                "generation": generation_number,
+            },
+        )
         await self._guard.gated_append(
             lineage_converged(
                 lineage.lineage_id,
@@ -661,6 +681,7 @@ class EvolutionaryLoop:
             TerminationReason.REPETITIVE,
         ):
             return lineage, StepAction.STAGNATED
+        # CONVERGED or unknown
         return lineage, StepAction.CONVERGED
 
     async def _run_generation(

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -71,6 +71,12 @@ class EvolutionaryLoopConfig:
     enable_oscillation_detection: bool = True
     eval_gate_enabled: bool = True
     eval_min_score: float = 0.7
+    ac_gate_mode: str = "all"
+    ac_min_pass_ratio: float = 1.0
+    regression_gate_enabled: bool = True
+    validation_gate_enabled: bool = True
+    ontology_completeness_gate_enabled: bool = False
+    ontology_min_fields: int = 3
 
 
 @dataclass(frozen=True, slots=True)
@@ -172,6 +178,12 @@ class EvolutionaryLoop:
             enable_oscillation_detection=self.config.enable_oscillation_detection,
             eval_gate_enabled=self.config.eval_gate_enabled,
             eval_min_score=self.config.eval_min_score,
+            ac_gate_mode=self.config.ac_gate_mode,
+            ac_min_pass_ratio=self.config.ac_min_pass_ratio,
+            regression_gate_enabled=self.config.regression_gate_enabled,
+            validation_gate_enabled=self.config.validation_gate_enabled,
+            ontology_completeness_gate_enabled=self.config.ontology_completeness_gate_enabled,
+            ontology_min_fields=self.config.ontology_min_fields,
         )
 
     def set_project_dir(self, project_dir: str | None) -> Token[str | None]:

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -424,7 +424,11 @@ class EvolutionaryLoop:
                 return Result.err(OuroborosError("Failed to project lineage from events"))
 
             # Check if lineage is already terminated
-            if lineage.status in (LineageStatus.CONVERGED, LineageStatus.EXHAUSTED):
+            if lineage.status in (
+                LineageStatus.CONVERGED,
+                LineageStatus.EXHAUSTED,
+                LineageStatus.ABORTED,
+            ):
                 return Result.err(
                     OuroborosError(
                         f"Lineage already terminated with status: {lineage.status.value}"
@@ -612,6 +616,16 @@ class EvolutionaryLoop:
             )
         )
 
+    # Dispatch table: TerminationReason → (event_factory_key, LineageStatus)
+    # event_factory_key: "exhausted", "stagnated", or "converged"
+    _TERMINATION_DISPATCH: dict[TerminationReason, tuple[str, LineageStatus]] = {
+        TerminationReason.EXHAUSTED: ("exhausted", LineageStatus.EXHAUSTED),
+        TerminationReason.STAGNATED: ("stagnated", LineageStatus.CONVERGED),
+        TerminationReason.OSCILLATED: ("stagnated", LineageStatus.CONVERGED),
+        TerminationReason.REPETITIVE: ("stagnated", LineageStatus.CONVERGED),
+        TerminationReason.CONVERGED: ("converged", LineageStatus.CONVERGED),
+    }
+
     async def _emit_termination(
         self,
         signal: ConvergenceSignal,
@@ -620,65 +634,48 @@ class EvolutionaryLoop:
     ) -> OntologyLineage:
         """Emit termination event and update lineage status. Used by run()."""
         tr = signal.termination_reason
+        dispatch = self._TERMINATION_DISPATCH.get(tr)
 
-        if tr == TerminationReason.EXHAUSTED:
-            await self._guard.gated_append(
-                lineage_exhausted(
-                    lineage.lineage_id,
-                    generation_number,
-                    self.config.max_generations,
-                    termination_reason=str(tr),
-                )
+        if dispatch is None:
+            # Defensive: unknown TerminationReason falls back to CONVERGED
+            logger.warning(
+                "evolution.termination.unknown_reason",
+                extra={
+                    "termination_reason": str(tr),
+                    "lineage_id": lineage.lineage_id,
+                    "generation": generation_number,
+                },
             )
-            return lineage.with_status(LineageStatus.EXHAUSTED, termination_reason=tr)
+            dispatch = ("converged", LineageStatus.CONVERGED)
 
-        if tr in (
-            TerminationReason.STAGNATED,
-            TerminationReason.OSCILLATED,
-            TerminationReason.REPETITIVE,
-        ):
-            await self._guard.gated_append(
-                lineage_stagnated(
-                    lineage.lineage_id,
-                    generation_number,
-                    signal.reason,
-                    self.config.stagnation_window,
-                    termination_reason=str(tr),
-                )
+        event_key, target_status = dispatch
+
+        if event_key == "exhausted":
+            event = lineage_exhausted(
+                lineage.lineage_id,
+                generation_number,
+                self.config.max_generations,
+                termination_reason=str(tr),
             )
-            return lineage.with_status(LineageStatus.CONVERGED, termination_reason=tr)
-
-        if tr == TerminationReason.CONVERGED:
-            await self._guard.gated_append(
-                lineage_converged(
-                    lineage.lineage_id,
-                    generation_number,
-                    signal.reason,
-                    signal.ontology_similarity,
-                    termination_reason=str(tr),
-                )
+        elif event_key == "stagnated":
+            event = lineage_stagnated(
+                lineage.lineage_id,
+                generation_number,
+                signal.reason,
+                self.config.stagnation_window,
+                termination_reason=str(tr),
             )
-            return lineage.with_status(LineageStatus.CONVERGED, termination_reason=tr)
-
-        # Defensive: unknown TerminationReason falls back to CONVERGED with warning
-        logger.warning(
-            "evolution.termination.unknown_reason",
-            extra={
-                "termination_reason": str(tr),
-                "lineage_id": lineage.lineage_id,
-                "generation": generation_number,
-            },
-        )
-        await self._guard.gated_append(
-            lineage_converged(
+        else:  # converged
+            event = lineage_converged(
                 lineage.lineage_id,
                 generation_number,
                 signal.reason,
                 signal.ontology_similarity,
                 termination_reason=str(tr),
             )
-        )
-        return lineage.with_status(LineageStatus.CONVERGED, termination_reason=tr)
+
+        await self._guard.gated_append(event)
+        return lineage.with_status(target_status, termination_reason=tr)
 
     async def _emit_termination_step(
         self,

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -184,9 +184,7 @@ class LineageProjector:
                             tr = _DEFAULT_TERMINATION[event.type]
                     else:
                         raw_reason = event.data.get("reason", "")
-                        tr = _LEGACY_REASON_MAP.get(
-                            raw_reason, _DEFAULT_TERMINATION[event.type]
-                        )
+                        tr = _LEGACY_REASON_MAP.get(raw_reason, _DEFAULT_TERMINATION[event.type])
                     lineage = lineage.with_status(target_status, termination_reason=tr)
 
             elif event.type == "lineage.rewound":

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -13,9 +13,27 @@ from ouroboros.core.lineage import (
     LineageStatus,
     OntologyLineage,
     RewindRecord,
+    TerminationReason,
 )
 from ouroboros.core.seed import OntologySchema
 from ouroboros.events.base import BaseEvent
+from ouroboros.evolution.transitions import TERMINAL_EVENT_STATUS
+
+# Legacy reason strings → TerminationReason mapping for events
+# stored before TerminationReason was introduced.
+_LEGACY_REASON_MAP: dict[str, TerminationReason] = {
+    "ontology_converged": TerminationReason.CONVERGED,
+    "max_generations": TerminationReason.EXHAUSTED,
+    "stagnation": TerminationReason.STAGNATED,
+}
+
+# Default TerminationReason by event type (fallback when neither
+# termination_reason nor reason is in event data).
+_DEFAULT_TERMINATION: dict[str, TerminationReason] = {
+    "lineage.converged": TerminationReason.CONVERGED,
+    "lineage.exhausted": TerminationReason.EXHAUSTED,
+    "lineage.stagnated": TerminationReason.STAGNATED,
+}
 
 # Sentinel for generations that haven't completed (started/failed).
 # These don't have a real ontology yet, but GenerationRecord requires one.
@@ -30,6 +48,24 @@ class LineageProjector:
         projector = LineageProjector()
         lineage = projector.project(events)
     """
+
+    @staticmethod
+    def resolve_status(events: list[BaseEvent]) -> LineageStatus:
+        """Determine current LineageStatus from event stream.
+
+        Scans events in reverse for early return. Uses TERMINAL_EVENT_STATUS
+        as the single source of truth (shared with guard.py).
+
+        Args:
+            events: Ordered list of lineage events from EventStore.replay().
+
+        Returns:
+            Current LineageStatus (defaults to ACTIVE if no terminal events found).
+        """
+        for event in reversed(events):
+            if event.type in TERMINAL_EVENT_STATUS:
+                return TERMINAL_EVENT_STATUS[event.type]
+        return LineageStatus.ACTIVE
 
     def project(self, events: list[BaseEvent]) -> OntologyLineage | None:
         """Fold events into OntologyLineage state.
@@ -133,26 +169,25 @@ class LineageProjector:
                         failure_error=error_msg,
                     )
 
-            elif event.type == "lineage.converged":
+            elif event.type in ("lineage.converged", "lineage.exhausted", "lineage.stagnated"):
                 if lineage is not None:
-                    reason = event.data.get("reason", "ontology_converged")
-                    lineage = lineage.with_status(
-                        LineageStatus.CONVERGED, termination_reason=reason
-                    )
-
-            elif event.type == "lineage.exhausted":
-                if lineage is not None:
-                    reason = event.data.get("reason", "max_generations")
-                    lineage = lineage.with_status(
-                        LineageStatus.EXHAUSTED, termination_reason=reason
-                    )
-
-            elif event.type == "lineage.stagnated":
-                if lineage is not None:
-                    reason = event.data.get("reason", "stagnation")
-                    lineage = lineage.with_status(
-                        LineageStatus.CONVERGED, termination_reason=reason
-                    )
+                    target_status = TERMINAL_EVENT_STATUS[event.type]
+                    # Resolve termination_reason with fallback chain:
+                    # 1. New field: event.data["termination_reason"] (enum value string)
+                    # 2. Legacy field: event.data["reason"] → _LEGACY_REASON_MAP
+                    # 3. Default by event type
+                    raw_tr = event.data.get("termination_reason")
+                    if raw_tr:
+                        try:
+                            tr: TerminationReason | str = TerminationReason(raw_tr)
+                        except ValueError:
+                            tr = _DEFAULT_TERMINATION[event.type]
+                    else:
+                        raw_reason = event.data.get("reason", "")
+                        tr = _LEGACY_REASON_MAP.get(
+                            raw_reason, _DEFAULT_TERMINATION[event.type]
+                        )
+                    lineage = lineage.with_status(target_status, termination_reason=tr)
 
             elif event.type == "lineage.rewound":
                 data = event.data

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -135,15 +135,24 @@ class LineageProjector:
 
             elif event.type == "lineage.converged":
                 if lineage is not None:
-                    lineage = lineage.with_status(LineageStatus.CONVERGED)
+                    reason = event.data.get("reason", "ontology_converged")
+                    lineage = lineage.with_status(
+                        LineageStatus.CONVERGED, termination_reason=reason
+                    )
 
             elif event.type == "lineage.exhausted":
                 if lineage is not None:
-                    lineage = lineage.with_status(LineageStatus.EXHAUSTED)
+                    reason = event.data.get("reason", "max_generations")
+                    lineage = lineage.with_status(
+                        LineageStatus.EXHAUSTED, termination_reason=reason
+                    )
 
             elif event.type == "lineage.stagnated":
                 if lineage is not None:
-                    lineage = lineage.with_status(LineageStatus.CONVERGED)
+                    reason = event.data.get("reason", "stagnation")
+                    lineage = lineage.with_status(
+                        LineageStatus.CONVERGED, termination_reason=reason
+                    )
 
             elif event.type == "lineage.rewound":
                 data = event.data

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -179,7 +179,7 @@ class LineageProjector:
                     raw_tr = event.data.get("termination_reason")
                     if raw_tr:
                         try:
-                            tr: TerminationReason | str = TerminationReason(raw_tr)
+                            tr: TerminationReason = TerminationReason(raw_tr)
                         except ValueError:
                             tr = _DEFAULT_TERMINATION[event.type]
                     else:

--- a/src/ouroboros/evolution/transitions.py
+++ b/src/ouroboros/evolution/transitions.py
@@ -1,0 +1,63 @@
+"""Lineage state transition matrix for Gate Guard validation.
+
+Defines which events are allowed in each LineageStatus, and the mapping
+from terminal events to their resulting status. Both guard.py and
+projector.py reference these definitions as the single source of truth.
+"""
+
+from __future__ import annotations
+
+from ouroboros.core.lineage import LineageStatus
+
+# Terminal event → resulting LineageStatus mapping.
+# Used by LineageProjector.resolve_status() and project() to determine
+# lineage status from events. Single source of truth for both guard and projector.
+TERMINAL_EVENT_STATUS: dict[str, LineageStatus] = {
+    "lineage.converged": LineageStatus.CONVERGED,
+    "lineage.stagnated": LineageStatus.CONVERGED,  # stagnation is a form of convergence
+    "lineage.exhausted": LineageStatus.EXHAUSTED,
+    "lineage.rewound": LineageStatus.ACTIVE,
+}
+
+# LineageStatus × event_type → allowed?
+# lineage.created is handled separately (always allowed as the first event).
+# Non-lineage events (aggregate_type != "lineage") bypass the guard entirely.
+# Observation events (ontology.evolved, wonder.degraded) don't change status
+# but are only valid while the lineage is ACTIVE.
+ALLOWED_TRANSITIONS: dict[LineageStatus, frozenset[str]] = {
+    LineageStatus.ACTIVE: frozenset(
+        {
+            "lineage.generation.started",
+            "lineage.generation.completed",
+            "lineage.generation.phase_changed",
+            "lineage.generation.failed",
+            "lineage.ontology.evolved",
+            "lineage.converged",
+            "lineage.exhausted",
+            "lineage.stagnated",
+            "lineage.rewound",
+            "lineage.wonder.degraded",
+        }
+    ),
+    LineageStatus.CONVERGED: frozenset(
+        {
+            "lineage.rewound",  # rewind restores ACTIVE status
+        }
+    ),
+    LineageStatus.EXHAUSTED: frozenset(
+        {
+            "lineage.rewound",
+        }
+    ),
+    # ABORTED is a terminal state with no exit transitions.
+    # Entry event (lineage.aborted) is not yet implemented.
+    LineageStatus.ABORTED: frozenset(),
+}
+
+
+def is_transition_allowed(status: LineageStatus, event_type: str) -> bool:
+    """Check if an event type is allowed in the given lineage status."""
+    allowed = ALLOWED_TRANSITIONS.get(status)
+    if allowed is None:
+        return False
+    return event_type in allowed

--- a/tests/unit/evolution/test_event_contract.py
+++ b/tests/unit/evolution/test_event_contract.py
@@ -8,10 +8,8 @@ drops when new lineage events are added without updating the projector.
 from __future__ import annotations
 
 import ast
-import re
 from pathlib import Path
-
-import pytest
+import re
 
 # --- Paths ---
 _SRC = Path(__file__).resolve().parents[3] / "src" / "ouroboros"

--- a/tests/unit/evolution/test_event_contract.py
+++ b/tests/unit/evolution/test_event_contract.py
@@ -24,9 +24,7 @@ def _extract_event_types_from_factories(path: Path) -> set[str]:
     types: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.keyword) and node.arg == "type":
-            if isinstance(node.value, ast.Constant) and isinstance(
-                node.value.value, str
-            ):
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
                 types.add(node.value.value)
     return types
 
@@ -37,7 +35,7 @@ def _extract_handled_types_from_projector(path: Path) -> set[str]:
     # Match event.type == "..."
     types = set(re.findall(r'event\.type\s*==\s*"([^"]+)"', source))
     # Match event.type in ("...", "...", ...)
-    in_matches = re.findall(r'event\.type\s+in\s*\(([^)]+)\)', source)
+    in_matches = re.findall(r"event\.type\s+in\s*\(([^)]+)\)", source)
     for match in in_matches:
         types |= set(re.findall(r'"([^"]+)"', match))
     return types

--- a/tests/unit/evolution/test_event_contract.py
+++ b/tests/unit/evolution/test_event_contract.py
@@ -1,0 +1,120 @@
+"""Contract test: lineage event factory types must match projector handling.
+
+Ensures every event type defined in events/lineage.py is explicitly handled
+(or explicitly excluded) by LineageProjector.project(). Prevents silent event
+drops when new lineage events are added without updating the projector.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+# --- Paths ---
+_SRC = Path(__file__).resolve().parents[3] / "src" / "ouroboros"
+_LINEAGE_EVENTS = _SRC / "events" / "lineage.py"
+_PROJECTOR = _SRC / "evolution" / "projector.py"
+
+
+def _extract_event_types_from_factories(path: Path) -> set[str]:
+    """Extract all event type strings from BaseEvent(type=...) calls."""
+    source = path.read_text()
+    tree = ast.parse(source)
+    types: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "type":
+            if isinstance(node.value, ast.Constant) and isinstance(
+                node.value.value, str
+            ):
+                types.add(node.value.value)
+    return types
+
+
+def _extract_handled_types_from_projector(path: Path) -> set[str]:
+    """Extract all event.type == '...' and event.type in (...) comparisons from projector."""
+    source = path.read_text()
+    # Match event.type == "..."
+    types = set(re.findall(r'event\.type\s*==\s*"([^"]+)"', source))
+    # Match event.type in ("...", "...", ...)
+    in_matches = re.findall(r'event\.type\s+in\s*\(([^)]+)\)', source)
+    for match in in_matches:
+        types |= set(re.findall(r'"([^"]+)"', match))
+    return types
+
+
+# Events that are intentionally NOT handled by the projector.
+# Each entry must have a justification comment.
+INTENTIONALLY_UNHANDLED: dict[str, str] = {
+    "lineage.ontology.evolved": (
+        "Observability-only event. Ontology data is already captured "
+        "in lineage.generation.completed via ontology_snapshot field."
+    ),
+    "lineage.wonder.degraded": (
+        "Observability-only event. Degraded wonder questions are still "
+        "recorded in generation.completed. No OntologyLineage field exists "
+        "for degradation state."
+    ),
+}
+
+
+class TestLineageEventContract:
+    """Verify that lineage event factories and projector stay in sync."""
+
+    def test_all_factory_events_are_handled_or_excluded(self) -> None:
+        """Every event type in events/lineage.py must be either:
+        - handled in projector.py (event.type == "...")
+        - listed in INTENTIONALLY_UNHANDLED with justification
+        """
+        factory_types = _extract_event_types_from_factories(_LINEAGE_EVENTS)
+        handled_types = _extract_handled_types_from_projector(_PROJECTOR)
+        excluded_types = set(INTENTIONALLY_UNHANDLED.keys())
+
+        unaccounted = factory_types - handled_types - excluded_types
+
+        assert not unaccounted, (
+            f"Lineage event types defined in events/lineage.py but neither "
+            f"handled by LineageProjector nor listed in INTENTIONALLY_UNHANDLED: "
+            f"{sorted(unaccounted)}. "
+            f"Either add handling in projector.py or add to "
+            f"INTENTIONALLY_UNHANDLED with justification."
+        )
+
+    def test_projector_handles_no_phantom_events(self) -> None:
+        """Projector must not handle event types that don't exist in factories."""
+        factory_types = _extract_event_types_from_factories(_LINEAGE_EVENTS)
+        handled_types = _extract_handled_types_from_projector(_PROJECTOR)
+
+        phantom = handled_types - factory_types
+
+        assert not phantom, (
+            f"LineageProjector handles event types not defined in "
+            f"events/lineage.py: {sorted(phantom)}. "
+            f"Remove stale handlers or add missing factory functions."
+        )
+
+    def test_exclusion_list_has_no_stale_entries(self) -> None:
+        """INTENTIONALLY_UNHANDLED must not contain events that are now handled."""
+        handled_types = _extract_handled_types_from_projector(_PROJECTOR)
+        excluded_types = set(INTENTIONALLY_UNHANDLED.keys())
+
+        stale = excluded_types & handled_types
+
+        assert not stale, (
+            f"Events in INTENTIONALLY_UNHANDLED are now handled by projector: "
+            f"{sorted(stale)}. Remove them from the exclusion list."
+        )
+
+    def test_exclusion_entries_exist_in_factories(self) -> None:
+        """INTENTIONALLY_UNHANDLED entries must reference real factory events."""
+        factory_types = _extract_event_types_from_factories(_LINEAGE_EVENTS)
+        excluded_types = set(INTENTIONALLY_UNHANDLED.keys())
+
+        invalid = excluded_types - factory_types
+
+        assert not invalid, (
+            f"INTENTIONALLY_UNHANDLED references non-existent event types: "
+            f"{sorted(invalid)}. Remove invalid entries."
+        )

--- a/tests/unit/evolution/test_guard.py
+++ b/tests/unit/evolution/test_guard.py
@@ -1,0 +1,178 @@
+"""Unit tests for LineageGuard — transition validation before persistence.
+
+Tests the gated_append() flow:
+- Non-lineage events pass through without validation
+- lineage.created always passes
+- Valid transitions are allowed
+- Invalid transitions raise TransitionError
+- Rewind re-enables generation events after convergence
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ouroboros.core.errors import TransitionError
+from ouroboros.core.lineage import LineageStatus
+from ouroboros.events.base import BaseEvent
+from ouroboros.events.lineage import (
+    lineage_converged,
+    lineage_created,
+    lineage_exhausted,
+    lineage_generation_started,
+    lineage_rewound,
+    lineage_stagnated,
+)
+from ouroboros.evolution.guard import LineageGuard
+
+
+@pytest.fixture
+def mock_event_store() -> AsyncMock:
+    store = AsyncMock()
+    store.append = AsyncMock()
+    store.replay_lineage = AsyncMock(return_value=[])
+    return store
+
+
+@pytest.fixture
+def guard(mock_event_store: AsyncMock) -> LineageGuard:
+    return LineageGuard(mock_event_store)
+
+
+class TestNonLineagePassthrough:
+    """Non-lineage events bypass guard entirely."""
+
+    @pytest.mark.asyncio
+    async def test_drift_event_passes_through(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        event = BaseEvent(
+            type="drift.measured",
+            aggregate_type="execution",
+            aggregate_id="exec_123",
+            data={},
+        )
+        await guard.gated_append(event)
+        mock_event_store.append.assert_awaited_once_with(event)
+
+    @pytest.mark.asyncio
+    async def test_session_event_passes_through(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        event = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id="sess_123",
+            data={},
+        )
+        await guard.gated_append(event)
+        mock_event_store.append.assert_awaited_once_with(event)
+
+
+class TestCreatedAlwaysPasses:
+    """lineage.created always passes without status check."""
+
+    @pytest.mark.asyncio
+    async def test_created_bypasses_validation(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        event = lineage_created("lin_abc", "test goal")
+        await guard.gated_append(event)
+        mock_event_store.append.assert_awaited_once_with(event)
+        # replay_lineage should NOT be called for created events
+        mock_event_store.replay_lineage.assert_not_awaited()
+
+
+class TestValidTransitions:
+    """Events allowed by the transition matrix are stored."""
+
+    @pytest.mark.asyncio
+    async def test_active_allows_generation_started(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        """ACTIVE lineage allows generation.started."""
+        # No terminal events → status is ACTIVE
+        mock_event_store.replay_lineage.return_value = []
+        event = lineage_generation_started("lin_abc", 1, "wondering")
+        await guard.gated_append(event)
+        mock_event_store.append.assert_awaited_once_with(event)
+
+
+class TestInvalidTransitions:
+    """Events not in the transition matrix raise TransitionError."""
+
+    @pytest.mark.asyncio
+    async def test_converged_rejects_generation_started(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        """CONVERGED lineage rejects generation.started."""
+        # Simulate converged state
+        mock_event_store.replay_lineage.return_value = [
+            lineage_created("lin_abc", "goal"),
+            lineage_converged("lin_abc", 3, "stable", 0.98),
+        ]
+        event = lineage_generation_started("lin_abc", 4, "wondering")
+        with pytest.raises(TransitionError) as exc_info:
+            await guard.gated_append(event)
+        assert exc_info.value.current_status == "converged"
+        assert exc_info.value.event_type == "lineage.generation.started"
+        # Event should NOT be stored
+        mock_event_store.append.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_exhausted_rejects_generation_started(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        mock_event_store.replay_lineage.return_value = [
+            lineage_created("lin_abc", "goal"),
+            lineage_exhausted("lin_abc", 30, 30),
+        ]
+        event = lineage_generation_started("lin_abc", 31, "wondering")
+        with pytest.raises(TransitionError):
+            await guard.gated_append(event)
+
+    @pytest.mark.asyncio
+    async def test_stagnated_maps_to_converged(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        """lineage.stagnated results in CONVERGED status (same as projector)."""
+        mock_event_store.replay_lineage.return_value = [
+            lineage_created("lin_abc", "goal"),
+            lineage_stagnated("lin_abc", 5, "Stagnation detected", 3),
+        ]
+        event = lineage_generation_started("lin_abc", 6, "wondering")
+        with pytest.raises(TransitionError) as exc_info:
+            await guard.gated_append(event)
+        assert exc_info.value.current_status == "converged"
+
+
+class TestRewindReactivation:
+    """Rewind restores ACTIVE status, enabling new generation events."""
+
+    @pytest.mark.asyncio
+    async def test_rewind_after_converged_allows_generation(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        # Converged, then rewound → ACTIVE
+        mock_event_store.replay_lineage.return_value = [
+            lineage_created("lin_abc", "goal"),
+            lineage_converged("lin_abc", 3, "stable", 0.98),
+            lineage_rewound("lin_abc", 3, 2),
+        ]
+        event = lineage_generation_started("lin_abc", 3, "wondering")
+        await guard.gated_append(event)
+        mock_event_store.append.assert_awaited_once_with(event)
+
+    @pytest.mark.asyncio
+    async def test_converged_allows_rewound(
+        self, guard: LineageGuard, mock_event_store: AsyncMock
+    ) -> None:
+        mock_event_store.replay_lineage.return_value = [
+            lineage_created("lin_abc", "goal"),
+            lineage_converged("lin_abc", 3, "stable", 0.98),
+        ]
+        event = lineage_rewound("lin_abc", 3, 2)
+        await guard.gated_append(event)
+        mock_event_store.append.assert_awaited_once_with(event)

--- a/tests/unit/evolution/test_guard.py
+++ b/tests/unit/evolution/test_guard.py
@@ -10,12 +10,11 @@ Tests the gated_append() flow:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from ouroboros.core.errors import TransitionError
-from ouroboros.core.lineage import LineageStatus
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.lineage import (
     lineage_converged,

--- a/tests/unit/evolution/test_reflect_engine.py
+++ b/tests/unit/evolution/test_reflect_engine.py
@@ -1,0 +1,138 @@
+"""Unit tests for ReflectEngine._parse_response.
+
+Tests JSON parsing, mutation extraction, and fallback behavior without LLM calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.core.lineage import MutationAction
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.evolution.reflect import OntologyMutation, ReflectEngine, ReflectOutput
+
+
+def _make_engine() -> ReflectEngine:
+    """Create ReflectEngine with a dummy adapter (not used in these tests)."""
+
+    class DummyAdapter:
+        async def complete(self, messages, config):
+            raise NotImplementedError
+
+    return ReflectEngine(llm_adapter=DummyAdapter())  # type: ignore[arg-type]
+
+
+def _make_seed(**overrides) -> Seed:
+    defaults = {
+        "goal": "Build a task manager",
+        "constraints": ("Must use Python",),
+        "acceptance_criteria": ("Tasks can be created",),
+        "ontology_schema": OntologySchema(
+            name="TaskManager",
+            description="A task management system",
+            fields=(
+                OntologyField(name="task", field_type="entity", description="A work item"),
+            ),
+        ),
+        "metadata": SeedMetadata(),
+    }
+    defaults.update(overrides)
+    return Seed(**defaults)
+
+
+class TestParseResponse:
+    """Tests for ReflectEngine._parse_response."""
+
+    def test_valid_full_response(self) -> None:
+        engine = _make_engine()
+        seed = _make_seed()
+        result = engine._parse_response(
+            '{"refined_goal": "Build a prioritized task manager", '
+            '"refined_constraints": ["Must use Python", "Must support priorities"], '
+            '"refined_acs": ["Tasks can be created", "Tasks can be prioritized"], '
+            '"ontology_mutations": ['
+            '  {"action": "add", "field_name": "priority", "field_type": "enum", '
+            '   "description": "Task priority level", "reason": "Missing from ontology"}'
+            '], '
+            '"reasoning": "Priority was identified as a gap"}',
+            seed,
+        )
+        assert result is not None
+        assert result.refined_goal == "Build a prioritized task manager"
+        assert len(result.refined_constraints) == 2
+        assert len(result.refined_acs) == 2
+        assert len(result.ontology_mutations) == 1
+        assert result.ontology_mutations[0].action == MutationAction.ADD
+        assert result.ontology_mutations[0].field_name == "priority"
+
+    def test_json_with_markdown_fences(self) -> None:
+        engine = _make_engine()
+        seed = _make_seed()
+        result = engine._parse_response(
+            '```json\n{"refined_goal": "g", "refined_constraints": [], '
+            '"refined_acs": [], "ontology_mutations": [], "reasoning": "r"}\n```',
+            seed,
+        )
+        assert result is not None
+        assert result.refined_goal == "g"
+
+    def test_invalid_json_returns_none(self) -> None:
+        engine = _make_engine()
+        seed = _make_seed()
+        result = engine._parse_response("not json", seed)
+        assert result is None
+
+    def test_missing_fields_use_seed_defaults(self) -> None:
+        engine = _make_engine()
+        seed = _make_seed()
+        result = engine._parse_response("{}", seed)
+        assert result is not None
+        assert result.refined_goal == seed.goal
+        assert result.refined_constraints == seed.constraints
+        assert result.refined_acs == seed.acceptance_criteria
+
+    def test_invalid_mutation_action_defaults_to_modify(self) -> None:
+        engine = _make_engine()
+        seed = _make_seed()
+        result = engine._parse_response(
+            '{"ontology_mutations": [{"action": "invalid_action", "field_name": "x"}]}',
+            seed,
+        )
+        assert result is not None
+        assert result.ontology_mutations[0].action == MutationAction.MODIFY
+
+    def test_mutation_missing_field_name_defaults(self) -> None:
+        engine = _make_engine()
+        seed = _make_seed()
+        result = engine._parse_response(
+            '{"ontology_mutations": [{"action": "add"}]}',
+            seed,
+        )
+        assert result is not None
+        assert result.ontology_mutations[0].field_name == "unknown"
+
+    def test_multiple_mutations(self) -> None:
+        engine = _make_engine()
+        seed = _make_seed()
+        result = engine._parse_response(
+            '{"ontology_mutations": ['
+            '  {"action": "add", "field_name": "a", "reason": "r1"},'
+            '  {"action": "modify", "field_name": "task", "reason": "r2"},'
+            '  {"action": "remove", "field_name": "old", "reason": "r3"}'
+            "]}",
+            seed,
+        )
+        assert result is not None
+        assert len(result.ontology_mutations) == 3
+        actions = [m.action for m in result.ontology_mutations]
+        assert actions == [MutationAction.ADD, MutationAction.MODIFY, MutationAction.REMOVE]
+
+    def test_empty_mutations_list(self) -> None:
+        engine = _make_engine()
+        seed = _make_seed()
+        result = engine._parse_response(
+            '{"refined_goal": "g", "ontology_mutations": []}',
+            seed,
+        )
+        assert result is not None
+        assert result.ontology_mutations == ()

--- a/tests/unit/evolution/test_reflect_engine.py
+++ b/tests/unit/evolution/test_reflect_engine.py
@@ -5,7 +5,6 @@ Tests JSON parsing, mutation extraction, and fallback behavior without LLM calls
 
 from __future__ import annotations
 
-
 from ouroboros.core.lineage import MutationAction
 from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
 from ouroboros.evolution.reflect import ReflectEngine

--- a/tests/unit/evolution/test_reflect_engine.py
+++ b/tests/unit/evolution/test_reflect_engine.py
@@ -28,9 +28,7 @@ def _make_seed(**overrides) -> Seed:
         "ontology_schema": OntologySchema(
             name="TaskManager",
             description="A task management system",
-            fields=(
-                OntologyField(name="task", field_type="entity", description="A work item"),
-            ),
+            fields=(OntologyField(name="task", field_type="entity", description="A work item"),),
         ),
         "metadata": SeedMetadata(),
     }
@@ -51,7 +49,7 @@ class TestParseResponse:
             '"ontology_mutations": ['
             '  {"action": "add", "field_name": "priority", "field_type": "enum", '
             '   "description": "Task priority level", "reason": "Missing from ontology"}'
-            '], '
+            "], "
             '"reasoning": "Priority was identified as a gap"}',
             seed,
         )

--- a/tests/unit/evolution/test_reflect_engine.py
+++ b/tests/unit/evolution/test_reflect_engine.py
@@ -5,11 +5,10 @@ Tests JSON parsing, mutation extraction, and fallback behavior without LLM calls
 
 from __future__ import annotations
 
-import pytest
 
 from ouroboros.core.lineage import MutationAction
 from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
-from ouroboros.evolution.reflect import OntologyMutation, ReflectEngine, ReflectOutput
+from ouroboros.evolution.reflect import ReflectEngine
 
 
 def _make_engine() -> ReflectEngine:

--- a/tests/unit/evolution/test_transitions.py
+++ b/tests/unit/evolution/test_transitions.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from ouroboros.core.lineage import LineageStatus
+from ouroboros.core.lineage import LineageStatus, TerminationReason
 from ouroboros.evolution.transitions import (
     ALLOWED_TRANSITIONS,
     TERMINAL_EVENT_STATUS,
@@ -166,5 +166,46 @@ class TestAbortedTransitions:
 class TestUnknownStatus:
     def test_unknown_status_returns_false(self) -> None:
         """A status not in ALLOWED_TRANSITIONS defaults to rejection."""
-        # Simulate by checking the function logic directly
         assert not is_transition_allowed(LineageStatus.ACTIVE, "totally.unknown.event")
+
+
+# --- TerminationReason exhaustiveness ---
+
+
+class TestTerminationReasonExhaustiveness:
+    """Every TerminationReason member must be explicitly handled in _emit_termination."""
+
+    # The known groupings in loop.py _emit_termination():
+    _EXHAUSTED_GROUP = {TerminationReason.EXHAUSTED}
+    _STAGNATED_GROUP = {
+        TerminationReason.STAGNATED,
+        TerminationReason.OSCILLATED,
+        TerminationReason.REPETITIVE,
+    }
+    _CONVERGED_GROUP = {TerminationReason.CONVERGED}
+
+    def test_all_members_are_in_a_group(self) -> None:
+        """Every TerminationReason member must belong to exactly one dispatch group."""
+        all_grouped = self._EXHAUSTED_GROUP | self._STAGNATED_GROUP | self._CONVERGED_GROUP
+        for member in TerminationReason:
+            assert member in all_grouped, (
+                f"TerminationReason.{member.name} is not in any dispatch group in "
+                f"_emit_termination(). Add it to the appropriate group."
+            )
+
+    def test_no_group_overlap(self) -> None:
+        """Dispatch groups must not overlap."""
+        groups = [self._EXHAUSTED_GROUP, self._STAGNATED_GROUP, self._CONVERGED_GROUP]
+        for i, a in enumerate(groups):
+            for b in groups[i + 1 :]:
+                overlap = a & b
+                assert not overlap, f"Dispatch groups overlap: {overlap}"
+
+    def test_groups_cover_all_members(self) -> None:
+        """Union of all groups equals the full enum."""
+        all_grouped = self._EXHAUSTED_GROUP | self._STAGNATED_GROUP | self._CONVERGED_GROUP
+        all_members = set(TerminationReason)
+        assert all_grouped == all_members, (
+            f"Groups missing: {all_members - all_grouped}, "
+            f"Extra in groups: {all_grouped - all_members}"
+        )

--- a/tests/unit/evolution/test_transitions.py
+++ b/tests/unit/evolution/test_transitions.py
@@ -1,0 +1,170 @@
+"""Unit tests for lineage state transition matrix.
+
+Validates that:
+1. Every LineageStatus has an entry in ALLOWED_TRANSITIONS
+2. Every event factory type from events/lineage.py is in the matrix
+3. Transition rules are correct per status
+4. TERMINAL_EVENT_STATUS is consistent with ALLOWED_TRANSITIONS
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from ouroboros.core.lineage import LineageStatus
+from ouroboros.evolution.transitions import (
+    ALLOWED_TRANSITIONS,
+    TERMINAL_EVENT_STATUS,
+    is_transition_allowed,
+)
+
+_SRC = Path(__file__).resolve().parents[3] / "src" / "ouroboros"
+_LINEAGE_EVENTS = _SRC / "events" / "lineage.py"
+
+
+def _extract_event_types_from_factories(path: Path) -> set[str]:
+    """Extract all event type strings from BaseEvent(type=...) calls."""
+    source = path.read_text()
+    tree = ast.parse(source)
+    types: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "type":
+            if isinstance(node.value, ast.Constant) and isinstance(
+                node.value.value, str
+            ):
+                types.add(node.value.value)
+    return types
+
+
+# --- Completeness tests ---
+
+
+class TestMatrixCompleteness:
+    """Every LineageStatus and event type must be accounted for."""
+
+    def test_all_statuses_have_transition_entry(self) -> None:
+        """Every LineageStatus member must be a key in ALLOWED_TRANSITIONS."""
+        for status in LineageStatus:
+            assert status in ALLOWED_TRANSITIONS, (
+                f"LineageStatus.{status.name} missing from ALLOWED_TRANSITIONS. "
+                f"Add it with the appropriate allowed event set."
+            )
+
+    def test_all_factory_event_types_in_matrix(self) -> None:
+        """Every event type from events/lineage.py must appear in the matrix.
+
+        lineage.created is handled separately by Guard (always pass),
+        but all others must be in ACTIVE's allowed set at minimum.
+        """
+        factory_types = _extract_event_types_from_factories(_LINEAGE_EVENTS)
+        all_matrix_types = set()
+        for allowed in ALLOWED_TRANSITIONS.values():
+            all_matrix_types |= allowed
+        # lineage.created is bypassed by guard, not in matrix
+        factory_types_without_created = factory_types - {"lineage.created"}
+        missing = factory_types_without_created - all_matrix_types
+        assert not missing, (
+            f"Event types defined in events/lineage.py but missing from "
+            f"ALLOWED_TRANSITIONS: {missing}"
+        )
+
+    def test_terminal_event_status_keys_in_matrix(self) -> None:
+        """Every TERMINAL_EVENT_STATUS key must appear in some ALLOWED_TRANSITIONS set."""
+        all_matrix_types = set()
+        for allowed in ALLOWED_TRANSITIONS.values():
+            all_matrix_types |= allowed
+        for event_type in TERMINAL_EVENT_STATUS:
+            assert event_type in all_matrix_types, (
+                f"TERMINAL_EVENT_STATUS key '{event_type}' not found in any "
+                f"ALLOWED_TRANSITIONS set"
+            )
+
+
+# --- ACTIVE state ---
+
+
+class TestActiveTransitions:
+    """ACTIVE state allows all generation lifecycle events."""
+
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            "lineage.generation.started",
+            "lineage.generation.completed",
+            "lineage.generation.phase_changed",
+            "lineage.generation.failed",
+            "lineage.ontology.evolved",
+            "lineage.converged",
+            "lineage.exhausted",
+            "lineage.stagnated",
+            "lineage.rewound",
+            "lineage.wonder.degraded",
+        ],
+    )
+    def test_active_allows_event(self, event_type: str) -> None:
+        assert is_transition_allowed(LineageStatus.ACTIVE, event_type)
+
+    def test_active_rejects_unknown_event(self) -> None:
+        assert not is_transition_allowed(LineageStatus.ACTIVE, "lineage.unknown")
+
+
+# --- CONVERGED state ---
+
+
+class TestConvergedTransitions:
+    def test_converged_allows_rewound(self) -> None:
+        assert is_transition_allowed(LineageStatus.CONVERGED, "lineage.rewound")
+
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            "lineage.generation.started",
+            "lineage.generation.completed",
+            "lineage.converged",
+            "lineage.exhausted",
+            "lineage.stagnated",
+        ],
+    )
+    def test_converged_rejects_non_rewind(self, event_type: str) -> None:
+        assert not is_transition_allowed(LineageStatus.CONVERGED, event_type)
+
+
+# --- EXHAUSTED state ---
+
+
+class TestExhaustedTransitions:
+    def test_exhausted_allows_rewound(self) -> None:
+        assert is_transition_allowed(LineageStatus.EXHAUSTED, "lineage.rewound")
+
+    def test_exhausted_rejects_generation_started(self) -> None:
+        assert not is_transition_allowed(
+            LineageStatus.EXHAUSTED, "lineage.generation.started"
+        )
+
+
+# --- ABORTED state ---
+
+
+class TestAbortedTransitions:
+    def test_aborted_rejects_everything(self) -> None:
+        """ABORTED is a terminal state with no allowed transitions."""
+        for event_type in ALLOWED_TRANSITIONS[LineageStatus.ACTIVE]:
+            assert not is_transition_allowed(LineageStatus.ABORTED, event_type), (
+                f"ABORTED should reject '{event_type}'"
+            )
+
+    def test_aborted_rejects_rewound(self) -> None:
+        assert not is_transition_allowed(LineageStatus.ABORTED, "lineage.rewound")
+
+
+# --- Unknown status ---
+
+
+class TestUnknownStatus:
+    def test_unknown_status_returns_false(self) -> None:
+        """A status not in ALLOWED_TRANSITIONS defaults to rejection."""
+        # Simulate by checking the function logic directly
+        assert not is_transition_allowed(LineageStatus.ACTIVE, "totally.unknown.event")

--- a/tests/unit/evolution/test_transitions.py
+++ b/tests/unit/evolution/test_transitions.py
@@ -32,9 +32,7 @@ def _extract_event_types_from_factories(path: Path) -> set[str]:
     types: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.keyword) and node.arg == "type":
-            if isinstance(node.value, ast.Constant) and isinstance(
-                node.value.value, str
-            ):
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
                 types.add(node.value.value)
     return types
 
@@ -78,8 +76,7 @@ class TestMatrixCompleteness:
             all_matrix_types |= allowed
         for event_type in TERMINAL_EVENT_STATUS:
             assert event_type in all_matrix_types, (
-                f"TERMINAL_EVENT_STATUS key '{event_type}' not found in any "
-                f"ALLOWED_TRANSITIONS set"
+                f"TERMINAL_EVENT_STATUS key '{event_type}' not found in any ALLOWED_TRANSITIONS set"
             )
 
 
@@ -140,9 +137,7 @@ class TestExhaustedTransitions:
         assert is_transition_allowed(LineageStatus.EXHAUSTED, "lineage.rewound")
 
     def test_exhausted_rejects_generation_started(self) -> None:
-        assert not is_transition_allowed(
-            LineageStatus.EXHAUSTED, "lineage.generation.started"
-        )
+        assert not is_transition_allowed(LineageStatus.EXHAUSTED, "lineage.generation.started")
 
 
 # --- ABORTED state ---

--- a/tests/unit/evolution/test_wonder_engine.py
+++ b/tests/unit/evolution/test_wonder_engine.py
@@ -5,7 +5,6 @@ Tests the JSON parsing logic and degraded mode heuristics without LLM calls.
 
 from __future__ import annotations
 
-
 from ouroboros.core.lineage import EvaluationSummary
 from ouroboros.core.seed import OntologyField, OntologySchema
 from ouroboros.evolution.wonder import WonderEngine

--- a/tests/unit/evolution/test_wonder_engine.py
+++ b/tests/unit/evolution/test_wonder_engine.py
@@ -1,0 +1,137 @@
+"""Unit tests for WonderEngine._parse_response and _degraded_output.
+
+Tests the JSON parsing logic and degraded mode heuristics without LLM calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.core.lineage import ACResult, EvaluationSummary
+from ouroboros.core.seed import OntologyField, OntologySchema
+from ouroboros.evolution.wonder import WonderEngine, WonderOutput
+
+
+def _make_engine() -> WonderEngine:
+    """Create WonderEngine with a dummy adapter (not used in these tests)."""
+
+    class DummyAdapter:
+        async def complete(self, messages, config):
+            raise NotImplementedError
+
+    return WonderEngine(llm_adapter=DummyAdapter())  # type: ignore[arg-type]
+
+
+class TestParseResponse:
+    """Tests for WonderEngine._parse_response."""
+
+    def test_valid_json(self) -> None:
+        engine = _make_engine()
+        result = engine._parse_response(
+            '{"questions": ["q1", "q2"], "ontology_tensions": ["t1"], '
+            '"should_continue": true, "reasoning": "analysis"}'
+        )
+        assert result.questions == ("q1", "q2")
+        assert result.ontology_tensions == ("t1",)
+        assert result.should_continue is True
+        assert result.reasoning == "analysis"
+
+    def test_json_with_markdown_fences(self) -> None:
+        engine = _make_engine()
+        result = engine._parse_response(
+            '```json\n{"questions": ["q1"], "ontology_tensions": [], '
+            '"should_continue": false, "reasoning": "done"}\n```'
+        )
+        assert result.questions == ("q1",)
+        assert result.should_continue is False
+
+    def test_invalid_json_returns_fallback(self) -> None:
+        engine = _make_engine()
+        result = engine._parse_response("not valid json at all")
+        assert len(result.questions) > 0
+        assert result.should_continue is True
+        assert "Parse error" in result.reasoning
+
+    def test_empty_json_object(self) -> None:
+        engine = _make_engine()
+        result = engine._parse_response("{}")
+        assert result.questions == ()
+        assert result.ontology_tensions == ()
+        assert result.should_continue is True
+
+    def test_partial_json_missing_fields(self) -> None:
+        engine = _make_engine()
+        result = engine._parse_response('{"questions": ["only questions"]}')
+        assert result.questions == ("only questions",)
+        assert result.ontology_tensions == ()
+        assert result.should_continue is True
+
+    def test_should_continue_false(self) -> None:
+        engine = _make_engine()
+        result = engine._parse_response(
+            '{"questions": [], "ontology_tensions": [], '
+            '"should_continue": false, "reasoning": "ontology is complete"}'
+        )
+        assert result.should_continue is False
+
+
+class TestDegradedOutput:
+    """Tests for WonderEngine._degraded_output heuristics."""
+
+    def _make_ontology(self, num_fields: int = 5) -> OntologySchema:
+        return OntologySchema(
+            name="TestOntology",
+            description="Test",
+            fields=tuple(
+                OntologyField(name=f"field_{i}", field_type="string", description=f"Field {i}")
+                for i in range(num_fields)
+            ),
+        )
+
+    def test_no_eval_summary(self) -> None:
+        engine = _make_engine()
+        result = engine._degraded_output(None, self._make_ontology())
+        assert len(result.questions) > 0
+        assert result.should_continue is True
+        assert "Degraded mode" in result.reasoning
+
+    def test_failed_evaluation(self) -> None:
+        engine = _make_engine()
+        eval_summary = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=1,
+            failure_reason="Stage 1 failed: lint errors",
+        )
+        result = engine._degraded_output(eval_summary, self._make_ontology())
+        assert any("fundamental" in q.lower() or "missing" in q.lower() for q in result.questions)
+
+    def test_high_drift(self) -> None:
+        engine = _make_engine()
+        eval_summary = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            drift_score=0.5,
+        )
+        result = engine._degraded_output(eval_summary, self._make_ontology())
+        assert any("drift" in q.lower() for q in result.questions)
+        assert len(result.ontology_tensions) > 0
+
+    def test_sparse_ontology(self) -> None:
+        engine = _make_engine()
+        eval_summary = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=3,
+        )
+        result = engine._degraded_output(eval_summary, self._make_ontology(num_fields=2))
+        assert any("missing" in q.lower() or "entities" in q.lower() for q in result.questions)
+
+    def test_fully_approved_rich_ontology(self) -> None:
+        engine = _make_engine()
+        eval_summary = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=3,
+            score=0.95,
+        )
+        result = engine._degraded_output(eval_summary, self._make_ontology(num_fields=10))
+        assert result.should_continue is True
+        assert len(result.questions) > 0  # always at least a fallback question

--- a/tests/unit/evolution/test_wonder_engine.py
+++ b/tests/unit/evolution/test_wonder_engine.py
@@ -5,11 +5,10 @@ Tests the JSON parsing logic and degraded mode heuristics without LLM calls.
 
 from __future__ import annotations
 
-import pytest
 
-from ouroboros.core.lineage import ACResult, EvaluationSummary
+from ouroboros.core.lineage import EvaluationSummary
 from ouroboros.core.seed import OntologyField, OntologySchema
-from ouroboros.evolution.wonder import WonderEngine, WonderOutput
+from ouroboros.evolution.wonder import WonderEngine
 
 
 def _make_engine() -> WonderEngine:

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -941,6 +941,52 @@ class TestWonderGate:
         assert "Wonder gate" in signal.reason
         assert "novel questions" in signal.reason
 
+    def test_blocks_when_latest_gen_has_same_questions(self) -> None:
+        """Wonder gate still blocks even when latest generation already contains the questions.
+
+        Regression test: the gate must exclude the latest generation when building
+        the set of previously-seen questions, otherwise every question appears
+        "already seen" and the gate can never fire.
+        """
+        schema_a = _schema(("x",))
+        schema_b = _schema(("name", "age", "email"))
+        novel_qs = ("brand new A", "brand new B")
+        # Gen1-2 have old questions; gen3 (latest) has the novel questions
+        lineage = OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=(
+                GenerationRecord(
+                    generation_number=1,
+                    seed_id="s1",
+                    ontology_snapshot=schema_a,
+                    wonder_questions=("old Q1",),
+                ),
+                GenerationRecord(
+                    generation_number=2,
+                    seed_id="s2",
+                    ontology_snapshot=schema_b,
+                    wonder_questions=("old Q2",),
+                ),
+                GenerationRecord(
+                    generation_number=3,
+                    seed_id="s3",
+                    ontology_snapshot=schema_b,
+                    wonder_questions=novel_qs,
+                ),
+            ),
+        )
+        wonder = WonderOutput(questions=novel_qs, should_continue=True)
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            wonder_gate_enabled=True,
+            wonder_novelty_threshold=0.5,
+        )
+        signal = criteria.evaluate(lineage, latest_wonder=wonder)
+        assert not signal.converged
+        assert "Wonder gate" in signal.reason
+
     def test_allows_when_all_questions_are_repeated(self) -> None:
         """Wonder gate allows convergence when all questions are old."""
         prev = ("question A", "question B")

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -779,7 +779,7 @@ class TestOntologyCompletenessGate:
             description="Test schema",
             fields=tuple(
                 OntologyField(name=n, field_type="string", description=d, required=True)
-                for n, d in zip(fields, descriptions)
+                for n, d in zip(fields, descriptions, strict=True)
             ),
         )
         return OntologyLineage(

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -511,11 +511,15 @@ class TestEvolutionGateDetection:
     """
 
     def test_blocks_when_ontology_never_evolved(self) -> None:
-        """Identical ontology across all generations -> convergence withheld."""
+        """Identical ontology across 2 generations -> convergence withheld.
+
+        Uses stagnation_window=4 to avoid stagnation safety firing first.
+        """
         lineage = _lineage_with_schemas(SCHEMA_A, SCHEMA_A, SCHEMA_A)
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
             min_generations=2,
+            stagnation_window=4,
             eval_gate_enabled=False,
         )
         signal = criteria.evaluate(lineage)
@@ -753,3 +757,129 @@ class TestTerminationReasonEnum:
         assert signal.converged
         assert signal.termination_reason == TerminationReason.OSCILLATED
         assert "Oscillation" in signal.reason
+
+
+# --- Ontology Completeness Gate ---
+
+
+class TestOntologyCompletenessGate:
+    """Tests for ontology_completeness_gate in convergence criteria."""
+
+    @staticmethod
+    def _stable_lineage(
+        fields: tuple[str, ...],
+        descriptions: tuple[str, ...] | None = None,
+    ) -> OntologyLineage:
+        """Create a lineage where the last 2 gens have identical ontology."""
+        if descriptions is None:
+            descriptions = tuple(f"Description of {f}" for f in fields)
+        schema_init = _schema(("initial_different_field",))
+        schema = OntologySchema(
+            name="Test",
+            description="Test schema",
+            fields=tuple(
+                OntologyField(name=n, field_type="string", description=d, required=True)
+                for n, d in zip(fields, descriptions)
+            ),
+        )
+        return OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=(
+                GenerationRecord(generation_number=1, seed_id="s1", ontology_snapshot=schema_init),
+                GenerationRecord(generation_number=2, seed_id="s2", ontology_snapshot=schema),
+                GenerationRecord(generation_number=3, seed_id="s3", ontology_snapshot=schema),
+            ),
+        )
+
+    def test_blocks_when_too_few_fields(self) -> None:
+        """Completeness gate blocks when field count < min_fields."""
+        lineage = self._stable_lineage(("name", "age"))
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            ontology_completeness_gate_enabled=True,
+            ontology_min_fields=3,
+        )
+        signal = criteria.evaluate(lineage)
+        assert not signal.converged
+        assert "completeness gate" in signal.reason.lower()
+        assert "2 fields" in signal.reason
+
+    def test_blocks_when_trivial_descriptions(self) -> None:
+        """Completeness gate blocks when majority of descriptions are trivial."""
+        lineage = self._stable_lineage(
+            ("name", "age", "email"),
+            descriptions=("name", "age", "Detailed email address for contact"),
+        )
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            ontology_completeness_gate_enabled=True,
+            ontology_min_fields=3,
+        )
+        signal = criteria.evaluate(lineage)
+        assert not signal.converged
+        assert "trivial descriptions" in signal.reason.lower()
+
+    def test_passes_when_sufficient_fields_and_descriptions(self) -> None:
+        """Completeness gate passes with enough fields and good descriptions."""
+        lineage = self._stable_lineage(
+            ("name", "age", "email"),
+            descriptions=(
+                "Full legal name of the person",
+                "Age in years since birth",
+                "Primary email address for contact",
+            ),
+        )
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            ontology_completeness_gate_enabled=True,
+            ontology_min_fields=3,
+        )
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+        assert signal.termination_reason == TerminationReason.CONVERGED
+
+    def test_disabled_allows_convergence(self) -> None:
+        """Disabled completeness gate allows convergence regardless."""
+        lineage = self._stable_lineage(("x",))
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            ontology_completeness_gate_enabled=False,
+        )
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+
+    def test_stagnation_safety_overrides_gate_blocking(self) -> None:
+        """When stagnation_window is reached, stagnation terminates even if gate blocks."""
+        schema_init = _schema(("different",))
+        schema = OntologySchema(
+            name="T",
+            description="T",
+            fields=(OntologyField(name="x", field_type="string", description="x", required=True),),
+        )
+        # 4 gens: gen1 different, gen2-4 identical → stagnation_window=3 reached
+        lineage = OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=(
+                GenerationRecord(generation_number=1, seed_id="s1", ontology_snapshot=schema_init),
+                GenerationRecord(generation_number=2, seed_id="s2", ontology_snapshot=schema),
+                GenerationRecord(generation_number=3, seed_id="s3", ontology_snapshot=schema),
+                GenerationRecord(generation_number=4, seed_id="s4", ontology_snapshot=schema),
+            ),
+        )
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            stagnation_window=3,
+            ontology_completeness_gate_enabled=True,
+            ontology_min_fields=5,  # would block: only 1 field
+        )
+        signal = criteria.evaluate(lineage)
+        # Stagnation safety should override the completeness gate
+        assert signal.converged
+        assert signal.termination_reason == TerminationReason.STAGNATED

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -903,15 +903,21 @@ class TestWonderGate:
             goal="test",
             generations=(
                 GenerationRecord(
-                    generation_number=1, seed_id="s1", ontology_snapshot=schema_a,
+                    generation_number=1,
+                    seed_id="s1",
+                    ontology_snapshot=schema_a,
                     wonder_questions=prev_questions,
                 ),
                 GenerationRecord(
-                    generation_number=2, seed_id="s2", ontology_snapshot=schema_b,
+                    generation_number=2,
+                    seed_id="s2",
+                    ontology_snapshot=schema_b,
                     wonder_questions=prev_questions,
                 ),
                 GenerationRecord(
-                    generation_number=3, seed_id="s3", ontology_snapshot=schema_b,
+                    generation_number=3,
+                    seed_id="s3",
+                    ontology_snapshot=schema_b,
                     wonder_questions=prev_questions,
                 ),
             ),
@@ -992,16 +998,22 @@ class TestDriftTrendGate:
         schema = _schema(("name", "age", "email"))
         gens: list[GenerationRecord] = [
             GenerationRecord(
-                generation_number=1, seed_id="s1", ontology_snapshot=schema_init,
+                generation_number=1,
+                seed_id="s1",
+                ontology_snapshot=schema_init,
             )
         ]
         for i, ds in enumerate(drift_scores, start=2):
-            eval_summary = EvaluationSummary(
-                final_approved=True,
-                highest_stage_passed=2,
-                score=0.8,
-                drift_score=ds,
-            ) if ds is not None else None
+            eval_summary = (
+                EvaluationSummary(
+                    final_approved=True,
+                    highest_stage_passed=2,
+                    score=0.8,
+                    drift_score=ds,
+                )
+                if ds is not None
+                else None
+            )
             gens.append(
                 GenerationRecord(
                     generation_number=i,

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -883,3 +883,97 @@ class TestOntologyCompletenessGate:
         # Stagnation safety should override the completeness gate
         assert signal.converged
         assert signal.termination_reason == TerminationReason.STAGNATED
+
+
+# --- Wonder Gate ---
+
+
+class TestWonderGate:
+    """Tests for wonder_gate in convergence criteria."""
+
+    @staticmethod
+    def _stable_lineage_with_wonder(
+        prev_questions: tuple[str, ...] = (),
+    ) -> OntologyLineage:
+        """Create a stable lineage where gen2-3 have identical ontology."""
+        schema_a = _schema(("x",))
+        schema_b = _schema(("name", "age", "email"))
+        return OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=(
+                GenerationRecord(
+                    generation_number=1, seed_id="s1", ontology_snapshot=schema_a,
+                    wonder_questions=prev_questions,
+                ),
+                GenerationRecord(
+                    generation_number=2, seed_id="s2", ontology_snapshot=schema_b,
+                    wonder_questions=prev_questions,
+                ),
+                GenerationRecord(
+                    generation_number=3, seed_id="s3", ontology_snapshot=schema_b,
+                    wonder_questions=prev_questions,
+                ),
+            ),
+        )
+
+    def test_blocks_when_novel_questions_exceed_threshold(self) -> None:
+        """Wonder gate blocks when majority of questions are novel."""
+        lineage = self._stable_lineage_with_wonder(("old question 1", "old question 2"))
+        wonder = WonderOutput(
+            questions=("brand new question A", "brand new question B", "old question 1"),
+            should_continue=True,
+        )
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            wonder_gate_enabled=True,
+            wonder_novelty_threshold=0.5,
+        )
+        signal = criteria.evaluate(lineage, latest_wonder=wonder)
+        assert not signal.converged
+        assert "Wonder gate" in signal.reason
+        assert "novel questions" in signal.reason
+
+    def test_allows_when_all_questions_are_repeated(self) -> None:
+        """Wonder gate allows convergence when all questions are old."""
+        prev = ("question A", "question B")
+        lineage = self._stable_lineage_with_wonder(prev)
+        wonder = WonderOutput(
+            questions=("question A", "question B"),
+            should_continue=True,
+        )
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            wonder_gate_enabled=True,
+            wonder_novelty_threshold=0.5,
+        )
+        signal = criteria.evaluate(lineage, latest_wonder=wonder)
+        assert signal.converged
+
+    def test_allows_when_wonder_is_none(self) -> None:
+        """Wonder gate passes when no wonder output is provided."""
+        lineage = self._stable_lineage_with_wonder()
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            wonder_gate_enabled=True,
+        )
+        signal = criteria.evaluate(lineage, latest_wonder=None)
+        assert signal.converged
+
+    def test_disabled_allows_convergence(self) -> None:
+        """Disabled wonder gate allows convergence regardless of novelty."""
+        lineage = self._stable_lineage_with_wonder()
+        wonder = WonderOutput(
+            questions=("completely new question",),
+            should_continue=True,
+        )
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            wonder_gate_enabled=False,
+        )
+        signal = criteria.evaluate(lineage, latest_wonder=wonder)
+        assert signal.converged

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -977,3 +977,102 @@ class TestWonderGate:
         )
         signal = criteria.evaluate(lineage, latest_wonder=wonder)
         assert signal.converged
+
+
+# --- Drift Trend Gate ---
+
+
+class TestDriftTrendGate:
+    """Tests for drift_trend_gate in convergence criteria."""
+
+    @staticmethod
+    def _stable_lineage_with_drift(drift_scores: list[float | None]) -> OntologyLineage:
+        """Create a stable lineage with specified drift_scores per generation."""
+        schema_init = _schema(("different",))
+        schema = _schema(("name", "age", "email"))
+        gens: list[GenerationRecord] = [
+            GenerationRecord(
+                generation_number=1, seed_id="s1", ontology_snapshot=schema_init,
+            )
+        ]
+        for i, ds in enumerate(drift_scores, start=2):
+            eval_summary = EvaluationSummary(
+                final_approved=True,
+                highest_stage_passed=2,
+                score=0.8,
+                drift_score=ds,
+            ) if ds is not None else None
+            gens.append(
+                GenerationRecord(
+                    generation_number=i,
+                    seed_id=f"s{i}",
+                    ontology_snapshot=schema,
+                    evaluation_summary=eval_summary,
+                )
+            )
+        return OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=tuple(gens),
+        )
+
+    def test_blocks_when_drift_monotonically_increasing(self) -> None:
+        """Drift trend gate blocks when drift_score increases every generation."""
+        lineage = self._stable_lineage_with_drift([0.2, 0.4, 0.6])
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            stagnation_window=5,  # avoid stagnation safety firing first
+            drift_trend_gate_enabled=True,
+            drift_trend_window=3,
+        )
+        signal = criteria.evaluate(lineage)
+        assert not signal.converged
+        assert "Drift trend gate" in signal.reason
+
+    def test_allows_when_drift_decreasing(self) -> None:
+        """Drift trend gate allows convergence when drift is improving."""
+        lineage = self._stable_lineage_with_drift([0.6, 0.4, 0.2])
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            drift_trend_gate_enabled=True,
+            drift_trend_window=3,
+        )
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+
+    def test_allows_when_drift_mixed(self) -> None:
+        """Drift trend gate allows when drift fluctuates (not monotonic)."""
+        lineage = self._stable_lineage_with_drift([0.3, 0.5, 0.4])
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            drift_trend_gate_enabled=True,
+            drift_trend_window=3,
+        )
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+
+    def test_passes_when_drift_scores_none(self) -> None:
+        """Gate passes when drift_score is None (fewer than 2 valid scores)."""
+        lineage = self._stable_lineage_with_drift([None, None, 0.5])
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            drift_trend_gate_enabled=True,
+            drift_trend_window=3,
+        )
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+
+    def test_disabled_allows_convergence(self) -> None:
+        """Disabled drift trend gate allows convergence regardless."""
+        lineage = self._stable_lineage_with_drift([0.2, 0.4, 0.6])
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            drift_trend_gate_enabled=False,
+        )
+        signal = criteria.evaluate(lineage)
+        assert signal.converged

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -1004,8 +1004,13 @@ class TestWonderGate:
         signal = criteria.evaluate(lineage, latest_wonder=wonder)
         assert signal.converged
 
-    def test_allows_when_wonder_is_none(self) -> None:
-        """Wonder gate passes when no wonder output is provided."""
+    def test_blocks_when_wonder_is_none(self) -> None:
+        """Wonder gate blocks when no wonder output is available.
+
+        "Unable to generate questions" is not the same as "no questions remain".
+        When wonder_gate is enabled, absence of wonder output should block
+        convergence to avoid false convergence.
+        """
         lineage = self._stable_lineage_with_wonder()
         criteria = ConvergenceCriteria(
             convergence_threshold=0.95,
@@ -1013,7 +1018,9 @@ class TestWonderGate:
             wonder_gate_enabled=True,
         )
         signal = criteria.evaluate(lineage, latest_wonder=None)
-        assert signal.converged
+        assert not signal.converged
+        assert signal.blocking_gate == "wonder"
+        assert "unavailable" in signal.reason
 
     def test_disabled_allows_convergence(self) -> None:
         """Disabled wonder gate allows convergence regardless of novelty."""

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -10,9 +10,10 @@ from ouroboros.core.lineage import (
     GenerationRecord,
     OntologyDelta,
     OntologyLineage,
+    TerminationReason,
 )
 from ouroboros.core.seed import OntologyField, OntologySchema
-from ouroboros.evolution.convergence import ConvergenceCriteria
+from ouroboros.evolution.convergence import ConvergenceCriteria, ConvergenceSignal
 from ouroboros.evolution.wonder import WonderOutput
 
 # -- Helpers --
@@ -634,3 +635,121 @@ class TestValidationGate:
             validation_output="Validation skipped: no project directory",
         )
         assert signal.converged
+
+
+# --- TerminationReason enum tests ---
+
+
+class TestTerminationReasonEnum:
+    """Verify TerminationReason is correctly set for all converged=True paths."""
+
+    def test_converged_true_requires_termination_reason(self) -> None:
+        """__post_init__ enforces that converged=True has termination_reason."""
+        with pytest.raises(ValueError, match="requires termination_reason"):
+            ConvergenceSignal(
+                converged=True,
+                reason="test",
+                ontology_similarity=0.99,
+                generation=1,
+            )
+
+    def test_converged_false_allows_none(self) -> None:
+        """converged=False can have termination_reason=None."""
+        signal = ConvergenceSignal(
+            converged=False,
+            reason="test",
+            ontology_similarity=0.5,
+            generation=1,
+        )
+        assert signal.termination_reason is None
+
+    def test_max_generations_returns_exhausted(self) -> None:
+        schema_a = _schema(("name",))
+        lineage = OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=tuple(
+                GenerationRecord(
+                    generation_number=i,
+                    seed_id=f"s{i}",
+                    ontology_snapshot=schema_a,
+                )
+                for i in range(1, 4)
+            ),
+        )
+        criteria = ConvergenceCriteria(max_generations=3, min_generations=2)
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+        assert signal.termination_reason == TerminationReason.EXHAUSTED
+
+    def test_ontology_stable_returns_converged(self) -> None:
+        # Gen 1: different schema, Gen 2-3: same schema → evolution happened, then stable
+        schema_a = _schema(("name",))
+        schema_b = _schema(("name", "age"))
+        lineage = OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=(
+                GenerationRecord(generation_number=1, seed_id="s1", ontology_snapshot=schema_a),
+                GenerationRecord(generation_number=2, seed_id="s2", ontology_snapshot=schema_b),
+                GenerationRecord(generation_number=3, seed_id="s3", ontology_snapshot=schema_b),
+            ),
+        )
+        criteria = ConvergenceCriteria(convergence_threshold=0.95, min_generations=2)
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+        assert signal.termination_reason == TerminationReason.CONVERGED
+
+    def test_stagnation_returns_stagnated(self) -> None:
+        # Gen 1: different, Gen 2-5: same → evolution gate passes, stagnation detected
+        schema_a = _schema(("x",))
+        schema_b = _schema(("name", "age"))
+        lineage = OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=(
+                GenerationRecord(generation_number=1, seed_id="s1", ontology_snapshot=schema_a),
+                *(
+                    GenerationRecord(
+                        generation_number=i,
+                        seed_id=f"s{i}",
+                        ontology_snapshot=schema_b,
+                    )
+                    for i in range(2, 6)
+                ),
+            ),
+        )
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            stagnation_window=3,
+            min_generations=2,
+        )
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+        assert signal.termination_reason in (
+            TerminationReason.CONVERGED,
+            TerminationReason.STAGNATED,
+        )
+
+    def test_oscillation_returns_oscillated(self) -> None:
+        schema_a = _schema(("name",))
+        schema_b = _schema(("title",))
+        lineage = OntologyLineage(
+            lineage_id="test",
+            goal="test",
+            generations=(
+                GenerationRecord(generation_number=1, seed_id="s1", ontology_snapshot=schema_a),
+                GenerationRecord(generation_number=2, seed_id="s2", ontology_snapshot=schema_b),
+                GenerationRecord(generation_number=3, seed_id="s3", ontology_snapshot=schema_a),
+                GenerationRecord(generation_number=4, seed_id="s4", ontology_snapshot=schema_b),
+            ),
+        )
+        criteria = ConvergenceCriteria(
+            convergence_threshold=0.95,
+            min_generations=2,
+            enable_oscillation_detection=True,
+        )
+        signal = criteria.evaluate(lineage)
+        assert signal.converged
+        assert signal.termination_reason == TerminationReason.OSCILLATED
+        assert "Oscillation" in signal.reason

--- a/tests/unit/test_enum_safety.py
+++ b/tests/unit/test_enum_safety.py
@@ -7,9 +7,8 @@ enum member is added but not handled.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
-
+import re
 
 from ouroboros.core.lineage import MutationAction
 

--- a/tests/unit/test_enum_safety.py
+++ b/tests/unit/test_enum_safety.py
@@ -1,0 +1,59 @@
+"""StrEnum exhaustiveness safety tests.
+
+Ensures that when new members are added to StrEnum types, all dispatch
+sites that handle them are updated. These tests fail-fast when a new
+enum member is added but not handled.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from ouroboros.core.lineage import MutationAction, TerminationReason
+
+_SRC = Path(__file__).resolve().parents[2] / "src" / "ouroboros"
+
+
+class TestMutationActionExhaustiveness:
+    """Every MutationAction member must be handled in seed_generator._apply_mutations."""
+
+    _SEED_GENERATOR = _SRC / "bigbang" / "seed_generator.py"
+
+    def test_all_actions_in_apply_mutations(self) -> None:
+        """Every MutationAction value appears in _apply_mutations if/elif chain."""
+        source = self._SEED_GENERATOR.read_text()
+        # Extract string comparisons: action == "add", action == "modify", etc.
+        handled = set(re.findall(r'action\s*==\s*"(\w+)"', source))
+        for member in MutationAction:
+            assert member.value in handled, (
+                f"MutationAction.{member.name} ('{member.value}') is not handled "
+                f"in seed_generator.py _apply_mutations(). "
+                f"Handled actions: {sorted(handled)}"
+            )
+
+
+class TestTerminationReasonProjectorCoverage:
+    """Projector legacy/default mappings must cover all terminal event types."""
+
+    def test_legacy_map_covers_known_defaults(self) -> None:
+        """_LEGACY_REASON_MAP has entries for all historical default reason strings."""
+        from ouroboros.evolution.projector import _LEGACY_REASON_MAP
+
+        # These are the known legacy default strings from before enum introduction
+        expected_keys = {"ontology_converged", "max_generations", "stagnation"}
+        assert set(_LEGACY_REASON_MAP.keys()) == expected_keys
+
+    def test_default_termination_covers_terminal_events(self) -> None:
+        """_DEFAULT_TERMINATION has entries for all terminal event types."""
+        from ouroboros.evolution.projector import _DEFAULT_TERMINATION
+        from ouroboros.evolution.transitions import TERMINAL_EVENT_STATUS
+
+        # Every terminal event type (except rewound, which doesn't set termination_reason)
+        terminal_events_with_reason = {
+            et for et in TERMINAL_EVENT_STATUS if et != "lineage.rewound"
+        }
+        assert set(_DEFAULT_TERMINATION.keys()) == terminal_events_with_reason

--- a/tests/unit/test_enum_safety.py
+++ b/tests/unit/test_enum_safety.py
@@ -7,13 +7,11 @@ enum member is added but not handled.
 
 from __future__ import annotations
 
-import ast
 import re
 from pathlib import Path
 
-import pytest
 
-from ouroboros.core.lineage import MutationAction, TerminationReason
+from ouroboros.core.lineage import MutationAction
 
 _SRC = Path(__file__).resolve().parents[2] / "src" / "ouroboros"
 

--- a/tests/unit/test_enum_safety.py
+++ b/tests/unit/test_enum_safety.py
@@ -33,6 +33,23 @@ class TestMutationActionExhaustiveness:
             )
 
 
+class TestTerminationReasonDispatchCoverage:
+    """_TERMINATION_DISPATCH must cover all TerminationReason members."""
+
+    def test_dispatch_covers_all_termination_reasons(self) -> None:
+        """Every TerminationReason member has a dispatch entry in loop.py."""
+        from ouroboros.core.lineage import TerminationReason
+        from ouroboros.evolution.loop import EvolutionaryLoop
+
+        dispatch = EvolutionaryLoop._TERMINATION_DISPATCH
+        for member in TerminationReason:
+            assert member in dispatch, (
+                f"TerminationReason.{member.name} is not in "
+                f"EvolutionaryLoop._TERMINATION_DISPATCH. "
+                f"Dispatched: {sorted(m.name for m in dispatch)}"
+            )
+
+
 class TestTerminationReasonProjectorCoverage:
     """Projector legacy/default mappings must cover all terminal event types."""
 

--- a/tests/unit/test_projector_rewind.py
+++ b/tests/unit/test_projector_rewind.py
@@ -225,6 +225,10 @@ class TestProjectRewind:
 
         assert lineage is not None
         assert lineage.status == LineageStatus.ACTIVE
+        assert lineage.termination_reason is None, (
+            "Rewind must clear termination_reason — stale terminal metadata "
+            "on an ACTIVE lineage is internally inconsistent"
+        )
         # Rewind from gen 1 to gen 1 means no discarded generations
         assert len(lineage.rewind_history) == 1
         assert lineage.rewind_history[0].discarded_generations == ()


### PR DESCRIPTION
## 이 PR이 해결하는 문제

Ouroboros의 진화 루프(evolve loop)는 "언제 멈출지"를 판단하는 **수렴 판정(convergence evaluation)** 과정을 거칩니다. 현재 이 판정에 두 가지 약점이 있습니다:

1. **종료 사유가 문자열로 관리됩니다.** `"Stagnation" in signal.reason` 같은 패턴 매칭으로 종료 이유를 판별하기 때문에, 오타나 메시지 변경 시 로직이 조용히 깨집니다.

2. **수렴 조건이 너무 느슨합니다.** ontology 유사도가 높기만 하면 수렴으로 판정하는데, 실제로는 ontology가 아직 빈약하거나, 새로운 질문이 남아있거나, drift가 증가 추세일 수 있습니다. 이런 경우 "겉보기 수렴"이 발생합니다.

## 변경 내용

### 1. TerminationReason enum — 종료 사유 타입 안전성 확보

종료 사유를 문자열이 아닌 정해진 값 5개(`CONVERGED`, `STAGNATED`, `OSCILLATED`, `EXHAUSTED`, `REPETITIVE`) 중 하나로만 표현합니다.

- **기존**: `"Stagnation detected"` 같은 자유형 문자열 → 오탈자로 버그 발생 가능
- **변경 후**: `TerminationReason.STAGNATED` → 잘못된 값 사용 시 즉시 에러

### 2. Gate Guard — 이벤트 상태 전이 검증

진화 루프에서 발생하는 이벤트들(시작 → 실행 → 평가 → 수렴)의 순서가 올바른지 검증합니다. 예를 들어 "평가 완료" 이벤트 다음에 "실행 시작"이 오는 것은 허용하지만, "수렴 완료" 다음에 다시 "실행 시작"이 오는 것은 차단합니다.

### 3. 품질 게이트 3종 (모두 opt-in, 기본 꺼짐)

기존 동작에 영향 없이, 필요한 사용자만 켤 수 있는 추가 수렴 조건 3개:

| 게이트 | 설정명 | 역할 |
|--------|--------|------|
| **Ontology 완전성** | `ontology_completeness_gate_enabled` | 필드 수가 너무 적거나 설명이 빈약하면 수렴 차단 |
| **Wonder** | `wonder_gate_enabled` | 아직 답변되지 않은 유의미한 질문이 남아있으면 수렴 차단 |
| **Drift 추세** | `drift_trend_gate_enabled` | 목표에서 점점 멀어지는 추세이면 수렴 차단 |

추가로, 게이트가 반복적으로 수렴을 차단하지만 ontology가 더 이상 변하지 않는 상황을 감지하는 **정체 안전망(stagnation safety net)** 도 포함됩니다.

### 4. validation_passed 플래그

기존에는 실행 출력에 `"error"` 문자열이 포함되어 있는지로 검증 통과 여부를 판단했습니다. 이 방식은 정상 출력에 `"error"` 단어가 들어있으면 오탐이 발생합니다. 명시적인 `True/False` 플래그를 추가하여 정확한 판정이 가능합니다. 기존 코드가 이 플래그를 전달하지 않으면 자동으로 기존 방식으로 동작합니다.

### 5. StrEnum 완전성 테스트

enum에 새 멤버를 추가했는데 처리 로직을 업데이트하지 않으면, 테스트가 실패하여 즉시 알 수 있습니다.

### 6. wonder.py / reflect.py 테스트 추가

Wonder 엔진과 Reflect 엔진의 JSON 파싱, 마크다운 처리, 오류 시 대체 동작(fallback) 등에 대한 19개 테스트 케이스를 추가했습니다.

## 기존 동작에 미치는 영향

**없습니다.** 모든 새 기능은 다음과 같이 설계되었습니다:

- 새 게이트는 모두 **기본 꺼짐** (`enabled=False`)
- 새 필드는 모두 **기본값 있음** (`None`, `False`)
- `validation_passed`를 전달하지 않으면 **기존 문자열 매칭으로 자동 대체**
- `TerminationReason`은 `StrEnum`이므로 **JSON 직렬화 호환**
- `OntologyLineage.termination_reason`은 `str | None`도 수용하여 **기존 이벤트 저장소와 호환**

## 검증 결과

| 항목 | 결과 |
|------|------|
| 전체 테스트 (Python 3.12/3.13/3.14) | 2,798개 통과 |
| mypy 타입 검사 | 이슈 0건 |
| ruff lint | 에러 0건 |
| 하위 호환성 검토 | 기존 동작 변경 없음 확인 |

## Test plan

- [x] `uv run pytest tests/` — full suite passes
- [x] `uv run mypy` — no type errors
- [x] `uv run ruff check` — no lint errors
- [x] All new gates default to disabled — existing behavior unchanged
- [x] TerminationReason enum covers all termination paths
- [x] Gate Guard validates all event state transitions
- [ ] Manual: run `evolve` loop with gates enabled to verify blocking/unblocking behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)