### PR TITLE
fix(mcp): resolve double-backgrounding in job tracking and differentiate polling

### DIFF
--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -55,12 +55,19 @@ When the user invokes this skill:
        cursor = job.meta["cursor"]
 
        # Poll for progress (non-blocking, shows intermediate state)
-       # Use timeout_seconds=60 to reduce context consumption
+       # Use timeout_seconds=120 (2-min long-poll) to reduce context consumption
+       # Only report when AC completed count changes (level-based polling)
+       prev_completed = 0
        while not terminal:
-           wait_result = await job_wait(job_id, cursor, timeout_seconds=60)
+           wait_result = await job_wait(job_id, cursor, timeout_seconds=120)
            cursor = wait_result.meta["cursor"]
            status = wait_result.meta["status"]
-           # Report progress concisely (one line per poll)
+           # Parse AC Progress from response, report only on level completion
+           current_completed = <parse AC completed from response>
+           if current_completed > prev_completed:
+               # Report progress concisely (one line per poll)
+               print: [Level complete] AC: {current_completed}/{total} | Phase: {phase}
+               prev_completed = current_completed
            terminal = status in ("completed", "failed", "cancelled")
 
        # Fetch final result

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -127,22 +127,62 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
    Then **stop** — do NOT proceed to polling steps.
 
 6. **Poll for progress** using `ouroboros_job_wait` (only if user chose to poll):
+
+   The polling behavior differs based on the user's interval choice:
+
+   **Option A: "Per level (Recommended)"**
+   ```
+   prev_completed = 0
+
+   loop:
+     Tool: ouroboros_job_wait
+     Arguments:
+       job_id: <job_id from step 3>
+       cursor: <cursor from previous response, starts at 0>
+       timeout_seconds: 120   # 2-min long-poll
+
+     # Parse "AC Progress: X/Y" from the response text
+     current_completed = <X from AC Progress>
+     total = <Y from AC Progress>
+     phase = <current phase from response>
+
+     if current_completed > prev_completed:
+       # A level completed — report to user
+       print: [Level complete] AC: {current_completed}/{total} | Phase: {phase}
+       prev_completed = current_completed
+     # else: continue silently (no output)
+
+     # Continue until status is "completed", "failed", or "cancelled"
+   ```
+
+   **Option B: "Every 10 minutes"**
    ```
    loop:
      Tool: ouroboros_job_wait
      Arguments:
        job_id: <job_id from step 3>
        cursor: <cursor from previous response, starts at 0>
-       timeout_seconds: 60
-   
-     # Returns immediately when state changes; waits up to 60s otherwise.
-     # This reduces tool call round-trips and context consumption.
+       timeout_seconds: 600   # 10-min long-poll
+
+     # Report on every return regardless of change
+     print: [10m check] AC: {completed}/{total} | Phase: {phase}
+
      # Continue until status is "completed", "failed", or "cancelled"
    ```
 
-   Between polls, report progress concisely (one line):
+   **Option C: "Every 20 minutes"**
    ```
-   [Executing] Phase: <current_phase> | AC: <completed>/<total>
+   loop:
+     Tool: ouroboros_job_wait
+     Arguments:
+       job_id: <job_id from step 3>
+       cursor: <cursor from previous response, starts at 0>
+       timeout_seconds: 1200  # 20-min long-poll
+
+     # Report on every return regardless of change
+     print: [20m check] AC: {completed}/{total} | Phase: {phase}
+
+     # Continue until status is "completed", "failed", or "cancelled"
    ```
 
 7. **Fetch final result** with `ouroboros_job_result`:

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -181,6 +181,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         *,
         execution_id: str | None = None,
         session_id_override: str | None = None,
