### PR TITLE
fix(mcp): evaluator must not reuse max_turns=1 shared adapter (fixes #305)

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -802,6 +802,15 @@ def create_ouroboros_server(
     )
 
     # Create shared LLM adapter for interview/seed/evaluation paths.
+    #
+    # NOTE: ``max_turns=1`` is appropriate for interview question generation
+    # and seed synthesis, where the adapter returns a single-shot response.
+    # Evaluation (Stage 2 semantic) DOES NOT use this adapter — see
+    # ``EvaluateHandler.handle`` in ``mcp/tools/evaluation_handlers.py`` which
+    # constructs a fresh adapter with ``max_turns=20`` so the semantic
+    # evaluator can issue tool calls when reading spec files. Do not bump
+    # this value without first auditing every caller of ``self.llm_adapter``
+    # — it affects interview latency and token usage.
     llm_adapter = create_llm_adapter(
         backend=llm_backend,
         max_turns=1,

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -402,7 +402,23 @@ class EvaluateHandler:
             # Use injected or create services.
             # Evaluation reads multiple spec files (one Read call per AC), so
             # max_turns must be well above 1.
-            llm_adapter = self.llm_adapter or create_llm_adapter(
+            #
+            # IMPORTANT: The shared ``self.llm_adapter`` that may have been
+            # injected by ``build_mcp_server`` (see ``mcp/server/adapter.py``)
+            # is constructed with ``max_turns=1`` for interview / seed-generation
+            # use cases. That value is fatal for evaluation because the Stage 2
+            # semantic evaluator issues at least one ``Read`` tool call per AC to
+            # inspect spec files. With ``max_turns=1`` the Agent SDK returns
+            # ``error_max_turns`` on the very first tool call, surfacing as
+            # ``Command failed with exit code 1`` at the MCP tool boundary.
+            #
+            # To ensure the evaluator always has enough turns, construct a
+            # fresh adapter here rather than relying on the injected instance.
+            # The old ``self.llm_adapter or create_llm_adapter(...)`` pattern
+            # short-circuited on the injected adapter and silently preserved
+            # the ``max_turns=1`` ceiling — see issue #305 for the user-facing
+            # failure it produced.
+            llm_adapter = create_llm_adapter(
                 backend=self.llm_backend,
                 max_turns=20,
             )

--- a/tests/unit/mcp/tools/test_evaluation_handler.py
+++ b/tests/unit/mcp/tools/test_evaluation_handler.py
@@ -135,14 +135,91 @@ class TestEvaluateHandlerAdapterCreation:
             "at least one turn per AC file read. Use max_turns >= 10."
         )
 
-    async def test_injected_adapter_skips_create_llm_adapter(self):
-        """When an adapter is injected (e.g. in tests), create_llm_adapter is not called."""
-        handler = EvaluateHandler(llm_adapter=_make_mock_adapter())
+    async def test_injected_adapter_is_ignored_for_evaluation(self):
+        """Evaluation ALWAYS creates a fresh adapter, even when one is injected.
+
+        Regression for issue #305 / related max_turns fix:
+
+        The shared adapter wired up in ``build_mcp_server``
+        (``mcp/server/adapter.py``) is constructed with ``max_turns=1`` because
+        interview and seed-generation paths only need a single-shot response.
+        If the evaluator reuses that adapter, the very first ``Read`` tool
+        call issued by the Stage 2 semantic evaluator hits ``error_max_turns``
+        and surfaces as ``Command failed with exit code 1`` at the MCP tool
+        boundary.
+
+        To prevent that, the handler now ignores ``self.llm_adapter`` and
+        always constructs a fresh adapter with ``max_turns=20``.
+        """
+        captured: dict = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return _make_mock_adapter()
+
+        # Simulate the shared adapter that build_mcp_server would inject.
+        shared_adapter = _make_mock_adapter()
+        handler = EvaluateHandler(llm_adapter=shared_adapter)
 
         with (
-            patch("ouroboros.mcp.tools.evaluation_handlers.create_llm_adapter") as mock_create,
+            patch(
+                "ouroboros.mcp.tools.evaluation_handlers.create_llm_adapter",
+                side_effect=_capture,
+            ),
             _patch_pipeline(),
         ):
             await handler.handle(_BASE_ARGUMENTS)
 
-        mock_create.assert_not_called()
+        # Fresh adapter was created with a sufficient max_turns budget, even
+        # though one was already injected on the handler.
+        assert "max_turns" in captured, (
+            "create_llm_adapter was not called — the handler must build a "
+            "fresh adapter for evaluation instead of reusing the shared "
+            "interview-tuned adapter."
+        )
+        assert captured["max_turns"] >= 10, (
+            f"max_turns={captured['max_turns']} is too low."
+        )
+
+    async def test_injected_max_turns_1_adapter_does_not_leak(self):
+        """Regression for issue #305: injecting a max_turns=1 adapter must not
+        cause evaluation to inherit the pathological ceiling.
+
+        This guards against a future refactor re-introducing the
+        ``self.llm_adapter or create_llm_adapter(...)`` short-circuit pattern.
+        """
+        # The shared MCP adapter is built with max_turns=1; verify that the
+        # handler does not forward that adapter into the evaluation pipeline.
+        low_turn_adapter = _make_mock_adapter()
+        low_turn_adapter._max_turns = 1  # mirror ClaudeCodeAdapter attribute
+        handler = EvaluateHandler(llm_adapter=low_turn_adapter)
+
+        captured_pipeline_adapters: list = []
+
+        def _capture_pipeline(llm_adapter, config):  # noqa: ARG001
+            mock_pipeline = MagicMock()
+            mock_pipeline.evaluate = AsyncMock(
+                return_value=Result.ok(_make_approved_eval_result()),
+            )
+            captured_pipeline_adapters.append(llm_adapter)
+            return mock_pipeline
+
+        with (
+            patch(
+                "ouroboros.mcp.tools.evaluation_handlers.create_llm_adapter",
+                return_value=_make_mock_adapter(),
+            ),
+            patch(
+                "ouroboros.evaluation.EvaluationPipeline",
+                side_effect=_capture_pipeline,
+            ),
+        ):
+            await handler.handle(_BASE_ARGUMENTS)
+
+        assert captured_pipeline_adapters, "EvaluationPipeline was not constructed"
+        pipeline_adapter = captured_pipeline_adapters[0]
+        assert pipeline_adapter is not low_turn_adapter, (
+            "EvaluationPipeline was constructed with the injected max_turns=1 "
+            "adapter — this is the bug described in issue #305. The handler "
+            "must build a fresh adapter with a higher max_turns budget."
+        )

--- a/tests/unit/mcp/tools/test_evaluation_handler.py
+++ b/tests/unit/mcp/tools/test_evaluation_handler.py
@@ -177,9 +177,7 @@ class TestEvaluateHandlerAdapterCreation:
             "fresh adapter for evaluation instead of reusing the shared "
             "interview-tuned adapter."
         )
-        assert captured["max_turns"] >= 10, (
-            f"max_turns={captured['max_turns']} is too low."
-        )
+        assert captured["max_turns"] >= 10, f"max_turns={captured['max_turns']} is too low."
 
     async def test_injected_max_turns_1_adapter_does_not_leak(self):
         """Regression for issue #305: injecting a max_turns=1 adapter must not


### PR DESCRIPTION
## Summary

Fixes the `ooo evaluate` / `ouroboros_evaluate` MCP tool failure described
in #305 (`Claude Agent SDK request failed: Command failed with exit code 1`).

Root cause analysis on `main` (v0.28.3) shows the bug has a different
underlying mechanism than #305 originally hypothesised. The nested Claude
CLI subprocess exits with `exit code 1` because the SDK query hits
`error_max_turns` on the very first tool call — not because the nested CLI
itself fails to start.

## Root Cause

`build_mcp_server` constructs a single shared `llm_adapter` with
`max_turns=1`, which is correct for interview and seed-generation paths
(those are single-shot completions):

```python
# src/ouroboros/mcp/server/adapter.py:805
llm_adapter = create_llm_adapter(
    backend=llm_backend,
    max_turns=1,     # correct for interview / seed generation
    cwd=Path.cwd(),
)
```

That adapter is then injected into every handler including
`EvaluateHandler`. The handler's adapter lookup uses the `or` short-circuit
pattern:

```python
# src/ouroboros/mcp/tools/evaluation_handlers.py:405
llm_adapter = self.llm_adapter or create_llm_adapter(
    backend=self.llm_backend,
    max_turns=20,
)
```

Because `self.llm_adapter` is *always truthy* in production (`build_mcp_server`
injected it), the `or` branch never runs and the `max_turns=20` fallback is
dead code. Stage 2 semantic evaluation inherits the `max_turns=1` ceiling
and fails on the very first `Read` tool call it issues to inspect a spec
file, surfacing as `error_max_turns` in the SDK and `exit code 1` at the
MCP tool boundary.

The existing `CLAUDECODE` env stripping workaround at
`claude_code_adapter.py:557-564` does not help here — it is a separate
issue about nested session detection.

## Fix

Always construct a fresh adapter in `EvaluateHandler.handle`, regardless of
whether one was injected. The shared adapter is still appropriate for
interview / seed generation; only evaluation needs the higher budget.

**`src/ouroboros/mcp/tools/evaluation_handlers.py`**
- Drop the `or` short-circuit; always call `create_llm_adapter(max_turns=20)`.
- Expand inline comment to document the invariant and reference #305.

**`src/ouroboros/mcp/server/adapter.py`**
- No code change. Add a block comment pointing future readers at the
  evaluator path so the interaction between the shared `max_turns=1` and
  the evaluator's private adapter is obvious. Prevents a well-meaning
  refactor from \"bumping max_turns from 1 to 20\" and inadvertently
  breaking interview latency.

## Tests

**`tests/unit/mcp/tools/test_evaluation_handler.py`**

- `test_injected_adapter_skips_create_llm_adapter` — renamed to
  `test_injected_adapter_is_ignored_for_evaluation`. The old test
  *guaranteed* the buggy short-circuit; the new assertion flips the
  invariant: even when an adapter is injected, `create_llm_adapter` must
  still be called with a sufficient `max_turns` budget.
- New regression test `test_injected_max_turns_1_adapter_does_not_leak`:
  constructs an adapter with `_max_turns = 1`, injects it, and asserts
  that the `EvaluationPipeline` receives a *different* adapter instance.
  Guards against a future refactor re-introducing the short-circuit
  pattern.
- `test_creates_adapter_with_sufficient_max_turns` unchanged — still
  asserts `max_turns >= 10` for the adapter used inside the pipeline.

Full suite:

```
.venv/bin/python -m pytest tests/unit/mcp/ -q
584 passed in 4.29s
```

## Verification (external reproducer)

Before the fix, running the `EvaluationPipeline` directly on an
in-the-wild seed:

```
warning mcp.tool.evaluate.pipeline_failed
  error=\"Claude Agent SDK request failed: Command failed with exit code 1
         ... subtype='error_max_turns' max_turns=1 ...\"
```

After patching the same paths on my local install, 32 evaluation calls
across 17 task-level ACs + 5 retroactive audits + 1 holistic aggregate
returned `final_approved=True` (aggregate score 0.88). The same code
also runs cleanly under the existing unit tests.

## Compatibility

- Backwards compatible for all non-test callers: the shared adapter
  stays on `max_turns=1`, interview latency unchanged.
- External callers passing `llm_adapter=` to `EvaluateHandler(...)`
  should note that the injected adapter is no longer consulted for the
  evaluation pipeline (it was broken anyway for `max_turns<10`).
- Interview / seed generation paths untouched.

## Related

- Fixes #305 (evaluator exit code 1 in nested session)
- Adjacent but separate: #269 (evolve subprocess leak), #310 (MCP server
  startup scan), #199 (decomposed AC summary evidence loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)