### PR TITLE
feat(orchestrator): skip externally satisfied ACs

### DIFF
--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -152,6 +152,64 @@ def _resolve_max_decomposition_depth(seed_data: dict[str, Any], cli_value: int |
     return DEFAULT_MAX_DECOMPOSITION_DEPTH
 
 
+def _load_skip_completed_markers(
+    marker_path: str | None,
+    *,
+    total_acs: int,
+) -> dict[int, dict[str, Any]]:
+    """Load a YAML marker file describing already-satisfied top-level ACs."""
+    if not marker_path:
+        return {}
+
+    path = Path(marker_path).expanduser()
+    if not path.exists() or not path.is_file():
+        print_error(f"--skip-completed file not found: {path}")
+        raise typer.Exit(1)
+
+    try:
+        raw_data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print_error(f"Failed to read --skip-completed file: {exc}")
+        raise typer.Exit(1) from exc
+
+    if raw_data is None:
+        return {}
+
+    if isinstance(raw_data, dict):
+        raw_entries = raw_data.get("completed_acs", [])
+    elif isinstance(raw_data, list):
+        raw_entries = raw_data
+    else:
+        print_error("--skip-completed must be a YAML list or a mapping with completed_acs")
+        raise typer.Exit(1)
+
+    if not isinstance(raw_entries, list):
+        print_error("--skip-completed completed_acs must be a YAML list")
+        raise typer.Exit(1)
+
+    resolved: dict[int, dict[str, Any]] = {}
+    for index, entry in enumerate(raw_entries, start=1):
+        source = f"{path}: completed_acs[{index}]"
+        if isinstance(entry, dict):
+            ac_number = _coerce_non_negative_int(entry.get("ac"), source=f"{source}.ac")
+            metadata = {
+                "reason": entry.get("reason"),
+                "commit": entry.get("commit"),
+            }
+        else:
+            ac_number = _coerce_non_negative_int(entry, source=source)
+            metadata = {}
+
+        if ac_number < 1 or ac_number > total_acs:
+            print_error(
+                f"{source} references AC {ac_number}, but the seed only has {total_acs} ACs"
+            )
+            raise typer.Exit(1)
+        resolved[ac_number - 1] = metadata
+
+    return resolved
+
+
 async def _initialize_mcp_manager(
     config_path: Path,
     tool_prefix: str,  # noqa: ARG001
@@ -224,6 +282,7 @@ async def _run_orchestrator(
     no_qa: bool = False,
     runtime_backend: str | None = None,
     max_decomposition_depth: int | None = None,
+    skip_completed: str | None = None,
 ) -> None:
     """Run workflow via orchestrator mode.
 
@@ -237,6 +296,7 @@ async def _run_orchestrator(
         no_qa: Skip post-execution QA. Default: False.
         runtime_backend: Optional orchestrator runtime backend override.
         max_decomposition_depth: Optional recursive decomposition depth cap override.
+        skip_completed: Optional path to a marker file for already-satisfied ACs.
     """
     from ouroboros.core.seed import Seed
     from ouroboros.orchestrator import OrchestratorRunner, create_agent_runtime
@@ -256,11 +316,22 @@ async def _run_orchestrator(
         seed_data,
         max_decomposition_depth,
     )
+    externally_satisfied_acs = {}
+    if skip_completed:
+        if resume_session:
+            print_warning("--skip-completed is ignored when resuming an existing session.")
+        else:
+            externally_satisfied_acs = _load_skip_completed_markers(
+                skip_completed,
+                total_acs=len(seed.acceptance_criteria),
+            )
 
     if debug:
         print_info(f"Loaded seed: {seed.goal[:80]}...")
         print_info(f"Acceptance criteria: {len(seed.acceptance_criteria)}")
         print_info(f"Max decomposition depth: {resolved_max_decomposition_depth}")
+        if externally_satisfied_acs:
+            print_info(f"Externally satisfied ACs: {len(externally_satisfied_acs)}")
 
     # Initialize MCP manager if config provided
     mcp_manager = None
@@ -342,6 +413,7 @@ async def _run_orchestrator(
                 execution_id=execution_id,
                 session_id=session_id_for_run,
                 parallel=parallel,
+                externally_satisfied_acs=externally_satisfied_acs,
             )
 
         # Handle result
@@ -490,6 +562,16 @@ def workflow(
             ),
         ),
     ] = None,
