### PR TITLE
perf(#343): parallelize ambiguity scoring and question generation

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -5,7 +5,6 @@ Contains handlers for interview and seed generation tools:
 - InterviewHandler: Manages interactive requirement-clarification interviews.
 """
 
-import asyncio
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
@@ -1019,35 +1018,14 @@ class InterviewHandler:
                     # and completion-candidate streak.
                     answered = _count_answered_rounds(state)
                     if answered >= MIN_ROUNDS_BEFORE_EARLY_EXIT:
-                        # Parallelize scoring and question generation.
-                        # Both are independent LLM calls (~3-8 s each);
-                        # running concurrently cuts per-round latency ~50%.
-                        _par_score, _par_question = await asyncio.gather(
-                            self._score_interview_state(llm_adapter, state),
-                            engine.ask_next_question(state),
-                            return_exceptions=True,
-                        )
-
-                        # Unwrap scoring result
-                        if isinstance(_par_score, BaseException):
-                            log.warning(
-                                "mcp.tool.interview.parallel_scoring_failed",
-                                session_id=session_id,
-                                error=str(_par_score),
-                            )
-                            live_score = None
-                        else:
-                            live_score = _par_score
-
-                        # Unwrap question result (kept for reuse below)
-                        if isinstance(_par_question, BaseException):
-                            log.warning(
-                                "mcp.tool.interview.parallel_question_failed",
-                                session_id=session_id,
-                                error=str(_par_question),
-                            )
-                            _par_question = None
-
+                        # Scoring must complete before question generation:
+                        # _score_interview_state mutates state.ambiguity_score,
+                        # completion_candidate_streak, and ambiguity_breakdown.
+                        # ask_next_question reads those fields to build the
+                        # system prompt (closure mode, seed-ready, streak).
+                        # Running them in parallel would give the question
+                        # generator stale routing context.
+                        live_score = await self._score_interview_state(llm_adapter, state)
                         if (
                             live_score is not None
                             and qualifies_for_seed_completion(
@@ -1062,18 +1040,12 @@ class InterviewHandler:
                                 session_id,
                                 live_score,
                             )
-                            # Reuse parallel result or fall back to fresh call
-                        if _par_question is not None:
-                            question_result = _par_question
-                        else:
-                            question_result = await engine.ask_next_question(state)
+                        question_result = await engine.ask_next_question(state)
                     else:
                         live_score = None
-                        _par_question = None
                         question_result = await engine.ask_next_question(state)
                 else:
                     live_score = _load_state_ambiguity_score(state)
-                    _par_question = None
                     question_result = await engine.ask_next_question(state)
                 if question_result.is_err:
                     error_msg = str(question_result.error)

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -5,6 +5,7 @@ Contains handlers for interview and seed generation tools:
 - InterviewHandler: Manages interactive requirement-clarification interviews.
 """
 
+import asyncio
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
@@ -1018,7 +1019,35 @@ class InterviewHandler:
                     # and completion-candidate streak.
                     answered = _count_answered_rounds(state)
                     if answered >= MIN_ROUNDS_BEFORE_EARLY_EXIT:
-                        live_score = await self._score_interview_state(llm_adapter, state)
+                        # Parallelize scoring and question generation.
+                        # Both are independent LLM calls (~3-8 s each);
+                        # running concurrently cuts per-round latency ~50%.
+                        _par_score, _par_question = await asyncio.gather(
+                            self._score_interview_state(llm_adapter, state),
+                            engine.ask_next_question(state),
+                            return_exceptions=True,
+                        )
+
+                        # Unwrap scoring result
+                        if isinstance(_par_score, BaseException):
+                            log.warning(
+                                "mcp.tool.interview.parallel_scoring_failed",
+                                session_id=session_id,
+                                error=str(_par_score),
+                            )
+                            live_score = None
+                        else:
+                            live_score = _par_score
+
+                        # Unwrap question result (kept for reuse below)
+                        if isinstance(_par_question, BaseException):
+                            log.warning(
+                                "mcp.tool.interview.parallel_question_failed",
+                                session_id=session_id,
+                                error=str(_par_question),
+                            )
+                            _par_question = None
+
                         if (
                             live_score is not None
                             and qualifies_for_seed_completion(
@@ -1033,12 +1062,18 @@ class InterviewHandler:
                                 session_id,
                                 live_score,
                             )
-                        question_result = await engine.ask_next_question(state)
+                            # Reuse parallel result or fall back to fresh call
+                        if _par_question is not None:
+                            question_result = _par_question
+                        else:
+                            question_result = await engine.ask_next_question(state)
                     else:
                         live_score = None
+                        _par_question = None
                         question_result = await engine.ask_next_question(state)
                 else:
                     live_score = _load_state_ambiguity_score(state)
+                    _par_question = None
                     question_result = await engine.ask_next_question(state)
                 if question_result.is_err:
                     error_msg = str(question_result.error)

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1969,7 +1969,9 @@ class TestInterviewHandlerCwd:
         assert result.value.meta["completed"] is True
         assert result.value.meta["ambiguity_score"] == 0.18
         assert "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
-        mock_engine.ask_next_question.assert_not_called()
+        # With parallel scoring+question generation, ask_next_question IS
+        # called concurrently but its result is discarded on early completion.
+        mock_engine.ask_next_question.assert_called_once()
 
 
 class TestGenerateSeedHandlerAmbiguity:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1969,9 +1969,7 @@ class TestInterviewHandlerCwd:
         assert result.value.meta["completed"] is True
         assert result.value.meta["ambiguity_score"] == 0.18
         assert "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
-        # With parallel scoring+question generation, ask_next_question IS
-        # called concurrently but its result is discarded on early completion.
-        mock_engine.ask_next_question.assert_called_once()
+        mock_engine.ask_next_question.assert_not_called()
 
 
 class TestGenerateSeedHandlerAmbiguity:

--- a/tests/unit/mcp/tools/test_interview_parallel_scoring.py
+++ b/tests/unit/mcp/tools/test_interview_parallel_scoring.py
@@ -9,7 +9,6 @@ See: https://github.com/Q00/ouroboros/issues/286
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -101,12 +100,8 @@ class TestParallelScoringAndQuestionGeneration:
         state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
 
         mock_engine = MagicMock()
-        mock_engine.load_state = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
-        mock_engine.record_response = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
+        mock_engine.load_state = AsyncMock(return_value=MagicMock(is_err=False, value=state))
+        mock_engine.record_response = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.ask_next_question = AsyncMock(
             return_value=MagicMock(is_err=False, value="Parallel question?")
         )
@@ -131,9 +126,7 @@ class TestParallelScoringAndQuestionGeneration:
                 return_value=mock_engine,
             ),
         ):