+        synchronous: bool = False,
     ) -> Result[MCPToolResult, MCPServerError]:
         """Handle a seed execution request.
 
@@ -189,6 +190,9 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             execution_id: Pre-allocated execution ID (used by StartExecuteSeedHandler).
             session_id_override: Pre-allocated session ID for new executions
                 (used by StartExecuteSeedHandler).
+            synchronous: When True, run execution inline (blocking) instead of
+                fire-and-forget.  Used by StartExecuteSeedHandler so the Job
+                system can track the real execution lifetime.
 
         Returns:
             Result containing execution result or error.
@@ -420,9 +424,8 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                         )
                     tracker = prepared.value
 
-                # Fire-and-forget: launch execution in a background task and
-                # return the session/execution IDs immediately so the MCP
-                # client is not blocked by Codex's tool-call timeout.
+                # Background execution coroutine — either awaited directly
+                # (synchronous=True) or wrapped in create_task (fire-and-forget).
                 async def _run_in_background(
                     _runner: OrchestratorRunner,
                     _seed: Seed,
@@ -518,20 +521,56 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                             except Exception:
                                 log.exception("mcp.tool.execute_seed.event_store_close_error")
 
-                task = asyncio.create_task(
-                    _run_in_background(runner, seed, tracker, seed_content, is_resume, skip_qa)
-                )
-                launched = True
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
+                if synchronous:
+                    # Run inline — the caller (StartExecuteSeedHandler / Job
+                    # system) already handles backgrounding.  Pass
+                    # _owns_event_store=False so cleanup stays with the caller;
+                    # reconstruct_session below still needs the store open.
+                    launched = True
+                    await _run_in_background(
+                        runner,
+                        seed,
+                        tracker,
+                        seed_content,
+                        is_resume,
+                        skip_qa,
+                        _owns_event_store=False,
+                    )
 
+                    # Derive actual outcome from session state.
+                    try:
+                        post_result = await session_repo.reconstruct_session(tracker.session_id)
+                        session_status = post_result.value.status if post_result.is_ok else None
+                    except Exception:
+                        session_status = None
+
+                    status_label = session_status.value if session_status is not None else "unknown"
+                    success = session_status == SessionStatus.COMPLETED
+                else:
+                    # Fire-and-forget: launch in a background task.
+                    task = asyncio.create_task(
+                        _run_in_background(runner, seed, tracker, seed_content, is_resume, skip_qa)
+                    )
+                    launched = True
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+                    status_label = "running"
+                    success = None  # unknown yet
+
+                # --- shared message / meta construction ---
+                header = {
+                    True: "Seed Execution COMPLETED",
+                    False: "Seed Execution FINISHED",
+                    None: "Seed Execution LAUNCHED",  # fire-and-forget
+                }[success]
                 message = (
-                    f"Seed Execution LAUNCHED\n"
+                    f"{header}\n"
                     f"{'=' * 60}\n"
                     f"Seed ID: {seed.metadata.seed_id}\n"
                     f"Session ID: {tracker.session_id}\n"
                     f"Execution ID: {tracker.execution_id}\n"
                     f"Goal: {seed.goal}\n\n"
+                    f"Status: {status_label}\n"
                     f"Runtime Backend: {effective_runtime_backend}\n"
                     f"LLM Backend: {resolved_llm_backend}\n"
                 )
@@ -540,22 +579,25 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                         f"Task Worktree: {workspace.worktree_path}\n"
                         f"Task Branch: {workspace.branch}\n"
                     )
-                message += (
-                    "\nExecution is running in the background.\n"
-                    "Use ouroboros_session_status to track progress.\n"
-                    "Use ouroboros_query_events for detailed event history.\n"
-                )
+                if not synchronous:
+                    message += (
+                        "\nExecution is running in the background.\n"
+                        "Use ouroboros_session_status to track progress.\n"
+                        "Use ouroboros_query_events for detailed event history.\n"
+                    )
 
-                meta = {
+                meta: dict[str, Any] = {
                     "seed_id": seed.metadata.seed_id,
                     "session_id": tracker.session_id,
                     "execution_id": tracker.execution_id,
                     "launched": True,
-                    "status": "running",
+                    "status": status_label,
                     "runtime_backend": effective_runtime_backend,
                     "llm_backend": resolved_llm_backend,
                     "resume_requested": is_resume,
                 }
+                if success is not None:
+                    meta["success"] = success
                 if workspace is not None:
                     meta["worktree_path"] = workspace.worktree_path
                     meta["worktree_branch"] = workspace.branch
@@ -563,14 +605,17 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 return Result.ok(
                     MCPToolResult(
                         content=(MCPContentItem(type=ContentType.TEXT, text=message),),
-                        is_error=False,
+                        is_error=success is False,
                         meta=meta,
                     )
                 )
             finally:
-                if workspace is not None and not launched:
+                # In synchronous mode, _run_in_background was told NOT to own
+                # cleanup (_owns_event_store=False), so the caller cleans up
+                # after reconstruct_session has finished using the store.
+                if workspace is not None and (not launched or synchronous):
                     release_lock(workspace.lock_path)
-                if owns_event_store and not launched:
+                if owns_event_store and (not launched or synchronous):
                     try:
                         close_result = event_store.close()
                         if inspect.isawaitable(close_result):
@@ -796,6 +841,7 @@ class StartExecuteSeedHandler:
                 arguments,
                 execution_id=execution_id,
                 session_id_override=new_session_id,
+                synchronous=True,
             )
             if result.is_err:
                 raise RuntimeError(str(result.error))

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -213,12 +213,25 @@ class CancelExecutionHandler:
             )
 
 
-_render_cache: dict[tuple[str, int], str] = {}
+_EMPTY_PROGRESS: dict[str, Any] = {
+    "ac_completed": None,
+    "ac_total": None,
+    "current_phase": None,
+    "activity": None,
+}
+
+_render_cache: dict[tuple[str, int], tuple[str, dict[str, Any]]] = {}
 _RENDER_CACHE_MAX = 64
 
 
-async def _render_job_snapshot(snapshot: JobSnapshot, event_store: EventStore) -> str:
+async def _render_job_snapshot(
+    snapshot: JobSnapshot, event_store: EventStore
+) -> tuple[str, dict[str, Any]]:
     """Format a user-facing job summary with linked execution context.
