### PR TITLE
refactor(pm): align PMSeed and pm.md fields

### DIFF
--- a/src/ouroboros/bigbang/pm_document.py
+++ b/src/ouroboros/bigbang/pm_document.py
@@ -417,8 +417,10 @@ class PMDocumentGenerator:
         parts.append("## Extracted Requirements (PMSeed)")
         parts.append("")
         parts.append(f"**Product Name:** {seed.product_name or 'Unnamed'}")
-        parts.append(f"**PM ID:** {seed.pm_id}")
-        parts.append(f"**Interview ID:** {seed.interview_id}")
+        if seed.pm_id:
+            parts.append(f"**PM ID:** {seed.pm_id}")
+        if seed.interview_id:
+            parts.append(f"**Interview ID:** {seed.interview_id}")
         parts.append(f"**Goal:** {seed.goal or 'Not specified'}")
         parts.append("")
 
@@ -458,10 +460,11 @@ class PMDocumentGenerator:
         if seed.brownfield_repos:
             parts.append("**Brownfield Repositories:**")
             for repo in seed.brownfield_repos:
-                name = repo.get("name", "Unknown")
-                path = repo.get("path", "")
+                name = repo.get("name") or repo.get("path") or "Unknown"
+                path = repo.get("path") or ""
                 desc = repo.get("desc", "")
-                parts.append(f"- {name} ({path}){f' — {desc}' if desc else ''}")
+                label = f"{name} ({path})" if path else name
+                parts.append(f"- {label}{f' — {desc}' if desc else ''}")
             parts.append("")
 
         # Q&A transcript

--- a/tests/unit/bigbang/test_pm_document_generator.py
+++ b/tests/unit/bigbang/test_pm_document_generator.py
@@ -309,6 +309,51 @@ class TestPMDocumentGeneratorPrompt:
         assert "Not specified" in prompt  # goal fallback
         assert "Unnamed" in prompt  # product_name fallback
 
+    def test_prompt_omits_empty_pm_id_and_interview_id(self):
+        """Prompt omits PM ID and Interview ID lines when values are empty."""
+        seed = PMSeed(pm_id="", interview_id="")
+        prompt = PMDocumentGenerator._build_generation_prompt(seed)
+
+        assert "**PM ID:**" not in prompt
+        assert "**Interview ID:**" not in prompt
+
+    def test_prompt_includes_pm_id_when_present(self):
+        """Prompt includes PM ID when it has a value."""
+        seed = _make_seed()
+        prompt = PMDocumentGenerator._build_generation_prompt(seed)
+
+        assert "**PM ID:** pm_seed_test123" in prompt
+        assert "**Interview ID:** int_abc" in prompt
+
+    def test_prompt_brownfield_repo_empty_name_uses_path(self):
+        """Prompt builder falls back to path when brownfield repo name is empty."""
+        seed = _make_seed(
+            brownfield_repos=({"name": "", "path": "/repo/path", "desc": "desc"},),
+        )
+        prompt = PMDocumentGenerator._build_generation_prompt(seed)
+
+        assert "/repo/path (/repo/path)" in prompt
+        assert "desc" in prompt
+
+    def test_prompt_brownfield_repo_none_name_uses_path(self):
+        """Prompt builder falls back to path when brownfield repo name is None."""
+        seed = _make_seed(
+            brownfield_repos=({"name": None, "path": "/repo/path"},),
+        )
+        prompt = PMDocumentGenerator._build_generation_prompt(seed)
+
+        assert "/repo/path" in prompt
+
+    def test_prompt_brownfield_repo_missing_path(self):
+        """Prompt builder handles brownfield repo with missing path."""
+        seed = _make_seed(
+            brownfield_repos=({"name": "MyApp"},),
+        )
+        prompt = PMDocumentGenerator._build_generation_prompt(seed)
+
+        assert "MyApp ()" not in prompt
+        assert "MyApp" in prompt
+
     def test_prompt_generation_instruction_at_end(self):
         """Prompt ends with the generation instruction."""
         seed = _make_seed()

--- a/tests/unit/bigbang/test_pm_document_writer.py
+++ b/tests/unit/bigbang/test_pm_document_writer.py
@@ -215,6 +215,21 @@ class TestGeneratePrdMarkdown:
         assert "**MyApp**" in md
         assert "(``)" not in md
 
+    def test_omits_empty_pm_id(self):
+        """PM ID is omitted when empty."""
+        seed = PMSeed(pm_id="", product_name="Test", goal="A goal", interview_id="int_1")
+        md = generate_pm_markdown(seed)
+        assert "PM ID" not in md
+        assert "*Interview ID: int_1*" in md
+
+    def test_omits_footer_when_both_ids_empty(self):
+        """Footer separator is omitted when both PM ID and Interview ID are empty."""
+        seed = PMSeed(pm_id="", product_name="Test", goal="A goal", interview_id="")
+        md = generate_pm_markdown(seed)
+        assert "---" not in md
+        assert "PM ID" not in md
+        assert "Interview ID" not in md
+
 
 # ──────────────────────────────────────────────────────────────────
 # save_pm_document tests


### PR DESCRIPTION
## Summary
- remove `codebase_context` from `PMSeed` so the seed only contains fields that also appear in `pm.md`
- remove legacy-only PMSeed members and keep legacy input migration in `from_dict()` instead of as dataclass fields
- render `created_at` in `pm.md` so the markdown and PM seed JSON share the same field set
- update PM seed and PM document tests to match the canonical field set

## Test plan
- `uv run pytest -q tests/unit/bigbang/test_pm_seed_save.py tests/unit/bigbang/test_pm_seed_ac12.py tests/unit/bigbang/test_pm_document_writer.py tests/unit/bigbang/test_pm_document_generator.py`
- `uv run pytest -q tests/unit/pm/test_renderer.py tests/unit/bigbang/test_pm_interview.py`