### PR TITLE
refactor(cli): deprecate --orchestrator flag, resolve backend from config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,7 +452,7 @@ Any change to a file under `src/ouroboros/cli/commands/` requires reviewing and 
 
 #### `init.py` — `ouroboros init` / `ouroboros init start`
 
-Flags covered: `--resume`, `--state-dir`, `--orchestrator`, `--runtime`, `--llm-backend`, `--debug`
+Flags covered: `--resume`, `--state-dir`, `--runtime`, `--llm-backend`, `--debug` (`--orchestrator` is deprecated/hidden)
 
 **Must update:**
 - `docs/cli-reference.md` — `init` command section (flags, examples)
@@ -461,7 +461,7 @@ Flags covered: `--resume`, `--state-dir`, `--orchestrator`, `--runtime`, `--llm-
 - `docs/getting-started.md` — onboarding flow
 
 **Also check:**
-- `docs/runtime-guides/claude-code.md` and `docs/runtime-guides/codex.md` — if `--orchestrator` or `--runtime` behavior changes
+- `docs/runtime-guides/claude-code.md` and `docs/runtime-guides/codex.md` — if `--runtime` or `--llm-backend` behavior changes
 
 #### `run.py` — `ouroboros run workflow`
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,6 @@
 
 Ouroboros sits between you and your AI runtime (Claude Code, Codex CLI, or others). It replaces ad-hoc prompting with a structured specification-first workflow: interview, crystallize, execute, evaluate, evolve.
 
-<!-- TODO: Replace with demo GIF or asciicast -->
-<p align="center">
-  <em>[Demo: 2-minute walkthrough from vague idea to verified code -- coming soon]</em>
-</p>
-
 ---
 
 ## Why Ouroboros?
@@ -135,24 +130,6 @@ After one loop of the Ouroboros cycle, a vague idea becomes a verified codebase:
 | **Seed** | No spec | Immutable specification with acceptance criteria, ontology, constraints |
 | **Evaluate** | Manual review | 3-stage gate: Mechanical (free) -> Semantic -> Multi-Model Consensus |
 
-<!-- Screenshots: replace placeholder paths with actual images after recording -->
-<p align="center">
-  <strong>Interview Transcript</strong><br/>
-  <img src="./docs/images/demo-interview.png" width="720" alt="Ouroboros Socratic interview exposing hidden assumptions from a vague prompt"/><br/>
-  <sub>The Socratic Interviewer turns "build me a task CLI" into 12 clarified decisions.</sub>
-</p>
-
-<p align="center">
-  <strong>Seed Artifact</strong><br/>
-  <img src="./docs/images/demo-seed.png" width="720" alt="Ouroboros seed specification with acceptance criteria, ontology, and constraints"/><br/>
-  <sub>Immutable seed spec locks intent -- acceptance criteria, ontology, and constraints -- before a line of code is written.</sub>
-</p>
-
-<p align="center">
-  <strong>Evaluation Verdict</strong><br/>
-  <img src="./docs/images/demo-evaluation.png" width="720" alt="Ouroboros 3-stage evaluation gate showing mechanical, semantic, and consensus results"/><br/>
-  <sub>3-stage verification gate: Mechanical (free) -> Semantic -> Multi-Model Consensus.</sub>
-</p>
 
 <details>
 <summary><strong>What just happened?</strong></summary>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -130,9 +130,8 @@ ouroboros init [start] [OPTIONS] [CONTEXT]
 |--------|-------------|
 | `-r, --resume TEXT` | Resume an existing interview by ID |
 | `--state-dir DIRECTORY` | Custom directory for interview state files |
-| `-o, --orchestrator` | Use Claude Code for the interview/seed flow; combine with `--runtime` to choose the workflow handoff backend |
-| `--runtime TEXT` | Agent runtime backend for the workflow execution step after seed generation. Shipped values: `claude`, `codex`. `opencode` appears in the CLI enum but is out of scope. Custom adapters registered in `runtime_factory.py` are also accepted. |
-| `--llm-backend TEXT` | LLM backend for interview, ambiguity scoring, and seed generation (`claude_code`, `litellm`, `codex`). `opencode` appears in the CLI enum but is out of scope |
+| `--runtime TEXT` | Agent runtime backend for the workflow execution step after seed generation (`claude`, `codex`). |
+| `--llm-backend TEXT` | LLM backend override for interview, ambiguity scoring, and seed generation (`claude_code`, `litellm`, `codex`). Resolved from config (`llm.backend`) by default. |
 | `-d, --debug` | Show verbose logs including debug messages |
 
 **Examples:**
@@ -144,13 +143,10 @@ ouroboros init "I want to build a task management CLI tool"
 # Explicit subcommand (equivalent)
 ouroboros init start "I want to build a task management CLI tool"
 
-# Start with Claude Code (no API key needed)
-ouroboros init --orchestrator "Build a REST API"
-
 # Specify runtime backend for the workflow step
-ouroboros init --orchestrator --runtime codex "Build a REST API"
+ouroboros init --runtime codex "Build a REST API"
 
-# Use Codex as the LLM backend for interview and seed generation
+# Override LLM backend for interview and seed generation
 ouroboros init --llm-backend codex "Build a REST API"
 
 # Resume an interrupted interview
@@ -203,7 +199,7 @@ ouroboros run [workflow] [OPTIONS] SEED_FILE
 
 | Option | Description |
 |--------|-------------|
-| `-o/-O, --orchestrator/--no-orchestrator` | Use the agent-runtime orchestrator for execution (default: enabled) |
+| `-o/-O, --orchestrator/--no-orchestrator` | Orchestrator mode (default: enabled). `--no-orchestrator` falls back to legacy placeholder mode. |
 | `--runtime TEXT` | Agent runtime backend override (`claude`, `codex`). Uses configured default if omitted. (`opencode` is in the CLI enum but out of scope) |
 | `-r, --resume TEXT` | Resume a previous orchestrator session by ID |
 | `--mcp-config PATH` | Path to MCP client configuration YAML file |

--- a/docs/guides/seed-authoring.md
+++ b/docs/guides/seed-authoring.md
@@ -335,7 +335,7 @@ acceptance_criteria:
 
 ## Validation
 
-> **Note — `--dry-run` is not functional in the current implementation.** In the default orchestrator mode (`--orchestrator` is `True` by default), the `--dry-run` flag is silently ignored and execution proceeds normally. In non-orchestrator mode (`--no-orchestrator`), `--dry-run` prints a placeholder message without performing any YAML or schema checks. This limitation is tracked for a future release.
+> **Note — `--dry-run` is not functional in the current implementation.** In the default orchestrator mode, the `--dry-run` flag is silently ignored and execution proceeds normally. In legacy non-orchestrator mode (`--no-orchestrator`), `--dry-run` prints a placeholder message without performing any YAML or schema checks. This limitation is tracked for a future release.
 
 **Current approach to pre-run validation:** Run the workflow normally. Schema validation errors surface *before* any agent sessions start, so an invalid seed will print an error and exit without executing:
 
@@ -394,10 +394,10 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 # or
 export OPENAI_API_KEY="sk-..."
 
-# To avoid needing an API key, use Claude Code (Max Plan):
+# To avoid needing an API key, use Claude Code or Codex CLI (configured in llm.backend):
 ooo interview "Build a REST API"
 # or standalone:
-ouroboros init start --orchestrator "Build a REST API"
+ouroboros init start "Build a REST API"
 ```
 
 #### LLM rate-limit or transient API error during questioning
