### PR TITLE
fix(interview): prevent ambiguity score override on seed generation

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -130,6 +130,29 @@ def _format_question_with_ambiguity(question: str, score: AmbiguityScore | None)
     return f"(ambiguity: {score.overall_score:.2f}) {question}"
 
 
+def _ambiguity_warning_for_failed_question(score: AmbiguityScore | None) -> str:
+    """Build an explicit ambiguity warning for question-generation failures.
+
+    When question generation fails mid-interview, the main session must NOT
+    assume the interview is complete.
+    See: https://github.com/Q00/ouroboros/issues/210
+    """
+    if score is None:
+        return (
+            "\n\nWARNING: Ambiguity score is unknown. "
+            "The interview is NOT complete — do NOT generate a Seed. "
+            "Resume the interview to continue clarifying requirements."
+        )
+    if not score.is_ready_for_seed:
+        return (
+            f"\n\nWARNING: Current ambiguity is {score.overall_score:.2f} "
+            f"(threshold: {AMBIGUITY_THRESHOLD}). "
+            f"The interview is NOT complete — do NOT generate a Seed. "
+            f"Resume the interview to continue clarifying requirements."
+        )
+    return ""
+
+
 def _load_state_ambiguity_score(state: InterviewState) -> AmbiguityScore | None:
     """Rebuild a stored ambiguity snapshot from interview state."""
     if state.ambiguity_score is None:
@@ -318,36 +341,44 @@ class GenerateSeedHandler:
 
             state: InterviewState = state_result.value
 
-            # Use provided ambiguity score, a persisted snapshot, or compute on demand.
+            # Always use a trusted ambiguity score: persisted snapshot or
+            # freshly computed.  The caller-supplied ``ambiguity_score``
+            # parameter is intentionally ignored to prevent LLM callers
+            # from overriding the gate with an arbitrary low value.
+            # See: https://github.com/Q00/ouroboros/issues/210
             if ambiguity_score_value is not None:
-                ambiguity_score = self._build_ambiguity_score_from_value(ambiguity_score_value)
-            else:
-                ambiguity_score = self._load_stored_ambiguity_score(state)
-                if ambiguity_score is None:
-                    scorer = AmbiguityScorer(
-                        llm_adapter=llm_adapter,
-                    )
-                    score_result = await scorer.score(state)
-                    if score_result.is_err:
-                        return Result.err(
-                            MCPToolError(
-                                f"Failed to calculate ambiguity: {score_result.error}",
-                                tool_name="ouroboros_generate_seed",
-                            )
-                        )
+                log.warning(
+                    "mcp.tool.generate_seed.ignoring_caller_ambiguity_score",
+                    session_id=session_id,
+                    caller_value=ambiguity_score_value,
+                )
 