+    skip_completed: Annotated[
+        str | None,
+        typer.Option(
+            "--skip-completed",
+            help=(
+                "Path to a YAML marker file listing already-satisfied top-level ACs. "
+                "Entries use 1-based AC numbers under completed_acs."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Execute a workflow from a seed file.
 
@@ -528,6 +610,9 @@ def workflow(
 
         # Limit recursive decomposition depth
         ouroboros run seed.yaml --max-decomposition-depth 1
+
+        # Skip ACs already satisfied by the working tree
+        ouroboros run seed.yaml --skip-completed docs/completed.yaml
     """
     # Validate MCP config requires orchestrator mode
     if mcp_config and not orchestrator and not resume_session:
@@ -553,6 +638,7 @@ def workflow(
                     no_qa=no_qa,
                     runtime_backend=runtime.value if runtime else None,
                     max_decomposition_depth=max_decomposition_depth,
+                    skip_completed=skip_completed,
                 )
             )
         except (ValueError, NotImplementedError) as e:

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -130,6 +130,15 @@ def _coerce_non_negative_int(value: object, *, source: str) -> int:
     return parsed
 
 
+def _coerce_positive_int(value: object, *, source: str) -> int:
+    """Parse a positive integer from CLI or env config."""
+    parsed = _coerce_non_negative_int(value, source=source)
+    if parsed <= 0:
+        print_error(f"{source} must be greater than 0")
+        raise typer.Exit(1)
+    return parsed
+
+
 def _resolve_max_decomposition_depth(seed_data: dict[str, Any], cli_value: int | None) -> int:
     """Resolve decomposition depth from CLI, env, seed config, then default."""
     if cli_value is not None:
@@ -208,6 +217,17 @@ def _load_skip_completed_markers(
         resolved[ac_number - 1] = metadata
 
     return resolved
+
+
+def _resolve_max_parallel_workers() -> int:
+    """Resolve the parallel worker cap from the environment."""
+    env_value = os.environ.get("OUROBOROS_MAX_PARALLEL_WORKERS", "").strip()
+    if env_value:
+        return _coerce_positive_int(
+            env_value,
+            source="OUROBOROS_MAX_PARALLEL_WORKERS",
+        )
+    return 3
 
 
 async def _initialize_mcp_manager(
@@ -316,7 +336,8 @@ async def _run_orchestrator(
         seed_data,
         max_decomposition_depth,
     )
-    externally_satisfied_acs = {}
+    resolved_max_parallel_workers = _resolve_max_parallel_workers()
+    externally_satisfied_acs: dict[int, dict[str, Any]] | None = None
     if skip_completed:
         if resume_session:
             print_warning("--skip-completed is ignored when resuming an existing session.")
@@ -330,6 +351,7 @@ async def _run_orchestrator(
         print_info(f"Loaded seed: {seed.goal[:80]}...")
         print_info(f"Acceptance criteria: {len(seed.acceptance_criteria)}")
         print_info(f"Max decomposition depth: {resolved_max_decomposition_depth}")
+        print_info(f"Max parallel workers: {resolved_max_parallel_workers}")
         if externally_satisfied_acs:
             print_info(f"Externally satisfied ACs: {len(externally_satisfied_acs)}")
 
@@ -393,6 +415,7 @@ async def _run_orchestrator(
         debug=debug,
         task_workspace=workspace,
         max_decomposition_depth=resolved_max_decomposition_depth,
+        max_parallel_workers=resolved_max_parallel_workers,
     )
 
     # Execute
@@ -408,13 +431,15 @@ async def _run_orchestrator(
                 print_info("Parallel mode: independent ACs will run concurrently")
             else:
                 print_info("Sequential mode: ACs will run one at a time")
-            result = await runner.execute_seed(
-                seed,
-                execution_id=execution_id,
-                session_id=session_id_for_run,
-                parallel=parallel,
-                externally_satisfied_acs=externally_satisfied_acs,
-            )
+            execute_kwargs: dict[str, Any] = {
+                "seed": seed,
+                "execution_id": execution_id,
+                "session_id": session_id_for_run,
+                "parallel": parallel,
+            }
+            if externally_satisfied_acs:
+                execute_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+            result = await runner.execute_seed(**execute_kwargs)
 
         # Handle result
         if result.is_ok:

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -28,6 +28,14 @@ from typing import TYPE_CHECKING, Any, Protocol
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
+from ouroboros.orchestrator.rate_limit import (
+    DEFAULT_ANTHROPIC_RPM_CEILING,
+    DEFAULT_ANTHROPIC_TPM_CEILING,
+    RATE_LIMIT_HEARTBEAT_SECONDS,
+    RateLimitSnapshot,
+    SharedRateLimitBucket,
+    estimate_runtime_request_tokens,
+)
 
 if TYPE_CHECKING:
     from ouroboros.providers.base import CompletionConfig, CompletionResponse, Message
@@ -767,6 +775,7 @@ class ClaudeAgentAdapter:
         self._model = model
         self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
         self._cli_path = str(Path(cli_path).expanduser()) if cli_path is not None else None
+        self._rate_limit_bucket = self._build_rate_limit_bucket()
 
         log.info(
             "orchestrator.adapter.initialized",
@@ -774,6 +783,7 @@ class ClaudeAgentAdapter:
             has_api_key=bool(self._api_key),
             cwd=self._cwd,
             cli_path=self._cli_path,
+            shared_rate_limit_enabled=self._rate_limit_bucket.enabled,
         )
 
     # -- AgentRuntime protocol properties ----------------------------------
@@ -801,6 +811,96 @@ class ClaudeAgentAdapter:
         """
         error_str = str(error).lower()
         return any(pattern in error_str for pattern in TRANSIENT_ERROR_PATTERNS)
+
+    @staticmethod
+    def _parse_optional_positive_int(
+        env_name: str,
+        *,
+        default: int,
+    ) -> int | None:
+        """Parse an optional positive integer env var; 0 disables the limit."""
+        raw_value = os.environ.get(env_name, "").strip()
+        if not raw_value:
+            return default
+
+        try:
+            parsed = int(raw_value)
+        except ValueError:
+            log.warning(
+                "orchestrator.adapter.invalid_rate_limit_env",
+                env_name=env_name,
+                raw_value=raw_value,
+            )
+            return default
+
+        if parsed <= 0:
+            return None
+        return parsed
+
+    def _build_rate_limit_bucket(self) -> SharedRateLimitBucket:
+        """Create the shared Anthropic rate-limit bucket for orchestrator workers."""
+        return SharedRateLimitBucket(
+            runtime_backend=self._runtime_backend,
+            request_limit=self._parse_optional_positive_int(
+                "OUROBOROS_ANTHROPIC_RPM_CEILING",
+                default=DEFAULT_ANTHROPIC_RPM_CEILING,
+            ),
+            token_limit=self._parse_optional_positive_int(
+                "OUROBOROS_ANTHROPIC_TPM_CEILING",
+                default=DEFAULT_ANTHROPIC_TPM_CEILING,
+            ),
+        )
+
+    @staticmethod
+    def _rate_limit_snapshot_data(snapshot: RateLimitSnapshot) -> dict[str, Any]:
+        """Serialize a shared-budget snapshot into message metadata."""
+        return {
+            "runtime_backend": snapshot.runtime_backend,
+            "requests_in_window": snapshot.requests_in_window,
+            "request_limit": snapshot.request_limit,
+            "tokens_in_window": snapshot.tokens_in_window,
+            "token_limit": snapshot.token_limit,
+        }
+
+    async def _wait_for_shared_rate_limit_budget(
+        self,
+        *,
+        estimated_tokens: int,
+        attempt: int,
+    ) -> AsyncIterator[AgentMessage]:
+        """Yield heartbeat messages while waiting for shared budget headroom."""
+        if not self._rate_limit_bucket.enabled:
+            return
+
+        while True:
+            wait_seconds, snapshot = await self._rate_limit_bucket.acquire(estimated_tokens)
+            if wait_seconds <= 0:
+                return
+
+            sleep_seconds = min(wait_seconds, RATE_LIMIT_HEARTBEAT_SECONDS)
+            yield AgentMessage(
+                type="system",
+                content=(
+                    "Shared Anthropic budget saturated; waiting "
+                    f"{sleep_seconds:.1f}s before retrying worker dispatch."
+                ),
+                data={
+                    "subtype": "rate_limit_backoff",
+                    "backoff_seconds": sleep_seconds,
+                    "retry_attempt": attempt,
+                    "source": "shared_rate_limit_bucket",
+                    **self._rate_limit_snapshot_data(snapshot),
+                },
+            )
+            await asyncio.sleep(sleep_seconds)
+
+    @staticmethod
+    def _transient_backoff_subtype(error: Exception) -> str:
+        """Classify transient backoff messages for observability."""
+        error_text = str(error).lower()
+        if "429" in error_text or "rate" in error_text or "concurrency" in error_text:
+            return "rate_limit_backoff"
+        return "transient_backoff"
 
     def _build_runtime_handle(
         self,
@@ -986,10 +1086,17 @@ class ClaudeAgentAdapter:
         last_error: Exception | None = None
         current_runtime_handle = dispatch.runtime_handle
         current_session_id = dispatch.resume_session_id
+        estimated_tokens = estimate_runtime_request_tokens(prompt, system_prompt=system_prompt)
 
         while attempt < MAX_RETRIES:
             attempt += 1
             try:
+                async for budget_message in self._wait_for_shared_rate_limit_budget(
+                    estimated_tokens=estimated_tokens,
+                    attempt=attempt,
+                ):
+                    yield budget_message
+
                 effective_permission_mode = (
                     current_runtime_handle.approval_mode
                     if current_runtime_handle and current_runtime_handle.approval_mode
@@ -1084,6 +1191,18 @@ class ClaudeAgentAdapter:
                     wait_time = min(
                         RETRY_WAIT_INITIAL * (2 ** (attempt - 1)),
                         RETRY_WAIT_MAX,
+                    )
+                    yield AgentMessage(
+                        type="system",
+                        content=(
+                            f"Transient backend backoff for {wait_time:.1f}s "
+                            f"before retrying: {e!s}"
+                        ),
+                        data={
+                            "subtype": self._transient_backoff_subtype(e),
+                            "backoff_seconds": wait_time,
+                            "retry_attempt": attempt,
+                        },
                     )
                     log.warning(
                         "orchestrator.adapter.transient_error_retry",

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -334,10 +334,13 @@ def render_parallel_verification_report(
     max_decomposition_depth: int = DEFAULT_MAX_DECOMPOSITION_DEPTH,
 ) -> str:
     """Build the canonical QA artifact for parallel execution results."""
+    total_satisfied = parallel_result.success_count + parallel_result.externally_satisfied_count
     lines = [
         "Parallel Execution Verification Report",
-        f"Success: {parallel_result.success_count}/{total_acceptance_criteria}",
+        f"Success: {total_satisfied}/{total_acceptance_criteria}",
     ]
+    if parallel_result.externally_satisfied_count > 0:
+        lines.append(f"Externally Satisfied: {parallel_result.externally_satisfied_count}")
     if parallel_result.failure_count > 0:
         lines.append(f"Failed: {parallel_result.failure_count}")
     if parallel_result.skipped_count > 0:
@@ -394,10 +397,13 @@ def render_parallel_completion_message(
     total_acceptance_criteria: int,
 ) -> str:
     """Build a concise operator-facing completion summary."""
+    total_satisfied = parallel_result.success_count + parallel_result.externally_satisfied_count
     lines = [
         "Parallel Execution Complete",
-        f"Success: {parallel_result.success_count}/{total_acceptance_criteria}",
+        f"Success: {total_satisfied}/{total_acceptance_criteria}",
     ]
+    if parallel_result.externally_satisfied_count > 0:
+        lines.append(f"Externally Satisfied: {parallel_result.externally_satisfied_count}")
     if parallel_result.failure_count > 0:
         lines.append(f"Failed: {parallel_result.failure_count}")
     if parallel_result.skipped_count > 0:
@@ -406,8 +412,12 @@ def render_parallel_completion_message(
     lines.append("")
     lines.append("AC Status:")
     for result in parallel_result.results:
-        status = "PASS" if result.success else "FAIL"
-        suffix = f" ({len(result.sub_results)} sub-ACs)" if result.is_decomposed else ""
+        if result.outcome == ACExecutionOutcome.SATISFIED_EXTERNALLY:
+            status = "PASS"
+            suffix = " (externally satisfied)"
+        else:
+            status = "PASS" if result.success else "FAIL"
+            suffix = f" ({len(result.sub_results)} sub-ACs)" if result.is_decomposed else ""
         lines.append(f"- AC {result.ac_index + 1}: [{status}] {result.ac_content}{suffix}")
     return "\n".join(lines)
 
@@ -1446,6 +1456,7 @@ class ParallelACExecutor:
         dependency_graph: DependencyGraph | None = None,
         execution_plan: StagedExecutionPlan | None = None,
         reconciled_level_contexts: list[LevelContext] | None = None,
+        externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
     ) -> ParallelExecutionResult:
         """Execute ACs according to a staged execution plan.
 
@@ -1461,6 +1472,8 @@ class ParallelACExecutor:
                 from a previous execution attempt. Reopened ACs receive these
                 as prompt context so they continue from the current shared
                 workspace state instead of the original failed-attempt state.
+            externally_satisfied_acs: Top-level ACs already satisfied by the
+                current working tree and therefore skipped for re-execution.
 
         Returns:
             ParallelExecutionResult with outcomes for all ACs.
@@ -1480,6 +1493,7 @@ class ParallelACExecutor:
 
         total_levels = execution_plan.total_stages
         total_acs = len(seed.acceptance_criteria)
+        external_completed = externally_satisfied_acs or {}
         execution_counters = {
             "messages_count": 0,
             "tool_calls_count": 0,
@@ -1652,6 +1666,7 @@ class ParallelACExecutor:
                 # Check for blocked ACs (dependencies failed or were blocked upstream)
                 executable: list[int] = []
                 blocked: list[int] = []
+                externally_satisfied: list[int] = []
                 stage_ac_results: list[ACExecutionResult] = []
 
                 for ac_idx in level:
@@ -1659,11 +1674,51 @@ class ParallelACExecutor:
                     if ac_idx < 0 or ac_idx >= total_acs:
                         continue
 
+                    if ac_idx in external_completed:
+                        externally_satisfied.append(ac_idx)
+                        continue
+
                     deps = execution_plan.get_dependencies(ac_idx)
                     if any(dep in failed_indices or dep in blocked_indices for dep in deps):
                         blocked.append(ac_idx)
                     else:
                         executable.append(ac_idx)
+
+                level_success = 0
+                level_failed = 0
+
+                for ac_idx in externally_satisfied:
+                    metadata = external_completed.get(ac_idx, {})
+                    reason = metadata.get("reason")
+                    commit = metadata.get("commit")
+                    notes: list[str] = [
+                        "Skipped via --skip-completed; existing working tree state is treated as satisfied."
+                    ]
+                    if isinstance(reason, str) and reason.strip():
+                        notes.append(f"Reason: {reason.strip()}")
+                    if isinstance(commit, str) and commit.strip():
+                        notes.append(f"Commit: {commit.strip()}")
+
+                    satisfied_result = ACExecutionResult(
+                        ac_index=ac_idx,
+                        ac_content=seed.acceptance_criteria[ac_idx],
+                        success=True,
+                        final_message="\n".join(notes),
+                        retry_attempt=ac_retry_attempts[ac_idx],
+                        outcome=ACExecutionOutcome.SATISFIED_EXTERNALLY,
+                    )
+                    all_results.append(satisfied_result)
+                    stage_ac_results.append(satisfied_result)
+                    ac_statuses[ac_idx] = "completed"
+                    completed_count += 1
+                    level_success += 1
+                    log.info(
+                        "parallel_executor.ac.satisfied_externally",
+                        session_id=session_id,
+                        ac_index=ac_idx,
+                        reason=reason,
+                        commit=commit,
+                    )
 
                 # Add blocked results
                 for ac_idx in blocked:
@@ -1687,20 +1742,21 @@ class ParallelACExecutor:
                     )
 
                 if not executable:
+                    stage_started = bool(externally_satisfied)
                     stage_result = ParallelExecutionStageResult(
                         stage_index=level_idx,
                         ac_indices=tuple(level),
                         results=tuple(sorted(stage_ac_results, key=lambda result: result.ac_index)),
-                        started=False,
+                        started=stage_started,
                     )
                     stage_results.append(stage_result)
                     await self._emit_level_completed(
                         session_id=session_id,
                         level=level_num,
-                        success_count=0,
-                        failure_count=0,
+                        success_count=stage_result.success_count,
+                        failure_count=stage_result.failure_count,
                         blocked_count=stage_result.blocked_count,
-                        started=False,
+                        started=stage_started,
                         outcome=stage_result.outcome.value,
                     )
                     continue
@@ -1725,10 +1781,6 @@ class ParallelACExecutor:
 
                 # Capture current contexts for this level's closure
                 current_contexts = list(level_contexts)
-
-                # Process results
-                level_success = 0
-                level_failed = 0
 
                 for batch_index, batch in enumerate(stage_batches, start=1):
                     batch_executable = [ac_idx for ac_idx in batch if ac_idx in executable]
@@ -1886,7 +1938,7 @@ class ParallelACExecutor:
                 self._flush_console()
 
                 # Extract context from this level for next level's ACs
-                if level_success > 0:
+                if executable and level_success > 0:
                     level_ac_data = [
                         (r.ac_index, r.ac_content, r.success, r.messages, r.final_message)
                         for r in stage_ac_results
@@ -1997,6 +2049,9 @@ class ParallelACExecutor:
         sorted_results = sorted(all_results, key=lambda r: r.ac_index)
         total_duration = (datetime.now(UTC) - start_time).total_seconds()
         success_count = sum(1 for r in sorted_results if r.outcome == ACExecutionOutcome.SUCCEEDED)
+        externally_satisfied_count = sum(
+            1 for r in sorted_results if r.outcome == ACExecutionOutcome.SATISFIED_EXTERNALLY
+        )
         failure_count = sum(1 for r in sorted_results if r.outcome == ACExecutionOutcome.FAILED)
         blocked_count = sum(1 for r in sorted_results if r.outcome == ACExecutionOutcome.BLOCKED)
         invalid_count = sum(1 for r in sorted_results if r.outcome == ACExecutionOutcome.INVALID)
@@ -2007,6 +2062,7 @@ class ParallelACExecutor:
             "parallel_executor.execution.completed",
             session_id=session_id,
             success_count=success_count,
+            externally_satisfied_count=externally_satisfied_count,
             failure_count=failure_count,
             blocked_count=blocked_count,
             invalid_count=invalid_count,
@@ -2019,6 +2075,7 @@ class ParallelACExecutor:
             results=tuple(sorted_results),
             success_count=success_count,
             failure_count=failure_count,
+            externally_satisfied_count=externally_satisfied_count,
             skipped_count=skipped_count,
             blocked_count=blocked_count,
             invalid_count=invalid_count,

--- a/src/ouroboros/orchestrator/parallel_executor_models.py
+++ b/src/ouroboros/orchestrator/parallel_executor_models.py
@@ -25,6 +25,7 @@ class ACExecutionOutcome(str, Enum):  # noqa: UP042
     """Normalized outcome for a single AC execution."""
 
     SUCCEEDED = "succeeded"
+    SATISFIED_EXTERNALLY = "satisfied_externally"
     FAILED = "failed"
     BLOCKED = "blocked"
     INVALID = "invalid"
@@ -91,6 +92,11 @@ class ACExecutionResult:
         return self.outcome == ACExecutionOutcome.BLOCKED
 
     @property
+    def is_satisfied_externally(self) -> bool:
+        """True when the AC was skipped because the working tree already satisfied it."""
+        return self.outcome == ACExecutionOutcome.SATISFIED_EXTERNALLY
+
+    @property
     def is_failure(self) -> bool:
         """True when the AC executed and failed."""
         return self.outcome == ACExecutionOutcome.FAILED
@@ -133,7 +139,24 @@ class ParallelExecutionStageResult:
     @property
     def success_count(self) -> int:
         """Number of successful ACs in this stage."""
-        return sum(1 for result in self.results if result.outcome == ACExecutionOutcome.SUCCEEDED)
+        return sum(
+            1
+            for result in self.results
+            if result.outcome
+            in {
+                ACExecutionOutcome.SUCCEEDED,
+                ACExecutionOutcome.SATISFIED_EXTERNALLY,
+            }
+        )
+
+    @property
+    def externally_satisfied_count(self) -> int:
+        """Number of ACs skipped because the working tree already satisfies them."""
+        return sum(
+            1
+            for result in self.results
+            if result.outcome == ACExecutionOutcome.SATISFIED_EXTERNALLY
+        )
 
     @property
     def failure_count(self) -> int:
@@ -185,6 +208,7 @@ class ParallelExecutionResult:
     Attributes:
         results: Individual results for each AC.
         success_count: Number of successful ACs.
+        externally_satisfied_count: Number of ACs satisfied without re-execution.
         failure_count: Number of failed ACs.
         skipped_count: Number of skipped ACs (due to failed dependencies).
         blocked_count: Number of ACs blocked by dependency failures.
@@ -202,6 +226,7 @@ class ParallelExecutionResult:
     results: tuple[ACExecutionResult, ...]
     success_count: int
     failure_count: int
+    externally_satisfied_count: int = 0
     skipped_count: int = 0
     blocked_count: int = 0
     invalid_count: int = 0
@@ -218,7 +243,7 @@ class ParallelExecutionResult:
     @property
     def any_succeeded(self) -> bool:
         """Return True if at least one AC succeeded."""
-        return self.success_count > 0
+        return self.success_count > 0 or self.externally_satisfied_count > 0
 
 
 __all__ = [

--- a/src/ouroboros/orchestrator/rate_limit.py
+++ b/src/ouroboros/orchestrator/rate_limit.py
@@ -1,0 +1,135 @@
+"""Shared runtime rate-limit coordination for orchestrator workers."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+import time
+
+RATE_LIMIT_WINDOW_SECONDS = 60.0
+RATE_LIMIT_HEARTBEAT_SECONDS = 30.0
+DEFAULT_ANTHROPIC_RPM_CEILING = 40
+DEFAULT_ANTHROPIC_TPM_CEILING = 32_000
+_TOKEN_ESTIMATE_DIVISOR = 4
+_TOKEN_COMPLETION_CUSHION = 1024
+
+
+@dataclass(frozen=True, slots=True)
+class RateLimitSnapshot:
+    """Current shared-budget usage for one runtime backend."""
+
+    runtime_backend: str
+    requests_in_window: int
+    request_limit: int | None
+    tokens_in_window: int
+    token_limit: int | None
+
+
+class SharedRateLimitBucket:
+    """Sliding-window request/token budget shared by concurrent runtime workers."""
+
+    def __init__(
+        self,
+        *,
+        runtime_backend: str,
+        request_limit: int | None,
+        token_limit: int | None,
+        window_seconds: float = RATE_LIMIT_WINDOW_SECONDS,
+        time_provider: Callable[[], float] | None = None,
+    ) -> None:
+        self._runtime_backend = runtime_backend
+        self._request_limit = request_limit if request_limit and request_limit > 0 else None
+        self._token_limit = token_limit if token_limit and token_limit > 0 else None
+        self._window_seconds = window_seconds
+        self._time = time_provider or time.monotonic
+        self._lock = asyncio.Lock()
+        self._reservations: deque[tuple[float, int]] = deque()
+
+    @property
+    def enabled(self) -> bool:
+        """Return True when either request or token budgets are active."""
+        return self._request_limit is not None or self._token_limit is not None
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - self._window_seconds
+        while self._reservations and self._reservations[0][0] <= cutoff:
+            self._reservations.popleft()
+
+    def _tokens_in_window(self) -> int:
+        return sum(tokens for _, tokens in self._reservations)
+
+    def _snapshot(self) -> RateLimitSnapshot:
+        return RateLimitSnapshot(
+            runtime_backend=self._runtime_backend,
+            requests_in_window=len(self._reservations),
+            request_limit=self._request_limit,
+            tokens_in_window=self._tokens_in_window(),
+            token_limit=self._token_limit,
+        )
+
+    def _request_wait_seconds(self, now: float) -> float:
+        if self._request_limit is None or len(self._reservations) < self._request_limit:
+            return 0.0
+        oldest_timestamp, _ = self._reservations[0]
+        return max(0.0, oldest_timestamp + self._window_seconds - now)
+
+    def _token_wait_seconds(self, now: float, estimated_tokens: int) -> float:
+        if self._token_limit is None:
+            return 0.0
+
+        current_tokens = self._tokens_in_window()
+        if current_tokens + estimated_tokens <= self._token_limit:
+            return 0.0
+
+        remaining_tokens = current_tokens
+        wait_seconds = 0.0
+        for timestamp, reserved_tokens in self._reservations:
+            remaining_tokens -= reserved_tokens
+            wait_seconds = max(0.0, timestamp + self._window_seconds - now)
+            if remaining_tokens + estimated_tokens <= self._token_limit:
+                return wait_seconds
+
+        if not self._reservations:
+            return 0.0
+        newest_timestamp, _ = self._reservations[-1]
+        return max(0.0, newest_timestamp + self._window_seconds - now)
+
+    async def acquire(self, estimated_tokens: int) -> tuple[float, RateLimitSnapshot]:
+        """Reserve capacity immediately or return the wait time before retry."""
+        normalized_tokens = max(1, estimated_tokens)
+        async with self._lock:
+            now = self._time()
+            self._prune(now)
+            wait_seconds = max(
+                self._request_wait_seconds(now),
+                self._token_wait_seconds(now, normalized_tokens),
+            )
+            if wait_seconds <= 0:
+                self._reservations.append((now, normalized_tokens))
+                return 0.0, self._snapshot()
+            return wait_seconds, self._snapshot()
+
+
+def estimate_runtime_request_tokens(
+    prompt: str,
+    *,
+    system_prompt: str | None = None,
+) -> int:
+    """Estimate the cost of starting one runtime request."""
+    prompt_chars = len(prompt)
+    system_chars = len(system_prompt or "")
+    prompt_tokens = (prompt_chars + system_chars) // _TOKEN_ESTIMATE_DIVISOR
+    return max(1, prompt_tokens + _TOKEN_COMPLETION_CUSHION)
+
+
+__all__ = [
+    "DEFAULT_ANTHROPIC_RPM_CEILING",
+    "DEFAULT_ANTHROPIC_TPM_CEILING",
+    "RATE_LIMIT_HEARTBEAT_SECONDS",
+    "RATE_LIMIT_WINDOW_SECONDS",
+    "RateLimitSnapshot",
+    "SharedRateLimitBucket",
+    "estimate_runtime_request_tokens",
+]

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1264,6 +1264,7 @@ class OrchestratorRunner:
         execution_id: str | None = None,
         session_id: str | None = None,
         parallel: bool = True,
+        externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
     ) -> Result[OrchestratorResult, OrchestratorError]:
         """Execute seed via Claude Agent.
 
@@ -1277,6 +1278,8 @@ class OrchestratorRunner:
             session_id: Optional session ID to preallocate for external tracking.
             parallel: Enable parallel AC execution. When True, independent ACs
                      run concurrently. Default: True (parallel execution).
+            externally_satisfied_acs: Top-level ACs already satisfied by the
+                current working tree and therefore skipped for re-execution.
 
         Returns:
             Result containing OrchestratorResult on success.
@@ -1289,6 +1292,7 @@ class OrchestratorRunner:
             seed=seed,
             tracker=session_result.value,
             parallel=parallel,
+            externally_satisfied_acs=externally_satisfied_acs,
         )
 
     async def prepare_session(
@@ -1340,6 +1344,7 @@ class OrchestratorRunner:
         seed: Seed,
         tracker: SessionTracker,
         parallel: bool = True,
+        externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
     ) -> Result[OrchestratorResult, OrchestratorError]:
         """Execute a seed using an already-persisted orchestrator session."""
         exec_id = tracker.execution_id
@@ -1401,6 +1406,7 @@ class OrchestratorRunner:
                     tool_catalog=tool_catalog,
                     system_prompt=system_prompt,
                     start_time=start_time,
+                    externally_satisfied_acs=externally_satisfied_acs,
                 )
         except Exception as e:
             self._cleanup_pre_execution_state(
@@ -1727,6 +1733,7 @@ class OrchestratorRunner:
         tool_catalog: SessionToolCatalog,
         system_prompt: str,
         start_time: datetime,
+        externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
     ) -> Result[OrchestratorResult, OrchestratorError]:
         """Execute seed with parallel AC execution.
 
@@ -1740,6 +1747,8 @@ class OrchestratorRunner:
             merged_tools: Available tools.
             system_prompt: System prompt for agents.
             start_time: Execution start time.
+            externally_satisfied_acs: Top-level ACs already satisfied by the
+                current working tree and therefore skipped for re-execution.
 
         Returns:
             Result containing OrchestratorResult on success.
@@ -1833,6 +1842,7 @@ class OrchestratorRunner:
             tools=merged_tools,
             tool_catalog=tool_catalog.tools,
             system_prompt=system_prompt,
+            externally_satisfied_acs=externally_satisfied_acs,
         )
 
         # Check for cancellation after parallel execution
@@ -1864,6 +1874,10 @@ class OrchestratorRunner:
             "acceptance_criteria_count": len(seed.acceptance_criteria),
             "parallel_execution": True,
             "success_count": parallel_result.success_count,
+            "externally_satisfied_count": parallel_result.externally_satisfied_count,
+            "satisfied_count": (
+                parallel_result.success_count + parallel_result.externally_satisfied_count
+            ),
             "failure_count": parallel_result.failure_count,
             "blocked_count": parallel_result.blocked_count,
             "invalid_count": parallel_result.invalid_count,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -347,6 +347,7 @@ class OrchestratorRunner:
         task_workspace: TaskWorkspace | None = None,
         checkpoint_store: CheckpointStore | None = None,
         max_decomposition_depth: int = DEFAULT_MAX_DECOMPOSITION_DEPTH,
+        max_parallel_workers: int = 3,
     ) -> None:
         """Initialize orchestrator runner.
 
@@ -370,6 +371,7 @@ class OrchestratorRunner:
             checkpoint_store: Optional checkpoint store for execution state persistence
                         and recovery. When provided, enables per-level state snapshots.
             max_decomposition_depth: Maximum recursive AC decomposition depth.
+            max_parallel_workers: Maximum concurrent AC workers for parallel execution.
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -385,6 +387,7 @@ class OrchestratorRunner:
         self._task_cwd = task_cwd
         self._task_workspace = task_workspace
         self._max_decomposition_depth = max(0, max_decomposition_depth)
+        self._max_parallel_workers = max(1, max_parallel_workers)
         # Track active session for external cancellation by execution_id
         self._active_sessions: dict[str, str] = {}  # execution_id -> session_id
 
@@ -1288,12 +1291,15 @@ class OrchestratorRunner:
         if session_result.is_err:
             return Result.err(session_result.error)
 
-        return await self.execute_precreated_session(
-            seed=seed,
-            tracker=session_result.value,
-            parallel=parallel,
-            externally_satisfied_acs=externally_satisfied_acs,
-        )
+        execute_kwargs: dict[str, Any] = {
+            "seed": seed,
+            "tracker": session_result.value,
+            "parallel": parallel,
+        }
+        if externally_satisfied_acs:
+            execute_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+
+        return await self.execute_precreated_session(**execute_kwargs)
 
     async def prepare_session(
         self,
@@ -1398,16 +1404,19 @@ class OrchestratorRunner:
 
             # Check for parallel execution mode
             if parallel and len(seed.acceptance_criteria) > 1:
-                return await self._execute_parallel(
-                    seed=seed,
-                    exec_id=exec_id,
-                    tracker=tracker,
-                    merged_tools=merged_tools,
-                    tool_catalog=tool_catalog,
-                    system_prompt=system_prompt,
-                    start_time=start_time,
-                    externally_satisfied_acs=externally_satisfied_acs,
-                )
+                parallel_kwargs: dict[str, Any] = {
+                    "seed": seed,
+                    "exec_id": exec_id,
+                    "tracker": tracker,
+                    "merged_tools": merged_tools,
+                    "tool_catalog": tool_catalog,
+                    "system_prompt": system_prompt,
+                    "start_time": start_time,
+                }
+                if externally_satisfied_acs:
+                    parallel_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+
+                return await self._execute_parallel(**parallel_kwargs)
         except Exception as e:
             self._cleanup_pre_execution_state(
                 exec_id,
@@ -1819,6 +1828,7 @@ class OrchestratorRunner:
             event_store=self._event_store,
             console=self._console,
             enable_decomposition=self._enable_decomposition,
+            max_concurrent=self._max_parallel_workers,
             max_decomposition_depth=self._max_decomposition_depth,
             inherited_runtime_handle=self._inherited_runtime_handle,
             task_cwd=self._effective_cwd(),
@@ -1884,6 +1894,7 @@ class OrchestratorRunner:
             "skipped_count": parallel_result.skipped_count,
             "total_levels": execution_plan.total_stages,
             "max_decomposition_depth": self._max_decomposition_depth,
+            "max_parallel_workers": self._max_parallel_workers,
             "verification_report": verification_report,
             **self._task_summary(),
         }

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ouroboros.cli.commands.run import _resolve_max_decomposition_depth, _run_orchestrator
+from ouroboros.cli.commands.run import (
+    _load_skip_completed_markers,
+    _resolve_max_decomposition_depth,
+    _run_orchestrator,
+)
 from ouroboros.core.types import Result
 from ouroboros.evaluation.verification_artifacts import VerificationArtifacts
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
@@ -90,6 +94,26 @@ def test_resolve_max_decomposition_depth_prefers_cli_then_env_then_seed(
 
     assert _resolve_max_decomposition_depth(seed_data, None) == 4
     assert _resolve_max_decomposition_depth(seed_data, 1) == 1
+
+
+def test_load_skip_completed_markers_parses_yaml_metadata(tmp_path: Path) -> None:
+    """The skip-completed marker file should resolve 1-based AC numbers."""
+    marker_file = tmp_path / "completed.yaml"
+    marker_file.write_text(
+        "completed_acs:\n"
+        "  - ac: 1\n"
+        "    reason: Done manually\n"
+        "    commit: abc1234\n"
+        "  - 2\n",
+        encoding="utf-8",
+    )
+
+    markers = _load_skip_completed_markers(str(marker_file), total_acs=3)
+
+    assert markers == {
+        0: {"reason": "Done manually", "commit": "abc1234"},
+        1: {},
+    }
 
 
 @pytest.mark.asyncio
@@ -183,6 +207,58 @@ async def test_run_orchestrator_passes_resolved_depth_cap_to_runner(tmp_path: Pa
         await _run_orchestrator(seed_file)
 
     assert mock_runner_cls.call_args.kwargs["max_decomposition_depth"] == 3
+
+
+@pytest.mark.asyncio
+async def test_run_orchestrator_passes_skip_completed_markers_to_runner(tmp_path: Path) -> None:
+    """CLI orchestration should pass parsed skip-completed markers into the runner."""
+    seed_file = tmp_path / "seed.yaml"
+    seed_file.write_text("goal: ignored\n", encoding="utf-8")
+    marker_file = tmp_path / "completed.yaml"
+    marker_file.write_text(
+        "completed_acs:\n"
+        "  - ac: 1\n"
+        "    reason: Hybrid flow\n"
+        "    commit: deadbee\n",
+        encoding="utf-8",
+    )
+
+    fake_exec = SimpleNamespace(
+        success=True,
+        session_id="sess-test",
+        messages_processed=5,
+        duration_seconds=1.0,
+        execution_id="exec-test",
+        summary={"verification_report": "Parallel Execution Verification Report"},
+        final_message="fallback final message",
+    )
+    mock_runner = MagicMock()
+    mock_runner.execute_seed = AsyncMock(return_value=Result.ok(fake_exec))
+    mock_runner.resume_session = AsyncMock()
+
+    with (
+        patch("ouroboros.cli.commands.run._load_seed_from_yaml", return_value=VALID_SEED_DATA),
+        patch("ouroboros.orchestrator.create_agent_runtime"),
+        patch("ouroboros.orchestrator.OrchestratorRunner", return_value=mock_runner),
+        patch("ouroboros.persistence.event_store.EventStore") as mock_event_store_cls,
+        patch(
+            "ouroboros.cli.commands.run.build_verification_artifacts",
+            new_callable=AsyncMock,
+            return_value=FAKE_VERIFICATION_ARTIFACTS,
+        ),
+        patch(
+            "ouroboros.mcp.tools.qa.QAHandler.handle",
+            new_callable=AsyncMock,
+            return_value=FAKE_QA_RESULT,
+        ),
+    ):
+        mock_event_store_cls.return_value.initialize = AsyncMock()
+        await _run_orchestrator(seed_file, skip_completed=str(marker_file))
+
+    execute_kwargs = mock_runner.execute_seed.await_args.kwargs
+    assert execute_kwargs["externally_satisfied_acs"] == {
+        0: {"reason": "Hybrid flow", "commit": "deadbee"},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -11,6 +11,7 @@ import pytest
 from ouroboros.cli.commands.run import (
     _load_skip_completed_markers,
     _resolve_max_decomposition_depth,
+    _resolve_max_parallel_workers,
     _run_orchestrator,
 )
 from ouroboros.core.types import Result
@@ -114,6 +115,13 @@ def test_load_skip_completed_markers_parses_yaml_metadata(tmp_path: Path) -> Non
         0: {"reason": "Done manually", "commit": "abc1234"},
         1: {},
     }
+
+
+def test_resolve_max_parallel_workers_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parallel worker caps should be configurable via environment variable."""
+    monkeypatch.setenv("OUROBOROS_MAX_PARALLEL_WORKERS", "5")
+
+    assert _resolve_max_parallel_workers() == 5
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_adapter.py
+++ b/tests/unit/orchestrator/test_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import ModuleType
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -16,6 +16,7 @@ from ouroboros.orchestrator.adapter import (
     TaskResult,
     _clone_runtime_handle_data,
 )
+from ouroboros.orchestrator.rate_limit import RateLimitSnapshot, SharedRateLimitBucket
 
 
 # Helper function to create mock SDK messages with correct class names
@@ -1091,6 +1092,100 @@ class TestBuildRuntimeHandleFreshPath:
         handle.metadata["config"]["key"] = "changed"
         assert nested_metadata["tools"][0]["name"] == "Read"  # type: ignore[index]
         assert nested_metadata["config"]["key"] == "val"  # type: ignore[index]
+
+    @pytest.mark.asyncio
+    async def test_execute_task_emits_shared_rate_limit_backoff_messages(self) -> None:
+        """Shared bucket waits should surface as system heartbeat messages."""
+
+        async def _query_impl(*, prompt: str, options: Any) -> Any:
+            del prompt, options
+            yield _create_mock_sdk_message(
+                "ResultMessage",
+                result="[TASK_COMPLETE]",
+                subtype="success",
+                is_error=False,
+                session_id="sess_123",
+            )
+
+        class _StubBucket:
+            enabled = True
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def acquire(self, estimated_tokens: int) -> tuple[float, RateLimitSnapshot]:
+                self.calls += 1
+                if self.calls == 1:
+                    return (
+                        0.25,
+                        RateLimitSnapshot(
+                            runtime_backend="claude",
+                            requests_in_window=1,
+                            request_limit=1,
+                            tokens_in_window=estimated_tokens,
+                            token_limit=estimated_tokens * 2,
+                        ),
+                    )
+                return (
+                    0.0,
+                    RateLimitSnapshot(
+                        runtime_backend="claude",
+                        requests_in_window=1,
+                        request_limit=1,
+                        tokens_in_window=estimated_tokens,
+                        token_limit=estimated_tokens * 2,
+                    ),
+                )
+
+        adapter = ClaudeAgentAdapter(api_key="test")
+        adapter._rate_limit_bucket = _StubBucket()
+
+        with (
+            patch.dict("sys.modules", _build_mock_claude_agent_sdk(query_impl=_query_impl)),
+            patch("ouroboros.orchestrator.adapter.asyncio.sleep", new=AsyncMock()),
+        ):
+            messages = [message async for message in adapter.execute_task(prompt="Fix it")]
+
+        assert messages[0].type == "system"
+        assert messages[0].data["subtype"] == "rate_limit_backoff"
+        assert messages[0].data["source"] == "shared_rate_limit_bucket"
+        assert messages[-1].is_final is True
+
+    @pytest.mark.asyncio
+    async def test_execute_task_emits_rate_limit_backoff_on_transient_retry(self) -> None:
+        """Retryable 429 errors should emit heartbeat-style backoff messages."""
+        attempts = {"count": 0}
+
+        async def _query_impl(*, prompt: str, options: Any) -> Any:
+            del prompt, options
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("429 rate limit")
+            yield _create_mock_sdk_message(
+                "ResultMessage",
+                result="[TASK_COMPLETE]",
+                subtype="success",
+                is_error=False,
+                session_id="sess_456",
+            )
+
+        adapter = ClaudeAgentAdapter(api_key="test")
+        adapter._rate_limit_bucket = SharedRateLimitBucket(
+            runtime_backend="claude",
+            request_limit=None,
+            token_limit=None,
+        )
+
+        with (
+            patch.dict("sys.modules", _build_mock_claude_agent_sdk(query_impl=_query_impl)),
+            patch("ouroboros.orchestrator.adapter.asyncio.sleep", new=AsyncMock()),
+        ):
+            messages = [message async for message in adapter.execute_task(prompt="Retry it")]
+
+        assert messages[0].type == "system"
+        assert messages[0].data["subtype"] == "rate_limit_backoff"
+        assert messages[0].data["backoff_seconds"] == 1.0
+        assert messages[-1].is_final is True
 
 
 class TestNonStringSelectorErrorMessage:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -746,6 +746,50 @@ class TestParallelACExecutor:
             3,
         ]
 
+    @pytest.mark.asyncio
+    async def test_execute_parallel_skips_externally_satisfied_acs(self) -> None:
+        """Top-level ACs flagged by --skip-completed should not be re-executed."""
+        seed = _make_seed("AC 1", "AC 2")
+        dependency_graph = DependencyGraph(
+            nodes=(
+                ACNode(index=0, content="AC 1", depends_on=()),
+                ACNode(index=1, content="AC 2", depends_on=()),
+            ),
+            execution_levels=((0, 1),),
+        )
+        executor = _make_executor()
+        executor._execute_ac_batch = AsyncMock(
+            return_value=[
+                ACExecutionResult(
+                    ac_index=1,
+                    ac_content="AC 2",
+                    success=True,
+                    final_message="Implemented AC 2",
+                )
+            ]
+        )
+
+        result = await executor.execute_parallel(
+            seed=seed,
+            execution_plan=dependency_graph.to_execution_plan(),
+            session_id="orch_skip_completed",
+            execution_id="exec_skip_completed",
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            externally_satisfied_acs={
+                0: {"reason": "Implemented manually", "commit": "abc1234"},
+            },
+        )
+
+        assert result.success_count == 1
+        assert result.externally_satisfied_count == 1
+        assert result.failure_count == 0
+        assert result.results[0].outcome == ACExecutionOutcome.SATISFIED_EXTERNALLY
+        assert "Implemented manually" in result.results[0].final_message
+        assert "abc1234" in result.results[0].final_message
+        executor._execute_ac_batch.assert_awaited_once()
+
     def test_verification_report_emits_depth_warning_feedback_metadata(self) -> None:
         """Verification report should expose depth warnings as structured metadata."""
         parallel_result = ParallelExecutionResult(

--- a/tests/unit/orchestrator/test_rate_limit.py
+++ b/tests/unit/orchestrator/test_rate_limit.py
@@ -1,0 +1,59 @@
+"""Unit tests for shared orchestrator rate-limit coordination."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.rate_limit import SharedRateLimitBucket, estimate_runtime_request_tokens
+
+
+@pytest.mark.asyncio
+async def test_shared_rate_limit_bucket_waits_when_request_budget_is_exhausted() -> None:
+    """The shared bucket should defer new reservations once RPM is exhausted."""
+    clock = {"now": 0.0}
+    bucket = SharedRateLimitBucket(
+        runtime_backend="claude",
+        request_limit=1,
+        token_limit=None,
+        time_provider=lambda: clock["now"],
+    )
+
+    wait_seconds, _ = await bucket.acquire(estimated_tokens=100)
+    assert wait_seconds == 0.0
+
+    wait_seconds, snapshot = await bucket.acquire(estimated_tokens=100)
+    assert wait_seconds == 60.0
+    assert snapshot.requests_in_window == 1
+    assert snapshot.request_limit == 1
+
+    clock["now"] = 60.0
+    wait_seconds, snapshot = await bucket.acquire(estimated_tokens=100)
+    assert wait_seconds == 0.0
+    assert snapshot.requests_in_window == 1
+
+
+@pytest.mark.asyncio
+async def test_shared_rate_limit_bucket_waits_when_token_budget_is_exhausted() -> None:
+    """The shared bucket should defer reservations once TPM is exhausted."""
+    clock = {"now": 0.0}
+    bucket = SharedRateLimitBucket(
+        runtime_backend="claude",
+        request_limit=None,
+        token_limit=200,
+        time_provider=lambda: clock["now"],
+    )
+
+    wait_seconds, _ = await bucket.acquire(estimated_tokens=150)
+    assert wait_seconds == 0.0
+
+    wait_seconds, snapshot = await bucket.acquire(estimated_tokens=100)
+    assert wait_seconds == 60.0
+    assert snapshot.tokens_in_window == 150
+    assert snapshot.token_limit == 200
+
+
+def test_estimate_runtime_request_tokens_adds_completion_cushion() -> None:
+    """Runtime token estimates should always include a non-zero completion cushion."""
+    estimate = estimate_runtime_request_tokens("abcd" * 100, system_prompt="system")
+
+    assert estimate > 100


### PR DESCRIPTION
## Summary
- add `--skip-completed` marker-file support for top-level ACs that are already satisfied in the working tree
- treat marked ACs as externally satisfied in the parallel executor instead of rerunning them
- report externally satisfied counts in the completion summary and verification artifact

Refs #370

## Testing
- `.venv/bin/pytest tests/unit/orchestrator/test_parallel_executor.py -q`
- `.venv/bin/pytest tests/unit/cli/test_run_qa.py -q`