### PR TITLE
feat(interview): wire ambiguity milestones into prompt and MCP response (#363)

### DIFF
--- a/src/ouroboros/bigbang/ambiguity.py
+++ b/src/ouroboros/bigbang/ambiguity.py
@@ -10,6 +10,7 @@ The scoring algorithm evaluates three key components:
 """
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 import json
 import re
 from typing import Any
@@ -52,6 +53,87 @@ SCORING_TEMPERATURE = 0.1
 
 # Maximum token limit (None = no limit, rely on model's context window)
 MAX_TOKEN_LIMIT: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Ambiguity milestones — semantic labels for score ranges
+# ---------------------------------------------------------------------------
+
+
+class AmbiguityMilestone(StrEnum):
+    """Named milestones for ambiguity score ranges.
+
+    Each milestone represents a qualitative stage in the interview's progress
+    toward Seed-ready clarity.  Milestones are consumed by:
+    * ``format_score_display`` — human-readable progress label
+    * ``_build_ambiguity_snapshot_prompt`` (interview.py) — LLM context so the
+      question generator can adapt its strategy to the current stage
+    * MCP response ``meta`` — structured data for downstream tooling
+    """
+
+    INITIAL = "initial"
+    PROGRESS = "progress"
+    REFINED = "refined"
+    READY = "ready"
+
+
+# (upper_bound, milestone, description) — evaluated top-down; first match wins.
+MILESTONE_DEFINITIONS: tuple[tuple[float, AmbiguityMilestone, str], ...] = (
+    (
+        1.0,
+        AmbiguityMilestone.INITIAL,
+        "Core requirements identified. Major gaps in constraints and success criteria.",
+    ),
+    (
+        0.4,
+        AmbiguityMilestone.PROGRESS,
+        "Most requirements captured. Some details and edge cases missing.",
+    ),
+    (
+        0.3,
+        AmbiguityMilestone.REFINED,
+        "Success criteria partially defined. Edge cases and non-goals remain.",
+    ),
+    (
+        AMBIGUITY_THRESHOLD,
+        AmbiguityMilestone.READY,
+        "All criteria concrete and testable. Ready for Seed generation.",
+    ),
+)
+
+
+def get_milestone(score: float) -> tuple[AmbiguityMilestone, str]:
+    """Return the current milestone and its description for *score*.
+
+    Milestones are evaluated from the lowest threshold upward so the most
+    advanced matching milestone is returned.
+
+    >>> get_milestone(0.55)
+    (<AmbiguityMilestone.INITIAL: 'initial'>, 'Core requirements ...')
+    >>> get_milestone(0.15)
+    (<AmbiguityMilestone.READY: 'ready'>, 'All criteria ...')
+    """
+    # Walk from the most advanced milestone (lowest threshold) upward.
+    for threshold, milestone, description in reversed(MILESTONE_DEFINITIONS):
+        if score <= threshold:
+            return milestone, description
+    # score > 1.0 (shouldn't happen) — fall back to INITIAL.
+    return MILESTONE_DEFINITIONS[0][1], MILESTONE_DEFINITIONS[0][2]
+
+
+def get_next_milestone(
+    score: float,
+) -> tuple[float, AmbiguityMilestone, str] | None:
+    """Return the next milestone to reach, or ``None`` if already READY.
+
+    The "next" milestone is the most advanced one whose threshold is still
+    strictly below the current *score*.  We iterate top-down (highest
+    threshold first) and return the first entry the score hasn't yet reached.
+    """
+    for threshold, milestone, description in MILESTONE_DEFINITIONS:
+        if score > threshold:
+            return threshold, milestone, description
+    return None
 
 
 class ComponentScore(BaseModel):
@@ -658,18 +740,27 @@ def is_ready_for_seed(score: AmbiguityScore) -> bool:
 def format_score_display(score: AmbiguityScore) -> str:
     """Format ambiguity score for display after interview round.
 
+    Includes the current milestone label and, when the interview is not yet
+    Seed-ready, the next milestone target so users understand what remains.
+
     Args:
         score: The ambiguity score to format.
 
     Returns:
         Formatted string for display.
     """
+    milestone, milestone_desc = get_milestone(score.overall_score)
+    next_ms = get_next_milestone(score.overall_score)
+
     lines = [
-        f"Ambiguity Score: {score.overall_score:.2f}",
-        f"Ready for Seed: {'Yes' if score.is_ready_for_seed else 'No'}",
-        "",
-        "Component Breakdown:",
+        f"Ambiguity Score: {score.overall_score:.2f} [{milestone.value.upper()}]",
+        f"  {milestone_desc}",
     ]
+    if next_ms is not None:
+        lines.append(f"  Next: {next_ms[1].value} (<= {next_ms[0]:.1f})")
+    lines.append(f"Ready for Seed: {'Yes' if score.is_ready_for_seed else 'No'}")
+    lines.append("")
+    lines.append("Component Breakdown:")
 
     for component in score.breakdown.components:
         clarity_percent = component.clarity_score * 100

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -615,28 +615,42 @@ class InterviewEngine:
             AmbiguityScore,
             ScoreBreakdown,
             get_completion_floor_failures,
+            get_milestone,
+            get_next_milestone,
         )
+
+        milestone, milestone_desc = get_milestone(state.ambiguity_score)
+        next_ms = get_next_milestone(state.ambiguity_score)
 
         lines = [
             "## Current Ambiguity Snapshot",
             f"- Overall ambiguity: {state.ambiguity_score:.2f}",
-            f"- Seed-ready threshold: {AMBIGUITY_THRESHOLD:.2f}",
-            f"- Closure-mode threshold: {SEED_CLOSER_ACTIVATION_THRESHOLD:.2f}",
-            (
-                "- Seed-ready now: yes"
-                if state.ambiguity_score <= AMBIGUITY_THRESHOLD
-                else "- Seed-ready now: no"
-            ),
-            (
-                "- Closure mode active: yes"
-                if state.ambiguity_score <= SEED_CLOSER_ACTIVATION_THRESHOLD
-                else "- Closure mode active: no"
-            ),
-            (
-                "- Completion candidate streak: "
-                f"{state.completion_candidate_streak}/{AUTO_COMPLETE_STREAK_REQUIRED}"
-            ),
+            f"- Milestone: **{milestone.value.upper()}** — {milestone_desc}",
         ]
+        if next_ms is not None:
+            lines.append(
+                f"- Next milestone: {next_ms[1].value} (<= {next_ms[0]:.1f}) — {next_ms[2]}"
+            )
+        lines.extend(
+            [
+                f"- Seed-ready threshold: {AMBIGUITY_THRESHOLD:.2f}",
+                f"- Closure-mode threshold: {SEED_CLOSER_ACTIVATION_THRESHOLD:.2f}",
+                (
+                    "- Seed-ready now: yes"
+                    if state.ambiguity_score <= AMBIGUITY_THRESHOLD
+                    else "- Seed-ready now: no"
+                ),
+                (
+                    "- Closure mode active: yes"
+                    if state.ambiguity_score <= SEED_CLOSER_ACTIVATION_THRESHOLD
+                    else "- Closure mode active: no"
+                ),
+                (
+                    "- Completion candidate streak: "
+                    f"{state.completion_candidate_streak}/{AUTO_COMPLETE_STREAK_REQUIRED}"
+                ),
+            ]
+        )
 
         reconstructed_score: AmbiguityScore | None = None
         if isinstance(state.ambiguity_breakdown, dict):

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -23,6 +23,7 @@ from ouroboros.bigbang.ambiguity import (
     ComponentScore,
     ScoreBreakdown,
     get_completion_floor_failures,
+    get_milestone,
     qualifies_for_seed_completion,
 )
 from ouroboros.bigbang.interview import (
@@ -160,10 +161,21 @@ def _completion_gate_reason(
     return "requirements are not stable enough to close yet"
 
 
+def _milestone_for_score(score: AmbiguityScore | None) -> str | None:
+    """Return the milestone label for an ambiguity score, or None."""
+    if score is None:
+        return None
+    milestone, _ = get_milestone(score.overall_score)
+    return milestone.value
+
+
 def _format_question_with_ambiguity(question: str, score: AmbiguityScore | None) -> str:
     """Attach the current ambiguity score to a question for display."""
     if score is None:
         return question
+    milestone_label = _milestone_for_score(score)
+    if milestone_label:
+        return f"(ambiguity: {score.overall_score:.2f} [{milestone_label}]) {question}"
     return f"(ambiguity: {score.overall_score:.2f}) {question}"
 
 
@@ -612,6 +624,7 @@ class InterviewHandler:
                 meta={
                     "session_id": session_id,
                     "ambiguity_score": (score.overall_score if score is not None else None),
+                    "milestone": _milestone_for_score(score),
                     "seed_ready": False,
                 },
             )
@@ -653,7 +666,10 @@ class InterviewHandler:
 
         score_line = ""
         if score is not None:
-            score_line = f"(ambiguity: {score.overall_score:.2f}) Ready for Seed generation.\n"
+            ms_label = _milestone_for_score(score)
+            score_line = (
+                f"(ambiguity: {score.overall_score:.2f} [{ms_label}]) Ready for Seed generation.\n"
+            )
 
         return Result.ok(
             MCPToolResult(
@@ -672,6 +688,7 @@ class InterviewHandler:
                     "session_id": session_id,
                     "completed": True,
                     "ambiguity_score": score.overall_score if score is not None else None,
+                    "milestone": _milestone_for_score(score),
                     "seed_ready": score.is_ready_for_seed if score is not None else None,
                 },
             )
@@ -881,6 +898,7 @@ class InterviewHandler:
                             "ambiguity_score": (
                                 live_score.overall_score if live_score is not None else None
                             ),
+                            "milestone": _milestone_for_score(live_score),
                             "seed_ready": (
                                 live_score.is_ready_for_seed if live_score is not None else None
                             ),
@@ -919,6 +937,11 @@ class InterviewHandler:
                             meta={
                                 "session_id": session_id,
                                 "ambiguity_score": state.ambiguity_score,
+                                "milestone": (
+                                    get_milestone(state.ambiguity_score)[0].value
+                                    if state.ambiguity_score is not None
+                                    else None
+                                ),
                                 "seed_ready": (
                                     state.ambiguity_score is not None
                                     and state.ambiguity_score <= AMBIGUITY_THRESHOLD
@@ -1124,6 +1147,7 @@ class InterviewHandler:
                             "ambiguity_score": (
                                 live_score.overall_score if live_score is not None else None
                             ),
+                            "milestone": _milestone_for_score(live_score),
                             "seed_ready": (
                                 live_score.is_ready_for_seed if live_score is not None else None
                             ),

--- a/tests/unit/bigbang/test_ambiguity.py
+++ b/tests/unit/bigbang/test_ambiguity.py
@@ -9,13 +9,17 @@ from ouroboros.bigbang.ambiguity import (
     CONSTRAINT_CLARITY_WEIGHT,
     GOAL_CLARITY_WEIGHT,
     MAX_TOKEN_LIMIT,
+    MILESTONE_DEFINITIONS,
     SCORING_TEMPERATURE,
     SUCCESS_CRITERIA_CLARITY_WEIGHT,
+    AmbiguityMilestone,
     AmbiguityScore,
     AmbiguityScorer,
     ComponentScore,
     ScoreBreakdown,
     format_score_display,
+    get_milestone,
+    get_next_milestone,
     is_ready_for_seed,
 )
 from ouroboros.bigbang.interview import InterviewRound, InterviewState
@@ -981,7 +985,7 @@ class TestFormatScoreDisplay:
     """Test format_score_display helper function."""
 
     def test_format_score_display_ready(self) -> None:
-        """format_score_display shows 'Yes' when ready for seed."""
+        """format_score_display shows 'Yes' and READY milestone when ready for seed."""
         breakdown = ScoreBreakdown(
             goal_clarity=ComponentScore(
                 name="Goal Clarity",
@@ -1007,13 +1011,14 @@ class TestFormatScoreDisplay:
         output = format_score_display(score)
 
         assert "0.15" in output
+        assert "[READY]" in output
         assert "Ready for Seed: Yes" in output
         assert "Goal Clarity" in output
         assert "90% clear" in output
         assert "Well-defined goal." in output
 
     def test_format_score_display_not_ready(self) -> None:
-        """format_score_display shows 'No' when not ready for seed."""
+        """format_score_display shows 'No' and INITIAL milestone when not ready."""
         breakdown = ScoreBreakdown(
             goal_clarity=ComponentScore(
                 name="Goal Clarity",
@@ -1039,7 +1044,9 @@ class TestFormatScoreDisplay:
         output = format_score_display(score)
 
         assert "0.50" in output
+        assert "[INITIAL]" in output
         assert "Ready for Seed: No" in output
+        assert "Next: progress" in output
 
     def test_format_score_display_includes_all_components(self) -> None:
         """format_score_display includes all component information."""
@@ -1349,3 +1356,150 @@ class TestAmbiguityScorerAdditionalContext:
 
         assert "Which deployment strategy?" in user_message
         assert "Context Clarity" in system_message
+
+
+class TestAmbiguityMilestone:
+    """Test AmbiguityMilestone enum and milestone helpers."""
+
+    def test_milestone_enum_values(self) -> None:
+        """AmbiguityMilestone has exactly four stages."""
+        assert AmbiguityMilestone.INITIAL == "initial"
+        assert AmbiguityMilestone.PROGRESS == "progress"
+        assert AmbiguityMilestone.REFINED == "refined"
+        assert AmbiguityMilestone.READY == "ready"
+        assert len(AmbiguityMilestone) == 4
+
+    def test_milestone_definitions_ordered_descending(self) -> None:
+        """MILESTONE_DEFINITIONS thresholds are in descending order."""
+        thresholds = [t for t, _, _ in MILESTONE_DEFINITIONS]
+        assert thresholds == sorted(thresholds, reverse=True)
+
+    def test_milestone_definitions_last_is_ambiguity_threshold(self) -> None:
+        """The lowest milestone threshold equals AMBIGUITY_THRESHOLD."""
+        assert MILESTONE_DEFINITIONS[-1][0] == AMBIGUITY_THRESHOLD
+
+
+class TestGetMilestone:
+    """Test get_milestone() for various score ranges."""
+
+    def test_high_ambiguity_returns_initial(self) -> None:
+        """Scores above 0.4 map to INITIAL."""
+        milestone, desc = get_milestone(0.7)
+        assert milestone == AmbiguityMilestone.INITIAL
+        assert "Core requirements" in desc
+
+    def test_score_0_5_returns_initial(self) -> None:
+        """Score exactly 0.5 maps to INITIAL (within the 0.4-1.0 band)."""
+        milestone, _ = get_milestone(0.5)
+        assert milestone == AmbiguityMilestone.INITIAL
+
+    def test_score_0_4_returns_progress(self) -> None:
+        """Score exactly 0.4 maps to PROGRESS."""
+        milestone, desc = get_milestone(0.4)
+        assert milestone == AmbiguityMilestone.PROGRESS
+        assert "Most requirements" in desc
+
+    def test_score_0_35_returns_progress(self) -> None:
+        """Score 0.35 (between 0.3 and 0.4) maps to PROGRESS."""
+        milestone, _ = get_milestone(0.35)
+        assert milestone == AmbiguityMilestone.PROGRESS
+
+    def test_score_0_3_returns_refined(self) -> None:
+        """Score exactly 0.3 maps to REFINED."""
+        milestone, desc = get_milestone(0.3)
+        assert milestone == AmbiguityMilestone.REFINED
+        assert "Success criteria" in desc
+
+    def test_score_0_25_returns_refined(self) -> None:
+        """Score 0.25 (between 0.2 and 0.3) maps to REFINED."""
+        milestone, _ = get_milestone(0.25)
+        assert milestone == AmbiguityMilestone.REFINED
+
+    def test_score_0_2_returns_ready(self) -> None:
+        """Score exactly at AMBIGUITY_THRESHOLD maps to READY."""
+        milestone, desc = get_milestone(0.2)
+        assert milestone == AmbiguityMilestone.READY
+        assert "Ready for Seed" in desc
+
+    def test_score_below_threshold_returns_ready(self) -> None:
+        """Score below threshold still maps to READY."""
+        milestone, _ = get_milestone(0.1)
+        assert milestone == AmbiguityMilestone.READY
+
+    def test_score_zero_returns_ready(self) -> None:
+        """Perfect clarity (0.0) maps to READY."""
+        milestone, _ = get_milestone(0.0)
+        assert milestone == AmbiguityMilestone.READY
+
+    def test_score_1_0_returns_initial(self) -> None:
+        """Maximum ambiguity (1.0) maps to INITIAL."""
+        milestone, _ = get_milestone(1.0)
+        assert milestone == AmbiguityMilestone.INITIAL
+
+
+class TestGetNextMilestone:
+    """Test get_next_milestone() for progression targets."""
+
+    def test_high_score_next_is_progress(self) -> None:
+        """From INITIAL (0.5), next milestone is PROGRESS (0.4)."""
+        result = get_next_milestone(0.5)
+        assert result is not None
+        threshold, milestone, _ = result
+        assert threshold == 0.4
+        assert milestone == AmbiguityMilestone.PROGRESS
+
+    def test_progress_score_next_is_refined(self) -> None:
+        """From PROGRESS (0.35), next milestone is REFINED (0.3)."""
+        result = get_next_milestone(0.35)
+        assert result is not None
+        threshold, milestone, _ = result
+        assert threshold == 0.3
+        assert milestone == AmbiguityMilestone.REFINED
+
+    def test_refined_score_next_is_ready(self) -> None:
+        """From REFINED (0.25), next milestone is READY (0.2)."""
+        result = get_next_milestone(0.25)
+        assert result is not None
+        threshold, milestone, _ = result
+        assert threshold == AMBIGUITY_THRESHOLD
+        assert milestone == AmbiguityMilestone.READY
+
+    def test_ready_score_returns_none(self) -> None:
+        """At READY (0.15), there is no next milestone."""
+        result = get_next_milestone(0.15)
+        assert result is None
+
+    def test_exactly_at_threshold_returns_none(self) -> None:
+        """At exactly AMBIGUITY_THRESHOLD, no next milestone."""
+        result = get_next_milestone(0.2)
+        assert result is None
+
+    def test_zero_returns_none(self) -> None:
+        """At perfect clarity, no next milestone."""
+        result = get_next_milestone(0.0)
+        assert result is None
+
+    def test_score_1_0_next_is_progress(self) -> None:
+        """From maximum ambiguity, next milestone is PROGRESS."""
+        result = get_next_milestone(1.0)
+        assert result is not None
+        _, milestone, _ = result
+        assert milestone == AmbiguityMilestone.PROGRESS
+
+    def test_boundary_0_41_next_is_progress(self) -> None:
+        """Score just above 0.4 points to PROGRESS as next."""
+        result = get_next_milestone(0.41)
+        assert result is not None
+        assert result[0] == 0.4
+
+    def test_boundary_0_31_next_is_refined(self) -> None:
+        """Score just above 0.3 points to REFINED as next."""
+        result = get_next_milestone(0.31)
+        assert result is not None
+        assert result[0] == 0.3
+
+    def test_boundary_0_21_next_is_ready(self) -> None:
+        """Score just above threshold points to READY as next."""
+        result = get_next_milestone(0.21)
+        assert result is not None
+        assert result[0] == AMBIGUITY_THRESHOLD

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -810,6 +810,7 @@ class TestInterviewEngineSystemPrompt:
 
         assert "## Current Ambiguity Snapshot" in prompt
         assert "Overall ambiguity: 0.24" in prompt
+        assert "Milestone:" in prompt
         assert "Weakest area: Constraint Clarity" in prompt
         assert "Constraints need work." in prompt
 

--- a/tests/unit/mcp/tools/test_channel_workflow_handler.py
+++ b/tests/unit/mcp/tools/test_channel_workflow_handler.py
@@ -23,7 +23,7 @@ class FakeInterviewHandler(InterviewHandler):
                     content=(
                         MCPContentItem(
                             type=ContentType.TEXT,
-                            text="Session sess_1\n\n(ambiguity: 0.80) What should this do?",
+                            text="Session sess_1\n\n(ambiguity: 0.80 [initial]) What should this do?",
                         ),
                     ),
                     is_error=False,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1627,7 +1627,7 @@ class TestInterviewHandlerCwd:
         assert result.is_ok
         assert state.ambiguity_score == 0.44
         assert state.ambiguity_breakdown is not None
-        assert "(ambiguity: 0.44) Next question?" in result.value.content[0].text
+        assert "(ambiguity: 0.44 [initial]) Next question?" in result.value.content[0].text
 
     async def test_interview_handle_done_completes_without_new_question(self) -> None:
         """Explicit completion signals should stop the interview instead of asking again."""
@@ -1968,7 +1968,9 @@ class TestInterviewHandlerCwd:
         assert state.status == InterviewStatus.COMPLETED
         assert result.value.meta["completed"] is True
         assert result.value.meta["ambiguity_score"] == 0.18
-        assert "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
+        assert (
+            "(ambiguity: 0.18 [ready]) Ready for Seed generation." in result.value.content[0].text
+        )
         mock_engine.ask_next_question.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- Wire milestone context into `_build_ambiguity_snapshot_prompt()` so the LLM question generator adapts strategy per stage (broad questions at INITIAL → edge-case focus at REFINED)
- Add `"milestone"` field to all 5 MCP response `meta` blocks in `InterviewHandler` for downstream tooling and user-facing display
- Update `_format_question_with_ambiguity()` to show milestone inline: `(ambiguity: 0.44 [initial]) Question?`
- Update completion response `score_line` to include milestone: `(ambiguity: 0.18 [ready]) Ready for Seed generation.`

## Why this is needed

PR #379 defined the milestone data layer but didn't expose it anywhere. Without wiring, milestones are invisible to both users and agents.

This PR connects milestones to the two consumers that matter:

1. **LLM prompt** — The question generator now sees `"Milestone: **REFINED** — Success criteria partially defined. Edge cases and non-goals remain."` and can tailor its questioning strategy accordingly. Previously it only saw a raw number like `0.28`.

2. **MCP response meta** — Main sessions and downstream tools receive structured `"milestone": "refined"` in every response, enabling adaptive routing (e.g., auto-confirm decisions at INITIAL vs. precise edge-case questions at REFINED).

## Depends on

- #379 (`feat/ambiguity-milestones-data`) — milestone enum + helper functions

## Test plan

- [x] Updated 4 existing test assertions to match new display format
- [x] All 1078 unit tests pass (bigbang + mcp)
- [x] ruff check + format clean
- [x] New milestone prompt text verified in `test_interview.py`