+
+    Returns (text, progress_dict).  The progress dict contains structured
+    AC progress (ac_completed, ac_total, current_phase, activity) extracted
+    from the same query used for rendering — no duplicate event-store hit.
 
     Results are cached by (job_id, cursor) to avoid redundant EventStore queries
     when the same snapshot is rendered repeatedly (e.g. poll loops).
@@ -228,21 +241,23 @@ async def _render_job_snapshot(snapshot: JobSnapshot, event_store: EventStore) -
     if not snapshot.is_terminal and cache_key in _render_cache:
         return _render_cache[cache_key]
 
-    text = await _render_job_snapshot_inner(snapshot, event_store)
+    text, progress = await _render_job_snapshot_inner(snapshot, event_store)
 
     if not snapshot.is_terminal:
         if len(_render_cache) >= _RENDER_CACHE_MAX:
-            # Evict oldest entries
             to_remove = list(_render_cache.keys())[: _RENDER_CACHE_MAX // 2]
             for key in to_remove:
                 _render_cache.pop(key, None)
-        _render_cache[cache_key] = text
+        _render_cache[cache_key] = (text, progress)
 
-    return text
+    return text, progress
 
 
-async def _render_job_snapshot_inner(snapshot: JobSnapshot, event_store: EventStore) -> str:
-    """Inner render without caching."""
+async def _render_job_snapshot_inner(
+    snapshot: JobSnapshot, event_store: EventStore
+) -> tuple[str, dict[str, Any]]:
+    """Inner render without caching.  Returns (text, progress_dict)."""
+    progress = dict(_EMPTY_PROGRESS)
     lines = [
         f"## Job: {snapshot.job_id}",
         "",
@@ -262,14 +277,20 @@ async def _render_job_snapshot_inner(snapshot: JobSnapshot, event_store: EventSt
         workflow_event = next((e for e in events if e.type == "workflow.progress.updated"), None)
         if workflow_event is not None:
             data = workflow_event.data
+            progress = {
+                "ac_completed": data.get("completed_count"),
+                "ac_total": data.get("total_count"),
+                "current_phase": data.get("current_phase") or "Working",
+                "activity": data.get("activity_detail") or data.get("activity") or "running",
+            }
             lines.extend(
                 [
                     "",
                     "### Execution",
                     f"**Execution ID**: {snapshot.links.execution_id}",
-                    f"**Phase**: {data.get('current_phase') or 'Working'}",
-                    f"**Activity**: {data.get('activity_detail') or data.get('activity') or 'running'}",
-                    f"**AC Progress**: {data.get('completed_count', 0)}/{data.get('total_count', '?')}",
+                    f"**Phase**: {progress['current_phase']}",
+                    f"**Activity**: {progress['activity']}",
+                    f"**AC Progress**: {progress['ac_completed']}/{progress['ac_total'] or '?'}",
                 ]
             )
 
@@ -348,7 +369,7 @@ async def _render_job_snapshot_inner(snapshot: JobSnapshot, event_store: EventSt
     if snapshot.error:
         lines.extend(["", f"**Error**: {snapshot.error}"])
 
-    return "\n".join(lines)
+    return "\n".join(lines), progress
 
 
 @dataclass
@@ -395,7 +416,7 @@ class JobStatusHandler:
         except ValueError as exc:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_job_status"))
 
-        text = await _render_job_snapshot(snapshot, self._event_store)
+        text, progress = await _render_job_snapshot(snapshot, self._event_store)
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
@@ -407,6 +428,7 @@ class JobStatusHandler:
                     "session_id": snapshot.links.session_id,
                     "execution_id": snapshot.links.execution_id,
                     "lineage_id": snapshot.links.lineage_id,
+                    **progress,
                 },
             )
         )
@@ -480,7 +502,7 @@ class JobWaitHandler:
         except ValueError as exc:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_job_wait"))
 
-        text = await _render_job_snapshot(snapshot, self._event_store)
+        text, progress = await _render_job_snapshot(snapshot, self._event_store)
         if not changed:
             text += "\n\nNo new job-level events during this wait window."
         return Result.ok(
@@ -492,6 +514,7 @@ class JobWaitHandler:
                     "status": snapshot.status.value,
                     "cursor": snapshot.cursor,
                     "changed": changed,
+                    **progress,
                 },
             )
         )
