### PR TITLE
feat(#267): wire mcp_bridge into evolution executor closure

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -753,10 +753,18 @@ def create_ouroboros_server(
             cwd=task_cwd or Path.cwd(),
             llm_backend=llm_backend,
         )
+        _evo_mcp_manager = mcp_bridge.manager if mcp_bridge is not None else None
+        _evo_mcp_prefix = (
+            mcp_bridge.tool_prefix
+            if mcp_bridge is not None and hasattr(mcp_bridge, "tool_prefix")
+            else ""
+        )
         evolution_runner = OrchestratorRunner(
             adapter=runner_adapter,
             event_store=event_store,
             console=Console(stderr=True),
+            mcp_manager=_evo_mcp_manager,
+            mcp_tool_prefix=_evo_mcp_prefix,
             debug=False,
             enable_decomposition=True,
         )


### PR DESCRIPTION
## Summary

Rebased PR #268 by @shaun0927 onto current `main` (after #279 + #280 merge).

- Wire `mcp_bridge` into the `_evolution_executor` closure so that `evolve_step` can access external MCP tools during evolution cycles
- The closure captures scope variables from the composition root, not from handler fields, so BridgeAwareMixin alone doesn't solve this

## Original PR

Supersedes #268

## Test plan

- [ ] Existing evolution tests pass
- [ ] Verify mcp_manager is forwarded in evolution executor's OrchestratorRunner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: JunghwanNA <70629228+shaun0927@users.noreply.github.com>