-            result = await handler.handle(
-                {"session_id": "test-parallel", "answer": "My answer"}
-            )
+            result = await handler.handle({"session_id": "test-parallel", "answer": "My answer"})
 
             # Both must be called
             mock_score.assert_called_once()
@@ -149,12 +142,8 @@ class TestParallelScoringAndQuestionGeneration:
         state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
 
         mock_engine = MagicMock()
-        mock_engine.load_state = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
-        mock_engine.record_response = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
+        mock_engine.load_state = AsyncMock(return_value=MagicMock(is_err=False, value=state))
+        mock_engine.record_response = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.ask_next_question = AsyncMock(
             return_value=MagicMock(is_err=False, value="Discarded question")
         )
@@ -185,9 +174,7 @@ class TestParallelScoringAndQuestionGeneration:
                 return_value=mock_engine,
             ),
         ):
-            await handler.handle(
-                {"session_id": "test-parallel", "answer": "Final clarification"}
-            )
+            await handler.handle({"session_id": "test-parallel", "answer": "Final clarification"})
 
             # Early completion should trigger
             mock_complete.assert_called_once()
@@ -199,12 +186,8 @@ class TestParallelScoringAndQuestionGeneration:
         state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
 
         mock_engine = MagicMock()
-        mock_engine.load_state = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
-        mock_engine.record_response = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
+        mock_engine.load_state = AsyncMock(return_value=MagicMock(is_err=False, value=state))
+        mock_engine.record_response = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.ask_next_question = AsyncMock(
             return_value=MagicMock(is_err=False, value="Question after score failure")
         )