-                    ambiguity_score = score_result.value
-                    state.store_ambiguity(
-                        score=ambiguity_score.overall_score,
-                        breakdown=ambiguity_score.breakdown.model_dump(mode="json"),
-                    )
-                    save_result = await interview_engine.save_state(state)
-                    if save_result.is_err:
-                        log.warning(
-                            "mcp.tool.generate_seed.persist_ambiguity_failed",
-                            session_id=session_id,
-                            error=str(save_result.error),
+            ambiguity_score = self._load_stored_ambiguity_score(state)
+            if ambiguity_score is None:
+                scorer = AmbiguityScorer(
+                    llm_adapter=llm_adapter,
+                )
+                score_result = await scorer.score(state)
+                if score_result.is_err:
+                    return Result.err(
+                        MCPToolError(
+                            f"Failed to calculate ambiguity: {score_result.error}",
+                            tool_name="ouroboros_generate_seed",
                         )
+                    )
+
+                ambiguity_score = score_result.value
+                state.store_ambiguity(
+                    score=ambiguity_score.overall_score,
+                    breakdown=ambiguity_score.breakdown.model_dump(mode="json"),
+                )
+                save_result = await interview_engine.save_state(state)
+                if save_result.is_err:
+                    log.warning(
+                        "mcp.tool.generate_seed.persist_ambiguity_failed",
+                        session_id=session_id,
+                        error=str(save_result.error),
+                    )
 
             # Use injected or create seed generator
             generator = self.seed_generator or SeedGenerator(
@@ -675,15 +706,24 @@ class InterviewHandler:
                     if "empty response" in error_msg.lower():
                         # Persist state so the session can actually be resumed
                         await engine.save_state(state)
+                        amb_warning = _ambiguity_warning_for_failed_question(live_score)
+                        stderr_info = ""
+                        err = question_result.error
+                        if hasattr(err, "details") and isinstance(err.details, dict):
+                            stderr = err.details.get("stderr", "")
+                            if stderr:
+                                stderr_info = f"\n\nDiagnostics (stderr):\n{stderr}"
                         return Result.ok(
                             MCPToolResult(
                                 content=(
                                     MCPContentItem(
                                         type=ContentType.TEXT,
                                         text=(
-                                            f"Interview started but question generation failed after retries. "
+                                            f"Question generation failed (empty response from Agent SDK). "
                                             f"Session ID: {state.interview_id}\n\n"
                                             f'Resume with: session_id="{state.interview_id}"'
+                                            f"{amb_warning}"
+                                            f"{stderr_info}"
                                         ),
                                     ),
                                 ),
@@ -891,15 +931,25 @@ class InterviewHandler:
                         )
                     )
                     if "empty response" in error_msg.lower():
+                        amb_warning = _ambiguity_warning_for_failed_question(live_score)
+                        # Extract stderr from ProviderError details for diagnostics
+                        stderr_info = ""
+                        err = question_result.error
+                        if hasattr(err, "details") and isinstance(err.details, dict):
+                            stderr = err.details.get("stderr", "")
+                            if stderr:
+                                stderr_info = f"\n\nDiagnostics (stderr):\n{stderr}"
                         return Result.ok(
                             MCPToolResult(
                                 content=(
                                     MCPContentItem(
                                         type=ContentType.TEXT,
                                         text=(
-                                            f"Question generation failed after retries. "
+                                            f"Question generation failed (empty response from Agent SDK). "
                                             f"Session ID: {session_id}\n\n"
                                             f'Resume with: session_id="{session_id}"'
+                                            f"{amb_warning}"
+                                            f"{stderr_info}"
                                         ),
                                     ),
                                 ),

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -379,7 +379,10 @@ class ClaudeCodeAdapter:
         if os.environ.get("CLAUDECODE"):
             env_overrides["CLAUDECODE"] = ""
 
+        stderr_lines: list[str] = []
+
         def _stderr_callback(line: str) -> None:
+            stderr_lines.append(line[:500])
             log.debug("claude_code_adapter.stderr", line=line[:200])
 
         options_kwargs: dict = {
@@ -504,17 +507,25 @@ class ClaudeCodeAdapter:
 
         # Check for empty response — always an error regardless of session_id
         if not content:
+            # Include captured stderr for diagnostics — helps identify
+            # why the CLI produced no output (rate limits, auth, etc.)
+            stderr_tail = "\n".join(stderr_lines[-20:]) if stderr_lines else ""
             if session_id:
                 log.warning(
                     "claude_code_adapter.empty_response",
                     content_length=0,
                     session_id=session_id,
+                    stderr_lines=len(stderr_lines),
                     hint="CLI started but produced no content",
                 )
                 return Result.err(
                     ProviderError(
                         message="Empty response from CLI - session started but no content produced",
-                        details={"session_id": session_id, "content_length": 0},
+                        details={
+                            "session_id": session_id,
+                            "content_length": 0,
+                            "stderr": stderr_tail,
+                        },
                     )
                 )
             else:
@@ -522,12 +533,17 @@ class ClaudeCodeAdapter:
                     "claude_code_adapter.empty_response",
                     content_length=0,
                     session_id=session_id,
+                    stderr_lines=len(stderr_lines),
                     hint="CLI may still be starting (custom CLI sync, etc.)",
                 )
                 return Result.err(
                     ProviderError(
                         message="Empty response from CLI - may need retry (timeout/startup)",
-                        details={"session_id": session_id, "content_length": 0},
+                        details={
+                            "session_id": session_id,
+                            "content_length": 0,
+                            "stderr": stderr_tail,
+                        },
                     )
                 )
 

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1692,6 +1692,59 @@ class TestGenerateSeedHandlerAmbiguity:
         generate_call = mock_seed_generator.generate.await_args
         assert generate_call.args[1].overall_score == 0.11
 
+    async def test_generate_seed_ignores_caller_ambiguity_score_override(self) -> None:
+        """Caller-supplied ambiguity_score must be ignored to prevent LLM gate bypass.
+
+        Regression test for https://github.com/Q00/ouroboros/issues/210
+        """
+        state = InterviewState(
+            interview_id="sess-bypass",
+            initial_context="Build something",
+            ambiguity_score=0.35,
+            ambiguity_breakdown={
+                "goal_clarity": {
+                    "name": "goal_clarity",
+                    "clarity_score": 0.65,
+                    "weight": 0.4,
+                    "justification": "Vague goal",
+                },
+                "constraint_clarity": {
+                    "name": "constraint_clarity",
+                    "clarity_score": 0.65,
+                    "weight": 0.3,
+                    "justification": "Vague constraints",
+                },
+                "success_criteria_clarity": {
+                    "name": "success_criteria_clarity",
+                    "clarity_score": 0.65,
+                    "weight": 0.3,
+                    "justification": "Vague success criteria",
+                },
+            },
+        )
+        mock_adapter = MagicMock()
+        mock_interview_engine = MagicMock()
+        mock_interview_engine.load_state = AsyncMock(return_value=Result.ok(state))
+        mock_seed_generator = MagicMock()
+        mock_seed_generator.generate = AsyncMock(return_value=Result.err(RuntimeError("boom")))
+        handler = GenerateSeedHandler(
+            llm_adapter=mock_adapter,
+            interview_engine=mock_interview_engine,
+            seed_generator=mock_seed_generator,
+        )
+
+        # LLM tries to pass ambiguity_score=0.18 to bypass the gate
+        await handler.handle(
+            {
+                "session_id": "sess-bypass",
+                "ambiguity_score": 0.18,
+            }
+        )
+
+        # The stored score (0.35) should be used, NOT the caller's 0.18
+        generate_call = mock_seed_generator.generate.await_args
+        assert generate_call.args[1].overall_score == 0.35
+
 
 class TestCancelExecutionHandler:
     """Test CancelExecutionHandler class."""


### PR DESCRIPTION
## Summary
- **Block ambiguity gate bypass**: `GenerateSeedHandler` now ignores caller-supplied `ambiguity_score` parameter to prevent LLM callers from passing `0.18` to bypass the `0.2` threshold. Always uses stored/recomputed score.
- **Improve empty response diagnostics**: Capture Agent SDK CLI stderr into `ProviderError.details["stderr"]` so failure causes (rate limits, auth errors, etc.) are traceable.
- **Add ambiguity warning on question generation failure**: Failed responses now explicitly state the current ambiguity score and warn that the interview is NOT complete, preventing the main session from mistakenly declaring seed-readiness.

Closes #210

## Checks passed
- [x] ruff lint
- [x] ruff format
- [x] mypy
- [x] pytest (104 passed)

## Test plan
- [x] Regression test: `GenerateSeedHandler` with caller `ambiguity_score=0.18` uses stored score `0.35` instead
- [x] Verify stderr diagnostics are included in error details on empty response
- [x] Verify ambiguity WARNING appears in question generation failure responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)