### PR TITLE
feat(#287): add PATH 4 research interlude for mid-interview exploration

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -144,6 +144,30 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    - If any part of the question requires judgment, route the ENTIRE question to user
    - Prefix answer with `[from-user]` (human made the decision)
 
+   **PATH 4 — Research Interlude** (external knowledge needed):
+   When the question asks about third-party APIs, pricing models, library
+   capabilities, version compatibility, security advisories, or industry
+   standards that are NOT answerable from the local codebase:
+   - Use WebFetch/WebSearch to gather external information
+   - Present findings to user as a **confirmation question** via AskUserQuestion
+     (same pattern as PATH 1, but with web sources instead of code):
+     ```json
+     {
+       "questions": [{
+         "question": "MCP asks: What rate limits does the Stripe API have?\n\nI found: Stripe allows 100 read ops/sec and 25 write ops/sec in live mode.\n\nIs this correct?",
+         "header": "Q<N> — Research Confirmation",
+         "options": [
+           {"label": "Yes, correct", "description": "Use this as the answer"},
+           {"label": "No, let me correct", "description": "I'll provide the right answer"}
+         ],
+         "multiSelect": false
+       }]
+     }
+     ```
+   - Prefix answer with `[from-research]` when sending to MCP
+   - **Facts, not decisions**: "Stripe rate limit is 100 req/s" is research.
+     "We should use Stripe" is a DECISION — route to PATH 2.
+
    **When in doubt, use PATH 2.** It's safer to ask the user than to guess.
 
 3. **Send the answer back to MCP**:
@@ -151,7 +175,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    Tool: ouroboros_interview
    Arguments:
      session_id: <session ID>
-     answer: "[from-code] JWT-based auth in src/auth/jwt.py" or "[from-user] Stripe Billing"
+     answer: "[from-code] JWT-based auth in src/auth/jwt.py" or "[from-user] Stripe Billing" or "[from-research] Stripe: 100 read ops/sec live mode"
    ```
    MCP records the answer, generates the next question, and returns it.
 
@@ -169,10 +193,11 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
 
 #### Dialectic Rhythm Guard
 
-Track consecutive PATH 1 (code confirmation) answers. If 3 consecutive questions
-were answered via PATH 1, the next question MUST be routed to PATH 2 (directly
-to user), even if it appears code-answerable. This preserves the Socratic
-dialectic rhythm — the interview is with the human, not the codebase.
+Track consecutive PATH 1/PATH 4 (code/research confirmation) answers. If 3
+consecutive questions were answered via PATH 1 or PATH 4, the next question MUST
+be routed to PATH 2 (directly to user), even if it appears code- or
+research-answerable. This preserves the Socratic dialectic rhythm — the interview
+is with the human, not the codebase or external docs.
 Reset the counter whenever user answers directly (PATH 2 or PATH 3).
 
 #### Retry on Failure

--- a/src/ouroboros/agents/socratic-interviewer.md
+++ b/src/ouroboros/agents/socratic-interviewer.md
@@ -24,7 +24,8 @@ You are an expert requirements engineer conducting a Socratic interview to clari
 When the interview is brownfield, the caller provides code-enriched answers:
 - Answers prefixed with `[from-code]` describe existing codebase state (factual).
 - Answers prefixed with `[from-user]` are human decisions/judgments.
-- Use `[from-code]` facts as context, but focus questions on INTENT and DECISIONS.
+- Answers prefixed with `[from-research]` contain externally researched information (API docs, pricing, compatibility).
+- Use `[from-code]` and `[from-research]` facts as context, but focus questions on INTENT and DECISIONS.
 - Ask "Why?" and "What should change?" rather than "What exists?"
 - GOOD: "Given that JWT auth exists, should the new module extend it or use a different approach?"
 - BAD: "What authentication method do you use?" (the caller already told you)

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -550,14 +550,20 @@ class InterviewEngine:
                 f"Initial context: {state.initial_context}\n"
             )
 
+        # Answer prefix hints — always present so the question generator
+        # can interpret enriched answers regardless of brownfield status.
+        dynamic_header += (
+            "\n\nAnswer prefixes the caller may use:\n"
+            "- [from-code]: Existing codebase state (factual, read from files).\n"
+            "- [from-user]: Human decisions/judgments.\n"
+            "- [from-research]: Externally researched information (API docs, pricing, compatibility)."
+        )
         # Brownfield hint: main session handles code reading, MCP just asks questions
         if state.is_brownfield:
             dynamic_header += (
                 "\n\nThis is a BROWNFIELD project. The caller (main session) has direct "
                 "codebase access and will enrich answers with code context. Focus your "
-                "questions on INTENT and DECISIONS, not on discovering what exists. "
-                "Answers prefixed with [from-code] describe existing code state. "
-                "Answers prefixed with [from-user] are human decisions."
+                "questions on INTENT and DECISIONS, not on discovering what exists."
             )
 
         ambiguity_snapshot = self._build_ambiguity_snapshot_prompt(state)

--- a/tests/unit/bigbang/test_interview_research_prefix.py
+++ b/tests/unit/bigbang/test_interview_research_prefix.py
@@ -1,0 +1,77 @@
+"""Tests for [from-research] prefix in interview system prompt.
+
+Verifies that the system prompt always includes all three answer prefix
+hints ([from-code], [from-user], [from-research]) regardless of whether
+the interview is brownfield or greenfield.
+
+See: https://github.com/Q00/ouroboros/issues/287
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ouroboros.bigbang.interview import (
+    InterviewEngine,
+    InterviewState,
+    InterviewStatus,
+)
+
+
+def _make_engine() -> InterviewEngine:
+    return InterviewEngine(
+        llm_adapter=MagicMock(),
+        state_dir=MagicMock(),
+        model="test-model",
+    )
+
+
+class TestResearchPrefixInSystemPrompt:
+    """[from-research] prefix must appear in the system prompt."""
+
+    def test_greenfield_includes_all_prefixes(self) -> None:
+        """Greenfield interviews include all three answer prefixes."""
+        engine = _make_engine()
+        state = InterviewState(
+            interview_id="test-001",
+            initial_context="Build an app",
+            status=InterviewStatus.IN_PROGRESS,
+            is_brownfield=False,
+        )
+
+        prompt = engine._build_system_prompt(state)
+
+        assert "[from-code]" in prompt
+        assert "[from-user]" in prompt
+        assert "[from-research]" in prompt
+
+    def test_brownfield_includes_all_prefixes(self) -> None:
+        """Brownfield interviews also include all three answer prefixes."""
+        engine = _make_engine()
+        state = InterviewState(
+            interview_id="test-002",
+            initial_context="Add feature to existing app",
+            status=InterviewStatus.IN_PROGRESS,
+            is_brownfield=True,
+        )
+
+        prompt = engine._build_system_prompt(state)
+
+        assert "[from-code]" in prompt
+        assert "[from-user]" in prompt
+        assert "[from-research]" in prompt
+        assert "BROWNFIELD" in prompt
+
+    def test_research_prefix_describes_external_sources(self) -> None:
+        """The [from-research] hint mentions external information sources."""
+        engine = _make_engine()
+        state = InterviewState(
+            interview_id="test-003",
+            initial_context="Build an app",
+            status=InterviewStatus.IN_PROGRESS,
+        )
+
+        prompt = engine._build_system_prompt(state)
+
+        # The hint should describe what [from-research] means
+        assert "externally researched" in prompt.lower() or "API docs" in prompt


### PR DESCRIPTION
## Summary

Add a fourth routing path (PATH 4 — Research Interlude) to the interview skill that enables the main Claude session to use WebFetch/WebSearch to gather external information before answering MCP questions.

## Motivation

The interview system currently has 3 routing paths:
- **PATH 1** (Code Confirmation): Read/Glob/Grep local code → `[from-code]`
- **PATH 2** (Human Judgment): Route to user → `[from-user]`
- **PATH 3** (Code + Judgment): Read code then route to user → `[from-user]`

When a question asks about third-party APIs, pricing, library compatibility, or industry standards, none of these paths apply. The user must manually research externally and type findings — there is no structured way to enrich answers with external data.

## Design Decision: Why client-side only (not MCP-side tools)

We evaluated four options (detailed in #287). The key finding that eliminated Option C (enabling tools on the MCP-side LLM):

1. **Shared adapter conflict**: The server composition root (`adapter.py:667`) creates one `llm_adapter` for all handlers. The interview handler's `allowed_tools=[]` is actually dead code — the shared adapter is always injected. Enabling tools would require restructuring the server wiring.
2. **3-4x latency increase**: Each tool call adds an API roundtrip within the subprocess. A research-capable question generator with `max_turns=5` could take 8-30s per question vs. the current 3-8s.
3. **Response pollution**: `claude_code_adapter.py:634` accumulates text from all turns (`content += text`), so intermediate "Let me check..." text would mix into the question.

PATH 4 achieves the same goal with zero MCP changes — the main session (which already has full tool access) performs research and sends an enriched answer.

## Changes

| File | Change |
|------|--------|
| `skills/interview/SKILL.md` | PATH 4 definition: trigger conditions, AskUserQuestion template, `[from-research]` prefix |
| `skills/interview/SKILL.md` | Updated answer example to include `[from-research]` |
| `skills/interview/SKILL.md` | Dialectic Rhythm Guard: PATH 4 counts alongside PATH 1 for the consecutive-confirmation counter |
| `src/ouroboros/bigbang/interview.py` | Added unconditional answer-prefix hints (`[from-code]`, `[from-user]`, `[from-research]`) to the system prompt — previously only brownfield interviews documented prefixes |
| `src/ouroboros/agents/socratic-interviewer.md` | Added `[from-research]` to the BROWNFIELD CONTEXT prefix documentation |
| `tests/unit/bigbang/test_interview_research_prefix.py` | New: 3 tests verifying all prefixes appear in greenfield, brownfield, and with correct description |

## How it works

```
MCP Q5: "What rate limits does the Stripe API have for webhooks?"

Main session:
  1. Detects PATH 4 trigger (third-party API question, not code-answerable)
  2. Uses WebSearch to find Stripe docs
  3. Presents to user: "I found: 100 read ops/sec, 25 write ops/sec. Correct?"
  4. User confirms
  5. Sends to MCP: "[from-research] Stripe: 100 read/sec, 25 write/sec live mode"

MCP receives the enriched answer in conversation history and uses it
to generate a better follow-up question.
```

## Backward compatibility

- **MCP server is prefix-agnostic** (`authoring_handlers.py:859-903`): it records whatever answer string is sent without parsing prefixes. `[from-research]` is just text.
- **System prompt change is additive**: the prefix hints were previously inside the brownfield `if` block; now they are unconditional. Greenfield interviews gain prefix documentation they previously lacked.
- **Pydantic state model unchanged**: no new fields, no migration needed.

## Test plan

- [x] `uv run pytest tests/unit/bigbang/test_interview_research_prefix.py -v` — 3 passed
- [x] `uv run pytest tests/unit/ -q` — 3929 passed, 9 skipped
- [x] `uv run ruff check && ruff format --check` — all checks passed

Closes #287