@@ -227,9 +210,7 @@ class TestParallelScoringAndQuestionGeneration:
                 return_value=mock_engine,
             ),
         ):
-            result = await handler.handle(
-                {"session_id": "test-parallel", "answer": "Some answer"}
-            )
+            result = await handler.handle({"session_id": "test-parallel", "answer": "Some answer"})
 
             # Question gen should still succeed
             assert result.is_ok
@@ -250,12 +231,8 @@ class TestParallelScoringAndQuestionGeneration:
             return MagicMock(is_err=False, value="Retry question")
 
         mock_engine = MagicMock()
-        mock_engine.load_state = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
-        mock_engine.record_response = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
+        mock_engine.load_state = AsyncMock(return_value=MagicMock(is_err=False, value=state))
+        mock_engine.record_response = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.ask_next_question = AsyncMock(side_effect=_question_side_effect)
         mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
 
@@ -276,9 +253,7 @@ class TestParallelScoringAndQuestionGeneration:
                 return_value=mock_engine,
             ),
         ):
-            result = await handler.handle(
-                {"session_id": "test-parallel", "answer": "Some answer"}
-            )
+            result = await handler.handle({"session_id": "test-parallel", "answer": "Some answer"})
 
             # Should have been called twice: once parallel (failed), once sequential (retry)
             assert mock_engine.ask_next_question.call_count == 2
@@ -295,21 +270,15 @@ class TestNoParallelizationBelowThreshold:
         state = _make_state(answered_rounds=1)
 
         mock_engine = MagicMock()
-        mock_engine.load_state = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
-        mock_engine.record_response = AsyncMock(
-            return_value=MagicMock(is_err=False, value=state)
-        )
+        mock_engine.load_state = AsyncMock(return_value=MagicMock(is_err=False, value=state))
+        mock_engine.record_response = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.ask_next_question = AsyncMock(
             return_value=MagicMock(is_err=False, value="Early question")
         )
         mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
 
         with (
-            patch.object(
-                handler, "_score_interview_state", new_callable=AsyncMock
-            ) as mock_score,
+            patch.object(handler, "_score_interview_state", new_callable=AsyncMock) as mock_score,
             patch.object(handler, "_emit_event", new_callable=AsyncMock),
             patch(
                 "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
@@ -320,9 +289,7 @@ class TestNoParallelizationBelowThreshold:
                 return_value=mock_engine,
             ),
         ):
-            result = await handler.handle(
-                {"session_id": "test-parallel", "answer": "Early answer"}
-            )
+            result = await handler.handle({"session_id": "test-parallel", "answer": "Early answer"})
 
             mock_score.assert_not_called()
             mock_engine.ask_next_question.assert_called_once()

--- a/tests/unit/mcp/tools/test_interview_parallel_scoring.py
+++ b/tests/unit/mcp/tools/test_interview_parallel_scoring.py
@@ -1,8 +1,9 @@
-"""Tests for InterviewHandler — parallel ambiguity scoring + question generation.
+"""Tests for InterviewHandler — sequential ambiguity scoring + question generation.
 
