### PR TITLE
fix(tui): show correct session status in workflow monitor

### DIFF
--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -403,13 +403,15 @@ class EventStore:
             ) from e
 
     async def get_all_sessions(self) -> list[BaseEvent]:
-        """Get all session start events.
+        """Get all session lifecycle events.
 
-        This method retrieves all events of type 'orchestrator.session.started'
-        to identify every session recorded in the event store.
+        This method retrieves all ``orchestrator.session.*`` events so that
+        callers can reconstruct the current status of every session by
+        replaying events in chronological order.
 
         Returns:
-            List of session start events, ordered by timestamp descending.
+            List of session events, ordered by timestamp ascending (oldest
+            first) so that later events naturally overwrite earlier status.
 
         Raises:
             PersistenceError: If the query fails.
@@ -424,8 +426,8 @@ class EventStore:
             async with self._engine.begin() as conn:
                 query = (
                     select(events_table)
-                    .where(events_table.c.event_type == "orchestrator.session.started")
-                    .order_by(events_table.c.timestamp.desc())
+                    .where(events_table.c.event_type.like("orchestrator.session.%"))
+                    .order_by(events_table.c.timestamp.asc())
                 )
 
                 result = await conn.execute(query)
@@ -436,7 +438,7 @@ class EventStore:
                 f"Failed to get all sessions: {e}",
                 operation="select",
                 table="events",
-                details={"event_type": "orchestrator.session.started"},
+                details={"event_type": "orchestrator.session.%"},
             ) from e
 
     async def query_events(

--- a/src/ouroboros/tui/screens/session_selector.py
+++ b/src/ouroboros/tui/screens/session_selector.py
@@ -83,7 +83,8 @@ class SessionSelectorScreen(Screen[None]):
                 table.add_row("[dim]No sessions found in the database.[/dim]")
                 return
 
-            # Deduplicate and collect session info
+            # Replay events chronologically to reconstruct session state.
+            # Events arrive ASC so later events naturally overwrite status.
             self._session_info = {}
             for event in sessions:
                 agg_id = event.aggregate_id
@@ -95,6 +96,11 @@ class SessionSelectorScreen(Screen[None]):
                         "timestamp": event.timestamp,
                         "status": "started",
                     }
+                # Always update seed_goal/execution_id when present
+                if event.data.get("seed_goal"):
+                    self._session_info[agg_id]["seed_goal"] = event.data["seed_goal"]
+                if event.data.get("execution_id"):
+                    self._session_info[agg_id]["execution_id"] = event.data["execution_id"]
                 # Update status based on event type
                 if "completed" in event.type:
                     self._session_info[agg_id]["status"] = "completed"

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -553,6 +553,71 @@ class TestEventStoreErrorHandling:
             await store.replay("test", "test-123")
 
 
+class TestGetAllSessions:
+    """Test get_all_sessions returns all session lifecycle events."""
+
+    async def test_returns_all_session_event_types(self, event_store: EventStore) -> None:
+        """get_all_sessions returns started, completed, cancelled, and failed events."""
+        started = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id="sess-1",
+            data={"seed_goal": "Build API"},
+        )
+        completed = BaseEvent(
+            type="orchestrator.session.completed",
+            aggregate_type="session",
+            aggregate_id="sess-1",
+            data={"summary": "done"},
+        )
+        cancelled = BaseEvent(
+            type="orchestrator.session.cancelled",
+            aggregate_type="session",
+            aggregate_id="sess-2",
+            data={"reason": "orphaned"},
+        )
+        # Unrelated event should not appear
+        unrelated = BaseEvent(
+            type="orchestrator.execution.started",
+            aggregate_type="execution",
+            aggregate_id="exec-1",
+            data={},
+        )
+        for evt in [started, completed, cancelled, unrelated]:
+            await event_store.append(evt)
+
+        result = await event_store.get_all_sessions()
+        types = [e.type for e in result]
+        assert "orchestrator.session.started" in types
+        assert "orchestrator.session.completed" in types
+        assert "orchestrator.session.cancelled" in types
+        assert "orchestrator.execution.started" not in types
+
+    async def test_returns_events_in_ascending_order(self, event_store: EventStore) -> None:
+        """Events are returned oldest-first so callers can replay status."""
+        for suffix in ("started", "completed"):
+            await event_store.append(
+                BaseEvent(
+                    type=f"orchestrator.session.{suffix}",
+                    aggregate_type="session",
+                    aggregate_id="sess-asc",
+                    data={},
+                )
+            )
+
+        result = await event_store.get_all_sessions()
+        sess_events = [e for e in result if e.aggregate_id == "sess-asc"]
+        assert len(sess_events) == 2
+        assert sess_events[0].type == "orchestrator.session.started"
+        assert sess_events[1].type == "orchestrator.session.completed"
+
+    async def test_raises_when_not_initialized(self) -> None:
+        """get_all_sessions raises PersistenceError when store not initialized."""
+        store = EventStore("sqlite+aiosqlite:///dummy.db")
+        with pytest.raises(PersistenceError):
+            await store.get_all_sessions()
+
+
 class TestEventStoreTransactions:
     """Test transaction handling per AC7."""
 


### PR DESCRIPTION
## Summary
- `EventStore.get_all_sessions()` now queries all `orchestrator.session.*` events (was only querying `started`)
- Events ordered ASC for chronological replay — later events overwrite earlier status
- `SessionSelectorScreen._load_sessions()` updates `seed_goal` and `execution_id` from subsequent events

## Root Cause
The TUI session selector only saw `started` events, so every session appeared as "running" regardless of actual state.

## Test plan
- [x] `TestGetAllSessions.test_returns_all_session_event_types` — verifies completed/cancelled events are returned
- [x] `TestGetAllSessions.test_returns_events_in_ascending_order` — verifies replay ordering
- [x] `TestGetAllSessions.test_raises_when_not_initialized` — error handling
- [x] All 29 event store tests pass

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)