@@ -610,7 +633,7 @@ class CancelJobHandler:
         except ValueError as exc:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_cancel_job"))
 
-        text = await _render_job_snapshot(snapshot, self._event_store)
+        text, _progress = await _render_job_snapshot(snapshot, self._event_store)
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),


### PR DESCRIPTION
## Summary
- **Double-backgrounding fix**: `StartExecuteSeedHandler` now passes `synchronous=True` to `ExecuteSeedHandler`, so the Job system tracks actual execution lifetime instead of completing instantly when the inner handler fire-and-forgets
- **Resource ownership**: synchronous mode passes `_owns_event_store=False` to prevent premature event store closure before `reconstruct_session`
- **Deduplicated message/meta**: shared construction block for both sync and async paths, eliminating ~30 lines of copy-paste
- **Single-query progress**: merged `_extract_execution_progress` into `_render_job_snapshot` — one event store query returns both text and structured AC progress
- **Polling differentiation**: per-level (120s, silent unless AC count changes), 10m (600s), 20m (1200s) — previously all used identical 60s loops

## Checks passed
- [x] ruff lint
- [x] ruff format (auto-fixed 1 file)
- [x] mypy
- [x] pytest (504 passed, MCP unit tests)
- [x] pytest (3517 passed, full suite)

## Test plan
- [ ] Run `ooo run` with a multi-AC seed, choose "Per level" polling → verify Job stays `running` until execution completes
- [ ] Verify `job_wait` response meta includes `ac_completed`, `ac_total`, `current_phase`
- [ ] Choose "Every 10 minutes" → verify 600s timeout in job_wait calls
- [ ] Direct `ouroboros_execute_seed` (non-Start) still fire-and-forgets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)