@@ -708,22 +708,18 @@ ouroboros run minimal_seed.yaml
 
 ---
 
-### CLI Flag Warnings
+### CLI Flag Notes
 
-#### `--runtime` without `--orchestrator` (init command)
+#### `--orchestrator` (init command)
 
-**Symptom:**
-```
-Warning: --runtime only affects the workflow execution step when --orchestrator is enabled.
-```
+The `--orchestrator` flag on `ouroboros init` is **deprecated** and no longer needed. The LLM backend is resolved from config (`llm.backend`) automatically. The flag is accepted for backward compatibility but has no effect.
 
-**Cause:** `--runtime` (e.g., `--runtime codex`) was passed to `ouroboros init` without `--orchestrator`. The `--runtime` flag only controls which agent runtime backend is used when the generated seed is immediately handed off to workflow execution. Without `--orchestrator`, the workflow handoff step uses a placeholder.
-
-**Behavior:** This is a **warning only** — the interview and seed generation proceed normally. The runtime flag has no effect.
-
-**Fix:** Add `--orchestrator` if you want to use the specified runtime backend for the post-generation workflow step:
 ```bash
-ouroboros init start --orchestrator --runtime codex "Build a REST API"
+# Just use:
+ouroboros init start "Build a REST API"
+
+# Override backend explicitly if needed:
+ouroboros init start --llm-backend codex "Build a REST API"
 ```
 
 ---

