### PR TITLE
fix(mcp): register ACTreeHUDHandler in composition root

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -758,6 +758,7 @@ def create_ouroboros_server(
     from ouroboros.mcp.tools.brownfield_handler import BrownfieldHandler
     from ouroboros.mcp.tools.definitions import (
         ACDashboardHandler,
+        ACTreeHUDHandler,
         CancelExecutionHandler,
         CancelJobHandler,
         ChannelWorkflowHandler,
@@ -1403,6 +1404,9 @@ def create_ouroboros_server(
             evolutionary_loop=evolutionary_loop,
         ),
         ACDashboardHandler(
+            event_store=event_store,
+        ),
+        ACTreeHUDHandler(
             event_store=event_store,
         ),
         QAHandler(

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -731,7 +731,7 @@ def create_ouroboros_server(
         llm_backend: Optional LLM-only backend override.
 
     Returns:
-        Configured MCPServerAdapter with all 10 tools registered.
+        Configured MCPServerAdapter with all tools registered.
 
     Raises:
         ImportError: If MCP SDK is not installed.

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -484,6 +484,7 @@ class TestCreateOuroborosServer:
         assert server.info.name == "ouroboros-mcp"
         assert server.info.version == "1.0.0"
         tool_names = {tool.name for tool in server.info.tools}
+        assert "ouroboros_ac_tree_hud" in tool_names
         assert "ouroboros_channel_workflow" in tool_names
 
     def test_creates_server_with_custom_config(self) -> None:


### PR DESCRIPTION
## Summary
- `ACTreeHUDHandler` was defined in `definitions.py` but never added to `tool_handlers` in `create_server()` (composition root)
- This made `ouroboros_ac_tree_hud` MCP tool invisible to clients, causing "tool not found" errors during execution monitoring
- Added import + instance registration with shared `event_store`

## Checks passed
- [x] ruff lint
- [x] ruff format
- [x] mypy
- [x] pytest (570 passed)

## Test plan
- [ ] Start an Ouroboros execution via MCP and verify `ouroboros_ac_tree_hud` tool is discoverable
- [ ] Call `ouroboros_ac_tree_hud` with a valid session_id and confirm AC tree snapshot is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)