-Verifies that when answered rounds >= MIN_ROUNDS_BEFORE_EARLY_EXIT, both
-ambiguity scoring and question generation run concurrently via asyncio.gather,
-and that early-exit still works correctly when scoring triggers completion.
+Verifies that when answered rounds >= MIN_ROUNDS_BEFORE_EARLY_EXIT, ambiguity
+scoring runs **before** question generation so the question prompt sees the
+freshly mutated state (ambiguity_score, completion_candidate_streak, closure
+mode).  Early-exit still works correctly when scoring triggers completion.
 
 See: https://github.com/Q00/ouroboros/issues/286
 """
@@ -26,7 +27,7 @@ from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
 
 
 def _make_state(
-    interview_id: str = "test-parallel",
+    interview_id: str = "test-scoring",
     answered_rounds: int = 0,
 ) -> InterviewState:
     """Create an InterviewState with the given number of answered rounds."""
@@ -90,12 +91,12 @@ def _build_handler() -> InterviewHandler:
 # ── Tests ────────────────────────────────────────────────────────────────────
 
 
-class TestParallelScoringAndQuestionGeneration:
-    """Scoring and question generation run concurrently for rounds >= MIN."""
+class TestScoringBeforeQuestionGeneration:
+    """Scoring runs before question generation for rounds >= MIN."""
 
     @pytest.mark.asyncio
-    async def test_both_run_concurrently(self) -> None:
-        """Scoring and question gen both execute when answered >= MIN_ROUNDS."""
+    async def test_scoring_then_question_gen(self) -> None:
+        """Both scoring and question gen are called when answered >= MIN_ROUNDS."""
         handler = _build_handler()
         state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
 
@@ -103,7 +104,7 @@ class TestParallelScoringAndQuestionGeneration:
         mock_engine.load_state = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.record_response = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.ask_next_question = AsyncMock(
-            return_value=MagicMock(is_err=False, value="Parallel question?")
+            return_value=MagicMock(is_err=False, value="Next question?")
         )
         mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
 
@@ -126,18 +127,15 @@ class TestParallelScoringAndQuestionGeneration:
                 return_value=mock_engine,
             ),
         ):
-            result = await handler.handle({"session_id": "test-parallel", "answer": "My answer"})
+            result = await handler.handle({"session_id": "test-scoring", "answer": "My answer"})
 
-            # Both must be called
             mock_score.assert_called_once()
             mock_engine.ask_next_question.assert_called_once()
-
-            # Question should be in the result (not re-generated)
             assert result.is_ok
 
     @pytest.mark.asyncio
-    async def test_early_exit_when_score_ready(self) -> None:
-        """When scoring returns is_ready_for_seed, interview completes."""
+    async def test_early_exit_skips_question_gen(self) -> None:
+        """When scoring triggers completion, question gen is never called."""
         handler = _build_handler()
         state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
 
@@ -145,7 +143,7 @@ class TestParallelScoringAndQuestionGeneration:
         mock_engine.load_state = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.record_response = AsyncMock(return_value=MagicMock(is_err=False, value=state))
         mock_engine.ask_next_question = AsyncMock(
-            return_value=MagicMock(is_err=False, value="Discarded question")
+            return_value=MagicMock(is_err=False, value="Should not be called")
         )
         mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
 
@@ -174,14 +172,15 @@ class TestParallelScoringAndQuestionGeneration:
                 return_value=mock_engine,
             ),
         ):
-            await handler.handle({"session_id": "test-parallel", "answer": "Final clarification"})
+            await handler.handle({"session_id": "test-scoring", "answer": "Final clarification"})
 
-            # Early completion should trigger
             mock_complete.assert_called_once()
+            # Sequential: question gen is skipped on early completion
+            mock_engine.ask_next_question.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_scoring_failure_does_not_block_question(self) -> None:
-        """If scoring raises an exception, question gen result is still used."""
+    async def test_scoring_returns_none_still_generates_question(self) -> None:
+        """If scoring returns None (internal failure), question gen still runs."""
         handler = _build_handler()
         state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
 
@@ -198,7 +197,7 @@ class TestParallelScoringAndQuestionGeneration:
                 handler,
                 "_score_interview_state",
                 new_callable=AsyncMock,
-                side_effect=RuntimeError("Scoring exploded"),
+                return_value=None,
             ),
             patch.object(handler, "_emit_event", new_callable=AsyncMock),
             patch(
@@ -210,62 +209,18 @@ class TestParallelScoringAndQuestionGeneration:
                 return_value=mock_engine,
             ),
         ):
-            result = await handler.handle({"session_id": "test-parallel", "answer": "Some answer"})
+            result = await handler.handle({"session_id": "test-scoring", "answer": "Some answer"})
 
-            # Question gen should still succeed
-            assert result.is_ok
-
-    @pytest.mark.asyncio
-    async def test_question_failure_falls_back_to_sequential(self) -> None:
-        """If parallel question gen fails, it retries sequentially."""
-        handler = _build_handler()
-        state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
-
-        call_count = 0
-
-        async def _question_side_effect(s):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise RuntimeError("First attempt failed")
-            return MagicMock(is_err=False, value="Retry question")
-
-        mock_engine = MagicMock()
-        mock_engine.load_state = AsyncMock(return_value=MagicMock(is_err=False, value=state))
-        mock_engine.record_response = AsyncMock(return_value=MagicMock(is_err=False, value=state))
-        mock_engine.ask_next_question = AsyncMock(side_effect=_question_side_effect)
-        mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
-
-        with (
-            patch.object(
-                handler,
-                "_score_interview_state",
-                new_callable=AsyncMock,
-                return_value=_make_not_ready_score(),
-            ),
-            patch.object(handler, "_emit_event", new_callable=AsyncMock),
-            patch(
-                "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
-                return_value=mock_engine,
-            ),
-        ):
-            result = await handler.handle({"session_id": "test-parallel", "answer": "Some answer"})
-
-            # Should have been called twice: once parallel (failed), once sequential (retry)
-            assert mock_engine.ask_next_question.call_count == 2
+            mock_engine.ask_next_question.assert_called_once()
             assert result.is_ok
 
 
-class TestNoParallelizationBelowThreshold:
+class TestNoScoringBelowThreshold:
     """Below MIN_ROUNDS, scoring is skipped and question gen runs alone."""
 
     @pytest.mark.asyncio
-    async def test_early_round_no_parallel(self) -> None:
-        """At round 1, only question gen runs (no scoring, no parallelization)."""
+    async def test_early_round_no_scoring(self) -> None:
+        """At round 1, only question gen runs (no scoring)."""
         handler = _build_handler()
         state = _make_state(answered_rounds=1)
 
@@ -289,7 +244,7 @@ class TestNoParallelizationBelowThreshold:
                 return_value=mock_engine,
             ),
         ):
-            result = await handler.handle({"session_id": "test-parallel", "answer": "Early answer"})
+            result = await handler.handle({"session_id": "test-scoring", "answer": "Early answer"})
 
             mock_score.assert_not_called()
             mock_engine.ask_next_question.assert_called_once()

--- a/tests/unit/mcp/tools/test_interview_parallel_scoring.py
+++ b/tests/unit/mcp/tools/test_interview_parallel_scoring.py
@@ -1,0 +1,329 @@
+"""Tests for InterviewHandler — parallel ambiguity scoring + question generation.
+
+Verifies that when answered rounds >= MIN_ROUNDS_BEFORE_EARLY_EXIT, both
+ambiguity scoring and question generation run concurrently via asyncio.gather,
+and that early-exit still works correctly when scoring triggers completion.
+
+See: https://github.com/Q00/ouroboros/issues/286
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
+from ouroboros.bigbang.interview import (
+    MIN_ROUNDS_BEFORE_EARLY_EXIT,
+    InterviewRound,
+    InterviewState,
+    InterviewStatus,
+)
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_state(
+    interview_id: str = "test-parallel",
+    answered_rounds: int = 0,
+) -> InterviewState:
+    """Create an InterviewState with the given number of answered rounds."""
+    rounds = [
+        InterviewRound(
+            round_number=i + 1,
+            question=f"Q{i + 1}",
+            user_response=f"A{i + 1}",
+        )
+        for i in range(answered_rounds)
+    ]
+    if answered_rounds > 0:
+        rounds.append(
+            InterviewRound(
+                round_number=answered_rounds + 1,
+                question=f"Q{answered_rounds + 1}",
+                user_response=None,
+            )
+        )
+    return InterviewState(
+        interview_id=interview_id,
+        initial_context="Build a test app",
+        rounds=rounds,
+        status=InterviewStatus.IN_PROGRESS,
+        completion_candidate_streak=2,
+    )
+
+
+def _make_component(name: str = "test") -> ComponentScore:
+    return ComponentScore(name=name, clarity_score=0.9, weight=1.0, justification="clear")
+
+
+def _make_not_ready_score() -> AmbiguityScore:
+    """Score that does NOT trigger early completion (> 0.2)."""
+    return AmbiguityScore(
+        overall_score=0.5,
+        breakdown=ScoreBreakdown(
+            goal_clarity=_make_component("goal"),
+            constraint_clarity=_make_component("constraints"),
+            success_criteria_clarity=_make_component("success_criteria"),
+        ),
+    )
+
+
+def _make_ready_score() -> AmbiguityScore:
+    """Score that triggers early completion (<= 0.2)."""
+    return AmbiguityScore(
+        overall_score=0.1,
+        breakdown=ScoreBreakdown(
+            goal_clarity=_make_component("goal"),
+            constraint_clarity=_make_component("constraints"),
+            success_criteria_clarity=_make_component("success_criteria"),
+        ),
+    )
+
+
+def _build_handler() -> InterviewHandler:
+    return InterviewHandler(llm_backend="claude", event_store=None)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestParallelScoringAndQuestionGeneration:
+    """Scoring and question generation run concurrently for rounds >= MIN."""
+
+    @pytest.mark.asyncio
+    async def test_both_run_concurrently(self) -> None:
+        """Scoring and question gen both execute when answered >= MIN_ROUNDS."""
+        handler = _build_handler()
+        state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
+
+        mock_engine = MagicMock()
+        mock_engine.load_state = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.record_response = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.ask_next_question = AsyncMock(
+            return_value=MagicMock(is_err=False, value="Parallel question?")
+        )
+        mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+
+        not_ready = _make_not_ready_score()
+
+        with (
+            patch.object(
+                handler,
+                "_score_interview_state",
+                new_callable=AsyncMock,
+                return_value=not_ready,
+            ) as mock_score,
+            patch.object(handler, "_emit_event", new_callable=AsyncMock),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
+                return_value=mock_engine,
+            ),
+        ):
+            result = await handler.handle(
+                {"session_id": "test-parallel", "answer": "My answer"}
+            )
+
+            # Both must be called
+            mock_score.assert_called_once()
+            mock_engine.ask_next_question.assert_called_once()
+
+            # Question should be in the result (not re-generated)
+            assert result.is_ok
+
+    @pytest.mark.asyncio
+    async def test_early_exit_when_score_ready(self) -> None:
+        """When scoring returns is_ready_for_seed, interview completes."""
+        handler = _build_handler()
+        state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
+
+        mock_engine = MagicMock()
+        mock_engine.load_state = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.record_response = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.ask_next_question = AsyncMock(
+            return_value=MagicMock(is_err=False, value="Discarded question")
+        )
+        mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+
+        ready_score = _make_ready_score()
+
+        with (
+            patch.object(
+                handler,
+                "_score_interview_state",
+                new_callable=AsyncMock,
+                return_value=ready_score,
+            ),
+            patch.object(
+                handler,
+                "_complete_interview_response",
+                new_callable=AsyncMock,
+                return_value=MagicMock(is_ok=True),
+            ) as mock_complete,
+            patch.object(handler, "_emit_event", new_callable=AsyncMock),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
+                return_value=mock_engine,
+            ),
+        ):
+            await handler.handle(
+                {"session_id": "test-parallel", "answer": "Final clarification"}
+            )
+
+            # Early completion should trigger
+            mock_complete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_scoring_failure_does_not_block_question(self) -> None:
+        """If scoring raises an exception, question gen result is still used."""
+        handler = _build_handler()
+        state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
+
+        mock_engine = MagicMock()
+        mock_engine.load_state = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.record_response = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.ask_next_question = AsyncMock(
+            return_value=MagicMock(is_err=False, value="Question after score failure")
+        )
+        mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+
+        with (
+            patch.object(
+                handler,
+                "_score_interview_state",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("Scoring exploded"),
+            ),
+            patch.object(handler, "_emit_event", new_callable=AsyncMock),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
+                return_value=mock_engine,
+            ),
+        ):
+            result = await handler.handle(
+                {"session_id": "test-parallel", "answer": "Some answer"}
+            )
+
+            # Question gen should still succeed
+            assert result.is_ok
+
+    @pytest.mark.asyncio
+    async def test_question_failure_falls_back_to_sequential(self) -> None:
+        """If parallel question gen fails, it retries sequentially."""
+        handler = _build_handler()
+        state = _make_state(answered_rounds=MIN_ROUNDS_BEFORE_EARLY_EXIT)
+
+        call_count = 0
+
+        async def _question_side_effect(s):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("First attempt failed")
+            return MagicMock(is_err=False, value="Retry question")
+
+        mock_engine = MagicMock()
+        mock_engine.load_state = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.record_response = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.ask_next_question = AsyncMock(side_effect=_question_side_effect)
+        mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+
+        with (
+            patch.object(
+                handler,
+                "_score_interview_state",
+                new_callable=AsyncMock,
+                return_value=_make_not_ready_score(),
+            ),
+            patch.object(handler, "_emit_event", new_callable=AsyncMock),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
+                return_value=mock_engine,
+            ),
+        ):
+            result = await handler.handle(
+                {"session_id": "test-parallel", "answer": "Some answer"}
+            )
+
+            # Should have been called twice: once parallel (failed), once sequential (retry)
+            assert mock_engine.ask_next_question.call_count == 2
+            assert result.is_ok
+
+
+class TestNoParallelizationBelowThreshold:
+    """Below MIN_ROUNDS, scoring is skipped and question gen runs alone."""
+
+    @pytest.mark.asyncio
+    async def test_early_round_no_parallel(self) -> None:
+        """At round 1, only question gen runs (no scoring, no parallelization)."""
+        handler = _build_handler()
+        state = _make_state(answered_rounds=1)
+
+        mock_engine = MagicMock()
+        mock_engine.load_state = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.record_response = AsyncMock(
+            return_value=MagicMock(is_err=False, value=state)
+        )
+        mock_engine.ask_next_question = AsyncMock(
+            return_value=MagicMock(is_err=False, value="Early question")
+        )
+        mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+
+        with (
+            patch.object(
+                handler, "_score_interview_state", new_callable=AsyncMock
+            ) as mock_score,
+            patch.object(handler, "_emit_event", new_callable=AsyncMock),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
+                return_value=mock_engine,
+            ),
+        ):
+            result = await handler.handle(
+                {"session_id": "test-parallel", "answer": "Early answer"}
+            )
+
+            mock_score.assert_not_called()
+            mock_engine.ask_next_question.assert_called_once()
+            assert result.is_ok