--- a/docs/runtime-guides/claude-code.md
+++ b/docs/runtime-guides/claude-code.md
@@ -32,7 +32,7 @@ orchestrator:
   runtime_backend: claude
 ```
 
-When using the `--orchestrator` CLI flag, Claude Code is the default runtime backend.
+When `orchestrator.runtime_backend` is set to `claude`, Claude Code is used as the runtime backend.
 
 ## How It Works
 
@@ -72,8 +72,8 @@ All commands in this section run in your **regular terminal** (shell), not insid
 
 **Terminal:**
 ```bash
-# Start interactive interview (Claude Code runtime)
-uv run ouroboros init start --orchestrator "Your idea here"
+# Start interactive interview
+uv run ouroboros init start "Your idea here"
 
 # Resume an interrupted interview
 uv run ouroboros init start --resume interview_20260127_120000
@@ -86,24 +86,24 @@ uv run ouroboros init list
 
 **Terminal:**
 ```bash
-# Execute workflow (Claude Code runtime)
-uv run ouroboros run workflow --orchestrator seed.yaml
+# Execute workflow
+uv run ouroboros run workflow seed.yaml
 
 # Dry run (validate seed without executing)
 uv run ouroboros run workflow --dry-run seed.yaml
 
 # Debug output (show logs and agent thinking)
-uv run ouroboros run workflow --orchestrator --debug seed.yaml
+uv run ouroboros run workflow --debug seed.yaml
 
 # Resume a previous session
-uv run ouroboros run workflow --orchestrator --resume <session_id> seed.yaml
+uv run ouroboros run workflow --resume <session_id> seed.yaml
 ```
 
 ## Troubleshooting
 
 ### "Providers: warning" in health check
 
-This is normal when not using LiteLLM providers. The orchestrator mode uses Claude Code directly.
+This is normal when not using LiteLLM providers. The orchestrator mode uses the configured runtime backend directly.
 
 ### Session fails with empty error
 
