### PR TITLE
perf(#346): non-blocking event emissions on interview hot path

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -541,8 +541,22 @@ class InterviewHandler:
             await self._event_store.initialize()
             self._initialized = True
 
+    async def _drain_bg_tasks(self, timeout: float = 5.0) -> None:
+        """Await all pending background event tasks before shutdown."""
+        if not self._bg_tasks:
+            return
+        tasks = list(self._bg_tasks)
+        done, pending = await asyncio.wait(tasks, timeout=timeout)
+        for t in pending:
+            t.cancel()
+        # Await cancelled tasks so CancelledError propagates cleanly
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._bg_tasks.clear()
+
     async def close(self) -> None:
-        """Close the event store if this handler owns it."""
+        """Drain pending event tasks, then close the event store if owned."""
+        await self._drain_bg_tasks()
         if self._owns_event_store:
             await self._event_store.close()
             self._initialized = False

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -5,6 +5,7 @@ Contains handlers for interview and seed generation tools:
 - InterviewHandler: Manages interactive requirement-clarification interviews.
 """
 
+import asyncio
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
@@ -532,6 +533,7 @@ class InterviewHandler:
         self._owns_event_store = self.event_store is None
         self._event_store = self.event_store or EventStore()
         self._initialized = False
+        self._bg_tasks: set[asyncio.Task] = set()
 
     async def _ensure_initialized(self) -> None:
         """Ensure the event store is initialized."""
@@ -552,6 +554,12 @@ class InterviewHandler:
             await self._event_store.append(event)
         except Exception as e:
             log.warning("mcp.tool.interview.event_emission_failed", error=str(e))
+
+    def _emit_event_bg(self, event: Any) -> None:
+        """Fire-and-forget event emission — non-blocking on the hot path."""
+        task = asyncio.create_task(self._emit_event(event))
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
 
     async def _score_interview_state(
         self,
@@ -644,7 +652,7 @@ class InterviewHandler:
 
         from ouroboros.events.interview import interview_completed
 
-        await self._emit_event(
+        self._emit_event_bg(
             interview_completed(
                 interview_id=session_id,
                 total_rounds=len(state.rounds),
@@ -785,7 +793,7 @@ class InterviewHandler:
                     error_msg = str(question_result.error)
                     from ouroboros.events.interview import interview_failed
 
-                    await self._emit_event(
+                    self._emit_event_bg(
                         interview_failed(
                             state.interview_id,
                             error_msg,
@@ -852,7 +860,7 @@ class InterviewHandler:
                 # Emit interview started event
                 from ouroboros.events.interview import interview_started
 
-                await self._emit_event(
+                self._emit_event_bg(
                     interview_started(
                         state.interview_id,
                         resolved_context.value,
@@ -991,7 +999,7 @@ class InterviewHandler:
                     # Emit response recorded event
                     from ouroboros.events.interview import interview_response_recorded
 
-                    await self._emit_event(
+                    self._emit_event_bg(
                         interview_response_recorded(
                             interview_id=session_id,
                             round_number=len(state.rounds),
@@ -1044,7 +1052,7 @@ class InterviewHandler:
                     error_msg = str(question_result.error)
                     from ouroboros.events.interview import interview_failed
 
-                    await self._emit_event(
+                    self._emit_event_bg(
                         interview_failed(
                             session_id,
                             error_msg,
@@ -1144,7 +1152,7 @@ class InterviewHandler:
             if _interview_id:
                 from ouroboros.events.interview import interview_failed
 
-                await self._emit_event(
+                self._emit_event_bg(
                     interview_failed(
                         _interview_id,
                         str(e),

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -2512,3 +2512,58 @@ class TestStartExecuteSeedHandlerBackendPropagation:
         start_job_call = mock_job_manager.start_job.await_args
         runner = start_job_call.kwargs["runner"]
         runner.close()
+
+
+class TestInterviewHandlerDrain:
+    """Test that close() drains pending background event tasks."""
+
+    async def test_close_drains_pending_bg_tasks(self) -> None:
+        """close() should await all pending bg tasks before closing the event store."""
+        mock_store = AsyncMock()
+        handler = InterviewHandler(event_store=mock_store)
+        handler._owns_event_store = True
+
+        completed = asyncio.Event()
+
+        async def slow_emit() -> None:
+            await asyncio.sleep(0.05)
+            completed.set()
+
+        task = asyncio.create_task(slow_emit())
+        handler._bg_tasks.add(task)
+        task.add_done_callback(handler._bg_tasks.discard)
+
+        await handler.close()
+
+        assert completed.is_set()
+        assert len(handler._bg_tasks) == 0
+        mock_store.close.assert_awaited_once()
+
+    async def test_close_cancels_stuck_tasks_on_timeout(self) -> None:
+        """close() should cancel tasks that exceed the drain timeout."""
+        mock_store = AsyncMock()
+        handler = InterviewHandler(event_store=mock_store)
+        handler._owns_event_store = True
+
+        async def stuck_emit() -> None:
+            await asyncio.sleep(999)
+
+        task = asyncio.create_task(stuck_emit())
+        handler._bg_tasks.add(task)
+        task.add_done_callback(handler._bg_tasks.discard)
+
+        await handler._drain_bg_tasks(timeout=0.05)
+
+        assert task.cancelled()
+        assert len(handler._bg_tasks) == 0
+
+    async def test_close_without_bg_tasks_is_noop(self) -> None:
+        """close() with no pending tasks should just close the store."""
+        mock_store = AsyncMock()
+        handler = InterviewHandler(event_store=mock_store)
+        handler._owns_event_store = True
+
+        await handler.close()
+
+        assert len(handler._bg_tasks) == 0
+        mock_store.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Replace synchronous `await self._emit_event()` with fire-and-forget `self._emit_event_bg()` at all 6 call sites in `InterviewHandler`
- Store task references in `_bg_tasks: set[asyncio.Task]` with `done_callback` cleanup to prevent GC ([Python docs recommendation](https://docs.python.org/3/library/asyncio-task.html#creating-tasks))
- Events are diagnostic-only and already wrapped in `try/except` error swallowing — they should not block the interview hot path

## Motivation

Each `_emit_event()` call performs a synchronous `await` on a SQLite INSERT, adding 2-10ms of serial latency per round. Since events are non-critical diagnostics (the existing error handler silently swallows failures), blocking the interview flow on event persistence is unnecessary overhead.

Closes #346

## Test plan

- [x] All 37 existing interview handler tests pass
- [x] Full unit test suite: 3906 passed, 9 skipped
- [ ] Manual verification: interview round-trip time measured before/after