### PR TITLE
perf(#344): reduce per-call overhead in Claude adapter

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -52,7 +52,9 @@ log = structlog.get_logger(__name__)
 # Retry configuration for transient API errors
 _MAX_RETRIES = 5
 _MAX_JSON_RETRIES = 3  # Extra retries when response_format requires JSON but LLM returns prose
-_INITIAL_BACKOFF_SECONDS = 0.5  # Keep low for interactive loops; exponential backoff handles sustained failures
+_INITIAL_BACKOFF_SECONDS = (
+    0.5  # Keep low for interactive loops; exponential backoff handles sustained failures
+)
 _RETRYABLE_ERROR_PATTERNS = (
     "concurrency",
     "rate",

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -52,7 +52,7 @@ log = structlog.get_logger(__name__)
 # Retry configuration for transient API errors
 _MAX_RETRIES = 5
 _MAX_JSON_RETRIES = 3  # Extra retries when response_format requires JSON but LLM returns prose
-_INITIAL_BACKOFF_SECONDS = 2.0  # Increased for custom CLI startup
+_INITIAL_BACKOFF_SECONDS = 0.5  # Keep low for interactive loops; exponential backoff handles sustained failures
 _RETRYABLE_ERROR_PATTERNS = (
     "concurrency",
     "rate",
@@ -559,7 +559,13 @@ class ClaudeCodeAdapter:
         # to signal it's an SDK call, but the older check on CLAUDECODE fires
         # first, causing silent empty responses.  Strip it via env override.
         claudecode_present = bool(os.environ.get("CLAUDECODE"))
-        env_overrides: dict[str, str] = {}
+        env_overrides: dict[str, str] = {
+            # Skip the per-call `claude -v` subprocess that the Agent SDK runs
+            # to verify version compatibility.  This is advisory-only — version
+            # mismatches surface naturally as API errors — and saves ~0.3-0.8 s
+            # latency on every LLM call.
+            "CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK": "1",
+        }
         if claudecode_present:
             env_overrides["CLAUDECODE"] = ""
 

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -248,6 +248,51 @@ class TestExecuteSingleRequestSystemPrompt:
         options_call_kwargs = mock_options_cls.call_args.kwargs
         assert "system_prompt" not in options_call_kwargs
 
+
+class TestAdapterOverheadReductions:
+    """Test per-call overhead optimizations in ClaudeCodeAdapter."""
+
+    @pytest.mark.asyncio
+    async def test_version_check_skip_env_is_set(self) -> None:
+        """CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK=1 is passed to ClaudeAgentOptions."""
+        adapter = ClaudeCodeAdapter()
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        env = options_call_kwargs.get("env", {})
+        assert env.get("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK") == "1"
+
+    def test_initial_backoff_is_half_second(self) -> None:
+        """_INITIAL_BACKOFF_SECONDS should be 0.5 for interactive responsiveness."""
+        from ouroboros.providers.claude_code_adapter import _INITIAL_BACKOFF_SECONDS
+
+        assert _INITIAL_BACKOFF_SECONDS == 0.5
+
+
+class TestJsonSchemaHandling:
+    """Test JSON schema handling in ClaudeCodeAdapter."""
+
     @pytest.mark.asyncio
     async def test_json_schema_is_enforced_via_prompt_not_output_format(self) -> None:
         """json_schema requests should augment the prompt, not SDK output_format."""


### PR DESCRIPTION
## Summary

- Reduce `_INITIAL_BACKOFF_SECONDS` from 2.0 to 0.5 for faster first retry in interactive interview loops
- Set `CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK=1` to skip the per-call `claude -v` subprocess (~0.3-0.8s saved per LLM call)

## Motivation

Every LLM call through `ClaudeCodeAdapter` incurs two sources of overhead:

1. **SDK version check**: The Agent SDK runs `claude -v` as a subprocess before each query. This is advisory-only — version mismatches surface as API errors.
2. **Aggressive initial backoff**: The original 2.0s first-retry delay was set for "custom CLI startup" scenarios but penalizes interactive loops where transient errors resolve quickly.

Over a 5-round interview (~10 LLM calls), these compound to 3-8 seconds of unnecessary latency.

Closes #344

## Test plan

- [x] All 30 adapter unit tests pass
- [ ] Manual verification: measure round-trip time before/after