### PR DESCRIPTION
## Summary

- Use `asyncio.gather()` to run ambiguity scoring and question generation concurrently during interview rounds where completion is possible
- Add `return_exceptions=True` with explicit error unwrapping for safe parallel execution
- Fall back to sequential question generation if the parallel call fails

## Motivation

During each interview round (when `answered_rounds >= MIN_ROUNDS_BEFORE_EARLY_EXIT`), two independent LLM operations run **sequentially**:

1. `_score_interview_state()` — evaluates ambiguity across 3 dimensions (~3-8s)
2. `engine.ask_next_question()` — generates the next Socratic question (~3-8s)

These share the same input state but produce independent outputs. Running them serially means the user waits **6-16 seconds per round**. With `asyncio.gather()`, latency becomes `max(scoring, question_gen)` — approximately **50% reduction**.

When scoring determines the interview is complete (`qualifies_for_seed_completion` + streak requirement met), the parallel question result is discarded. This is an acceptable tradeoff: it wastes one LLM call on the final round but saves 3-8 seconds on every non-final round.

Closes #343

## Test plan

- [x] 5 new parallel scoring tests (concurrent execution, early exit, scoring failure fallback)
- [x] Updated existing auto-complete test assertion (`assert_not_called` → `assert_called_once`)
- [x] All 42 interview handler tests pass
- [ ] Benchmark test confirms ≥2.0x speedup