### PR TITLE
Teach the runtime engine what tools mean before it schedules them

### DIFF
--- a/src/ouroboros/claude_permissions.py
+++ b/src/ouroboros/claude_permissions.py
@@ -1,0 +1,58 @@
+"""Shared Claude Code permission policy helpers.
+
+Translation table between the engine-owned
+:class:`~ouroboros.orchestrator.policy.SandboxClass` vocabulary and the Claude
+Agent SDK's ``permission_mode`` values.  Mirrors the role of
+``codex_permissions.py`` for Claude so every provider adapter reads the same
+sandbox enum and resolves it through its own flat lookup table.  The module
+deliberately does not make policy decisions — those live in
+``orchestrator/policy.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import structlog
+
+from ouroboros.sandbox import SandboxClass
+
+log = structlog.get_logger(__name__)
+
+# Claude SDK accepts a fixed vocabulary for ``permission_mode``.  Exposed as
+# a type alias so downstream adapter code carries the narrow type rather than
+# an opaque ``str``.
+ClaudePermissionMode = Literal["default", "acceptEdits", "bypassPermissions"]
+
+# Engine SandboxClass → Claude SDK permission_mode.
+#
+# The mapping happens to be identity for the legacy mode strings because
+# Ouroboros previously adopted Claude's vocabulary as the shared lingua
+# franca.  Introducing the enum flips the ownership: the SandboxClass is
+# now authoritative and these strings are Claude-specific translations.
+_SANDBOX_TO_CLAUDE_MODE: dict[SandboxClass, ClaudePermissionMode] = {
+    SandboxClass.READ_ONLY: "default",
+    SandboxClass.WORKSPACE_WRITE: "acceptEdits",
+    SandboxClass.UNRESTRICTED: "bypassPermissions",
+}
+
+
+def claude_permission_mode_for_sandbox(sandbox: SandboxClass) -> ClaudePermissionMode:
+    """Translate an engine sandbox class into a Claude SDK permission_mode.
+
+    Raises ``KeyError`` if the enum grows and Claude's table was not updated —
+    failing loudly beats silently defaulting to a possibly-permissive mode.
+    """
+    mode = _SANDBOX_TO_CLAUDE_MODE.get(sandbox)
+    if mode is None:
+        msg = f"No Claude SDK permission_mode registered for sandbox class {sandbox!r}"
+        raise KeyError(msg)
+    if sandbox is SandboxClass.UNRESTRICTED:
+        log.warning("permissions.bypass_activated", sandbox=sandbox.value)
+    return mode
+
+
+__all__ = [
+    "ClaudePermissionMode",
+    "claude_permission_mode_for_sandbox",
+]

--- a/src/ouroboros/codex_permissions.py
+++ b/src/ouroboros/codex_permissions.py
@@ -1,8 +1,12 @@
 """Shared Codex CLI permission policy helpers.
 
-This module centralizes how Ouroboros maps internal permission modes onto the
-currently supported Codex CLI flags. Both the agent runtime and the Codex-based
-LLM adapter use the same policy so permission behavior stays predictable.
+This module is the *translation table* between the engine-owned
+:class:`~ouroboros.orchestrator.policy.SandboxClass` vocabulary and the Codex
+CLI's native ``--sandbox`` / ``--full-auto`` flags.  It deliberately does not
+make policy decisions; those live in ``orchestrator/policy.py``.  Both the
+Codex agent runtime and the Codex-based LLM adapter go through this module,
+so Codex-side behavior stays consistent and is derived from the same sandbox
+enum every other provider maps.
 """
 
 from __future__ import annotations
@@ -11,11 +15,33 @@ from typing import Literal
 
 import structlog
 
+from ouroboros.sandbox import SandboxClass
+
 log = structlog.get_logger(__name__)
 
 CodexPermissionMode = Literal["default", "acceptEdits", "bypassPermissions"]
 
 _VALID_PERMISSION_MODES = frozenset({"default", "acceptEdits", "bypassPermissions"})
+
+# Legacy permission-mode vocabulary → engine SandboxClass.  The ``default``
+# mode is read-only, ``acceptEdits`` maps to workspace-write (the Codex
+# ``--full-auto`` flag), and ``bypassPermissions`` removes both the sandbox
+# and the approval gate.  External callers that still speak the string
+# vocabulary funnel through this mapping on their way to the sandbox enum.
+_PERMISSION_MODE_TO_SANDBOX: dict[CodexPermissionMode, SandboxClass] = {
+    "default": SandboxClass.READ_ONLY,
+    "acceptEdits": SandboxClass.WORKSPACE_WRITE,
+    "bypassPermissions": SandboxClass.UNRESTRICTED,
+}
+
+# Engine SandboxClass → Codex CLI invocation flags.  This is the only place
+# Codex-specific flag names should appear for sandbox selection; new sandbox
+# classes must add an entry here or the invariant test fails.
+_SANDBOX_TO_CODEX_ARGS: dict[SandboxClass, list[str]] = {
+    SandboxClass.READ_ONLY: ["--sandbox", "read-only"],
+    SandboxClass.WORKSPACE_WRITE: ["--full-auto"],
+    SandboxClass.UNRESTRICTED: ["--dangerously-bypass-approvals-and-sandbox"],
+}
 
 
 def resolve_codex_permission_mode(
@@ -31,32 +57,50 @@ def resolve_codex_permission_mode(
     return candidate  # type: ignore[return-value]
 
 
+def build_codex_exec_args_for_sandbox(sandbox: SandboxClass) -> list[str]:
+    """Translate a sandbox class into Codex CLI exec flags.
+
+    This is the canonical entry point for new call sites.  Engine code
+    should derive a :class:`SandboxClass` from a
+    :class:`~ouroboros.orchestrator.policy.PolicyContext` and pass it here
+    directly rather than round-tripping through a permission-mode string.
+    """
+    args = _SANDBOX_TO_CODEX_ARGS.get(sandbox)
+    if args is None:
+        # Invariant: every SandboxClass must have a Codex mapping.  If the
+        # enum grows and this module was not updated, fail loudly instead
+        # of silently defaulting to a possibly-unsafe sandbox.
+        msg = f"No Codex CLI mapping registered for sandbox class {sandbox!r}"
+        raise KeyError(msg)
+    if sandbox is SandboxClass.UNRESTRICTED:
+        log.warning("permissions.bypass_activated", sandbox=sandbox.value)
+    return list(args)
+
+
 def build_codex_exec_permission_args(
     permission_mode: str | None,
     *,
     default_mode: CodexPermissionMode = "default",
 ) -> list[str]:
-    """Translate a permission mode into Codex CLI exec flags.
+    """Translate a legacy permission-mode string into Codex CLI exec flags.
+
+    Thin wrapper preserved for call sites that still hold a string; it
+    funnels through the SandboxClass enum so both call paths produce
+    byte-identical flag lists.
 
     Mapping:
-    - ``default`` -> read-only sandbox
-    - ``acceptEdits`` -> ``--full-auto`` (workspace-write + automatic execution)
-    - ``bypassPermissions`` -> no approvals, no sandbox
+    - ``default`` -> ``SandboxClass.READ_ONLY`` -> read-only sandbox
+    - ``acceptEdits`` -> ``SandboxClass.WORKSPACE_WRITE`` -> ``--full-auto``
+    - ``bypassPermissions`` -> ``SandboxClass.UNRESTRICTED`` -> no approvals,
+      no sandbox
     """
     resolved = resolve_codex_permission_mode(permission_mode, default_mode=default_mode)
-    if resolved == "default":
-        return ["--sandbox", "read-only"]
-    if resolved == "acceptEdits":
-        return ["--full-auto"]
-    log.warning(
-        "permissions.bypass_activated",
-        mode="bypassPermissions",
-    )
-    return ["--dangerously-bypass-approvals-and-sandbox"]
+    return build_codex_exec_args_for_sandbox(_PERMISSION_MODE_TO_SANDBOX[resolved])
 
 
 __all__ = [
     "CodexPermissionMode",
+    "build_codex_exec_args_for_sandbox",
     "build_codex_exec_permission_args",
     "resolve_codex_permission_mode",
 ]

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -46,6 +46,12 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
+from ouroboros.orchestrator.policy import (
+    PolicyContext,
+    PolicyExecutionPhase,
+    PolicySessionRole,
+    allowed_runtime_builtin_tool_names,
+)
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.providers import create_llm_adapter
 from ouroboros.providers.base import LLMAdapter
@@ -79,6 +85,18 @@ _INTERVIEW_COMPLETION_PHRASES = (
     "no ambiguity remains",
     "no ambiguity left",
 )
