### PR TITLE
fix(orchestrator): restore LLM-assisted top-level AC dependency planning

### DIFF
--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -82,10 +82,12 @@ from ouroboros.orchestrator.runtime_message_projection import (
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
 from ouroboros.orchestrator.workflow_state import coerce_ac_marker_update
 from ouroboros.persistence.checkpoint import CheckpointStore
+from ouroboros.providers import create_llm_adapter
 
 if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
     from ouroboros.mcp.client.manager import MCPClientManager
+    from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
     from ouroboros.persistence.event_store import EventStore
 
 log = get_logger(__name__)
@@ -563,6 +565,31 @@ class OrchestratorRunner:
             return runtime_handle.cwd
         cwd = self._adapter.working_directory
         return cwd if isinstance(cwd, str) and cwd else None
+
+    def _build_dependency_analyzer(self) -> DependencyAnalyzer:
+        """Create a dependency analyzer wired to the active LLM backend when available."""
+        from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
+
+        llm_backend = getattr(self._adapter, "_llm_backend", None)
+        backend = llm_backend if isinstance(llm_backend, str) and llm_backend else (
+            self._adapter.runtime_backend
+        )
+        try:
+            llm_adapter = create_llm_adapter(
+                backend=backend,
+                permission_mode=self._adapter.permission_mode,
+                cwd=self._effective_cwd(),
+                max_turns=1,
+            )
+        except Exception as exc:
+            log.warning(
+                "orchestrator.runner.dependency_analysis_llm_unavailable",
+                backend=backend,
+                error=str(exc),
+            )
+            return DependencyAnalyzer()
+
+        return DependencyAnalyzer(llm_adapter=llm_adapter)
 
     def _normalized_message_type(self, message: AgentMessage) -> str:
         """Collapse runtime-specific message details into shared progress categories."""
@@ -1711,7 +1738,7 @@ class OrchestratorRunner:
         Returns:
             Result containing OrchestratorResult on success.
         """
-        from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyAnalyzer
+        from ouroboros.orchestrator.dependency_analyzer import ACNode
         from ouroboros.orchestrator.parallel_executor import (
             ParallelACExecutor,
             render_parallel_completion_message,
@@ -1728,7 +1755,7 @@ class OrchestratorRunner:
         # Analyze dependencies
         self._console.print("\n[cyan]Analyzing AC dependencies...[/cyan]")
 
-        analyzer = DependencyAnalyzer()
+        analyzer = self._build_dependency_analyzer()
         dep_result = await analyzer.analyze(seed.acceptance_criteria)
 
         if dep_result.is_err:

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -571,8 +571,10 @@ class OrchestratorRunner:
         from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
 
         llm_backend = getattr(self._adapter, "_llm_backend", None)
-        backend = llm_backend if isinstance(llm_backend, str) and llm_backend else (
-            self._adapter.runtime_backend
+        backend = (
+            llm_backend
+            if isinstance(llm_backend, str) and llm_backend
+            else (self._adapter.runtime_backend)
         )
         try:
             llm_adapter = create_llm_adapter(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1530,6 +1530,80 @@ class TestOrchestratorRunner:
         assert kwargs["session_id"] == tracker.session_id
 
     @pytest.mark.asyncio
+    async def test_execute_parallel_builds_dependency_analyzer_with_llm_adapter(
+        self,
+        runner: OrchestratorRunner,
+        sample_seed: Seed,
+    ) -> None:
+        """Parallel execution should restore LLM-assisted dependency analysis."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        tracker = SessionTracker.create("exec_parallel", sample_seed.metadata.seed_id)
+        dependency_graph = DependencyGraph(
+            nodes=tuple(
+                ACNode(index=i, content=ac) for i, ac in enumerate(sample_seed.acceptance_criteria)
+            ),
+            execution_levels=((0, 1, 2),),
+        )
+        parallel_result = ParallelExecutionResult(
+            results=tuple(
+                ACExecutionResult(
+                    ac_index=i,
+                    ac_content=ac,
+                    success=True,
+                    final_message="done",
+                )
+                for i, ac in enumerate(sample_seed.acceptance_criteria)
+            ),
+            success_count=len(sample_seed.acceptance_criteria),
+            failure_count=0,
+            total_messages=len(sample_seed.acceptance_criteria),
+        )
+        llm_adapter = object()
+        analyzer_instance = MagicMock()
+        analyzer_instance.analyze = AsyncMock(return_value=Result.ok(dependency_graph))
+        dependency_analyzer_cls = MagicMock(return_value=analyzer_instance)
+
+        with (
+            patch(
+                "ouroboros.orchestrator.runner.create_llm_adapter",
+                return_value=llm_adapter,
+            ) as mock_create_llm_adapter,
+            patch(
+                "ouroboros.orchestrator.dependency_analyzer.DependencyAnalyzer",
+                dependency_analyzer_cls,
+            ),
+            patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner._session_repo,
+                "mark_completed",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch(
+                "ouroboros.orchestrator.parallel_executor.ParallelACExecutor.execute_parallel",
+                AsyncMock(return_value=parallel_result),
+            ),
+        ):
+            result = await runner._execute_parallel(
+                seed=sample_seed,
+                exec_id="exec_parallel",
+                tracker=tracker,
+                merged_tools=["Read"],
+                tool_catalog=assemble_session_tool_catalog(["Read"]),
+                system_prompt="system",
+                start_time=tracker.start_time,
+            )
+
+        assert result.is_ok
+        mock_create_llm_adapter.assert_called_once_with(
+            backend="opencode",
+            permission_mode="acceptEdits",
+            cwd="/tmp/project",
+            max_turns=1,
+        )
+        dependency_analyzer_cls.assert_called_once_with(llm_adapter=llm_adapter)
+
+    @pytest.mark.asyncio
     async def test_execute_seed_uses_inherited_runtime_handle(
         self,
         mock_event_store: AsyncMock,


### PR DESCRIPTION
## Summary
- wire top-level parallel dependency analysis to a 1-turn LLM adapter derived from the active runtime backend
- fall back to structured-only dependency analysis when the runtime-specific LLM adapter cannot be created
- add a regression test that verifies `_execute_parallel()` builds the dependency analyzer with the injected LLM adapter

## Problem
Top-level AC planning was instantiating `DependencyAnalyzer()` without an LLM adapter. After the analyzer stopped auto-creating its own adapter, plain-text seed ACs defaulted to `structured_only` analysis, which frequently collapsed the execution plan into a single `Level 1/1` batch.

## Testing
- `uv run pytest -q tests/unit/orchestrator/test_runner.py`
- `uv run ruff check src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_runner.py`
- `python3 -m compileall src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_runner.py`