### PR TITLE
docs(gemini): add Gemini CLI runtime guide and update backend references [1/5]

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,6 +113,7 @@ uv run ouroboros --version            # verify CLI
 | Claude Code (`ooo`) | Claude Code with plugin support |
 | Standalone CLI (`ouroboros`) | Python >= 3.12, API key (Anthropic or OpenAI) |
 | Codex CLI backend | Python >= 3.12, `npm install -g @openai/codex`, OpenAI API key with access to GPT-5.4 |
+| Gemini CLI backend | Python >= 3.12, `npm install -g @google/gemini-cli`, `GEMINI_API_KEY` or Google OAuth (browser) |
 
 ---
 
@@ -126,6 +127,9 @@ export ANTHROPIC_API_KEY="your-anthropic-key"
 
 # Codex-backed flows
 export OPENAI_API_KEY="your-openai-key"
+
+# Gemini-backed flows (API key — or sign in via OAuth browser flow: run `gemini` once)
+export GEMINI_API_KEY="your-api-key"   # from aistudio.google.com/apikey
 ```
 
 > Claude Code plugin users: your Claude Code session provides credentials automatically. No export needed.
@@ -136,10 +140,10 @@ export OPENAI_API_KEY="your-openai-key"
 
 ```yaml
 orchestrator:
-  runtime_backend: claude   # claude | codex
+  runtime_backend: claude   # claude | codex | gemini
 
 llm:
-  backend: claude_code      # claude_code | codex | litellm
+  backend: claude_code      # claude_code | codex | gemini | litellm
 
 logging:
   level: info
@@ -292,20 +296,22 @@ ooo run
 
 ## Choosing a Runtime Backend
 
-Ouroboros delegates code execution to a pluggable runtime backend. Two ship out of the box:
+Ouroboros delegates code execution to a pluggable runtime backend. Three ship out of the box:
 
-| | Claude Code | Codex CLI |
-|---|---|---|
-| **Best for** | Claude Code users; subscription billing | OpenAI ecosystem; pay-per-token billing |
-| **Install** | `pip install ouroboros-ai[claude]` | `pip install ouroboros-ai` + `npm install -g @openai/codex` |
-| **Skill shortcuts** | `ooo` inside Claude Code | `ooo` after `ouroboros setup --runtime codex` installs managed Codex skills |
-| **Config value** | `claude` | `codex` |
+| | Claude Code | Codex CLI | Gemini CLI |
+|---|---|---|---|
+| **Best for** | Claude Code users; subscription billing | OpenAI ecosystem; pay-per-token billing | Google ecosystem; free tier available |
+| **Install** | `pip install ouroboros-ai[claude]` | `pip install ouroboros-ai` + `npm install -g @openai/codex` | `pip install ouroboros-ai` + `npm install -g @google/gemini-cli` |
+| **Auth** | Max Plan subscription | `OPENAI_API_KEY` | `GEMINI_API_KEY` or Google OAuth (browser) |
+| **Skill shortcuts** | `ooo` inside Claude Code | `ooo` after `ouroboros setup --runtime codex` installs managed Codex skills | `ooo` after `ouroboros setup --runtime gemini` |
+| **Config value** | `claude` | `codex` | `gemini` |
 
-Both backends run the same core workflow engine (seed execution, TUI). However, user-facing commands still differ: Claude Code has native in-session `ooo` workflows, while Codex CLI relies on `ouroboros setup --runtime codex` to install managed rules/skills plus the MCP hookup. The `ouroboros` CLI remains the most universal terminal path, and some advanced operations are still MCP/Claude-only.
+All backends run the same core workflow engine (seed execution, TUI). However, user-facing commands still differ: Claude Code has native in-session `ooo` workflows, while Codex CLI relies on `ouroboros setup --runtime codex` to install managed rules/skills plus the MCP hookup, and Gemini CLI uses `ouroboros setup --runtime gemini` to register the MCP server in `~/.gemini/settings.json`. The `ouroboros` CLI remains the most universal terminal path, and some advanced operations are still MCP/Claude-only.
 
 For backend-specific configuration:
 - [Claude Code runtime guide](runtime-guides/claude-code.md)
 - [Codex CLI runtime guide](runtime-guides/codex.md)
