### PR TITLE
feat(mcp): add http/sse/streamable-http transport support

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -74,6 +74,7 @@ class TransportType(StrEnum):
     STDIO = "stdio"
     SSE = "sse"
     STREAMABLE_HTTP = "streamable-http"
+    HTTP = "http"
 ```
 
 ### Enum: `ContentType`
@@ -122,6 +123,13 @@ config = MCPServerConfig(
     transport=TransportType.SSE,
     url="https://api.example.com/mcp",
     headers={"Authorization": "Bearer xxx"},
+)
+
+# HTTP transport (alias for streamable-http, used by Claude Code)
+http_config = MCPServerConfig(
+    name="github-mcp",
+    transport=TransportType.HTTP,
+    url="http://localhost:3000/mcp",
 )
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -624,7 +624,7 @@ ouroboros mcp serve [OPTIONS]
 |--------|-------------|
 | `-h, --host TEXT` | Host to bind to (default: localhost) |
 | `-p, --port INTEGER` | Port to bind to (default: 8080) |
-| `-t, --transport TEXT` | Transport type: `stdio` or `sse` (default: stdio) |
+| `-t, --transport TEXT` | Transport type: `stdio` or `sse` (default: stdio). Note: `http` and `streamable-http` are supported as *client* transports for bridging upstream MCP servers via `mcp_servers.yaml`, not as serve transports. |
 | `--db TEXT` | Path to the EventStore database file |
 | `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `codex`, `opencode`). Affects which tool variants are instantiated |
 | `--llm-backend TEXT` | LLM backend for interview/seed/evaluation tools (`claude_code`, `litellm`, `codex`, `opencode`). Affects which tool variants are instantiated |

--- a/docs/guides/mcp-bridge.md
+++ b/docs/guides/mcp-bridge.md
@@ -37,6 +37,10 @@ mcp_servers:
     command: npx
     args: ["-y", "openchrome-mcp@latest", "serve", "--auto-launch"]
 
+  - name: github
+    transport: http
+    url: "http://localhost:3000/mcp"
+
 connection:
   timeout_seconds: 30
   retry_attempts: 3

--- a/src/ouroboros/mcp/client/adapter.py
+++ b/src/ouroboros/mcp/client/adapter.py
@@ -93,6 +93,7 @@ class MCPClientAdapter:
         self._transport_cm: Any = None
         self._read_stream: Any = None
         self._write_stream: Any = None
+        self._http_client: Any = None
         self._server_info: MCPServerInfo | None = None
         self._config: MCPServerConfig | None = None
 
@@ -227,10 +228,63 @@ class MCPClientAdapter:
                 await self._reset_connection_state()
                 raise
 
-        elif config.transport in (TransportType.SSE, TransportType.STREAMABLE_HTTP):
-            # SSE/HTTP transport would be implemented here
-            msg = f"Transport {config.transport} not yet implemented"
-            raise NotImplementedError(msg)
+        elif config.transport == TransportType.SSE:
+            if not config.url:
+                msg = "url is required for sse transport"
+                raise ValueError(msg)
+
+            from mcp.client.sse import sse_client
+
+            self._transport_cm = sse_client(
+                config.url,
+                headers=config.headers if config.headers else None,
+                timeout=config.timeout,
+            )
+            try:
+                self._read_stream, self._write_stream = await self._transport_cm.__aenter__()
+                self._session = ClientSession(self._read_stream, self._write_stream)
+                await self._session.__aenter__()
+
+                result = await self._session.initialize()
+                self._server_info = self._parse_server_info(result, config.name)
+            except Exception:
+                await self._reset_connection_state()
+                raise
+
+        elif config.transport in (TransportType.STREAMABLE_HTTP, TransportType.HTTP):
+            if not config.url:
+                msg = f"url is required for {config.transport} transport"
+                raise ValueError(msg)
+
+            import httpx
+            from mcp.client.streamable_http import streamable_http_client
+            from mcp.shared._httpx_utils import create_mcp_http_client
+
+            timeout = httpx.Timeout(config.timeout, read=max(config.timeout, 300.0))
+            http_client = create_mcp_http_client(
+                headers=config.headers if config.headers else None,
+                timeout=timeout,
+            )
+            self._http_client = http_client
+
+            try:
+                self._transport_cm = streamable_http_client(
+                    config.url,
+                    http_client=http_client,
+                )
+                # streamable_http_client yields 3-tuple: (read, write, get_session_id)
+                streams = await self._transport_cm.__aenter__()
+                self._read_stream = streams[0]
+                self._write_stream = streams[1]
+                self._session = ClientSession(self._read_stream, self._write_stream)
+                await self._session.__aenter__()
+
+                result = await self._session.initialize()
+                self._server_info = self._parse_server_info(result, config.name)
+            except Exception:
+                await self._reset_connection_state()
+                raise
+
         else:
             msg = f"Unknown transport: {config.transport}"
             raise ValueError(msg)
