### PR TITLE
fix: detect opencode.jsonc config alongside opencode.json (#356)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -552,7 +552,7 @@ logging:
   level: info
 ```
 
-OpenCode supports multiple model providers (Anthropic, OpenAI, Google, and others). Model selection is configured in OpenCode itself (`~/.config/opencode/opencode.json`), not in `config.yaml`. The `orchestrator.opencode_permission_mode` defaults to `bypassPermissions` since OpenCode runs non-interactively via `opencode run --format json`. The `llm.opencode_permission_mode` defaults to `acceptEdits`, but the factory forces `bypassPermissions` for interview/seed use cases to avoid CLI sandbox blocking.
+OpenCode supports multiple model providers (Anthropic, OpenAI, Google, and others). Model selection is configured in OpenCode itself (`~/.config/opencode/opencode.jsonc` or `opencode.json`), not in `config.yaml`. The `orchestrator.opencode_permission_mode` defaults to `bypassPermissions` since OpenCode runs non-interactively via `opencode run --format json`. The `llm.opencode_permission_mode` defaults to `acceptEdits`, but the factory forces `bypassPermissions` for interview/seed use cases to avoid CLI sandbox blocking.
 
 ### Full Config Skeleton
 

--- a/docs/runtime-guides/opencode.md
+++ b/docs/runtime-guides/opencode.md
@@ -19,7 +19,7 @@ No additional Python SDK is required beyond the base `ouroboros-ai` package.
 - A **provider configured in OpenCode** (run `opencode` and complete the first-run setup, or use `opencode providers auth <provider>`)
 - **Python >= 3.12**
 
-> **Note:** OpenCode manages its own provider authentication. You do not need to set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` environment variables for Ouroboros — OpenCode handles provider credentials internally via its own configuration at `~/.config/opencode/opencode.json`.
+> **Note:** OpenCode manages its own provider authentication. You do not need to set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` environment variables for Ouroboros — OpenCode handles provider credentials internally via its own configuration at `~/.config/opencode/opencode.jsonc` (or `opencode.json`).
 
 ## Installing OpenCode
 
@@ -80,7 +80,7 @@ uv run ouroboros run workflow --runtime opencode ~/.ouroboros/seeds/seed_abcd123
 
 Use `~/.ouroboros/config.yaml` for Ouroboros runtime settings (backend selection, permission mode, CLI path).
 
-Use `~/.config/opencode/opencode.json` (OpenCode's own config) for provider/model selection, MCP servers, and tool permissions. `ouroboros setup --runtime opencode` writes the Ouroboros MCP server entry into this file automatically.
+Use `~/.config/opencode/opencode.jsonc` or `opencode.json` (OpenCode's own config) for provider/model selection, MCP servers, and tool permissions. `ouroboros setup --runtime opencode` writes the Ouroboros MCP server entry into this file automatically.
 
 ```yaml
 # ~/.ouroboros/config.yaml
@@ -106,7 +106,7 @@ This:
 
 - Detects the `opencode` binary on your `PATH` and records it as `orchestrator.opencode_cli_path`
 - Writes `orchestrator.runtime_backend: opencode` and `llm.backend: opencode` to `~/.ouroboros/config.yaml`
-- Registers the Ouroboros MCP server in OpenCode's configuration file (`~/.config/opencode/opencode.json`). Note: The setup process rewrites the file as plain JSON and removes comments (the file supports JSONC format initially, but setup normalizes to JSON for compatibility).
+- Registers the Ouroboros MCP server in OpenCode's configuration file (`~/.config/opencode/opencode.jsonc` or `opencode.json`). If an existing `.jsonc` config is found, setup updates it in place instead of creating a separate `.json` file. Note: The setup process rewrites the file as plain JSON and removes comments (the file supports JSONC format initially, but setup normalizes to JSON for compatibility).
 
 ### `ooo` Skill Availability on OpenCode
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -382,18 +382,38 @@ def _strip_jsonc(text: str) -> str:
     return strip_jsonc(text)
 
 
+def _find_opencode_config() -> Path:
+    """Locate the existing OpenCode config file, or return a default path.
+
+    OpenCode checks (in order): ``opencode.jsonc``, ``opencode.json``,
+    ``config.json`` — all inside ``~/.config/opencode/``.  On Windows
+    ``Path.home()`` resolves to ``%USERPROFILE%`` which matches the
+    ``xdg-basedir`` fallback that OpenCode uses.
+
+    Returns the first file that exists, or ``opencode.json`` as the
+    default for new installations (plain JSON is the safer default
+    since we write with ``json.dump``).
+    """
+    config_dir = Path.home() / ".config" / "opencode"
+    for name in ("opencode.jsonc", "opencode.json"):
+        candidate = config_dir / name
+        if candidate.exists():
+            return candidate
+    return config_dir / "opencode.json"
+
+
 def _ensure_opencode_mcp_entry() -> None:
     """Ensure the global OpenCode config has a correct ouroboros MCP entry.
 
-    OpenCode reads config from ``~/.config/opencode/opencode.json`` (JSONC).
+    OpenCode reads config from ``~/.config/opencode/`` — either
+    ``opencode.jsonc`` or ``opencode.json`` (both support JSONC).
     The ``mcp`` key is a record of named MCP server configs.
 
     MCP entry format (local):
         ``{ "type": "local", "command": [...], "environment": {...}, "timeout": 300000 }``
     """
-    config_dir = Path.home() / ".config" / "opencode"
-    config_dir.mkdir(parents=True, exist_ok=True)
-    config_path = config_dir / "opencode.json"
+    config_path = _find_opencode_config()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
 
     data: dict = {}
     if config_path.exists():

--- a/src/ouroboros/cli/commands/uninstall.py
+++ b/src/ouroboros/cli/commands/uninstall.py
@@ -179,10 +179,24 @@ def _strip_jsonc(text: str) -> str:
     return strip_jsonc(text)
 
 
+def _find_opencode_config() -> Path | None:
+    """Locate existing OpenCode config (``opencode.jsonc`` or ``opencode.json``).
+
+    Returns the first file that exists, or ``None`` if neither is present.
+    Mirrors the lookup order that OpenCode itself uses.
+    """
+    config_dir = Path.home() / ".config" / "opencode"
+    for name in ("opencode.jsonc", "opencode.json"):
+        candidate = config_dir / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def _remove_opencode_mcp(dry_run: bool) -> bool:
-    """Remove ouroboros entry from OpenCode config (~/.config/opencode/opencode.json)."""
-    config_path = Path.home() / ".config" / "opencode" / "opencode.json"
-    if not config_path.exists():
+    """Remove ouroboros entry from OpenCode config (opencode.jsonc or opencode.json)."""
+    config_path = _find_opencode_config()
+    if config_path is None:
         return False
 
     try:
@@ -339,9 +353,9 @@ def uninstall(
     except OSError:
         targets.append("Codex MCP config (~/.codex/config.toml — may be unreadable)")
 
-    opencode_config = Path.home() / ".config" / "opencode" / "opencode.json"
+    opencode_config = _find_opencode_config()
     try:
-        if opencode_config.exists():
+        if opencode_config is not None:
             oc_data = json.loads(_strip_jsonc(opencode_config.read_text()))
             if isinstance(oc_data.get("mcp"), dict) and "ouroboros" in oc_data["mcp"]:
                 targets.append(f"OpenCode MCP config ({opencode_config})")

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -13,6 +13,7 @@ import ouroboros.cli.commands.setup as setup_cmd
 from ouroboros.cli.commands.setup import (
     _display_repos_table,
     _ensure_opencode_mcp_entry,
+    _find_opencode_config,
     _list_repos,
     _prompt_repo_selection,
     _scan_and_register_repos,
@@ -1465,3 +1466,103 @@ class TestOpenCodeSetupConfigYaml:
         assert result["orchestrator"]["runtime_backend"] == "opencode"
         assert isinstance(result["llm"], dict)
         assert result["llm"]["backend"] == "opencode"
+
+
+# ── JSONC config file detection tests ────────────────────────────
+
+
+class TestFindOpencodeConfig:
+    """Tests for _find_opencode_config — .jsonc/.json detection logic."""
+
+    def test_prefers_jsonc_over_json(self, tmp_path: Path) -> None:
+        """When both opencode.jsonc and opencode.json exist, .jsonc wins."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        (config_dir / "opencode.jsonc").write_text("{}", encoding="utf-8")
+        (config_dir / "opencode.json").write_text("{}", encoding="utf-8")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = _find_opencode_config()
+
+        assert result.name == "opencode.jsonc"
+
+    def test_falls_back_to_json(self, tmp_path: Path) -> None:
+        """When only opencode.json exists, it is returned."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        (config_dir / "opencode.json").write_text("{}", encoding="utf-8")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = _find_opencode_config()
+
+        assert result.name == "opencode.json"
+
+    def test_returns_json_default_when_neither_exists(self, tmp_path: Path) -> None:
+        """When no config exists, returns opencode.json as default for creation."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = _find_opencode_config()
+
+        assert result.name == "opencode.json"
+        assert not result.exists()
+
+    def test_only_jsonc_exists(self, tmp_path: Path) -> None:
+        """When only opencode.jsonc exists, it is returned."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        (config_dir / "opencode.jsonc").write_text("{}", encoding="utf-8")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = _find_opencode_config()
+
+        assert result.name == "opencode.jsonc"
+
+
+class TestSetupJsoncDetection:
+    """Tests for _ensure_opencode_mcp_entry picking up .jsonc files."""
+
+    def test_setup_reads_existing_jsonc(self, tmp_path: Path) -> None:
+        """Setup should read and update an existing opencode.jsonc file."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        jsonc_path = config_dir / "opencode.jsonc"
+        jsonc_path.write_text(
+            '{\n  // user comment\n  "theme": "dark",\n  "mcp": {}\n}\n',
+            encoding="utf-8",
+        )
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        # Must write back to .jsonc, not create a separate .json
+        data = json.loads(jsonc_path.read_text(encoding="utf-8"))
+        assert "ouroboros" in data["mcp"]
+        assert data["theme"] == "dark"
+        assert not (config_dir / "opencode.json").exists()
+
+    def test_setup_does_not_create_json_when_jsonc_exists(self, tmp_path: Path) -> None:
+        """No stray opencode.json should be created when .jsonc is present."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        jsonc_path = config_dir / "opencode.jsonc"
+        jsonc_path.write_text('{"mcp": {}}', encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
+                return_value={"command": ["ouroboros", "mcp", "serve"]},
+            ),
+        ):
+            _ensure_opencode_mcp_entry()
+
+        assert jsonc_path.exists()
+        assert not (config_dir / "opencode.json").exists()


### PR DESCRIPTION
## Summary

Fixes #356 — setup and uninstall now detect `opencode.jsonc` alongside `opencode.json`.

OpenCode checks config files in this order: `opencode.jsonc` → `opencode.json` → `config.json`. Previously, ouroboros always hardcoded `opencode.json`, so users with a `.jsonc` config would get a separate `.json` file created, splitting their configuration.

## What changed

- **`setup.py`**: Added `_find_opencode_config()` helper that checks for `.jsonc` first, then `.json` (matching OpenCode's own resolution order). `_ensure_opencode_mcp_entry()` now uses this helper instead of hardcoding the path.
- **`uninstall.py`**: Added the same helper. Updated `_remove_opencode_mcp()` and `_gather_targets()` to find whichever config file actually exists.
- **Tests**: 6 new tests covering `.jsonc` priority, fallback to `.json`, default path when neither exists, and end-to-end setup writing back to `.jsonc`.
- **Docs**: Updated `opencode.md` and `config-reference.md` to reference both file variants.

## Cross-platform

Works on Linux, macOS, and Windows — Python's `Path.home()` resolves to the same directory OpenCode uses via `xdg-basedir` on all platforms (`~/.config/opencode/` on Linux/Mac, `%USERPROFILE%/.config/opencode/` on Windows).

## Verification

- 390 CLI tests pass (1 pre-existing skip: `pip-fallback`)
- No new dependencies