+
+
+def _interview_allowed_tools(runtime_backend: str | None) -> list[str]:
+    """Return the policy-derived read-only tool envelope for interviews."""
+    return allowed_runtime_builtin_tool_names(
+        PolicyContext(
+            runtime_backend=runtime_backend,
+            session_role=PolicySessionRole.INTERVIEW,
+            execution_phase=PolicyExecutionPhase.INTERVIEW,
+        )
+    )
+
 
 _INTERVIEW_COMPLETION_NEGATIONS = (
     "not done",
@@ -784,7 +802,7 @@ class InterviewHandler:
             backend=self.llm_backend,
             max_turns=1,
             use_case="interview",
-            allowed_tools=[],
+            allowed_tools=_interview_allowed_tools(self.llm_backend),
         )
         engine = self.interview_engine or InterviewEngine(
             llm_adapter=llm_adapter,

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -31,11 +31,28 @@ from ouroboros.observability.drift import (
     DRIFT_THRESHOLD,
     DriftMeasurement,
 )
+from ouroboros.orchestrator.policy import (
+    PolicyContext,
+    PolicyExecutionPhase,
+    PolicySessionRole,
+    allowed_runtime_builtin_tool_names,
+)
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.providers import create_llm_adapter
 
 log = structlog.get_logger(__name__)
+
+
+def _evaluation_allowed_tools(runtime_backend: str | None) -> list[str]:
+    """Return the policy-derived read-only tool envelope for evaluation."""
+    return allowed_runtime_builtin_tool_names(
+        PolicyContext(
+            runtime_backend=runtime_backend,
+            session_role=PolicySessionRole.EVALUATION,
+            execution_phase=PolicyExecutionPhase.EVALUATION,
+        )
+    )
 
 
 @dataclass
@@ -438,6 +455,7 @@ class EvaluateHandler:
             # MCP adapter is max_turns=1 (tuned for interview/seed single-shot).
             llm_adapter = create_llm_adapter(
                 backend=self.llm_backend,
+                allowed_tools=_evaluation_allowed_tools(self.llm_backend),
                 max_turns=20,
             )
             working_dir_str = arguments.get("working_dir")

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 import os
+import stat
 from pathlib import Path
 from typing import Any
 
@@ -300,15 +301,39 @@ _RAW_OVERRIDES_CACHE: dict[Path, tuple[float, dict[str, Mapping[str, Any]]]] = {
 def _read_raw_tool_capability_overrides(path: Path) -> dict[str, Mapping[str, Any]]:
     """Read and parse the override YAML, returning raw per-tool mappings.
 
-    Every failure mode — missing file, unreadable file, malformed YAML,
-    unexpected top-level shape — is handled locally.  A broken user
-    config must never propagate out of this function, because the override
-    loader sits on the default capability-graph construction path and is
+    Every failure mode — missing file, non-regular file (FIFO, socket,
+    device, directory), unreadable file, malformed YAML, unexpected
+    top-level shape — is handled locally.  A broken user config must
+    never propagate out of this function, because the override loader
+    sits on the default capability-graph construction path and is
     therefore reached from interview, evaluation, and execution sessions
-    alike.  A single malformed YAML line in ``~/.ouroboros/`` would
-    otherwise take down unrelated orchestration paths.
+    alike.  A single malformed YAML line — or a ``OUROBOROS_TOOL_CAPABILITIES``
+    variable pointing at a FIFO — would otherwise take down unrelated
+    orchestration paths or hang startup indefinitely on ``read_text()``.
     """
-    if not path.exists():
+    try:
+        stat_result = path.stat()
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        log.warning(
+            "capability_override.stat_failed",
+            path=str(path),
+            error=str(exc),
+        )
+        return {}
+
+    # Refuse to open non-regular files.  ``read_text()`` on a FIFO or
+    # character device will block indefinitely because those paths have no
+    # EOF, and on a directory will raise ``IsADirectoryError`` too late
+    # (after the caller already paid the syscall).  Stop here so the
+    # override layer cannot wedge the orchestrator hot path.
+    if not stat.S_ISREG(stat_result.st_mode):
+        log.warning(
+            "capability_override.not_regular_file",
+            path=str(path),
+            mode=oct(stat_result.st_mode),
+        )
         return {}
 
     try:
@@ -371,7 +396,7 @@ def _load_raw_tool_capability_overrides(
         return {}
 
     try:
-        mtime = config_path.stat().st_mtime
+        stat_result = config_path.stat()
     except FileNotFoundError:
         _RAW_OVERRIDES_CACHE.pop(config_path, None)
         return {}
@@ -383,6 +408,19 @@ def _load_raw_tool_capability_overrides(
         )
         return {}
 
+    # Defense in depth: ``_read_raw_tool_capability_overrides`` also checks
+    # this, but rejecting non-regular files before we even touch the cache
+    # means a FIFO path cannot poison the cache with a bogus mtime entry.
+    if not stat.S_ISREG(stat_result.st_mode):
+        _RAW_OVERRIDES_CACHE.pop(config_path, None)
+        log.warning(
+            "capability_override.not_regular_file",
+            path=str(config_path),
+            mode=oct(stat_result.st_mode),
+        )
+        return {}
+
+    mtime = stat_result.st_mtime
     cached = _RAW_OVERRIDES_CACHE.get(config_path)
     if cached is not None and cached[0] == mtime:
         return cached[1]

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -2,21 +2,24 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
-from enum import StrEnum
 import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 from ouroboros.mcp.types import MCPToolDefinition
+from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.mcp_tools import (
     SessionToolCatalog,
     SessionToolCatalogEntry,
     ToolCatalogSourceMetadata,
 )
+
+log = get_logger(__name__)
 
 
 class CapabilityMutationClass(StrEnum):
@@ -251,24 +254,38 @@ def _coerce_capability_semantics(
     raw: Mapping[str, Any],
     *,
     fallback: CapabilitySemantics | None = None,
+    context: str | None = None,
 ) -> CapabilitySemantics:
+    """Build semantics from a raw mapping, treating missing keys as fallback.
+
+    Any unrecognized enum value raises ``ValueError``; callers that want
+    lenient behavior should catch and log, not silence.
+    """
     base = fallback or _default_attached_semantics()
-    return CapabilitySemantics(
-        mutation_class=CapabilityMutationClass(
-            str(raw.get("mutation_class", base.mutation_class.value))
-        ),
-        parallel_safety=CapabilityParallelSafety(
-            str(raw.get("parallel_safety", base.parallel_safety.value))
-        ),
-        interruptibility=CapabilityInterruptibility(
-            str(raw.get("interruptibility", base.interruptibility.value))
-        ),
-        approval_class=CapabilityApprovalClass(
-            str(raw.get("approval_class", base.approval_class.value))
-        ),
-        origin=CapabilityOrigin(str(raw.get("origin", base.origin.value))),
-        scope=CapabilityScope(str(raw.get("scope", base.scope.value))),
-    )
+    try:
+        return CapabilitySemantics(
+            mutation_class=CapabilityMutationClass(
+                str(raw.get("mutation_class", base.mutation_class.value))
+            ),
+            parallel_safety=CapabilityParallelSafety(
+                str(raw.get("parallel_safety", base.parallel_safety.value))
+            ),
+            interruptibility=CapabilityInterruptibility(
+                str(raw.get("interruptibility", base.interruptibility.value))
+            ),
+            approval_class=CapabilityApprovalClass(
+                str(raw.get("approval_class", base.approval_class.value))
+            ),
+            origin=CapabilityOrigin(str(raw.get("origin", base.origin.value))),
+            scope=CapabilityScope(str(raw.get("scope", base.scope.value))),
+        )
+    except ValueError as exc:
+        log.warning(
+            "capability_override.invalid_enum",
+            context=context,
+            error=str(exc),
+        )
+        raise
 
 
 def _default_tool_capability_override_path() -> Path:
@@ -278,10 +295,74 @@ def _default_tool_capability_override_path() -> Path:
     return Path.home() / ".ouroboros" / "tool_capabilities.yaml"
 
 
+# Mapping from resolved override path to (mtime, raw overrides).  Invalidated by
+# mtime so edits to ~/.ouroboros/tool_capabilities.yaml take effect without a
+# process restart, while repeated graph builds in the same process avoid
+# re-reading and re-parsing the YAML file on every call.
+_RAW_OVERRIDES_CACHE: dict[Path, tuple[float, dict[str, Mapping[str, Any]]]] = {}
+
+
+def _read_raw_tool_capability_overrides(path: Path) -> dict[str, Mapping[str, Any]]:
+    """Read and parse the override YAML, returning raw per-tool mappings."""
+    if not path.exists():
+        return {}
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        return {}
+
+    raw_tools = raw.get("tools", raw)
+    if not isinstance(raw_tools, Mapping):
+        return {}
+
+    parsed: dict[str, Mapping[str, Any]] = {}
+    for key, value in raw_tools.items():
+        if not isinstance(key, str) or not isinstance(value, Mapping):
+            continue
+        parsed[key] = dict(value)
+    return parsed
+
+
+def _load_raw_tool_capability_overrides(
+    path: str | Path | None = None,
+) -> dict[str, Mapping[str, Any]]:
+    """Load raw override mappings with mtime-based caching."""
+    config_path = (
+        Path(path).expanduser() if path is not None else _default_tool_capability_override_path()
+    )
+    try:
+        mtime = config_path.stat().st_mtime
+    except FileNotFoundError:
+        _RAW_OVERRIDES_CACHE.pop(config_path, None)
+        return {}
+    except OSError as exc:
+        log.warning(
+            "capability_override.read_failed",
+            path=str(config_path),
+            error=str(exc),
+        )
+        return {}
+
+    cached = _RAW_OVERRIDES_CACHE.get(config_path)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    raw = _read_raw_tool_capability_overrides(config_path)
+    _RAW_OVERRIDES_CACHE[config_path] = (mtime, raw)
+    return raw
+
+
 def load_tool_capability_overrides(
     path: str | Path | None = None,
 ) -> dict[str, CapabilitySemantics]:
     """Load user-defined capability semantics overrides from YAML.
+
+    The returned mapping contains fully coerced semantics for each declared
+    tool, with missing fields filled from the default attached-semantics.
+    When integrating into :func:`build_capability_graph` the override is
+    applied *on top of inferred* semantics via
+    :func:`_apply_raw_override_to_semantics`; this function is retained for
+    external callers (tests, diagnostics) that want pre-coerced semantics.
 
     Expected format:
 
@@ -293,30 +374,36 @@ def load_tool_capability_overrides(
         interruptibility: none
         approval_class: default
     ```
+
+    Invalid enum values are logged and the affected entry skipped.
     """
-    config_path = (
-        Path(path).expanduser() if path is not None else _default_tool_capability_override_path()
-    )
-    if not config_path.exists():
-        return {}
-
-    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    if not isinstance(raw, Mapping):
-        return {}
-
-    raw_tools = raw.get("tools", raw)
-    if not isinstance(raw_tools, Mapping):
-        return {}
-
-    overrides: dict[str, CapabilitySemantics] = {}
-    for key, value in raw_tools.items():
-        if not isinstance(key, str) or not isinstance(value, Mapping):
-            continue
+    raw_overrides = _load_raw_tool_capability_overrides(path)
+    coerced: dict[str, CapabilitySemantics] = {}
+    for key, value in raw_overrides.items():
         try:
-            overrides[key] = _coerce_capability_semantics(value)
+            coerced[key] = _coerce_capability_semantics(value, context=f"tool:{key}")
         except ValueError:
             continue
-    return overrides
+    return coerced
+
+
+def _apply_raw_override_to_semantics(
+    inferred: CapabilitySemantics,
+    raw: Mapping[str, Any],
+    *,
+    context: str,
+) -> CapabilitySemantics:
+    """Merge raw override fields onto already-inferred semantics.
+
+    Unlike wholesale replacement, this preserves inferred values for any
+    dimension the user did not explicitly set in their override YAML.  When
+    the override declares an invalid enum value, the inferred semantics are
+    returned unchanged (the warning is logged).
+    """
+    try:
+        return _coerce_capability_semantics(raw, fallback=inferred, context=context)
+    except ValueError:
+        return inferred
 
 
 def _semantics_for_entry(
@@ -350,20 +437,28 @@ def _descriptor_from_tool(
     source: ToolCatalogSourceMetadata | None = None,
     *,
     stable_id: str | None = None,
-    capability_overrides: Mapping[str, CapabilitySemantics] | None = None,
+    raw_capability_overrides: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> CapabilityDescriptor:
     resolved_source = source or _fallback_source_metadata(tool)
     resolved_stable_id = stable_id or _stable_id(tool, resolved_source)
     semantics = _semantics_for_entry(tool, resolved_source)
-    if resolved_source.kind != "builtin" and capability_overrides:
-        override = _match_capability_override(
+    # Built-in tools deliberately bypass user overrides: their semantics are
+    # part of the engine contract (e.g., Bash must remain EXTERNAL_SIDE_EFFECT
+    # regardless of user YAML) so that role envelopes cannot be silently
+    # widened.  Attached and provider-native tools are reclassifiable.
+    if resolved_source.kind != "builtin" and raw_capability_overrides:
+        raw = _match_raw_capability_override(
             tool,
             resolved_source,
             resolved_stable_id,
-            capability_overrides,
+            raw_capability_overrides,
         )
-        if override is not None:
-            semantics = override
+        if raw is not None:
+            semantics = _apply_raw_override_to_semantics(
+                semantics,
+                raw,
+                context=f"tool:{resolved_stable_id}",
+            )
     return CapabilityDescriptor(
         stable_id=resolved_stable_id,
         name=tool.name,
@@ -376,12 +471,12 @@ def _descriptor_from_tool(
     )
 
 
-def _match_capability_override(
+def _match_raw_capability_override(
     tool: MCPToolDefinition,
     source: ToolCatalogSourceMetadata,
     stable_id: str,
-    capability_overrides: Mapping[str, CapabilitySemantics],
-) -> CapabilitySemantics | None:
+    raw_capability_overrides: Mapping[str, Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
     source_name = source.server_name or source.name
     candidates = (
         stable_id,
@@ -391,8 +486,8 @@ def _match_capability_override(
         tool.name,
     )
     for candidate in candidates:
-        if candidate in capability_overrides:
-            return capability_overrides[candidate]
+        if candidate in raw_capability_overrides:
+            return raw_capability_overrides[candidate]
     return None
 
 
@@ -417,12 +512,21 @@ def build_capability_graph(
     *,
     capability_overrides: Mapping[str, CapabilitySemantics] | None = None,
 ) -> CapabilityGraph:
-    """Build a deterministic capability graph from the current tool surface."""
+    """Build a deterministic capability graph from the current tool surface.
+
+    ``capability_overrides`` accepts pre-coerced semantics (wholesale
+    replacement) for backward compatibility.  When omitted, raw overrides
+    are loaded from ``~/.ouroboros/tool_capabilities.yaml`` (cached by
+    mtime) and merged *onto* the inferred semantics so callers can override
+    only the specific dimensions they care about.
+    """
     descriptors: list[CapabilityDescriptor] = []
-    resolved_overrides = (
-        capability_overrides
-        if capability_overrides is not None
-        else load_tool_capability_overrides()
+    # When explicit fully-coerced overrides are passed, we honor wholesale
+    # replacement (preserves the legacy external contract).  Otherwise we
+    # load the raw YAML once per graph build and merge per-field.
+    legacy_overrides = capability_overrides
+    raw_overrides: Mapping[str, Mapping[str, Any]] = (
+        {} if legacy_overrides is not None else _load_raw_tool_capability_overrides()
     )
 
     inherited_capabilities: frozenset[str] = frozenset()
@@ -434,26 +538,46 @@ def build_capability_graph(
 
     for entry in entries:
         if isinstance(entry, SessionToolCatalogEntry):
-            descriptors.append(
-                _descriptor_from_tool(
-                    entry.tool,
-                    entry.source,
-                    stable_id=entry.stable_id,
-                    capability_overrides=resolved_overrides,
-                )
+            descriptor = _descriptor_from_tool(
+                entry.tool,
+                entry.source,
+                stable_id=entry.stable_id,
+                raw_capability_overrides=raw_overrides,
             )
         else:
-            descriptors.append(
-                _descriptor_from_tool(
-                    entry,
-                    capability_overrides=resolved_overrides,
-                )
+            descriptor = _descriptor_from_tool(
+                entry,
+                raw_capability_overrides=raw_overrides,
             )
+        if legacy_overrides is not None and descriptor.source_kind != "builtin":
+            replacement = _match_legacy_override(descriptor, legacy_overrides)
+            if replacement is not None:
+                descriptor = replace(descriptor, semantics=replacement)
+        descriptors.append(descriptor)
 
     for capability_name in sorted(inherited_capabilities):
         descriptors.append(_descriptor_from_inherited_capability(capability_name))
 
     return CapabilityGraph(capabilities=tuple(descriptors))
+
+
+def _match_legacy_override(
+    descriptor: CapabilityDescriptor,
+    capability_overrides: Mapping[str, CapabilitySemantics],
+) -> CapabilitySemantics | None:
+    """Resolve pre-coerced legacy-style overrides against a descriptor."""
+    source_name = descriptor.server_name or descriptor.source_name
+    candidates = (
+        descriptor.stable_id,
+        f"{descriptor.source_kind}:{source_name}:{descriptor.name}",
+        f"{source_name}:{descriptor.name}",
+        descriptor.original_name,
+        descriptor.name,
+    )
+    for candidate in candidates:
+        if candidate in capability_overrides:
+            return capability_overrides[candidate]
+    return None
 
 
 def serialize_capability_graph(

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -6,8 +6,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 import os
-import stat
 from pathlib import Path
+import stat
 from typing import Any
 
 import yaml

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from enum import StrEnum
 import os
 from pathlib import Path
@@ -397,41 +397,6 @@ def _load_raw_tool_capability_overrides(
     return raw
 
 
-def load_tool_capability_overrides(
-    path: str | Path | None = None,
-) -> dict[str, CapabilitySemantics]:
-    """Load user-defined capability semantics overrides from YAML.
-
-    The returned mapping contains fully coerced semantics for each declared
-    tool, with missing fields filled from the default attached-semantics.
-    When integrating into :func:`build_capability_graph` the override is
-    applied *on top of inferred* semantics via
-    :func:`_apply_raw_override_to_semantics`; this function is retained for
-    external callers (tests, diagnostics) that want pre-coerced semantics.
-
-    Expected format:
-
-    ```yaml
-    tools:
-      chrome_navigate:
-        mutation_class: read_only
-        parallel_safety: safe
-        interruptibility: none
-        approval_class: default
-    ```
-
-    Invalid enum values are logged and the affected entry skipped.
-    """
-    raw_overrides = _load_raw_tool_capability_overrides(path)
-    coerced: dict[str, CapabilitySemantics] = {}
-    for key, value in raw_overrides.items():
-        try:
-            coerced[key] = _coerce_capability_semantics(value, context=f"tool:{key}")
-        except ValueError:
-            continue
-    return coerced
-
-
 def _apply_raw_override_to_semantics(
     inferred: CapabilitySemantics,
     raw: Mapping[str, Any],
@@ -554,25 +519,17 @@ def build_capability_graph(
     tool_catalog: SessionToolCatalog
     | Sequence[MCPToolDefinition]
     | Sequence[SessionToolCatalogEntry],
-    *,
-    capability_overrides: Mapping[str, CapabilitySemantics] | None = None,
 ) -> CapabilityGraph:
     """Build a deterministic capability graph from the current tool surface.
 
-    ``capability_overrides`` accepts pre-coerced semantics (wholesale
-    replacement) for backward compatibility.  When omitted, raw overrides
-    are loaded from ``~/.ouroboros/tool_capabilities.yaml`` (cached by
-    mtime) and merged *onto* the inferred semantics so callers can override
+    User-defined capability overrides from
+    ``~/.ouroboros/tool_capabilities.yaml`` (or the path in
+    ``OUROBOROS_TOOL_CAPABILITIES``) are loaded lazily, cached by mtime,
+    and merged *onto* the inferred semantics so callers can override
     only the specific dimensions they care about.
     """
     descriptors: list[CapabilityDescriptor] = []
-    # When explicit fully-coerced overrides are passed, we honor wholesale
-    # replacement (preserves the legacy external contract).  Otherwise we
-    # load the raw YAML once per graph build and merge per-field.
-    legacy_overrides = capability_overrides
-    raw_overrides: Mapping[str, Mapping[str, Any]] = (
-        {} if legacy_overrides is not None else _load_raw_tool_capability_overrides()
-    )
+    raw_overrides = _load_raw_tool_capability_overrides()
 
     inherited_capabilities: frozenset[str] = frozenset()
     if isinstance(tool_catalog, SessionToolCatalog):
@@ -583,46 +540,26 @@ def build_capability_graph(
 
     for entry in entries:
         if isinstance(entry, SessionToolCatalogEntry):
-            descriptor = _descriptor_from_tool(
-                entry.tool,
-                entry.source,
-                stable_id=entry.stable_id,
-                raw_capability_overrides=raw_overrides,
+            descriptors.append(
+                _descriptor_from_tool(
+                    entry.tool,
+                    entry.source,
+                    stable_id=entry.stable_id,
+                    raw_capability_overrides=raw_overrides,
+                )
             )
         else:
-            descriptor = _descriptor_from_tool(
-                entry,
-                raw_capability_overrides=raw_overrides,
+            descriptors.append(
+                _descriptor_from_tool(
+                    entry,
+                    raw_capability_overrides=raw_overrides,
+                )
             )
-        if legacy_overrides is not None and descriptor.source_kind != "builtin":
-            replacement = _match_legacy_override(descriptor, legacy_overrides)
-            if replacement is not None:
-                descriptor = replace(descriptor, semantics=replacement)
-        descriptors.append(descriptor)
 
     for capability_name in sorted(inherited_capabilities):
         descriptors.append(_descriptor_from_inherited_capability(capability_name))
 
     return CapabilityGraph(capabilities=tuple(descriptors))
-
-
-def _match_legacy_override(
-    descriptor: CapabilityDescriptor,
-    capability_overrides: Mapping[str, CapabilitySemantics],
-) -> CapabilitySemantics | None:
-    """Resolve pre-coerced legacy-style overrides against a descriptor."""
-    source_name = descriptor.server_name or descriptor.source_name
-    candidates = (
-        descriptor.stable_id,
-        f"{descriptor.source_kind}:{source_name}:{descriptor.name}",
-        f"{source_name}:{descriptor.name}",
-        descriptor.original_name,
-        descriptor.name,
-    )
-    for candidate in candidates:
-        if candidate in capability_overrides:
-            return capability_overrides[candidate]
-    return None
 
 
 def serialize_capability_graph(
@@ -711,7 +648,6 @@ __all__ = [
     "CapabilityScope",
     "CapabilitySemantics",
     "build_capability_graph",
-    "load_tool_capability_overrides",
     "normalize_serialized_capability_graph",
     "serialize_capability_graph",
 ]

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
+import os
 from pathlib import Path
 from typing import Any
 

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
+import os
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 from ouroboros.mcp.types import MCPToolDefinition
 from ouroboros.orchestrator.mcp_tools import (
@@ -178,6 +182,26 @@ _BUILTIN_SEMANTICS: dict[str, CapabilitySemantics] = {
     ),
 }
 
+_INHERITED_CAPABILITY_SEMANTICS = CapabilitySemantics(
+    mutation_class=CapabilityMutationClass.EXTERNAL_SIDE_EFFECT,
+    parallel_safety=CapabilityParallelSafety.SERIALIZED,
+    interruptibility=CapabilityInterruptibility.SOFT,
+    approval_class=CapabilityApprovalClass.ELEVATED,
+    origin=CapabilityOrigin.ATTACHED_MCP,
+    scope=CapabilityScope.ATTACHMENT,
+)
+
+
+def _default_attached_semantics() -> CapabilitySemantics:
+    return CapabilitySemantics(
+        mutation_class=CapabilityMutationClass.EXTERNAL_SIDE_EFFECT,
+        parallel_safety=CapabilityParallelSafety.SERIALIZED,
+        interruptibility=CapabilityInterruptibility.SOFT,
+        approval_class=CapabilityApprovalClass.ELEVATED,
+        origin=CapabilityOrigin.ATTACHED_MCP,
+        scope=CapabilityScope.ATTACHMENT,
+    )
+
 
 def _fallback_source_metadata(tool: MCPToolDefinition) -> ToolCatalogSourceMetadata:
     source_kind = "attached_mcp" if tool.server_name else "builtin"
@@ -223,6 +247,78 @@ def _infer_attached_semantics(tool: MCPToolDefinition) -> CapabilitySemantics:
     )
 
 
+def _coerce_capability_semantics(
+    raw: Mapping[str, Any],
+    *,
+    fallback: CapabilitySemantics | None = None,
+) -> CapabilitySemantics:
+    base = fallback or _default_attached_semantics()
+    return CapabilitySemantics(
+        mutation_class=CapabilityMutationClass(
+            str(raw.get("mutation_class", base.mutation_class.value))
+        ),
+        parallel_safety=CapabilityParallelSafety(
+            str(raw.get("parallel_safety", base.parallel_safety.value))
+        ),
+        interruptibility=CapabilityInterruptibility(
+            str(raw.get("interruptibility", base.interruptibility.value))
+        ),
+        approval_class=CapabilityApprovalClass(
+            str(raw.get("approval_class", base.approval_class.value))
+        ),
+        origin=CapabilityOrigin(str(raw.get("origin", base.origin.value))),
+        scope=CapabilityScope(str(raw.get("scope", base.scope.value))),
+    )
+
+
+def _default_tool_capability_override_path() -> Path:
+    configured = os.environ.get("OUROBOROS_TOOL_CAPABILITIES")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".ouroboros" / "tool_capabilities.yaml"
+
+
+def load_tool_capability_overrides(
+    path: str | Path | None = None,
+) -> dict[str, CapabilitySemantics]:
+    """Load user-defined capability semantics overrides from YAML.
+
+    Expected format:
+
+    ```yaml
+    tools:
+      chrome_navigate:
+        mutation_class: read_only
+        parallel_safety: safe
+        interruptibility: none
+        approval_class: default
+    ```
+    """
+    config_path = (
+        Path(path).expanduser() if path is not None else _default_tool_capability_override_path()
+    )
+    if not config_path.exists():
+        return {}
+
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        return {}
+
+    raw_tools = raw.get("tools", raw)
+    if not isinstance(raw_tools, Mapping):
+        return {}
+
+    overrides: dict[str, CapabilitySemantics] = {}
+    for key, value in raw_tools.items():
+        if not isinstance(key, str) or not isinstance(value, Mapping):
+            continue
+        try:
+            overrides[key] = _coerce_capability_semantics(value)
+        except ValueError:
+            continue
+    return overrides
+
+
 def _semantics_for_entry(
     tool: MCPToolDefinition,
     source: ToolCatalogSourceMetadata,
@@ -254,17 +350,63 @@ def _descriptor_from_tool(
     source: ToolCatalogSourceMetadata | None = None,
     *,
     stable_id: str | None = None,
+    capability_overrides: Mapping[str, CapabilitySemantics] | None = None,
 ) -> CapabilityDescriptor:
     resolved_source = source or _fallback_source_metadata(tool)
+    resolved_stable_id = stable_id or _stable_id(tool, resolved_source)
+    semantics = _semantics_for_entry(tool, resolved_source)
+    if resolved_source.kind != "builtin" and capability_overrides:
+        override = _match_capability_override(
+            tool,
+            resolved_source,
+            resolved_stable_id,
+            capability_overrides,
+        )
+        if override is not None:
+            semantics = override
     return CapabilityDescriptor(
-        stable_id=stable_id or _stable_id(tool, resolved_source),
+        stable_id=resolved_stable_id,
         name=tool.name,
         original_name=resolved_source.original_name,
         description=tool.description,
         server_name=tool.server_name,
         source_kind=resolved_source.kind,
         source_name=resolved_source.name,
-        semantics=_semantics_for_entry(tool, resolved_source),
+        semantics=semantics,
+    )
+
+
+def _match_capability_override(
+    tool: MCPToolDefinition,
+    source: ToolCatalogSourceMetadata,
+    stable_id: str,
+    capability_overrides: Mapping[str, CapabilitySemantics],
+) -> CapabilitySemantics | None:
+    source_name = source.server_name or source.name
+    candidates = (
+        stable_id,
+        f"{source.kind}:{source_name}:{tool.name}",
+        f"{source_name}:{tool.name}",
+        source.original_name,
+        tool.name,
+    )
+    for candidate in candidates:
+        if candidate in capability_overrides:
+            return capability_overrides[candidate]
+    return None
+
+
+def _descriptor_from_inherited_capability(name: str) -> CapabilityDescriptor:
+    """Represent a delegated MCP grant without making it executable."""
+    return CapabilityDescriptor(
+        stable_id=f"inherited:{name}",
+        name=name,
+        original_name=name,
+        description="Inherited delegated capability pending live MCP discovery",
+        server_name=None,
+        source_kind="inherited_capability",
+        source_name="delegated_parent",
+        semantics=_INHERITED_CAPABILITY_SEMANTICS,
     )
 
 
@@ -272,12 +414,21 @@ def build_capability_graph(
     tool_catalog: SessionToolCatalog
     | Sequence[MCPToolDefinition]
     | Sequence[SessionToolCatalogEntry],
+    *,
+    capability_overrides: Mapping[str, CapabilitySemantics] | None = None,
 ) -> CapabilityGraph:
     """Build a deterministic capability graph from the current tool surface."""
     descriptors: list[CapabilityDescriptor] = []
+    resolved_overrides = (
+        capability_overrides
+        if capability_overrides is not None
+        else load_tool_capability_overrides()
+    )
 
+    inherited_capabilities: frozenset[str] = frozenset()
     if isinstance(tool_catalog, SessionToolCatalog):
         entries = tool_catalog.entries
+        inherited_capabilities = tool_catalog.inherited_capabilities
     else:
         entries = tool_catalog
 
@@ -288,10 +439,19 @@ def build_capability_graph(
                     entry.tool,
                     entry.source,
                     stable_id=entry.stable_id,
+                    capability_overrides=resolved_overrides,
                 )
             )
         else:
-            descriptors.append(_descriptor_from_tool(entry))
+            descriptors.append(
+                _descriptor_from_tool(
+                    entry,
+                    capability_overrides=resolved_overrides,
+                )
+            )
+
+    for capability_name in sorted(inherited_capabilities):
+        descriptors.append(_descriptor_from_inherited_capability(capability_name))
 
     return CapabilityGraph(capabilities=tuple(descriptors))
 
@@ -382,6 +542,7 @@ __all__ = [
     "CapabilityScope",
     "CapabilitySemantics",
     "build_capability_graph",
+    "load_tool_capability_overrides",
     "normalize_serialized_capability_graph",
     "serialize_capability_graph",
 ]

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -303,11 +303,39 @@ _RAW_OVERRIDES_CACHE: dict[Path, tuple[float, dict[str, Mapping[str, Any]]]] = {
 
 
 def _read_raw_tool_capability_overrides(path: Path) -> dict[str, Mapping[str, Any]]:
-    """Read and parse the override YAML, returning raw per-tool mappings."""
+    """Read and parse the override YAML, returning raw per-tool mappings.
+
+    Every failure mode — missing file, unreadable file, malformed YAML,
+    unexpected top-level shape — is handled locally.  A broken user
+    config must never propagate out of this function, because the override
+    loader sits on the default capability-graph construction path and is
+    therefore reached from interview, evaluation, and execution sessions
+    alike.  A single malformed YAML line in ``~/.ouroboros/`` would
+    otherwise take down unrelated orchestration paths.
+    """
     if not path.exists():
         return {}
 
-    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning(
+            "capability_override.read_failed",
+            path=str(path),
+            error=str(exc),
+        )
+        return {}
+
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        log.warning(
+            "capability_override.yaml_parse_failed",
+            path=str(path),
+            error=str(exc),
+        )
+        return {}
+
     if not isinstance(raw, Mapping):
         return {}
 
@@ -326,10 +354,27 @@ def _read_raw_tool_capability_overrides(path: Path) -> dict[str, Mapping[str, An
 def _load_raw_tool_capability_overrides(
     path: str | Path | None = None,
 ) -> dict[str, Mapping[str, Any]]:
-    """Load raw override mappings with mtime-based caching."""
-    config_path = (
-        Path(path).expanduser() if path is not None else _default_tool_capability_override_path()
-    )
+    """Load raw override mappings with mtime-based caching.
+
+    Fault-tolerant by design: any failure (missing file, permission error,
+    non-regular path, filesystem glitch) returns an empty mapping so that
+    downstream graph construction always succeeds.  The override layer is
+    an optional enhancement, not a prerequisite for orchestration.
+    """
+    try:
+        config_path = (
+            Path(path).expanduser()
+            if path is not None
+            else _default_tool_capability_override_path()
+        )
+    except (OSError, ValueError) as exc:
+        log.warning(
+            "capability_override.path_resolution_failed",
+            path=str(path),
+            error=str(exc),
+        )
+        return {}
+
     try:
         mtime = config_path.stat().st_mtime
     except FileNotFoundError:

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -185,7 +185,11 @@ _BUILTIN_SEMANTICS: dict[str, CapabilitySemantics] = {
     ),
 }
 
-_INHERITED_CAPABILITY_SEMANTICS = CapabilitySemantics(
+# Pessimistic default classification for any capability whose real semantics
+# cannot yet be inferred (inherited delegations, unmapped attached MCP tools).
+# Intentionally EXTERNAL_SIDE_EFFECT + SERIALIZED + ELEVATED so an unknown
+# tool never quietly widens a role envelope.
+_DEFAULT_ATTACHED_SEMANTICS = CapabilitySemantics(
     mutation_class=CapabilityMutationClass.EXTERNAL_SIDE_EFFECT,
     parallel_safety=CapabilityParallelSafety.SERIALIZED,
     interruptibility=CapabilityInterruptibility.SOFT,
@@ -193,17 +197,6 @@ _INHERITED_CAPABILITY_SEMANTICS = CapabilitySemantics(
     origin=CapabilityOrigin.ATTACHED_MCP,
     scope=CapabilityScope.ATTACHMENT,
 )
-
-
-def _default_attached_semantics() -> CapabilitySemantics:
-    return CapabilitySemantics(
-        mutation_class=CapabilityMutationClass.EXTERNAL_SIDE_EFFECT,
-        parallel_safety=CapabilityParallelSafety.SERIALIZED,
-        interruptibility=CapabilityInterruptibility.SOFT,
-        approval_class=CapabilityApprovalClass.ELEVATED,
-        origin=CapabilityOrigin.ATTACHED_MCP,
-        scope=CapabilityScope.ATTACHMENT,
-    )
 
 
 def _fallback_source_metadata(tool: MCPToolDefinition) -> ToolCatalogSourceMetadata:
@@ -253,31 +246,33 @@ def _infer_attached_semantics(tool: MCPToolDefinition) -> CapabilitySemantics:
 def _coerce_capability_semantics(
     raw: Mapping[str, Any],
     *,
-    fallback: CapabilitySemantics | None = None,
-    context: str | None = None,
-) -> CapabilitySemantics:
-    """Build semantics from a raw mapping, treating missing keys as fallback.
+    fallback: CapabilitySemantics,
+    context: str,
+) -> CapabilitySemantics | None:
+    """Merge a raw override mapping onto ``fallback``.
 
-    Any unrecognized enum value raises ``ValueError``; callers that want
-    lenient behavior should catch and log, not silence.
+    Returns ``None`` — and logs a structured warning — when the raw
+    mapping contains an unrecognized enum value.  The caller decides
+    what to do on failure (use fallback, skip the tool, etc.); this
+    function does not raise, so callers do not need to re-wrap it in
+    try/except just to preserve their own control flow.
     """
-    base = fallback or _default_attached_semantics()
     try:
         return CapabilitySemantics(
             mutation_class=CapabilityMutationClass(
-                str(raw.get("mutation_class", base.mutation_class.value))
+                str(raw.get("mutation_class", fallback.mutation_class.value))
             ),
             parallel_safety=CapabilityParallelSafety(
-                str(raw.get("parallel_safety", base.parallel_safety.value))
+                str(raw.get("parallel_safety", fallback.parallel_safety.value))
             ),
             interruptibility=CapabilityInterruptibility(
-                str(raw.get("interruptibility", base.interruptibility.value))
+                str(raw.get("interruptibility", fallback.interruptibility.value))
             ),
             approval_class=CapabilityApprovalClass(
-                str(raw.get("approval_class", base.approval_class.value))
+                str(raw.get("approval_class", fallback.approval_class.value))
             ),
-            origin=CapabilityOrigin(str(raw.get("origin", base.origin.value))),
-            scope=CapabilityScope(str(raw.get("scope", base.scope.value))),
+            origin=CapabilityOrigin(str(raw.get("origin", fallback.origin.value))),
+            scope=CapabilityScope(str(raw.get("scope", fallback.scope.value))),
         )
     except ValueError as exc:
         log.warning(
@@ -285,7 +280,7 @@ def _coerce_capability_semantics(
             context=context,
             error=str(exc),
         )
-        raise
+        return None
 
 
 def _default_tool_capability_override_path() -> Path:
@@ -405,15 +400,13 @@ def _apply_raw_override_to_semantics(
 ) -> CapabilitySemantics:
     """Merge raw override fields onto already-inferred semantics.
 
-    Unlike wholesale replacement, this preserves inferred values for any
-    dimension the user did not explicitly set in their override YAML.  When
-    the override declares an invalid enum value, the inferred semantics are
-    returned unchanged (the warning is logged).
+    Preserves inferred values for any dimension the user did not
+    explicitly set in their override YAML.  Returns inferred unchanged
+    when the override declares an invalid enum value (the warning is
+    logged by ``_coerce_capability_semantics``).
     """
-    try:
-        return _coerce_capability_semantics(raw, fallback=inferred, context=context)
-    except ValueError:
-        return inferred
+    merged = _coerce_capability_semantics(raw, fallback=inferred, context=context)
+    return merged if merged is not None else inferred
 
 
 def _semantics_for_entry(
@@ -511,7 +504,7 @@ def _descriptor_from_inherited_capability(name: str) -> CapabilityDescriptor:
         server_name=None,
         source_kind="inherited_capability",
         source_name="delegated_parent",
-        semantics=_INHERITED_CAPABILITY_SEMANTICS,
+        semantics=_DEFAULT_ATTACHED_SEMANTICS,
     )
 
 

--- a/src/ouroboros/orchestrator/events.py
+++ b/src/ouroboros/orchestrator/events.py
@@ -359,31 +359,6 @@ def create_mcp_tools_loaded_event(
     )
 
 
-def create_policy_capability_evaluated_event(
-    session_id: str,
-    descriptor: CapabilityDescriptor,
-    decision: PolicyDecision,
-    context: PolicyContext,
-) -> BaseEvent:
-    """Create a persisted audit event for one capability-policy decision."""
-    payload = _serialize_policy_capability_evaluation(descriptor, decision)
-    return BaseEvent(
-        type="policy.capability.evaluated",
-        aggregate_type="session",
-        aggregate_id=session_id,
-        data={
-            "capability": payload["capability"],
-            "decision": payload["decision"],
-            "context": {
-                "runtime_backend": context.runtime_backend,
-                "session_role": context.session_role.value,
-                "execution_phase": context.execution_phase.value,
-            },
-            "evaluated_at": datetime.now(UTC).isoformat(),
-        },
-    )
-
-
 def _serialize_policy_capability_evaluation(
     descriptor: CapabilityDescriptor,
     decision: PolicyDecision,
@@ -671,9 +646,8 @@ __all__ = [
     "create_drift_measured_event",
     "create_execution_terminal_event",
     "create_heartbeat_event",
-    "create_policy_capabilities_evaluated_event",
     "create_mcp_tools_loaded_event",
-    "create_policy_capability_evaluated_event",
+    "create_policy_capabilities_evaluated_event",
     "create_progress_event",
     "create_session_cancelled_event",
     "create_session_completed_event",

--- a/src/ouroboros/orchestrator/events.py
+++ b/src/ouroboros/orchestrator/events.py
@@ -21,6 +21,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.capabilities import CapabilityDescriptor, CapabilityGraph
+from ouroboros.orchestrator.policy import PolicyContext, PolicyDecision
 
 
 def create_session_started_event(
@@ -357,6 +359,87 @@ def create_mcp_tools_loaded_event(
     )
 
 
+def create_policy_capability_evaluated_event(
+    session_id: str,
+    descriptor: CapabilityDescriptor,
+    decision: PolicyDecision,
+    context: PolicyContext,
+) -> BaseEvent:
+    """Create a persisted audit event for one capability-policy decision."""
+    payload = _serialize_policy_capability_evaluation(descriptor, decision)
+    return BaseEvent(
+        type="policy.capability.evaluated",
+        aggregate_type="session",
+        aggregate_id=session_id,
+        data={
+            "capability": payload["capability"],
+            "decision": payload["decision"],
+            "context": {
+                "runtime_backend": context.runtime_backend,
+                "session_role": context.session_role.value,
+                "execution_phase": context.execution_phase.value,
+            },
+            "evaluated_at": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+def _serialize_policy_capability_evaluation(
+    descriptor: CapabilityDescriptor,
+    decision: PolicyDecision,
+) -> dict[str, Any]:
+    """Serialize one capability-policy decision for audit events."""
+    return {
+        "capability": {
+            "stable_id": descriptor.stable_id,
+            "name": descriptor.name,
+            "source_kind": descriptor.source_kind,
+            "source_name": descriptor.source_name,
+            "origin": descriptor.semantics.origin.value,
+            "scope": descriptor.semantics.scope.value,
+            "mutation_class": descriptor.semantics.mutation_class.value,
+            "parallel_safety": descriptor.semantics.parallel_safety.value,
+            "approval_class": descriptor.semantics.approval_class.value,
+        },
+        "decision": {
+            "visible": decision.visible,
+            "executable": decision.executable,
+            "approval_class": decision.approval_class.value,
+            "reasons": list(decision.reasons),
+        },
+    }
+
+
+def create_policy_capabilities_evaluated_event(
+    session_id: str,
+    graph: CapabilityGraph,
+    decisions: tuple[PolicyDecision, ...],
+    context: PolicyContext,
+) -> BaseEvent:
+    """Create one batched audit event for all capability-policy decisions."""
+    decisions_by_id = {decision.stable_id: decision for decision in decisions}
+    evaluations = [
+        _serialize_policy_capability_evaluation(descriptor, decision)
+        for descriptor in graph.capabilities
+        if (decision := decisions_by_id.get(descriptor.stable_id)) is not None
+    ]
+    return BaseEvent(
+        type="policy.capabilities.evaluated",
+        aggregate_type="session",
+        aggregate_id=session_id,
+        data={
+            "evaluations": evaluations,
+            "capability_count": len(evaluations),
+            "context": {
+                "runtime_backend": context.runtime_backend,
+                "session_role": context.session_role.value,
+                "execution_phase": context.execution_phase.value,
+            },
+            "evaluated_at": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
 def create_workflow_progress_event(
     execution_id: str,
     session_id: str,
@@ -588,7 +671,9 @@ __all__ = [
     "create_drift_measured_event",
     "create_execution_terminal_event",
     "create_heartbeat_event",
+    "create_policy_capabilities_evaluated_event",
     "create_mcp_tools_loaded_event",
+    "create_policy_capability_evaluated_event",
     "create_progress_event",
     "create_session_cancelled_event",
     "create_session_completed_event",

--- a/src/ouroboros/orchestrator/events.py
+++ b/src/ouroboros/orchestrator/events.py
@@ -13,6 +13,8 @@ Event Types:
     - orchestrator.task.started: Individual task started
     - orchestrator.task.completed: Individual task completed
     - orchestrator.tool.called: Tool was invoked by agent
+    - orchestrator.policy.capabilities.evaluated: Batched per-capability
+      policy decisions for a session-scoped policy evaluation
 """
 
 from __future__ import annotations
@@ -399,7 +401,7 @@ def create_policy_capabilities_evaluated_event(
         if (decision := decisions_by_id.get(descriptor.stable_id)) is not None
     ]
     return BaseEvent(
-        type="policy.capabilities.evaluated",
+        type="orchestrator.policy.capabilities.evaluated",
         aggregate_type="session",
         aggregate_id=session_id,
         data={

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -52,8 +52,6 @@ from ouroboros.orchestrator.capabilities import (
     serialize_capability_graph,
 )
 from ouroboros.orchestrator.control_plane import (
-    ControlPlaneExecutionMode,
-    ControlPlaneState,
     build_control_plane_state,
     serialize_control_plane_state,
 )
@@ -1395,39 +1393,6 @@ class ParallelACExecutor:
                 ordered_indices.append(ac_index)
         return tuple(ordered_indices)
 
-    def _build_tool_control_plane(
-        self,
-        tool_catalog: tuple[MCPToolDefinition, ...] | None,
-    ) -> ControlPlaneState | None:
-        """Build control-plane hints for the current executable tool surface."""
-        if not tool_catalog:
-            return None
-        capability_graph = build_capability_graph(tool_catalog)
-        policy_context = PolicyContext(
-            runtime_backend=self._adapter.runtime_backend,
-            session_role=PolicySessionRole.IMPLEMENTATION,
-            execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
-        )
-        decisions = evaluate_capability_policy(capability_graph, policy_context)
-        return build_control_plane_state(capability_graph, decisions)
-
-    def _control_plane_requires_serial_batch(
-        self,
-        tool_catalog: tuple[MCPToolDefinition, ...] | None,
-    ) -> bool:
-        """Return True when hints require single-AC batch execution."""
-        control_plane = self._build_tool_control_plane(tool_catalog)
-        if control_plane is None:
-            return False
-        blocking_modes = {
-            ControlPlaneExecutionMode.SERIALIZED,
-            ControlPlaneExecutionMode.ISOLATED,
-        }
-        return any(
-            hint.visible and hint.executable and hint.execution_mode in blocking_modes
-            for hint in control_plane.hints
-        )
-
     async def _execute_ac_batch(
         self,
         *,
@@ -1474,17 +1439,12 @@ class ParallelACExecutor:
                         raise
                     batch_results[idx] = e
 
-        if len(batch_indices) > 1 and self._control_plane_requires_serial_batch(tool_catalog):
-            log.info(
-                "parallel_executor.control_plane.serializing_batch",
-                session_id=session_id,
-                execution_id=execution_id,
-                batch_indices=batch_indices,
-            )
-            for idx, ac_idx in enumerate(batch_indices):
-                await _run_ac(idx, ac_idx)
-            return batch_results
-
+        # Cross-AC concurrency is governed by the LevelCoordinator's
+        # file-conflict guard, not by session-level tool catalog presence.
+        # Tool-call-level serialization (same runtime session cannot invoke
+        # ISOLATED_SESSION_REQUIRED capabilities concurrently) is enforced by
+        # the provider runtime, which is the correct layer: the batch
+        # scheduler does not know which ACs will actually invoke which tools.
         async with anyio.create_task_group() as tg:
             for idx, ac_idx in enumerate(batch_indices):
                 tg.start_soon(_run_ac, idx, ac_idx)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -52,6 +52,8 @@ from ouroboros.orchestrator.capabilities import (
     serialize_capability_graph,
 )
 from ouroboros.orchestrator.control_plane import (
+    ControlPlaneExecutionMode,
+    ControlPlaneState,
     build_control_plane_state,
     serialize_control_plane_state,
 )
@@ -1393,6 +1395,39 @@ class ParallelACExecutor:
                 ordered_indices.append(ac_index)
         return tuple(ordered_indices)
 
+    def _build_tool_control_plane(
+        self,
+        tool_catalog: tuple[MCPToolDefinition, ...] | None,
+    ) -> ControlPlaneState | None:
+        """Build control-plane hints for the current executable tool surface."""
+        if not tool_catalog:
+            return None
+        capability_graph = build_capability_graph(tool_catalog)
+        policy_context = PolicyContext(
+            runtime_backend=self._adapter.runtime_backend,
+            session_role=PolicySessionRole.IMPLEMENTATION,
+            execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
+        )
+        decisions = evaluate_capability_policy(capability_graph, policy_context)
+        return build_control_plane_state(capability_graph, decisions)
+
+    def _control_plane_requires_serial_batch(
+        self,
+        tool_catalog: tuple[MCPToolDefinition, ...] | None,
+    ) -> bool:
+        """Return True when hints require single-AC batch execution."""
+        control_plane = self._build_tool_control_plane(tool_catalog)
+        if control_plane is None:
+            return False
+        blocking_modes = {
+            ControlPlaneExecutionMode.SERIALIZED,
+            ControlPlaneExecutionMode.ISOLATED,
+        }
+        return any(
+            hint.visible and hint.executable and hint.execution_mode in blocking_modes
+            for hint in control_plane.hints
+        )
+
     async def _execute_ac_batch(
         self,
         *,
@@ -1438,6 +1473,17 @@ class ParallelACExecutor:
                     if isinstance(e, anyio.get_cancelled_exc_class()):
                         raise
                     batch_results[idx] = e
+
+        if len(batch_indices) > 1 and self._control_plane_requires_serial_batch(tool_catalog):
+            log.info(
+                "parallel_executor.control_plane.serializing_batch",
+                session_id=session_id,
+                execution_id=execution_id,
+                batch_indices=batch_indices,
+            )
+            for idx, ac_idx in enumerate(batch_indices):
+                await _run_ac(idx, ac_idx)
+            return batch_results
 
         async with anyio.create_task_group() as tg:
             for idx, ac_idx in enumerate(batch_indices):

--- a/src/ouroboros/orchestrator/policy.py
+++ b/src/ouroboros/orchestrator/policy.py
@@ -18,6 +18,7 @@ from ouroboros.orchestrator.mcp_tools import (
     assemble_session_tool_catalog,
     enumerate_runtime_builtin_tool_definitions,
 )
+from ouroboros.sandbox import SandboxClass
 
 
 class PolicySessionRole(StrEnum):
@@ -36,6 +37,12 @@ class PolicyExecutionPhase(StrEnum):
     COORDINATOR_REVIEW = "coordinator_review"
     INTERVIEW = "interview"
     EVALUATION = "evaluation"
+
+
+# ``SandboxClass`` lives in :mod:`ouroboros.sandbox` so provider-side
+# translation tables (``codex_permissions``, ``claude_permissions``) can
+# import it without pulling the orchestrator package's init chain.  We
+# re-export it here so engine callers keep a single import surface.
 
 
 @dataclass(frozen=True, slots=True)
@@ -235,13 +242,39 @@ def allowed_runtime_builtin_tool_names(
     return allowed_capability_names(graph, context)
 
 
+# Session role → backend-neutral sandbox class.
+#
+# Engine-owned: every admitted session role maps to exactly one sandbox class,
+# so the "how much can this role touch the host" question is answered in one
+# place and then translated (not re-decided) by each provider adapter.
+_ROLE_SANDBOX_CLASS: dict[PolicySessionRole, SandboxClass] = {
+    PolicySessionRole.INTERVIEW: SandboxClass.READ_ONLY,
+    PolicySessionRole.EVALUATION: SandboxClass.READ_ONLY,
+    PolicySessionRole.COORDINATOR: SandboxClass.WORKSPACE_WRITE,
+    PolicySessionRole.IMPLEMENTATION: SandboxClass.UNRESTRICTED,
+}
+
+
+def derive_sandbox_class(context: PolicyContext) -> SandboxClass:
+    """Return the backend-neutral sandbox class implied by a policy context.
+
+    This is the engine's authoritative answer to "what sandbox level does
+    this session deserve?".  Provider adapters must translate the returned
+    enum to their runtime-specific shape via a lookup table; they must not
+    recompute the decision from free-form permission strings.
+    """
+    return _ROLE_SANDBOX_CLASS[context.session_role]
+
+
 __all__ = [
     "PolicyContext",
     "PolicyDecision",
     "PolicyExecutionPhase",
     "PolicySessionRole",
     "RoleCapabilityProfile",
+    "SandboxClass",
     "allowed_capability_names",
     "allowed_runtime_builtin_tool_names",
+    "derive_sandbox_class",
     "evaluate_capability_policy",
 ]

--- a/src/ouroboros/orchestrator/policy.py
+++ b/src/ouroboros/orchestrator/policy.py
@@ -234,9 +234,17 @@ def allowed_runtime_builtin_tool_names(
     *,
     builtin_tools: tuple[str, ...] | None = None,
 ) -> list[str]:
-    """Return executable built-in runtime tools for a policy context."""
-    tool_names = builtin_tools or tuple(
-        definition.name for definition in enumerate_runtime_builtin_tool_definitions()
+    """Return executable built-in runtime tools for a policy context.
+
+    ``builtin_tools=None`` falls back to the runtime's full builtin set.
+    An explicit empty tuple is respected and means "this backend exposes
+    no runtime builtins" — not "re-use the default", which would silently
+    widen the envelope for backends that legitimately have none.
+    """
+    tool_names = (
+        builtin_tools
+        if builtin_tools is not None
+        else tuple(definition.name for definition in enumerate_runtime_builtin_tool_definitions())
     )
     graph = build_capability_graph(assemble_session_tool_catalog(tool_names))
     return allowed_capability_names(graph, context)

--- a/src/ouroboros/orchestrator/policy.py
+++ b/src/ouroboros/orchestrator/policy.py
@@ -77,7 +77,6 @@ class RoleCapabilityProfile:
     preferred_tool_names: tuple[str, ...] = ()
     allowed_origins: tuple[CapabilityOrigin, ...] = ()
     allowed_scopes: tuple[CapabilityScope, ...] = ()
-    allowed_stable_id_prefixes: tuple[str, ...] = ()
     allow_destructive: bool = False
 
 
@@ -136,15 +135,12 @@ def _matches_role_selector(
 ) -> bool:
     """Does ``descriptor`` satisfy the profile's admission selectors?
 
-    Selectors are combined as OR of three independent clauses, by
-    design:
+    Selectors are combined as OR of two independent clauses, by design:
 
     1. ``preferred_tool_names`` — explicit name allowlist for the
        baseline built-in envelope (e.g., ``Read`` always admitted for
        INTERVIEW even though its origin is BUILTIN, not PROVIDER_NATIVE).
-    2. ``allowed_stable_id_prefixes`` — namespaced admit rule for whole
-       provider/attachment families.
-    3. ``allowed_origins`` AND ``allowed_scopes`` — semantic-class
+    2. ``allowed_origins`` AND ``allowed_scopes`` — semantic-class
        admission, used by read-only roles to accept provider-native
        capabilities without enumerating every tool name.
 
@@ -154,20 +150,10 @@ def _matches_role_selector(
     origin/scope, remove the name from ``preferred_tool_names`` and
     rely on the semantic clause instead.
     """
-    if not (
-        profile.preferred_tool_names
-        or profile.allowed_origins
-        or profile.allowed_scopes
-        or profile.allowed_stable_id_prefixes
-    ):
+    if not (profile.preferred_tool_names or profile.allowed_origins or profile.allowed_scopes):
         return True
 
     if descriptor.name in profile.preferred_tool_names:
-        return True
-
-    if any(
-        descriptor.stable_id.startswith(prefix) for prefix in profile.allowed_stable_id_prefixes
-    ):
         return True
 
     origin_matches = (

--- a/src/ouroboros/orchestrator/policy.py
+++ b/src/ouroboros/orchestrator/policy.py
@@ -10,6 +10,13 @@ from ouroboros.orchestrator.capabilities import (
     CapabilityDescriptor,
     CapabilityGraph,
     CapabilityMutationClass,
+    CapabilityOrigin,
+    CapabilityScope,
+    build_capability_graph,
+)
+from ouroboros.orchestrator.mcp_tools import (
+    assemble_session_tool_catalog,
+    enumerate_runtime_builtin_tool_definitions,
 )
 
 
@@ -58,6 +65,9 @@ class RoleCapabilityProfile:
 
     max_mutation_class: CapabilityMutationClass
     preferred_tool_names: tuple[str, ...] = ()
+    allowed_origins: tuple[CapabilityOrigin, ...] = ()
+    allowed_scopes: tuple[CapabilityScope, ...] = ()
+    allowed_stable_id_prefixes: tuple[str, ...] = ()
     allow_destructive: bool = False
 
 
@@ -76,16 +86,28 @@ _ROLE_PROFILES = {
     PolicySessionRole.COORDINATOR: RoleCapabilityProfile(
         max_mutation_class=CapabilityMutationClass.EXTERNAL_SIDE_EFFECT,
         preferred_tool_names=("Read", "Bash", "Edit", "Grep", "Glob"),
+        allowed_origins=(CapabilityOrigin.PROVIDER_NATIVE, CapabilityOrigin.FUTURE_RUNTIME),
+        allowed_scopes=(
+            CapabilityScope.KERNEL,
+            CapabilityScope.SIDECAR,
+            CapabilityScope.SHELL_ONLY,
+        ),
     ),
     PolicySessionRole.INTERVIEW: RoleCapabilityProfile(
         max_mutation_class=CapabilityMutationClass.READ_ONLY,
         preferred_tool_names=("Read", "Grep", "Glob", "WebFetch", "WebSearch"),
+        allowed_origins=(CapabilityOrigin.PROVIDER_NATIVE, CapabilityOrigin.FUTURE_RUNTIME),
+        allowed_scopes=(CapabilityScope.KERNEL, CapabilityScope.SIDECAR),
     ),
     PolicySessionRole.EVALUATION: RoleCapabilityProfile(
         max_mutation_class=CapabilityMutationClass.READ_ONLY,
         preferred_tool_names=("Read", "Grep", "Glob", "WebFetch", "WebSearch"),
+        allowed_origins=(CapabilityOrigin.PROVIDER_NATIVE, CapabilityOrigin.FUTURE_RUNTIME),
+        allowed_scopes=(CapabilityScope.KERNEL, CapabilityScope.SIDECAR),
     ),
 }
+
+_NON_EXECUTABLE_SOURCE_KINDS = frozenset({"inherited_capability"})
 
 
 def _is_mutation_allowed(
@@ -96,6 +118,35 @@ def _is_mutation_allowed(
     if descriptor.semantics.mutation_class is CapabilityMutationClass.DESTRUCTIVE:
         return profile.allow_destructive
     return mutation_rank <= _MUTATION_CLASS_ORDER[profile.max_mutation_class]
+
+
+def _matches_role_selector(
+    descriptor: CapabilityDescriptor,
+    profile: RoleCapabilityProfile,
+) -> bool:
+    if not (
+        profile.preferred_tool_names
+        or profile.allowed_origins
+        or profile.allowed_scopes
+        or profile.allowed_stable_id_prefixes
+    ):
+        return True
+
+    if descriptor.name in profile.preferred_tool_names:
+        return True
+
+    if any(
+        descriptor.stable_id.startswith(prefix) for prefix in profile.allowed_stable_id_prefixes
+    ):
+        return True
+
+    origin_matches = (
+        not profile.allowed_origins or descriptor.semantics.origin in profile.allowed_origins
+    )
+    scope_matches = (
+        not profile.allowed_scopes or descriptor.semantics.scope in profile.allowed_scopes
+    )
+    return origin_matches and scope_matches
 
 
 def evaluate_capability_policy(
@@ -111,17 +162,22 @@ def evaluate_capability_policy(
         visible = _is_mutation_allowed(descriptor, profile)
         executable = visible
 
-        if visible and profile.preferred_tool_names:
-            if descriptor.name not in profile.preferred_tool_names:
-                visible = False
-                executable = False
-                reasons.append(
-                    f"{context.session_role.value} profile does not include {descriptor.name}"
-                )
+        if visible and not _matches_role_selector(descriptor, profile):
+            visible = False
+            executable = False
+            reasons.append(
+                f"{context.session_role.value} profile does not include {descriptor.name}"
+            )
         elif not visible:
             reasons.append(
                 f"mutation_class {descriptor.semantics.mutation_class.value} exceeds "
                 f"{context.session_role.value} policy"
+            )
+
+        if descriptor.source_kind in _NON_EXECUTABLE_SOURCE_KINDS:
+            executable = False
+            reasons.append(
+                f"{descriptor.source_kind} requires live provider discovery before execution"
             )
 
         decisions.append(
@@ -150,6 +206,19 @@ def allowed_capability_names(
     ]
 
 
+def allowed_runtime_builtin_tool_names(
+    context: PolicyContext,
+    *,
+    builtin_tools: tuple[str, ...] | None = None,
+) -> list[str]:
+    """Return executable built-in runtime tools for a policy context."""
+    tool_names = builtin_tools or tuple(
+        definition.name for definition in enumerate_runtime_builtin_tool_definitions()
+    )
+    graph = build_capability_graph(assemble_session_tool_catalog(tool_names))
+    return allowed_capability_names(graph, context)
+
+
 __all__ = [
     "PolicyContext",
     "PolicyDecision",
@@ -157,5 +226,6 @@ __all__ = [
     "PolicySessionRole",
     "RoleCapabilityProfile",
     "allowed_capability_names",
+    "allowed_runtime_builtin_tool_names",
     "evaluate_capability_policy",
 ]

--- a/src/ouroboros/orchestrator/policy.py
+++ b/src/ouroboros/orchestrator/policy.py
@@ -40,7 +40,17 @@ class PolicyExecutionPhase(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class PolicyContext:
-    """Inputs for engine capability-policy evaluation."""
+    """Inputs for engine capability-policy evaluation.
+
+    Only ``session_role`` drives the decision today; ``runtime_backend``
+    and ``execution_phase`` are persisted in the
+    ``policy.capabilities.evaluated`` audit event so replay and
+    debugging can attribute a decision to a specific backend/phase.
+    These fields exist as forward-compatibility hooks for
+    provider-specific or phase-specific policy branching; they are
+    deliberately part of the contract now so downstream consumers do
+    not have to migrate schemas when that branching lands.
+    """
 
     runtime_backend: str | None
     session_role: PolicySessionRole
@@ -124,6 +134,26 @@ def _matches_role_selector(
     descriptor: CapabilityDescriptor,
     profile: RoleCapabilityProfile,
 ) -> bool:
+    """Does ``descriptor`` satisfy the profile's admission selectors?
+
+    Selectors are combined as OR of three independent clauses, by
+    design:
+
+    1. ``preferred_tool_names`` — explicit name allowlist for the
+       baseline built-in envelope (e.g., ``Read`` always admitted for
+       INTERVIEW even though its origin is BUILTIN, not PROVIDER_NATIVE).
+    2. ``allowed_stable_id_prefixes`` — namespaced admit rule for whole
+       provider/attachment families.
+    3. ``allowed_origins`` AND ``allowed_scopes`` — semantic-class
+       admission, used by read-only roles to accept provider-native
+       capabilities without enumerating every tool name.
+
+    The OR is intentional: an explicit name whitelist is a stronger
+    signal of "this is definitely in the envelope" than origin/scope
+    alignment.  If you want to restrict a named tool to a specific
+    origin/scope, remove the name from ``preferred_tool_names`` and
+    rely on the semantic clause instead.
+    """
     if not (
         profile.preferred_tool_names
         or profile.allowed_origins

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -519,7 +519,7 @@ class OrchestratorRunner:
         ]
         return allowed_tools, capability_graph, policy_decisions, policy_context
 
-    async def _emit_policy_capability_evaluated_events(
+    async def _emit_policy_capabilities_evaluated_event(
         self,
         session_id: str,
         capability_graph: CapabilityGraph,
@@ -1164,7 +1164,7 @@ class OrchestratorRunner:
         ) = self._evaluate_tool_catalog_policy(session_catalog)
 
         if self._mcp_manager is None:
-            await self._emit_policy_capability_evaluated_events(
+            await self._emit_policy_capabilities_evaluated_event(
                 session_id,
                 capability_graph,
                 policy_decisions,
@@ -1173,7 +1173,7 @@ class OrchestratorRunner:
             return merged_tools, None, session_catalog
 
         async def _emit_current_policy_decisions() -> None:
-            await self._emit_policy_capability_evaluated_events(
+            await self._emit_policy_capabilities_evaluated_event(
                 session_id,
                 capability_graph,
                 policy_decisions,
@@ -1220,7 +1220,7 @@ class OrchestratorRunner:
             policy_decisions,
             policy_context,
         ) = self._evaluate_tool_catalog_policy(session_catalog)
-        await self._emit_policy_capability_evaluated_events(
+        await self._emit_policy_capabilities_evaluated_event(
             session_id,
             capability_graph,
             policy_decisions,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -545,15 +545,31 @@ class OrchestratorRunner:
         policy_decisions: tuple[PolicyDecision, ...],
         policy_context: PolicyContext,
     ) -> None:
-        """Persist capability policy decisions for audit/debuggability."""
-        await self._event_store.append(
-            create_policy_capabilities_evaluated_event(
-                session_id=session_id,
-                graph=capability_graph,
-                decisions=policy_decisions,
-                context=policy_context,
+        """Persist capability policy decisions for audit/debuggability.
+
+        Best-effort: the audit record is auxiliary to the orchestration
+        path, not a prerequisite for it.  An event-store failure here
+        must never take down interview/evaluation/execution — we log
+        the failure and continue, so that observability degradation
+        never becomes an availability incident.
+        """
+        try:
+            await self._event_store.append(
+                create_policy_capabilities_evaluated_event(
+                    session_id=session_id,
+                    graph=capability_graph,
+                    decisions=policy_decisions,
+                    context=policy_context,
+                )
             )
-        )
+        except Exception as exc:
+            log.warning(
+                "orchestrator.runner.policy_audit_emit_failed",
+                session_id=session_id,
+                capability_count=len(capability_graph.capabilities),
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
 
     def _seed_runtime_handle(
         self,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -23,7 +23,7 @@ import asyncio
 from contextlib import aclosing
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 from uuid import uuid4
 
 from rich.console import Console
@@ -100,6 +100,20 @@ log = get_logger(__name__)
 # =============================================================================
 # Result Types
 # =============================================================================
+
+
+class ToolCatalogPolicyResult(NamedTuple):
+    """Bundle returned by ``_evaluate_tool_catalog_policy``.
+
+    Using a named tuple instead of a positional 4-tuple lets callers read
+    fields by name and removes the refactor fragility that would come from
+    re-ordering a positional unpack.
+    """
+
+    allowed_tools: list[str]
+    capability_graph: CapabilityGraph
+    policy_decisions: tuple[PolicyDecision, ...]
+    policy_context: PolicyContext
 
 
 @dataclass(frozen=True, slots=True)
@@ -507,7 +521,7 @@ class OrchestratorRunner:
         tool_catalog: SessionToolCatalog,
         *,
         runtime_backend: str | None = None,
-    ) -> tuple[list[str], CapabilityGraph, tuple[PolicyDecision, ...], PolicyContext]:
+    ) -> ToolCatalogPolicyResult:
         """Evaluate the implementation policy for a normalized tool catalog."""
         capability_graph = build_capability_graph(tool_catalog)
         policy_context = self._implementation_policy_context(runtime_backend=runtime_backend)
@@ -517,7 +531,12 @@ class OrchestratorRunner:
             for decision in policy_decisions
             if decision.visible and decision.executable
         ]
-        return allowed_tools, capability_graph, policy_decisions, policy_context
+        return ToolCatalogPolicyResult(
+            allowed_tools=allowed_tools,
+            capability_graph=capability_graph,
+            policy_decisions=policy_decisions,
+            policy_context=policy_context,
+        )
 
     async def _emit_policy_capabilities_evaluated_event(
         self,
@@ -552,13 +571,18 @@ class OrchestratorRunner:
         metadata = dict(runtime_handle.metadata) if runtime_handle is not None else {}
         if tool_catalog is not None:
             metadata["tool_catalog"] = serialize_tool_catalog(tool_catalog)
-            _, capability_graph, policy_decisions, _ = self._evaluate_tool_catalog_policy(
+            policy_result = self._evaluate_tool_catalog_policy(
                 tool_catalog,
                 runtime_backend=backend,
             )
-            metadata["capability_graph"] = serialize_capability_graph(capability_graph)
+            metadata["capability_graph"] = serialize_capability_graph(
+                policy_result.capability_graph
+            )
             metadata["control_plane"] = serialize_control_plane_state(
-                build_control_plane_state(capability_graph, policy_decisions)
+                build_control_plane_state(
+                    policy_result.capability_graph,
+                    policy_result.policy_decisions,
+                )
             )
 
         cwd = self._effective_cwd(runtime_handle)
@@ -1156,29 +1180,20 @@ class OrchestratorRunner:
                 session_catalog,
                 inherited_capabilities=frozenset(inherited_mcp),
             )
-        (
-            merged_tools,
-            capability_graph,
-            policy_decisions,
-            policy_context,
-        ) = self._evaluate_tool_catalog_policy(session_catalog)
 
+        # Defer the pre-discovery policy evaluation.  Previously we computed
+        # it unconditionally and threw it away whenever MCP discovery
+        # succeeded.  Now we only evaluate once per path, so the
+        # post-discovery success case does not double-compute.
         if self._mcp_manager is None:
+            policy_result = self._evaluate_tool_catalog_policy(session_catalog)
             await self._emit_policy_capabilities_evaluated_event(
                 session_id,
-                capability_graph,
-                policy_decisions,
-                policy_context,
+                policy_result.capability_graph,
+                policy_result.policy_decisions,
+                policy_result.policy_context,
             )
-            return merged_tools, None, session_catalog
-
-        async def _emit_current_policy_decisions() -> None:
-            await self._emit_policy_capabilities_evaluated_event(
-                session_id,
-                capability_graph,
-                policy_decisions,
-                policy_context,
-            )
+            return policy_result.allowed_tools, None, session_catalog
 
         # Create provider and get MCP tools
         provider = MCPToolProvider(
@@ -1194,16 +1209,28 @@ class OrchestratorRunner:
                 session_id=session_id,
                 error=str(e),
             )
-            await _emit_current_policy_decisions()
-            return merged_tools, None, session_catalog
+            policy_result = self._evaluate_tool_catalog_policy(session_catalog)
+            await self._emit_policy_capabilities_evaluated_event(
+                session_id,
+                policy_result.capability_graph,
+                policy_result.policy_decisions,
+                policy_result.policy_context,
+            )
+            return policy_result.allowed_tools, None, session_catalog
 
         if not mcp_tools:
             log.info(
                 "orchestrator.runner.no_mcp_tools_available",
                 session_id=session_id,
             )
-            await _emit_current_policy_decisions()
-            return merged_tools, provider, session_catalog
+            policy_result = self._evaluate_tool_catalog_policy(session_catalog)
+            await self._emit_policy_capabilities_evaluated_event(
+                session_id,
+                policy_result.capability_graph,
+                policy_result.policy_decisions,
+                policy_result.policy_context,
+            )
+            return policy_result.allowed_tools, provider, session_catalog
 
         session_catalog = provider.session_catalog
         # Preserve inherited MCP capabilities after discovery replaces the
@@ -1214,17 +1241,13 @@ class OrchestratorRunner:
                 session_catalog,
                 inherited_capabilities=frozenset(inherited_mcp),
             )
-        (
-            merged_tools,
-            capability_graph,
-            policy_decisions,
-            policy_context,
-        ) = self._evaluate_tool_catalog_policy(session_catalog)
+        policy_result = self._evaluate_tool_catalog_policy(session_catalog)
+        merged_tools = policy_result.allowed_tools
         await self._emit_policy_capabilities_evaluated_event(
             session_id,
-            capability_graph,
-            policy_decisions,
-            policy_context,
+            policy_result.capability_graph,
+            policy_result.policy_decisions,
+            policy_result.policy_context,
         )
         mcp_tool_names = [t.name for t in mcp_tools]
 

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -42,6 +42,7 @@ from ouroboros.orchestrator.adapter import (
     RuntimeHandle,
 )
 from ouroboros.orchestrator.capabilities import (
+    CapabilityGraph,
     build_capability_graph,
     serialize_capability_graph,
 )
@@ -53,6 +54,7 @@ from ouroboros.orchestrator.events import (
     create_drift_measured_event,
     create_execution_terminal_event,
     create_mcp_tools_loaded_event,
+    create_policy_capabilities_evaluated_event,
     create_progress_event,
     create_session_completed_event,
     create_session_failed_event,
@@ -70,9 +72,9 @@ from ouroboros.orchestrator.mcp_tools import (
 from ouroboros.orchestrator.parallel_executor import DEFAULT_MAX_DECOMPOSITION_DEPTH
 from ouroboros.orchestrator.policy import (
     PolicyContext,
+    PolicyDecision,
     PolicyExecutionPhase,
     PolicySessionRole,
-    allowed_capability_names,
     evaluate_capability_policy,
 )
 from ouroboros.orchestrator.runtime_message_projection import (
@@ -488,6 +490,52 @@ class OrchestratorRunner:
 
         return None
 
+    def _implementation_policy_context(
+        self,
+        *,
+        runtime_backend: str | None = None,
+    ) -> PolicyContext:
+        """Return the policy context used for implementation tool catalogs."""
+        return PolicyContext(
+            runtime_backend=runtime_backend or self._adapter.runtime_backend,
+            session_role=PolicySessionRole.IMPLEMENTATION,
+            execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
+        )
+
+    def _evaluate_tool_catalog_policy(
+        self,
+        tool_catalog: SessionToolCatalog,
+        *,
+        runtime_backend: str | None = None,
+    ) -> tuple[list[str], CapabilityGraph, tuple[PolicyDecision, ...], PolicyContext]:
+        """Evaluate the implementation policy for a normalized tool catalog."""
+        capability_graph = build_capability_graph(tool_catalog)
+        policy_context = self._implementation_policy_context(runtime_backend=runtime_backend)
+        policy_decisions = evaluate_capability_policy(capability_graph, policy_context)
+        allowed_tools = [
+            decision.name
+            for decision in policy_decisions
+            if decision.visible and decision.executable
+        ]
+        return allowed_tools, capability_graph, policy_decisions, policy_context
+
+    async def _emit_policy_capability_evaluated_events(
+        self,
+        session_id: str,
+        capability_graph: CapabilityGraph,
+        policy_decisions: tuple[PolicyDecision, ...],
+        policy_context: PolicyContext,
+    ) -> None:
+        """Persist capability policy decisions for audit/debuggability."""
+        await self._event_store.append(
+            create_policy_capabilities_evaluated_event(
+                session_id=session_id,
+                graph=capability_graph,
+                decisions=policy_decisions,
+                context=policy_context,
+            )
+        )
+
     def _seed_runtime_handle(
         self,
         runtime_handle: RuntimeHandle | None,
@@ -504,13 +552,10 @@ class OrchestratorRunner:
         metadata = dict(runtime_handle.metadata) if runtime_handle is not None else {}
         if tool_catalog is not None:
             metadata["tool_catalog"] = serialize_tool_catalog(tool_catalog)
-            capability_graph = build_capability_graph(tool_catalog)
-            policy_context = PolicyContext(
+            _, capability_graph, policy_decisions, _ = self._evaluate_tool_catalog_policy(
+                tool_catalog,
                 runtime_backend=backend,
-                session_role=PolicySessionRole.IMPLEMENTATION,
-                execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
             )
-            policy_decisions = evaluate_capability_policy(capability_graph, policy_context)
             metadata["capability_graph"] = serialize_capability_graph(capability_graph)
             metadata["control_plane"] = serialize_control_plane_state(
                 build_control_plane_state(capability_graph, policy_decisions)
@@ -1111,18 +1156,29 @@ class OrchestratorRunner:
                 session_catalog,
                 inherited_capabilities=frozenset(inherited_mcp),
             )
-        capability_graph = build_capability_graph(session_catalog)
-        merged_tools = allowed_capability_names(
+        (
+            merged_tools,
             capability_graph,
-            PolicyContext(
-                runtime_backend=self._adapter.runtime_backend,
-                session_role=PolicySessionRole.IMPLEMENTATION,
-                execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
-            ),
-        )
+            policy_decisions,
+            policy_context,
+        ) = self._evaluate_tool_catalog_policy(session_catalog)
 
         if self._mcp_manager is None:
+            await self._emit_policy_capability_evaluated_events(
+                session_id,
+                capability_graph,
+                policy_decisions,
+                policy_context,
+            )
             return merged_tools, None, session_catalog
+
+        async def _emit_current_policy_decisions() -> None:
+            await self._emit_policy_capability_evaluated_events(
+                session_id,
+                capability_graph,
+                policy_decisions,
+                policy_context,
+            )
 
         # Create provider and get MCP tools
         provider = MCPToolProvider(
@@ -1138,6 +1194,7 @@ class OrchestratorRunner:
                 session_id=session_id,
                 error=str(e),
             )
+            await _emit_current_policy_decisions()
             return merged_tools, None, session_catalog
 
         if not mcp_tools:
@@ -1145,6 +1202,7 @@ class OrchestratorRunner:
                 "orchestrator.runner.no_mcp_tools_available",
                 session_id=session_id,
             )
+            await _emit_current_policy_decisions()
             return merged_tools, provider, session_catalog
 
         session_catalog = provider.session_catalog
@@ -1156,14 +1214,17 @@ class OrchestratorRunner:
                 session_catalog,
                 inherited_capabilities=frozenset(inherited_mcp),
             )
-        capability_graph = build_capability_graph(session_catalog)
-        merged_tools = allowed_capability_names(
+        (
+            merged_tools,
             capability_graph,
-            PolicyContext(
-                runtime_backend=self._adapter.runtime_backend,
-                session_role=PolicySessionRole.IMPLEMENTATION,
-                execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
-            ),
+            policy_decisions,
+            policy_context,
+        ) = self._evaluate_tool_catalog_policy(session_catalog)
+        await self._emit_policy_capability_evaluated_events(
+            session_id,
+            capability_graph,
+            policy_decisions,
+            policy_context,
         )
         mcp_tool_names = [t.name for t in mcp_tools]
 

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
+import structlog
+
 from ouroboros.config import (
     get_codex_cli_path,
     get_gemini_cli_path,
@@ -18,12 +20,35 @@ from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 from ouroboros.providers.gemini_cli_adapter import GeminiCLIAdapter
 from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
 
+log = structlog.get_logger(__name__)
+
 _CLAUDE_CODE_BACKENDS = {"claude", "claude_code"}
 _CODEX_BACKENDS = {"codex", "codex_cli"}
 _GEMINI_BACKENDS = {"gemini", "gemini_cli"}
 _OPENCODE_BACKENDS = {"opencode", "opencode_cli"}
 _LITELLM_BACKENDS = {"litellm", "openai", "openrouter"}
 _LLM_USE_CASES = frozenset({"default", "interview"})
+
+# Resolved backend names whose adapter enforces the ``allowed_tools``
+# envelope *softly* — the restriction is injected into the prompt rather
+# than into a hard CLI/SDK flag, because the underlying runtime has no
+# native allow-listing surface.  Callers still pass the envelope normally;
+# the adapter is responsible for making the trade-off visible (structured
+# warnings on init and on per-event violations, audit metadata marking the
+# session as soft-enforced).
+#
+# Gemini is the concrete case today: ``GeminiCLIAdapter`` cooperates by
+# prepending a ``<tool_envelope>`` directive to the system prompt and
+# emits ``gemini_cli_adapter.tool_envelope_violation`` for any ``tool_use``
+# stream event that names a tool outside the envelope.  Hard enforcement
+# would require either a Gemini CLI flag that does not exist yet or a
+# sandboxed subprocess surface that is out of scope for this slice.
+#
+# Claude/Codex/OpenCode enforce hard (SDK ``allowed_tools``, CLI
+# ``--sandbox``).  LiteLLM is not listed at all because it is a
+# completion-only API that never executes tools from the adapter —
+# enforcement is vacuously satisfied on that path.
+_BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT: frozenset[str] = frozenset({"gemini"})
 
 
 def resolve_llm_backend(backend: str | None = None) -> str:
@@ -84,6 +109,25 @@ def create_llm_adapter(
 ) -> LLMAdapter:
     """Create an LLM adapter from config or explicit options."""
     resolved_backend = resolve_llm_backend(backend)
+    # Backends in ``_BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT`` accept the
+    # envelope but enforce it via prompt injection + post-hoc detection
+    # rather than a hard runtime flag.  The session role's UX stays
+    # uninterrupted (no fail-fast in user-facing flows), while the
+    # trade-off surfaces as a structured warning at adapter
+    # construction and per-violation events at runtime.  Operators can
+    # tell a soft-enforced session apart from a hard one at audit time.
+    if allowed_tools is not None and resolved_backend in _BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT:
+        log.warning(
+            "create_llm_adapter.soft_tool_enforcement_backend",
+            backend=resolved_backend,
+            allowed_tools=list(allowed_tools),
+            hint=(
+                "This backend has no hard allowed_tools surface.  Envelope "
+                "is injected as a prompt directive and violations are "
+                "detected post-hoc.  Use claude_code / codex / opencode "
+                "if hard enforcement is required."
+            ),
+        )
     resolved_permission_mode = resolve_llm_permission_mode(
         backend=resolved_backend,
         permission_mode=permission_mode,
@@ -118,6 +162,7 @@ def create_llm_adapter(
             on_message=on_message,
             timeout=timeout,
             max_retries=max_retries,
+            allowed_tools=allowed_tools,
         )
     if resolved_backend == "opencode":
         return OpenCodeLLMAdapter(

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -37,18 +37,25 @@ _LLM_USE_CASES = frozenset({"default", "interview"})
 # warnings on init and on per-event violations, audit metadata marking the
 # session as soft-enforced).
 #
-# Gemini is the concrete case today: ``GeminiCLIAdapter`` cooperates by
-# prepending a ``<tool_envelope>`` directive to the system prompt and
-# emits ``gemini_cli_adapter.tool_envelope_violation`` for any ``tool_use``
-# stream event that names a tool outside the envelope.  Hard enforcement
-# would require either a Gemini CLI flag that does not exist yet or a
-# sandboxed subprocess surface that is out of scope for this slice.
+# Gemini: ``GeminiCLIAdapter`` prepends a ``<tool_envelope>`` directive
+# to the system prompt and emits
+# ``gemini_cli_adapter.tool_envelope_violation`` for any out-of-envelope
+# ``tool_use`` stream event.  Hard enforcement would need a Gemini CLI
+# flag that does not exist.
 #
-# Claude/Codex/OpenCode enforce hard (SDK ``allowed_tools``, CLI
-# ``--sandbox``).  LiteLLM is not listed at all because it is a
-# completion-only API that never executes tools from the adapter —
-# enforcement is vacuously satisfied on that path.
-_BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT: frozenset[str] = frozenset({"gemini"})
+# OpenCode: ``OpenCodeLLMAdapter`` injects a ``## Tool Constraints``
+# section into the composed prompt and emits
+# ``opencode_adapter.tool_envelope_violation`` for any ``tool_use``
+# event outside the envelope.  The ``opencode run`` CLI has no
+# ``--permission-mode``/``--allowed-tools`` flag either (see the
+# adapter docstring), so enforcement is cooperative here as well.
+#
+# Claude Code and Codex remain hard-enforced (SDK ``allowed_tools`` and
+# ``--sandbox`` respectively).  LiteLLM is *not* listed: it is a
+# completion-only API that never executes tools from the adapter, so an
+# envelope has nothing to restrict on that path (enforcement is
+# vacuously satisfied).
+_BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT: frozenset[str] = frozenset({"gemini", "opencode"})
 
 
 def resolve_llm_backend(backend: str | None = None) -> str:

--- a/src/ouroboros/providers/gemini_cli_adapter.py
+++ b/src/ouroboros/providers/gemini_cli_adapter.py
@@ -111,6 +111,7 @@ class GeminiCLIAdapter:
         timeout: float | None = 120.0,
         max_retries: int = 3,
         on_message: Callable[[str, str], None] | None = None,
+        allowed_tools: list[str] | None = None,
     ) -> None:
         """Initialise the Gemini CLI adapter.
 
@@ -126,6 +127,16 @@ class GeminiCLIAdapter:
             on_message: Optional callback invoked with ``(type, content)`` for
                 streaming events — ``"thinking"`` for text fragments, ``"tool"``
                 for tool-use events.
+            allowed_tools: Engine-derived tool envelope.  The Gemini CLI does
+                not expose an ``--allowed-tools`` flag, so enforcement here is
+                *soft*: the envelope is injected into the system prompt as a
+                hard instruction and out-of-envelope ``tool_use`` events in
+                the stream are reported via
+                ``gemini_cli_adapter.tool_envelope_violation``.  The soft
+                nature is recorded up-front via
+                ``gemini_cli_adapter.soft_tool_enforcement`` so operators can
+                tell Gemini sessions apart from the hard-enforced
+                Claude/Codex/OpenCode ones at audit time.
         """
         self._cli_path: Path = self._resolve_cli_path(cli_path)
         self._model: str = model or _DEFAULT_MODEL
@@ -133,12 +144,26 @@ class GeminiCLIAdapter:
         self._timeout: float | None = timeout
         self._max_retries: int = max_retries
         self._on_message: Callable[[str, str], None] | None = on_message
+        self._allowed_tools: tuple[str, ...] | None = (
+            tuple(allowed_tools) if allowed_tools is not None else None
+        )
 
         log.info(
             "gemini_cli_adapter.initialized",
             cli_path=str(self._cli_path),
             model=self._model,
         )
+        if self._allowed_tools is not None:
+            log.warning(
+                "gemini_cli_adapter.soft_tool_enforcement",
+                allowed_tools=list(self._allowed_tools),
+                reason=(
+                    "Gemini CLI has no native allowed_tools flag; the "
+                    "envelope is injected as a system-prompt instruction "
+                    "and violations are detected post-hoc in the tool_use "
+                    "stream.  Enforcement is cooperative, not mandatory."
+                ),
+            )
 
     # ------------------------------------------------------------------
     # Public interface
@@ -353,6 +378,22 @@ class GeminiCLIAdapter:
                 tool_input = event.get("input", {})
                 detail = self._format_tool_detail(tool_name, tool_input)
                 log.debug("gemini_cli_adapter.tool_use", tool=tool_name)
+                # Post-hoc soft enforcement: if an envelope was declared and
+                # Gemini invoked a tool outside it, record the violation as
+                # a structured warning so operators can audit drift.  The
+                # CLI has already issued the tool call by the time we see
+                # the event, so this is detection rather than prevention —
+                # that is the documented trade-off of Gemini's soft mode.
+                if (
+                    self._allowed_tools is not None
+                    and tool_name not in self._allowed_tools
+                    and tool_name != "unknown"
+                ):
+                    log.warning(
+                        "gemini_cli_adapter.tool_envelope_violation",
+                        tool=tool_name,
+                        allowed_tools=list(self._allowed_tools),
+                    )
                 if self._on_message:
                     self._on_message("tool", detail)
 
@@ -654,6 +695,14 @@ class GeminiCLIAdapter:
         block.  Subsequent user/assistant turns are formatted as a dialogue.
         The final user message acts as the primary request.
 
+        When ``allowed_tools`` is set on the adapter, an engine-owned
+        ``<tool_envelope>`` block is prepended to the system instructions.
+        The Gemini CLI has no native allow-listing surface so this
+        injection is the mechanism by which the engine's policy envelope
+        travels into the model's context.  Violations (Gemini invoking a
+        tool outside the envelope) are still surfaced at the ``tool_use``
+        stream-event layer in ``_collect_response``.
+
         Args:
             messages: Conversation messages.
 
@@ -665,9 +714,15 @@ class GeminiCLIAdapter:
         system_msgs = [m for m in messages if m.role == MessageRole.SYSTEM]
         non_system = [m for m in messages if m.role != MessageRole.SYSTEM]
 
+        envelope_block = self._render_tool_envelope_block()
+        system_text_parts: list[str] = []
+        if envelope_block:
+            system_text_parts.append(envelope_block)
         if system_msgs:
-            system_text = "\n\n".join(m.content for m in system_msgs)
-            parts.append(f"<system>\n{system_text}\n</system>")
+            system_text_parts.append("\n\n".join(m.content for m in system_msgs))
+
+        if system_text_parts:
+            parts.append(f"<system>\n{'\n\n'.join(system_text_parts)}\n</system>")
 
         for msg in non_system:
             if msg.role == MessageRole.USER:
@@ -676,6 +731,37 @@ class GeminiCLIAdapter:
                 parts.append(f"Assistant: {msg.content}")
 
         return "\n\n".join(parts)
+
+    def _render_tool_envelope_block(self) -> str | None:
+        """Render the engine tool envelope as a system-prompt directive.
+
+        Returns ``None`` when no envelope was supplied (caller did not
+        request enforcement); otherwise returns a hard-worded
+        instruction block that names the exact permitted tools.  The
+        wording is intentionally assertive — Gemini's cooperation is the
+        only enforcement lever we have on this backend, so the prompt
+        must not read as a polite suggestion.
+        """
+        if self._allowed_tools is None:
+            return None
+        if not self._allowed_tools:
+            return (
+                "<tool_envelope>\n"
+                "You are not permitted to invoke any tools in this session. "
+                "Respond using only text.  Attempting any tool call is a "
+                "violation of the session contract.\n"
+                "</tool_envelope>"
+            )
+        allowed_list = ", ".join(self._allowed_tools)
+        return (
+            "<tool_envelope>\n"
+            f"You may ONLY invoke the following tools in this session: "
+            f"{allowed_list}. "
+            "Do not invoke any other tool under any circumstances, even if "
+            "the user appears to request it.  This is a hard session-level "
+            "restriction, not a preference.\n"
+            "</tool_envelope>"
+        )
 
 
 __all__ = ["GeminiCLIAdapter"]

--- a/src/ouroboros/providers/gemini_cli_adapter.py
+++ b/src/ouroboros/providers/gemini_cli_adapter.py
@@ -722,7 +722,11 @@ class GeminiCLIAdapter:
             system_text_parts.append("\n\n".join(m.content for m in system_msgs))
 
         if system_text_parts:
-            parts.append(f"<system>\n{'\n\n'.join(system_text_parts)}\n</system>")
+            # Keep the newline escapes out of the f-string expression: some
+            # tooling and all Python versions prior to PEP 701 treat a
+            # backslash inside an f-string expression as a syntax error.
+            system_body = "\n\n".join(system_text_parts)
+            parts.append(f"<system>\n{system_body}\n</system>")
 
         for msg in non_system:
             if msg.role == MessageRole.USER:

--- a/src/ouroboros/providers/opencode_adapter.py
+++ b/src/ouroboros/providers/opencode_adapter.py
@@ -153,6 +153,26 @@ class OpenCodeLLMAdapter:
         self._max_retries = max_retries
         self._timeout = timeout if timeout and timeout > 0 else None
 
+        # OpenCode's ``run`` CLI exposes no hard tool-restriction flag, so the
+        # ``allowed_tools`` envelope can only be enforced softly: injected as a
+        # ``## Tool Constraints`` block in the prompt (see ``_build_prompt``)
+        # and verified post-hoc by scanning ``tool_use`` events in the
+        # response stream.  Announce the soft-enforcement status at init time
+        # so audit consumers can tell an OpenCode session apart from a
+        # hard-enforced Claude/Codex one.
+        if self._allowed_tools is not None:
+            log.warning(
+                "opencode_adapter.soft_tool_enforcement",
+                allowed_tools=list(self._allowed_tools),
+                reason=(
+                    "OpenCode CLI has no native allowed_tools flag; the "
+                    "envelope is injected as a prompt directive and "
+                    "violations are detected post-hoc in the tool_use "
+                    "event stream.  Enforcement is cooperative, not "
+                    "mandatory."
+                ),
+            )
+
     def _resolve_cli_path(self, cli_path: str | Path | None) -> str:
         """Resolve the OpenCode CLI binary path.
 
@@ -364,6 +384,32 @@ class OpenCodeLLMAdapter:
                 if isinstance(text, str) and text.strip():
                     text_parts.append(text.strip())
         return "\n".join(text_parts)
+
+    def _audit_tool_envelope_violations(self, events: list[dict[str, Any]]) -> None:
+        """Warn on ``tool_use`` events outside the declared envelope.
+
+        OpenCode's ``allowed_tools`` is enforced softly (prompt directive
+        only), so this scan is detection rather than prevention: by the
+        time we see the event the CLI has already issued the tool call.
+        The warning is the operator's signal that cooperative enforcement
+        was violated on this run.
+        """
+        if self._allowed_tools is None:
+            return
+        allowed = frozenset(self._allowed_tools)
+        for event in events:
+            if event.get("type") != "tool_use":
+                continue
+            part = event.get("part", {})
+            tool_name = part.get("tool") if isinstance(part, dict) else None
+            if not isinstance(tool_name, str) or not tool_name:
+                continue
+            if tool_name not in allowed:
+                log.warning(
+                    "opencode_adapter.tool_envelope_violation",
+                    tool=tool_name,
+                    allowed_tools=list(self._allowed_tools),
+                )
 
     def _extract_error_from_events(self, events: list[dict[str, Any]]) -> str | None:
         """Extract a terminal error message from OpenCode JSON events.
@@ -596,6 +642,12 @@ class OpenCodeLLMAdapter:
                     provider=self._provider_name,
                 )
             )
+
+        # Post-hoc soft-enforcement audit: if an envelope was declared,
+        # warn about any ``tool_use`` events outside it.  Runs regardless
+        # of success/failure so operators can diagnose violations even on
+        # failed runs.
+        self._audit_tool_envelope_violations(events)
 
         # Check for errors in the event stream
         error_msg = self._extract_error_from_events(events)

--- a/src/ouroboros/sandbox.py
+++ b/src/ouroboros/sandbox.py
@@ -1,0 +1,34 @@
+"""Backend-neutral sandbox class vocabulary.
+
+This module deliberately sits at the top level with zero upward dependencies
+so that both engine-side code (``orchestrator.policy``) and leaf provider
+translation tables (``codex_permissions``, ``claude_permissions``) can import
+it without creating a circular dependency on the orchestrator package.
+
+The enum is the single shared vocabulary at the engine/adapter boundary:
+the engine decides which sandbox level a session deserves, and every
+provider adapter looks the result up in its own flat translation table —
+never re-derives the decision from free-form permission strings.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class SandboxClass(StrEnum):
+    """Backend-neutral sandbox level for an orchestrator session.
+
+    - ``READ_ONLY``: the session may inspect state but not mutate the host.
+    - ``WORKSPACE_WRITE``: the session may mutate workspace files; host
+      state outside the workspace remains off-limits.
+    - ``UNRESTRICTED``: approval and sandbox gates are bypassed.  Every
+      provider adapter must emit a warning when this value is realized.
+    """
+
+    READ_ONLY = "read_only"
+    WORKSPACE_WRITE = "workspace_write"
+    UNRESTRICTED = "unrestricted"
+
+
+__all__ = ["SandboxClass"]

--- a/tests/unit/mcp/tools/test_evaluation_handler.py
+++ b/tests/unit/mcp/tools/test_evaluation_handler.py
@@ -134,6 +134,13 @@ class TestEvaluateHandlerAdapterCreation:
             f"max_turns={captured['max_turns']} is too low — the evaluator needs "
             "at least one turn per AC file read. Use max_turns >= 10."
         )
+        assert captured["allowed_tools"] == [
+            "Read",
+            "Glob",
+            "Grep",
+            "WebFetch",
+            "WebSearch",
+        ]
 
     async def test_always_creates_fresh_adapter(self):
         """Evaluation always creates its own adapter via create_llm_adapter.

--- a/tests/unit/mcp/tools/test_interview_scoring_flow.py
+++ b/tests/unit/mcp/tools/test_interview_scoring_flow.py
@@ -60,6 +60,7 @@ class TestStartPathScoringFlow:
     @pytest.mark.asyncio
     async def test_start_skips_scoring(self) -> None:
         handler = _build_handler()
+        captured_adapter_kwargs: dict = {}
 
         mock_engine = MagicMock()
         mock_engine.start_interview = AsyncMock(
@@ -72,11 +73,15 @@ class TestStartPathScoringFlow:
 
         score_mock = AsyncMock(return_value=None)
 
+        def _capture_adapter(**kwargs):
+            captured_adapter_kwargs.update(kwargs)
+            return MagicMock()
+
         with (
             patch.object(handler, "_score_interview_state", score_mock),
             patch(
                 "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
-                return_value=MagicMock(),
+                side_effect=_capture_adapter,
             ),
             patch(
                 "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
@@ -91,6 +96,13 @@ class TestStartPathScoringFlow:
 
         score_mock.assert_not_called()
         mock_engine.ask_next_question.assert_called_once()
+        assert captured_adapter_kwargs["allowed_tools"] == [
+            "Read",
+            "Glob",
+            "Grep",
+            "WebFetch",
+            "WebSearch",
+        ]
 
 
 class TestAnswerPathScoringFlow:

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -102,3 +102,72 @@ tools:
     assert descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
     assert descriptor.semantics.parallel_safety is CapabilityParallelSafety.SAFE
     assert descriptor.semantics.approval_class is CapabilityApprovalClass.DEFAULT
+
+
+def test_partial_override_merges_onto_inferred_semantics(
+    tmp_path, monkeypatch
+) -> None:
+    """Partial overrides should retain inferred fields the user did not set."""
+    override_path = tmp_path / "tool_capabilities.yaml"
+    override_path.write_text(
+        """
+tools:
+  browser:chrome_screenshot:
+    mutation_class: read_only
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OUROBOROS_TOOL_CAPABILITIES", str(override_path))
+    catalog = assemble_session_tool_catalog(
+        attached_tools=(
+            MCPToolDefinition(
+                name="chrome_screenshot",
+                description="Capture a screenshot",
+                server_name="browser",
+            ),
+        ),
+    )
+
+    graph = build_capability_graph(catalog)
+
+    descriptor = graph.capabilities[0]
+    # User only reclassified the mutation_class; remaining dimensions come
+    # from the conservative inferred defaults for an attached MCP tool.
+    assert descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+    assert descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+    assert descriptor.semantics.scope is CapabilityScope.ATTACHMENT
+    assert descriptor.semantics.approval_class is not None
+
+
+def test_invalid_override_enum_value_is_logged_and_skipped(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """Malformed overrides should log a warning instead of being silenced."""
+    override_path = tmp_path / "tool_capabilities.yaml"
+    override_path.write_text(
+        """
+tools:
+  browser:chrome_navigate:
+    mutation_class: totally-not-a-real-enum
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OUROBOROS_TOOL_CAPABILITIES", str(override_path))
+    catalog = assemble_session_tool_catalog(
+        attached_tools=(
+            MCPToolDefinition(
+                name="chrome_navigate",
+                description="Navigate the browser",
+                server_name="browser",
+            ),
+        ),
+    )
+
+    graph = build_capability_graph(catalog)
+
+    # Graph still produced with inferred semantics (fail-open classification
+    # rather than silent discard of the tool itself).
+    assert len(graph.capabilities) == 1
+    # A structlog warning was emitted so user typos do not go unnoticed.
+    captured = capsys.readouterr()
+    assert "capability_override.invalid_enum" in captured.err

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -137,8 +137,10 @@ tools:
     assert descriptor.semantics.approval_class is not None
 
 
-def test_invalid_override_enum_value_is_logged_and_skipped(tmp_path, monkeypatch, capsys) -> None:
+def test_invalid_override_enum_value_is_logged_and_skipped(tmp_path, monkeypatch) -> None:
     """Malformed overrides should log a warning instead of being silenced."""
+    import structlog
+
     override_path = tmp_path / "tool_capabilities.yaml"
     override_path.write_text(
         """
@@ -159,11 +161,68 @@ tools:
         ),
     )
 
-    graph = build_capability_graph(catalog)
+    with structlog.testing.capture_logs() as captured_events:
+        graph = build_capability_graph(catalog)
 
     # Graph still produced with inferred semantics (fail-open classification
     # rather than silent discard of the tool itself).
     assert len(graph.capabilities) == 1
     # A structlog warning was emitted so user typos do not go unnoticed.
-    captured = capsys.readouterr()
-    assert "capability_override.invalid_enum" in captured.err
+    assert any(
+        event.get("event") == "capability_override.invalid_enum" for event in captured_events
+    )
+
+
+def test_malformed_yaml_does_not_break_capability_graph(tmp_path, monkeypatch) -> None:
+    """YAML parse failures in the user override file must not propagate.
+
+    Regression guard for the design note that a single bad user config
+    line would otherwise take down unrelated orchestration paths
+    (interview, evaluation, execution) because they all build a
+    capability graph on the default path.
+    """
+    import structlog
+
+    override_path = tmp_path / "tool_capabilities.yaml"
+    # Invalid YAML: unmatched indentation + stray tabs.
+    override_path.write_text(
+        "tools:\n  browser:\n\tchrome_navigate:\n  mutation_class: [unclosed\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OUROBOROS_TOOL_CAPABILITIES", str(override_path))
+    catalog = assemble_session_tool_catalog(
+        attached_tools=(
+            MCPToolDefinition(
+                name="chrome_navigate",
+                description="Navigate the browser",
+                server_name="browser",
+            ),
+        ),
+    )
+
+    with structlog.testing.capture_logs() as captured_events:
+        # Must not raise — override layer is optional enhancement.
+        graph = build_capability_graph(catalog)
+
+    assert len(graph.capabilities) == 1
+    # The failure must still be visible to operators.
+    assert any(
+        event.get("event") == "capability_override.yaml_parse_failed"
+        for event in captured_events
+    )
+
+
+def test_unreadable_override_path_does_not_break_capability_graph(
+    tmp_path, monkeypatch
+) -> None:
+    """A directory (or other non-regular path) at the override location
+    must be handled gracefully rather than raising ``IsADirectoryError``.
+    """
+    # Point the override env var at a directory instead of a file.
+    monkeypatch.setenv("OUROBOROS_TOOL_CAPABILITIES", str(tmp_path))
+    catalog = assemble_session_tool_catalog(["Read"])
+
+    # Must not raise.
+    graph = build_capability_graph(catalog)
+
+    assert [descriptor.name for descriptor in graph.capabilities] == ["Read"]

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -236,3 +236,35 @@ def test_unreadable_override_path_does_not_break_capability_graph(tmp_path, monk
     graph = build_capability_graph(catalog)
 
     assert [descriptor.name for descriptor in graph.capabilities] == ["Read"]
+
+
+def test_fifo_override_path_does_not_hang_capability_graph(tmp_path, monkeypatch) -> None:
+    """A FIFO at the override location must not block ``read_text()``.
+
+    Regression guard for the reviewer's blocking finding on PR #353:
+    ``read_text()`` on a FIFO (or other non-regular file that has no
+    EOF — socket, character device) blocks indefinitely.  Because the
+    override loader sits on the default capability-graph construction
+    path, such a path would wedge interview/evaluation/execution
+    startup.  The loader must stat-check and refuse non-regular files
+    before attempting to read them.
+    """
+    import os
+    import sys
+
+    if sys.platform == "win32":
+        import pytest
+
+        pytest.skip("os.mkfifo is not available on Windows")
+
+    fifo_path = tmp_path / "tool_capabilities.yaml"
+    os.mkfifo(fifo_path)
+    monkeypatch.setenv("OUROBOROS_TOOL_CAPABILITIES", str(fifo_path))
+    catalog = assemble_session_tool_catalog(["Read"])
+
+    # If the guard is missing, this call hangs forever waiting on the FIFO
+    # write end.  With the guard in place it returns immediately with the
+    # inferred builtin semantics and no user overrides applied.
+    graph = build_capability_graph(catalog)
+
+    assert [descriptor.name for descriptor in graph.capabilities] == ["Read"]

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -104,9 +104,7 @@ tools:
     assert descriptor.semantics.approval_class is CapabilityApprovalClass.DEFAULT
 
 
-def test_partial_override_merges_onto_inferred_semantics(
-    tmp_path, monkeypatch
-) -> None:
+def test_partial_override_merges_onto_inferred_semantics(tmp_path, monkeypatch) -> None:
     """Partial overrides should retain inferred fields the user did not set."""
     override_path = tmp_path / "tool_capabilities.yaml"
     override_path.write_text(
@@ -139,9 +137,7 @@ tools:
     assert descriptor.semantics.approval_class is not None
 
 
-def test_invalid_override_enum_value_is_logged_and_skipped(
-    tmp_path, monkeypatch, capsys
-) -> None:
+def test_invalid_override_enum_value_is_logged_and_skipped(tmp_path, monkeypatch, capsys) -> None:
     """Malformed overrides should log a warning instead of being silenced."""
     override_path = tmp_path / "tool_capabilities.yaml"
     override_path.write_text(

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -105,13 +105,21 @@ tools:
 
 
 def test_partial_override_merges_onto_inferred_semantics(tmp_path, monkeypatch) -> None:
-    """Partial overrides should retain inferred fields the user did not set."""
+    """Partial overrides should retain inferred fields the user did not set.
+
+    The user's YAML only declares ``approval_class``.  Every other
+    dimension must keep the value inferred from the tool's
+    name/description fingerprint — the override must not silently
+    reset unspecified fields back to conservative defaults.
+    """
+    from ouroboros.orchestrator.capabilities import CapabilityInterruptibility
+
     override_path = tmp_path / "tool_capabilities.yaml"
     override_path.write_text(
         """
 tools:
-  browser:chrome_screenshot:
-    mutation_class: read_only
+  docs:search_docs:
+    approval_class: elevated
 """,
         encoding="utf-8",
     )
@@ -119,9 +127,9 @@ tools:
     catalog = assemble_session_tool_catalog(
         attached_tools=(
             MCPToolDefinition(
-                name="chrome_screenshot",
-                description="Capture a screenshot",
-                server_name="browser",
+                name="search_docs",
+                description="Search indexed project docs",
+                server_name="docs",
             ),
         ),
     )
@@ -129,12 +137,17 @@ tools:
     graph = build_capability_graph(catalog)
 
     descriptor = graph.capabilities[0]
-    # User only reclassified the mutation_class; remaining dimensions come
-    # from the conservative inferred defaults for an attached MCP tool.
+    # The only dimension the YAML declared:
+    assert descriptor.semantics.approval_class is CapabilityApprovalClass.ELEVATED
+    # Everything else is inherited from the read-leaning fingerprint
+    # ("search" keyword → READ_ONLY / SAFE / NONE).  These assertions
+    # would fail if the override layer were wholesale-replacing
+    # semantics instead of merging per-field.
     assert descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+    assert descriptor.semantics.parallel_safety is CapabilityParallelSafety.SAFE
+    assert descriptor.semantics.interruptibility is CapabilityInterruptibility.NONE
     assert descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
     assert descriptor.semantics.scope is CapabilityScope.ATTACHMENT
-    assert descriptor.semantics.approval_class is not None
 
 
 def test_invalid_override_enum_value_is_logged_and_skipped(tmp_path, monkeypatch) -> None:

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -207,14 +207,11 @@ def test_malformed_yaml_does_not_break_capability_graph(tmp_path, monkeypatch) -
     assert len(graph.capabilities) == 1
     # The failure must still be visible to operators.
     assert any(
-        event.get("event") == "capability_override.yaml_parse_failed"
-        for event in captured_events
+        event.get("event") == "capability_override.yaml_parse_failed" for event in captured_events
     )
 
 
-def test_unreadable_override_path_does_not_break_capability_graph(
-    tmp_path, monkeypatch
-) -> None:
+def test_unreadable_override_path_does_not_break_capability_graph(tmp_path, monkeypatch) -> None:
     """A directory (or other non-regular path) at the override location
     must be handled gracefully rather than raising ``IsADirectoryError``.
     """

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -12,7 +12,6 @@ from ouroboros.orchestrator.capabilities import (
     CapabilityParallelSafety,
     CapabilityScope,
     build_capability_graph,
-    load_tool_capability_overrides,
     normalize_serialized_capability_graph,
     serialize_capability_graph,
 )
@@ -72,7 +71,8 @@ def test_build_capability_graph_records_inherited_capabilities_without_entries()
     assert inherited.semantics.scope is CapabilityScope.ATTACHMENT
 
 
-def test_build_capability_graph_applies_attached_tool_override(tmp_path) -> None:
+def test_full_override_replaces_every_classified_dimension(tmp_path, monkeypatch) -> None:
+    """A fully-specified override sets every dimension explicitly."""
     override_path = tmp_path / "tool_capabilities.yaml"
     override_path.write_text(
         """
@@ -85,7 +85,7 @@ tools:
 """,
         encoding="utf-8",
     )
-    overrides = load_tool_capability_overrides(override_path)
+    monkeypatch.setenv("OUROBOROS_TOOL_CAPABILITIES", str(override_path))
     catalog = assemble_session_tool_catalog(
         attached_tools=(
             MCPToolDefinition(
@@ -96,7 +96,7 @@ tools:
         ),
     )
 
-    graph = build_capability_graph(catalog, capability_overrides=overrides)
+    graph = build_capability_graph(catalog)
 
     descriptor = graph.capabilities[0]
     assert descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from ouroboros.mcp.types import MCPToolDefinition
 from ouroboros.orchestrator.capabilities import (
+    CapabilityApprovalClass,
     CapabilityMutationClass,
     CapabilityOrigin,
+    CapabilityParallelSafety,
     CapabilityScope,
     build_capability_graph,
+    load_tool_capability_overrides,
     normalize_serialized_capability_graph,
     serialize_capability_graph,
 )
@@ -45,3 +50,55 @@ def test_capability_graph_serialization_round_trips() -> None:
     assert restored is not None
     assert [descriptor.name for descriptor in restored.capabilities] == ["Read", "Edit"]
     assert restored.capabilities[0].semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+
+
+def test_build_capability_graph_records_inherited_capabilities_without_entries() -> None:
+    catalog = replace(
+        assemble_session_tool_catalog(["Read"]),
+        inherited_capabilities=frozenset({"mcp__chrome-devtools__click"}),
+    )
+
+    graph = build_capability_graph(catalog)
+
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    inherited = descriptors["mcp__chrome-devtools__click"]
+    assert [descriptor.name for descriptor in graph.capabilities] == [
+        "Read",
+        "mcp__chrome-devtools__click",
+    ]
+    assert inherited.stable_id == "inherited:mcp__chrome-devtools__click"
+    assert inherited.source_kind == "inherited_capability"
+    assert inherited.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+    assert inherited.semantics.scope is CapabilityScope.ATTACHMENT
+
+
+def test_build_capability_graph_applies_attached_tool_override(tmp_path) -> None:
+    override_path = tmp_path / "tool_capabilities.yaml"
+    override_path.write_text(
+        """
+tools:
+  browser:chrome_navigate:
+    mutation_class: read_only
+    parallel_safety: safe
+    interruptibility: none
+    approval_class: default
+""",
+        encoding="utf-8",
+    )
+    overrides = load_tool_capability_overrides(override_path)
+    catalog = assemble_session_tool_catalog(
+        attached_tools=(
+            MCPToolDefinition(
+                name="chrome_navigate",
+                description="Navigate the browser",
+                server_name="browser",
+            ),
+        ),
+    )
+
+    graph = build_capability_graph(catalog, capability_overrides=overrides)
+
+    descriptor = graph.capabilities[0]
+    assert descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+    assert descriptor.semantics.parallel_safety is CapabilityParallelSafety.SAFE
+    assert descriptor.semantics.approval_class is CapabilityApprovalClass.DEFAULT

--- a/tests/unit/orchestrator/test_events.py
+++ b/tests/unit/orchestrator/test_events.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from ouroboros.orchestrator.capabilities import build_capability_graph
 from ouroboros.orchestrator.events import (
     create_policy_capabilities_evaluated_event,
-    create_policy_capability_evaluated_event,
     create_progress_event,
     create_session_cancelled_event,
     create_session_completed_event,
@@ -44,33 +43,6 @@ class TestSessionEvents:
         assert event.data["seed_id"] == "seed_789"
         assert event.data["seed_goal"] == "Build a CLI tool"
         assert "start_time" in event.data
-
-    def test_create_policy_capability_evaluated_event(self) -> None:
-        """Policy events should persist capability, decision, and context."""
-        graph = build_capability_graph(assemble_session_tool_catalog(["Read"]))
-        context = PolicyContext(
-            runtime_backend="opencode",
-            session_role=PolicySessionRole.IMPLEMENTATION,
-            execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
-        )
-        decision = evaluate_capability_policy(graph, context)[0]
-
-        event = create_policy_capability_evaluated_event(
-            session_id="sess_123",
-            descriptor=graph.capabilities[0],
-            decision=decision,
-            context=context,
-        )
-
-        assert event.type == "policy.capability.evaluated"
-        assert event.aggregate_type == "session"
-        assert event.aggregate_id == "sess_123"
-        assert event.data["capability"]["name"] == "Read"
-        assert event.data["capability"]["origin"] == "builtin"
-        assert event.data["decision"]["visible"] is True
-        assert event.data["decision"]["executable"] is True
-        assert event.data["context"]["runtime_backend"] == "opencode"
-        assert "evaluated_at" in event.data
 
     def test_create_policy_capabilities_evaluated_event_batches_decisions(self) -> None:
         """Batched policy events should preserve per-capability decisions."""

--- a/tests/unit/orchestrator/test_events.py
+++ b/tests/unit/orchestrator/test_events.py
@@ -61,7 +61,7 @@ class TestSessionEvents:
             context=context,
         )
 
-        assert event.type == "policy.capabilities.evaluated"
+        assert event.type == "orchestrator.policy.capabilities.evaluated"
         assert event.aggregate_type == "session"
         assert event.aggregate_id == "sess_123"
         assert event.data["capability_count"] == 2

--- a/tests/unit/orchestrator/test_events.py
+++ b/tests/unit/orchestrator/test_events.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from ouroboros.orchestrator.capabilities import build_capability_graph
 from ouroboros.orchestrator.events import (
+    create_policy_capabilities_evaluated_event,
+    create_policy_capability_evaluated_event,
     create_progress_event,
     create_session_cancelled_event,
     create_session_completed_event,
@@ -12,6 +15,13 @@ from ouroboros.orchestrator.events import (
     create_task_completed_event,
     create_task_started_event,
     create_tool_called_event,
+)
+from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+from ouroboros.orchestrator.policy import (
+    PolicyContext,
+    PolicyExecutionPhase,
+    PolicySessionRole,
+    evaluate_capability_policy,
 )
 
 
@@ -34,6 +44,61 @@ class TestSessionEvents:
         assert event.data["seed_id"] == "seed_789"
         assert event.data["seed_goal"] == "Build a CLI tool"
         assert "start_time" in event.data
+
+    def test_create_policy_capability_evaluated_event(self) -> None:
+        """Policy events should persist capability, decision, and context."""
+        graph = build_capability_graph(assemble_session_tool_catalog(["Read"]))
+        context = PolicyContext(
+            runtime_backend="opencode",
+            session_role=PolicySessionRole.IMPLEMENTATION,
+            execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
+        )
+        decision = evaluate_capability_policy(graph, context)[0]
+
+        event = create_policy_capability_evaluated_event(
+            session_id="sess_123",
+            descriptor=graph.capabilities[0],
+            decision=decision,
+            context=context,
+        )
+
+        assert event.type == "policy.capability.evaluated"
+        assert event.aggregate_type == "session"
+        assert event.aggregate_id == "sess_123"
+        assert event.data["capability"]["name"] == "Read"
+        assert event.data["capability"]["origin"] == "builtin"
+        assert event.data["decision"]["visible"] is True
+        assert event.data["decision"]["executable"] is True
+        assert event.data["context"]["runtime_backend"] == "opencode"
+        assert "evaluated_at" in event.data
+
+    def test_create_policy_capabilities_evaluated_event_batches_decisions(self) -> None:
+        """Batched policy events should preserve per-capability decisions."""
+        graph = build_capability_graph(assemble_session_tool_catalog(["Read", "Edit"]))
+        context = PolicyContext(
+            runtime_backend="opencode",
+            session_role=PolicySessionRole.INTERVIEW,
+            execution_phase=PolicyExecutionPhase.INTERVIEW,
+        )
+        decisions = evaluate_capability_policy(graph, context)
+
+        event = create_policy_capabilities_evaluated_event(
+            session_id="sess_123",
+            graph=graph,
+            decisions=decisions,
+            context=context,
+        )
+
+        assert event.type == "policy.capabilities.evaluated"
+        assert event.aggregate_type == "session"
+        assert event.aggregate_id == "sess_123"
+        assert event.data["capability_count"] == 2
+        evaluations = {
+            item["capability"]["name"]: item["decision"] for item in event.data["evaluations"]
+        }
+        assert evaluations["Read"]["executable"] is True
+        assert evaluations["Edit"]["executable"] is False
+        assert event.data["context"]["session_role"] == "interview"
 
     def test_create_session_completed_event(self) -> None:
         """Test creating session completed event."""

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -131,6 +131,64 @@ class TestParallelACExecutor:
         assert max_active_count == 1
 
     @pytest.mark.asyncio
+    async def test_control_plane_preserves_parallel_for_read_only_catalog(self) -> None:
+        """Safe read-only tools should keep the default parallel AC fanout.
+
+        Companion regression test for
+        ``test_control_plane_serializes_batch_with_write_capabilities``:
+        a future refactor that accidentally blanket-serializes every
+        batch would quietly remove the intended parallelism and go
+        unnoticed without this guard.
+        """
+        seed = _make_seed("Read parser", "Read formatter")
+        executor = _make_executor()
+        active_count = 0
+        max_active_count = 0
+
+        async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:
+            nonlocal active_count, max_active_count
+            ac_index = int(kwargs["ac_index"])
+            active_count += 1
+            max_active_count = max(max_active_count, active_count)
+            # Both ACs yield before decrementing so the sibling can enter
+            # the critical section.  With serial execution there is only
+            # one in-flight AC at a time and ``max_active_count`` stays
+            # at 1; with parallel execution it reaches 2.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            active_count -= 1
+            return ACExecutionResult(
+                ac_index=ac_index,
+                ac_content=str(kwargs["ac_content"]),
+                success=True,
+                final_message=f"AC {ac_index} complete",
+            )
+
+        with patch.object(executor, "_execute_single_ac", side_effect=fake_execute_single_ac):
+            results = await executor._execute_ac_batch(
+                seed=seed,
+                batch_indices=[0, 1],
+                session_id="sess_control_plane_safe",
+                execution_id="exec_control_plane_safe",
+                tools=["Read", "Grep"],
+                tool_catalog=(
+                    MCPToolDefinition(name="Read", description="Read files"),
+                    MCPToolDefinition(name="Grep", description="Search files"),
+                ),
+                system_prompt="test",
+                level_contexts=[],
+                ac_retry_attempts={0: 0, 1: 0},
+            )
+
+        assert [result.ac_index for result in results if isinstance(result, ACExecutionResult)] == [
+            0,
+            1,
+        ]
+        # Both ACs were in-flight concurrently — the control plane
+        # must NOT degrade safe read-only catalogs to serial execution.
+        assert max_active_count == 2
+
+    @pytest.mark.asyncio
     async def test_atomic_ac_uses_ac_scoped_runtime_handle(self) -> None:
         """Atomic AC execution should seed a fresh AC-scoped runtime handle."""
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -84,13 +84,24 @@ class TestParallelACExecutor:
     """Tests for staged hybrid result handling."""
 
     @pytest.mark.asyncio
-    async def test_control_plane_serializes_batch_with_write_capabilities(self) -> None:
-        """Serialized/isolated executable tools should prevent same-batch AC fanout."""
-        seed = _make_seed("Update parser", "Update formatter")
+    async def test_batch_fans_out_in_parallel_regardless_of_tool_catalog(self) -> None:
+        """Batch scheduling is tool-catalog-agnostic.
+
+        The control plane exists as declarative audit/metadata, not as a
+        batch-level scheduler.  Cross-AC safety is enforced by the
+        file-conflict guard (static) and by the provider runtime at
+        tool-invocation time (dynamic); the scheduler must not degrade
+        a batch to serial execution based on session-level tool
+        availability, because "tool is in the catalog" does not imply
+        "every AC in this batch will invoke it".
+
+        This test mixes read-only and write-capable tools in the same
+        catalog to pin that mixed catalogs also fan out in parallel.
+        """
+        seed = _make_seed("AC alpha", "AC beta")
         executor = _make_executor()
         active_count = 0
         max_active_count = 0
-        execution_order: list[int] = []
 
         async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:
             nonlocal active_count, max_active_count
@@ -98,7 +109,7 @@ class TestParallelACExecutor:
             active_count += 1
             max_active_count = max(max_active_count, active_count)
             await asyncio.sleep(0)
-            execution_order.append(ac_index)
+            await asyncio.sleep(0)
             active_count -= 1
             return ACExecutionResult(
                 ac_index=ac_index,
@@ -111,12 +122,13 @@ class TestParallelACExecutor:
             results = await executor._execute_ac_batch(
                 seed=seed,
                 batch_indices=[0, 1],
-                session_id="sess_control_plane",
-                execution_id="exec_control_plane",
-                tools=["Read", "Edit"],
+                session_id="sess_batch_parallel",
+                execution_id="exec_batch_parallel",
+                tools=["Read", "Edit", "Bash"],
                 tool_catalog=(
                     MCPToolDefinition(name="Read", description="Read files"),
                     MCPToolDefinition(name="Edit", description="Edit files"),
+                    MCPToolDefinition(name="Bash", description="Run shell"),
                 ),
                 system_prompt="test",
                 level_contexts=[],
@@ -127,65 +139,9 @@ class TestParallelACExecutor:
             0,
             1,
         ]
-        assert execution_order == [0, 1]
-        assert max_active_count == 1
-
-    @pytest.mark.asyncio
-    async def test_control_plane_preserves_parallel_for_read_only_catalog(self) -> None:
-        """Safe read-only tools should keep the default parallel AC fanout.
-
-        Companion regression test for
-        ``test_control_plane_serializes_batch_with_write_capabilities``:
-        a future refactor that accidentally blanket-serializes every
-        batch would quietly remove the intended parallelism and go
-        unnoticed without this guard.
-        """
-        seed = _make_seed("Read parser", "Read formatter")
-        executor = _make_executor()
-        active_count = 0
-        max_active_count = 0
-
-        async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:
-            nonlocal active_count, max_active_count
-            ac_index = int(kwargs["ac_index"])
-            active_count += 1
-            max_active_count = max(max_active_count, active_count)
-            # Both ACs yield before decrementing so the sibling can enter
-            # the critical section.  With serial execution there is only
-            # one in-flight AC at a time and ``max_active_count`` stays
-            # at 1; with parallel execution it reaches 2.
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            active_count -= 1
-            return ACExecutionResult(
-                ac_index=ac_index,
-                ac_content=str(kwargs["ac_content"]),
-                success=True,
-                final_message=f"AC {ac_index} complete",
-            )
-
-        with patch.object(executor, "_execute_single_ac", side_effect=fake_execute_single_ac):
-            results = await executor._execute_ac_batch(
-                seed=seed,
-                batch_indices=[0, 1],
-                session_id="sess_control_plane_safe",
-                execution_id="exec_control_plane_safe",
-                tools=["Read", "Grep"],
-                tool_catalog=(
-                    MCPToolDefinition(name="Read", description="Read files"),
-                    MCPToolDefinition(name="Grep", description="Search files"),
-                ),
-                system_prompt="test",
-                level_contexts=[],
-                ac_retry_attempts={0: 0, 1: 0},
-            )
-
-        assert [result.ac_index for result in results if isinstance(result, ACExecutionResult)] == [
-            0,
-            1,
-        ]
-        # Both ACs were in-flight concurrently — the control plane
-        # must NOT degrade safe read-only catalogs to serial execution.
+        # Regression guard: even a catalog containing SERIALIZED (Edit)
+        # and ISOLATED_SESSION_REQUIRED (Bash) tools must not collapse
+        # a batch to serial execution.
         assert max_active_count == 2
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -84,6 +84,53 @@ class TestParallelACExecutor:
     """Tests for staged hybrid result handling."""
 
     @pytest.mark.asyncio
+    async def test_control_plane_serializes_batch_with_write_capabilities(self) -> None:
+        """Serialized/isolated executable tools should prevent same-batch AC fanout."""
+        seed = _make_seed("Update parser", "Update formatter")
+        executor = _make_executor()
+        active_count = 0
+        max_active_count = 0
+        execution_order: list[int] = []
+
+        async def fake_execute_single_ac(**kwargs: Any) -> ACExecutionResult:
+            nonlocal active_count, max_active_count
+            ac_index = int(kwargs["ac_index"])
+            active_count += 1
+            max_active_count = max(max_active_count, active_count)
+            await asyncio.sleep(0)
+            execution_order.append(ac_index)
+            active_count -= 1
+            return ACExecutionResult(
+                ac_index=ac_index,
+                ac_content=str(kwargs["ac_content"]),
+                success=True,
+                final_message=f"AC {ac_index} complete",
+            )
+
+        with patch.object(executor, "_execute_single_ac", side_effect=fake_execute_single_ac):
+            results = await executor._execute_ac_batch(
+                seed=seed,
+                batch_indices=[0, 1],
+                session_id="sess_control_plane",
+                execution_id="exec_control_plane",
+                tools=["Read", "Edit"],
+                tool_catalog=(
+                    MCPToolDefinition(name="Read", description="Read files"),
+                    MCPToolDefinition(name="Edit", description="Edit files"),
+                ),
+                system_prompt="test",
+                level_contexts=[],
+                ac_retry_attempts={0: 0, 1: 0},
+            )
+
+        assert [result.ac_index for result in results if isinstance(result, ACExecutionResult)] == [
+            0,
+            1,
+        ]
+        assert execution_order == [0, 1]
+        assert max_active_count == 1
+
+    @pytest.mark.asyncio
     async def test_atomic_ac_uses_ac_scoped_runtime_handle(self) -> None:
         """Atomic AC execution should seed a fresh AC-scoped runtime handle."""
 

--- a/tests/unit/orchestrator/test_policy.py
+++ b/tests/unit/orchestrator/test_policy.py
@@ -167,3 +167,90 @@ def test_read_only_roles_derive_runtime_builtin_envelope_from_policy() -> None:
     assert "Edit" not in allowed
     assert "Write" not in allowed
     assert "Bash" not in allowed
+
+
+def test_coordinator_hides_unknown_side_effecting_provider_native() -> None:
+    """Regression guard: unknown side-effecting provider-native tools must
+    stay hidden from COORDINATOR even when they satisfy the origin filter.
+
+    COORDINATOR permits PROVIDER_NATIVE by origin (for future runtime
+    integrations) but must not admit a tool that the engine cannot
+    classify below ``EXTERNAL_SIDE_EFFECT``.  Without this guard a
+    downstream regression that accidentally relaxed the mutation
+    clamp would silently expand the coordinator envelope.
+    """
+    graph = CapabilityGraph(
+        capabilities=(
+            CapabilityDescriptor(
+                stable_id="provider:opencode:unrestricted_shell",
+                name="unrestricted_shell",
+                original_name="unrestricted_shell",
+                description="Provider-native destructive shell surface",
+                server_name=None,
+                source_kind="provider_native",
+                source_name="opencode",
+                semantics=CapabilitySemantics(
+                    mutation_class=CapabilityMutationClass.DESTRUCTIVE,
+                    parallel_safety=CapabilityParallelSafety.ISOLATED_SESSION_REQUIRED,
+                    interruptibility=CapabilityInterruptibility.HARD,
+                    approval_class=CapabilityApprovalClass.BYPASS_FORBIDDEN,
+                    origin=CapabilityOrigin.PROVIDER_NATIVE,
+                    scope=CapabilityScope.SHELL_ONLY,
+                ),
+            ),
+        )
+    )
+
+    decisions = evaluate_capability_policy(
+        graph,
+        PolicyContext(
+            runtime_backend="opencode",
+            session_role=PolicySessionRole.COORDINATOR,
+            execution_phase=PolicyExecutionPhase.COORDINATOR_REVIEW,
+        ),
+    )
+
+    assert decisions[0].visible is False
+    assert decisions[0].executable is False
+
+
+def test_coordinator_admits_provider_native_write_but_not_destructive() -> None:
+    """Scope + origin admission works for mid-severity provider-native tools
+    while still rejecting destructive ones.
+
+    This pins the two failure modes that the new selector can regress
+    into: either admitting everything by origin (too loose) or
+    admitting nothing at all (too tight).
+    """
+    graph = CapabilityGraph(
+        capabilities=(
+            CapabilityDescriptor(
+                stable_id="provider:opencode:workspace_write",
+                name="workspace_write",
+                original_name="workspace_write",
+                description="Provider-native workspace writer",
+                server_name=None,
+                source_kind="provider_native",
+                source_name="opencode",
+                semantics=CapabilitySemantics(
+                    mutation_class=CapabilityMutationClass.WORKSPACE_WRITE,
+                    parallel_safety=CapabilityParallelSafety.SERIALIZED,
+                    interruptibility=CapabilityInterruptibility.SOFT,
+                    approval_class=CapabilityApprovalClass.DEFAULT,
+                    origin=CapabilityOrigin.PROVIDER_NATIVE,
+                    scope=CapabilityScope.KERNEL,
+                ),
+            ),
+        )
+    )
+
+    allowed = allowed_capability_names(
+        graph,
+        PolicyContext(
+            runtime_backend="opencode",
+            session_role=PolicySessionRole.COORDINATOR,
+            execution_phase=PolicyExecutionPhase.COORDINATOR_REVIEW,
+        ),
+    )
+
+    assert allowed == ["workspace_write"]

--- a/tests/unit/orchestrator/test_policy.py
+++ b/tests/unit/orchestrator/test_policy.py
@@ -169,6 +169,26 @@ def test_read_only_roles_derive_runtime_builtin_envelope_from_policy() -> None:
     assert "Bash" not in allowed
 
 
+def test_empty_builtin_tools_is_respected_not_defaulted() -> None:
+    """An explicit empty tuple means "this backend has no runtime builtins".
+
+    Regression guard for the reviewer's non-blocking finding on
+    PR #353: the earlier ``builtin_tools or ...`` idiom coerced an
+    empty tuple to the default full builtin set, which would silently
+    widen the envelope for a backend that legitimately exposes nothing.
+    """
+    allowed = allowed_runtime_builtin_tool_names(
+        PolicyContext(
+            runtime_backend="hypothetical_no_builtins_backend",
+            session_role=PolicySessionRole.EVALUATION,
+            execution_phase=PolicyExecutionPhase.EVALUATION,
+        ),
+        builtin_tools=(),
+    )
+
+    assert allowed == []
+
+
 def test_coordinator_hides_unknown_side_effecting_provider_native() -> None:
     """Regression guard: unknown side-effecting provider-native tools must
     stay hidden from COORDINATOR even when they satisfy the origin filter.

--- a/tests/unit/orchestrator/test_policy.py
+++ b/tests/unit/orchestrator/test_policy.py
@@ -2,13 +2,28 @@
 
 from __future__ import annotations
 
-from ouroboros.orchestrator.capabilities import build_capability_graph
+from dataclasses import replace
+
+from ouroboros.orchestrator.capabilities import (
+    CapabilityApprovalClass,
+    CapabilityDescriptor,
+    CapabilityGraph,
+    CapabilityInterruptibility,
+    CapabilityMutationClass,
+    CapabilityOrigin,
+    CapabilityParallelSafety,
+    CapabilityScope,
+    CapabilitySemantics,
+    build_capability_graph,
+)
 from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 from ouroboros.orchestrator.policy import (
     PolicyContext,
     PolicyExecutionPhase,
     PolicySessionRole,
     allowed_capability_names,
+    allowed_runtime_builtin_tool_names,
+    evaluate_capability_policy,
 )
 
 
@@ -42,3 +57,113 @@ def test_coordinator_policy_derives_conservative_envelope() -> None:
     )
 
     assert allowed == ["Read", "Edit", "Bash", "Glob", "Grep"]
+
+
+def test_inherited_capability_is_auditable_but_not_executable() -> None:
+    catalog = replace(
+        assemble_session_tool_catalog(["Read"]),
+        inherited_capabilities=frozenset({"mcp__chrome-devtools__click"}),
+    )
+    graph = build_capability_graph(catalog)
+    context = PolicyContext(
+        runtime_backend="opencode",
+        session_role=PolicySessionRole.IMPLEMENTATION,
+        execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
+    )
+
+    decisions = {decision.name: decision for decision in evaluate_capability_policy(graph, context)}
+    allowed = allowed_capability_names(graph, context)
+
+    assert allowed == ["Read"]
+    inherited = decisions["mcp__chrome-devtools__click"]
+    assert inherited.visible is True
+    assert inherited.executable is False
+    assert inherited.reasons == (
+        "inherited_capability requires live provider discovery before execution",
+    )
+
+
+def test_read_only_roles_allow_provider_native_by_origin_and_scope() -> None:
+    graph = CapabilityGraph(
+        capabilities=(
+            CapabilityDescriptor(
+                stable_id="provider:opencode:workspace_snapshot",
+                name="workspace_snapshot",
+                original_name="workspace_snapshot",
+                description="Provider-native workspace inspection",
+                server_name=None,
+                source_kind="provider_native",
+                source_name="opencode",
+                semantics=CapabilitySemantics(
+                    mutation_class=CapabilityMutationClass.READ_ONLY,
+                    parallel_safety=CapabilityParallelSafety.SAFE,
+                    interruptibility=CapabilityInterruptibility.NONE,
+                    approval_class=CapabilityApprovalClass.DEFAULT,
+                    origin=CapabilityOrigin.PROVIDER_NATIVE,
+                    scope=CapabilityScope.SIDECAR,
+                ),
+            ),
+        )
+    )
+
+    allowed = allowed_capability_names(
+        graph,
+        PolicyContext(
+            runtime_backend="opencode",
+            session_role=PolicySessionRole.EVALUATION,
+            execution_phase=PolicyExecutionPhase.EVALUATION,
+        ),
+    )
+
+    assert allowed == ["workspace_snapshot"]
+
+
+def test_read_only_roles_still_hide_unknown_attached_tools() -> None:
+    graph = CapabilityGraph(
+        capabilities=(
+            CapabilityDescriptor(
+                stable_id="mcp:browser:browser_snapshot",
+                name="browser_snapshot",
+                original_name="browser_snapshot",
+                description="Attached browser screenshot",
+                server_name="browser",
+                source_kind="attached_mcp",
+                source_name="browser",
+                semantics=CapabilitySemantics(
+                    mutation_class=CapabilityMutationClass.READ_ONLY,
+                    parallel_safety=CapabilityParallelSafety.SAFE,
+                    interruptibility=CapabilityInterruptibility.NONE,
+                    approval_class=CapabilityApprovalClass.DEFAULT,
+                    origin=CapabilityOrigin.ATTACHED_MCP,
+                    scope=CapabilityScope.ATTACHMENT,
+                ),
+            ),
+        )
+    )
+
+    decisions = evaluate_capability_policy(
+        graph,
+        PolicyContext(
+            runtime_backend="opencode",
+            session_role=PolicySessionRole.EVALUATION,
+            execution_phase=PolicyExecutionPhase.EVALUATION,
+        ),
+    )
+
+    assert decisions[0].visible is False
+    assert decisions[0].executable is False
+
+
+def test_read_only_roles_derive_runtime_builtin_envelope_from_policy() -> None:
+    allowed = allowed_runtime_builtin_tool_names(
+        PolicyContext(
+            runtime_backend="opencode",
+            session_role=PolicySessionRole.EVALUATION,
+            execution_phase=PolicyExecutionPhase.EVALUATION,
+        )
+    )
+
+    assert allowed == ["Read", "Glob", "Grep", "WebFetch", "WebSearch"]
+    assert "Edit" not in allowed
+    assert "Write" not in allowed
+    assert "Bash" not in allowed

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2344,7 +2344,7 @@ class TestOrchestratorRunnerWithMCP:
         policy_events = [
             call.args[0]
             for call in mock_event_store.append.await_args_list
-            if getattr(call.args[0], "type", None) == "policy.capabilities.evaluated"
+            if getattr(call.args[0], "type", None) == "orchestrator.policy.capabilities.evaluated"
         ]
         assert len(policy_events) == 1
         events_by_name = {

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2323,6 +2323,47 @@ class TestOrchestratorRunnerWithMCP:
         assert provider is None
 
     @pytest.mark.asyncio
+    async def test_get_merged_tools_emits_policy_events_for_inherited_capabilities(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """Policy decisions are persisted, including non-executable inherited grants."""
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            inherited_tools=["Read", "mcp__chrome-devtools__click"],
+        )
+
+        merged_tools, provider, _tool_catalog = await runner._get_merged_tools("session_123")
+
+        assert provider is None
+        assert "mcp__chrome-devtools__click" not in merged_tools
+        policy_events = [
+            call.args[0]
+            for call in mock_event_store.append.await_args_list
+            if getattr(call.args[0], "type", None) == "policy.capabilities.evaluated"
+        ]
+        assert len(policy_events) == 1
+        events_by_name = {
+            item["capability"]["name"]: item for item in policy_events[0].data["evaluations"]
+        }
+
+        read_event = events_by_name["Read"]
+        assert read_event["decision"]["visible"] is True
+        assert read_event["decision"]["executable"] is True
+
+        inherited_event = events_by_name["mcp__chrome-devtools__click"]
+        assert inherited_event["capability"]["source_kind"] == "inherited_capability"
+        assert inherited_event["decision"]["visible"] is True
+        assert inherited_event["decision"]["executable"] is False
+        assert inherited_event["decision"]["reasons"] == [
+            "inherited_capability requires live provider discovery before execution"
+        ]
+
+    @pytest.mark.asyncio
     async def test_get_merged_tools_preserves_inherited_capabilities_after_discovery(
         self,
         mock_adapter: MagicMock,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2364,6 +2364,39 @@ class TestOrchestratorRunnerWithMCP:
         ]
 
     @pytest.mark.asyncio
+    async def test_policy_audit_emit_failure_does_not_break_orchestration(
+        self,
+        mock_adapter: MagicMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """A failing event store must not take down tool-catalog assembly.
+
+        The policy audit event is auxiliary observability, not a
+        prerequisite for orchestration.  If the event store fails
+        (disk full, DB locked, etc.), the orchestrator must keep
+        producing merged tools and degrade to a logged warning
+        instead of raising into the session flow.
+        """
+        failing_event_store = AsyncMock()
+        failing_event_store.append.side_effect = RuntimeError("event store unavailable")
+
+        runner = OrchestratorRunner(
+            mock_adapter,
+            failing_event_store,
+            mock_console,
+            inherited_tools=["Read"],
+        )
+
+        # Must not raise despite every append() failing.
+        merged_tools, provider, tool_catalog = await runner._get_merged_tools("session_123")
+
+        assert provider is None
+        assert "Read" in merged_tools
+        assert tool_catalog is not None
+        # The failed audit attempt was still made (best-effort, not skipped).
+        assert failing_event_store.append.await_count >= 1
+
+    @pytest.mark.asyncio
     async def test_get_merged_tools_preserves_inherited_capabilities_after_discovery(
         self,
         mock_adapter: MagicMock,

--- a/tests/unit/orchestrator/test_sandbox_class.py
+++ b/tests/unit/orchestrator/test_sandbox_class.py
@@ -1,0 +1,137 @@
+"""Cross-backend invariants for the engine ``SandboxClass`` vocabulary."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.claude_permissions import (
+    _SANDBOX_TO_CLAUDE_MODE,
+    claude_permission_mode_for_sandbox,
+)
+from ouroboros.codex_permissions import (
+    _SANDBOX_TO_CODEX_ARGS,
+    build_codex_exec_args_for_sandbox,
+    build_codex_exec_permission_args,
+)
+from ouroboros.orchestrator.policy import (
+    PolicyContext,
+    PolicyExecutionPhase,
+    PolicySessionRole,
+    SandboxClass,
+    derive_sandbox_class,
+)
+
+
+class TestDeriveSandboxClass:
+    """Every admitted session role resolves to exactly one sandbox class."""
+
+    def test_interview_and_evaluation_are_read_only(self) -> None:
+        for role, phase in (
+            (PolicySessionRole.INTERVIEW, PolicyExecutionPhase.INTERVIEW),
+            (PolicySessionRole.EVALUATION, PolicyExecutionPhase.EVALUATION),
+        ):
+            ctx = PolicyContext(
+                runtime_backend="opencode",
+                session_role=role,
+                execution_phase=phase,
+            )
+            assert derive_sandbox_class(ctx) is SandboxClass.READ_ONLY
+
+    def test_coordinator_is_workspace_write(self) -> None:
+        ctx = PolicyContext(
+            runtime_backend="opencode",
+            session_role=PolicySessionRole.COORDINATOR,
+            execution_phase=PolicyExecutionPhase.COORDINATOR_REVIEW,
+        )
+        assert derive_sandbox_class(ctx) is SandboxClass.WORKSPACE_WRITE
+
+    def test_implementation_is_unrestricted(self) -> None:
+        ctx = PolicyContext(
+            runtime_backend="codex",
+            session_role=PolicySessionRole.IMPLEMENTATION,
+            execution_phase=PolicyExecutionPhase.IMPLEMENTATION,
+        )
+        assert derive_sandbox_class(ctx) is SandboxClass.UNRESTRICTED
+
+    def test_every_role_maps_to_a_sandbox_class(self) -> None:
+        """Adding a role must also add a sandbox mapping — no silent defaults."""
+        role_phase_pairs = {
+            PolicySessionRole.IMPLEMENTATION: PolicyExecutionPhase.IMPLEMENTATION,
+            PolicySessionRole.COORDINATOR: PolicyExecutionPhase.COORDINATOR_REVIEW,
+            PolicySessionRole.INTERVIEW: PolicyExecutionPhase.INTERVIEW,
+            PolicySessionRole.EVALUATION: PolicyExecutionPhase.EVALUATION,
+        }
+        assert set(role_phase_pairs) == set(PolicySessionRole), (
+            "New PolicySessionRole must be covered here"
+        )
+        for role, phase in role_phase_pairs.items():
+            ctx = PolicyContext(
+                runtime_backend="codex",
+                session_role=role,
+                execution_phase=phase,
+            )
+            # Must not raise KeyError.
+            derive_sandbox_class(ctx)
+
+
+class TestBackendMappingCompleteness:
+    """Every SandboxClass value must have a mapping in every provider table.
+
+    This is the invariant that makes the layering honest: without it, a new
+    sandbox class could ship with a matching Codex entry but a missing Claude
+    entry, silently re-creating the drift this refactor exists to eliminate.
+    """
+
+    def test_codex_table_covers_every_sandbox_class(self) -> None:
+        for sandbox in SandboxClass:
+            # Does not raise; returns a non-empty list.
+            args = build_codex_exec_args_for_sandbox(sandbox)
+            assert args, f"Codex mapping for {sandbox!r} is empty"
+        assert set(_SANDBOX_TO_CODEX_ARGS) == set(SandboxClass)
+
+    def test_claude_table_covers_every_sandbox_class(self) -> None:
+        for sandbox in SandboxClass:
+            mode = claude_permission_mode_for_sandbox(sandbox)
+            assert mode, f"Claude mapping for {sandbox!r} is empty"
+        assert set(_SANDBOX_TO_CLAUDE_MODE) == set(SandboxClass)
+
+
+class TestCodexLegacyWrapperPreservesBehavior:
+    """``build_codex_exec_permission_args`` must produce the same flags as
+    the new SandboxClass entry point for every supported mode.  Otherwise
+    the two call paths could drift and a caller on the legacy string path
+    would get different Codex flags than a caller on the new enum path.
+    """
+
+    @pytest.mark.parametrize(
+        ("mode", "expected_sandbox"),
+        [
+            ("default", SandboxClass.READ_ONLY),
+            ("acceptEdits", SandboxClass.WORKSPACE_WRITE),
+            ("bypassPermissions", SandboxClass.UNRESTRICTED),
+        ],
+    )
+    def test_legacy_wrapper_routes_through_sandbox_enum(
+        self, mode: str, expected_sandbox: SandboxClass
+    ) -> None:
+        legacy_args = build_codex_exec_permission_args(mode)
+        enum_args = build_codex_exec_args_for_sandbox(expected_sandbox)
+        assert legacy_args == enum_args
+
+
+class TestClaudeLegacyVocabularyMatchesSandbox:
+    """Claude SDK historically consumed the same ``default``/``acceptEdits``/
+    ``bypassPermissions`` strings we now treat as engine sandbox values.
+    This test pins that the enum-driven mapping still produces exactly those
+    strings, so the Claude adapter can adopt the enum without a behavior
+    change visible to the SDK.
+    """
+
+    def test_read_only_renders_as_default(self) -> None:
+        assert claude_permission_mode_for_sandbox(SandboxClass.READ_ONLY) == "default"
+
+    def test_workspace_write_renders_as_accept_edits(self) -> None:
+        assert claude_permission_mode_for_sandbox(SandboxClass.WORKSPACE_WRITE) == "acceptEdits"
+
+    def test_unrestricted_renders_as_bypass_permissions(self) -> None:
+        assert claude_permission_mode_for_sandbox(SandboxClass.UNRESTRICTED) == "bypassPermissions"

--- a/tests/unit/providers/test_factory.py
+++ b/tests/unit/providers/test_factory.py
@@ -224,3 +224,69 @@ class TestResolveLLMPermissionMode:
             resolve_llm_permission_mode(backend="opencode", use_case="interview")
             == "bypassPermissions"
         )
+
+
+class TestGeminiSoftToolEnforcement:
+    """Gemini accepts ``allowed_tools`` but enforces them softly.
+
+    The Gemini CLI has no ``--allowed-tools`` flag, so the adapter injects
+    the envelope as a system-prompt directive and detects out-of-envelope
+    ``tool_use`` events post-hoc.  The factory's job is to (a) still
+    construct the adapter — failing fast would turn every interview or
+    evaluation on Gemini into a hard error with no recovery path — and
+    (b) make the soft-enforcement trade-off visible at construction time
+    so operators can tell it apart from hard-enforced sessions.
+    """
+
+    def _stub_gemini_cli(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        fake_cli = tmp_path / "gemini"
+        fake_cli.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+        fake_cli.chmod(0o755)
+        monkeypatch.setenv("OUROBOROS_GEMINI_CLI_PATH", str(fake_cli))
+
+    def test_gemini_backend_accepts_allowed_tools_with_soft_enforcement(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """Factory still builds a working adapter when Gemini gets an envelope."""
+        self._stub_gemini_cli(monkeypatch, tmp_path)
+
+        adapter = create_llm_adapter(
+            backend="gemini",
+            allowed_tools=["Read", "Grep", "Glob", "WebFetch", "WebSearch"],
+        )
+
+        assert adapter.__class__.__name__ == "GeminiCLIAdapter"
+        # The adapter keeps the envelope for prompt injection + post-hoc
+        # violation detection.
+        assert adapter._allowed_tools == (  # type: ignore[attr-defined]
+            "Read",
+            "Grep",
+            "Glob",
+            "WebFetch",
+            "WebSearch",
+        )
+
+    def test_gemini_backend_accepts_empty_allowed_tools(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """An explicit empty envelope still produces a working adapter —
+        the prompt directive becomes "no tools allowed" instead of a
+        named allowlist.
+        """
+        self._stub_gemini_cli(monkeypatch, tmp_path)
+
+        adapter = create_llm_adapter(backend="gemini", allowed_tools=[])
+
+        assert adapter.__class__.__name__ == "GeminiCLIAdapter"
+        assert adapter._allowed_tools == ()  # type: ignore[attr-defined]
+
+    def test_gemini_backend_accepts_unrestricted_callers(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """``allowed_tools=None`` means "caller did not request enforcement"."""
+        self._stub_gemini_cli(monkeypatch, tmp_path)
+
+        adapter = create_llm_adapter(backend="gemini", allowed_tools=None)
+
+        assert adapter.__class__.__name__ == "GeminiCLIAdapter"
+        assert adapter._allowed_tools is None  # type: ignore[attr-defined]

--- a/tests/unit/providers/test_gemini_cli_adapter.py
+++ b/tests/unit/providers/test_gemini_cli_adapter.py
@@ -559,3 +559,91 @@ class TestInputValidation:
 
         assert result.is_ok
         assert result.value.content == "Hello, world!"
+
+
+class TestGeminiToolEnvelopeInjection:
+    """Soft enforcement of ``allowed_tools`` on the Gemini CLI backend.
+
+    The CLI has no ``--allowed-tools`` flag, so the adapter's job is to
+    (a) inject the envelope as a hard system-prompt directive, and
+    (b) detect violations post-hoc in the ``tool_use`` event stream.
+    These tests pin both behaviors.
+    """
+
+    def test_no_envelope_produces_plain_system_block(self) -> None:
+        """No ``allowed_tools`` → no ``<tool_envelope>`` block."""
+        adapter = GeminiCLIAdapter(cli_path="gemini")
+
+        prompt = adapter._build_prompt(
+            [
+                Message(role=MessageRole.SYSTEM, content="Be concise."),
+                Message(role=MessageRole.USER, content="Hi"),
+            ]
+        )
+
+        assert "tool_envelope" not in prompt
+        assert "Be concise." in prompt
+
+    def test_envelope_is_injected_into_system_block(self) -> None:
+        """Allowed tools produce a hard directive before any user system text."""
+        adapter = GeminiCLIAdapter(
+            cli_path="gemini",
+            allowed_tools=["Read", "Grep"],
+        )
+
+        prompt = adapter._build_prompt(
+            [
+                Message(role=MessageRole.SYSTEM, content="Be concise."),
+                Message(role=MessageRole.USER, content="Hi"),
+            ]
+        )
+
+        assert "<tool_envelope>" in prompt
+        assert "You may ONLY invoke the following tools" in prompt
+        assert "Read, Grep" in prompt
+        assert "hard session-level restriction" in prompt
+        # User's own system message is preserved below the envelope.
+        assert "Be concise." in prompt
+
+    def test_empty_envelope_forbids_all_tools(self) -> None:
+        """``allowed_tools=[]`` renders as "no tools permitted"."""
+        adapter = GeminiCLIAdapter(cli_path="gemini", allowed_tools=[])
+
+        prompt = adapter._build_prompt([Message(role=MessageRole.USER, content="Hi")])
+
+        assert "not permitted to invoke any tools" in prompt
+
+    @pytest.mark.asyncio
+    async def test_out_of_envelope_tool_use_is_logged(self) -> None:
+        """A ``tool_use`` event for a tool outside the envelope is logged.
+
+        Runs a tiny stream through ``_collect_response`` that contains
+        one in-envelope tool (``Read``) and one out-of-envelope tool
+        (``Edit``) and asserts the latter triggers the structured
+        violation warning while the former does not.
+        """
+        import structlog
+
+        events = [
+            _INIT_EVENT,
+            {"type": "tool_use", "name": "Read", "input": {}},
+            {"type": "tool_use", "name": "Edit", "input": {}},
+            _RESULT_EVENT,
+        ]
+        stream = _make_stream(events)
+        process = _FakeProcess(stdout=stream, returncode=0)
+        adapter = GeminiCLIAdapter(
+            cli_path="gemini",
+            allowed_tools=["Read"],
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            result = await adapter._collect_response(process)
+
+        assert result.is_ok
+        violations = [
+            e for e in captured if e.get("event") == "gemini_cli_adapter.tool_envelope_violation"
+        ]
+        assert len(violations) == 1
+        assert violations[0]["tool"] == "Edit"
+        assert violations[0]["allowed_tools"] == ["Read"]

--- a/tests/unit/providers/test_opencode_adapter.py
+++ b/tests/unit/providers/test_opencode_adapter.py
@@ -513,3 +513,86 @@ class TestOpenCodeLLMAdapter:
         result = adapter._extract_text_from_events(events)
         assert "Here is my answer." in result
         assert "SECRET_TOOL_OUTPUT" not in result
+
+
+class TestOpenCodeToolEnvelopeSoftEnforcement:
+    """OpenCode enforces ``allowed_tools`` softly (prompt + post-hoc audit).
+
+    The ``opencode run`` CLI has no ``--allowed-tools`` or
+    ``--permission-mode`` flag, so the adapter must (a) make the
+    envelope visible to the model via a prompt directive and (b)
+    surface ``tool_use`` events outside the envelope as structured
+    warnings so drift is observable.  These tests pin both halves.
+    """
+
+    def test_envelope_is_injected_into_prompt(self) -> None:
+        """``allowed_tools`` shows up as a ``## Tool Constraints`` block."""
+        adapter = OpenCodeLLMAdapter(
+            cli_path="opencode",
+            cwd="/tmp",
+            allowed_tools=["Read", "Grep"],
+        )
+
+        prompt = adapter._build_prompt([Message(role=MessageRole.USER, content="Hi")])
+
+        assert "## Tool Constraints" in prompt
+        assert "Limit your tool usage to ONLY the following tools" in prompt
+        assert "- Read" in prompt
+        assert "- Grep" in prompt
+
+    def test_empty_envelope_forbids_all_tools(self) -> None:
+        """``allowed_tools=[]`` renders the "no tools" directive."""
+        adapter = OpenCodeLLMAdapter(
+            cli_path="opencode",
+            cwd="/tmp",
+            allowed_tools=[],
+        )
+
+        prompt = adapter._build_prompt([Message(role=MessageRole.USER, content="Hi")])
+
+        assert "Do NOT use any tools" in prompt
+
+    def test_audit_flags_tool_use_outside_envelope(self) -> None:
+        """A ``tool_use`` event for a tool outside the envelope triggers
+        the violation warning; an in-envelope event does not.
+        """
+        import structlog
+
+        adapter = OpenCodeLLMAdapter(
+            cli_path="opencode",
+            cwd="/tmp",
+            allowed_tools=["Read"],
+        )
+        events = [
+            {"type": "tool_use", "part": {"tool": "Read", "state": {"status": "completed"}}},
+            {"type": "tool_use", "part": {"tool": "Edit", "state": {"status": "completed"}}},
+            {"type": "text", "part": {"type": "text", "text": "done"}},
+        ]
+
+        with structlog.testing.capture_logs() as captured:
+            adapter._audit_tool_envelope_violations(events)
+
+        violations = [
+            e for e in captured if e.get("event") == "opencode_adapter.tool_envelope_violation"
+        ]
+        assert len(violations) == 1
+        assert violations[0]["tool"] == "Edit"
+        assert violations[0]["allowed_tools"] == ["Read"]
+
+    def test_no_envelope_means_no_audit(self) -> None:
+        """With no envelope declared, the audit is a no-op even when
+        ``tool_use`` events are present.
+        """
+        import structlog
+
+        adapter = OpenCodeLLMAdapter(cli_path="opencode", cwd="/tmp")
+        events = [
+            {"type": "tool_use", "part": {"tool": "Edit", "state": {"status": "completed"}}},
+        ]
+
+        with structlog.testing.capture_logs() as captured:
+            adapter._audit_tool_envelope_violations(events)
+
+        assert not [
+            e for e in captured if e.get("event") == "opencode_adapter.tool_envelope_violation"
+        ]


### PR DESCRIPTION
Adopt the first architecture slice from the Claude runtime adoption analysis by adding a capability graph, a policy plane, control-plane hints, and a derived coordinator envelope while preserving the existing tool-catalog seam.

<img width="659" height="633" alt="image" src="https://github.com/user-attachments/assets/fe15e200-26dc-4d2c-ac91-7073f079755a" />

New architecture provide the hints and description of tools and mcp. 
It is like
```

hammer 
safety: normal
parallel: true
approval: normal

saw
safety: low
parallel: false
approval: needs approval
```

https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code

The model calls tools less often and  reasons more. This produces better results in many cases.