@@ -239,11 +293,13 @@ class MCPClientAdapter:
         """Best-effort cleanup for partially initialized connection state."""
         session = self._session
         transport_cm = self._transport_cm
+        http_client = self._http_client
 
         self._session = None
         self._transport_cm = None
         self._read_stream = None
         self._write_stream = None
+        self._http_client = None
         self._server_info = None
 
         errors: list[BaseException] = []
@@ -257,6 +313,12 @@ class MCPClientAdapter:
         if transport_cm is not None:
             try:
                 await transport_cm.__aexit__(None, None, None)
+            except Exception as exc:  # pragma: no cover - defensive cleanup
+                errors.append(exc)
+
+        if http_client is not None:
+            try:
+                await http_client.aclose()
             except Exception as exc:  # pragma: no cover - defensive cleanup
                 errors.append(exc)
 
@@ -296,7 +358,7 @@ class MCPClientAdapter:
         Returns:
             Result containing None on success or MCPClientError on failure.
         """
-        if self._session is None and self._transport_cm is None:
+        if self._session is None and self._transport_cm is None and self._http_client is None:
             return Result.ok(None)
 
         server_name = self._config.name if self._config else "unknown"

--- a/src/ouroboros/mcp/types.py
+++ b/src/ouroboros/mcp/types.py
@@ -17,6 +17,7 @@ class TransportType(StrEnum):
     STDIO = "stdio"
     SSE = "sse"
     STREAMABLE_HTTP = "streamable-http"
+    HTTP = "http"
 
 
 class ToolInputType(StrEnum):
@@ -59,7 +60,15 @@ class MCPServerConfig:
         if self.transport == TransportType.STDIO and not self.command:
             msg = "command is required for stdio transport"
             raise ValueError(msg)
-        if self.transport in (TransportType.SSE, TransportType.STREAMABLE_HTTP) and not self.url:
+        if (
+            self.transport
+            in (
+                TransportType.SSE,
+                TransportType.STREAMABLE_HTTP,
+                TransportType.HTTP,
+            )
+            and not self.url
+        ):
             msg = f"url is required for {self.transport} transport"
             raise ValueError(msg)
 

--- a/tests/unit/mcp/client/test_adapter_transport_lifecycle.py
+++ b/tests/unit/mcp/client/test_adapter_transport_lifecycle.py
@@ -223,3 +223,224 @@ class TestHappyPath:
         transport_cm.__aexit__.assert_called_once()
         assert adapter._session is None
         assert adapter._transport_cm is None
+
+
+def _make_sse_config(name: str = "test") -> MCPServerConfig:
+    return MCPServerConfig(
+        name=name,
+        transport=TransportType.SSE,
+        url="http://localhost:8080/sse",
+    )
+
+
+def _make_http_config(
+    name: str = "test", transport: TransportType = TransportType.HTTP
+) -> MCPServerConfig:
+    return MCPServerConfig(
+        name=name,
+        transport=transport,
+        url="http://localhost:3000",
+    )
+
+
+def _mock_http_transport_cm(read=None, write=None, get_session_id=None):
+    """Create a mock streamable_http_client context manager (3-tuple)."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(
+        return_value=(read or MagicMock(), write or MagicMock(), get_session_id or MagicMock())
+    )
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+class TestSSETransportConnect:
+    """Tests for SSE transport connect lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_sse_connect_stores_session(self):
+        """SSE connect succeeds, session stored."""
+        adapter = MCPClientAdapter()
+        transport_cm = _mock_transport_cm()
+        session = _mock_session()
+
+        with (
+            patch("mcp.client.sse.sse_client", return_value=transport_cm),
+            patch("mcp.ClientSession", return_value=session),
+        ):
+            result = await adapter.connect(_make_sse_config())
+
+        assert result.is_ok
+        assert adapter._session is not None
+        assert adapter._transport_cm is transport_cm
+
+    @pytest.mark.asyncio
+    async def test_sse_connect_requires_url(self):
+        """SSE config without url raises ValueError."""
+        with pytest.raises(ValueError, match="url is required"):
+            MCPServerConfig(name="test", transport=TransportType.SSE)
+
+    @pytest.mark.asyncio
+    async def test_sse_connect_rollback_on_init_fail(self):
+        """If initialize() fails on SSE, transport cleaned up."""
+        adapter = MCPClientAdapter(max_retries=1)
+        transport_cm = _mock_transport_cm()
+        session = _mock_session(init_fail=True)
+
+        with (
+            patch("mcp.client.sse.sse_client", return_value=transport_cm),
+            patch("mcp.ClientSession", return_value=session),
+        ):
+            result = await adapter.connect(_make_sse_config())
+
+        assert result.is_err
+        transport_cm.__aexit__.assert_called_with(None, None, None)
+        assert adapter._transport_cm is None
+        assert adapter._session is None
+
+
+class TestHTTPTransportConnect:
+    """Tests for HTTP / streamable-http transport connect lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_http_connect_stores_session(self):
+        """HTTP connect succeeds, session stored."""
+        adapter = MCPClientAdapter()
+        transport_cm = _mock_http_transport_cm()
+        session = _mock_session()
+
+        with (
+            patch("mcp.client.streamable_http.streamable_http_client", return_value=transport_cm),
+            patch("mcp.ClientSession", return_value=session),
+            patch("mcp.shared._httpx_utils.create_mcp_http_client"),
+        ):
+            result = await adapter.connect(_make_http_config())
+
+        assert result.is_ok
+        assert adapter._session is not None
+        assert adapter._transport_cm is transport_cm
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_connect_stores_session(self):
+        """STREAMABLE_HTTP connect succeeds, session stored."""
+        adapter = MCPClientAdapter()
+        transport_cm = _mock_http_transport_cm()
+        session = _mock_session()
+
+        with (
+            patch("mcp.client.streamable_http.streamable_http_client", return_value=transport_cm),
+            patch("mcp.ClientSession", return_value=session),
+            patch("mcp.shared._httpx_utils.create_mcp_http_client"),
+        ):
+            result = await adapter.connect(
+                _make_http_config(transport=TransportType.STREAMABLE_HTTP)
+            )
+
+        assert result.is_ok
+        assert adapter._session is not None
+        assert adapter._transport_cm is transport_cm
+
+    @pytest.mark.asyncio
+    async def test_http_connect_requires_url(self):
+        """HTTP config without url raises ValueError."""
+        with pytest.raises(ValueError, match="url is required"):
+            MCPServerConfig(name="test", transport=TransportType.HTTP)
+
+    @pytest.mark.asyncio
+    async def test_http_connect_rollback_on_init_fail(self):
+        """If initialize() fails on HTTP, transport cleaned up."""
+        adapter = MCPClientAdapter(max_retries=1)
+        transport_cm = _mock_http_transport_cm()
+        session = _mock_session(init_fail=True)
+
+        with (
+            patch("mcp.client.streamable_http.streamable_http_client", return_value=transport_cm),
+            patch("mcp.ClientSession", return_value=session),
+            patch("mcp.shared._httpx_utils.create_mcp_http_client"),
+        ):
+            result = await adapter.connect(_make_http_config())
+
+        assert result.is_err
+        transport_cm.__aexit__.assert_called_with(None, None, None)
+        assert adapter._transport_cm is None
+        assert adapter._session is None
+
+    @pytest.mark.asyncio
+    async def test_http_connect_passes_headers(self):
+        """When config has headers, create_mcp_http_client called with them."""
+        adapter = MCPClientAdapter()
+        transport_cm = _mock_http_transport_cm()
+        session = _mock_session()
+
+        config = MCPServerConfig(
+            name="test",
+            transport=TransportType.HTTP,
+            url="http://localhost:3000",
+            headers={"Authorization": "Bearer token123"},
+        )
+
+        with (
+            patch(
+                "mcp.client.streamable_http.streamable_http_client", return_value=transport_cm
+            ) as mock_http,
+            patch("mcp.ClientSession", return_value=session),
+            patch("mcp.shared._httpx_utils.create_mcp_http_client") as mock_factory,
+        ):
+            result = await adapter.connect(config)
+
+        assert result.is_ok
+        mock_factory.assert_called_once()
+        call_kwargs = mock_factory.call_args
+        assert call_kwargs.kwargs["headers"] == {"Authorization": "Bearer token123"}
+        mock_http.assert_called_once_with(
+            "http://localhost:3000",
+            http_client=mock_factory.return_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_connect_uses_mcp_timeout_defaults(self):
+        """HTTP transport uses MCP-appropriate timeouts with extended read for streaming."""
+        adapter = MCPClientAdapter()
+        transport_cm = _mock_http_transport_cm()
+        session = _mock_session()
+
+        config = MCPServerConfig(
+            name="test",
+            transport=TransportType.HTTP,
+            url="http://localhost:3000",
+            timeout=15.0,
+        )
+
+        with (
+            patch("mcp.client.streamable_http.streamable_http_client", return_value=transport_cm),
+            patch("mcp.ClientSession", return_value=session),
+            patch("mcp.shared._httpx_utils.create_mcp_http_client") as mock_factory,
+            patch("httpx.Timeout") as mock_timeout,
+        ):
+            result = await adapter.connect(config)
+
+        assert result.is_ok
+        # read timeout should be max(config.timeout, 300.0) for SSE streaming
+        mock_timeout.assert_called_once_with(15.0, read=300.0)
+        mock_factory.assert_called_once_with(
+            headers=None,
+            timeout=mock_timeout.return_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_disconnect_cleans_transport_on_error(self):
+        """HTTP transport cleaned up when session init fails."""
+        adapter = MCPClientAdapter(max_retries=1)
+        transport_cm = _mock_http_transport_cm()
+        session = _mock_session(init_fail=True)
+
+        with (
+            patch("mcp.client.streamable_http.streamable_http_client", return_value=transport_cm),
+            patch("mcp.ClientSession", return_value=session),
+            patch("mcp.shared._httpx_utils.create_mcp_http_client"),
+        ):
+            result = await adapter.connect(_make_http_config())
+
+        assert result.is_err
+        transport_cm.__aexit__.assert_called_with(None, None, None)
+        assert adapter._transport_cm is None
+        assert adapter._session is None

--- a/tests/unit/mcp/test_types.py
+++ b/tests/unit/mcp/test_types.py
@@ -29,6 +29,7 @@ class TestTransportType:
         assert TransportType.STDIO == "stdio"
         assert TransportType.SSE == "sse"
         assert TransportType.STREAMABLE_HTTP == "streamable-http"
+        assert TransportType.HTTP == "http"
 
 
 class TestMCPServerConfig:
@@ -61,6 +62,23 @@ class TestMCPServerConfig:
                 name="test",
                 transport=TransportType.SSE,
             )
+
+    def test_http_config_requires_url(self) -> None:
+        """HTTP transport requires URL."""
+        with pytest.raises(ValueError, match="url is required"):
+            MCPServerConfig(
+                name="test",
+                transport=TransportType.HTTP,
+            )
+
+    def test_valid_http_config(self) -> None:
+        """Valid HTTP config is created successfully."""
+        config = MCPServerConfig(
+            name="test",
+            transport=TransportType.HTTP,
+            url="http://localhost:3000",
+        )
+        assert config.url == "http://localhost:3000"
 
     def test_valid_sse_config(self) -> None:
         """Valid SSE config is created successfully."""


### PR DESCRIPTION
## Summary

- add HTTP="http" to TransportType enum. alias for streamable-http per MCP spec. Claude Code uses "http" for what spec calls "streamable HTTP"
- wire mcp.client.sse.sse_client() for SSE transport in adapter._raw_connect()
- wire mcp.client.streamable_http.streamable_http_client() for HTTP/streamable-http transport
- previously only stdio worked. SSE + streamable-http raised NotImplementedError
- affects all runtimes: ooo run --mcp-config, ooo mcp serve (bridge), programmatic usage
- URL validation added for HTTP transport in MCPServerConfig
- 8 new unit tests for SSE/HTTP connect + rollback paths
- docs updated: api/mcp.md, cli-reference.md, mcp-bridge.md

## Verification

- 576 unit tests pass, 0 fail
- 84 integration tests pass, 0 fail
- ruff check + format clean
- all existing tests unaffected

Closes #327