@@ -112,7 +112,7 @@ Ensure you're running from the project directory:
 **Terminal:**
 ```bash
 cd /path/to/ouroboros
-uv run ouroboros run workflow --orchestrator seed.yaml
+uv run ouroboros run workflow seed.yaml
 ```
 
 ### "EventStore not initialized"

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -26,7 +26,7 @@ from ouroboros.bigbang.interview import (
 from ouroboros.bigbang.seed_generator import SeedGenerator
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
-from ouroboros.config import get_clarification_model
+from ouroboros.config import get_clarification_model, get_llm_backend
 from ouroboros.observability import LoggingConfig, configure_logging
 from ouroboros.providers import create_llm_adapter
 from ouroboros.providers.base import LLMAdapter
@@ -145,15 +145,15 @@ async def _multiline_prompt_async(prompt_text: str) -> str:
 
 
 def _get_adapter(
-    use_orchestrator: bool,
     backend: str | None = None,
     for_interview: bool = False,
     debug: bool = False,
 ) -> LLMAdapter:
     """Get the appropriate LLM adapter.
 
+    Resolution order: explicit backend arg > config llm.backend > "claude_code".
+
     Args:
-        use_orchestrator: If True, default to Claude Code for compatibility.
         backend: Optional explicit LLM backend override.
         for_interview: If True, enable Read/Glob/Grep tools for codebase exploration.
         debug: If True, show streaming messages (thinking, tool use).
@@ -161,7 +161,7 @@ def _get_adapter(
     Returns:
         LLM adapter instance.
     """
-    resolved_backend = backend or ("claude_code" if use_orchestrator else "litellm")
+    resolved_backend = backend or get_llm_backend()
 
     if for_interview:
         # Interview mode: request the interview-specific permission policy and
@@ -260,7 +260,6 @@ async def _run_interview(
     initial_context: str,
     resume_id: str | None = None,
     state_dir: Path | None = None,
-    use_orchestrator: bool = False,
     debug: bool = False,
     workflow_runtime_backend: str | None = None,
     llm_backend: str | None = None,
@@ -271,13 +270,11 @@ async def _run_interview(
         initial_context: Initial context or idea for the interview.
         resume_id: Optional interview ID to resume.
         state_dir: Optional custom state directory.
-        use_orchestrator: If True, use Claude Code (Max Plan) instead of LiteLLM.
         workflow_runtime_backend: Optional agent runtime backend for the workflow handoff.
         llm_backend: Optional LLM backend override for interview and seed generation.
     """
     # Initialize components
     llm_adapter = _get_adapter(
-        use_orchestrator,
         backend=llm_backend,
         for_interview=True,
         debug=debug,
@@ -370,7 +367,6 @@ async def _run_interview(
     if should_start_workflow:
         await _start_workflow(
             seed_path,
-            use_orchestrator,
             runtime_backend=workflow_runtime_backend,
         )
 
@@ -472,40 +468,32 @@ async def _generate_seed_from_interview(
 
 async def _start_workflow(
     seed_path: Path,
-    use_orchestrator: bool = False,
     parallel: bool = True,
     runtime_backend: str | None = None,
 ) -> None:
-    """Start workflow from generated seed.
+    """Start workflow from generated seed (always orchestrator mode).
 
     Args:
         seed_path: Path to the seed YAML file.
-        use_orchestrator: Whether to use Claude Code orchestrator.
         parallel: Execute independent ACs in parallel. Default: True.
         runtime_backend: Optional runtime backend for orchestrator execution.
     """
     console.print()
     console.print("[bold cyan]Starting workflow...[/]")
 
-    if use_orchestrator:
-        # Direct function call instead of subprocess
-        from ouroboros.cli.commands.run import _run_orchestrator
+    from ouroboros.cli.commands.run import _run_orchestrator
 
-        try:
-            await _run_orchestrator(
-                seed_path,
-                resume_session=None,
-                parallel=parallel,
-                runtime_backend=runtime_backend,
-            )
-        except typer.Exit:
-            pass  # Normal exit
-        except KeyboardInterrupt:
-            print_info("Workflow interrupted.")
-    else:
-        # Standard workflow (placeholder for now)
-        print_info(f"Would execute workflow from: {seed_path}")
-        print_info("Standard workflow execution not yet implemented.")
+    try:
+        await _run_orchestrator(
+            seed_path,
+            resume_session=None,
+            parallel=parallel,
+            runtime_backend=runtime_backend,
+        )
+    except typer.Exit:
+        pass  # Normal exit
+    except KeyboardInterrupt:
+        print_info("Workflow interrupted.")
 
 
 def _find_pm_seeds(seeds_dir: Path | None = None) -> list[Path]:
@@ -693,12 +681,13 @@ def start(
             dir_okay=True,
         ),
     ] = None,
-    orchestrator: Annotated[
+    orchestrator: Annotated[  # noqa: ARG001 — kept for backward compat
         bool,
         typer.Option(
             "--orchestrator",
             "-o",
-            help="Use Claude Code (Max Plan) instead of LiteLLM. No API key required.",
+            help="Deprecated: no longer needed. Backend is resolved from config (llm.backend).",
+            hidden=True,
         ),
     ] = False,
     runtime: Annotated[
@@ -737,12 +726,13 @@ def start(
     This command initiates the Big Bang phase, which transforms vague ideas
     into clear, executable requirements through iterative questioning.
 
+    The LLM backend is resolved from config (llm.backend) by default.
+    Override with --llm-backend if needed.
+
     Example:
         ouroboros init start "I want to build a task management CLI tool"
 
-        ouroboros init start --orchestrator "Build a REST API"
-
-        ouroboros init start --orchestrator --runtime codex "Build a REST API"
+        ouroboros init start --runtime codex "Build a REST API"
 
         ouroboros init start --llm-backend codex "Build a REST API"
 
@@ -802,21 +792,16 @@ def start(
         configure_logging(LoggingConfig(log_level="DEBUG"))
         print_info("Debug mode enabled - showing verbose logs")
 
-    if runtime and not orchestrator:
-        print_warning(
-            "--runtime only affects the workflow execution step when --orchestrator is enabled."
-        )
-
-    # Show mode info
-    if orchestrator:
-        print_info("Using Claude Code (Max Plan) - no API key required")
-        if runtime:
-            print_info(f"Workflow runtime backend: {runtime.value}")
-    else:
-        print_info("Using LiteLLM - API key required")
-
-    if llm_backend:
-        print_info(f"Interview LLM backend: {llm_backend.value}")
+    # Show mode info — resolve actual backend used
+    resolved_display = llm_backend.value if llm_backend else get_llm_backend()
+    backend_labels = {
+        "claude_code": "Claude Code - no API key required",
+        "codex": "Codex CLI - no API key required",
+        "litellm": "LiteLLM - API key required",
+    }
+    print_info(f"Using {backend_labels.get(resolved_display, resolved_display)}")
+    if runtime:
+        print_info(f"Workflow runtime backend: {runtime.value}")
 
     # Run interview
     try:
@@ -825,7 +810,6 @@ def start(
                 context or "",
                 resume,
                 state_dir,
-                orchestrator,
                 debug,
                 runtime.value if runtime else None,
                 llm_backend.value if llm_backend else None,
@@ -854,7 +838,7 @@ def list_interviews(
     ] = None,
 ) -> None:
     """List all interview sessions."""
-    llm_adapter = create_llm_adapter(backend="litellm")
+    llm_adapter = create_llm_adapter(backend=get_llm_backend())
     engine = InterviewEngine(
         llm_adapter=llm_adapter,
         state_dir=state_dir or Path.home() / ".ouroboros" / "data",

--- a/src/ouroboros/orchestrator/__init__.py
+++ b/src/ouroboros/orchestrator/__init__.py
@@ -25,11 +25,10 @@ Usage:
     runner = OrchestratorRunner(adapter, event_store, mcp_manager=mcp_manager)
 
 CLI Usage:
-    ouroboros run --orchestrator seed.yaml
-    ouroboros run --orchestrator seed.yaml --parallel  # Parallel AC execution
-    ouroboros run --orchestrator seed.yaml --resume <session_id>
-    ouroboros run --orchestrator seed.yaml --runtime codex
-    ouroboros run --orchestrator seed.yaml --mcp-config mcp.yaml
+    ouroboros run seed.yaml
+    ouroboros run seed.yaml --runtime codex
+    ouroboros run seed.yaml --resume <session_id>
+    ouroboros run seed.yaml --mcp-config mcp.yaml
 """
 
 from ouroboros.orchestrator.adapter import (

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -26,7 +26,6 @@ class TestInitWorkflowRuntimeHandoff:
         ):
             await _start_workflow(
                 Path("/tmp/generated-seed.yaml"),
-                use_orchestrator=True,
                 runtime_backend="codex",
             )
 
@@ -49,7 +48,6 @@ class TestInitWorkflowRuntimeHandoff:
                     "init",
                     "start",
                     "Build a REST API",
-                    "--orchestrator",
                     "--runtime",
                     "codex",
                     "--llm-backend",
@@ -58,8 +56,9 @@ class TestInitWorkflowRuntimeHandoff:
             )
 
         assert result.exit_code == 0
-        assert mock_run_interview.call_args.args[6] == "codex"
-        assert mock_run_interview.call_args.args[5] == "codex"
+        # _run_interview(context, resume, state_dir, debug, runtime, llm_backend)
+        assert mock_run_interview.call_args.args[5] == "codex"  # llm_backend
+        assert mock_run_interview.call_args.args[4] == "codex"  # runtime
 
     def test_get_adapter_uses_interview_use_case_for_codex(self) -> None:
         """Interview adapter creation stays backend-neutral for Codex."""
@@ -70,7 +69,6 @@ class TestInitWorkflowRuntimeHandoff:
             return_value=mock_adapter,
         ) as mock_create_adapter:
             adapter = _get_adapter(
-                use_orchestrator=True,
                 backend="codex",
                 for_interview=True,
                 debug=True,
@@ -90,7 +88,6 @@ class TestInitWorkflowRuntimeHandoff:
             return_value=mock_adapter,
         ) as mock_create_adapter:
             adapter = _get_adapter(
-                use_orchestrator=True,
                 backend="opencode",
                 for_interview=True,
                 debug=False,

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -255,7 +255,7 @@ class TestShorthandCommands:
 
     def test_init_list_subcommand_still_works(self) -> None:
         """Test backward compat: 'ouroboros init list' still routes to list."""
-        with patch("ouroboros.cli.commands.init.LiteLLMAdapter"):
+        with patch("ouroboros.cli.commands.init.create_llm_adapter"):
             with patch("ouroboros.cli.commands.init.asyncio.run") as mock_run:
                 mock_run.return_value = []
                 result = runner.invoke(app, ["init", "list"])


### PR DESCRIPTION
## Summary
- **Deprecate `--orchestrator` flag** on `init start` — backend is now resolved from config (`llm.backend`) via `get_llm_backend()`, no CLI flag needed
- **Workflow always orchestrator mode** — `_start_workflow()` no longer has a non-orchestrator fallback (matching `run workflow` default)
- **Fix `init list`** — was hardcoded to `litellm`, now uses config-resolved backend
- **Remove README demo placeholders** — empty screenshot/GIF placeholders removed (demo assets deferred to follow-up PR)
- **Update all docs** — cli-reference, claude-code runtime guide, seed-authoring guide, CONTRIBUTING

## Checks passed
- [x] ruff lint
- [x] ruff format
- [x] mypy
- [x] pytest (834 passed, 4 skipped)

## Test plan
- `ouroboros init start "test"` → should show `Using Codex CLI` (from config) instead of `Using LiteLLM`
- `ouroboros init start --llm-backend litellm "test"` → explicit override still works
- `ouroboros init start --orchestrator "test"` → accepted silently (backward compat), no effect
- `ouroboros init list` → no longer crashes with missing LiteLLM import

🤖 Generated with [Claude Code](https://claude.com/claude-code)