+- [Gemini CLI runtime guide](runtime-guides/gemini.md)
 
 ---
 
@@ -404,5 +410,6 @@ ouroboros cancel execution <session_id>
 - [Configuration Reference](config-reference.md) -- all config keys and defaults
 - [Claude Code runtime guide](runtime-guides/claude-code.md) -- backend-specific setup
 - [Codex CLI runtime guide](runtime-guides/codex.md) -- backend-specific setup
+- [Gemini CLI runtime guide](runtime-guides/gemini.md) -- backend-specific setup
 
 Need help? Open an issue on [GitHub](https://github.com/Q00/ouroboros/issues).

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -25,6 +25,7 @@ For installation instructions, see [Getting Started](getting-started.md).
 |--------------------|-------|-------|------------------|-------------------|
 | Claude Code        | Yes   | Yes   | Yes              | Experimental      |
 | Codex CLI          | Yes   | Yes   | Yes              | Not supported     |
+| Gemini CLI         | Yes   | Yes   | Yes              | Not supported     |
 | *(custom adapter)* | Depends on adapter | Depends on adapter | Depends on adapter | Depends on adapter |
 
 See the [runtime capability matrix](runtime-capability-matrix.md) for a feature comparison across backends.

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -13,7 +13,7 @@ The runtime backend is selected via the `orchestrator.runtime_backend` config ke
 
 ```yaml
 orchestrator:
-  runtime_backend: claude   # Supported values: claude | codex
+  runtime_backend: claude   # Supported values: claude | codex | gemini
                             # The runtime abstraction layer also accepts custom
                             # adapters registered in runtime_factory.py
 ```
@@ -22,11 +22,12 @@ Or on the command line with `--runtime`:
 
 ```bash
 ouroboros run workflow --runtime codex seed.yaml
+ouroboros run workflow --runtime gemini seed.yaml
 ```
 
 You can also override the configured backend with the `OUROBOROS_AGENT_RUNTIME` environment variable.
 
-> **Extensibility:** Ouroboros uses a pluggable `AgentRuntime` protocol. Claude Code and Codex CLI are the two shipped backends; additional runtimes can be registered by implementing the protocol and extending `runtime_factory.py`. See [Architecture — How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter).
+> **Extensibility:** Ouroboros uses a pluggable `AgentRuntime` protocol. Claude Code, Codex CLI, and Gemini CLI are the three shipped backends; additional runtimes can be registered by implementing the protocol and extending `runtime_factory.py`. See [Architecture — How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter).
 
 ## Capability Matrix
 
@@ -34,39 +35,39 @@ You can also override the configured backend with the `OUROBOROS_AGENT_RUNTIME` 
 
 These capabilities are part of the Ouroboros core engine and work the same way regardless of runtime backend.
 
-| Capability | Claude Code | Codex CLI | Notes |
-|------------|:-----------:|:---------:|-------|
-| Seed file parsing | Yes | Yes | Same YAML schema, same validation |
-| Acceptance criteria tree | Yes | Yes | Structured AC decomposition |
-| Evaluation principles | Yes | Yes | Weighted scoring against principles |
-| Exit conditions | Yes | Yes | Deterministic termination logic |
-| Event sourcing (SQLite) | Yes | Yes | Full event log, replay support |
-| Checkpoint / resume | Yes | Yes | `--resume <session_id>` |
-| TUI dashboard | Yes | Yes | Textual-based progress view |
-| Interview (Socratic seed creation) | Yes | Yes | `ouroboros init start ...` with the appropriate LLM backend |
-| Dry-run validation | Yes | Yes | `--dry-run` validates without executing |
+| Capability | Claude Code | Codex CLI | Gemini CLI | Notes |
+|------------|:-----------:|:---------:|:----------:|-------|
+| Seed file parsing | Yes | Yes | Yes | Same YAML schema, same validation |
+| Acceptance criteria tree | Yes | Yes | Yes | Structured AC decomposition |
+| Evaluation principles | Yes | Yes | Yes | Weighted scoring against principles |
+| Exit conditions | Yes | Yes | Yes | Deterministic termination logic |
+| Event sourcing (SQLite) | Yes | Yes | Yes | Full event log, replay support |
+| Checkpoint / resume | Yes | Yes | Yes | `--resume <session_id>` |
+| TUI dashboard | Yes | Yes | Yes | Textual-based progress view |
+| Interview (Socratic seed creation) | Yes | Yes | Yes | `ouroboros init start ...` with the appropriate LLM backend |
+| Dry-run validation | Yes | Yes | Yes | `--dry-run` validates without executing |
 
 ### Runtime Layer (differs by backend)
 
 These capabilities depend on the runtime backend's native features and execution model.
 
-| Capability | Claude Code | Codex CLI | Notes |
-|------------|:-----------:|:---------:|-------|
-| **Authentication** | Max Plan subscription | OpenAI API key | No API key needed for Claude Code |
-| **Underlying model** | Claude (Anthropic) | GPT-5.4+ (OpenAI) | Model choice follows the runtime |
-| **Tool surface** | Read, Write, Edit, Bash, Glob, Grep | Codex-native tool set | Different tool implementations; same task outcomes |
-| **Sandbox / permissions** | Claude Code permission system | Codex sandbox model | Each runtime manages its own safety boundaries |
-| **Cost model** | Included in Max Plan | Per-token API charges | See [OpenAI pricing](https://openai.com/pricing) for Codex costs |
+| Capability | Claude Code | Codex CLI | Gemini CLI | Notes |
+|------------|:-----------:|:---------:|:----------:|-------|
+| **Authentication** | Max Plan subscription | OpenAI API key | `GOOGLE_API_KEY` or `gcloud auth` | No API key needed for Claude Code; Gemini has a free tier |
+| **Underlying model** | Claude (Anthropic) | GPT-5.4+ (OpenAI) | Gemini 2.5 Pro (Google) | Model choice follows the runtime |
+| **Tool surface** | Read, Write, Edit, Bash, Glob, Grep | Codex-native tool set | Gemini-native tool set | Different tool implementations; same task outcomes |
+| **Sandbox / permissions** | Claude Code permission system | Codex sandbox model | Gemini CLI's internal execution model | Each runtime manages its own safety boundaries |
+| **Cost model** | Included in Max Plan | Per-token API charges | Free tier available; per-token charges on paid plans | See [OpenAI pricing](https://openai.com/pricing) / [Google AI pricing](https://ai.google.dev/pricing) |
 
 ### Integration Surface (UX differences)
 
-| Aspect | Claude Code | Codex CLI |
-|--------|-------------|-----------|
-| **Primary UX** | In-session skills and MCP server | Session-oriented Ouroboros runtime over Codex CLI transport |
-| **Skill shortcuts (`ooo`)** | Yes -- skills loaded into Claude Code session | Yes -- after `ouroboros setup --runtime codex` installs managed skills into `~/.codex/skills/`, rules into `~/.codex/rules/`, and the MCP/env hookup into `~/.codex/config.toml`. Keep role-specific Ouroboros model overrides in `~/.ouroboros/config.yaml` |
-| **MCP integration** | Native MCP server support | Deterministic skill/MCP dispatch through the Ouroboros Codex adapter |
-| **Session context** | Shares Claude Code session context | Preserved via runtime handles, native session IDs, and resume support |
-| **Install extras** | `ouroboros-ai[claude]` | `ouroboros-ai` (base package) + `codex` on PATH |
+| Aspect | Claude Code | Codex CLI | Gemini CLI |
+|--------|-------------|-----------|------------|
+| **Primary UX** | In-session skills and MCP server | Session-oriented Ouroboros runtime over Codex CLI transport | Session-oriented Ouroboros runtime over Gemini CLI transport |
+| **Skill shortcuts (`ooo`)** | Yes -- skills loaded into Claude Code session | Yes -- after `ouroboros setup --runtime codex` installs managed skills and rules | Yes -- after `ouroboros setup --runtime gemini` |
+| **MCP integration** | Native MCP server support | Deterministic skill/MCP dispatch through the Ouroboros Codex adapter | Via Ouroboros orchestration layer |
+| **Session context** | Shares Claude Code session context | Preserved via runtime handles, native session IDs, and resume support | Preserved via Ouroboros session tracking and resume support |
+| **Install extras** | `ouroboros-ai[claude]` | `ouroboros-ai` (base package) + `codex` on PATH | `ouroboros-ai` (base package) + `gemini` on PATH |
 
 ## What Stays the Same
 
@@ -91,21 +92,25 @@ The runtime backend affects:
 
 ## Choosing a Runtime
 
-The table below covers the two currently shipped backends. Because Ouroboros uses a pluggable `AgentRuntime` protocol, teams can register additional backends without modifying the core engine.
+The table below covers the three currently shipped backends. Because Ouroboros uses a pluggable `AgentRuntime` protocol, teams can register additional backends without modifying the core engine.
 
 | If you... | Consider |
 |-----------|----------|
 | Have a Claude Code Max Plan and want zero API key setup | Claude Code (`runtime_backend: claude`) |
-| Want a Codex-backed Ouroboros session instead of a Claude Code session | Codex CLI (`runtime_backend: codex`) |
+| Want a Codex-backed Ouroboros session | Codex CLI (`runtime_backend: codex`) |
+| Want a Gemini-backed Ouroboros session with a free tier option | Gemini CLI (`runtime_backend: gemini`) |
 | Want to use Anthropic's Claude models | Claude Code |
 | Want to use OpenAI's GPT models | Codex CLI |
+| Want to use Google's Gemini models | Gemini CLI |
 | Need MCP server integration | Claude Code |
-| Want minimal Python dependencies | Codex CLI (base package only) |
+| Want minimal Python dependencies | Codex CLI or Gemini CLI (base package only for both) |
+| Want a free tier for experimentation | Gemini CLI (Google free tier via `gcloud auth login`) |
 | Want to integrate a custom or third-party AI coding agent | Implement the `AgentRuntime` protocol and register it in `runtime_factory.py` |
 
 ## Further Reading
 
 - [Claude Code runtime guide](runtime-guides/claude-code.md)
 - [Codex CLI runtime guide](runtime-guides/codex.md)
+- [Gemini CLI runtime guide](runtime-guides/gemini.md)
 - [Platform support matrix](platform-support.md) (OS and Python version compatibility)
 - [Architecture overview](architecture.md) — including [How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter)

--- a/docs/runtime-guides/gemini.md
+++ b/docs/runtime-guides/gemini.md
@@ -1,0 +1,424 @@
+<!--
+doc_metadata:
+  runtime_scope: [gemini]
+-->
+
+# Running Ouroboros with Gemini CLI
+
+> For installation and first-run onboarding, see [Getting Started](../getting-started.md).
+
+Ouroboros can use **Google Gemini CLI** as a runtime backend. [Gemini CLI](https://github.com/google-gemini/gemini-cli) is the local Gemini execution surface that the adapter talks to. In Ouroboros, that backend is presented as a **session-oriented runtime** with the same specification-first workflow harness (acceptance criteria, evaluation principles, deterministic exit conditions), even though the adapter itself communicates with the local `gemini` executable.
+
+No additional Python SDK is required beyond the base `ouroboros-ai` package.
+
+> **Model recommendation:** Use **Gemini 2.5 Pro** (the Gemini CLI default) for the documented setup. Gemini 2.5 Pro provides strong coding, multi-step reasoning, and agentic task execution that pairs well with the Ouroboros specification-first workflow harness.
+
+## Prerequisites
+
+- **Gemini CLI** installed and on your `PATH` (see [install steps](#installing-gemini-cli) below)
+- Authenticated with Gemini CLI: a **Gemini API key** (`GEMINI_API_KEY`) or a Google account (OAuth via `gemini` browser flow)
+- **Python >= 3.12**
+
+## Installing Gemini CLI
+
+Gemini CLI is distributed as an npm package. Install it globally:
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+Verify the installation:
+
+```bash
+gemini --version
+```
+
+For alternative install methods and shell completions, see the [Gemini CLI README](https://github.com/google-gemini/gemini-cli#readme).
+
+## Installing Ouroboros
+
+> For all installation options (pip, one-liner, from source) and first-run onboarding, see **[Getting Started](../getting-started.md)**.
+> The base `ouroboros-ai` package includes the Gemini CLI runtime adapter — no extras are required.
+
+## Platform Notes
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| macOS (ARM/Intel) | Supported | Primary development platform |
+| Linux (x86_64/ARM64) | Supported | Tested on Ubuntu 22.04+, Debian 12+, Fedora 38+ |
+| Windows (WSL 2) | Supported | Recommended path for Windows users |
+| Windows (native) | Experimental | WSL 2 strongly recommended; native Windows may have path-handling and process-management issues. Gemini CLI itself does not support native Windows. |
+
+> **Windows users:** Install and run both Gemini CLI and Ouroboros inside a WSL 2 environment for full compatibility. See [Platform Support](../platform-support.md) for details.
+
+## Configuration
+
+To select Gemini CLI as the runtime backend, set the following in your Ouroboros configuration:
+
+```yaml
+orchestrator:
+  runtime_backend: gemini
+```
+
+Or pass the backend on the command line:
+
+```bash
+uv run ouroboros run workflow --runtime gemini ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+```
+
+### Where Gemini users configure what
+
+Use `~/.ouroboros/config.yaml` for Ouroboros runtime settings and per-role model overrides.
+
+```yaml
+# ~/.ouroboros/config.yaml
+orchestrator:
+  runtime_backend: gemini
+  gemini_cli_path: /usr/local/bin/gemini   # omit if gemini is already on PATH
+
+llm:
+  backend: gemini
+
+clarification:
+  default_model: gemini-2.5-pro
+
+evaluation:
+  semantic_model: gemini-2.5-pro
+
+consensus:
+  advocate_model: gemini-2.5-pro
+  devil_model: gemini-2.5-pro
+  judge_model: gemini-2.5-pro
+```
+
+When these keys are left at their shipped defaults, the Gemini-aware loader resolves them to Gemini CLI's active default model. Explicit `config.yaml` values always win.
+
+### Authentication
+
+Gemini CLI supports two authentication methods:
+
+**Option A — OAuth / Google account (recommended, free tier):**
+
+Run `gemini` once and follow the browser prompt to sign in with your Google account. No environment variable needed. Free tier: 1,000 requests/day.
+
+**Option B — Gemini API Key (automated workflows):**
+
+```bash
+export GEMINI_API_KEY="your-api-key"   # from aistudio.google.com/apikey
+```
+
+> See the [Gemini CLI authentication guide](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#-authentication-options) for the full list of options including Vertex AI enterprise setup.
+
+## Command Surface
+
+From the user's perspective, the Gemini integration behaves like a **session-oriented Ouroboros runtime** — the same specification-first workflow harness that drives the Claude and Codex runtimes.
+
+Under the hood, `GeminiCLIAdapter` talks to the local `gemini` executable by writing the prompt to stdin and reading the response from stdout, making each completion a single subprocess invocation.
+
+`ouroboros setup --runtime gemini` currently:
+
+- Detects the `gemini` binary on your `PATH`
+- Writes `orchestrator.runtime_backend: gemini` and `llm.backend: gemini` to `~/.ouroboros/config.yaml`
+- Records `orchestrator.gemini_cli_path` when available
+
+### `ooo` Skill Availability on Gemini CLI
+
+After running `ouroboros setup --runtime gemini`, all core `ooo` skills are available via Ouroboros and their CLI equivalents listed below.
+
+| `ooo` Skill | CLI equivalent (Terminal) |
+|-------------|--------------------------|
+| `ooo interview` | `ouroboros init start --llm-backend gemini "your idea"` |
+| `ooo seed` | *(bundled in `ouroboros init start`)* |
+| `ooo run` | `ouroboros run workflow --runtime gemini seed.yaml` |
+| `ooo status` | `ouroboros status execution <session_id>` |
+| `ooo evaluate` | *(MCP only)* |
+| `ooo evolve` | *(MCP only)* |
+| `ooo ralph` | *(MCP only)* |
+| `ooo cancel` | `ouroboros cancel execution <session_id>` |
+| `ooo unstuck` | *(MCP only)* |
+| `ooo update` | `pip install --upgrade ouroboros-ai` |
+| `ooo help` | `ouroboros --help` |
+| `ooo qa` | *(MCP only)* |
+| `ooo setup` | `ouroboros setup --runtime gemini` |
+
+> **Note on `ooo seed` vs `ooo interview`:** These are two distinct skills. `ooo interview` runs a Socratic Q&A session and returns a `session_id`. `ooo seed` accepts that `session_id` and generates a structured Seed YAML (with ambiguity scoring). From the terminal, both steps are performed in a single `ouroboros init start` invocation.
+
+## Quick Start
+
+> For the full first-run onboarding flow (interview → seed → execute), see **[Getting Started](../getting-started.md)**.
+
+### Verify Installation
+
+```bash
+gemini --version
+ouroboros --help
+```
+
+### Run Your First Workflow
+
+```bash
+# 1. Interview to generate a seed spec
+ouroboros init start --llm-backend gemini "Build a task management CLI"
+
+# 2. Execute the generated seed (replace <seed_id> with your actual seed ID)
+ouroboros run workflow --runtime gemini ~/.ouroboros/seeds/seed_<seed_id>.yaml
+```
+
+## How It Works
+
+```
++-----------------+     +------------------+     +-----------------+
+|   Seed YAML     | --> |   Orchestrator   | --> |   Gemini CLI    |
+|  (your task)    |     | (runtime_factory)|     |   (runtime)     |
++-----------------+     +------------------+     +-----------------+
+                                |
+                                v
+                        +------------------+
+                        |  Gemini executes |
+                        |  with its own    |
+                        |  tool set and    |
+                        |  model context   |
+                        +------------------+
+```
+
+The `GeminiCLIAdapter` invokes `gemini` as a subprocess, writing the prompt via stdin and reading the response from stdout. The `GeminiEventNormalizer` converts raw output (plain text or NDJSON) into the internal Ouroboros event schema, so the same workflow engine drives execution regardless of the output format the CLI emits.
+
+> For a side-by-side comparison of all runtime backends, see the [runtime capability matrix](../runtime-capability-matrix.md).
+
+## Gemini CLI Strengths
+
+- **Flexible authentication** -- supports both a Google API key and OAuth (gcloud), making it easy to use in both personal and CI environments
+- **Generous free tier** -- Gemini API offers a free tier suitable for personal projects and experimentation
+- **Strong multimodal reasoning** -- Gemini 2.5 Pro provides excellent code generation and multi-step reasoning
+- **Ouroboros harness** -- the specification-first workflow engine adds structured acceptance criteria, evaluation principles, and deterministic exit conditions on top of Gemini CLI's capabilities
+
+## Runtime Differences
+
+Gemini CLI, Claude Code, and Codex CLI are independent runtime backends with different tool sets, permission models, and authentication flows. The same Seed file works with all of them, but execution paths may differ.
+
+| Aspect | Gemini CLI | Codex CLI | Claude Code |
+|--------|------------|-----------|-------------|
+| What it is | Ouroboros session runtime backed by Gemini CLI | Ouroboros session runtime backed by Codex CLI | Anthropic's agentic coding tool |
+| Authentication | `GEMINI_API_KEY` or Google OAuth (browser) | OpenAI API key | Max Plan subscription |
+| Model | Gemini 2.5 Pro (default) | GPT-5.4 with medium reasoning effort (recommended) | Claude (via claude-agent-sdk) |
+| Sandbox | Gemini CLI's internal execution model | Codex CLI's own sandbox model | Claude Code's permission system |
+| Tool surface | Gemini-native tools | Codex-native tools (file I/O, shell) | Read, Write, Edit, Bash, Glob, Grep |
+| Cost model | Google API usage charges (free tier available) | OpenAI API usage charges | Included in Max Plan subscription |
+| Windows (native) | Not supported | Not supported | Experimental |
+
+> **Note:** The Ouroboros workflow model (Seed files, acceptance criteria, evaluation principles) is identical across runtimes. However, because Gemini CLI, Codex CLI, and Claude Code have different underlying agent capabilities, tool access, and sandboxing, they may produce different execution paths and results for the same Seed file.
+
+## CLI Options
+
+### Workflow Commands
+
+```bash
+# Execute workflow (Gemini runtime)
+# Seeds generated by ouroboros init are saved to ~/.ouroboros/seeds/seed_{id}.yaml
+uv run ouroboros run workflow --runtime gemini ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+
+# Dry run (validate seed without executing)
+uv run ouroboros run workflow --dry-run ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+
+# Debug output (show logs and agent output)
+uv run ouroboros run workflow --runtime gemini --debug ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+
+# Resume a previous session
+uv run ouroboros run workflow --runtime gemini --resume <session_id> ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+```
+
+### Environment Variables
+
+```bash
+# Override the LLM backend (highest priority)
+export OUROBOROS_LLM_BACKEND=gemini
+
+# Specify an explicit path to the gemini binary
+export OUROBOROS_GEMINI_CLI_PATH=/usr/local/bin/gemini
+
+# Provide a Gemini API key (from aistudio.google.com/apikey)
+export GEMINI_API_KEY=your-api-key
+```
+
+## Seed File Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `goal` | Yes | Primary objective |
+| `task_type` | No | Execution strategy: `code` (default), `research`, or `analysis` |
+| `constraints` | No | Hard constraints to satisfy |
+| `acceptance_criteria` | No | Specific success criteria |
+| `ontology_schema` | Yes | Output structure definition |
+| `evaluation_principles` | No | Principles for evaluation |
+| `exit_conditions` | No | Termination conditions |
+| `metadata.ambiguity_score` | Yes | Must be <= 0.2 |
+
+### Example Seed File
+
+```yaml
+goal: "Build a command-line tool that summarises Git commit history"
+
+constraints:
+  - "Python >= 3.12"
+  - "Use subprocess to invoke git"
+  - "Output plain text — no external formatting libraries"
+
+acceptance_criteria:
+  - "Accepts a --since flag for date range filtering"
+  - "Groups commits by author"
+  - "Prints a configurable maximum number of commits per author"
+  - "All tests pass with pytest"
+
+ontology_schema:
+  name: "GitSummary"
+  description: "Git commit history summariser"
+  fields:
+    - name: "summary"
+      field_type: "string"
+      description: "The formatted commit summary"
+
+evaluation_principles:
+  - "Output is human-readable and concise"
+  - "Edge cases (empty repo, no commits in range) are handled gracefully"
+
+metadata:
+  ambiguity_score: 0.12
+```
+
+## Programmatic Usage
+
+You can also use `GeminiCLIAdapter` directly in Python code:
+
+```python
+import asyncio
+from ouroboros.providers.factory import create_llm_adapter
+from ouroboros.providers.base import CompletionConfig, Message, MessageRole
+
+
+async def main() -> None:
+    # Create a Gemini CLI adapter via the factory
+    adapter = create_llm_adapter(
+        backend="gemini",
+        timeout=60.0,
+        max_retries=2,
+    )
+
+    messages = [
+        Message(role=MessageRole.USER, content="Explain async/await in Python in two sentences."),
+    ]
+    config = CompletionConfig(model="gemini-2.5-pro")
+
+    result = await adapter.complete(messages, config)
+
+    if result.is_ok:
+        print(result.value.content)
+    else:
+        print(f"Error: {result.error.message}")
+
+
+asyncio.run(main())
+```
+
+To instantiate the adapter directly (bypassing the factory):
+
+```python
+from ouroboros.providers.gemini_cli_adapter import GeminiCLIAdapter
+from ouroboros.providers.base import CompletionConfig, Message, MessageRole
+
+adapter = GeminiCLIAdapter(
+    cli_path="/usr/local/bin/gemini",  # optional; falls back to PATH
+    timeout=30.0,
+    max_retries=3,
+    on_message=lambda msg_type, content: print(f"[{msg_type}] {content}"),
+)
+```
+
+### Using the Event Normalizer
+
+If you are processing raw Gemini CLI output outside of the adapter, use `GeminiEventNormalizer` directly:
+
+```python
+from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
+
+normalizer = GeminiEventNormalizer()
+
+# Process plain-text output
+for line in gemini_output.splitlines():
+    event = normalizer.normalize_line(line)
+    if not event["is_error"]:
+        print(event["content"])
+
+# Or process an entire output block at once
+events = normalizer.normalize_lines(gemini_output)
+text_events = [e for e in events if e["type"] == "text"]
+```
+
+## Troubleshooting
+
+### Gemini CLI not found
+
+Ensure `gemini` is installed and available on your `PATH`:
+
+```bash
+which gemini
+gemini --version
+```
+
+If not installed, install via npm:
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+See the [Gemini CLI README](https://github.com/google-gemini/gemini-cli#readme) for alternative installation methods.
+
+### Authentication errors
+
+If using an API key, verify it is set:
+
+```bash
+echo $GEMINI_API_KEY   # should be non-empty
+```
+
+If using OAuth (Google account), re-run the browser sign-in flow:
+
+```bash
+gemini   # follow the "Sign in with Google" prompt
+```
+
+### Rate limit / quota errors
+
+The free tier of the Gemini API has rate limits. If you see `"rate limit"` or `"resource exhausted"` in the error output, the adapter will automatically retry with exponential backoff (up to `max_retries` attempts). To avoid hitting limits on long workflows, reduce parallelism or use an API key with a paid quota tier.
+
+### "Providers: warning" in health check
+
+This is normal when using the orchestrator runtime backends. The warning refers to LiteLLM providers, which are not used in orchestrator mode.
+
+### "EventStore not initialized"
+
+The database will be created automatically at `~/.ouroboros/ouroboros.db`.
+
+### Explicit CLI path
+
+If `gemini` is not on your `PATH`, set the path explicitly:
+
+```bash
+export OUROBOROS_GEMINI_CLI_PATH=/opt/homebrew/bin/gemini
+```
+
+Or set it in your config:
+
+```yaml
+# ~/.ouroboros/config.yaml
+orchestrator:
+  gemini_cli_path: /opt/homebrew/bin/gemini
+```
+
+## Cost
+
+Using Gemini CLI as the runtime backend may incur Google API usage charges depending on your authentication method and quota tier:
+
+- **OAuth / Google account** — free tier: 1,000 requests/day; suitable for experimentation and personal projects
+- **Gemini API key (`GEMINI_API_KEY`)** — standard per-token charges above the free quota; see [Google AI pricing](https://ai.google.dev/pricing) for current rates
+
+Refer to Google's documentation for quota limits and pricing details.


### PR DESCRIPTION
## Summary

Documentation-only PR — no source changes. This is **PR 1 of 5** in a stacked series for issue #165.

- `docs/runtime-guides/gemini.md` — new end-user guide for configuring and running Ouroboros with the Gemini CLI backend (prerequisites, auth, `config.yaml` snippet, available skills, quick-start). Modelled on the existing Codex runtime guide.
- `docs/getting-started.md` — add Gemini CLI to the backend comparison table and env-var section.
- `docs/platform-support.md` — add Gemini CLI row to the platform support matrix.
- `docs/runtime-capability-matrix.md` — add `gemini` to supported backend values.

## Stack

| PR | Branch | Contents |
|----|--------|----------|
| **1/5 (this)** | `feat/gemini-cli-adapter-docs` | Documentation |
| 2/5 | `feat/gemini-cli-adapter-normalizer` | `GeminiEventNormalizer` + normalizer tests |
| 3/5 | `feat/gemini-cli-adapter-provider` | `GeminiCLIAdapter` + provider factory |
| 4/5 | `feat/gemini-cli-adapter-runtime` | `GeminiCLIRuntime` + orchestrator/config wiring |
| 5/5 | `feat/gemini-cli-adapter-integration` | Integration and E2E tests |

> Each PR contains exactly one commit on top of the previous. To see the incremental diff for any PR, compare its branch against the previous branch in the stack.

## Test plan

- [ ] Runtime guide accurately describes the adapter interface (stdin-based prompt, `--model` flag)
- [ ] Model names match what the API accepts (`gemini-2.5-pro`, `gemini-2.5-flash`)
- [ ] No source changes — no test execution required

🤖 Generated with [Claude Code](https://claude.ai/claude-code)