### PR TITLE
feat(providers): OpenCode runtime adapter for LLM completions (#164)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 <!--
 doc_metadata:
-  runtime_scope: [local, claude, codex]
+  runtime_scope: [local, claude, codex, opencode]
 -->
 
 # CLI Reference
@@ -56,7 +56,7 @@ ouroboros [OPTIONS] COMMAND [ARGS]...
 Detect available runtime backends and configure Ouroboros for your environment.
 
 Ouroboros supports multiple runtime backends via a pluggable `AgentRuntime` protocol. The `setup` command auto-detects
-which runtimes are available in your PATH (currently: Claude Code, Codex CLI) and
+which runtimes are available in your PATH (currently: Claude Code, Codex CLI, OpenCode) and
 configures `orchestrator.runtime_backend` accordingly. Additional runtimes can be registered
 by implementing the protocol — see [Architecture](architecture.md#how-to-add-a-new-runtime-adapter).
 
@@ -68,7 +68,7 @@ ouroboros setup [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `-r, --runtime TEXT` | Runtime backend to configure. Shipped values: `claude`, `codex`. Auto-detected if omitted |
+| `-r, --runtime TEXT` | Runtime backend to configure. Shipped values: `claude`, `codex`, `opencode`. Auto-detected if omitted |
 | `--non-interactive` | Skip interactive prompts (for scripted installs) |
 
 **Examples:**
@@ -97,10 +97,9 @@ ouroboros setup --non-interactive
 - For Codex CLI: installs managed Ouroboros rules into `~/.codex/rules/`
 - For Codex CLI: installs managed Ouroboros skills into `~/.codex/skills/`
 - For Codex CLI: registers the Ouroboros MCP/env block in `~/.codex/config.toml`
+- For OpenCode: registers the Ouroboros MCP server in OpenCode's configuration
 
 > **Codex config split:** put persistent Ouroboros per-role model overrides in `~/.ouroboros/config.yaml` (`clarification.default_model`, `llm.qa_model`, `evaluation.semantic_model`, `consensus.models`, `consensus.advocate_model`, `consensus.devil_model`, `consensus.judge_model`). `~/.codex/config.toml` is only the Codex MCP/env hookup file used by setup.
-
-> **`opencode` caveat:** `setup` detects the `opencode` binary in PATH but cannot configure it — if `opencode` is your only installed runtime, `setup` exits with `Error: Unsupported runtime: opencode`. The `opencode` runtime backend is **not yet implemented** (`runtime_factory.py` raises `NotImplementedError`). It is planned for a future release.
 
 ---
 
@@ -132,8 +131,8 @@ ouroboros init [start] [OPTIONS] [CONTEXT]
 | `-r, --resume TEXT` | Resume an existing interview by ID |
 | `--state-dir DIRECTORY` | Custom directory for interview state files |
 | `-o, --orchestrator` | Use Claude Code for the interview/seed flow; combine with `--runtime` to choose the workflow handoff backend |
-| `--runtime TEXT` | Agent runtime backend for the workflow execution step after seed generation. Shipped values: `claude`, `codex`. `opencode` appears in the CLI enum but is out of scope. Custom adapters registered in `runtime_factory.py` are also accepted. |
-| `--llm-backend TEXT` | LLM backend for interview, ambiguity scoring, and seed generation (`claude_code`, `litellm`, `codex`). `opencode` appears in the CLI enum but is out of scope |
+| `--runtime TEXT` | Agent runtime backend for the workflow execution step after seed generation. Shipped values: `claude`, `codex`, `opencode`. Custom adapters registered in `runtime_factory.py` are also accepted. |
+| `--llm-backend TEXT` | LLM backend for interview, ambiguity scoring, and seed generation (`claude_code`, `litellm`, `codex`, `opencode`) |
 | `-d, --debug` | Show verbose logs including debug messages |
 
 **Examples:**
@@ -209,7 +208,7 @@ ouroboros run [workflow] [OPTIONS] SEED_FILE
 | Option | Description |
 |--------|-------------|
 | `-o/-O, --orchestrator/--no-orchestrator` | Use the agent-runtime orchestrator for execution (default: enabled) |
-| `--runtime TEXT` | Agent runtime backend override (`claude`, `codex`). Uses configured default if omitted. (`opencode` is in the CLI enum but out of scope) |
+| `--runtime TEXT` | Agent runtime backend override (`claude`, `codex`, `opencode`). Uses configured default if omitted |
 | `-r, --resume TEXT` | Resume a previous orchestrator session by ID |
 | `--mcp-config PATH` | Path to MCP client configuration YAML file |
 | `--mcp-tool-prefix TEXT` | Prefix to add to all MCP tool names (e.g., `mcp_`) |
@@ -352,7 +351,7 @@ ouroboros config backend [BACKEND]
 
 | Argument | Description |
 |----------|-------------|
-| `BACKEND` | Backend to switch to: `claude` or `codex`. Omit to show current |
+| `BACKEND` | Backend to switch to: `claude` or `codex`. Omit to show current. For `opencode`, use `ouroboros setup` instead |
 
 **Examples:**
 
@@ -631,8 +630,8 @@ ouroboros mcp serve [OPTIONS]
 | `-p, --port INTEGER` | Port to bind to (default: 8080) |
 | `-t, --transport TEXT` | Transport type: `stdio` or `sse` (default: stdio) |
 | `--db TEXT` | Path to the EventStore database file |
-| `--runtime TEXT` | Runtime backend for orchestrator-driven tools (`claude`, `codex`). (`opencode` is in the CLI enum but out of scope) |
-| `--llm-backend TEXT` | LLM backend for interview/seed/evaluation tools (`claude_code`, `litellm`, `codex`). (`opencode` is in the CLI enum but out of scope) |
+| `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `codex`, `opencode`). Affects which tool variants are instantiated |
+| `--llm-backend TEXT` | LLM backend for interview/seed/evaluation tools (`claude_code`, `litellm`, `codex`, `opencode`). Affects which tool variants are instantiated |
 
 **Examples:**
 
@@ -689,7 +688,7 @@ If Ouroboros is installed directly (not via `uvx`), use:
 
 ```yaml
 orchestrator:
-  runtime_backend: claude   # or "codex"
+  runtime_backend: claude   # or "codex" or "opencode"
 ```
 
 Override per-session with the `OUROBOROS_AGENT_RUNTIME` environment variable if needed.
@@ -706,8 +705,8 @@ ouroboros mcp info [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `codex`). Affects which tool variants are instantiated |
-| `--llm-backend TEXT` | LLM backend for interview/seed/evaluation tools (`claude_code`, `litellm`, `codex`). Affects which tool variants are instantiated |
+| `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `codex`, `opencode`). Affects which tool variants are instantiated |
+| `--llm-backend TEXT` | LLM backend for interview/seed/evaluation tools (`claude_code`, `litellm`, `codex`, `opencode`). Affects which tool variants are instantiated |
 
 **Available Tools:**
 
@@ -722,7 +721,7 @@ ouroboros mcp info [OPTIONS]
 ## Typical Workflows
 
 > For first-time setup and the complete onboarding flow, see **[Getting Started](getting-started.md)**.
-> For runtime-specific configuration, see the [Claude Code](runtime-guides/claude-code.md) and [Codex CLI](runtime-guides/codex.md) runtime guides.
+> For runtime-specific configuration, see the [Claude Code](runtime-guides/claude-code.md), [Codex CLI](runtime-guides/codex.md), and [OpenCode](runtime-guides/opencode.md) runtime guides.
 
 ### Cancelling Stuck Executions
 
@@ -745,11 +744,12 @@ The table below covers the most commonly used variables. For the full list — i
 | `ANTHROPIC_API_KEY` | — | Anthropic API key for Claude models |
 | `OPENAI_API_KEY` | — | OpenAI API key for LiteLLM / Codex CLI |
 | `OPENROUTER_API_KEY` | — | OpenRouter API key for consensus and LiteLLM |
-| `OUROBOROS_AGENT_RUNTIME` | `orchestrator.runtime_backend` | Override the runtime backend (`claude`, `codex`) |
-| `OUROBOROS_AGENT_PERMISSION_MODE` | `orchestrator.permission_mode` | Permission mode for non-OpenCode runtimes |
+| `OUROBOROS_AGENT_RUNTIME` | `orchestrator.runtime_backend` | Override the runtime backend (`claude`, `codex`, `opencode`) |
+| `OUROBOROS_AGENT_PERMISSION_MODE` | `orchestrator.permission_mode` | Permission mode for Claude Code / Codex runtimes (no-op for OpenCode) |
 | `OUROBOROS_LLM_BACKEND` | `llm.backend` | Override the LLM-only flow backend |
 | `OUROBOROS_CLI_PATH` | `orchestrator.cli_path` | Path to the Claude CLI binary |
 | `OUROBOROS_CODEX_CLI_PATH` | `orchestrator.codex_cli_path` | Path to the Codex CLI binary |
+| `OUROBOROS_OPENCODE_CLI_PATH` | `orchestrator.opencode_cli_path` | Path to the OpenCode CLI binary |
 
 ---
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -75,7 +75,7 @@ Controls how Ouroboros launches and communicates with the agent runtime backend.
 
 ```yaml
 orchestrator:
-  runtime_backend: claude       # "claude" | "codex" | "opencode" (opencode: not yet implemented)
+  runtime_backend: claude       # "claude" | "codex" | "opencode"
   permission_mode: acceptEdits  # "default" | "acceptEdits" | "bypassPermissions"
   opencode_permission_mode: bypassPermissions
   cli_path: null                # Path to Claude CLI binary; null = use SDK default
@@ -93,8 +93,6 @@ orchestrator:
 | `codex_cli_path` | `string \| null` | `null` | Absolute path to the Codex CLI binary (`~` is expanded). When `null`, resolved from `PATH` at runtime. Overridable via `OUROBOROS_CODEX_CLI_PATH`. |
 | `opencode_cli_path` | `string \| null` | `null` | Absolute path to the OpenCode CLI binary (`~` is expanded). When `null`, resolved from `PATH` at runtime. Overridable via `OUROBOROS_OPENCODE_CLI_PATH`. |
 | `default_max_turns` | `int >= 1` | `10` | Default maximum number of turns per agent execution task. |
-
-> **OpenCode scope note:** The `opencode` runtime backend is **not yet implemented** — setting `runtime_backend: opencode` will raise `NotImplementedError` at runtime. The `opencode_*` options are listed here for forward-compatibility; support is planned for a future release.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ That's it. `ooo interview` runs a Socratic interview that auto-generates a seed 
 
 ### Alternative: Standalone CLI (`ouroboros`)
 
-Use this path if you prefer a standalone terminal workflow, or are using a non-Claude runtime (e.g., Codex CLI).
+Use this path if you prefer a standalone terminal workflow, or are using a non-Claude runtime (e.g., Codex CLI, OpenCode).
 
 **Requires Python >= 3.12.**
 
@@ -114,6 +114,7 @@ uv run ouroboros --version            # verify CLI
 | Claude Code (`ooo`) | Claude Code with plugin support |
 | Standalone CLI (`ouroboros`) | Python >= 3.12, API key (Anthropic or OpenAI) |
 | Codex CLI backend | Python >= 3.12, `npm install -g @openai/codex`, OpenAI API key with access to GPT-5.4 |
+| OpenCode backend | Python >= 3.12, `opencode` on PATH, API key for your configured provider |
 
 ---
 
@@ -137,7 +138,7 @@ export OPENAI_API_KEY="your-openai-key"
 
 ```yaml
 orchestrator:
-  runtime_backend: claude   # claude | codex
+  runtime_backend: claude   # claude | codex | opencode
 
 llm:
   backend: claude_code      # claude_code | codex | litellm
@@ -293,20 +294,21 @@ ooo run
 
 ## Choosing a Runtime Backend
 
-Ouroboros delegates code execution to a pluggable runtime backend. Two ship out of the box:
+Ouroboros delegates code execution to a pluggable runtime backend. Three ship out of the box:
 
-| | Claude Code | Codex CLI |
-|---|---|---|
-| **Best for** | Claude Code users; subscription billing | OpenAI ecosystem; pay-per-token billing |
-| **Install** | `pip install ouroboros-ai[claude]` | `pip install ouroboros-ai` + `npm install -g @openai/codex` |
-| **Skill shortcuts** | `ooo` inside Claude Code | `ooo` after `ouroboros setup --runtime codex` installs managed Codex skills |
-| **Config value** | `claude` | `codex` |
+| | Claude Code | Codex CLI | OpenCode |
+|---|---|---|---|
+| **Best for** | Claude Code users; subscription billing | OpenAI ecosystem; pay-per-token billing | Multi-provider flexibility; open-source tooling |
+| **Install** | `pip install ouroboros-ai[claude]` | `pip install ouroboros-ai` + `npm install -g @openai/codex` | `pip install ouroboros-ai` + `opencode` on PATH |
+| **Skill shortcuts** | `ooo` inside Claude Code | `ooo` after `ouroboros setup --runtime codex` installs managed Codex skills | `ooo` after `ouroboros setup --runtime opencode` |
+| **Config value** | `claude` | `codex` | `opencode` |
 
-Both backends run the same core workflow engine (seed execution, TUI). However, user-facing commands still differ: Claude Code has native in-session `ooo` workflows, while Codex CLI relies on `ouroboros setup --runtime codex` to install managed rules/skills plus the MCP hookup. The `ouroboros` CLI remains the most universal terminal path, and some advanced operations are still MCP/Claude-only.
+All three backends run the same core workflow engine (seed execution, TUI). However, user-facing commands still differ: Claude Code has native in-session `ooo` workflows, while Codex CLI and OpenCode rely on `ouroboros setup --runtime <backend>` to configure the integration. The `ouroboros` CLI remains the most universal terminal path, and some advanced operations are still MCP/Claude-only.
 
 For backend-specific configuration:
 - [Claude Code runtime guide](runtime-guides/claude-code.md)
 - [Codex CLI runtime guide](runtime-guides/codex.md)
+- [OpenCode runtime guide](runtime-guides/opencode.md)
 
 ---
 
@@ -405,5 +407,6 @@ ouroboros cancel execution <session_id>
 - [Configuration Reference](config-reference.md) -- all config keys and defaults
 - [Claude Code runtime guide](runtime-guides/claude-code.md) -- backend-specific setup
 - [Codex CLI runtime guide](runtime-guides/codex.md) -- backend-specific setup
+- [OpenCode runtime guide](runtime-guides/opencode.md) -- backend-specific setup
 
 Need help? Open an issue on [GitHub](https://github.com/Q00/ouroboros/issues).

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -13,7 +13,7 @@ The runtime backend is selected via the `orchestrator.runtime_backend` config ke
 
 ```yaml
 orchestrator:
-  runtime_backend: claude   # Supported values: claude | codex
+  runtime_backend: claude   # Supported values: claude | codex | opencode
                             # The runtime abstraction layer also accepts custom
                             # adapters registered in runtime_factory.py
 ```
@@ -26,7 +26,7 @@ ouroboros run workflow --runtime codex seed.yaml
 
 You can also override the configured backend with the `OUROBOROS_AGENT_RUNTIME` environment variable.
 
-> **Extensibility:** Ouroboros uses a pluggable `AgentRuntime` protocol. Claude Code and Codex CLI are the two shipped backends; additional runtimes can be registered by implementing the protocol and extending `runtime_factory.py`. See [Architecture — How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter).
+> **Extensibility:** Ouroboros uses a pluggable `AgentRuntime` protocol. Claude Code, Codex CLI, and OpenCode are the three shipped backends; additional runtimes can be registered by implementing the protocol and extending `runtime_factory.py`. See [Architecture — How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter).
 
 ## Capability Matrix
 
@@ -34,39 +34,39 @@ You can also override the configured backend with the `OUROBOROS_AGENT_RUNTIME` 
 
 These capabilities are part of the Ouroboros core engine and work the same way regardless of runtime backend.
 
-| Capability | Claude Code | Codex CLI | Notes |
-|------------|:-----------:|:---------:|-------|
-| Seed file parsing | Yes | Yes | Same YAML schema, same validation |
-| Acceptance criteria tree | Yes | Yes | Structured AC decomposition |
-| Evaluation principles | Yes | Yes | Weighted scoring against principles |
-| Exit conditions | Yes | Yes | Deterministic termination logic |
-| Event sourcing (SQLite) | Yes | Yes | Full event log, replay support |
-| Checkpoint / resume | Yes | Yes | `--resume <session_id>` |
-| TUI dashboard | Yes | Yes | Textual-based progress view |
-| Interview (Socratic seed creation) | Yes | Yes | `ouroboros init start ...` with the appropriate LLM backend |
-| Dry-run validation | Yes | Yes | `--dry-run` validates without executing |
+| Capability | Claude Code | Codex CLI | OpenCode | Notes |
+|------------|:-----------:|:---------:|:--------:|-------|
+| Seed file parsing | Yes | Yes | Yes | Same YAML schema, same validation |
+| Acceptance criteria tree | Yes | Yes | Yes | Structured AC decomposition |
+| Evaluation principles | Yes | Yes | Yes | Weighted scoring against principles |
+| Exit conditions | Yes | Yes | Yes | Deterministic termination logic |
+| Event sourcing (SQLite) | Yes | Yes | Yes | Full event log, replay support |
+| Checkpoint / resume | Yes | Yes | Yes | `--resume <session_id>` |
+| TUI dashboard | Yes | Yes | Yes | Textual-based progress view |
+| Interview (Socratic seed creation) | Yes | Yes | Yes | `ouroboros init start ...` with the appropriate LLM backend |
+| Dry-run validation | Yes | Yes | Yes | `--dry-run` validates without executing |
 
 ### Runtime Layer (differs by backend)
 
 These capabilities depend on the runtime backend's native features and execution model.
 
-| Capability | Claude Code | Codex CLI | Notes |
-|------------|:-----------:|:---------:|-------|
-| **Authentication** | Max Plan subscription | OpenAI API key | No API key needed for Claude Code |
-| **Underlying model** | Claude (Anthropic) | GPT-5.4+ (OpenAI) | Model choice follows the runtime |
-| **Tool surface** | Read, Write, Edit, Bash, Glob, Grep | Codex-native tool set | Different tool implementations; same task outcomes |
-| **Sandbox / permissions** | Claude Code permission system | Codex sandbox model | Each runtime manages its own safety boundaries |
-| **Cost model** | Included in Max Plan | Per-token API charges | See [OpenAI pricing](https://openai.com/pricing) for Codex costs |
+| Capability | Claude Code | Codex CLI | OpenCode | Notes |
+|------------|:-----------:|:---------:|:--------:|-------|
+| **Authentication** | Max Plan subscription | OpenAI API key | Provider API keys (configured in OpenCode) | No API key needed for Claude Code |
+| **Underlying model** | Claude (Anthropic) | GPT-5.4+ (OpenAI) | Provider-dependent (OpenCode supports multiple providers) | Model choice follows the runtime |
+| **Tool surface** | Read, Write, Edit, Bash, Glob, Grep | Codex-native tool set | Read, Write, Edit, Bash, Glob, Grep | Different tool implementations; same task outcomes |
+| **Sandbox / permissions** | Claude Code permission system | Codex sandbox model | OpenCode permission system | Each runtime manages its own safety boundaries |
+| **Cost model** | Included in Max Plan | Per-token API charges | Depends on configured provider | See [OpenAI pricing](https://openai.com/pricing) for Codex costs |
 
 ### Integration Surface (UX differences)
 
-| Aspect | Claude Code | Codex CLI |
-|--------|-------------|-----------|
-| **Primary UX** | In-session skills and MCP server | Session-oriented Ouroboros runtime over Codex CLI transport |
-| **Skill shortcuts (`ooo`)** | Yes -- skills loaded into Claude Code session | Yes -- after `ouroboros setup --runtime codex` installs managed skills into `~/.codex/skills/`, rules into `~/.codex/rules/`, and the MCP/env hookup into `~/.codex/config.toml`. Keep role-specific Ouroboros model overrides in `~/.ouroboros/config.yaml` |
-| **MCP integration** | Native MCP server support | Deterministic skill/MCP dispatch through the Ouroboros Codex adapter |
-| **Session context** | Shares Claude Code session context | Preserved via runtime handles, native session IDs, and resume support |
-| **Install extras** | `ouroboros-ai[claude]` | `ouroboros-ai` (base package) + `codex` on PATH |
+| Aspect | Claude Code | Codex CLI | OpenCode |
+|--------|-------------|-----------|----------|
+| **Primary UX** | In-session skills and MCP server | Session-oriented Ouroboros runtime over Codex CLI transport | MCP server integration |
+| **Skill shortcuts (`ooo`)** | Yes -- skills loaded into Claude Code session | Yes -- after `ouroboros setup --runtime codex` installs managed skills into `~/.codex/skills/`, rules into `~/.codex/rules/`, and the MCP/env hookup into `~/.codex/config.toml`. Keep role-specific Ouroboros model overrides in `~/.ouroboros/config.yaml` | Yes -- after `ouroboros setup --runtime opencode` |
+| **MCP integration** | Native MCP server support | Deterministic skill/MCP dispatch through the Ouroboros Codex adapter | Native MCP server support |
+| **Session context** | Shares Claude Code session context | Preserved via runtime handles, native session IDs, and resume support | Session IDs + resume via `--session` |
+| **Install extras** | `ouroboros-ai[claude]` | `ouroboros-ai` (base package) + `codex` on PATH | `ouroboros-ai` (base package) + `opencode` on PATH |
 
 ## What Stays the Same
 
@@ -97,15 +97,18 @@ The table below covers the two currently shipped backends. Because Ouroboros use
 |-----------|----------|
 | Have a Claude Code Max Plan and want zero API key setup | Claude Code (`runtime_backend: claude`) |
 | Want a Codex-backed Ouroboros session instead of a Claude Code session | Codex CLI (`runtime_backend: codex`) |
+| Want to use OpenCode with multiple model providers | OpenCode (`runtime_backend: opencode`) |
 | Want to use Anthropic's Claude models | Claude Code |
 | Want to use OpenAI's GPT models | Codex CLI |
-| Need MCP server integration | Claude Code |
-| Want minimal Python dependencies | Codex CLI (base package only) |
+| Want to use multiple providers via a single runtime | OpenCode |
+| Need MCP server integration | Claude Code or OpenCode |
+| Want minimal Python dependencies | Codex CLI or OpenCode (base package only) |
 | Want to integrate a custom or third-party AI coding agent | Implement the `AgentRuntime` protocol and register it in `runtime_factory.py` |
 
 ## Further Reading
 
 - [Claude Code runtime guide](runtime-guides/claude-code.md)
 - [Codex CLI runtime guide](runtime-guides/codex.md)
+- [OpenCode runtime guide](runtime-guides/opencode.md)
 - [Platform support matrix](platform-support.md) (OS and Python version compatibility)
 - [Architecture overview](architecture.md) — including [How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter)

--- a/docs/runtime-guides/opencode.md
+++ b/docs/runtime-guides/opencode.md
@@ -1,0 +1,165 @@
+<!--
+doc_metadata:
+  runtime_scope: [opencode]
+-->
+
+# Running Ouroboros with OpenCode
+
+> For installation and first-run onboarding, see [Getting Started](../getting-started.md).
+
+Ouroboros can use **OpenCode** as a runtime backend. [OpenCode](https://opencode.ai) is an open-source AI coding agent that supports multiple model providers (Anthropic, OpenAI, Google, and others). In Ouroboros, the OpenCode backend is presented as a **session-oriented runtime** with the same specification-first workflow harness (acceptance criteria, evaluation principles, deterministic exit conditions).
+
+No additional Python SDK is required beyond the base `ouroboros-ai` package.
+
+## Prerequisites
+
+- **OpenCode** installed and on your `PATH` (see [install steps](#installing-opencode) below)
+- An **API key** for your configured provider (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`)
+- **Python >= 3.12**
+
+## Installing OpenCode
+
+OpenCode is distributed as a standalone binary. Install via the official script:
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+Verify the installation:
+
+```bash
+opencode --version
+```
+
+For alternative install methods, see the [OpenCode documentation](https://opencode.ai/docs).
+
+## Configuration
+
+To select OpenCode as the runtime backend, set the following in your Ouroboros configuration:
+
+```yaml
+orchestrator:
+  runtime_backend: opencode
+```
+
+Or pass the backend on the command line:
+
+```bash
+uv run ouroboros run workflow --runtime opencode ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+```
+
+### Setup
+
+Run the setup command to auto-configure:
+
+```bash
+ouroboros setup --runtime opencode
+```
+
+This:
+
+- Detects the `opencode` binary on your `PATH`
+- Writes `orchestrator.runtime_backend: opencode` to `~/.ouroboros/config.yaml`
+- Registers the Ouroboros MCP server in OpenCode's configuration
+
+## How It Works
+
+```
++-----------------+     +------------------+     +-----------------+
+|   Seed YAML     | --> |   Orchestrator   | --> |    OpenCode     |
+|  (your task)    |     | (runtime_factory)|     |   (runtime)     |
++-----------------+     +------------------+     +-----------------+
+                                |
+                                v
+                        +------------------+
+                        |  Tools Available |
+                        |  - Read          |
+                        |  - Write         |
+                        |  - Edit          |
+                        |  - Bash          |
+                        |  - Glob          |
+                        |  - Grep          |
+                        +------------------+
+```
+
+The `OpenCodeRuntime` adapter launches `opencode run --format json` as a subprocess for each task execution. The orchestrator pipes the prompt via stdin and parses the structured JSON event stream from stdout.
+
+> For a side-by-side comparison of all runtime backends, see the [runtime capability matrix](../runtime-capability-matrix.md).
+
+## OpenCode-Specific Strengths
+
+- **Multi-provider support** -- use Anthropic, OpenAI, Google, or other providers through a single runtime
+- **Rich tool access** -- full suite of file, shell, and search tools (same surface as Claude Code)
+- **Native MCP integration** -- OpenCode has built-in MCP server support
+- **Open-source** -- fully open-source, allowing inspection and contribution
+
+## CLI Options
+
+### Workflow Commands
+
+```bash
+# Execute workflow (OpenCode runtime)
+uv run ouroboros run workflow --runtime opencode ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+
+# Debug output (show logs and agent output)
+uv run ouroboros run workflow --runtime opencode --debug ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+
+# Resume a previous session
+uv run ouroboros run workflow --runtime opencode --resume <session_id> ~/.ouroboros/seeds/seed_abcd1234ef56.yaml
+```
+
+## Known Limitations
+
+### Session pollution
+
+Each task execution via `opencode run` creates a visible session in OpenCode's session history. Long-running workflows with many orchestrator steps will accumulate sessions. A future phase will reparent these sessions under the caller to prevent polluting the session picker (see GitHub #164 Phase 2).
+
+### No interactive mode
+
+The adapter uses `opencode run --format json` (non-interactive). Features that require interactive OpenCode sessions (e.g., manual approval prompts) are not available during Ouroboros execution.
+
+## Troubleshooting
+
+### OpenCode not found
+
+Ensure `opencode` is installed and available on your `PATH`:
+
+```bash
+which opencode
+```
+
+If not installed:
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+### API key errors
+
+Verify your provider API key is set:
+
+```bash
+# For Anthropic
+echo $ANTHROPIC_API_KEY
+
+# For OpenAI
+echo $OPENAI_API_KEY
+```
+
+### "Providers: warning" in health check
+
+This is normal when using the orchestrator runtime backends. The warning refers to LiteLLM providers, which are not used in orchestrator mode.
+
+### "EventStore not initialized"
+
+The database will be created automatically at `~/.ouroboros/ouroboros.db`.
+
+## Cost
+
+Using OpenCode as the runtime backend incurs API charges from your configured provider. Costs depend on:
+
+- Provider and model selected in OpenCode configuration
+- Task complexity and token usage
+- Number of tool calls and iterations
+
+Refer to your provider's pricing page for current rates.

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -50,6 +50,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
 
     CLAUDE = "claude"
     CODEX = "codex"
+    OPENCODE = "opencode"
 
 
 class LLMBackend(str, Enum):  # noqa: UP042
@@ -58,6 +59,7 @@ class LLMBackend(str, Enum):  # noqa: UP042
     CLAUDE_CODE = "claude_code"
     LITELLM = "litellm"
     CODEX = "codex"
+    OPENCODE = "opencode"
 
 
 class _DefaultStartGroup(typer.core.TyperGroup):
@@ -669,7 +671,7 @@ def start(
             "--runtime",
             help=(
                 "Agent runtime backend for the workflow execution step after seed generation "
-                "(claude or codex)."
+                "(claude, codex, or opencode)."
             ),
             case_sensitive=False,
         ),
@@ -680,7 +682,7 @@ def start(
             "--llm-backend",
             help=(
                 "LLM backend for interview, ambiguity scoring, and seed generation "
-                "(claude_code, litellm, or codex)."
+                "(claude_code, litellm, codex, or opencode)."
             ),
             case_sensitive=False,
         ),

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -29,6 +29,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
 
     CLAUDE = "claude"
     CODEX = "codex"
+    OPENCODE = "opencode"
 
 
 class LLMBackend(str, Enum):  # noqa: UP042
@@ -37,6 +38,7 @@ class LLMBackend(str, Enum):  # noqa: UP042
     CLAUDE_CODE = "claude_code"
     LITELLM = "litellm"
     CODEX = "codex"
+    OPENCODE = "opencode"
 
 
 def _write_pid_file() -> bool:
@@ -262,7 +264,7 @@ def serve(
         AgentRuntimeBackend | None,
         typer.Option(
             "--runtime",
-            help="Agent runtime backend for orchestrator-driven tools (claude or codex).",
+            help="Agent runtime backend for orchestrator-driven tools (claude, codex, or opencode).",
             case_sensitive=False,
         ),
     ] = None,
@@ -271,7 +273,7 @@ def serve(
         typer.Option(
             "--llm-backend",
             help=(
-                "LLM backend for interview/seed/evaluation tools (claude_code, litellm, or codex)."
+                "LLM backend for interview/seed/evaluation tools (claude_code, litellm, codex, or opencode)."
             ),
             case_sensitive=False,
         ),
@@ -296,8 +298,8 @@ def serve(
         # Start with SSE transport on custom port
         ouroboros mcp serve --transport sse --port 9000
 
-        # Start with Codex runtime for orchestrator-driven tools
-        ouroboros mcp serve --runtime codex
+        # Start with OpenCode runtime
+        ouroboros mcp serve --runtime opencode
 
         # Use Codex CLI for LLM-only tools as well
         ouroboros mcp serve --runtime codex --llm-backend codex
@@ -349,7 +351,7 @@ def info(
         AgentRuntimeBackend | None,
         typer.Option(
             "--runtime",
-            help="Agent runtime backend for orchestrator-driven tools (claude or codex).",
+            help="Agent runtime backend for orchestrator-driven tools (claude, codex, or opencode).",
             case_sensitive=False,
         ),
     ] = None,
@@ -358,7 +360,7 @@ def info(
         typer.Option(
             "--llm-backend",
             help=(
-                "LLM backend for interview/seed/evaluation tools (claude_code, litellm, or codex)."
+                "LLM backend for interview/seed/evaluation tools (claude_code, litellm, codex, or opencode)."
             ),
             case_sensitive=False,
         ),

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -59,6 +59,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
 
     CLAUDE = "claude"
     CODEX = "codex"
+    OPENCODE = "opencode"
 
 
 def _derive_quality_bar(seed: "Seed") -> str:
@@ -418,7 +419,7 @@ def workflow(
         AgentRuntimeBackend | None,
         typer.Option(
             "--runtime",
-            help="Agent runtime backend for orchestrator mode (claude or codex).",
+            help="Agent runtime backend for orchestrator mode (claude, codex, or opencode).",
             case_sensitive=False,
         ),
     ] = None,

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -370,6 +370,205 @@ def _setup_claude(claude_path: str) -> None:
     print_info(f"Config saved to: {config_path}")
 
 
+def _strip_jsonc(text: str) -> str:
+    """Strip JSONC features (comments, trailing commas) to produce valid JSON.
+
+    .. deprecated::
+        Forwards to :func:`ouroboros.cli.jsonc.strip_jsonc` which handles
+        quoted strings correctly.
+    """
+    from ouroboros.cli.jsonc import strip_jsonc
+
+    return strip_jsonc(text)
+
+
+def _ensure_opencode_mcp_entry() -> None:
+    """Ensure the global OpenCode config has a correct ouroboros MCP entry.
+
+    OpenCode reads config from ``~/.config/opencode/opencode.json`` (JSONC).
+    The ``mcp`` key is a record of named MCP server configs.
+
+    MCP entry format (local):
+        ``{ "type": "local", "command": [...], "environment": {...}, "timeout": 300000 }``
+    """
+    config_dir = Path.home() / ".config" / "opencode"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "opencode.json"
+
+    data: dict = {}
+    if config_path.exists():
+        try:
+            data = json.loads(_strip_jsonc(config_path.read_text()))
+        except (json.JSONDecodeError, OSError):
+            print_warning(
+                f"Could not parse {config_path} — skipping MCP registration to avoid "
+                "overwriting existing settings.  Fix the JSON syntax and re-run setup."
+            )
+            return
+
+    if not isinstance(data, dict):
+        print_warning(f"{config_path} top-level is not an object — resetting to {{}}.")
+        data = {}
+
+    mcp = data.get("mcp")
+    if mcp is None:
+        mcp = {}
+        data["mcp"] = mcp
+    elif not isinstance(mcp, dict):
+        print_warning(f"{config_path} 'mcp' key is not an object — replacing with {{}}.")
+        mcp = {}
+        data["mcp"] = mcp
+
+    # Detect the best command to run ouroboros mcp serve
+    detected = _detect_opencode_mcp_command()
+    if detected is None:
+        print_warning(
+            "Cannot register MCP server: no working ouroboros installation found.\n"
+            "Install with: pip install ouroboros-ai[all]"
+        )
+        return
+
+    entry = {
+        "type": "local",
+        "command": detected["command"],
+        "environment": {
+            "OUROBOROS_AGENT_RUNTIME": "opencode",
+            "OUROBOROS_LLM_BACKEND": "opencode",
+        },
+        "timeout": 300000,
+    }
+
+    existing = mcp.get("ouroboros")
+    if not isinstance(existing, dict):
+        mcp["ouroboros"] = entry
+        print_success(f"Registered MCP server in {config_path}")
+    else:
+        # Update command only for known standard launchers. Custom entries
+        # (docker, nix wrappers, etc.) are left untouched so we don't break
+        # user-managed configurations — mirrors the Claude setup path.
+        _KNOWN_COMMANDS = {"ouroboros", "python3", "python", "uvx", "uv"}
+        existing_cmd = existing.get("command")
+        # OpenCode expects command: string[]. If it's a bare string (hand-edited
+        # or legacy), replace it unconditionally since it can't launch.
+        if isinstance(existing_cmd, str):
+            existing["command"] = entry["command"]
+            print_info("Replaced invalid command string with proper array format.")
+        else:
+            # First element is the binary
+            existing_binary = (
+                existing_cmd[0] if isinstance(existing_cmd, list) and existing_cmd else None
+            )
+            # Repair malformed arrays: empty list, non-string first element
+            if not isinstance(existing_binary, str):
+                existing["command"] = entry["command"]
+                print_info("Replaced malformed command array with proper launcher.")
+            elif existing_binary in _KNOWN_COMMANDS:
+                if existing_cmd != entry["command"]:
+                    existing["command"] = entry["command"]
+                    print_info("Updated MCP server command to match current install.")
+        # Normalise stale transport type (e.g. "remote" → "local")
+        if existing.get("type") != "local":
+            existing["type"] = "local"
+        # Ensure runtime env vars are set — repair non-dict environment
+        env = existing.get("environment")
+        if not isinstance(env, dict):
+            env = {}
+            existing["environment"] = env
+        env["OUROBOROS_AGENT_RUNTIME"] = "opencode"
+        env["OUROBOROS_LLM_BACKEND"] = "opencode"
+        if "timeout" not in existing:
+            existing["timeout"] = 300000
+        print_info("MCP server already registered — verified config.")
+
+    # Write back as plain JSON.  This intentionally discards JSONC
+    # comments — the same approach Claude and Codex setup use for their
+    # respective config files.  A comment-preserving JSONC writer is out
+    # of scope for this module.
+    try:
+        with config_path.open("w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+    except OSError:
+        print_warning(f"Could not write {config_path} — skipping.")
+
+
+def _detect_opencode_mcp_command() -> dict[str, list[str]] | None:
+    """Detect the best command to run ouroboros MCP server for OpenCode.
+
+    OpenCode MCP uses ``command: string[]`` format (array, not separate command+args).
+
+    Detection order mirrors the Claude setup path: prefer ``uvx`` (pinned
+    extras) over a bare ``ouroboros`` binary so that machines with both a
+    stale global binary and a newer uvx install use the newer one.
+    """
+    if shutil.which("uvx"):
+        return {"command": ["uvx", "--from", "ouroboros-ai[all]", "ouroboros", "mcp", "serve"]}
+    if shutil.which("ouroboros"):
+        return {"command": ["ouroboros", "mcp", "serve"]}
+    # Check if ouroboros is importable via python
+    import subprocess
+
+    python_path = shutil.which("python3") or shutil.which("python")
+    if python_path:
+        try:
+            subprocess.run(
+                [python_path, "-c", "import ouroboros"],
+                capture_output=True,
+                timeout=10,
+                check=True,
+            )
+            return {"command": [python_path, "-m", "ouroboros", "mcp", "serve"]}
+        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+    return None
+
+
+def _setup_opencode(opencode_path: str) -> None:
+    """Configure Ouroboros for the OpenCode runtime."""
+    from ouroboros.config.loader import create_default_config, ensure_config_dir
+
+    config_dir = ensure_config_dir()
+    config_path = config_dir / "config.yaml"
+
+    if config_path.exists():
+        config_dict = yaml.safe_load(config_path.read_text()) or {}
+    else:
+        create_default_config(config_dir)
+        config_dict = yaml.safe_load(config_path.read_text()) or {}
+
+    # Repair non-dict top-level / section shapes
+    if not isinstance(config_dict, dict):
+        print_warning("~/.ouroboros/config.yaml top-level is not a mapping — resetting.")
+        config_dict = {}
+
+    # Set runtime and LLM backend to opencode
+    orch = config_dict.get("orchestrator")
+    if not isinstance(orch, dict):
+        orch = {}
+        config_dict["orchestrator"] = orch
+    orch["runtime_backend"] = "opencode"
+    orch["opencode_cli_path"] = opencode_path
+
+    llm = config_dict.get("llm")
+    if not isinstance(llm, dict):
+        llm = {}
+        config_dict["llm"] = llm
+    llm["backend"] = "opencode"
+
+    with config_path.open("w") as f:
+        yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+
+    print_success(f"Configured OpenCode runtime (CLI: {opencode_path})")
+    print_info(f"Config saved to: {config_path}")
+
+    # Register MCP server in OpenCode config
+    _ensure_opencode_mcp_entry()
+
+    # Also register for Claude Code if present
+    if (Path.home() / ".claude").is_dir():
+        _ensure_claude_mcp_entry()
+
+
 # ── Brownfield repo helpers ──────────────────────────────────────
 
 
@@ -535,7 +734,7 @@ def setup(
         typer.Option(
             "--runtime",
             "-r",
-            help="Runtime backend to configure (claude, codex).",
+            help="Runtime backend to configure (claude, codex, opencode).",
         ),
     ] = None,
     non_interactive: Annotated[
@@ -548,13 +747,14 @@ def setup(
 ) -> None:
     """Set up Ouroboros for your environment.
 
-    Detects available runtimes (Claude Code, Codex) and configures
+    Detects available runtimes (Claude Code, Codex, OpenCode) and configures
     Ouroboros to use the selected backend.
 
     [dim]Examples:[/dim]
-    [dim]    ouroboros setup                    # auto-detect[/dim]
-    [dim]    ouroboros setup --runtime codex    # use Codex[/dim]
-    [dim]    ouroboros setup --runtime claude   # use Claude Code[/dim]
+    [dim]    ouroboros setup                      # auto-detect[/dim]
+    [dim]    ouroboros setup --runtime codex      # use Codex[/dim]
+    [dim]    ouroboros setup --runtime claude     # use Claude Code[/dim]
+    [dim]    ouroboros setup --runtime opencode   # use OpenCode[/dim]
     [dim]    ouroboros setup scan               # scan brownfield repos[/dim]
     [dim]    ouroboros setup list               # list brownfield repos[/dim]
     [dim]    ouroboros setup default            # toggle default repos[/dim]
@@ -618,7 +818,8 @@ def setup(
                 "No runtimes found.\n\n"
                 "Install one of:\n"
                 "  • Claude Code: https://claude.ai/download\n"
-                "  • Codex CLI:   npm install -g @openai/codex"
+                "  • Codex CLI:   npm install -g @openai/codex\n"
+                "  • OpenCode:    npm install -g opencode-ai"
             )
             raise typer.Exit(1)
 
@@ -635,6 +836,12 @@ def setup(
             print_error("Codex CLI not found in PATH.")
             raise typer.Exit(1)
         _setup_codex(codex_path)
+    elif selected in ("opencode", "opencode_cli"):
+        opencode_path = available.get("opencode")
+        if not opencode_path:
+            print_error("OpenCode CLI not found in PATH.")
+            raise typer.Exit(1)
+        _setup_opencode(opencode_path)
     else:
         print_error(f"Unsupported runtime: {selected}")
         raise typer.Exit(1)

--- a/src/ouroboros/cli/commands/uninstall.py
+++ b/src/ouroboros/cli/commands/uninstall.py
@@ -167,6 +167,47 @@ def _remove_codex_artifacts(dry_run: bool) -> bool:
     return had_work and all_ok
 
 
+def _strip_jsonc(text: str) -> str:
+    """Strip JSONC features (comments, trailing commas) to produce valid JSON.
+
+    .. deprecated::
+        Forwards to :func:`ouroboros.cli.jsonc.strip_jsonc` which handles
+        quoted strings correctly.
+    """
+    from ouroboros.cli.jsonc import strip_jsonc
+
+    return strip_jsonc(text)
+
+
+def _remove_opencode_mcp(dry_run: bool) -> bool:
+    """Remove ouroboros entry from OpenCode config (~/.config/opencode/opencode.json)."""
+    config_path = Path.home() / ".config" / "opencode" / "opencode.json"
+    if not config_path.exists():
+        return False
+
+    try:
+        data = json.loads(_strip_jsonc(config_path.read_text()))
+    except (json.JSONDecodeError, OSError):
+        print_warning(f"{config_path} is malformed — skipping.")
+        return False
+    mcp = data.get("mcp")
+    if not isinstance(mcp, dict) or "ouroboros" not in mcp:
+        return False
+
+    if dry_run:
+        print_info(f"[dry-run] Would remove ouroboros from {config_path}")
+        return True
+
+    del mcp["ouroboros"]
+    try:
+        config_path.write_text(json.dumps(data, indent=2) + "\n")
+    except OSError:
+        print_warning(f"Could not write {config_path} — skipping.")
+        return False
+    print_success(f"Removed ouroboros from {config_path}")
+    return True
+
+
 def _remove_claude_md_block(project_dir: Path, dry_run: bool) -> bool:
     """Remove <!-- ooo:START --> … <!-- ooo:END --> block from CLAUDE.md."""
     claude_md = project_dir / "CLAUDE.md"
@@ -298,6 +339,15 @@ def uninstall(
     except OSError:
         targets.append("Codex MCP config (~/.codex/config.toml — may be unreadable)")
 
+    opencode_config = Path.home() / ".config" / "opencode" / "opencode.json"
+    try:
+        if opencode_config.exists():
+            oc_data = json.loads(_strip_jsonc(opencode_config.read_text()))
+            if isinstance(oc_data.get("mcp"), dict) and "ouroboros" in oc_data["mcp"]:
+                targets.append(f"OpenCode MCP config ({opencode_config})")
+    except (json.JSONDecodeError, OSError):
+        targets.append(f"OpenCode MCP config ({opencode_config} — may be malformed)")
+
     codex_rules = Path.home() / ".codex" / "rules" / "ouroboros.md"
     codex_skills = Path.home() / ".codex" / "skills" / "ouroboros"
     if codex_rules.exists() or codex_skills.exists():
@@ -359,6 +409,10 @@ def uninstall(
     if not _remove_codex_mcp(dry_run=False):
         if any("codex/config.toml" in t for t in targets):
             failed.append("~/.codex/config.toml")
+
+    if not _remove_opencode_mcp(dry_run=False):
+        if any("OpenCode MCP" in t for t in targets):
+            failed.append("OpenCode MCP config")
 
     if not _remove_codex_artifacts(dry_run=False):
         if any("Codex rules" in t for t in targets):

--- a/src/ouroboros/cli/jsonc.py
+++ b/src/ouroboros/cli/jsonc.py
@@ -1,0 +1,93 @@
+"""String-aware JSONC-to-JSON converter.
+
+Strips ``//`` line comments, ``/* … */`` block comments, and trailing commas
+from JSONC text **without** mangling content inside quoted strings.
+
+This module is shared by :mod:`~ouroboros.cli.commands.setup` and
+:mod:`~ouroboros.cli.commands.uninstall` to keep config file handling
+consistent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+# Matches, in order of priority:
+#  1. A double-quoted JSON string (may contain escaped chars)
+#  2. A block comment  /* ... */
+#  3. A line comment   // ...
+_JSONC_TOKEN_RE = re.compile(
+    r"""
+    (?P<string>   "(?:[^"\\]|\\.)*" )   # JSON string literal
+    | (?P<block>  /\*.*?\*/           )   # block comment
+    | (?P<line>   //[^\n]*            )   # line comment
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+
+# Trailing comma before closing brace/bracket — must be string-aware
+# to avoid rewriting commas inside quoted values like ",}" or ",]".
+_TRAILING_COMMA_TOKEN_RE = re.compile(
+    r"""
+    (?P<string>   "(?:[^"\\]|\\.)*" )   # JSON string literal — keep
+    | (?P<comma>  ,\s*[}\]]          )   # trailing comma — strip comma
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+
+
+def strip_jsonc(text: str) -> str:
+    """Convert JSONC text to strict JSON by removing comments and trailing commas.
+
+    Unlike a simple regex sweep, this parser is **string-aware**: comment
+    tokens and trailing commas inside quoted strings are preserved verbatim.
+
+    Examples::
+
+        >>> strip_jsonc('{ "url": "https://foo" }')
+        '{ "url": "https://foo" }'
+        >>> strip_jsonc('{ "a": 1, // comment\\n}')
+        '{ "a": 1, \\n}'
+
+    Args:
+        text: Raw JSONC content.
+
+    Returns:
+        Cleaned string safe for :func:`json.loads`.
+    """
+
+    def _replace_comments(m: re.Match[str]) -> str:
+        if m.group("string"):
+            return m.group("string")
+        return ""
+
+    def _replace_trailing(m: re.Match[str]) -> str:
+        if m.group("string"):
+            return m.group("string")
+        # Keep only the closing bracket/brace, drop the comma + whitespace
+        matched = m.group("comma")
+        return matched.lstrip(",").lstrip()
+
+    text = _JSONC_TOKEN_RE.sub(_replace_comments, text)
+    text = _TRAILING_COMMA_TOKEN_RE.sub(_replace_trailing, text)
+    return text
+
+
+def parse_jsonc(text: str) -> Any:
+    """Parse JSONC text into a Python object.
+
+    Convenience wrapper that strips comments/trailing commas then delegates
+    to :func:`json.loads`.
+
+    Args:
+        text: Raw JSONC content.
+
+    Returns:
+        The parsed JSON value (usually a dict).
+
+    Raises:
+        json.JSONDecodeError: If the cleaned text is not valid JSON.
+    """
+    return json.loads(strip_jsonc(text))

--- a/src/ouroboros/orchestrator/__init__.py
+++ b/src/ouroboros/orchestrator/__init__.py
@@ -47,12 +47,9 @@ from ouroboros.orchestrator.coordinator import (
     FileConflict,
     LevelCoordinator,
 )
-
-# TODO: uncomment when OpenCode runtime is shipped
-# from ouroboros.orchestrator.opencode_runtime import (
-#     OpenCodeRuntime,
-#     OpenCodeRuntimeAdapter,
-# )
+from ouroboros.orchestrator.opencode_runtime import (
+    OpenCodeRuntime,
+)
 
 try:
     from ouroboros.orchestrator.dependency_analyzer import (
@@ -116,13 +113,11 @@ from ouroboros.orchestrator.mcp_tools import (
     MCPToolsLoadedEvent,
     ToolConflict,
 )
-
-# TODO: uncomment when OpenCode runtime is shipped
-# from ouroboros.orchestrator.opencode_event_normalizer import (
-#     OpenCodeEventContext,
-#     OpenCodeEventNormalizer,
-#     normalize_opencode_event,
-# )
+from ouroboros.orchestrator.opencode_event_normalizer import (
+    OpenCodeEventContext,
+    OpenCodeEventNormalizer,
+    normalize_opencode_event,
+)
 from ouroboros.orchestrator.parallel_executor import (
     ACExecutionOutcome,
     ACExecutionResult,
@@ -155,8 +150,7 @@ __all__ = [
     "ClaudeAgentAdapter",
     "ClaudeCodeRuntime",
     "CodexCliRuntime",
-    # "OpenCodeRuntime",  # TODO: uncomment when shipped
-    # "OpenCodeRuntimeAdapter",  # TODO: uncomment when shipped
+    "OpenCodeRuntime",
     "DEFAULT_TOOLS",
     "RuntimeHandle",
     "TaskResult",
@@ -210,9 +204,9 @@ __all__ = [
     "ParallelExecutionStageResult",
     "ParallelExecutionResult",
     "StageExecutionOutcome",
-    # "OpenCodeEventContext",  # TODO: uncomment when shipped
-    # "OpenCodeEventNormalizer",  # TODO: uncomment when shipped
-    # "normalize_opencode_event",  # TODO: uncomment when shipped
+    "OpenCodeEventContext",
+    "OpenCodeEventNormalizer",
+    "normalize_opencode_event",
     # Level Context
     "ACContextSummary",
     "LevelContext",

--- a/src/ouroboros/orchestrator/opencode_event_normalizer.py
+++ b/src/ouroboros/orchestrator/opencode_event_normalizer.py
@@ -1,0 +1,414 @@
+"""Event normalization for OpenCode CLI runtime output.
+
+OpenCode's ``run --format json`` emits JSON lines with a distinct event schema
+compared to Codex CLI.  This module converts those events into the internal
+:class:`~ouroboros.orchestrator.adapter.AgentMessage` format used by the
+Ouroboros orchestrator.
+
+OpenCode JSON event types:
+    - ``tool_use``    — tool call completed (or errored)
+    - ``text``        — assistant text block
+    - ``reasoning``   — thinking/reasoning block
+    - ``step_start``  — turn/step lifecycle start
+    - ``step_finish`` — turn/step lifecycle end
+    - ``error``       — session-level error
+
+Each event carries a ``sessionID`` field and a ``part`` payload whose shape
+varies by type.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+
+
+@dataclass(frozen=True, slots=True)
+class OpenCodeEventContext:
+    """Contextual state tracked across a stream of OpenCode events.
+
+    Attributes:
+        session_id: The OpenCode session ID for the current execution.
+        current_handle: The latest RuntimeHandle for resume support.
+    """
+
+    session_id: str | None = None
+    current_handle: RuntimeHandle | None = None
+
+
+class OpenCodeEventNormalizer:
+    """Stateless converter from OpenCode JSON events to AgentMessage tuples.
+
+    All conversion logic is exposed as ``@classmethod`` or
+    ``@staticmethod`` methods.  No instance state is kept; the class
+    serves purely as a namespace for the normalisation functions.
+
+    Attributes:
+        _TOOL_NAME_MAP: Mapping from lowercase OpenCode tool names to
+            their canonical Ouroboros equivalents.
+    """
+
+    # Tool names that map to well-known Ouroboros tool concepts.
+    _TOOL_NAME_MAP: dict[str, str] = {
+        "bash": "Bash",
+        "edit": "Edit",
+        "write": "Write",
+        "read": "Read",
+        "glob": "Glob",
+        "grep": "Grep",
+        "list": "List",
+        "webfetch": "WebFetch",
+        "websearch": "WebSearch",
+        "codesearch": "CodeSearch",
+        "task": "Task",
+        "todowrite": "TodoWrite",
+        "skill": "Skill",
+    }
+
+    @classmethod
+    def normalize(
+        cls,
+        event: dict[str, Any],
+        context: OpenCodeEventContext,
+    ) -> tuple[AgentMessage, ...]:
+        """Convert a single OpenCode JSON event into zero or more messages.
+
+        Dispatches to the appropriate per-type handler based on the
+        ``type`` field of *event*.
+
+        Args:
+            event: Parsed JSON dict from an
+                ``opencode run --format json`` line.
+            context: Accumulated session context for handle tracking.
+
+        Returns:
+            Tuple of normalised
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`
+            values (possibly empty).
+        """
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            return ()
+
+        handler = _EVENT_HANDLERS.get(event_type)
+        if handler is not None:
+            return handler(event, context)
+
+        return ()
+
+    # ------------------------------------------------------------------
+    # Per-type handlers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _handle_tool_use(
+        event: dict[str, Any],
+        context: OpenCodeEventContext,
+    ) -> tuple[AgentMessage, ...]:
+        """Normalise a ``tool_use`` event into an assistant message.
+
+        Extracts tool name, input, status, output, error, and
+        metadata from the event payload and produces a single
+        :class:`~ouroboros.orchestrator.adapter.AgentMessage` with
+        a human-readable content summary.
+
+        Args:
+            event: Parsed ``tool_use`` JSON event dict.
+            context: Session context carrying the current handle.
+
+        Returns:
+            Single-element tuple containing the normalised
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`,
+            or an empty tuple if the event payload is malformed.
+        """
+        part = event.get("part", {})
+        if not isinstance(part, dict):
+            return ()
+
+        tool = part.get("tool", "unknown")
+        state = part.get("state", {})
+        if not isinstance(state, dict):
+            state = {}
+
+        status = state.get("status", "")
+        tool_input = state.get("input", {})
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+
+        mapped_tool = OpenCodeEventNormalizer._TOOL_NAME_MAP.get(tool, tool)
+
+        # Build a human-readable content summary
+        detail = OpenCodeEventNormalizer._extract_tool_detail(tool, tool_input)
+        content = (
+            f"Calling tool: {mapped_tool}: {detail}" if detail else f"Calling tool: {mapped_tool}"
+        )
+
+        data: dict[str, Any] = {
+            "tool_input": tool_input,
+            "opencode_tool": tool,
+            "status": status,
+        }
+
+        # Include output for completed tools
+        output = state.get("output", "")
+        if isinstance(output, str) and output.strip():
+            data["output"] = output.strip()
+
+        # Include error for failed tools
+        error = state.get("error", "")
+        if isinstance(error, str) and error.strip():
+            data["error"] = error.strip()
+            data["subtype"] = "runtime_error"
+
+        # Include metadata if present
+        metadata = state.get("metadata", {})
+        if isinstance(metadata, dict) and metadata:
+            data["metadata"] = metadata
+
+        return (
+            AgentMessage(
+                type="assistant",
+                content=content,
+                tool_name=mapped_tool,
+                data=data,
+                resume_handle=context.current_handle,
+            ),
+        )
+
+    @staticmethod
+    def _handle_text(
+        event: dict[str, Any],
+        context: OpenCodeEventContext,
+    ) -> tuple[AgentMessage, ...]:
+        """Normalise a ``text`` event into an assistant message.
+
+        Args:
+            event: Parsed ``text`` JSON event dict.
+            context: Session context carrying the current handle.
+
+        Returns:
+            Single-element tuple with the text message, or an empty
+            tuple when the text payload is empty or missing.
+        """
+        part = event.get("part", {})
+        if not isinstance(part, dict):
+            return ()
+
+        text = part.get("text", "")
+        if not isinstance(text, str) or not text.strip():
+            return ()
+
+        return (
+            AgentMessage(
+                type="assistant",
+                content=text.strip(),
+                resume_handle=context.current_handle,
+            ),
+        )
+
+    @staticmethod
+    def _handle_reasoning(
+        event: dict[str, Any],
+        context: OpenCodeEventContext,
+    ) -> tuple[AgentMessage, ...]:
+        """Normalise a ``reasoning`` event into an assistant message.
+
+        The reasoning text is stored in the ``data["thinking"]`` key
+        alongside the main content.
+
+        Args:
+            event: Parsed ``reasoning`` JSON event dict.
+            context: Session context carrying the current handle.
+
+        Returns:
+            Single-element tuple with the reasoning message, or an
+            empty tuple when empty.
+        """
+        part = event.get("part", {})
+        if not isinstance(part, dict):
+            return ()
+
+        text = part.get("text", "")
+        if not isinstance(text, str) or not text.strip():
+            return ()
+
+        return (
+            AgentMessage(
+                type="assistant",
+                content=text.strip(),
+                data={"thinking": text.strip()},
+                resume_handle=context.current_handle,
+            ),
+        )
+
+    @staticmethod
+    def _handle_error(
+        event: dict[str, Any],
+        context: OpenCodeEventContext,
+    ) -> tuple[AgentMessage, ...]:
+        """Normalise an ``error`` event into a final result message.
+
+        Extracts a human-readable error string from the ``error``
+        field, which may be a dict with ``name``/``data`` keys or a
+        plain string.
+
+        Args:
+            event: Parsed ``error`` JSON event dict.
+            context: Session context carrying the current handle.
+
+        Returns:
+            Single-element tuple containing a ``result``-type
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`.
+        """
+        error = event.get("error", {})
+        if isinstance(error, dict):
+            name = error.get("name", "")
+            data = error.get("data", {})
+            msg = ""
+            if isinstance(data, dict):
+                msg = data.get("message", "")
+            error_text = msg or name or "OpenCode reported an error"
+        elif isinstance(error, str):
+            error_text = error
+        else:
+            error_text = "OpenCode reported an error"
+
+        return (
+            AgentMessage(
+                type="result",
+                content=error_text,
+                data={"subtype": "error", "error_type": "OpenCodeError"},
+                resume_handle=context.current_handle,
+            ),
+        )
+
+    @staticmethod
+    def _handle_step_start(
+        _event: dict[str, Any],
+        context: OpenCodeEventContext,
+    ) -> tuple[AgentMessage, ...]:
+        """Normalise a ``step_start`` event into a system message.
+
+        Emitted as a lifecycle marker so downstream consumers can
+        track turn boundaries.
+
+        Args:
+            _event: Parsed ``step_start`` JSON event dict (unused).
+            context: Session context carrying the current handle.
+
+        Returns:
+            Single-element tuple containing a ``system``-type
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`.
+        """
+        return (
+            AgentMessage(
+                type="system",
+                content="OpenCode step started",
+                data={"subtype": "step_start"},
+                resume_handle=context.current_handle,
+            ),
+        )
+
+    @staticmethod
+    def _handle_step_finish(
+        _event: dict[str, Any],
+        context: OpenCodeEventContext,
+    ) -> tuple[AgentMessage, ...]:
+        """Normalise a ``step_finish`` event into a system message.
+
+        Args:
+            _event: Parsed ``step_finish`` JSON event dict (unused).
+            context: Session context carrying the current handle.
+
+        Returns:
+            Single-element tuple containing a ``system``-type
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`.
+        """
+        return (
+            AgentMessage(
+                type="system",
+                content="OpenCode step finished",
+                data={"subtype": "step_finish"},
+                resume_handle=context.current_handle,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_tool_detail(tool: str, tool_input: dict[str, Any]) -> str:
+        """Extract a short human-readable detail from tool input.
+
+        Looks up a canonical key for the given tool (e.g.
+        ``"command"`` for bash, ``"filePath"`` for edit) and returns
+        its value, truncated to 80 characters.
+
+        Args:
+            tool: Lowercase OpenCode tool name.
+            tool_input: Parsed input dict from the event payload.
+
+        Returns:
+            Detail string (up to 80 chars), or an empty string when
+            no suitable key is found.
+        """
+        _detail_keys: dict[str, str] = {
+            "bash": "command",
+            "edit": "filePath",
+            "write": "filePath",
+            "read": "filePath",
+            "glob": "pattern",
+            "grep": "pattern",
+            "webfetch": "url",
+            "websearch": "query",
+            "codesearch": "query",
+            "task": "description",
+            "skill": "name",
+        }
+        key = _detail_keys.get(tool)
+        if key:
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                detail = value.strip()
+                if len(detail) > 80:
+                    return detail[:77] + "..."
+                return detail
+        return ""
+
+
+def normalize_opencode_event(
+    event: dict[str, Any],
+    context: OpenCodeEventContext,
+) -> tuple[AgentMessage, ...]:
+    """Module-level convenience for :meth:`OpenCodeEventNormalizer.normalize`.
+
+    Args:
+        event: Parsed JSON event dict.
+        context: Session context for handle tracking.
+
+    Returns:
+        Tuple of normalised
+        :class:`~ouroboros.orchestrator.adapter.AgentMessage` values.
+    """
+    return OpenCodeEventNormalizer.normalize(event, context)
+
+
+# Dispatch table mapping event type strings to handler methods.
+_EVENT_HANDLERS: dict[str, Any] = {
+    "tool_use": OpenCodeEventNormalizer._handle_tool_use,
+    "text": OpenCodeEventNormalizer._handle_text,
+    "reasoning": OpenCodeEventNormalizer._handle_reasoning,
+    "error": OpenCodeEventNormalizer._handle_error,
+    "step_start": OpenCodeEventNormalizer._handle_step_start,
+    "step_finish": OpenCodeEventNormalizer._handle_step_finish,
+}
+
+
+__all__ = [
+    "OpenCodeEventContext",
+    "OpenCodeEventNormalizer",
+    "normalize_opencode_event",
+]

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -1,0 +1,1547 @@
+"""OpenCode CLI runtime for Ouroboros orchestrator execution.
+
+This module provides an ``AgentRuntime`` implementation that drives workflows
+through the OpenCode CLI (``opencode run --format json``).  It follows the same
+subprocess-based architecture as :class:`CodexCliRuntime` but is adapted for
+OpenCode's JSON event format and session model.
+
+Key features:
+    - Subprocess execution via ``opencode run --format json``
+    - Event normalization through :mod:`opencode_event_normalizer`
+    - Session resume via ``--session <id>`` / ``--continue``
+    - Subagent support: evaluation and LLM sub-tasks can run as child
+      sessions within the same OpenCode instance rather than spawning
+      independent processes
+    - Skill interception compatible with Ouroboros MCP dispatch
+"""
+
+from __future__ import annotations
+
+import asyncio
+import codecs
+from collections import deque
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+import contextlib
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+from typing import Any
+
+import yaml
+
+from ouroboros.codex import resolve_packaged_codex_skill_path
+from ouroboros.config import get_opencode_cli_path
+from ouroboros.core.errors import ProviderError
+from ouroboros.core.types import Result
+from ouroboros.observability.logging import get_logger
+from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle, TaskResult
+from ouroboros.orchestrator.opencode_event_normalizer import (
+    OpenCodeEventContext,
+    OpenCodeEventNormalizer,
+)
+
+log = get_logger(__name__)
+
+_SKILL_COMMAND_PATTERN = re.compile(
+    r"^\s*(?:(?P<ooo_prefix>ooo)\s+(?P<ooo_skill>[a-z0-9][a-z0-9_-]*)|"
+    r"(?P<slash_prefix>/ouroboros:)(?P<slash_skill>[a-z0-9][a-z0-9_-]*))"
+    r"(?:\s+(?P<remainder>.*))?$",
+    re.IGNORECASE,
+)
+_MCP_TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SAFE_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_MAX_LINE_BUFFER_BYTES = 50 * 1024 * 1024  # 50 MB
+
+_INTERVIEW_SESSION_METADATA_KEY = "ouroboros_interview_session_id"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillInterceptRequest:
+    """Metadata for a deterministic MCP skill intercept.
+
+    Attributes:
+        skill_name: Normalised skill name (e.g. ``"interview"``).
+        command_prefix: Original prefix that triggered the intercept
+            (``"ooo interview"`` or ``"/ouroboros:interview"``).
+        prompt: Full prompt string that matched the skill pattern.
+        skill_path: Filesystem path to the resolved ``SKILL.md``.
+        mcp_tool: MCP tool name extracted from the YAML frontmatter.
+        mcp_args: Default argument dict from the YAML frontmatter.
+        first_argument: First positional argument following the
+            command prefix, or ``None``.
+    """
+
+    skill_name: str
+    command_prefix: str
+    prompt: str
+    skill_path: Path
+    mcp_tool: str
+    mcp_args: dict[str, Any]
+    first_argument: str | None
+
+
+type SkillDispatchHandler = Callable[
+    [SkillInterceptRequest, RuntimeHandle | None],
+    Awaitable[tuple[AgentMessage, ...] | None],
+]
+
+
+class OpenCodeRuntime:
+    """Agent runtime that shells out to the locally installed OpenCode CLI.
+
+    This runtime implements the ``AgentRuntime`` protocol by invoking
+    ``opencode run --format json <prompt>`` and streaming the resulting
+    JSON events through :class:`OpenCodeEventNormalizer`.
+
+    Subagent support:
+        OpenCode natively supports child sessions (subagents) through
+        its ``task`` tool.  When the orchestrator needs to run
+        evaluation or other LLM sub-tasks, this runtime can continue
+        the same OpenCode session via ``--session <id>`` rather than
+        spawning a completely independent process.  This keeps context,
+        tool state, and provider authentication shared across parent
+        and child tasks.
+
+    Attributes:
+        _runtime_handle_backend: Backend tag written into
+            :class:`~ouroboros.orchestrator.adapter.RuntimeHandle`.
+        _runtime_backend: Backend identifier for MCP tool lookup.
+        _requires_memory_gate: Whether memory-gate middleware is
+            needed (always ``False`` for OpenCode).
+        _provider_name: Provider label for error reports.
+        _runtime_error_type: Error type string emitted on failure.
+        _log_namespace: Structured-log event prefix.
+        _display_name: Human-readable runtime name.
+        _default_cli_name: Binary name resolved from ``PATH``.
+        _default_llm_backend: Fallback LLM backend identifier.
+        _tempfile_prefix: Prefix for temporary files.
+        _process_shutdown_timeout_seconds: Grace period before
+            ``SIGKILL`` on child process shutdown.
+        _max_resume_retries: Maximum session resume attempts.
+        _max_ouroboros_depth: Recursion depth cap.
+        _startup_output_timeout_seconds: Timeout waiting for first
+            stdout output from the CLI.
+        _stdout_idle_timeout_seconds: Timeout between successive
+            stdout chunks.
+        _max_stderr_lines: Tail-cap for collected stderr lines.
+        _cli_path: Resolved path to the ``opencode`` binary.
+        _permission_mode: OpenCode permission mode string.
+        _model: Optional model override passed via ``--model``.
+        _cwd: Working directory for subprocess execution.
+        _skills_dir: Optional override directory for packaged skills.
+        _skill_dispatcher: Optional external skill dispatch handler.
+        _llm_backend: Active LLM backend identifier.
+        _builtin_mcp_handlers: Lazily-loaded local MCP handler cache.
+    """
+
+    _runtime_handle_backend = "opencode"
+    _runtime_backend = "opencode"
+    _requires_memory_gate = False
+    _provider_name = "opencode"
+    _runtime_error_type = "OpenCodeError"
+    _log_namespace = "opencode_runtime"
+    _display_name = "OpenCode"
+    _default_cli_name = "opencode"
+    _default_llm_backend = "opencode"
+    _tempfile_prefix = "ouroboros-opencode-"
+    _process_shutdown_timeout_seconds = 5.0
+    _max_resume_retries = 3
+    _max_ouroboros_depth = 5
+    _startup_output_timeout_seconds = 120.0
+    _stdout_idle_timeout_seconds = 600.0
+    _max_stderr_lines = 512
+
+    def __init__(
+        self,
+        cli_path: str | Path | None = None,
+        permission_mode: str | None = None,
+        model: str | None = None,
+        cwd: str | Path | None = None,
+        skills_dir: str | Path | None = None,
+        skill_dispatcher: SkillDispatchHandler | None = None,
+        llm_backend: str | None = None,
+    ) -> None:
+        """Initialise the OpenCode runtime.
+
+        Args:
+            cli_path: Explicit path to the ``opencode`` binary.
+                Resolved from
+                :func:`~ouroboros.config.get_opencode_cli_path`,
+                then ``PATH`` if not supplied.
+            permission_mode: OpenCode permission mode string.
+                Stored for forward compatibility and surfaced in
+                :attr:`RuntimeHandle.approval_mode`, but currently a
+                **no-op**: ``opencode run`` has no permission flag.
+            model: Optional model override passed to the CLI via
+                ``--model``.
+            cwd: Working directory for the subprocess.  Defaults to
+                the current process working directory.
+            skills_dir: Optional directory containing custom skill
+                overrides.
+            skill_dispatcher: Optional external callable for skill
+                intercept dispatch.  Falls back to the built-in
+                local MCP handler when ``None``.
+            llm_backend: LLM backend identifier used when loading
+                MCP tool handlers.
+        """
+        self._cli_path = self._resolve_cli_path(cli_path)
+        self._permission_mode = permission_mode or "bypassPermissions"
+        self._model = model
+        self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
+        self._skills_dir = self._resolve_skills_dir(skills_dir)
+        self._skill_dispatcher = skill_dispatcher
+        self._llm_backend = llm_backend or self._default_llm_backend
+        self._builtin_mcp_handlers: dict[str, Any] | None = None
+
+        log.info(
+            f"{self._log_namespace}.initialized",
+            cli_path=self._cli_path,
+            permission_mode=permission_mode,
+            model=model,
+            cwd=self._cwd,
+        )
+
+    # -- AgentRuntime protocol properties ----------------------------------
+
+    @property
+    def runtime_backend(self) -> str:
+        """Return the backend identifier for this runtime.
+
+        Returns:
+            The ``_runtime_handle_backend`` class attribute.
+        """
+        return self._runtime_handle_backend
+
+    @property
+    def working_directory(self) -> str | None:
+        """Return the working directory used by this runtime.
+
+        Returns:
+            Absolute path string, or ``None`` if unset.
+        """
+        return self._cwd
+
+    @property
+    def permission_mode(self) -> str | None:
+        """Return the OpenCode permission mode.
+
+        Returns:
+            Permission mode string (e.g. ``"bypassPermissions"``).
+        """
+        return self._permission_mode
+
+    # -- CLI resolution ----------------------------------------------------
+
+    def _resolve_cli_path(self, cli_path: str | Path | None) -> str:
+        """Resolve the OpenCode CLI binary path.
+
+        Checks, in order: *cli_path* argument,
+        :func:`~ouroboros.config.get_opencode_cli_path`, ``PATH``
+        lookup, and finally the bare binary name.
+
+        Args:
+            cli_path: Explicit override path, or ``None`` to
+                auto-resolve.
+
+        Returns:
+            Absolute or bare binary path string.
+        """
+        if cli_path is not None:
+            candidate = str(Path(cli_path).expanduser())
+        else:
+            candidate = (
+                get_opencode_cli_path()
+                or shutil.which(self._default_cli_name)
+                or self._default_cli_name
+            )
+
+        path = Path(candidate).expanduser()
+        if path.exists():
+            return str(path)
+        return candidate
+
+    def _resolve_skills_dir(self, skills_dir: str | Path | None) -> Path | None:
+        """Resolve an optional explicit skill override directory.
+
+        Args:
+            skills_dir: Directory path, or ``None`` to skip.
+
+        Returns:
+            Expanded :class:`~pathlib.Path`, or ``None`` when no
+            override is configured.
+        """
+        if skills_dir is None:
+            return None
+        return Path(skills_dir).expanduser()
+
+    def _normalize_model(self, model: str | None) -> str | None:
+        """Normalize backend model values before passing to the CLI.
+
+        Strips whitespace and converts the ``"default"`` sentinel to
+        ``None``.
+
+        Args:
+            model: Raw model name string or ``None``.
+
+        Returns:
+            Sanitised model string, or ``None`` when the default
+            model should be used.
+        """
+        if model is None:
+            return None
+        candidate = model.strip()
+        if not candidate or candidate == "default":
+            return None
+        return candidate
+
+    # -- RuntimeHandle management ------------------------------------------
+
+    def _build_runtime_handle(
+        self,
+        session_id: str | None,
+        current_handle: RuntimeHandle | None = None,
+    ) -> RuntimeHandle | None:
+        """Build or update a runtime handle for an OpenCode session.
+
+        When *current_handle* is provided its fields are carried
+        forward and the session ID is updated in place.  Otherwise a
+        fresh :class:`~ouroboros.orchestrator.adapter.RuntimeHandle`
+        is created.
+
+        Args:
+            session_id: OpenCode session identifier, or ``None``.
+            current_handle: Existing handle to update, or ``None``
+                to create a new one.
+
+        Returns:
+            Updated or new
+            :class:`~ouroboros.orchestrator.adapter.RuntimeHandle`,
+            or ``None`` when *session_id* is falsy.
+        """
+        if not session_id:
+            return None
+
+        if current_handle is not None:
+            return replace(
+                current_handle,
+                backend=current_handle.backend or self._runtime_handle_backend,
+                kind=current_handle.kind or "agent_runtime",
+                native_session_id=session_id,
+                cwd=current_handle.cwd or self._cwd,
+                approval_mode=current_handle.approval_mode or self._permission_mode,
+                updated_at=datetime.now(UTC).isoformat(),
+                metadata=dict(current_handle.metadata),
+            )
+
+        return RuntimeHandle(
+            backend=self._runtime_handle_backend,
+            kind="agent_runtime",
+            native_session_id=session_id,
+            cwd=self._cwd,
+            approval_mode=self._permission_mode,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+
+    # -- Prompt composition ------------------------------------------------
+
+    def _compose_prompt(
+        self,
+        prompt: str,
+        system_prompt: str | None,
+        tools: list[str] | None,
+    ) -> str:
+        """Compose a single prompt string for the OpenCode CLI.
+
+        Assembles system instructions, tool guidance, and the user
+        prompt into a markdown-structured string.
+
+        Args:
+            prompt: Primary task prompt text.
+            system_prompt: Optional system instructions prepended
+                under a ``## System Instructions`` header.
+            tools: Optional tool names rendered under a
+                ``## Tooling Guidance`` header.
+
+        Returns:
+            Concatenated prompt string.
+        """
+        parts: list[str] = []
+
+        if system_prompt:
+            parts.append(f"## System Instructions\n{system_prompt}")
+
+        if tools:
+            tool_list = "\n".join(f"- {tool}" for tool in tools)
+            parts.append(
+                "## Tooling Guidance\n"
+                "Prefer to solve the task using the following tool set when possible:\n"
+                f"{tool_list}"
+            )
+
+        parts.append(prompt)
+        return "\n\n".join(part for part in parts if part.strip())
+
+    # -- Command building --------------------------------------------------
+
+    def _build_command(
+        self,
+        *,
+        resume_session_id: str | None = None,
+        prompt: str | None = None,
+    ) -> list[str]:
+        """Assemble the CLI argument list for ``opencode run``.
+
+        The prompt is **not** included in argv — it is piped via stdin
+        to avoid OS ``ARG_MAX`` / ``MAX_ARG_STRLEN`` limits (~128 KB per
+        argument on Linux).  OpenCode auto-detects piped stdin when
+        ``!process.stdin.isTTY``.
+
+        Args:
+            resume_session_id: Optional session ID for
+                ``--session`` based resume.
+            prompt: Unused — kept for signature compatibility.
+                Prompt is fed via :meth:`execute_task` stdin pipe.
+
+        Returns:
+            Argument list suitable for
+            :func:`asyncio.create_subprocess_exec`.
+
+        Raises:
+            ValueError: If *resume_session_id* contains disallowed
+                characters.
+        """
+        command = [self._cli_path, "run", "--format", "json"]
+
+        normalized_model = self._normalize_model(self._model)
+        if normalized_model:
+            command.extend(["--model", normalized_model])
+
+        if resume_session_id:
+            if not _SAFE_SESSION_ID_PATTERN.match(resume_session_id):
+                raise ValueError(
+                    f"Invalid resume_session_id: contains disallowed characters: "
+                    f"{resume_session_id!r}"
+                )
+            command.extend(["--session", resume_session_id])
+
+        return command
+
+    def _build_child_env(self) -> dict[str, str]:
+        """Build an isolated environment for child runtime processes.
+
+        Strips Ouroboros runtime env vars to prevent recursive MCP
+        startup loops and tracks nesting depth to prevent fork bombs.
+
+        Returns:
+            Copy of ``os.environ`` with Ouroboros keys removed and
+            depth counter incremented.
+
+        Raises:
+            RuntimeError: If the nesting depth exceeds
+                ``_max_ouroboros_depth``.
+        """
+        env = os.environ.copy()
+        for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
+            env.pop(key, None)
+        # Track and enforce recursion depth
+        try:
+            depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+        except (ValueError, TypeError):
+            depth = 1
+        if depth > self._max_ouroboros_depth:
+            msg = f"Maximum Ouroboros nesting depth ({self._max_ouroboros_depth}) exceeded"
+            raise RuntimeError(msg)
+        env["_OUROBOROS_DEPTH"] = str(depth)
+        return env
+
+    # -- Stream parsing ----------------------------------------------------
+
+    async def _iter_stream_lines(
+        self,
+        stream: asyncio.StreamReader | None,
+        *,
+        chunk_size: int = 16384,
+        first_chunk_timeout_seconds: float | None = None,
+        chunk_timeout_seconds: float | None = None,
+    ) -> AsyncIterator[str]:
+        """Yield decoded lines from a subprocess stdout stream.
+
+        Reads raw bytes in *chunk_size* increments, decodes UTF-8
+        with replacement, and splits on newline boundaries.  Enforces
+        ``_MAX_LINE_BUFFER_BYTES`` to prevent unbounded memory use.
+
+        Args:
+            stream: Async stream reader from the subprocess, or
+                ``None`` (returns immediately).
+            chunk_size: Number of bytes to read per iteration.
+            first_chunk_timeout_seconds: Maximum wait for the very
+                first chunk (startup guard).
+            chunk_timeout_seconds: Maximum wait between subsequent
+                chunks (idle guard).
+
+        Yields:
+            Individual newline-delimited strings with trailing
+            ``\\r`` stripped.
+
+        Raises:
+            TimeoutError: If a timeout is exceeded.
+            ProviderError: If the internal line buffer overflows.
+        """
+        if stream is None:
+            return
+
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        buffer = ""
+        buffer_byte_estimate = 0
+        saw_chunk = False
+
+        while True:
+            timeout_seconds: float | None = None
+            if not saw_chunk:
+                timeout_seconds = first_chunk_timeout_seconds
+            elif chunk_timeout_seconds is not None:
+                timeout_seconds = chunk_timeout_seconds
+
+            try:
+                if timeout_seconds is None:
+                    chunk = await stream.read(chunk_size)
+                else:
+                    chunk = await asyncio.wait_for(
+                        stream.read(chunk_size),
+                        timeout=timeout_seconds,
+                    )
+            except TimeoutError as exc:
+                phase = "startup" if not saw_chunk else "idle"
+                raise TimeoutError(
+                    f"{self._display_name} produced no stdout during {phase} "
+                    f"window ({timeout_seconds:.0f}s)"
+                ) from exc
+            if not chunk:
+                break
+
+            saw_chunk = True
+            decoded = decoder.decode(chunk)
+            buffer += decoded
+            buffer_byte_estimate += len(decoded) * 4
+            if buffer_byte_estimate > _MAX_LINE_BUFFER_BYTES:
+                log.error(
+                    f"{self._log_namespace}.line_buffer_overflow",
+                    buffer_size=len(buffer),
+                    limit=_MAX_LINE_BUFFER_BYTES,
+                )
+                raise ProviderError(f"JSONL line buffer exceeded {_MAX_LINE_BUFFER_BYTES} bytes")
+            while True:
+                newline_index = buffer.find("\n")
+                if newline_index < 0:
+                    break
+                line = buffer[:newline_index]
+                buffer = buffer[newline_index + 1 :]
+                buffer_byte_estimate = len(buffer) * 4
+                yield line.rstrip("\r")
+
+        buffer += decoder.decode(b"", final=True)
+        if buffer:
+            yield buffer.rstrip("\r")
+
+    async def _collect_stream_lines(
+        self,
+        stream: asyncio.StreamReader | None,
+        *,
+        max_lines: int | None = None,
+    ) -> list[str]:
+        """Drain a subprocess stream into a list of lines.
+
+        Collects all lines without blocking the event loop.  When
+        *max_lines* is set the collection is tail-capped via a
+        :class:`~collections.deque`.
+
+        Args:
+            stream: Async stream reader, or ``None``.
+            max_lines: Optional cap on retained lines (keeps the
+                most recent).
+
+        Returns:
+            List of decoded line strings.
+        """
+        if stream is None:
+            return []
+
+        if max_lines is not None and max_lines > 0:
+            lines: deque[str] = deque(maxlen=max_lines)
+        else:
+            lines = deque()
+        async for line in self._iter_stream_lines(stream):
+            if line:
+                lines.append(line)
+        return list(lines)
+
+    # -- Process management ------------------------------------------------
+
+    async def _terminate_process(self, process: Any) -> None:
+        """Best-effort subprocess shutdown.
+
+        Sends ``SIGTERM``, waits up to
+        ``_process_shutdown_timeout_seconds``, then escalates to
+        ``SIGKILL`` if the process is still alive.
+
+        Args:
+            process: Subprocess object (must expose ``terminate``,
+                ``kill``, and ``wait`` methods).
+        """
+        if getattr(process, "returncode", None) is not None:
+            return
+
+        terminate = getattr(process, "terminate", None)
+        kill = getattr(process, "kill", None)
+
+        try:
+            if callable(terminate):
+                terminate()
+            elif callable(kill):
+                kill()
+            else:
+                return
+        except ProcessLookupError:
+            return
+        except Exception as exc:
+            log.warning(
+                f"{self._log_namespace}.process_terminate_failed",
+                error=str(exc),
+            )
+            return
+
+        try:
+            await asyncio.wait_for(
+                process.wait(),
+                timeout=self._process_shutdown_timeout_seconds,
+            )
+            return
+        except (TimeoutError, ProcessLookupError):
+            pass
+
+        if callable(kill):
+            with contextlib.suppress(ProcessLookupError, Exception):
+                kill()
+            with contextlib.suppress(asyncio.TimeoutError, ProcessLookupError, Exception):
+                await asyncio.wait_for(
+                    process.wait(),
+                    timeout=self._process_shutdown_timeout_seconds,
+                )
+
+    # -- Event conversion --------------------------------------------------
+
+    def _parse_json_event(self, line: str) -> dict[str, Any] | None:
+        """Parse a single JSON line into a dict.
+
+        Args:
+            line: Raw string from the subprocess stdout stream.
+
+        Returns:
+            Parsed dict, or ``None`` if the line is not valid JSON
+            or is not a dict.
+        """
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        return event if isinstance(event, dict) else None
+
+    def _extract_event_session_id(self, event: dict[str, Any]) -> str | None:
+        """Extract the OpenCode session ID from a JSON event.
+
+        Args:
+            event: Parsed JSON event dict.
+
+        Returns:
+            Stripped session ID string, or ``None`` if absent.
+        """
+        session_id = event.get("sessionID")
+        if isinstance(session_id, str) and session_id.strip():
+            return session_id.strip()
+        return None
+
+    def _convert_event(
+        self,
+        event: dict[str, Any],
+        context: OpenCodeEventContext,
+    ) -> list[AgentMessage]:
+        """Convert an OpenCode JSON event into normalised messages.
+
+        Delegates to
+        :meth:`OpenCodeEventNormalizer.normalize` and returns the
+        result as a mutable list.
+
+        Args:
+            event: Parsed JSON event dict.
+            context: Accumulated session context for handle tracking.
+
+        Returns:
+            List of
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`
+            values (possibly empty).
+        """
+        return list(OpenCodeEventNormalizer.normalize(event, context))
+
+    # -- Skill interception ------------------------------------------------
+
+    def _extract_first_argument(self, remainder: str | None) -> str | None:
+        """Extract the first positional argument from a command tail.
+
+        Uses :func:`shlex.split` for proper quoting, falling back
+        to a naive whitespace split on parse errors.
+
+        Args:
+            remainder: The command string following the skill prefix,
+                or ``None``.
+
+        Returns:
+            First argument string, or ``None`` if *remainder* is
+            empty.
+        """
+        if not remainder or not remainder.strip():
+            return None
+        try:
+            args = shlex.split(remainder)
+        except ValueError:
+            args = remainder.strip().split(maxsplit=1)
+        return args[0] if args else None
+
+    def _load_skill_frontmatter(self, skill_md_path: Path) -> dict[str, Any]:
+        """Load YAML frontmatter from a packaged ``SKILL.md`` file.
+
+        Parses the leading ``---``-delimited YAML block and returns
+        it as a plain dict.
+
+        Args:
+            skill_md_path: Filesystem path to the ``SKILL.md`` file.
+
+        Returns:
+            Parsed frontmatter dict, or an empty dict if no
+            frontmatter is present.
+
+        Raises:
+            ValueError: If frontmatter delimiters are malformed or
+                the parsed value is not a mapping.
+        """
+        content = skill_md_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        if not lines or lines[0].strip() != "---":
+            return {}
+
+        closing_index = next(
+            (index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"),
+            None,
+        )
+        if closing_index is None:
+            msg = f"Unterminated frontmatter in {skill_md_path}"
+            raise ValueError(msg)
+
+        raw_frontmatter = "\n".join(lines[1:closing_index]).strip()
+        if not raw_frontmatter:
+            return {}
+
+        parsed = yaml.safe_load(raw_frontmatter)
+        if parsed is None:
+            return {}
+        if not isinstance(parsed, dict):
+            msg = f"Frontmatter must be a mapping in {skill_md_path}"
+            raise ValueError(msg)
+        return parsed
+
+    def _normalize_mcp_frontmatter(
+        self,
+        frontmatter: dict[str, Any],
+    ) -> tuple[tuple[str, dict[str, Any]] | None, str | None]:
+        """Validate and normalise MCP dispatch metadata from frontmatter.
+
+        Checks that ``mcp_tool`` and ``mcp_args`` keys are present
+        and well-typed.
+
+        Args:
+            frontmatter: Parsed YAML frontmatter dict.
+
+        Returns:
+            A 2-tuple ``(normalised, error)``.  On success
+            *normalised* is ``(mcp_tool, mcp_args)`` and *error* is
+            ``None``.  On failure *normalised* is ``None`` and
+            *error* contains a human-readable reason string.
+        """
+        raw_mcp_tool = frontmatter.get("mcp_tool")
+        if raw_mcp_tool is None:
+            return None, "missing required frontmatter key: mcp_tool"
+        if not isinstance(raw_mcp_tool, str) or not raw_mcp_tool.strip():
+            return None, "mcp_tool must be a non-empty string"
+
+        mcp_tool = raw_mcp_tool.strip()
+        if _MCP_TOOL_NAME_PATTERN.fullmatch(mcp_tool) is None:
+            return None, "mcp_tool must contain only letters, digits, and underscores"
+
+        if "mcp_args" not in frontmatter:
+            return None, "missing required frontmatter key: mcp_args"
+
+        raw_mcp_args = frontmatter.get("mcp_args")
+        if not isinstance(raw_mcp_args, Mapping):
+            return None, "mcp_args must be a mapping with string keys and YAML-safe values"
+
+        return (mcp_tool, dict(raw_mcp_args)), None
+
+    def _get_builtin_mcp_handlers(self) -> dict[str, Any]:
+        """Load and cache local Ouroboros MCP handlers.
+
+        Lazily imports
+        :func:`~ouroboros.mcp.tools.definitions.get_ouroboros_tools`
+        and indexes handlers by tool name for exact-prefix dispatch.
+
+        Returns:
+            Dict mapping MCP tool names to handler objects.
+        """
+        if self._builtin_mcp_handlers is None:
+            from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+
+            self._builtin_mcp_handlers = {
+                handler.definition.name: handler
+                for handler in get_ouroboros_tools(
+                    runtime_backend=self._runtime_backend,
+                    llm_backend=self._llm_backend,
+                )
+            }
+        return self._builtin_mcp_handlers
+
+    def _get_mcp_tool_handler(self, tool_name: str) -> Any | None:
+        """Look up a local MCP handler by tool name.
+
+        Args:
+            tool_name: Registered MCP tool name.
+
+        Returns:
+            Handler object, or ``None`` if not registered.
+        """
+        return self._get_builtin_mcp_handlers().get(tool_name)
+
+    def _build_tool_arguments(
+        self,
+        intercept: SkillInterceptRequest,
+        current_handle: RuntimeHandle | None,
+    ) -> dict[str, Any]:
+        """Build the MCP argument payload for an intercepted skill.
+
+        For ``ouroboros_interview`` tools, injects the persisted
+        interview session ID and the first positional argument as
+        ``answer`` when available.
+
+        Args:
+            intercept: Resolved skill intercept metadata.
+            current_handle: Active runtime handle carrying session
+                metadata, or ``None``.
+
+        Returns:
+            Dict of MCP tool arguments ready for dispatch.
+        """
+        if intercept.mcp_tool != "ouroboros_interview" or current_handle is None:
+            return dict(intercept.mcp_args)
+
+        session_id = current_handle.metadata.get(_INTERVIEW_SESSION_METADATA_KEY)
+        if not isinstance(session_id, str) or not session_id.strip():
+            return dict(intercept.mcp_args)
+
+        arguments: dict[str, Any] = dict(intercept.mcp_args)
+        arguments["session_id"] = session_id.strip()
+        if intercept.first_argument is not None:
+            arguments["answer"] = intercept.first_argument
+        return arguments
+
+    def _build_resume_handle(
+        self,
+        current_handle: RuntimeHandle | None,
+        intercept: SkillInterceptRequest,
+        tool_result: Any,
+    ) -> RuntimeHandle | None:
+        """Attach interview session metadata to the runtime handle.
+
+        After an ``ouroboros_interview`` tool call, persists the
+        returned ``session_id`` into the handle's metadata so
+        subsequent turns can resume the same interview.
+
+        Args:
+            current_handle: Existing handle, or ``None``.
+            intercept: Skill intercept metadata.
+            tool_result: MCP tool result containing a ``meta`` dict.
+
+        Returns:
+            Updated or new
+            :class:`~ouroboros.orchestrator.adapter.RuntimeHandle`,
+            or ``None`` if no session ID was found.
+        """
+        if intercept.mcp_tool != "ouroboros_interview":
+            return current_handle
+
+        session_id = tool_result.meta.get("session_id")
+        if not isinstance(session_id, str) or not session_id.strip():
+            return current_handle
+
+        metadata = dict(current_handle.metadata) if current_handle is not None else {}
+        metadata[_INTERVIEW_SESSION_METADATA_KEY] = session_id.strip()
+        updated_at = datetime.now(UTC).isoformat()
+
+        if current_handle is not None:
+            return replace(current_handle, metadata=metadata, updated_at=updated_at)
+
+        return RuntimeHandle(
+            backend=self.runtime_backend,
+            cwd=self.working_directory,
+            approval_mode=self.permission_mode,
+            updated_at=updated_at,
+            metadata=metadata,
+        )
+
+    async def _dispatch_skill_intercept_locally(
+        self,
+        intercept: SkillInterceptRequest,
+        current_handle: RuntimeHandle | None,
+    ) -> tuple[AgentMessage, ...] | None:
+        """Dispatch an exact-prefix intercept to a local MCP handler.
+
+        Looks up the handler by ``intercept.mcp_tool``, invokes it,
+        and wraps the outcome in a pair of
+        :class:`~ouroboros.orchestrator.adapter.AgentMessage` values
+        (tool call + result).
+
+        Args:
+            intercept: Resolved skill intercept metadata.
+            current_handle: Active runtime handle, or ``None``.
+
+        Returns:
+            Tuple of ``(assistant, result)``
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`
+            values, or ``None`` if dispatch failed.
+
+        Raises:
+            LookupError: If no local handler is registered for the
+                requested tool.
+        """
+        handler = self._get_mcp_tool_handler(intercept.mcp_tool)
+        if handler is None:
+            raise LookupError(f"No local handler registered for tool: {intercept.mcp_tool}")
+
+        tool_arguments = self._build_tool_arguments(intercept, current_handle)
+        tool_result = await handler.handle(tool_arguments)
+        if tool_result.is_err:
+            error = tool_result.error
+            error_data: dict[str, Any] = {
+                "subtype": "error",
+                "error_type": type(error).__name__,
+                "recoverable": True,
+            }
+            return (
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: {intercept.mcp_tool}",
+                    tool_name=intercept.mcp_tool,
+                    data={"tool_input": tool_arguments},
+                    resume_handle=current_handle,
+                ),
+                AgentMessage(
+                    type="result",
+                    content=str(error),
+                    data=error_data,
+                    resume_handle=current_handle,
+                ),
+            )
+
+        resolved_result = tool_result.value
+        resume_handle = self._build_resume_handle(current_handle, intercept, resolved_result)
+        result_text = resolved_result.text_content.strip() or f"{intercept.mcp_tool} completed."
+        result_data: dict[str, Any] = {
+            "subtype": "error" if resolved_result.is_error else "success",
+            "tool_name": intercept.mcp_tool,
+        }
+
+        return (
+            AgentMessage(
+                type="assistant",
+                content=f"Calling tool: {intercept.mcp_tool}",
+                tool_name=intercept.mcp_tool,
+                data={"tool_input": tool_arguments},
+                resume_handle=resume_handle,
+            ),
+            AgentMessage(
+                type="result",
+                content=result_text,
+                data=result_data,
+                resume_handle=resume_handle,
+            ),
+        )
+
+    def _resolve_skill_intercept(self, prompt: str) -> SkillInterceptRequest | None:
+        """Resolve a deterministic MCP intercept from a skill command.
+
+        Matches the prompt against ``_SKILL_COMMAND_PATTERN``, locates
+        the corresponding ``SKILL.md``, and extracts MCP dispatch
+        metadata from its YAML frontmatter.
+
+        Args:
+            prompt: Raw prompt string to test for skill prefixes.
+
+        Returns:
+            :class:`SkillInterceptRequest` when the prompt matches a
+            known skill with valid MCP frontmatter, or ``None``.
+        """
+        match = _SKILL_COMMAND_PATTERN.match(prompt)
+        if match is None:
+            return None
+
+        skill_name = (match.group("ooo_skill") or match.group("slash_skill") or "").lower()
+        if not skill_name:
+            return None
+
+        command_prefix = (
+            f"ooo {skill_name}"
+            if match.group("ooo_skill") is not None
+            else f"/ouroboros:{skill_name}"
+        )
+        try:
+            with resolve_packaged_codex_skill_path(
+                skill_name,
+                skills_dir=self._skills_dir,
+            ) as skill_md_path:
+                frontmatter = self._load_skill_frontmatter(skill_md_path)
+        except FileNotFoundError:
+            return None
+        except (OSError, ValueError, yaml.YAMLError) as e:
+            log.warning(
+                f"{self._log_namespace}.skill_intercept_frontmatter_invalid",
+                skill=skill_name,
+                error=str(e),
+            )
+            return None
+
+        normalized, validation_error = self._normalize_mcp_frontmatter(frontmatter)
+        if normalized is None:
+            if validation_error and not validation_error.startswith(
+                "missing required frontmatter key:"
+            ):
+                log.warning(
+                    f"{self._log_namespace}.skill_intercept_frontmatter_invalid",
+                    skill=skill_name,
+                    error=validation_error,
+                )
+            return None
+
+        mcp_tool, mcp_args = normalized
+        first_argument = self._extract_first_argument(match.group("remainder"))
+        return SkillInterceptRequest(
+            skill_name=skill_name,
+            command_prefix=command_prefix,
+            prompt=prompt,
+            skill_path=skill_md_path,
+            mcp_tool=mcp_tool,
+            mcp_args=self._resolve_dispatch_templates(
+                mcp_args,
+                first_argument=first_argument,
+            ),
+            first_argument=first_argument,
+        )
+
+    def _resolve_dispatch_templates(
+        self,
+        value: Any,
+        *,
+        first_argument: str | None,
+    ) -> Any:
+        """Resolve ``$1`` / ``$CWD`` placeholders in MCP dispatch arguments.
+
+        Mirrors :meth:`CodexCliRuntime._resolve_dispatch_templates` so that
+        shipped skill frontmatter like ``mcp_args: {seed_path: "$1"}`` is
+        expanded before the MCP tool call.
+
+        Args:
+            value: Argument tree (str, dict, list, or primitive).
+            first_argument: The first positional word after the command prefix.
+
+        Returns:
+            Expanded copy of *value*.
+        """
+        if isinstance(value, str):
+            if value == "$1":
+                return first_argument if first_argument is not None else ""
+            if value == "$CWD":
+                return self._cwd
+            return value
+
+        if isinstance(value, Mapping):
+            return {
+                key: self._resolve_dispatch_templates(item, first_argument=first_argument)
+                for key, item in value.items()
+            }
+
+        if isinstance(value, list):
+            return [
+                self._resolve_dispatch_templates(item, first_argument=first_argument)
+                for item in value
+            ]
+
+        return value
+
+    async def _maybe_dispatch_skill_intercept(
+        self,
+        prompt: str,
+        current_handle: RuntimeHandle | None,
+    ) -> tuple[AgentMessage, ...] | None:
+        """Attempt deterministic skill dispatch before invoking OpenCode.
+
+        Falls back to ``None`` (no interception) when the prompt does
+        not match a known skill, when dispatch raises, or when the
+        result contains a recoverable error that should be retried by
+        the main CLI path.
+
+        Args:
+            prompt: Raw prompt string.
+            current_handle: Active runtime handle, or ``None``.
+
+        Returns:
+            Tuple of
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`
+            values if dispatched, or ``None`` to fall through to the
+            CLI path.
+        """
+        intercept = self._resolve_skill_intercept(prompt)
+        if intercept is None:
+            return None
+
+        dispatcher = self._skill_dispatcher or self._dispatch_skill_intercept_locally
+        try:
+            dispatched_messages = await dispatcher(intercept, current_handle)
+        except Exception as e:
+            log.warning(
+                f"{self._log_namespace}.skill_intercept_dispatch_failed",
+                skill=intercept.skill_name,
+                error=str(e),
+            )
+            return None
+
+        # Check for recoverable errors that should fall through to OpenCode
+        if dispatched_messages:
+            final_msg = next(
+                (m for m in reversed(dispatched_messages) if m.is_final and m.is_error),
+                None,
+            )
+            if final_msg is not None:
+                data = final_msg.data
+                if data.get("recoverable") is True or data.get("is_retriable") is True:
+                    return None
+
+        return dispatched_messages
+
+    # -- Runtime handle controls -------------------------------------------
+
+    def _bind_runtime_handle_controls(
+        self,
+        handle: RuntimeHandle | None,
+        *,
+        process: Any,
+        control_state: dict[str, Any],
+    ) -> RuntimeHandle | None:
+        """Attach live observe/terminate callbacks to a runtime handle.
+
+        The callbacks close over *process* and *control_state* so
+        callers can inspect or terminate the subprocess through the
+        handle abstraction.
+
+        Args:
+            handle: Runtime handle to bind, or ``None``.
+            process: Live subprocess object.
+            control_state: Mutable dict tracking PID, return code,
+                and termination flag.
+
+        Returns:
+            Handle with bound controls, or ``None`` when *handle*
+            is ``None``.
+        """
+        if handle is None:
+            return None
+
+        async def _observe(_handle: RuntimeHandle) -> dict[str, Any]:
+            snapshot = _handle.snapshot()
+            pid = control_state.get("process_id")
+            if isinstance(pid, int):
+                snapshot["process_id"] = pid
+            rc = control_state.get("returncode")
+            if isinstance(rc, int):
+                snapshot["returncode"] = rc
+                snapshot["lifecycle_state"] = "completed" if rc == 0 else "failed"
+            return snapshot
+
+        async def _terminate(_handle: RuntimeHandle) -> bool:
+            if control_state.get("terminated") is True:
+                return False
+            if getattr(process, "returncode", None) is not None:
+                return False
+            control_state["runtime_status"] = "terminating"
+            await self._terminate_process(process)
+            control_state["terminated"] = True
+            rc = getattr(process, "returncode", None)
+            control_state["returncode"] = rc
+            control_state["runtime_status"] = (
+                "completed" if rc == 0 else ("terminated" if rc and rc < 0 else "failed")
+            )
+            return True
+
+        return handle.bind_controls(
+            observe_callback=_observe,
+            terminate_callback=_terminate,
+        )
+
+    # -- Main execute_task -------------------------------------------------
+
+    async def execute_task(
+        self,
+        prompt: str,
+        tools: list[str] | None = None,
+        system_prompt: str | None = None,
+        resume_handle: RuntimeHandle | None = None,
+        resume_session_id: str | None = None,
+    ) -> AsyncIterator[AgentMessage]:
+        """Execute a task via the OpenCode CLI and stream messages.
+
+        Tries skill interception first; if no intercept matches,
+        spawns ``opencode run --format json``, streams JSON events,
+        normalises them into
+        :class:`~ouroboros.orchestrator.adapter.AgentMessage` values,
+        and yields each one.
+
+        Args:
+            prompt: Primary task prompt text.
+            tools: Optional tool names injected into the prompt.
+            system_prompt: Optional system instructions prepended to
+                the prompt.
+            resume_handle: Existing
+                :class:`~ouroboros.orchestrator.adapter.RuntimeHandle`
+                for session resume.
+            resume_session_id: Alternative session ID string for
+                resume (used when *resume_handle* is ``None``).
+
+        Yields:
+            :class:`~ouroboros.orchestrator.adapter.AgentMessage`
+            values as they arrive from the CLI.
+        """
+        current_handle = resume_handle or self._build_runtime_handle(resume_session_id)
+
+        # Try skill interception first
+        intercepted = await self._maybe_dispatch_skill_intercept(prompt, current_handle)
+        if intercepted is not None:
+            for message in intercepted:
+                if message.resume_handle is not None:
+                    current_handle = message.resume_handle
+                yield message
+            return
+
+        composed_prompt = self._compose_prompt(prompt, system_prompt, tools)
+        attempted_resume_session_id = (
+            current_handle.native_session_id if current_handle is not None else resume_session_id
+        )
+
+        try:
+            command = self._build_command(
+                resume_session_id=attempted_resume_session_id,
+            )
+        except Exception as e:
+            yield AgentMessage(
+                type="result",
+                content=f"Failed to prepare {self._display_name}: {e}",
+                data={"subtype": "error", "error_type": type(e).__name__},
+                resume_handle=current_handle,
+            )
+            return
+
+        log.info(
+            f"{self._log_namespace}.task_started",
+            command=command[:4],
+            cwd=self._cwd,
+            has_resume_handle=current_handle is not None,
+        )
+
+        stderr_lines: list[str] = []
+        last_content = ""
+        yielded_final = False
+        process: Any | None = None
+        process_finished = False
+        process_terminated = False
+        control_state: dict[str, Any] | None = None
+        stderr_task: asyncio.Task[list[str]] | None = None
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=self._cwd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._build_child_env(),
+            )
+        except FileNotFoundError as e:
+            yield AgentMessage(
+                type="result",
+                content=(
+                    f"{self._display_name} not found: {e}. "
+                    "Install with: npm i -g opencode-ai@latest"
+                ),
+                data={"subtype": "error", "error_type": type(e).__name__},
+                resume_handle=current_handle,
+            )
+            return
+        except Exception as e:
+            yield AgentMessage(
+                type="result",
+                content=f"Failed to start {self._display_name}: {e}",
+                data={"subtype": "error", "error_type": type(e).__name__},
+                resume_handle=current_handle,
+            )
+            return
+
+        control_state = {
+            "handle": current_handle,
+            "process_id": getattr(process, "pid", None),
+            "returncode": getattr(process, "returncode", None),
+            "runtime_status": (
+                current_handle.lifecycle_state if current_handle is not None else "starting"
+            ),
+            "terminated": False,
+        }
+        current_handle = self._bind_runtime_handle_controls(
+            current_handle,
+            process=process,
+            control_state=control_state,
+        )
+
+        # Feed prompt via stdin to avoid OS ARG_MAX / MAX_ARG_STRLEN limits
+        # (~128 KB per single argument on Linux).  OpenCode auto-reads stdin
+        # when !process.stdin.isTTY, so piping works out of the box.
+        if composed_prompt and process.stdin is not None:
+            try:
+                process.stdin.write(composed_prompt.encode("utf-8"))
+                await process.stdin.drain()
+                process.stdin.close()
+                await process.stdin.wait_closed()
+            except (BrokenPipeError, ConnectionResetError, OSError) as exc:
+                # OpenCode exited before consuming stdin — close the pipe and
+                # fall through to normal stderr-based failure reporting.
+                log.warning(
+                    f"{self._log_namespace}.stdin_write_failed",
+                    error=str(exc),
+                )
+                with contextlib.suppress(OSError):
+                    process.stdin.close()
+
+        stderr_task = asyncio.create_task(
+            self._collect_stream_lines(
+                process.stderr,
+                max_lines=self._max_stderr_lines,
+            )
+        )
+
+        try:
+            if process.stdout is not None:
+                async for line in self._iter_stream_lines(
+                    process.stdout,
+                    first_chunk_timeout_seconds=self._startup_output_timeout_seconds,
+                    chunk_timeout_seconds=self._stdout_idle_timeout_seconds,
+                ):
+                    if not line:
+                        continue
+
+                    event = self._parse_json_event(line)
+                    if event is None:
+                        continue
+
+                    # Track session ID from events
+                    event_session_id = self._extract_event_session_id(event)
+                    if event_session_id and (
+                        current_handle is None
+                        or current_handle.native_session_id != event_session_id
+                    ):
+                        current_handle = self._build_runtime_handle(
+                            event_session_id,
+                            current_handle,
+                        )
+                        current_handle = self._bind_runtime_handle_controls(
+                            current_handle,
+                            process=process,
+                            control_state=control_state,
+                        )
+
+                    context = OpenCodeEventContext(
+                        session_id=event_session_id,
+                        current_handle=current_handle,
+                    )
+
+                    for message in self._convert_event(event, context):
+                        if message.resume_handle is not None:
+                            current_handle = message.resume_handle
+                            current_handle = self._bind_runtime_handle_controls(
+                                current_handle,
+                                process=process,
+                                control_state=control_state,
+                            )
+                            message = replace(message, resume_handle=current_handle)
+                        if message.content:
+                            last_content = message.content
+                        if message.is_final:
+                            yielded_final = True
+                        yield message
+
+        except TimeoutError as e:
+            if process is not None and control_state is not None:
+                await self._terminate_process(process)
+                control_state["terminated"] = True
+            process_terminated = True
+            if stderr_task is not None:
+                stderr_lines = await stderr_task
+            final_message = "\n".join(stderr_lines).strip()
+            if not final_message:
+                final_message = f"{self._display_name} became unresponsive and was terminated: {e}"
+            yield AgentMessage(
+                type="result",
+                content=final_message,
+                data={"subtype": "error", "error_type": type(e).__name__},
+                resume_handle=current_handle,
+            )
+            return
+        except asyncio.CancelledError:
+            if process is not None:
+                log.warning(f"{self._log_namespace}.task_cancelled", cwd=self._cwd)
+                await self._terminate_process(process)
+                process_terminated = True
+                if control_state is not None:
+                    control_state["terminated"] = True
+            raise
+        else:
+            # Normal completion — stdout stream finished
+            returncode = await process.wait()
+            process_finished = True
+            control_state["returncode"] = returncode
+            control_state["runtime_status"] = "completed" if returncode == 0 else "failed"
+            current_handle = self._bind_runtime_handle_controls(
+                current_handle,
+                process=process,
+                control_state=control_state,
+            )
+            stderr_lines = await stderr_task
+
+            if yielded_final:
+                return
+
+            final_message = last_content or "\n".join(stderr_lines).strip()
+            # On failure, prefer stderr over stale last_content (which may be
+            # a lifecycle marker or tool summary rather than the real error).
+            if returncode != 0:
+                stderr_text = "\n".join(stderr_lines).strip()
+                final_message = stderr_text or last_content or ""
+            if not final_message:
+                if returncode == 0:
+                    final_message = f"{self._display_name} task completed."
+                else:
+                    final_message = f"{self._display_name} exited with code {returncode}."
+
+            result_data: dict[str, Any] = {
+                "subtype": ("error" if returncode != 0 else "success"),
+                "returncode": returncode,
+            }
+            if current_handle is not None and current_handle.native_session_id:
+                result_data["session_id"] = current_handle.native_session_id
+            if returncode != 0:
+                result_data["error_type"] = self._runtime_error_type
+
+            yield AgentMessage(
+                type="result",
+                content=final_message,
+                data=result_data,
+                resume_handle=current_handle,
+            )
+        finally:
+            if process is not None:
+                if (
+                    not process_finished
+                    and not process_terminated
+                    and getattr(process, "returncode", None) is None
+                ):
+                    await self._terminate_process(process)
+            if stderr_task is not None and not stderr_task.done():
+                stderr_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await stderr_task
+
+    async def execute_task_to_result(
+        self,
+        prompt: str,
+        tools: list[str] | None = None,
+        system_prompt: str | None = None,
+        resume_handle: RuntimeHandle | None = None,
+        resume_session_id: str | None = None,
+    ) -> Result[TaskResult, ProviderError]:
+        """Execute a task and collect all messages into a result.
+
+        Convenience wrapper around :meth:`execute_task` that
+        accumulates every yielded message and returns a single
+        :class:`~ouroboros.core.types.Result`.
+
+        Args:
+            prompt: Primary task prompt text.
+            tools: Optional tool names injected into the prompt.
+            system_prompt: Optional system instructions prepended to
+                the prompt.
+            resume_handle: Existing
+                :class:`~ouroboros.orchestrator.adapter.RuntimeHandle`
+                for session resume.
+            resume_session_id: Alternative session ID string for
+                resume.
+
+        Returns:
+            :class:`~ouroboros.core.types.Result` wrapping either a
+            :class:`~ouroboros.orchestrator.adapter.TaskResult` or a
+            :class:`~ouroboros.core.errors.ProviderError`.
+        """
+        messages: list[AgentMessage] = []
+        final_message = ""
+        success = True
+        final_handle = resume_handle
+
+        async for message in self.execute_task(
+            prompt=prompt,
+            tools=tools,
+            system_prompt=system_prompt,
+            resume_handle=resume_handle,
+            resume_session_id=resume_session_id,
+        ):
+            messages.append(message)
+            if message.resume_handle is not None:
+                final_handle = message.resume_handle
+            if message.is_final:
+                final_message = message.content
+                success = not message.is_error
+
+        if not success:
+            return Result.err(
+                ProviderError(
+                    message=final_message,
+                    provider=self._provider_name,
+                    details={"messages": [m.content for m in messages]},
+                )
+            )
+
+        return Result.ok(
+            TaskResult(
+                success=success,
+                final_message=final_message,
+                messages=tuple(messages),
+                session_id=final_handle.native_session_id if final_handle else None,
+                resume_handle=final_handle,
+            )
+        )
+
+
+__all__ = ["OpenCodeRuntime", "SkillInterceptRequest"]

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -13,10 +13,8 @@ from ouroboros.config import (
 )
 from ouroboros.orchestrator.adapter import AgentRuntime, ClaudeAgentAdapter
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
-
-# TODO: uncomment when OpenCode runtime is shipped
-# from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 from ouroboros.orchestrator.command_dispatcher import create_codex_command_dispatcher
+from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 
 _CLAUDE_BACKENDS = {"claude", "claude_code"}
 _CODEX_BACKENDS = {"codex", "codex_cli"}
@@ -31,8 +29,7 @@ def resolve_agent_runtime_backend(backend: str | None = None) -> str:
     if candidate in _CODEX_BACKENDS:
         return "codex"
     if candidate in _OPENCODE_BACKENDS:
-        msg = "OpenCode runtime is not yet available. Supported backends: claude, codex"
-        raise ValueError(msg)
+        return "opencode"
 
     msg = f"Unsupported orchestrator runtime backend: {candidate}"
     raise ValueError(msg)
@@ -78,7 +75,14 @@ def create_agent_runtime(
             **runtime_kwargs,
         )
 
-    # opencode is rejected at resolve time; this is a defensive fallback
+    if resolved_backend == "opencode":
+        from ouroboros.config import get_opencode_cli_path
+
+        return OpenCodeRuntime(
+            cli_path=cli_path or get_opencode_cli_path(),
+            **runtime_kwargs,
+        )
+
     msg = f"Unsupported orchestrator runtime backend: {resolved_backend}"
     raise ValueError(msg)
 

--- a/src/ouroboros/providers/__init__.py
+++ b/src/ouroboros/providers/__init__.py
@@ -31,10 +31,10 @@ def __getattr__(name: str) -> object:
         from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 
         return CodexCliLLMAdapter
-    # TODO: uncomment when OpenCode adapter is shipped
-    # if name == "OpenCodeLLMAdapter":
-    #     from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
-    #     return OpenCodeLLMAdapter
+    if name == "OpenCodeLLMAdapter":
+        from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
+
+        return OpenCodeLLMAdapter
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -50,7 +50,7 @@ __all__ = [
     # Implementations (AnthropicAdapter is the recommended default)
     "AnthropicAdapter",
     "CodexCliLLMAdapter",
-    # "OpenCodeLLMAdapter",  # TODO: uncomment when shipped
+    "OpenCodeLLMAdapter",
     "LiteLLMAdapter",
     # Factory helpers
     "create_llm_adapter",

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -16,9 +16,7 @@ from ouroboros.providers.base import LLMAdapter
 from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 from ouroboros.providers.gemini_cli_adapter import GeminiCLIAdapter
-
-# TODO: uncomment when OpenCode adapter is shipped
-# from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
+from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
 
 _CLAUDE_CODE_BACKENDS = {"claude", "claude_code"}
 _CODEX_BACKENDS = {"codex", "codex_cli"}
@@ -38,11 +36,7 @@ def resolve_llm_backend(backend: str | None = None) -> str:
     if candidate in _GEMINI_BACKENDS:
         return "gemini"
     if candidate in _OPENCODE_BACKENDS:
-        msg = (
-            "OpenCode LLM adapter is not yet available. "
-            "Supported backends: claude_code, codex, gemini, litellm"
-        )
-        raise ValueError(msg)
+        return "opencode"
     if candidate in _LITELLM_BACKENDS:
         return "litellm"
 
@@ -65,7 +59,7 @@ def resolve_llm_permission_mode(
         raise ValueError(msg)
 
     resolved = resolve_llm_backend(backend)
-    if use_case == "interview" and resolved in ("claude_code", "codex", "gemini"):
+    if use_case == "interview" and resolved in ("claude_code", "codex", "gemini", "opencode"):
         # Interview uses LLM to generate questions — no file writes, but
         # CLI sandbox modes block LLM output entirely. Must bypass.
         return "bypassPermissions"
@@ -125,7 +119,18 @@ def create_llm_adapter(
             timeout=timeout,
             max_retries=max_retries,
         )
-    # opencode is rejected at resolve time; this is a defensive fallback
+    if resolved_backend == "opencode":
+        return OpenCodeLLMAdapter(
+            cli_path=cli_path,
+            cwd=cwd,
+            permission_mode=resolved_permission_mode,
+            allowed_tools=allowed_tools,
+            max_turns=max_turns,
+            on_message=on_message,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+    # litellm is the fallback
     try:
         from ouroboros.providers.litellm_adapter import LiteLLMAdapter
     except ImportError as exc:

--- a/src/ouroboros/providers/opencode_adapter.py
+++ b/src/ouroboros/providers/opencode_adapter.py
@@ -1,0 +1,660 @@
+"""OpenCode CLI adapter for LLM completion using local OpenCode authentication.
+
+This adapter shells out to ``opencode run --format json`` in non-interactive mode,
+allowing Ouroboros to use a local OpenCode CLI session for single-turn completion
+tasks without requiring a separate API key.
+
+The OpenCode CLI must be installed and authenticated before use.
+
+.. note::
+
+    Each invocation creates a top-level OpenCode session.  A future
+    phase will reparent these sessions under the caller's session to
+    prevent polluting the session picker (see GitHub #164 Phase 2).
+
+Usage::
+
+    adapter = OpenCodeLLMAdapter()
+    result = await adapter.complete(
+        messages=[Message(role=MessageRole.USER, content="Hello!")],
+        config=CompletionConfig(model="default"),
+    )
+    if result.is_ok:
+        print(result.value.content)
+
+Custom CLI path::
+
+    adapter = OpenCodeLLMAdapter(cli_path="/usr/local/bin/opencode")
+    # or
+    # export OUROBOROS_OPENCODE_CLI_PATH=/usr/local/bin/opencode
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import contextlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+from typing import Any
+
+import structlog
+
+from ouroboros.config import get_opencode_cli_path
+from ouroboros.core.errors import ProviderError
+from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH, InputValidator
+from ouroboros.core.types import Result
+from ouroboros.providers.base import (
+    CompletionConfig,
+    CompletionResponse,
+    Message,
+    MessageRole,
+    UsageInfo,
+)
+from ouroboros.providers.codex_cli_stream import (
+    collect_stream_lines,
+    iter_stream_lines,
+    terminate_process,
+)
+
+log = structlog.get_logger()
+
+_SAFE_MODEL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_./:@-]+$")
+_MAX_OUROBOROS_DEPTH = 5
+
+_RETRYABLE_ERROR_PATTERNS = (
+    "rate limit",
+    "temporarily unavailable",
+    "timeout",
+    "overloaded",
+    "try again",
+    "connection reset",
+)
+
+
+class OpenCodeLLMAdapter:
+    """LLM adapter backed by local OpenCode CLI execution.
+
+    Implements the :class:`ouroboros.providers.base.LLMAdapter` protocol by
+    spawning ``opencode run --format json`` as a subprocess and collecting
+    its output.  This lets Ouroboros use OpenCode's existing provider
+    configuration instead of embedding a separate API key.
+
+    Attributes:
+        _provider_name: Backend identifier used in
+            :class:`~ouroboros.core.errors.ProviderError` reports.
+        _display_name: Human-readable name for log messages.
+        _default_cli_name: Binary name looked up on ``PATH`` when no
+            explicit path is given.
+        _tempfile_prefix: Prefix for any temporary files created during
+            execution.
+        _process_shutdown_timeout_seconds: Grace period before
+            ``SIGKILL`` when terminating a child process.
+        _cli_path: Resolved path to the ``opencode`` binary.
+        _cwd: Working directory passed to the subprocess.
+        _permission_mode: OpenCode permission mode string.
+        _allowed_tools: Optional tool allow-list injected into prompts.
+        _max_turns: Maximum conversation turns per invocation.
+        _on_message: Optional callback invoked with ``(role, content)``
+            for each assistant response.
+        _max_retries: Number of retry attempts on transient failures.
+        _timeout: Optional per-invocation timeout in seconds.
+    """
+
+    _provider_name = "opencode"
+    _display_name = "OpenCode"
+    _default_cli_name = "opencode"
+    _tempfile_prefix = "ouroboros-opencode-llm-"
+    _process_shutdown_timeout_seconds = 5.0
+
+    def __init__(
+        self,
+        *,
+        cli_path: str | Path | None = None,
+        cwd: str | Path | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
+        max_turns: int = 1,
+        on_message: Callable[[str, str], None] | None = None,
+        max_retries: int = 3,
+        timeout: float | None = None,
+    ) -> None:
+        """Initialise the OpenCode CLI adapter.
+
+        Args:
+            cli_path: Explicit path to ``opencode``.  Resolved from
+                :func:`~ouroboros.config.get_opencode_cli_path`, then
+                ``PATH`` if not supplied.
+            cwd: Working directory for the subprocess.  Defaults to
+                the current process working directory.
+            permission_mode: OpenCode permission mode string.  Stored
+                for forward compatibility but currently a **no-op**:
+                the ``opencode run`` CLI has no ``--permission-mode``
+                flag — it runs non-interactively by default.  Same
+                limitation applies to the Gemini CLI adapter.
+            allowed_tools: Optional tool allow-list injected into the
+                composed prompt.
+            max_turns: Maximum conversation turns per CLI invocation.
+            on_message: Optional ``(role, content)`` callback fired
+                for each assistant response.
+            max_retries: Number of retry attempts on transient errors.
+            timeout: Per-invocation timeout in seconds.  ``None`` or
+                non-positive values disable the timeout.
+        """
+        self._cli_path = self._resolve_cli_path(cli_path)
+        self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
+        self._permission_mode = permission_mode or "acceptEdits"
+        self._allowed_tools = list(allowed_tools) if allowed_tools is not None else None
+        self._max_turns = max_turns
+        self._on_message = on_message
+        self._max_retries = max_retries
+        self._timeout = timeout if timeout and timeout > 0 else None
+
+    def _resolve_cli_path(self, cli_path: str | Path | None) -> str:
+        """Resolve the OpenCode CLI binary path.
+
+        Checks, in order: *cli_path* argument,
+        :func:`~ouroboros.config.get_opencode_cli_path`, ``PATH``
+        lookup, and finally the bare binary name as a last resort.
+
+        Args:
+            cli_path: Explicit override path, or ``None`` to auto-resolve.
+
+        Returns:
+            Absolute or bare binary path string.
+        """
+        if cli_path is not None:
+            candidate = str(Path(cli_path).expanduser())
+        else:
+            candidate = (
+                get_opencode_cli_path()
+                or shutil.which(self._default_cli_name)
+                or self._default_cli_name
+            )
+
+        path = Path(candidate).expanduser()
+        if path.exists():
+            return str(path)
+        return candidate
+
+    def _normalize_model(self, model: str) -> str | None:
+        """Normalize a model name for the OpenCode CLI.
+
+        Strips whitespace and rejects the sentinel ``"default"`` value.
+        Model names are validated against a strict character allow-list.
+
+        Args:
+            model: Raw model name string from
+                :class:`~ouroboros.providers.base.CompletionConfig`.
+
+        Returns:
+            Sanitised model string, or ``None`` when the default model
+            should be used.
+
+        Raises:
+            ValueError: If *model* contains characters outside the
+                safe set defined by ``_SAFE_MODEL_NAME_PATTERN``.
+        """
+        candidate = model.strip()
+        if not candidate or candidate == "default":
+            return None
+        if not _SAFE_MODEL_NAME_PATTERN.match(candidate):
+            msg = f"Unsafe model name rejected: {candidate!r}"
+            raise ValueError(msg)
+        return candidate
+
+    def _build_prompt(self, messages: list[Message]) -> str:
+        """Build a plain-text prompt from conversation messages.
+
+        System messages are grouped under a ``## System Instructions``
+        header, tool constraints are appended when ``_allowed_tools``
+        is set, and user/assistant turns appear under
+        ``## Conversation``.
+
+        Args:
+            messages: Ordered list of
+                :class:`~ouroboros.providers.base.Message` objects.
+
+        Returns:
+            Concatenated markdown-formatted prompt string.
+        """
+        parts: list[str] = []
+
+        system_messages = [
+            message.content for message in messages if message.role == MessageRole.SYSTEM
+        ]
+        if system_messages:
+            parts.append("## System Instructions")
+            parts.append("\n\n".join(system_messages))
+
+        if self._allowed_tools is not None:
+            if self._allowed_tools:
+                parts.append("## Tool Constraints")
+                parts.append(
+                    "Limit your tool usage to ONLY the following tools:\n"
+                    + "\n".join(f"- {tool}" for tool in self._allowed_tools)
+                )
+            else:
+                parts.append("## Tool Constraints")
+                parts.append("Do NOT use any tools. Respond with text only.")
+
+        if self._max_turns == 1:
+            parts.append("## Execution Constraints")
+            parts.append("Respond in a single turn. Do not ask follow-up questions.")
+        elif self._max_turns > 1:
+            parts.append("## Execution Constraints")
+            parts.append(f"Complete your response within {self._max_turns} turns maximum.")
+
+        conversation_parts: list[str] = []
+        for message in messages:
+            if message.role == MessageRole.SYSTEM:
+                continue
+            prefix = "User" if message.role == MessageRole.USER else "Assistant"
+            conversation_parts.append(f"### {prefix}\n{message.content}")
+
+        if conversation_parts:
+            parts.append("## Conversation")
+            parts.extend(conversation_parts)
+
+        return "\n\n".join(parts)
+
+    def _build_command(
+        self,
+        prompt: str,
+        model: str | None = None,
+    ) -> list[str]:
+        """Assemble the ``opencode run`` CLI invocation.
+
+        The prompt is **not** included in argv — it is piped via stdin
+        to avoid OS ``ARG_MAX`` / ``MAX_ARG_STRLEN`` limits (~128 KB per
+        single argument on Linux).
+
+        Args:
+            prompt: Unused — kept for signature compatibility.
+                Prompt is fed via stdin in :meth:`complete`.
+            model: Optional model override appended via ``--model``.
+
+        Returns:
+            Argument list suitable for
+            :func:`asyncio.create_subprocess_exec`.
+        """
+        command = [
+            self._cli_path,
+            "run",
+            "--format",
+            "json",
+        ]
+
+        if model:
+            command.extend(["--model", model])
+
+        return command
+
+    def _build_child_env(self) -> dict[str, str]:
+        """Build an isolated environment for child runtime processes.
+
+        Strips Ouroboros runtime env vars to prevent recursive MCP
+        startup loops and increments ``_OUROBOROS_DEPTH`` to enforce
+        a maximum nesting limit.
+
+        Returns:
+            Copy of ``os.environ`` with Ouroboros keys removed and
+            depth counter incremented.
+
+        Raises:
+            RuntimeError: If the nesting depth exceeds
+                ``_MAX_OUROBOROS_DEPTH``.
+        """
+        env = os.environ.copy()
+        # Prevent child from re-entering Ouroboros MCP
+        for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
+            env.pop(key, None)
+        # Track and enforce recursion depth
+        try:
+            depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+        except (ValueError, TypeError):
+            depth = 1
+        if depth > _MAX_OUROBOROS_DEPTH:
+            msg = f"Maximum Ouroboros nesting depth ({_MAX_OUROBOROS_DEPTH}) exceeded"
+            raise RuntimeError(msg)
+        env["_OUROBOROS_DEPTH"] = str(depth)
+        return env
+
+    def _is_retryable(self, error_message: str) -> bool:
+        """Check if an error message suggests a retryable failure.
+
+        Matches against known transient-error substrings such as
+        ``"rate limit"`` and ``"timeout"``.
+
+        Args:
+            error_message: The error string to inspect.
+
+        Returns:
+            ``True`` if any retryable pattern is found in the
+            lower-cased message.
+        """
+        lower = error_message.lower()
+        return any(pattern in lower for pattern in _RETRYABLE_ERROR_PATTERNS)
+
+    def _extract_text_from_events(self, events: list[dict[str, Any]]) -> str:
+        """Extract assistant text content from OpenCode JSON events.
+
+        Only collects ``text`` event payloads (the model's own words).
+        Tool outputs are intentionally excluded to prevent raw ``bash``,
+        ``read``, etc. results from being returned as the completion
+        text.
+
+        Args:
+            events: List of parsed JSON event dicts from the CLI
+                stdout stream.
+
+        Returns:
+            Joined assistant text, or an empty string if no text was
+            found.
+        """
+        text_parts: list[str] = []
+        for event in events:
+            event_type = event.get("type")
+            if event_type == "text":
+                part = event.get("part", {})
+                text = part.get("text", "")
+                if isinstance(text, str) and text.strip():
+                    text_parts.append(text.strip())
+        return "\n".join(text_parts)
+
+    def _extract_error_from_events(self, events: list[dict[str, Any]]) -> str | None:
+        """Extract a terminal error message from OpenCode JSON events.
+
+        Only top-level ``error``-type events are treated as terminal.
+        Tool-level errors (``tool_use`` with ``state.error``) are
+        **not** surfaced here because OpenCode agents can self-correct
+        by retrying or switching tools mid-run — the process exit code
+        is the authoritative success/failure signal.
+
+        Args:
+            events: List of parsed JSON event dicts from the CLI
+                stdout stream.
+
+        Returns:
+            Error message string, or ``None`` if no terminal error.
+        """
+        for event in events:
+            # Top-level error events are always terminal
+            if event.get("type") == "error":
+                error = event.get("error", {})
+                if isinstance(error, dict):
+                    name = error.get("name", "")
+                    data = error.get("data", {})
+                    msg = data.get("message", "") if isinstance(data, dict) else ""
+                    return msg or name or "Unknown error"
+                return str(error) if error else None
+
+        return None
+
+    async def complete(
+        self,
+        messages: list[Message],
+        config: CompletionConfig,
+    ) -> Result[CompletionResponse, ProviderError]:
+        """Make a single-turn completion request via the OpenCode CLI.
+
+        Shells out to ``opencode run --format json`` and collects the
+        final text output.  Retries on transient failures up to
+        ``_max_retries`` times with exponential back-off.
+
+        Args:
+            messages: Conversation messages to be composed into a
+                prompt.
+            config: Completion configuration carrying the model name
+                and other tuning knobs.
+
+        Returns:
+            :class:`~ouroboros.core.types.Result` wrapping either a
+            :class:`~ouroboros.providers.base.CompletionResponse` or
+            a :class:`~ouroboros.core.errors.ProviderError`.
+        """
+        prompt = self._build_prompt(messages)
+        if len(prompt) > MAX_LLM_RESPONSE_LENGTH:
+            return Result.err(
+                ProviderError(
+                    message=f"Prompt exceeds maximum length ({MAX_LLM_RESPONSE_LENGTH} chars)",
+                    provider=self._provider_name,
+                )
+            )
+
+        model = self._normalize_model(config.model)
+        last_error: str = ""
+
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                result = await self._run_once(prompt, model)
+            except Exception as exc:
+                last_error = str(exc)
+                if attempt < self._max_retries and self._is_retryable(last_error):
+                    log.warning(
+                        "opencode_adapter.retry",
+                        attempt=attempt,
+                        error=last_error,
+                    )
+                    await asyncio.sleep(min(attempt * 2, 10))
+                    continue
+                return Result.err(
+                    ProviderError(
+                        message=f"OpenCode CLI failed: {last_error}",
+                        provider=self._provider_name,
+                        details={"attempt": attempt},
+                    )
+                )
+
+            if result.is_ok:
+                return result
+            if attempt < self._max_retries and self._is_retryable(result.error.message):
+                log.warning(
+                    "opencode_adapter.retry",
+                    attempt=attempt,
+                    error=result.error.message,
+                )
+                await asyncio.sleep(min(attempt * 2, 10))
+                continue
+            return result
+
+        return Result.err(
+            ProviderError(
+                message=f"OpenCode CLI failed after {self._max_retries} attempts: {last_error}",
+                provider=self._provider_name,
+            )
+        )
+
+    async def _run_once(
+        self,
+        prompt: str,
+        model: str | None,
+    ) -> Result[CompletionResponse, ProviderError]:
+        """Execute a single OpenCode CLI invocation.
+
+        Spawns the subprocess, streams JSON events from stdout,
+        collects stderr, and converts the output into a
+        :class:`~ouroboros.providers.base.CompletionResponse`.
+
+        Args:
+            prompt: Fully composed prompt string.
+            model: Normalised model name, or ``None`` for the
+                default.
+
+        Returns:
+            :class:`~ouroboros.core.types.Result` wrapping either a
+            :class:`~ouroboros.providers.base.CompletionResponse` or
+            a :class:`~ouroboros.core.errors.ProviderError`.
+        """
+        command = self._build_command(prompt, model)
+
+        try:
+            env = self._build_child_env()
+        except RuntimeError as exc:
+            return Result.err(
+                ProviderError(
+                    message=str(exc),
+                    provider=self._provider_name,
+                )
+            )
+
+        log.debug(
+            "opencode_adapter.exec",
+            command=command[:3],
+            cwd=self._cwd,
+        )
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=self._cwd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+        except FileNotFoundError:
+            return Result.err(
+                ProviderError(
+                    message=(
+                        f"OpenCode CLI not found at {self._cli_path}. "
+                        "Install with: npm i -g opencode-ai@latest"
+                    ),
+                    provider=self._provider_name,
+                )
+            )
+
+        # Feed prompt via stdin to avoid OS ARG_MAX / MAX_ARG_STRLEN limits.
+        if prompt and process.stdin is not None:
+            try:
+                process.stdin.write(prompt.encode("utf-8"))
+                await process.stdin.drain()
+                process.stdin.close()
+                await process.stdin.wait_closed()
+            except (BrokenPipeError, ConnectionResetError, OSError) as exc:
+                log.warning("opencode_adapter.stdin_write_failed", error=str(exc))
+                with contextlib.suppress(OSError):
+                    process.stdin.close()
+
+        async def _collect() -> tuple[list[dict[str, Any]], int, str]:
+            """Collect events, wait for exit, read stderr."""
+            evts: list[dict[str, Any]] = []
+            if process.stdout is not None:
+                async for line in iter_stream_lines(process.stdout):
+                    if not line:
+                        continue
+                    try:
+                        event = json.loads(line)
+                        if isinstance(event, dict):
+                            evts.append(event)
+                    except json.JSONDecodeError:
+                        continue
+
+            rc = await process.wait()
+            stderr = ""
+            if process.stderr is not None:
+                stderr_lines = await collect_stream_lines(process.stderr)
+                stderr = "\n".join(stderr_lines)
+            return evts, rc, stderr
+
+        try:
+            events, returncode, stderr_text = await asyncio.wait_for(
+                _collect(),
+                timeout=self._timeout,
+            )
+        except TimeoutError:
+            await terminate_process(
+                process,
+                shutdown_timeout=self._process_shutdown_timeout_seconds,
+            )
+            return Result.err(
+                ProviderError(
+                    message=(f"OpenCode CLI timed out after {self._timeout}s"),
+                    provider=self._provider_name,
+                )
+            )
+        except asyncio.CancelledError:
+            await terminate_process(
+                process,
+                shutdown_timeout=self._process_shutdown_timeout_seconds,
+            )
+            raise
+        except Exception as exc:
+            await terminate_process(
+                process,
+                shutdown_timeout=self._process_shutdown_timeout_seconds,
+            )
+            return Result.err(
+                ProviderError(
+                    message=f"OpenCode CLI execution error: {exc}",
+                    provider=self._provider_name,
+                )
+            )
+
+        # Check for errors in the event stream
+        error_msg = self._extract_error_from_events(events)
+        if error_msg:
+            return Result.err(
+                ProviderError(
+                    message=f"OpenCode error: {error_msg}",
+                    provider=self._provider_name,
+                    details={"returncode": returncode},
+                )
+            )
+
+        if returncode != 0:
+            return Result.err(
+                ProviderError(
+                    message=(
+                        f"OpenCode CLI exited with code {returncode}"
+                        + (f": {stderr_text}" if stderr_text else "")
+                    ),
+                    provider=self._provider_name,
+                    details={"returncode": returncode},
+                )
+            )
+
+        content = self._extract_text_from_events(events)
+        if not content:
+            return Result.err(
+                ProviderError(
+                    message=f"Empty response from {self._display_name}",
+                    provider=self._provider_name,
+                    details={
+                        "returncode": returncode,
+                        "stderr": stderr_text.strip(),
+                    },
+                )
+            )
+
+        # Validate response length
+        is_valid, _ = InputValidator.validate_llm_response(content)
+        if not is_valid:
+            log.warning(
+                "opencode_adapter.response.truncated",
+                length=len(content),
+                max_length=MAX_LLM_RESPONSE_LENGTH,
+            )
+            content = content[:MAX_LLM_RESPONSE_LENGTH]
+
+        if self._on_message:
+            self._on_message("assistant", content)
+
+        return Result.ok(
+            CompletionResponse(
+                content=content,
+                model=model or "opencode-default",
+                usage=UsageInfo(
+                    prompt_tokens=0,
+                    completion_tokens=0,
+                    total_tokens=0,
+                ),
+                finish_reason="stop",
+            )
+        )
+
+
+__all__ = ["OpenCodeLLMAdapter"]

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -541,10 +541,21 @@ class TestCreateOuroborosServer:
         assert mock_create_llm_adapter.call_args.kwargs["backend"] == "codex"
         assert mock_create_llm_adapter.call_args.kwargs["max_turns"] == 1
 
-    def test_opencode_backend_is_rejected_at_server_creation(self) -> None:
-        """OpenCode is not yet available — server creation should raise early."""
-        with pytest.raises(ValueError, match="not yet available"):
+    def test_opencode_backend_is_accepted_at_server_creation(self) -> None:
+        """OpenCode backend is forwarded through the shared adapter factory."""
+        with (
+            patch("ouroboros.providers.create_llm_adapter") as mock_create_llm_adapter,
+            patch("ouroboros.orchestrator.create_agent_runtime") as mock_create_runtime,
+        ):
+            mock_create_llm_adapter.return_value = MagicMock()
+            mock_create_runtime.return_value = MagicMock()
+
             create_ouroboros_server(runtime_backend="opencode", llm_backend="opencode")
+
+        mock_create_llm_adapter.assert_called_once()
+        assert mock_create_llm_adapter.call_args.kwargs["backend"] == "opencode"
+        mock_create_runtime.assert_called_once()
+        assert mock_create_runtime.call_args.kwargs["backend"] == "opencode"
 
 
 class TestMCPServerAdapterConcurrency:

--- a/tests/unit/cli/test_jsonc.py
+++ b/tests/unit/cli/test_jsonc.py
@@ -1,0 +1,141 @@
+"""Unit tests for the shared JSONC-to-JSON converter."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.cli.jsonc import parse_jsonc, strip_jsonc
+
+
+class TestStripJsonc:
+    """Tests for strip_jsonc — the string-aware JSONC stripper."""
+
+    def test_passthrough_valid_json(self) -> None:
+        """Plain JSON passes through unchanged."""
+        text = '{"key": "value", "n": 42}'
+        assert strip_jsonc(text) == text
+
+    def test_removes_full_line_comments(self) -> None:
+        """Full-line // comments are removed."""
+        text = '{\n  // this is a comment\n  "a": 1\n}'
+        result = strip_jsonc(text)
+        parsed = parse_jsonc(text)
+        assert parsed == {"a": 1}
+        assert "//" not in result
+
+    def test_removes_inline_comments(self) -> None:
+        """Inline // comments after values are removed."""
+        text = '{\n  "a": 1 // inline comment\n}'
+        parsed = parse_jsonc(text)
+        assert parsed == {"a": 1}
+
+    def test_removes_block_comments(self) -> None:
+        """Block /* ... */ comments are removed."""
+        text = '{\n  /* block\n     comment */\n  "a": 1\n}'
+        parsed = parse_jsonc(text)
+        assert parsed == {"a": 1}
+
+    def test_removes_trailing_commas_before_brace(self) -> None:
+        """Trailing commas before } are stripped."""
+        text = '{"a": 1,}'
+        parsed = parse_jsonc(text)
+        assert parsed == {"a": 1}
+
+    def test_removes_trailing_commas_before_bracket(self) -> None:
+        """Trailing commas before ] are stripped."""
+        text = '{"a": [1, 2,]}'
+        parsed = parse_jsonc(text)
+        assert parsed == {"a": [1, 2]}
+
+    # ── Quoted-string edge cases ──────────────────────────────
+
+    def test_preserves_double_slash_in_url_value(self) -> None:
+        """Double-slash inside a URL string must not be treated as a comment."""
+        text = '{"url": "https://example.com/path"}'
+        assert strip_jsonc(text) == text
+        assert parse_jsonc(text)["url"] == "https://example.com/path"
+
+    def test_preserves_double_slash_in_middle_of_string(self) -> None:
+        """// inside a quoted value (not a URL) must not be stripped."""
+        text = '{"note": "keep // this intact"}'
+        assert strip_jsonc(text) == text
+        assert parse_jsonc(text)["note"] == "keep // this intact"
+
+    def test_preserves_block_comment_syntax_in_string(self) -> None:
+        """/* ... */ inside a quoted value must not be stripped."""
+        text = '{"pattern": "a/*b*/c"}'
+        assert strip_jsonc(text) == text
+        assert parse_jsonc(text)["pattern"] == "a/*b*/c"
+
+    def test_preserves_escaped_quotes_in_strings(self) -> None:
+        r"""Escaped quotes inside strings must not break the parser."""
+        text = r'{"msg": "say \"hello\" // world"}'
+        result = strip_jsonc(text)
+        assert "// world" in result  # must survive — inside string
+        parsed = parse_jsonc(text)
+        assert "// world" in parsed["msg"]
+
+    def test_comment_after_string_with_slashes(self) -> None:
+        """A real comment after a value containing slashes is still removed."""
+        text = '{\n  "url": "https://example.com" // this is a comment\n}'
+        parsed = parse_jsonc(text)
+        assert parsed == {"url": "https://example.com"}
+
+    # ── Combined features ─────────────────────────────────────
+
+    def test_all_jsonc_features_combined(self) -> None:
+        """Realistic config with comments, trailing commas, and URLs."""
+        text = """{
+  // OpenCode config
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["foo",], /* plugins list */
+  "mcp": {
+    "server": {
+      "url": "https://my.server/api", // endpoint
+    },
+  },
+}"""
+        parsed = parse_jsonc(text)
+        assert parsed["$schema"] == "https://opencode.ai/config.json"
+        assert parsed["plugin"] == ["foo"]
+        assert parsed["mcp"]["server"]["url"] == "https://my.server/api"
+
+    def test_empty_input(self) -> None:
+        """Empty string returns empty string."""
+        assert strip_jsonc("") == ""
+
+    def test_only_comments(self) -> None:
+        """Input that is purely comments with no JSON raises on parse."""
+        text = "// just a comment\n/* block */"
+        with pytest.raises(Exception):
+            parse_jsonc(text)
+
+    def test_trailing_comma_inside_string_preserved(self) -> None:
+        """Commas followed by } or ] inside strings must not be stripped."""
+        text = '{"pattern": ",}", "list": ",]"}'
+        result = strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed["pattern"] == ",}"
+        assert parsed["list"] == ",]"
+
+    def test_trailing_comma_inside_string_with_actual_trailing(self) -> None:
+        """String containing ,} plus actual trailing comma — both handled."""
+        text = '{"x": ",}",\n}'
+        result = strip_jsonc(text)
+        parsed = json.loads(result)
+        assert parsed["x"] == ",}"
+
+
+class TestParseJsonc:
+    """Tests for parse_jsonc convenience wrapper."""
+
+    def test_returns_dict(self) -> None:
+        """Standard config returns a dict."""
+        assert parse_jsonc('{"a": 1}') == {"a": 1}
+
+    def test_raises_on_invalid_json(self) -> None:
+        """Malformed content raises JSONDecodeError after stripping."""
+        with pytest.raises(Exception):
+            parse_jsonc("{not valid json}")

--- a/tests/unit/cli/test_pm_runtime_adapter.py
+++ b/tests/unit/cli/test_pm_runtime_adapter.py
@@ -163,7 +163,7 @@ def test_pm_command_formats_factory_errors() -> None:
     ctx = SimpleNamespace(invoked_subcommand=None)
 
     with (
-        patch("ouroboros.cli.commands.pm.get_llm_backend", return_value="opencode"),
+        patch("ouroboros.cli.commands.pm.get_llm_backend", return_value="invalid_backend_xyz"),
         patch("ouroboros.cli.commands.pm.get_clarification_model", return_value="default"),
         patch("ouroboros.cli.commands.pm.print_error") as mock_error,
     ):
@@ -180,9 +180,7 @@ def test_pm_command_formats_factory_errors() -> None:
         else:
             raise AssertionError("Expected typer.Exit for backend configuration errors")
 
-    mock_error.assert_called_once_with(
-        "OpenCode LLM adapter is not yet available. Supported backends: claude_code, codex, gemini, litellm"
-    )
+    mock_error.assert_called_once_with("Unsupported LLM backend: invalid_backend_xyz")
 
 
 def test_pm_command_formats_missing_litellm_dependency() -> None:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -12,6 +12,7 @@ import yaml
 import ouroboros.cli.commands.setup as setup_cmd
 from ouroboros.cli.commands.setup import (
     _display_repos_table,
+    _ensure_opencode_mcp_entry,
     _list_repos,
     _prompt_repo_selection,
     _scan_and_register_repos,
@@ -1014,3 +1015,453 @@ class TestSetDefaultRepoExtended:
                 await _set_default_repo("/a")
 
         mock_store.close.assert_awaited_once()
+
+
+# ── OpenCode MCP setup tests ─────────────────────────────────────
+
+
+class TestOpenCodeMCPSetup:
+    """Tests for OpenCode JSONC config handling in _ensure_opencode_mcp_entry."""
+
+    def test_jsonc_comments_preserved(self, tmp_path: Path) -> None:
+        """JSONC with line and block comments parses without crashing and preserves non-MCP keys."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            '{\n  // line comment\n  /* block comment */\n  "theme": "dark",\n  "mcp": {}\n}\n',
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "theme" in data
+        assert data["theme"] == "dark"
+        assert "ouroboros" in data["mcp"]
+
+    def test_jsonc_trailing_commas_preserved(self, tmp_path: Path) -> None:
+        """JSONC with trailing commas parses correctly and preserves keys."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            '{\n  "editor": "vim",\n  "mcp": {},\n}\n',
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["editor"] == "vim"
+        assert "ouroboros" in data["mcp"]
+
+    def test_existing_keys_survive_setup(self, tmp_path: Path) -> None:
+        """Non-MCP keys like $schema and plugin survive _ensure_opencode_mcp_entry."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps(
+                {"$schema": "https://example.com/schema.json", "plugin": ["foo"], "mcp": {}}
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["$schema"] == "https://example.com/schema.json"
+        assert data["plugin"] == ["foo"]
+        assert "ouroboros" in data["mcp"]
+
+    def test_mcp_as_non_dict_is_replaced(self, tmp_path: Path) -> None:
+        """If mcp is a list instead of a dict, setup replaces it with a valid dict."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps({"mcp": ["invalid"]}),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert isinstance(data["mcp"], dict)
+        assert "ouroboros" in data["mcp"]
+
+    def test_ouroboros_entry_as_non_dict_is_replaced(self, tmp_path: Path) -> None:
+        """If mcp.ouroboros is a string, setup replaces it with a proper entry."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps({"mcp": {"ouroboros": "disabled"}}),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert isinstance(data["mcp"]["ouroboros"], dict)
+        assert data["mcp"]["ouroboros"]["type"] == "local"
+
+    def test_quoted_slashes_in_config_values_survive(self, tmp_path: Path) -> None:
+        """URLs and patterns containing // or /* */ inside values are preserved."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            '{\n  "$schema": "https://opencode.ai/config.json",\n  "mcp": {}\n}\n',
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["$schema"] == "https://opencode.ai/config.json"
+        assert "ouroboros" in data["mcp"]
+
+    def test_environment_as_string_is_replaced(self, tmp_path: Path) -> None:
+        """If mcp.ouroboros.environment is a string, setup replaces it with a valid dict."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "ouroboros": {
+                            "type": "local",
+                            "command": ["ouroboros", "mcp", "serve"],
+                            "environment": "BROKEN_STRING_VALUE",
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        env = data["mcp"]["ouroboros"]["environment"]
+        assert isinstance(env, dict)
+
+    def test_malformed_json_aborts_without_overwriting(self, tmp_path: Path) -> None:
+        """If the config file is unparseable, setup must abort — not overwrite it."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        original_content = '{"theme": "dark", BROKEN JSON HERE}'
+        config_path.write_text(original_content, encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        # File must be unchanged — setup should not have touched it
+        assert config_path.read_text(encoding="utf-8") == original_content
+
+    def test_custom_command_not_overwritten(self, tmp_path: Path) -> None:
+        """User-managed commands (docker, nix, etc.) must survive setup."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        custom_cmd = ["docker", "run", "--rm", "ouroboros", "mcp", "serve"]
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "ouroboros": {
+                            "type": "local",
+                            "command": custom_cmd,
+                            "environment": {},
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["mcp"]["ouroboros"]["command"] == custom_cmd, (
+            "Custom command must not be overwritten by setup"
+        )
+
+    def test_stale_type_remote_rewritten_to_local(self, tmp_path: Path) -> None:
+        """A stale type='remote' must be normalised to 'local' by setup."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "ouroboros": {
+                            "type": "remote",
+                            "command": ["ouroboros", "mcp", "serve"],
+                            "environment": {},
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["mcp"]["ouroboros"]["type"] == "local"
+
+    def test_command_as_bare_string_replaced_with_array(self, tmp_path: Path) -> None:
+        """A hand-edited command: "ouroboros" string must be replaced with array."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "ouroboros": {
+                            "type": "local",
+                            "command": "ouroboros mcp serve",
+                            "environment": {},
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert isinstance(data["mcp"]["ouroboros"]["command"], list)
+        assert data["mcp"]["ouroboros"]["command"] == ["ouroboros", "mcp", "serve"]
+
+    def test_empty_list_command_replaced(self, tmp_path: Path) -> None:
+        """An empty command array must be replaced with the detected launcher."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "ouroboros": {
+                            "type": "local",
+                            "command": [],
+                            "environment": {},
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["mcp"]["ouroboros"]["command"] == ["ouroboros", "mcp", "serve"]
+
+    def test_non_string_first_element_replaced(self, tmp_path: Path) -> None:
+        """A command array with non-string first element must be replaced."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "ouroboros": {
+                            "type": "local",
+                            "command": [123, "mcp", "serve"],
+                            "environment": {},
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["mcp"]["ouroboros"]["command"] == ["ouroboros", "mcp", "serve"]
+
+    def test_none_first_element_replaced(self, tmp_path: Path) -> None:
+        """A command array with null first element must be replaced."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "opencode.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcp": {
+                        "ouroboros": {
+                            "type": "local",
+                            "command": [None, "mcp", "serve"],
+                            "environment": {},
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["mcp"]["ouroboros"]["command"] == ["ouroboros", "mcp", "serve"]
+
+
+class TestOpenCodeSetupConfigYaml:
+    """Tests for _setup_opencode config.yaml shape handling."""
+
+    def test_scalar_top_level_repaired(self, tmp_path: Path) -> None:
+        """If config.yaml is a scalar, _setup_opencode repairs it."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("just_a_string\n", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry"),
+            patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry"),
+        ):
+            from ouroboros.cli.commands.setup import _setup_opencode
+
+            _setup_opencode("/usr/bin/opencode")
+
+        result = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert isinstance(result, dict)
+        assert result["orchestrator"]["runtime_backend"] == "opencode"
+        assert result["llm"]["backend"] == "opencode"
+
+    def test_orchestrator_as_list_repaired(self, tmp_path: Path) -> None:
+        """If orchestrator is a list, _setup_opencode replaces with dict."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text(
+            yaml.dump({"orchestrator": ["bad"], "llm": "codex"}),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry"),
+            patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry"),
+        ):
+            from ouroboros.cli.commands.setup import _setup_opencode
+
+            _setup_opencode("/usr/bin/opencode")
+
+        result = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert isinstance(result["orchestrator"], dict)
+        assert result["orchestrator"]["runtime_backend"] == "opencode"
+        assert isinstance(result["llm"], dict)
+        assert result["llm"]["backend"] == "opencode"

--- a/tests/unit/orchestrator/test_opencode_runtime.py
+++ b/tests/unit/orchestrator/test_opencode_runtime.py
@@ -1,0 +1,781 @@
+"""Unit tests for OpenCodeRuntime."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
+
+
+class _FakeStream:
+    def __init__(self, lines: list[str]) -> None:
+        encoded = "".join(f"{line}\n" for line in lines).encode()
+        self._buffer = bytearray(encoded)
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self._buffer:
+            return b""
+        if n < 0 or n >= len(self._buffer):
+            data = bytes(self._buffer)
+            self._buffer.clear()
+            return data
+        data = bytes(self._buffer[:n])
+        del self._buffer[:n]
+        return data
+
+
+class _FakeStdin:
+    """Minimal stdin mock that supports write/drain/close/wait_closed."""
+
+    def __init__(self) -> None:
+        self.written = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.written += data
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        stdout_lines: list[str],
+        stderr_lines: list[str],
+        returncode: int = 0,
+    ) -> None:
+        self.stdin = _FakeStdin()
+        self.stdout = _FakeStream(stdout_lines)
+        self.stderr = _FakeStream(stderr_lines)
+        self._returncode = returncode
+        self.returncode = None
+        self.pid = 12345
+        self.terminated = False
+
+    async def wait(self) -> int:
+        self.returncode = self._returncode
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = self._returncode
+
+    def kill(self) -> None:
+        self.returncode = self._returncode
+
+
+class TestOpenCodeRuntimeProperties:
+    """Test basic runtime properties."""
+
+    def test_runtime_backend(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        assert runtime.runtime_backend == "opencode"
+
+    def test_working_directory(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp/project")
+        assert runtime.working_directory == "/tmp/project"
+
+    def test_permission_mode_default(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        assert runtime.permission_mode == "bypassPermissions"
+
+    def test_permission_mode_custom(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp", permission_mode="acceptEdits")
+        assert runtime.permission_mode == "acceptEdits"
+
+
+class TestOpenCodeRuntimeBuildCommand:
+    """Test command building."""
+
+    def test_basic_command(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="/usr/bin/opencode", cwd="/tmp")
+        cmd = runtime._build_command(prompt="Hello world")
+        assert cmd == ["/usr/bin/opencode", "run", "--format", "json"]
+        assert "Hello world" not in cmd  # prompt piped via stdin, not argv
+
+    def test_command_with_model(self) -> None:
+        runtime = OpenCodeRuntime(
+            cli_path="opencode", cwd="/tmp", model="anthropic/claude-sonnet-4-20250514"
+        )
+        cmd = runtime._build_command(prompt="Hello")
+        assert "--model" in cmd
+        assert "anthropic/claude-sonnet-4-20250514" in cmd
+
+    def test_command_with_resume_session(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        cmd = runtime._build_command(
+            resume_session_id="sess-abc123",
+            prompt="Continue",
+        )
+        assert "--session" in cmd
+        assert "sess-abc123" in cmd
+        assert "Continue" not in cmd  # prompt piped via stdin
+
+    def test_command_rejects_unsafe_session_id(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        with pytest.raises(ValueError, match="Invalid resume_session_id"):
+            runtime._build_command(
+                resume_session_id="sess; rm -rf /",
+                prompt="Hello",
+            )
+
+
+class TestOpenCodeRuntimeComposePrompt:
+    """Test prompt composition."""
+
+    def test_basic_prompt(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        result = runtime._compose_prompt("Do the thing", None, None)
+        assert result == "Do the thing"
+
+    def test_prompt_with_system(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        result = runtime._compose_prompt("Do the thing", "Be helpful.", None)
+        assert "## System Instructions" in result
+        assert "Be helpful." in result
+        assert "Do the thing" in result
+
+    def test_prompt_with_tools(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        result = runtime._compose_prompt("Do the thing", None, ["Read", "Edit"])
+        assert "## Tooling Guidance" in result
+        assert "- Read" in result
+        assert "- Edit" in result
+
+
+class TestOpenCodeRuntimeHandleManagement:
+    """Test runtime handle creation."""
+
+    def test_build_runtime_handle_new(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        handle = runtime._build_runtime_handle("sess-123")
+        assert handle is not None
+        assert handle.backend == "opencode"
+        assert handle.native_session_id == "sess-123"
+        assert handle.cwd == "/tmp"
+
+    def test_build_runtime_handle_none(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        handle = runtime._build_runtime_handle(None)
+        assert handle is None
+
+    def test_build_runtime_handle_update(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        existing = RuntimeHandle(
+            backend="opencode",
+            native_session_id="sess-old",
+            cwd="/tmp",
+        )
+        updated = runtime._build_runtime_handle("sess-new", existing)
+        assert updated is not None
+        assert updated.native_session_id == "sess-new"
+        assert updated.backend == "opencode"
+
+
+class TestOpenCodeRuntimeEventConversion:
+    """Test JSON event parsing and conversion."""
+
+    def test_parse_json_event_valid(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        event = runtime._parse_json_event('{"type": "text", "part": {}}')
+        assert event == {"type": "text", "part": {}}
+
+    def test_parse_json_event_invalid(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        assert runtime._parse_json_event("not json") is None
+        assert runtime._parse_json_event("42") is None
+        assert runtime._parse_json_event('"string"') is None
+
+    def test_extract_session_id(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        assert runtime._extract_event_session_id({"sessionID": "sess-1"}) == "sess-1"
+        assert runtime._extract_event_session_id({"type": "text"}) is None
+        assert runtime._extract_event_session_id({"sessionID": ""}) is None
+
+    def test_convert_text_event(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        from ouroboros.orchestrator.opencode_event_normalizer import OpenCodeEventContext
+
+        ctx = OpenCodeEventContext(session_id="sess-1")
+        event = {
+            "type": "text",
+            "sessionID": "sess-1",
+            "part": {"type": "text", "text": "Hello there!"},
+        }
+        messages = runtime._convert_event(event, ctx)
+        assert len(messages) == 1
+        assert messages[0].type == "assistant"
+        assert messages[0].content == "Hello there!"
+
+    def test_convert_tool_use_event(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        from ouroboros.orchestrator.opencode_event_normalizer import OpenCodeEventContext
+
+        ctx = OpenCodeEventContext(session_id="sess-1")
+        event = {
+            "type": "tool_use",
+            "sessionID": "sess-1",
+            "part": {
+                "tool": "bash",
+                "state": {
+                    "input": {"command": "ls -la"},
+                    "status": "completed",
+                    "output": "total 42",
+                },
+            },
+        }
+        messages = runtime._convert_event(event, ctx)
+        assert len(messages) == 1
+        assert messages[0].tool_name == "Bash"
+        assert "ls -la" in messages[0].content
+
+    def test_convert_error_event(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        from ouroboros.orchestrator.opencode_event_normalizer import OpenCodeEventContext
+
+        ctx = OpenCodeEventContext(session_id="sess-1")
+        event = {
+            "type": "error",
+            "sessionID": "sess-1",
+            "error": {"name": "AuthError", "data": {"message": "Bad key"}},
+        }
+        messages = runtime._convert_event(event, ctx)
+        assert len(messages) == 1
+        assert messages[0].type == "result"
+        assert messages[0].is_error
+        assert "Bad key" in messages[0].content
+
+    def test_convert_reasoning_event(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        from ouroboros.orchestrator.opencode_event_normalizer import OpenCodeEventContext
+
+        ctx = OpenCodeEventContext(session_id="sess-1")
+        event = {
+            "type": "reasoning",
+            "sessionID": "sess-1",
+            "part": {"type": "reasoning", "text": "Let me think..."},
+        }
+        messages = runtime._convert_event(event, ctx)
+        assert len(messages) == 1
+        assert messages[0].data.get("thinking") == "Let me think..."
+
+
+class TestOpenCodeRuntimeExecuteTask:
+    """Test execute_task integration."""
+
+    @pytest.mark.asyncio
+    async def test_execute_task_success(self) -> None:
+        """Successful task execution streams messages and produces a final result."""
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-abc",
+                "part": {"type": "text", "text": "Task completed successfully."},
+            }
+        )
+
+        process = _FakeProcess(
+            stdout_lines=[text_event],
+            stderr_lines=[],
+            returncode=0,
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp/project")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Do something"):
+                messages.append(msg)
+
+        assert len(messages) >= 1
+        # Should have at least the text message and a final result
+        text_msgs = [m for m in messages if m.type == "assistant"]
+        [m for m in messages if m.type == "result"]
+        assert len(text_msgs) >= 1
+        assert "Task completed" in text_msgs[0].content
+
+    @pytest.mark.asyncio
+    async def test_execute_task_with_session_tracking(self) -> None:
+        """Session ID from events is captured into the runtime handle."""
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-tracked-123",
+                "part": {"type": "text", "text": "Working..."},
+            }
+        )
+
+        process = _FakeProcess(
+            stdout_lines=[text_event],
+            stderr_lines=[],
+            returncode=0,
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Do something"):
+                messages.append(msg)
+
+        # Find a message with a resume handle that has the session ID
+        handles = [m.resume_handle for m in messages if m.resume_handle is not None]
+        assert any(h.native_session_id == "sess-tracked-123" for h in handles)
+
+    @pytest.mark.asyncio
+    async def test_execute_task_cli_not_found(self) -> None:
+        """FileNotFoundError yields a result error message."""
+        runtime = OpenCodeRuntime(cli_path="/nonexistent/opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=FileNotFoundError("/nonexistent/opencode"),
+        ):
+            async for msg in runtime.execute_task("Hello"):
+                messages.append(msg)
+
+        assert len(messages) == 1
+        assert messages[0].type == "result"
+        assert messages[0].is_error
+        assert "not found" in messages[0].content.lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_task_nonzero_exit(self) -> None:
+        """Non-zero exit code produces an error result."""
+        process = _FakeProcess(
+            stdout_lines=[],
+            stderr_lines=["Something went wrong"],
+            returncode=1,
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Hello"):
+                messages.append(msg)
+
+        result_msgs = [m for m in messages if m.type == "result"]
+        assert len(result_msgs) == 1
+        assert result_msgs[0].data.get("subtype") == "error"
+        assert result_msgs[0].data.get("returncode") == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_task_error_event_is_final(self) -> None:
+        """Error events in the stream are treated as final results."""
+        error_event = json.dumps(
+            {
+                "type": "error",
+                "sessionID": "sess-1",
+                "error": {"name": "Crash", "data": {"message": "Internal error"}},
+            }
+        )
+
+        process = _FakeProcess(
+            stdout_lines=[error_event],
+            stderr_lines=[],
+            returncode=1,
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Hello"):
+                messages.append(msg)
+
+        error_msgs = [m for m in messages if m.type == "result" and m.is_error]
+        assert len(error_msgs) >= 1
+        assert "Internal error" in error_msgs[0].content
+
+    @pytest.mark.asyncio
+    async def test_execute_task_to_result_success(self) -> None:
+        """execute_task_to_result collects messages into a TaskResult."""
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-1",
+                "part": {"type": "text", "text": "Done!"},
+            }
+        )
+
+        process = _FakeProcess(
+            stdout_lines=[text_event],
+            stderr_lines=[],
+            returncode=0,
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            result = await runtime.execute_task_to_result("Do it")
+
+        assert result.is_ok
+        assert result.value.success is True
+        assert len(result.value.messages) >= 1
+
+    @pytest.mark.asyncio
+    async def test_execute_task_multiple_events(self) -> None:
+        """Multiple events in the stream are all converted."""
+        events = [
+            json.dumps(
+                {
+                    "type": "tool_use",
+                    "sessionID": "sess-1",
+                    "part": {
+                        "tool": "read",
+                        "state": {
+                            "input": {"filePath": "README.md"},
+                            "status": "completed",
+                            "output": "# Hello",
+                        },
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "text",
+                    "sessionID": "sess-1",
+                    "part": {"type": "text", "text": "I read the README."},
+                }
+            ),
+        ]
+
+        process = _FakeProcess(
+            stdout_lines=events,
+            stderr_lines=[],
+            returncode=0,
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Read README"):
+                messages.append(msg)
+
+        tool_msgs = [m for m in messages if m.tool_name is not None]
+        [m for m in messages if m.type == "assistant" and m.tool_name is None]
+        assert len(tool_msgs) >= 1
+        assert tool_msgs[0].tool_name == "Read"
+
+
+class TestResolveDispatchTemplates:
+    """Test ``$1`` / ``$CWD`` template expansion in skill-intercept args."""
+
+    def test_string_dollar_one_replaced(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/project")
+        result = runtime._resolve_dispatch_templates("$1", first_argument="seed.yaml")
+        assert result == "seed.yaml"
+
+    def test_string_dollar_cwd_replaced(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/project")
+        result = runtime._resolve_dispatch_templates("$CWD", first_argument=None)
+        assert result == "/project"
+
+    def test_string_dollar_one_none_becomes_empty(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/project")
+        result = runtime._resolve_dispatch_templates("$1", first_argument=None)
+        assert result == ""
+
+    def test_plain_string_unchanged(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/project")
+        result = runtime._resolve_dispatch_templates("hello", first_argument="x")
+        assert result == "hello"
+
+    def test_dict_recursive(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/project")
+        result = runtime._resolve_dispatch_templates(
+            {"seed_path": "$1", "cwd": "$CWD", "keep": "value"},
+            first_argument="my.yaml",
+        )
+        assert result == {"seed_path": "my.yaml", "cwd": "/project", "keep": "value"}
+
+    def test_list_recursive(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/project")
+        result = runtime._resolve_dispatch_templates(
+            ["$1", "$CWD", "literal"],
+            first_argument="arg",
+        )
+        assert result == ["arg", "/project", "literal"]
+
+    def test_nested_dict_in_list(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/project")
+        result = runtime._resolve_dispatch_templates(
+            [{"path": "$1"}],
+            first_argument="file.txt",
+        )
+        assert result == [{"path": "file.txt"}]
+
+    def test_non_string_passthrough(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/project")
+        assert runtime._resolve_dispatch_templates(42, first_argument="x") == 42
+        assert runtime._resolve_dispatch_templates(None, first_argument="x") is None
+        assert runtime._resolve_dispatch_templates(True, first_argument="x") is True
+
+
+class TestExitCodeDeterminesSuccess:
+    """Runtime trusts the process exit code as the authoritative signal.
+
+    Tool-level errors during the run are *not* latched — if the process
+    exits 0 the runtime reports success, matching the Codex runtime
+    pattern.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_error_with_zero_exit_reports_success(self) -> None:
+        """A tool_use with state.error + returncode=0 must still be success.
+
+        The exit code is the ground truth for subprocess runtimes.
+        Intermediate tool errors are expected when agents self-correct.
+        """
+        tool_error_event = json.dumps(
+            {
+                "type": "tool_use",
+                "sessionID": "sess-err",
+                "part": {
+                    "tool": "bash",
+                    "state": {
+                        "input": {"command": "bad-cmd"},
+                        "status": "completed",
+                        "output": "command not found",
+                        "error": "command not found",
+                    },
+                },
+            }
+        )
+
+        process = _FakeProcess(
+            stdout_lines=[tool_error_event],
+            stderr_lines=[],
+            returncode=0,  # exit code 0 — agent decided it succeeded
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Run bad-cmd"):
+                messages.append(msg)
+
+        result_msgs = [m for m in messages if m.type == "result"]
+        assert len(result_msgs) >= 1
+        final = result_msgs[-1]
+        assert final.data.get("subtype") == "success", (
+            "Exit code 0 must produce success regardless of tool errors"
+        )
+        assert final.data.get("returncode") == 0
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_without_tool_error_reports_success(self) -> None:
+        """No tool errors + returncode=0 must produce subtype 'success'."""
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-ok",
+                "part": {"type": "text", "text": "All done."},
+            }
+        )
+
+        process = _FakeProcess(
+            stdout_lines=[text_event],
+            stderr_lines=[],
+            returncode=0,
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Do something safe"):
+                messages.append(msg)
+
+        result_msgs = [m for m in messages if m.type == "result"]
+        assert len(result_msgs) >= 1
+        final = result_msgs[-1]
+        assert final.data.get("subtype") == "success"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_with_tool_error_reports_error(self) -> None:
+        """Exit code != 0 produces error regardless of stream content."""
+        tool_error_event = json.dumps(
+            {
+                "type": "tool_use",
+                "sessionID": "sess-r",
+                "part": {
+                    "tool": "bash",
+                    "state": {
+                        "input": {"command": "bad-cmd"},
+                        "status": "completed",
+                        "output": "",
+                        "error": "command not found",
+                    },
+                },
+            }
+        )
+
+        process = _FakeProcess(
+            stdout_lines=[tool_error_event],
+            stderr_lines=["fatal error"],
+            returncode=1,
+        )
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Do something"):
+                messages.append(msg)
+
+        result_msgs = [m for m in messages if m.type == "result"]
+        assert len(result_msgs) >= 1
+        final = result_msgs[-1]
+        assert final.data.get("subtype") == "error"
+        assert final.data.get("returncode") == 1
+
+    """Prompt must be piped via stdin, not argv."""
+
+    @pytest.mark.asyncio
+    async def test_prompt_written_to_stdin(self) -> None:
+        """execute_task must write the composed prompt to the process stdin."""
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-1",
+                "part": {"type": "text", "text": "Done."},
+            }
+        )
+        process = _FakeProcess(stdout_lines=[text_event], stderr_lines=[], returncode=0)
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        captured_process = None
+
+        async def _fake_exec(*args, **kwargs):
+            nonlocal captured_process
+            captured_process = process
+            return process
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec) as mock_exec:
+            messages = []
+            async for msg in runtime.execute_task("Hello big prompt"):
+                messages.append(msg)
+
+            # Prompt must NOT appear in argv
+            call_args = mock_exec.call_args[0]
+            assert "Hello big prompt" not in call_args
+
+        # Prompt must have been written to stdin
+        assert captured_process is not None
+        assert b"Hello big prompt" in captured_process.stdin.written
+        assert captured_process.stdin.closed
+
+    def test_build_command_excludes_prompt(self) -> None:
+        """_build_command must not include the prompt in argv."""
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        cmd = runtime._build_command(prompt="This should not appear")
+        assert "This should not appear" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_stdin_broken_pipe_yields_error_result(self) -> None:
+        """BrokenPipeError on stdin write must not crash — falls through to stderr."""
+
+        class _BrokenStdin(_FakeStdin):
+            def write(self, data: bytes) -> None:
+                raise BrokenPipeError("opencode exited early")
+
+        process = _FakeProcess(
+            stdout_lines=[],
+            stderr_lines=["opencode: invalid argument"],
+            returncode=1,
+        )
+        process.stdin = _BrokenStdin()
+
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Hello"):
+                messages.append(msg)
+
+        result_msgs = [m for m in messages if m.type == "result"]
+        assert len(result_msgs) >= 1
+        final = result_msgs[-1]
+        # Should have fallen through to normal stderr reporting
+        assert final.data.get("subtype") == "error"
+        assert "invalid argument" in final.content
+
+
+class TestStderrPriorityOnFailure:
+    """On non-zero exit, stderr should win over stale last_content."""
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_prefers_stderr(self) -> None:
+        """When process exits non-zero, stderr should be the final message."""
+        # Emit a text event (stale content), then exit with error + stderr
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-1",
+                "part": {"type": "text", "text": "Calling tool: Bash..."},
+            }
+        )
+        process = _FakeProcess(
+            stdout_lines=[text_event],
+            stderr_lines=["FATAL: segfault in plugin"],
+            returncode=1,
+        )
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        messages: list[AgentMessage] = []
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            async for msg in runtime.execute_task("Do something"):
+                messages.append(msg)
+
+        result_msgs = [m for m in messages if m.type == "result"]
+        assert len(result_msgs) >= 1
+        final = result_msgs[-1]
+        assert "segfault" in final.content, (
+            "On non-zero exit, stderr must win over stale last_content"
+        )
+        assert "Calling tool" not in final.content
+
+
+class TestOpenCodeRuntimeChildEnv:
+    """Test child environment construction."""
+
+    def test_strips_ouroboros_vars(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        with patch.dict(
+            "os.environ",
+            {
+                "OUROBOROS_AGENT_RUNTIME": "opencode",
+                "OUROBOROS_LLM_BACKEND": "opencode",
+            },
+        ):
+            env = runtime._build_child_env()
+        assert "OUROBOROS_AGENT_RUNTIME" not in env
+        assert "OUROBOROS_LLM_BACKEND" not in env
+
+    def test_increments_depth(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        with patch.dict("os.environ", {"_OUROBOROS_DEPTH": "2"}):
+            env = runtime._build_child_env()
+        assert env["_OUROBOROS_DEPTH"] == "3"
+
+    def test_depth_guard(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        with patch.dict("os.environ", {"_OUROBOROS_DEPTH": "5"}):
+            with pytest.raises(RuntimeError, match="Maximum Ouroboros nesting depth"):
+                runtime._build_child_env()

--- a/tests/unit/orchestrator/test_runtime_factory.py
+++ b/tests/unit/orchestrator/test_runtime_factory.py
@@ -8,9 +8,7 @@ import pytest
 
 from ouroboros.orchestrator.adapter import ClaudeAgentAdapter
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
-
-# TODO: uncomment when OpenCode runtime is shipped
-# from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
+from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 from ouroboros.orchestrator.runtime_factory import (
     create_agent_runtime,
     resolve_agent_runtime_backend,
@@ -32,15 +30,10 @@ class TestResolveAgentRuntimeBackend:
         ):
             assert resolve_agent_runtime_backend() == "codex"
 
-    def test_resolve_rejects_opencode_at_boundary(self) -> None:
-        """OpenCode is rejected at resolve time since it is not yet shipped."""
-        with pytest.raises(ValueError, match="not yet available"):
-            resolve_agent_runtime_backend("opencode")
-
-    def test_resolve_rejects_opencode_cli_alias_at_boundary(self) -> None:
-        """OpenCode CLI alias is also rejected at resolve time."""
-        with pytest.raises(ValueError, match="not yet available"):
-            resolve_agent_runtime_backend("opencode_cli")
+    def test_resolve_opencode_aliases(self) -> None:
+        """OpenCode aliases normalize to opencode."""
+        assert resolve_agent_runtime_backend("opencode") == "opencode"
+        assert resolve_agent_runtime_backend("opencode_cli") == "opencode"
 
     def test_resolve_rejects_unknown_backend(self) -> None:
         """Raises for unsupported backends."""
@@ -96,39 +89,21 @@ class TestCreateAgentRuntime:
         assert runtime._cwd == "/tmp/project"
         assert runtime._cli_path == "/tmp/claude"
 
-    @pytest.mark.skip(reason="OpenCode runtime not yet shipped")
     def test_create_opencode_runtime_uses_configured_cli_path(self) -> None:
-        """Creates OpenCode runtime with the configured CLI path."""
-        mock_dispatcher = object()
+        """Creates OpenCode runtime with the explicit CLI path."""
+        runtime = create_agent_runtime(
+            backend="opencode",
+            permission_mode="acceptEdits",
+            cwd="/tmp/project",
+            cli_path="/tmp/opencode",
+        )
 
-        with (
-            patch(
-                "ouroboros.orchestrator.runtime_factory.get_opencode_cli_path",
-                return_value="/tmp/opencode",
-            ),
-            patch(
-                "ouroboros.orchestrator.runtime_factory.create_codex_command_dispatcher",
-                return_value=mock_dispatcher,
-            ) as mock_create_dispatcher,
-        ):
-            runtime = create_agent_runtime(
-                backend="opencode",
-                permission_mode="acceptEdits",
-                cwd="/tmp/project",
-            )
-
-        assert isinstance(runtime, OpenCodeRuntime)  # type: ignore[name-defined]  # noqa: F821
+        assert isinstance(runtime, OpenCodeRuntime)
         assert runtime._cli_path == "/tmp/opencode"
         assert runtime._cwd == "/tmp/project"
-        assert runtime._skill_dispatcher is mock_dispatcher
-        assert mock_create_dispatcher.call_args.kwargs["cwd"] == "/tmp/project"
-        assert mock_create_dispatcher.call_args.kwargs["runtime_backend"] == "opencode"
 
-    @pytest.mark.skip(reason="OpenCode runtime not yet shipped")
     def test_create_runtime_uses_configured_opencode_alias_when_backend_omitted(self) -> None:
         """Configured OpenCode aliases should resolve through the shared runtime factory."""
-        mock_dispatcher = object()
-
         with (
             patch(
                 "ouroboros.orchestrator.runtime_factory.get_agent_runtime_backend",
@@ -142,24 +117,13 @@ class TestCreateAgentRuntime:
                 "ouroboros.orchestrator.runtime_factory.get_llm_backend",
                 return_value="opencode",
             ),
-            patch(
-                "ouroboros.orchestrator.runtime_factory.get_opencode_cli_path",
-                return_value="/tmp/opencode",
-            ),
-            patch(
-                "ouroboros.orchestrator.runtime_factory.create_codex_command_dispatcher",
-                return_value=mock_dispatcher,
-            ) as mock_create_dispatcher,
         ):
             runtime = create_agent_runtime(cwd="/tmp/project")
 
-        assert isinstance(runtime, OpenCodeRuntime)  # type: ignore[name-defined]  # noqa: F821
-        assert runtime._cli_path == "/tmp/opencode"
+        assert isinstance(runtime, OpenCodeRuntime)
         assert runtime._cwd == "/tmp/project"
         assert runtime._permission_mode == "acceptEdits"
-        assert runtime._skill_dispatcher is mock_dispatcher
         assert mock_get_permission_mode.call_args.kwargs["backend"] == "opencode"
-        assert mock_create_dispatcher.call_args.kwargs["runtime_backend"] == "opencode"
 
     def test_create_runtime_uses_configured_permission_mode(self) -> None:
         """Runtime factory uses config/env permission defaults when omitted."""
@@ -172,7 +136,6 @@ class TestCreateAgentRuntime:
         assert isinstance(runtime, CodexCliRuntime)
         assert runtime._permission_mode == "bypassPermissions"
 
-    @pytest.mark.skip(reason="OpenCode runtime not yet shipped")
     def test_create_opencode_runtime_uses_backend_specific_permission_default(self) -> None:
         """OpenCode runtime asks the shared config helper for the OpenCode-specific mode."""
         with (
@@ -187,7 +150,7 @@ class TestCreateAgentRuntime:
         ):
             runtime = create_agent_runtime(backend="opencode")
 
-        assert isinstance(runtime, OpenCodeRuntime)  # type: ignore[name-defined]  # noqa: F821
+        assert isinstance(runtime, OpenCodeRuntime)
         assert runtime._permission_mode == "bypassPermissions"
         assert mock_get_permission_mode.call_args.kwargs["backend"] == "opencode"
 

--- a/tests/unit/providers/test_factory.py
+++ b/tests/unit/providers/test_factory.py
@@ -7,15 +7,13 @@ import pytest
 
 from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
-
-# TODO: uncomment when OpenCode adapter is shipped
-# from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
 from ouroboros.providers.factory import (
     create_llm_adapter,
     resolve_llm_backend,
     resolve_llm_permission_mode,
 )
 from ouroboros.providers.litellm_adapter import LiteLLMAdapter
+from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
 
 
 class TestResolveLLMBackend:
@@ -37,15 +35,10 @@ class TestResolveLLMBackend:
         assert resolve_llm_backend("codex") == "codex"
         assert resolve_llm_backend("codex_cli") == "codex"
 
-    def test_rejects_opencode_at_boundary(self) -> None:
-        """OpenCode is rejected at resolve time since it is not yet shipped."""
-        with pytest.raises(ValueError, match="not yet available"):
-            resolve_llm_backend("opencode")
-
-    def test_rejects_opencode_cli_alias_at_boundary(self) -> None:
-        """OpenCode CLI alias is also rejected at resolve time."""
-        with pytest.raises(ValueError, match="not yet available"):
-            resolve_llm_backend("opencode_cli")
+    def test_resolves_opencode_aliases(self) -> None:
+        """OpenCode aliases normalize to opencode."""
+        assert resolve_llm_backend("opencode") == "opencode"
+        assert resolve_llm_backend("opencode_cli") == "opencode"
 
     def test_falls_back_to_configured_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Configured backend is used when no explicit backend is provided."""
@@ -120,30 +113,26 @@ class TestCreateLLMAdapter:
         assert isinstance(adapter, CodexCliLLMAdapter)
         assert adapter._cli_path == "/tmp/codex"
 
-    @pytest.mark.skip(reason="OpenCode adapter not yet shipped")
     def test_creates_opencode_adapter(self) -> None:
         """OpenCode backend returns OpenCodeLLMAdapter."""
         adapter = create_llm_adapter(backend="opencode", cwd="/tmp/project")
-        assert isinstance(adapter, OpenCodeLLMAdapter)  # type: ignore[name-defined]  # noqa: F821
+        assert isinstance(adapter, OpenCodeLLMAdapter)
         assert adapter._cwd == "/tmp/project"
-        assert adapter._permission_mode == "acceptEdits"
 
-    @pytest.mark.skip(reason="OpenCode adapter not yet shipped")
     def test_creates_opencode_adapter_uses_configured_cli_path(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """OpenCode factory consumes the shared CLI path helper when no explicit path is passed."""
         monkeypatch.setattr(
-            "ouroboros.providers.factory.get_opencode_cli_path",
+            "ouroboros.providers.opencode_adapter.get_opencode_cli_path",
             lambda: "/tmp/opencode",
         )
 
         adapter = create_llm_adapter(backend="opencode", cwd="/tmp/project")
 
-        assert isinstance(adapter, OpenCodeLLMAdapter)  # type: ignore[name-defined]  # noqa: F821
+        assert isinstance(adapter, OpenCodeLLMAdapter)
         assert adapter._cli_path == "/tmp/opencode"
 
-    @pytest.mark.skip(reason="OpenCode adapter not yet shipped")
     def test_uses_configured_opencode_backend_alias_when_backend_omitted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -156,7 +145,7 @@ class TestCreateLLMAdapter:
 
         adapter = create_llm_adapter(cwd="/tmp/project", allowed_tools=["Read"], max_turns=2)
 
-        assert isinstance(adapter, OpenCodeLLMAdapter)  # type: ignore[name-defined]  # noqa: F821
+        assert isinstance(adapter, OpenCodeLLMAdapter)
         assert adapter._cwd == "/tmp/project"
         assert adapter._permission_mode == "acceptEdits"
         assert adapter._allowed_tools == ["Read"]
@@ -197,7 +186,6 @@ class TestCreateLLMAdapter:
         assert isinstance(adapter, CodexCliLLMAdapter)
         assert adapter._permission_mode == "acceptEdits"
 
-    @pytest.mark.skip(reason="OpenCode adapter not yet shipped")
     def test_opencode_adapter_uses_backend_specific_permission_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -209,7 +197,7 @@ class TestCreateLLMAdapter:
 
         adapter = create_llm_adapter(backend="opencode", cwd="/tmp/project")
 
-        assert isinstance(adapter, OpenCodeLLMAdapter)  # type: ignore[name-defined]  # noqa: F821
+        assert isinstance(adapter, OpenCodeLLMAdapter)
         assert adapter._permission_mode == "acceptEdits"
 
 
@@ -230,7 +218,9 @@ class TestResolveLLMPermissionMode:
             == "bypassPermissions"
         )
 
-    def test_interview_mode_rejects_opencode(self) -> None:
-        """OpenCode is rejected at resolve time, even for interview use case."""
-        with pytest.raises(ValueError, match="not yet available"):
+    def test_interview_mode_escalates_to_bypass_for_opencode(self) -> None:
+        """Interview needs bypassPermissions for OpenCode — read-only sandbox blocks LLM output."""
+        assert (
             resolve_llm_permission_mode(backend="opencode", use_case="interview")
+            == "bypassPermissions"
+        )

--- a/tests/unit/providers/test_opencode_adapter.py
+++ b/tests/unit/providers/test_opencode_adapter.py
@@ -1,0 +1,515 @@
+"""Unit tests for the OpenCode CLI-backed LLM adapter."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from ouroboros.providers.base import CompletionConfig, Message, MessageRole
+from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
+
+
+class _FakeStream:
+    def __init__(
+        self,
+        text: str = "",
+        *,
+        read_size: int | None = None,
+    ) -> None:
+        self._buffer = text.encode("utf-8")
+        self._cursor = 0
+        self._read_size = read_size
+
+    async def read(self, chunk_size: int = 16384) -> bytes:
+        if self._cursor >= len(self._buffer):
+            return b""
+
+        size = self._read_size or chunk_size
+        next_cursor = min(self._cursor + size, len(self._buffer))
+        chunk = self._buffer[self._cursor : next_cursor]
+        self._cursor = next_cursor
+        return chunk
+
+
+class _FakeAdapterStdin:
+    """Minimal stdin mock for adapter tests."""
+
+    def __init__(self) -> None:
+        self.written = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.written += data
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+        read_size: int | None = None,
+    ) -> None:
+        self.stdin = _FakeAdapterStdin()
+        self.stdout = _FakeStream(stdout, read_size=read_size)
+        self.stderr = _FakeStream(stderr, read_size=read_size)
+        self.returncode = returncode
+        self._final_returncode = returncode
+        self.terminated = False
+        self.killed = False
+
+    async def wait(self) -> int:
+        self.returncode = self._final_returncode
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = self._final_returncode
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = self._final_returncode
+
+
+class TestOpenCodeLLMAdapter:
+    """Tests for OpenCodeLLMAdapter."""
+
+    def test_build_prompt_preserves_system_and_roles(self) -> None:
+        """Prompt builder keeps system instructions and conversation order."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp/project")
+        messages = [
+            Message(role=MessageRole.SYSTEM, content="Be concise."),
+            Message(role=MessageRole.USER, content="Hello!"),
+        ]
+        prompt = adapter._build_prompt(messages)
+        assert "## System Instructions" in prompt
+        assert "Be concise." in prompt
+        assert "### User" in prompt
+        assert "Hello!" in prompt
+
+    def test_build_prompt_multi_turn(self) -> None:
+        """Multi-turn conversations preserve all messages."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp/project")
+        messages = [
+            Message(role=MessageRole.USER, content="What is 2+2?"),
+            Message(role=MessageRole.ASSISTANT, content="4"),
+            Message(role=MessageRole.USER, content="And 3+3?"),
+        ]
+        prompt = adapter._build_prompt(messages)
+        assert "What is 2+2?" in prompt
+        assert "4" in prompt
+        assert "And 3+3?" in prompt
+
+    def test_build_command_basic(self) -> None:
+        """Command includes run --format json but NOT the prompt (piped via stdin)."""
+        adapter = OpenCodeLLMAdapter(cli_path="/usr/bin/opencode", cwd="/tmp")
+        cmd = adapter._build_command("Hello world")
+        assert cmd == ["/usr/bin/opencode", "run", "--format", "json"]
+        assert "Hello world" not in cmd
+
+    def test_build_command_with_model(self) -> None:
+        """Command includes --model when specified."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        cmd = adapter._build_command("Hello", model="anthropic/claude-sonnet-4-20250514")
+        assert "--model" in cmd
+        assert "anthropic/claude-sonnet-4-20250514" in cmd
+
+    def test_normalize_model_default(self) -> None:
+        """Default model returns None."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        assert adapter._normalize_model("default") is None
+        assert adapter._normalize_model("") is None
+
+    def test_normalize_model_unsafe(self) -> None:
+        """Unsafe model names are rejected."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        with pytest.raises(ValueError, match="Unsafe model name"):
+            adapter._normalize_model("model; rm -rf /")
+
+    def test_extract_text_from_events(self) -> None:
+        """Text extraction finds assistant text from events."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        events = [
+            {
+                "type": "text",
+                "part": {"type": "text", "text": "Hello from OpenCode!"},
+            },
+            {
+                "type": "tool_use",
+                "part": {
+                    "tool": "bash",
+                    "state": {"status": "completed", "output": "file.txt"},
+                },
+            },
+        ]
+        result = adapter._extract_text_from_events(events)
+        assert "Hello from OpenCode!" in result
+
+    def test_extract_error_from_events(self) -> None:
+        """Error extraction finds error messages from events."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        events = [
+            {
+                "type": "error",
+                "error": {
+                    "name": "RateLimitError",
+                    "data": {"message": "Rate limit exceeded"},
+                },
+            },
+        ]
+        result = adapter._extract_error_from_events(events)
+        assert result == "Rate limit exceeded"
+
+    def test_extract_error_no_errors(self) -> None:
+        """No error returns None."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        events = [{"type": "text", "part": {"text": "OK"}}]
+        assert adapter._extract_error_from_events(events) is None
+
+    def test_extract_error_ignores_tool_use_state(self) -> None:
+        """tool_use with state.error is NOT treated as terminal.
+
+        Only top-level error events are terminal — tool errors are
+        expected during normal agent self-correction workflows.
+        """
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        events = [
+            {
+                "type": "tool_use",
+                "part": {
+                    "tool": "bash",
+                    "state": {
+                        "input": {"command": "bad-cmd"},
+                        "status": "completed",
+                        "output": "",
+                        "error": "command not found",
+                    },
+                },
+            },
+        ]
+        result = adapter._extract_error_from_events(events)
+        assert result is None, "tool_use.state.error must not be terminal"
+
+    @pytest.mark.asyncio
+    async def test_complete_tool_error_with_zero_exit_is_success(self) -> None:
+        """tool_use.state.error + exit 0 = success (exit code is authoritative).
+
+        The adapter trusts the process exit code. Intermediate tool
+        errors are normal for agents that retry or switch strategies.
+        """
+        tool_error_event = json.dumps(
+            {
+                "type": "tool_use",
+                "sessionID": "sess-1",
+                "part": {
+                    "tool": "bash",
+                    "state": {
+                        "input": {"command": "failing-tool"},
+                        "status": "completed",
+                        "output": "",
+                        "error": "tool crashed hard",
+                    },
+                },
+            }
+        )
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-1",
+                "part": {"type": "text", "text": "Recovered and done."},
+            }
+        )
+        stdout = tool_error_event + "\n" + text_event + "\n"
+        process = _FakeProcess(stdout=stdout, returncode=0)
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Run it")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_ok, "tool_use.state.error + exit 0 must be success"
+        assert "Recovered" in result.value.content
+
+    @pytest.mark.asyncio
+    async def test_complete_top_level_error_overrides_exit_code(self) -> None:
+        """A top-level error event must produce ProviderError even with exit 0."""
+        error_event = json.dumps(
+            {
+                "type": "error",
+                "sessionID": "sess-1",
+                "error": {
+                    "name": "RuntimeError",
+                    "data": {"message": "Session crashed"},
+                },
+            }
+        )
+        stdout = error_event + "\n"
+        process = _FakeProcess(stdout=stdout, returncode=0)
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+
+        with patch("asyncio.create_subprocess_exec", return_value=process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Calculate")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_err, "Top-level error must override exit code"
+        assert "Session crashed" in result.error.message
+
+    def test_extract_error_tool_use_not_terminal(self) -> None:
+        """tool_use.state.error is not returned by _extract_error_from_events."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        events = [
+            {
+                "type": "tool_use",
+                "part": {
+                    "tool": "bash",
+                    "state": {"error": "fail"},
+                },
+            },
+            {
+                "type": "text",
+                "part": {"type": "text", "text": "Recovered."},
+            },
+        ]
+        assert adapter._extract_error_from_events(events) is None
+
+    @pytest.mark.asyncio
+    async def test_complete_success(self) -> None:
+        """Successful completion returns text content."""
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-1",
+                "part": {"type": "text", "text": "The answer is 42."},
+            }
+        )
+        stdout = text_event + "\n"
+
+        fake_process = _FakeProcess(stdout=stdout, returncode=0)
+
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp/project")
+
+        with patch("asyncio.create_subprocess_exec", return_value=fake_process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="What is 42?")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_ok
+        assert "42" in result.value.content
+
+    @pytest.mark.asyncio
+    async def test_complete_error_event(self) -> None:
+        """Error events are surfaced as ProviderError."""
+        error_event = json.dumps(
+            {
+                "type": "error",
+                "sessionID": "sess-1",
+                "error": {"name": "AuthError", "data": {"message": "Invalid API key"}},
+            }
+        )
+        stdout = error_event + "\n"
+
+        fake_process = _FakeProcess(stdout=stdout, returncode=1)
+
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp/project", max_retries=1)
+
+        with patch("asyncio.create_subprocess_exec", return_value=fake_process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Hello")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert "Invalid API key" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_complete_nonzero_exit(self) -> None:
+        """Non-zero exit code returns error."""
+        fake_process = _FakeProcess(stdout="", stderr="segfault", returncode=139)
+
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp", max_retries=1)
+
+        with patch("asyncio.create_subprocess_exec", return_value=fake_process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Hello")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert "139" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_complete_no_text_with_stderr_is_error(self) -> None:
+        """Exit 0 with no assistant text must be an error, not stderr-as-response.
+
+        stderr is transport/runtime noise and must never be promoted
+        to completion content.  Matches the Codex adapter pattern.
+        """
+        # Only a tool_use event, no text event — exit 0
+        tool_event = json.dumps(
+            {
+                "type": "tool_use",
+                "sessionID": "sess-1",
+                "part": {"tool": "bash", "state": {"status": "completed"}},
+            }
+        )
+        stdout = tool_event + "\n"
+        fake_process = _FakeProcess(stdout=stdout, stderr="plugin loaded OK", returncode=0)
+
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp", max_retries=1)
+
+        with patch("asyncio.create_subprocess_exec", return_value=fake_process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Hello")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_err, "No assistant text + exit 0 must be an error"
+        assert "Empty response" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_complete_empty_stdout_empty_stderr_is_error(self) -> None:
+        """Exit 0 with no stdout and no stderr must still be an error."""
+        fake_process = _FakeProcess(stdout="", stderr="", returncode=0)
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp", max_retries=1)
+
+        with patch("asyncio.create_subprocess_exec", return_value=fake_process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Hello")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_err, "Completely empty output + exit 0 must be an error"
+        assert "Empty response" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_complete_writes_prompt_to_stdin(self) -> None:
+        """The adapter must pipe the prompt via stdin, not argv."""
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-1",
+                "part": {"type": "text", "text": "Got it."},
+            }
+        )
+        fake_process = _FakeProcess(stdout=text_event + "\n", returncode=0)
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+
+        with patch("asyncio.create_subprocess_exec", return_value=fake_process):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="My prompt text")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_ok
+        # Verify prompt was written to stdin
+        assert fake_process.stdin.written, "Prompt must be written to stdin"
+        written_text = fake_process.stdin.written.decode("utf-8")
+        assert "My prompt text" in written_text
+
+    @pytest.mark.asyncio
+    async def test_complete_not_found(self) -> None:
+        """FileNotFoundError is handled gracefully."""
+        adapter = OpenCodeLLMAdapter(cli_path="/nonexistent/opencode", cwd="/tmp", max_retries=1)
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=FileNotFoundError("/nonexistent/opencode"),
+        ):
+            result = await adapter.complete(
+                messages=[Message(role=MessageRole.USER, content="Hello")],
+                config=CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert "not found" in result.error.message.lower()
+
+    def test_is_retryable(self) -> None:
+        """Retryable error patterns are detected."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        assert adapter._is_retryable("rate limit exceeded") is True
+        assert adapter._is_retryable("timeout waiting for response") is True
+        assert adapter._is_retryable("invalid syntax in prompt") is False
+
+    def test_build_child_env_strips_ouroboros_vars(self) -> None:
+        """Child environment strips Ouroboros runtime variables."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        with patch.dict(
+            "os.environ",
+            {"OUROBOROS_AGENT_RUNTIME": "opencode", "OUROBOROS_LLM_BACKEND": "opencode"},
+        ):
+            env = adapter._build_child_env()
+        assert "OUROBOROS_AGENT_RUNTIME" not in env
+        assert "OUROBOROS_LLM_BACKEND" not in env
+        assert env["_OUROBOROS_DEPTH"] == "1"
+
+    def test_build_child_env_depth_guard(self) -> None:
+        """Exceeding max nesting depth raises RuntimeError."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        with patch.dict("os.environ", {"_OUROBOROS_DEPTH": "5"}):
+            with pytest.raises(RuntimeError, match="Maximum Ouroboros nesting depth"):
+                adapter._build_child_env()
+
+    def test_allowed_tools_empty_forces_text_only(self) -> None:
+        """Empty allowed_tools list produces a text-only constraint in the prompt."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp", allowed_tools=[])
+        messages = [Message(role=MessageRole.USER, content="Hello")]
+        prompt = adapter._build_prompt(messages)
+        assert "Do NOT use any tools" in prompt
+
+    def test_allowed_tools_none_no_constraint(self) -> None:
+        """Default (None) allowed_tools omits Tool Constraints from the prompt."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        messages = [Message(role=MessageRole.USER, content="Hello")]
+        prompt = adapter._build_prompt(messages)
+        assert "Tool Constraints" not in prompt
+
+    def test_max_turns_one_single_turn_constraint(self) -> None:
+        """max_turns=1 adds single turn constraint to the prompt."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp", max_turns=1)
+        messages = [Message(role=MessageRole.USER, content="Hello")]
+        prompt = adapter._build_prompt(messages)
+        assert "single turn" in prompt
+
+    def test_max_turns_multi_turn_constraint(self) -> None:
+        """max_turns=5 adds a 5 turns constraint to the prompt."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp", max_turns=5)
+        messages = [Message(role=MessageRole.USER, content="Hello")]
+        prompt = adapter._build_prompt(messages)
+        assert "5 turns" in prompt
+
+    def test_extract_text_excludes_tool_output(self) -> None:
+        """Text extraction returns only text events, not tool_use output."""
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        events = [
+            {
+                "type": "text",
+                "part": {"type": "text", "text": "Here is my answer."},
+            },
+            {
+                "type": "tool_use",
+                "part": {
+                    "tool": "bash",
+                    "state": {"status": "completed", "output": "SECRET_TOOL_OUTPUT"},
+                },
+            },
+        ]
+        result = adapter._extract_text_from_events(events)
+        assert "Here is my answer." in result
+        assert "SECRET_TOOL_OUTPUT" not in result


### PR DESCRIPTION
## Summary

Adds OpenCode as a fully supported runtime and LLM provider. Users can now run ouroboros evolutionary workflows through OpenCode instead of Claude Code or Gemini CLI.

Closes #164

## What's included

**New modules:**
- `OpenCodeLLMAdapter` — single-turn LLM provider that calls `opencode run --format json`
- `OpenCodeRuntime` — multi-turn agent orchestrator with session resumption via `--session`
- `OpenCodeEventNormalizer` — translates OpenCode JSONL streaming output to ouroboros events

**Integration:**
- Registered in runtime + provider factories
- `OPENCODE` enum added to CLI commands (`init`, `mcp`, `run`)
- `ooo setup --runtime opencode` wires MCP server config automatically
- `ooo uninstall` cleans up OpenCode MCP entries
- Binary detection via `which opencode` with `npx` fallback

**Tests:**
- 47 new unit tests for adapter, runtime, event normalizer
- Factory tests updated for OpenCode registration
- All 4163 tests pass (2 pre-existing failures in `test_setup.py` and `test_pm_runtime_adapter.py` unrelated to this PR)

## Design decisions

Follows the same adapter pattern established by `ClaudeCodeAdapter`/`GeminiCLIAdapter` and `ClaudeCodeRuntime`/`GeminiCLIRuntime`. OpenCode streams JSONL with a different event schema than Claude Code, so a dedicated event normalizer handles the translation.

The adapter shells out to `opencode run --format json` as a subprocess — same approach used by the existing Claude Code and Gemini adapters. Session resumption for multi-turn workflows uses `--session <id>`.

## Testing

```
pytest tests/unit/ -q
4163 passed, 5 skipped, 2 warnings
```