### PR TITLE
fix(codex): prevent recursive MCP startup loop on Windows

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -739,8 +739,11 @@ class CodexCliRuntime:
         # Prevent child from re-entering Ouroboros MCP
         for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
             env.pop(key, None)
-        # Track recursion depth for diagnostics
-        depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+        # Track recursion depth for diagnostics (defensive: ignore malformed values)
+        try:
+            depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+        except (ValueError, TypeError):
+            depth = 1
         env["_OUROBOROS_DEPTH"] = str(depth)
         return env
 

--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -621,7 +621,10 @@ class CodexCliLLMAdapter:
         env = os.environ.copy()
         for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
             env.pop(key, None)
-        depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+        try:
+            depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+        except (ValueError, TypeError):
+            depth = 1
         env["_OUROBOROS_DEPTH"] = str(depth)
         return env
 

--- a/tests/unit/orchestrator/test_codex_recursion_guard.py
+++ b/tests/unit/orchestrator/test_codex_recursion_guard.py
@@ -9,44 +9,63 @@ from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 
 
+def _make_runtime() -> CodexCliRuntime:
+    """Create a bare CodexCliRuntime without __init__ side effects."""
+    return CodexCliRuntime.__new__(CodexCliRuntime)
+
+
 class TestCodexCliRuntimeChildEnv:
     """Test _build_child_env strips dangerous env vars."""
 
     def test_strips_ouroboros_agent_runtime(self) -> None:
         """Child env must not contain OUROBOROS_AGENT_RUNTIME."""
-        runtime = CodexCliRuntime.__new__(CodexCliRuntime)
+        runtime = _make_runtime()
         with patch.dict(os.environ, {"OUROBOROS_AGENT_RUNTIME": "codex"}):
             env = runtime._build_child_env()
         assert "OUROBOROS_AGENT_RUNTIME" not in env
 
     def test_strips_ouroboros_llm_backend(self) -> None:
         """Child env must not contain OUROBOROS_LLM_BACKEND."""
-        runtime = CodexCliRuntime.__new__(CodexCliRuntime)
+        runtime = _make_runtime()
         with patch.dict(os.environ, {"OUROBOROS_LLM_BACKEND": "codex"}):
             env = runtime._build_child_env()
         assert "OUROBOROS_LLM_BACKEND" not in env
 
     def test_increments_depth_counter(self) -> None:
         """Each child process increments _OUROBOROS_DEPTH."""
-        runtime = CodexCliRuntime.__new__(CodexCliRuntime)
-        with patch.dict(os.environ, {"_OUROBOROS_DEPTH": "2"}, clear=False):
+        runtime = _make_runtime()
+        with patch.dict(os.environ, {"_OUROBOROS_DEPTH": "2"}):
             env = runtime._build_child_env()
         assert env["_OUROBOROS_DEPTH"] == "3"
 
-    def test_depth_starts_at_one(self) -> None:
+    def test_depth_starts_at_one_when_absent(self) -> None:
         """First child starts at depth 1 when parent has no depth var."""
-        runtime = CodexCliRuntime.__new__(CodexCliRuntime)
-        with patch.dict(os.environ, {}, clear=False):
+        runtime = _make_runtime()
+        env_clean = {k: v for k, v in os.environ.items() if k != "_OUROBOROS_DEPTH"}
+        with patch.dict(os.environ, env_clean, clear=True):
+            env = runtime._build_child_env()
+        assert env["_OUROBOROS_DEPTH"] == "1"
+
+    def test_malformed_depth_defaults_to_one(self) -> None:
+        """Non-integer _OUROBOROS_DEPTH falls back to 1 instead of crashing."""
+        runtime = _make_runtime()
+        with patch.dict(os.environ, {"_OUROBOROS_DEPTH": "not_a_number"}):
+            env = runtime._build_child_env()
+        assert env["_OUROBOROS_DEPTH"] == "1"
+
+    def test_empty_depth_defaults_to_one(self) -> None:
+        """Empty string _OUROBOROS_DEPTH falls back to 1."""
+        runtime = _make_runtime()
+        with patch.dict(os.environ, {"_OUROBOROS_DEPTH": ""}):
             env = runtime._build_child_env()
         assert env["_OUROBOROS_DEPTH"] == "1"
 
     def test_preserves_other_env_vars(self) -> None:
         """Non-Ouroboros env vars are preserved."""
-        runtime = CodexCliRuntime.__new__(CodexCliRuntime)
-        with patch.dict(os.environ, {"PATH": "/usr/bin", "HOME": "/home/test"}):
+        runtime = _make_runtime()
+        with patch.dict(os.environ, {"MY_TEST_VAR": "hello"}):
             env = runtime._build_child_env()
-        assert env.get("PATH") == "/usr/bin"
-        assert env.get("HOME") == "/home/test"
+        assert env.get("MY_TEST_VAR") == "hello"
 
 
 class TestCodexCliAdapterChildEnv:
@@ -60,6 +79,12 @@ class TestCodexCliAdapterChildEnv:
 
     def test_increments_depth(self) -> None:
         """Adapter also tracks recursion depth."""
-        with patch.dict(os.environ, {"_OUROBOROS_DEPTH": "0"}, clear=False):
+        with patch.dict(os.environ, {"_OUROBOROS_DEPTH": "0"}):
+            env = CodexCliLLMAdapter._build_child_env()
+        assert env["_OUROBOROS_DEPTH"] == "1"
+
+    def test_malformed_depth_defaults_to_one(self) -> None:
+        """Adapter handles non-integer _OUROBOROS_DEPTH gracefully."""
+        with patch.dict(os.environ, {"_OUROBOROS_DEPTH": "garbage"}):
             env = CodexCliLLMAdapter._build_child_env()
         assert env["_OUROBOROS_DEPTH"] == "1"


### PR DESCRIPTION
## Summary
- `CodexCliRuntime._build_child_env()` strips `OUROBOROS_AGENT_RUNTIME` and `OUROBOROS_LLM_BACKEND` from child process env
- `CodexCliLLMAdapter._build_child_env()` applies the same isolation
- `_OUROBOROS_DEPTH` counter tracks recursion depth for diagnostics

## Root Cause
When Codex loads the Ouroboros MCP server and `OUROBOROS_AGENT_RUNTIME=codex`, child Codex processes inherit the same env and re-load the MCP server, causing an infinite recursive startup loop that crashes the Codex interactive UI.

## Test plan
- [x] 7 tests in `test_codex_recursion_guard.py` covering both runtime and adapter
- [x] Verifies env var stripping, depth tracking, and preservation of other vars
- [x] ruff/lint clean

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)