### PR TITLE
fix(orchestrator): share Anthropic rate budget across workers

### DIFF
--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -130,6 +130,15 @@ def _coerce_non_negative_int(value: object, *, source: str) -> int:
     return parsed
 
 
+def _coerce_positive_int(value: object, *, source: str) -> int:
+    """Parse a positive integer from CLI or env config."""
+    parsed = _coerce_non_negative_int(value, source=source)
+    if parsed <= 0:
+        print_error(f"{source} must be greater than 0")
+        raise typer.Exit(1)
+    return parsed
+
+
 def _resolve_max_decomposition_depth(seed_data: dict[str, Any], cli_value: int | None) -> int:
     """Resolve decomposition depth from CLI, env, seed config, then default."""
     if cli_value is not None:
@@ -208,6 +217,17 @@ def _load_skip_completed_markers(
         resolved[ac_number - 1] = metadata
 
     return resolved
+
+
+def _resolve_max_parallel_workers() -> int:
+    """Resolve the parallel worker cap from the environment."""
+    env_value = os.environ.get("OUROBOROS_MAX_PARALLEL_WORKERS", "").strip()
+    if env_value:
+        return _coerce_positive_int(
+            env_value,
+            source="OUROBOROS_MAX_PARALLEL_WORKERS",
+        )
+    return 3
 
 
 async def _initialize_mcp_manager(
@@ -316,7 +336,8 @@ async def _run_orchestrator(
         seed_data,
         max_decomposition_depth,
     )
-    externally_satisfied_acs = {}
+    resolved_max_parallel_workers = _resolve_max_parallel_workers()
+    externally_satisfied_acs: dict[int, dict[str, Any]] | None = None
     if skip_completed:
         if resume_session:
             print_warning("--skip-completed is ignored when resuming an existing session.")
@@ -330,6 +351,7 @@ async def _run_orchestrator(
         print_info(f"Loaded seed: {seed.goal[:80]}...")
         print_info(f"Acceptance criteria: {len(seed.acceptance_criteria)}")
         print_info(f"Max decomposition depth: {resolved_max_decomposition_depth}")
+        print_info(f"Max parallel workers: {resolved_max_parallel_workers}")
         if externally_satisfied_acs:
             print_info(f"Externally satisfied ACs: {len(externally_satisfied_acs)}")
 
@@ -393,6 +415,7 @@ async def _run_orchestrator(
         debug=debug,
         task_workspace=workspace,
         max_decomposition_depth=resolved_max_decomposition_depth,
+        max_parallel_workers=resolved_max_parallel_workers,
     )
 
     # Execute
@@ -408,13 +431,15 @@ async def _run_orchestrator(
                 print_info("Parallel mode: independent ACs will run concurrently")
             else:
                 print_info("Sequential mode: ACs will run one at a time")
-            result = await runner.execute_seed(
-                seed,
-                execution_id=execution_id,
-                session_id=session_id_for_run,
-                parallel=parallel,
-                externally_satisfied_acs=externally_satisfied_acs,
-            )
+            execute_kwargs: dict[str, Any] = {
+                "seed": seed,
+                "execution_id": execution_id,
+                "session_id": session_id_for_run,
+                "parallel": parallel,
+            }
+            if externally_satisfied_acs:
+                execute_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+            result = await runner.execute_seed(**execute_kwargs)
 
         # Handle result
         if result.is_ok:

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -28,6 +28,14 @@ from typing import TYPE_CHECKING, Any, Protocol
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
+from ouroboros.orchestrator.rate_limit import (
+    DEFAULT_ANTHROPIC_RPM_CEILING,
+    DEFAULT_ANTHROPIC_TPM_CEILING,
+    RATE_LIMIT_HEARTBEAT_SECONDS,
+    RateLimitSnapshot,
+    SharedRateLimitBucket,
+    estimate_runtime_request_tokens,
+)
 
 if TYPE_CHECKING:
     from ouroboros.providers.base import CompletionConfig, CompletionResponse, Message
@@ -767,6 +775,7 @@ class ClaudeAgentAdapter:
         self._model = model
         self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
         self._cli_path = str(Path(cli_path).expanduser()) if cli_path is not None else None
+        self._rate_limit_bucket = self._build_rate_limit_bucket()
 
         log.info(
             "orchestrator.adapter.initialized",
@@ -774,6 +783,7 @@ class ClaudeAgentAdapter:
             has_api_key=bool(self._api_key),
             cwd=self._cwd,
             cli_path=self._cli_path,
+            shared_rate_limit_enabled=self._rate_limit_bucket.enabled,
         )
 
     # -- AgentRuntime protocol properties ----------------------------------
@@ -801,6 +811,96 @@ class ClaudeAgentAdapter:
         """
         error_str = str(error).lower()
         return any(pattern in error_str for pattern in TRANSIENT_ERROR_PATTERNS)
+
+    @staticmethod
+    def _parse_optional_positive_int(
+        env_name: str,
+        *,
+        default: int,
+    ) -> int | None:
+        """Parse an optional positive integer env var; 0 disables the limit."""
+        raw_value = os.environ.get(env_name, "").strip()
+        if not raw_value:
+            return default
+
+        try:
+            parsed = int(raw_value)
+        except ValueError:
+            log.warning(
+                "orchestrator.adapter.invalid_rate_limit_env",
+                env_name=env_name,
+                raw_value=raw_value,
+            )
+            return default
+
+        if parsed <= 0:
+            return None
+        return parsed
+
+    def _build_rate_limit_bucket(self) -> SharedRateLimitBucket:
+        """Create the shared Anthropic rate-limit bucket for orchestrator workers."""
+        return SharedRateLimitBucket(
+            runtime_backend=self._runtime_backend,
+            request_limit=self._parse_optional_positive_int(
+                "OUROBOROS_ANTHROPIC_RPM_CEILING",
+                default=DEFAULT_ANTHROPIC_RPM_CEILING,
+            ),
+            token_limit=self._parse_optional_positive_int(
+                "OUROBOROS_ANTHROPIC_TPM_CEILING",
+                default=DEFAULT_ANTHROPIC_TPM_CEILING,
+            ),
+        )
+
+    @staticmethod
+    def _rate_limit_snapshot_data(snapshot: RateLimitSnapshot) -> dict[str, Any]:
+        """Serialize a shared-budget snapshot into message metadata."""
+        return {
+            "runtime_backend": snapshot.runtime_backend,
+            "requests_in_window": snapshot.requests_in_window,
+            "request_limit": snapshot.request_limit,
+            "tokens_in_window": snapshot.tokens_in_window,
+            "token_limit": snapshot.token_limit,
+        }
+
+    async def _wait_for_shared_rate_limit_budget(
+        self,
+        *,
+        estimated_tokens: int,
+        attempt: int,
+    ) -> AsyncIterator[AgentMessage]:
+        """Yield heartbeat messages while waiting for shared budget headroom."""
+        if not self._rate_limit_bucket.enabled:
+            return
+
+        while True:
+            wait_seconds, snapshot = await self._rate_limit_bucket.acquire(estimated_tokens)
+            if wait_seconds <= 0:
+                return
+
+            sleep_seconds = min(wait_seconds, RATE_LIMIT_HEARTBEAT_SECONDS)
+            yield AgentMessage(
+                type="system",
+                content=(
+                    "Shared Anthropic budget saturated; waiting "
+                    f"{sleep_seconds:.1f}s before retrying worker dispatch."
+                ),
+                data={
+                    "subtype": "rate_limit_backoff",
+                    "backoff_seconds": sleep_seconds,
+                    "retry_attempt": attempt,
+                    "source": "shared_rate_limit_bucket",
+                    **self._rate_limit_snapshot_data(snapshot),
+                },
+            )
+            await asyncio.sleep(sleep_seconds)
+
+    @staticmethod
+    def _transient_backoff_subtype(error: Exception) -> str:
+        """Classify transient backoff messages for observability."""
+        error_text = str(error).lower()
+        if "429" in error_text or "rate" in error_text or "concurrency" in error_text:
+            return "rate_limit_backoff"
+        return "transient_backoff"
 
     def _build_runtime_handle(
         self,
@@ -986,10 +1086,17 @@ class ClaudeAgentAdapter:
         last_error: Exception | None = None
         current_runtime_handle = dispatch.runtime_handle
         current_session_id = dispatch.resume_session_id
+        estimated_tokens = estimate_runtime_request_tokens(prompt, system_prompt=system_prompt)
 
         while attempt < MAX_RETRIES:
             attempt += 1
             try:
+                async for budget_message in self._wait_for_shared_rate_limit_budget(
+                    estimated_tokens=estimated_tokens,
+                    attempt=attempt,
+                ):
+                    yield budget_message
+
                 effective_permission_mode = (
                     current_runtime_handle.approval_mode
                     if current_runtime_handle and current_runtime_handle.approval_mode
@@ -1084,6 +1191,18 @@ class ClaudeAgentAdapter:
                     wait_time = min(
                         RETRY_WAIT_INITIAL * (2 ** (attempt - 1)),
                         RETRY_WAIT_MAX,
+                    )
+                    yield AgentMessage(
+                        type="system",
+                        content=(
+                            f"Transient backend backoff for {wait_time:.1f}s "
+                            f"before retrying: {e!s}"
+                        ),
+                        data={
+                            "subtype": self._transient_backoff_subtype(e),
+                            "backoff_seconds": wait_time,
+                            "retry_attempt": attempt,
+                        },
                     )
                     log.warning(
                         "orchestrator.adapter.transient_error_retry",

--- a/src/ouroboros/orchestrator/rate_limit.py
+++ b/src/ouroboros/orchestrator/rate_limit.py
@@ -1,0 +1,135 @@
+"""Shared runtime rate-limit coordination for orchestrator workers."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+import time
+
+RATE_LIMIT_WINDOW_SECONDS = 60.0
+RATE_LIMIT_HEARTBEAT_SECONDS = 30.0
+DEFAULT_ANTHROPIC_RPM_CEILING = 40
+DEFAULT_ANTHROPIC_TPM_CEILING = 32_000
+_TOKEN_ESTIMATE_DIVISOR = 4
+_TOKEN_COMPLETION_CUSHION = 1024
+
+
+@dataclass(frozen=True, slots=True)
+class RateLimitSnapshot:
+    """Current shared-budget usage for one runtime backend."""
+
+    runtime_backend: str
+    requests_in_window: int
+    request_limit: int | None
+    tokens_in_window: int
+    token_limit: int | None
+
+
+class SharedRateLimitBucket:
+    """Sliding-window request/token budget shared by concurrent runtime workers."""
+
+    def __init__(
+        self,
+        *,
+        runtime_backend: str,
+        request_limit: int | None,
+        token_limit: int | None,
+        window_seconds: float = RATE_LIMIT_WINDOW_SECONDS,
+        time_provider: Callable[[], float] | None = None,
+    ) -> None:
+        self._runtime_backend = runtime_backend
+        self._request_limit = request_limit if request_limit and request_limit > 0 else None
+        self._token_limit = token_limit if token_limit and token_limit > 0 else None
+        self._window_seconds = window_seconds
+        self._time = time_provider or time.monotonic
+        self._lock = asyncio.Lock()
+        self._reservations: deque[tuple[float, int]] = deque()
+
+    @property
+    def enabled(self) -> bool:
+        """Return True when either request or token budgets are active."""
+        return self._request_limit is not None or self._token_limit is not None
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - self._window_seconds
+        while self._reservations and self._reservations[0][0] <= cutoff:
+            self._reservations.popleft()
+
+    def _tokens_in_window(self) -> int:
+        return sum(tokens for _, tokens in self._reservations)
+
+    def _snapshot(self) -> RateLimitSnapshot:
+        return RateLimitSnapshot(
+            runtime_backend=self._runtime_backend,
+            requests_in_window=len(self._reservations),
+            request_limit=self._request_limit,
+            tokens_in_window=self._tokens_in_window(),
+            token_limit=self._token_limit,
+        )
+
+    def _request_wait_seconds(self, now: float) -> float:
+        if self._request_limit is None or len(self._reservations) < self._request_limit:
+            return 0.0
+        oldest_timestamp, _ = self._reservations[0]
+        return max(0.0, oldest_timestamp + self._window_seconds - now)
+
+    def _token_wait_seconds(self, now: float, estimated_tokens: int) -> float:
+        if self._token_limit is None:
+            return 0.0
+
+        current_tokens = self._tokens_in_window()
+        if current_tokens + estimated_tokens <= self._token_limit:
+            return 0.0
+
+        remaining_tokens = current_tokens
+        wait_seconds = 0.0
+        for timestamp, reserved_tokens in self._reservations:
+            remaining_tokens -= reserved_tokens
+            wait_seconds = max(0.0, timestamp + self._window_seconds - now)
+            if remaining_tokens + estimated_tokens <= self._token_limit:
+                return wait_seconds
+
+        if not self._reservations:
+            return 0.0
+        newest_timestamp, _ = self._reservations[-1]
+        return max(0.0, newest_timestamp + self._window_seconds - now)
+
+    async def acquire(self, estimated_tokens: int) -> tuple[float, RateLimitSnapshot]:
+        """Reserve capacity immediately or return the wait time before retry."""
+        normalized_tokens = max(1, estimated_tokens)
+        async with self._lock:
+            now = self._time()
+            self._prune(now)
+            wait_seconds = max(
+                self._request_wait_seconds(now),
+                self._token_wait_seconds(now, normalized_tokens),
+            )
+            if wait_seconds <= 0:
+                self._reservations.append((now, normalized_tokens))
+                return 0.0, self._snapshot()
+            return wait_seconds, self._snapshot()
+
+
+def estimate_runtime_request_tokens(
+    prompt: str,
+    *,
+    system_prompt: str | None = None,
+) -> int:
+    """Estimate the cost of starting one runtime request."""
+    prompt_chars = len(prompt)
+    system_chars = len(system_prompt or "")
+    prompt_tokens = (prompt_chars + system_chars) // _TOKEN_ESTIMATE_DIVISOR
+    return max(1, prompt_tokens + _TOKEN_COMPLETION_CUSHION)
+
+
+__all__ = [
+    "DEFAULT_ANTHROPIC_RPM_CEILING",
+    "DEFAULT_ANTHROPIC_TPM_CEILING",
+    "RATE_LIMIT_HEARTBEAT_SECONDS",
+    "RATE_LIMIT_WINDOW_SECONDS",
+    "RateLimitSnapshot",
+    "SharedRateLimitBucket",
+    "estimate_runtime_request_tokens",
+]

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -347,6 +347,7 @@ class OrchestratorRunner:
         task_workspace: TaskWorkspace | None = None,
         checkpoint_store: CheckpointStore | None = None,
         max_decomposition_depth: int = DEFAULT_MAX_DECOMPOSITION_DEPTH,
+        max_parallel_workers: int = 3,
     ) -> None:
         """Initialize orchestrator runner.
 
@@ -370,6 +371,7 @@ class OrchestratorRunner:
             checkpoint_store: Optional checkpoint store for execution state persistence
                         and recovery. When provided, enables per-level state snapshots.
             max_decomposition_depth: Maximum recursive AC decomposition depth.
+            max_parallel_workers: Maximum concurrent AC workers for parallel execution.
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -385,6 +387,7 @@ class OrchestratorRunner:
         self._task_cwd = task_cwd
         self._task_workspace = task_workspace
         self._max_decomposition_depth = max(0, max_decomposition_depth)
+        self._max_parallel_workers = max(1, max_parallel_workers)
         # Track active session for external cancellation by execution_id
         self._active_sessions: dict[str, str] = {}  # execution_id -> session_id
 
@@ -1288,12 +1291,15 @@ class OrchestratorRunner:
         if session_result.is_err:
             return Result.err(session_result.error)
 
-        return await self.execute_precreated_session(
-            seed=seed,
-            tracker=session_result.value,
-            parallel=parallel,
-            externally_satisfied_acs=externally_satisfied_acs,
-        )
+        execute_kwargs: dict[str, Any] = {
+            "seed": seed,
+            "tracker": session_result.value,
+            "parallel": parallel,
+        }
+        if externally_satisfied_acs:
+            execute_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+
+        return await self.execute_precreated_session(**execute_kwargs)
 
     async def prepare_session(
         self,
@@ -1398,16 +1404,19 @@ class OrchestratorRunner:
 
             # Check for parallel execution mode
             if parallel and len(seed.acceptance_criteria) > 1:
-                return await self._execute_parallel(
-                    seed=seed,
-                    exec_id=exec_id,
-                    tracker=tracker,
-                    merged_tools=merged_tools,
-                    tool_catalog=tool_catalog,
-                    system_prompt=system_prompt,
-                    start_time=start_time,
-                    externally_satisfied_acs=externally_satisfied_acs,
-                )
+                parallel_kwargs: dict[str, Any] = {
+                    "seed": seed,
+                    "exec_id": exec_id,
+                    "tracker": tracker,
+                    "merged_tools": merged_tools,
+                    "tool_catalog": tool_catalog,
+                    "system_prompt": system_prompt,
+                    "start_time": start_time,
+                }
+                if externally_satisfied_acs:
+                    parallel_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+
+                return await self._execute_parallel(**parallel_kwargs)
         except Exception as e:
             self._cleanup_pre_execution_state(
                 exec_id,
@@ -1819,6 +1828,7 @@ class OrchestratorRunner:
             event_store=self._event_store,
             console=self._console,
             enable_decomposition=self._enable_decomposition,
+            max_concurrent=self._max_parallel_workers,
             max_decomposition_depth=self._max_decomposition_depth,
             inherited_runtime_handle=self._inherited_runtime_handle,
             task_cwd=self._effective_cwd(),
@@ -1884,6 +1894,7 @@ class OrchestratorRunner:
             "skipped_count": parallel_result.skipped_count,
             "total_levels": execution_plan.total_stages,
             "max_decomposition_depth": self._max_decomposition_depth,
+            "max_parallel_workers": self._max_parallel_workers,
             "verification_report": verification_report,
             **self._task_summary(),
         }

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -11,6 +11,7 @@ import pytest
 from ouroboros.cli.commands.run import (
     _load_skip_completed_markers,
     _resolve_max_decomposition_depth,
+    _resolve_max_parallel_workers,
     _run_orchestrator,
 )
 from ouroboros.core.types import Result
@@ -114,6 +115,13 @@ def test_load_skip_completed_markers_parses_yaml_metadata(tmp_path: Path) -> Non
         0: {"reason": "Done manually", "commit": "abc1234"},
         1: {},
     }
+
+
+def test_resolve_max_parallel_workers_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parallel worker caps should be configurable via environment variable."""
+    monkeypatch.setenv("OUROBOROS_MAX_PARALLEL_WORKERS", "5")
+
+    assert _resolve_max_parallel_workers() == 5
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_adapter.py
+++ b/tests/unit/orchestrator/test_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import ModuleType
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -16,6 +16,7 @@ from ouroboros.orchestrator.adapter import (
     TaskResult,
     _clone_runtime_handle_data,
 )
+from ouroboros.orchestrator.rate_limit import RateLimitSnapshot, SharedRateLimitBucket
 
 
 # Helper function to create mock SDK messages with correct class names
@@ -1091,6 +1092,100 @@ class TestBuildRuntimeHandleFreshPath:
         handle.metadata["config"]["key"] = "changed"
         assert nested_metadata["tools"][0]["name"] == "Read"  # type: ignore[index]
         assert nested_metadata["config"]["key"] == "val"  # type: ignore[index]
+
+    @pytest.mark.asyncio
+    async def test_execute_task_emits_shared_rate_limit_backoff_messages(self) -> None:
+        """Shared bucket waits should surface as system heartbeat messages."""
+
+        async def _query_impl(*, prompt: str, options: Any) -> Any:
+            del prompt, options
+            yield _create_mock_sdk_message(
+                "ResultMessage",
+                result="[TASK_COMPLETE]",
+                subtype="success",
+                is_error=False,
+                session_id="sess_123",
+            )
+
+        class _StubBucket:
+            enabled = True
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def acquire(self, estimated_tokens: int) -> tuple[float, RateLimitSnapshot]:
+                self.calls += 1
+                if self.calls == 1:
+                    return (
+                        0.25,
+                        RateLimitSnapshot(
+                            runtime_backend="claude",
+                            requests_in_window=1,
+                            request_limit=1,
+                            tokens_in_window=estimated_tokens,
+                            token_limit=estimated_tokens * 2,
+                        ),
+                    )
+                return (
+                    0.0,
+                    RateLimitSnapshot(
+                        runtime_backend="claude",
+                        requests_in_window=1,
+                        request_limit=1,
+                        tokens_in_window=estimated_tokens,
+                        token_limit=estimated_tokens * 2,
+                    ),
+                )
+
+        adapter = ClaudeAgentAdapter(api_key="test")
+        adapter._rate_limit_bucket = _StubBucket()
+
+        with (
+            patch.dict("sys.modules", _build_mock_claude_agent_sdk(query_impl=_query_impl)),
+            patch("ouroboros.orchestrator.adapter.asyncio.sleep", new=AsyncMock()),
+        ):
+            messages = [message async for message in adapter.execute_task(prompt="Fix it")]
+
+        assert messages[0].type == "system"
+        assert messages[0].data["subtype"] == "rate_limit_backoff"
+        assert messages[0].data["source"] == "shared_rate_limit_bucket"
+        assert messages[-1].is_final is True
+
+    @pytest.mark.asyncio
+    async def test_execute_task_emits_rate_limit_backoff_on_transient_retry(self) -> None:
+        """Retryable 429 errors should emit heartbeat-style backoff messages."""
+        attempts = {"count": 0}
+
+        async def _query_impl(*, prompt: str, options: Any) -> Any:
+            del prompt, options
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("429 rate limit")
+            yield _create_mock_sdk_message(
+                "ResultMessage",
+                result="[TASK_COMPLETE]",
+                subtype="success",
+                is_error=False,
+                session_id="sess_456",
+            )
+
+        adapter = ClaudeAgentAdapter(api_key="test")
+        adapter._rate_limit_bucket = SharedRateLimitBucket(
+            runtime_backend="claude",
+            request_limit=None,
+            token_limit=None,
+        )
+
+        with (
+            patch.dict("sys.modules", _build_mock_claude_agent_sdk(query_impl=_query_impl)),
+            patch("ouroboros.orchestrator.adapter.asyncio.sleep", new=AsyncMock()),
+        ):
+            messages = [message async for message in adapter.execute_task(prompt="Retry it")]
+
+        assert messages[0].type == "system"
+        assert messages[0].data["subtype"] == "rate_limit_backoff"
+        assert messages[0].data["backoff_seconds"] == 1.0
+        assert messages[-1].is_final is True
 
 
 class TestNonStringSelectorErrorMessage:

--- a/tests/unit/orchestrator/test_rate_limit.py
+++ b/tests/unit/orchestrator/test_rate_limit.py
@@ -1,0 +1,59 @@
+"""Unit tests for shared orchestrator rate-limit coordination."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.rate_limit import SharedRateLimitBucket, estimate_runtime_request_tokens
+
+
+@pytest.mark.asyncio
+async def test_shared_rate_limit_bucket_waits_when_request_budget_is_exhausted() -> None:
+    """The shared bucket should defer new reservations once RPM is exhausted."""
+    clock = {"now": 0.0}
+    bucket = SharedRateLimitBucket(
+        runtime_backend="claude",
+        request_limit=1,
+        token_limit=None,
+        time_provider=lambda: clock["now"],
+    )
+
+    wait_seconds, _ = await bucket.acquire(estimated_tokens=100)
+    assert wait_seconds == 0.0
+
+    wait_seconds, snapshot = await bucket.acquire(estimated_tokens=100)
+    assert wait_seconds == 60.0
+    assert snapshot.requests_in_window == 1
+    assert snapshot.request_limit == 1
+
+    clock["now"] = 60.0
+    wait_seconds, snapshot = await bucket.acquire(estimated_tokens=100)
+    assert wait_seconds == 0.0
+    assert snapshot.requests_in_window == 1
+
+
+@pytest.mark.asyncio
+async def test_shared_rate_limit_bucket_waits_when_token_budget_is_exhausted() -> None:
+    """The shared bucket should defer reservations once TPM is exhausted."""
+    clock = {"now": 0.0}
+    bucket = SharedRateLimitBucket(
+        runtime_backend="claude",
+        request_limit=None,
+        token_limit=200,
+        time_provider=lambda: clock["now"],
+    )
+
+    wait_seconds, _ = await bucket.acquire(estimated_tokens=150)
+    assert wait_seconds == 0.0
+
+    wait_seconds, snapshot = await bucket.acquire(estimated_tokens=100)
+    assert wait_seconds == 60.0
+    assert snapshot.tokens_in_window == 150
+    assert snapshot.token_limit == 200
+
+
+def test_estimate_runtime_request_tokens_adds_completion_cushion() -> None:
+    """Runtime token estimates should always include a non-zero completion cushion."""
+    estimate = estimate_runtime_request_tokens("abcd" * 100, system_prompt="system")
+
+    assert estimate > 100


### PR DESCRIPTION
## Summary
- add a shared Anthropic request/token bucket so concurrent Claude workers respect one budget
- emit `rate_limit_backoff` heartbeat messages during shared-budget waits and transient retry backoffs
- thread `OUROBOROS_MAX_PARALLEL_WORKERS` into the orchestrator worker cap and expose it in runner summaries

Refs #371

## Testing
- `.venv/bin/pytest tests/unit/orchestrator/test_adapter.py tests/unit/orchestrator/test_rate_limit.py tests/unit/orchestrator/test_runner.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_parallel_executor_recursive_depth.py tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py tests/unit/cli/test_run_qa.py -q`
- `.venv/bin/pytest tests/e2e/test_cli_commands.py::TestRunWorkflowCommand -q`