### PR TITLE
fix(mcp): guard against None optional params in measure_drift handler

### DIFF
--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -134,8 +134,8 @@ class MeasureDriftHandler:
                 )
             )
 
-        constraint_violations_raw = arguments.get("constraint_violations", [])
-        current_concepts_raw = arguments.get("current_concepts", [])
+        constraint_violations_raw = arguments.get("constraint_violations") or []
+        current_concepts_raw = arguments.get("current_concepts") or []
 
         log.info(
             "mcp.tool.measure_drift",

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1202,6 +1202,24 @@ class TestMeasureDriftHandler:
 
         assert result.is_err
 
+    async def test_handle_none_optional_params(self) -> None:
+        """handle succeeds when optional params are explicitly None (#275)."""
+        handler = MeasureDriftHandler()
+        result = await handler.handle(
+            {
+                "session_id": "test-session",
+                "current_output": "Built a test task with Python 3.14",
+                "seed_content": VALID_SEED_YAML,
+                "constraint_violations": None,
+                "current_concepts": None,
+            }
+        )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert "combined_drift" in meta
+        assert meta["constraint_drift"] == 0.0
+
 
 class TestEvaluateHandler:
     """Test EvaluateHandler class."""


### PR DESCRIPTION
## Summary

Fixes #275 — `ouroboros_measure_drift` crashes with `TypeError: object of type 'NoneType' has no len()` when optional array parameters are `null`.

### Root Cause

`MeasureDriftHandler.handle()` uses `arguments.get("constraint_violations", [])` to read optional parameters. When an MCP client sends an explicit JSON `null` for these fields (rather than omitting the key), `.get()` returns `None` because the key **exists** — the default `[]` is only used when the key is **missing**.

This `None` then hits `len(constraint_violations_raw)` in the `log.info()` call (line 144), causing the `TypeError` before the drift engine is even reached.

### Fix

Replace `.get(key, [])` with `.get(key) or []` for both optional array parameters. The `or []` pattern handles both cases:
- Key missing → `None or []` → `[]`
- Key present with `null` → `None or []` → `[]`

### Changes

- `src/ouroboros/mcp/tools/evaluation_handlers.py`: 2-line fix for `constraint_violations` and `current_concepts` parameter handling
- `tests/unit/mcp/tools/test_definitions.py`: Add regression test that passes `None` for both optional params and verifies successful drift measurement

### Note on issue comments

The issue comments suggest the crash is in `drift.py:155,213` (Jaccard similarity calculation), but those lines compute set operations (`&`, `|`) which always produce sets, never `None`. The actual crash occurs earlier in the handler's `log.info()` call. The drift calculation functions already have `if not x:` guards that safely handle `None`.

## Test plan

- [x] `TestMeasureDriftHandler::test_handle_none_optional_params` — new test, passes
- [x] All 8 MeasureDriftHandler tests pass
- [x] All 27 drift engine tests pass (no regression)
- [x] Full unit suite: 4117 passed, 0 failed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)