### PR TITLE
perf(#345): optimize ambiguity scorer token usage and enforce format error limit

### DIFF
--- a/src/ouroboros/bigbang/ambiguity.py
+++ b/src/ouroboros/bigbang/ambiguity.py
@@ -196,7 +196,7 @@ class AmbiguityScorer:
     llm_adapter: LLMAdapter
     model: str = field(default_factory=get_clarification_model)
     temperature: float = SCORING_TEMPERATURE
-    initial_max_tokens: int = 2048
+    initial_max_tokens: int = 512
     max_retries: int | None = 10  # Default to 10 retries (None = unlimited)
     max_format_error_retries: int = 5  # Stop after N format errors (non-truncation)
 
@@ -259,6 +259,7 @@ class AmbiguityScorer:
         last_error: Exception | ProviderError | None = None
         last_response: str = ""
         attempt = 0
+        format_error_count = 0
 
         while True:
             # Check retry limit if set
@@ -337,11 +338,22 @@ class AmbiguityScorer:
                     current_max_tokens = next_tokens
                 else:
                     # Format error without truncation - retry with same tokens
+                    format_error_count += 1
+                    if format_error_count >= self.max_format_error_retries:
+                        log.warning(
+                            "ambiguity.scoring.format_errors_exhausted",
+                            interview_id=state.interview_id,
+                            error=str(e),
+                            format_error_count=format_error_count,
+                            max_format_error_retries=self.max_format_error_retries,
+                        )
+                        break
                     log.warning(
                         "ambiguity.scoring.format_error_retrying",
                         interview_id=state.interview_id,
                         error=str(e),
                         attempt=attempt,
+                        format_error_count=format_error_count,
                         finish_reason=result.value.finish_reason,
                     )
 

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -234,7 +234,7 @@ class InterviewEngine:
     state_dir: Path = field(default_factory=lambda: Path.home() / ".ouroboros" / "data")
     model: str = field(default_factory=get_clarification_model)
     temperature: float = 0.7
-    max_tokens: int = 2048
+    max_tokens: int = 512
 
     def __post_init__(self) -> None:
         """Ensure state directory exists."""

--- a/tests/unit/bigbang/test_ambiguity.py
+++ b/tests/unit/bigbang/test_ambiguity.py
@@ -308,7 +308,7 @@ class TestAmbiguityScorerInit:
         assert scorer.llm_adapter == mock_adapter
         assert scorer.model == get_clarification_model()
         assert scorer.temperature == SCORING_TEMPERATURE
-        assert scorer.initial_max_tokens == 2048
+        assert scorer.initial_max_tokens == 512
         assert scorer.max_retries == 10  # Default to 10 retries
 
     def test_scorer_custom_values(self) -> None:


### PR DESCRIPTION
## Summary

- Reduce `initial_max_tokens` from 2048 to 512 in `AmbiguityScorer` and `InterviewEngine`
- Enforce the existing but unused `max_format_error_retries` field with a dedicated counter in the retry loop

## Motivation

### Token over-allocation
Typical scoring responses are 200-350 tokens (structured JSON with 3 dimension scores + justifications), yet the scorer reserves 2048 tokens on every call. Reducing to 512 matches actual usage. The adaptive retry mechanism already handles truncation: if `finish_reason == "length"`, tokens double automatically (512 → 1024 → 2048).

### Unused format error limit
`AmbiguityScorer` defines `max_format_error_retries = 5` but never checks it in the retry loop. When the LLM produces malformed JSON (not truncated — wrong format), the scorer retries with identical parameters until the global `max_retries` is exhausted. Unlike truncation errors (which benefit from doubling tokens), format errors indicate a prompt problem that retrying cannot fix. This wastes 2-5 seconds per futile retry.

The fix adds a `format_error_count` counter that increments only on non-truncation parse failures and breaks when `max_format_error_retries` is reached.

Closes #345

## Test plan

- [x] All 60 ambiguity scorer tests pass
- [x] Default value assertion updated in `test_scorer_default_values`
- [ ] Manual verification: scoring latency measured before/after
