### PR TITLE
fix(codex): unify wrapper-safe CLI resolution across runtime and provider paths

### DIFF
--- a/src/ouroboros/codex/cli_policy.py
+++ b/src/ouroboros/codex/cli_policy.py
@@ -1,0 +1,160 @@
+"""Shared Codex CLI launch policy helpers for runtime and provider callers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+DEFAULT_CODEX_CLI_NAME = "codex"
+DEFAULT_MAX_OUROBOROS_DEPTH = 5
+DEFAULT_CODEX_CHILD_ENV_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS = ("CODEX_THREAD_ID",)
+_WRAPPER_MAGIC_HEADERS = (
+    b"\xcf\xfa\xed\xfe",  # Mach-O 64-bit
+    b"\xce\xfa\xed\xfe",  # Mach-O 32-bit
+    b"\x7fELF",  # ELF
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CodexCliResolution:
+    """Resolved Codex CLI selection metadata."""
+
+    cli_path: str
+    candidate_path: str
+    wrapper_path: str | None = None
+    fallback_path: str | None = None
+
+
+def resolve_codex_cli_path(
+    *,
+    explicit_cli_path: str | Path | None,
+    configured_cli_path: str | None,
+    default_cli_name: str = DEFAULT_CODEX_CLI_NAME,
+    logger: object,
+    log_namespace: str,
+) -> CodexCliResolution:
+    """Resolve the safest Codex CLI path for nested automation.
+
+    When the configured candidate is a compiled wrapper (for example a Zeude
+    shim), prefer the next real ``codex`` binary on ``PATH`` instead.
+    """
+    if explicit_cli_path is not None:
+        candidate = str(Path(explicit_cli_path).expanduser())
+    else:
+        candidate = configured_cli_path or _which(default_cli_name) or default_cli_name
+
+    path = Path(candidate).expanduser()
+    if not path.exists():
+        return CodexCliResolution(cli_path=candidate, candidate_path=candidate)
+
+    resolved = str(path)
+    if not is_wrapper_binary(resolved):
+        return CodexCliResolution(cli_path=resolved, candidate_path=resolved)
+
+    logger.warning(
+        f"{log_namespace}.cli_wrapper_detected",
+        wrapper_path=resolved,
+        hint="Searching PATH for the real Node.js codex CLI.",
+    )
+    fallback = find_real_cli(default_cli_name=default_cli_name, skip=resolved)
+    if fallback is not None:
+        logger.info(
+            f"{log_namespace}.cli_resolved_via_fallback",
+            fallback_path=fallback,
+        )
+        return CodexCliResolution(
+            cli_path=fallback,
+            candidate_path=resolved,
+            wrapper_path=resolved,
+            fallback_path=fallback,
+        )
+
+    logger.warning(
+        f"{log_namespace}.cli_no_fallback",
+        wrapper_path=resolved,
+    )
+    return CodexCliResolution(
+        cli_path=resolved,
+        candidate_path=resolved,
+        wrapper_path=resolved,
+    )
+
+
+def is_wrapper_binary(path: str) -> bool:
+    """Return True when *path* looks like a compiled wrapper."""
+    try:
+        with open(path, "rb") as fh:
+            magic = fh.read(4)
+    except OSError:
+        return False
+    return magic in _WRAPPER_MAGIC_HEADERS
+
+
+def find_real_cli(*, default_cli_name: str = DEFAULT_CODEX_CLI_NAME, skip: str) -> str | None:
+    """Walk ``PATH`` for the first executable ``codex`` that is not a wrapper."""
+    skip_path = Path(skip).resolve()
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory, default_cli_name)
+        if not os.path.isfile(candidate) or not os.access(candidate, os.X_OK):
+            continue
+        resolved = Path(candidate).resolve()
+        if resolved == skip_path:
+            continue
+        if is_wrapper_binary(candidate):
+            continue
+        return candidate
+    return None
+
+
+def build_codex_child_env(
+    *,
+    base_env: Mapping[str, str] | None = None,
+    max_depth: int = DEFAULT_MAX_OUROBOROS_DEPTH,
+    child_session_env_keys: Sequence[str] = DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS,
+    depth_error_factory: Callable[[int, int], Exception],
+) -> dict[str, str]:
+    """Build an isolated environment for nested Codex subprocesses."""
+    env = dict(os.environ if base_env is None else base_env)
+    for key in DEFAULT_CODEX_CHILD_ENV_KEYS:
+        env.pop(key, None)
+    for key in child_session_env_keys:
+        env.pop(key, None)
+    # Strip CLAUDECODE so child codex does not detect the parent Codex/Claude
+    # session and hang or refuse to start.
+    env.pop("CLAUDECODE", None)
+
+    try:
+        depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+    except (ValueError, TypeError):
+        depth = 1
+
+    if depth > max_depth:
+        raise depth_error_factory(depth, max_depth)
+
+    env["_OUROBOROS_DEPTH"] = str(depth)
+    return env
+
+
+def _which(name: str) -> str | None:
+    """Small local ``which`` helper to keep path resolution pure/testable."""
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory, name)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+__all__ = [
+    "CodexCliResolution",
+    "DEFAULT_CODEX_CHILD_ENV_KEYS",
+    "DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS",
+    "DEFAULT_CODEX_CLI_NAME",
+    "DEFAULT_MAX_OUROBOROS_DEPTH",
+    "build_codex_child_env",
+    "find_real_cli",
+    "is_wrapper_binary",
+    "resolve_codex_cli_path",
+]

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -14,13 +14,18 @@ import os
 from pathlib import Path
 import re
 import shlex
-import shutil
 import tempfile
 from typing import Any
 
 import yaml
 
 from ouroboros.codex import resolve_packaged_codex_skill_path
+from ouroboros.codex.cli_policy import (
+    DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS,
+    DEFAULT_MAX_OUROBOROS_DEPTH,
+    build_codex_child_env,
+    resolve_codex_cli_path,
+)
 from ouroboros.codex_permissions import (
     build_codex_exec_permission_args,
     resolve_codex_permission_mode,
@@ -85,11 +90,11 @@ class CodexCliRuntime:
     _skills_package_uri = "packaged://ouroboros.codex/skills"
     _process_shutdown_timeout_seconds = 5.0
     _max_resume_retries = 3
-    _max_ouroboros_depth = 5
+    _max_ouroboros_depth = DEFAULT_MAX_OUROBOROS_DEPTH
     _startup_output_timeout_seconds = 60.0
     _stdout_idle_timeout_seconds = 300.0
     _max_stderr_lines = 512
-    _child_session_env_keys = ("CODEX_THREAD_ID",)
+    _child_session_env_keys = DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS
 
     def __init__(
         self,
@@ -135,6 +140,11 @@ class CodexCliRuntime:
     def permission_mode(self) -> str | None:
         return self._permission_mode
 
+    @property
+    def cli_path(self) -> str:
+        """Resolved Codex CLI path used for subprocess execution."""
+        return self._cli_path
+
     def _resolve_permission_mode(self, permission_mode: str | None) -> str:
         """Validate and normalize the runtime permission mode."""
         return resolve_codex_permission_mode(
@@ -154,80 +164,15 @@ class CodexCliRuntime:
         return get_codex_cli_path()
 
     def _resolve_cli_path(self, cli_path: str | Path | None) -> str:
-        """Resolve the Codex CLI path from explicit, config, or PATH values.
-
-        Validates that the resolved binary is the real Node.js CLI and not a
-        platform wrapper (e.g. zeude) that can fork-bomb when invoked without
-        a TTY.  When a wrapper is detected the method falls back to the next
-        ``codex`` on ``PATH`` that passes validation.
-        """
-        if cli_path is not None:
-            candidate = str(Path(cli_path).expanduser())
-        else:
-            candidate = (
-                self._get_configured_cli_path()
-                or shutil.which(self._default_cli_name)
-                or self._default_cli_name
-            )
-
-        path = Path(candidate).expanduser()
-        if path.exists():
-            resolved = str(path)
-            if not self._is_wrapper_binary(resolved):
-                return resolved
-            # The candidate is a wrapper — try to find the real CLI on PATH.
-            log.warning(
-                f"{self._log_namespace}.cli_wrapper_detected",
-                wrapper_path=resolved,
-                hint="Searching PATH for the real Node.js codex CLI.",
-            )
-            fallback = self._find_real_cli(skip=resolved)
-            if fallback is not None:
-                log.info(
-                    f"{self._log_namespace}.cli_resolved_via_fallback",
-                    fallback_path=fallback,
-                )
-                return fallback
-            # No fallback found — use the wrapper and hope for the best.
-            log.warning(
-                f"{self._log_namespace}.cli_no_fallback",
-                wrapper_path=resolved,
-            )
-            return resolved
-        return candidate
-
-    @staticmethod
-    def _is_wrapper_binary(path: str) -> bool:
-        """Return True when *path* looks like a compiled wrapper, not the real CLI.
-
-        The real ``codex`` CLI is a Node.js script (``#!/usr/bin/env node``).
-        Platform wrappers (e.g. zeude) are native Mach-O / ELF binaries that
-        delegate to the real CLI but may perform recursive version checks that
-        fork-bomb when invoked from a non-TTY subprocess.
-        """
-        try:
-            with open(path, "rb") as fh:
-                magic = fh.read(4)
-            # Mach-O: \xcf\xfa\xed\xfe (64-bit) or \xce\xfa\xed\xfe (32-bit)
-            # ELF:    \x7fELF
-            return magic in (b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe", b"\x7fELF")
-        except OSError:
-            return False
-
-    def _find_real_cli(self, *, skip: str) -> str | None:
-        """Walk ``PATH`` for the first ``codex`` that is not *skip* and not a wrapper."""
-        path_dirs = os.environ.get("PATH", "").split(os.pathsep)
-        for d in path_dirs:
-            candidate = os.path.join(d, self._default_cli_name)
-            if not os.path.isfile(candidate) or not os.access(candidate, os.X_OK):
-                continue
-            resolved = str(Path(candidate).resolve())
-            if resolved == str(Path(skip).resolve()):
-                continue
-            if self._is_wrapper_binary(candidate):
-                continue
-            return candidate
-        return None
+        """Resolve the Codex CLI path from explicit, config, or PATH values."""
+        resolution = resolve_codex_cli_path(
+            explicit_cli_path=cli_path,
+            configured_cli_path=self._get_configured_cli_path(),
+            default_cli_name=self._default_cli_name,
+            logger=log,
+            log_namespace=self._log_namespace,
+        )
+        return resolution.cli_path
 
     def _resolve_skills_dir(self, skills_dir: str | Path | None) -> Path | None:
         """Resolve an optional explicit skill override directory for intercept metadata."""
@@ -817,25 +762,13 @@ class CodexCliRuntime:
         parent Codex thread/session env so nested ``codex exec`` starts a fresh
         subprocess instead of inheriting the current agent thread.
         """
-        env = os.environ.copy()
-        # Prevent child from re-entering Ouroboros MCP
-        for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
-            env.pop(key, None)
-        for key in self._child_session_env_keys:
-            env.pop(key, None)
-        # Strip CLAUDECODE so the child codex doesn't think it's a nested
-        # session inside Claude Code and refuse to start / hang (#269).
-        env.pop("CLAUDECODE", None)
-        # Track and enforce recursion depth to prevent fork bombs.
-        try:
-            depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
-        except (ValueError, TypeError):
-            depth = 1
-        if depth > self._max_ouroboros_depth:
-            msg = f"Maximum Ouroboros nesting depth ({self._max_ouroboros_depth}) exceeded"
-            raise RuntimeError(msg)
-        env["_OUROBOROS_DEPTH"] = str(depth)
-        return env
+        return build_codex_child_env(
+            max_depth=self._max_ouroboros_depth,
+            child_session_env_keys=self._child_session_env_keys,
+            depth_error_factory=lambda _depth, max_depth: RuntimeError(
+                f"Maximum Ouroboros nesting depth ({max_depth}) exceeded"
+            ),
+        )
 
     def _requires_process_stdin(self) -> bool:
         """Return True when the runtime needs a writable stdin pipe."""

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -583,10 +583,13 @@ class OrchestratorRunner:
             if isinstance(llm_backend, str) and llm_backend
             else (self._adapter.runtime_backend)
         )
+        cli_path = getattr(self._adapter, "cli_path", None)
+        resolved_cli_path = cli_path if isinstance(cli_path, str) and cli_path else None
         try:
             llm_adapter = create_llm_adapter(
                 backend=backend,
                 permission_mode=self._adapter.permission_mode,
+                cli_path=resolved_cli_path,
                 cwd=self._effective_cwd(),
                 max_turns=1,
             )

--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -14,12 +14,17 @@ import json
 import os
 from pathlib import Path
 import re
-import shutil
 import tempfile
 from typing import Any
 
 import structlog
 
+from ouroboros.codex.cli_policy import (
+    DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS,
+    DEFAULT_MAX_OUROBOROS_DEPTH,
+    build_codex_child_env,
+    resolve_codex_cli_path,
+)
 from ouroboros.codex_permissions import (
     build_codex_exec_permission_args,
     resolve_codex_permission_mode,
@@ -44,8 +49,6 @@ from ouroboros.providers.codex_cli_stream import (
 log = structlog.get_logger()
 
 _SAFE_MODEL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_./:@-]+$")
-_MAX_OUROBOROS_DEPTH = 5
-
 _RETRYABLE_ERROR_PATTERNS = (
     "rate limit",
     "temporarily unavailable",
@@ -65,6 +68,9 @@ class CodexCliLLMAdapter:
     _tempfile_prefix = "ouroboros-codex-llm-"
     _schema_tempfile_prefix = "ouroboros-codex-schema-"
     _process_shutdown_timeout_seconds = 5.0
+    _log_namespace = "codex_cli_adapter"
+    _max_ouroboros_depth = DEFAULT_MAX_OUROBOROS_DEPTH
+    _child_session_env_keys = DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS
 
     def __init__(
         self,
@@ -106,19 +112,14 @@ class CodexCliLLMAdapter:
 
     def _resolve_cli_path(self, cli_path: str | Path | None) -> str:
         """Resolve Codex CLI path from explicit path, config, or PATH."""
-        if cli_path is not None:
-            candidate = str(Path(cli_path).expanduser())
-        else:
-            candidate = (
-                self._get_configured_cli_path()
-                or shutil.which(self._default_cli_name)
-                or self._default_cli_name
-            )
-
-        path = Path(candidate).expanduser()
-        if path.exists():
-            return str(path)
-        return candidate
+        resolution = resolve_codex_cli_path(
+            explicit_cli_path=cli_path,
+            configured_cli_path=self._get_configured_cli_path(),
+            default_cli_name=self._default_cli_name,
+            logger=log,
+            log_namespace=self._log_namespace,
+        )
+        return resolution.cli_path
 
     def _normalize_model(self, model: str) -> str | None:
         """Normalize a model name for Codex CLI.
@@ -623,31 +624,21 @@ class CodexCliLLMAdapter:
 
         return stdout_lines, stderr_lines, session_id, last_content
 
-    @staticmethod
-    def _build_child_env() -> dict[str, str]:
+    @classmethod
+    def _build_child_env(cls) -> dict[str, str]:
         """Build an isolated environment for child Codex processes.
 
         Strips Ouroboros MCP env vars to prevent recursive startup (#185).
         """
-        env = os.environ.copy()
-        for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
-            env.pop(key, None)
-        env.pop("CODEX_THREAD_ID", None)
-        # Strip CLAUDECODE so child codex doesn't hang in nested session
-        # detection when invoked from within Claude Code (#269).
-        env.pop("CLAUDECODE", None)
-        try:
-            depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
-        except (ValueError, TypeError):
-            depth = 1
-        if depth > _MAX_OUROBOROS_DEPTH:
-            raise ProviderError(
-                message=f"Maximum Ouroboros nesting depth ({_MAX_OUROBOROS_DEPTH}) exceeded",
-                provider="codex_cli",
+        return build_codex_child_env(
+            max_depth=cls._max_ouroboros_depth,
+            child_session_env_keys=cls._child_session_env_keys,
+            depth_error_factory=lambda depth, max_depth: ProviderError(
+                message=f"Maximum Ouroboros nesting depth ({max_depth}) exceeded",
+                provider=cls._provider_name,
                 details={"depth": depth},
-            )
-        env["_OUROBOROS_DEPTH"] = str(depth)
-        return env
+            ),
+        )
 
     async def _complete_once(
         self,

--- a/tests/unit/codex/test_cli_policy.py
+++ b/tests/unit/codex/test_cli_policy.py
@@ -1,0 +1,137 @@
+"""Tests for shared Codex CLI launch policy helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ouroboros.codex.cli_policy import (
+    build_codex_child_env,
+    resolve_codex_cli_path,
+)
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.events.append(("warning", event, kwargs))
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.events.append(("info", event, kwargs))
+
+
+def _write_wrapper(path: Path) -> Path:
+    path.write_bytes(b"\xcf\xfa\xed\xfe")
+    path.chmod(0o755)
+    return path
+
+
+def _write_script(path: Path) -> Path:
+    path.write_text("#!/usr/bin/env node\nconsole.log('codex')\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+class TestResolveCodexCliPath:
+    def test_falls_back_from_wrapper_to_real_cli(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Wrapper candidates should resolve to the first real CLI on PATH."""
+        wrapper = _write_wrapper(tmp_path / "codex-wrapper")
+        real_dir = tmp_path / "real-bin"
+        real_dir.mkdir()
+        real_cli = _write_script(real_dir / "codex")
+        logger = _FakeLogger()
+
+        monkeypatch.setenv("PATH", str(real_dir))
+
+        resolution = resolve_codex_cli_path(
+            explicit_cli_path=wrapper,
+            configured_cli_path=None,
+            logger=logger,
+            log_namespace="codex_cli_adapter",
+        )
+
+        assert resolution.cli_path == str(real_cli)
+        assert resolution.wrapper_path == str(wrapper)
+        assert resolution.fallback_path == str(real_cli)
+        assert logger.events == [
+            (
+                "warning",
+                "codex_cli_adapter.cli_wrapper_detected",
+                {
+                    "wrapper_path": str(wrapper),
+                    "hint": "Searching PATH for the real Node.js codex CLI.",
+                },
+            ),
+            (
+                "info",
+                "codex_cli_adapter.cli_resolved_via_fallback",
+                {"fallback_path": str(real_cli)},
+            ),
+        ]
+
+    def test_keeps_wrapper_when_no_real_cli_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Wrapper candidates should only pass through when no fallback exists."""
+        wrapper = _write_wrapper(tmp_path / "codex-wrapper")
+        logger = _FakeLogger()
+
+        monkeypatch.setenv("PATH", "")
+
+        resolution = resolve_codex_cli_path(
+            explicit_cli_path=wrapper,
+            configured_cli_path=None,
+            logger=logger,
+            log_namespace="codex_cli_runtime",
+        )
+
+        assert resolution.cli_path == str(wrapper)
+        assert resolution.wrapper_path == str(wrapper)
+        assert resolution.fallback_path is None
+        assert logger.events[-1] == (
+            "warning",
+            "codex_cli_runtime.cli_no_fallback",
+            {"wrapper_path": str(wrapper)},
+        )
+
+
+class TestBuildCodexChildEnv:
+    def test_strips_recursive_markers_and_increments_depth(self) -> None:
+        """Shared child-env policy should remove Ouroboros/Codex recursion markers."""
+        env = build_codex_child_env(
+            base_env={
+                "OUROBOROS_AGENT_RUNTIME": "codex",
+                "OUROBOROS_LLM_BACKEND": "codex",
+                "CODEX_THREAD_ID": "thread-123",
+                "CLAUDECODE": "1",
+                "_OUROBOROS_DEPTH": "2",
+                "KEEP_ME": "ok",
+            },
+            depth_error_factory=lambda depth, max_depth: RuntimeError(f"depth {depth}/{max_depth}"),
+        )
+
+        assert "OUROBOROS_AGENT_RUNTIME" not in env
+        assert "OUROBOROS_LLM_BACKEND" not in env
+        assert "CODEX_THREAD_ID" not in env
+        assert "CLAUDECODE" not in env
+        assert env["_OUROBOROS_DEPTH"] == "3"
+        assert env["KEEP_ME"] == "ok"
+
+    def test_uses_supplied_error_factory_for_depth_guard(self) -> None:
+        """Callers can keep their own exception type while sharing policy."""
+
+        class DepthExceededError(RuntimeError):
+            pass
+
+        with pytest.raises(DepthExceededError, match="depth 6/5"):
+            build_codex_child_env(
+                base_env={"_OUROBOROS_DEPTH": "5"},
+                depth_error_factory=lambda depth, max_depth: DepthExceededError(
+                    f"depth {depth}/{max_depth}"
+                ),
+            )

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -164,6 +165,18 @@ class TestCodexCliRuntime:
     """Tests for CodexCliRuntime."""
 
     @staticmethod
+    def _write_wrapper(path: Path) -> Path:
+        path.write_bytes(b"\xcf\xfa\xed\xfe")
+        path.chmod(0o755)
+        return path
+
+    @staticmethod
+    def _write_real_cli(path: Path) -> Path:
+        path.write_text("#!/usr/bin/env node\nconsole.log('codex')\n", encoding="utf-8")
+        path.chmod(0o755)
+        return path
+
+    @staticmethod
     def _write_skill(
         skills_dir: Path,
         skill_name: str,
@@ -217,6 +230,31 @@ class TestCodexCliRuntime:
         assert command.index("--output-last-message") < resume_index
         assert command.index("-C") < resume_index
         assert command[command.index("-C") + 1] == "/tmp/project"
+
+    def test_resolve_cli_path_falls_back_from_wrapper(self, tmp_path: Path) -> None:
+        """Runtime should bypass wrappers the same way provider adapters do."""
+        wrapper = self._write_wrapper(tmp_path / "codex-wrapper")
+        real_dir = tmp_path / "bin"
+        real_dir.mkdir()
+        real_cli = self._write_real_cli(real_dir / "codex")
+
+        with (
+            patch.dict(os.environ, {"PATH": str(real_dir)}),
+            patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
+            patch("ouroboros.orchestrator.codex_cli_runtime.log.info") as mock_info,
+        ):
+            runtime = CodexCliRuntime(cli_path=wrapper)
+
+        assert runtime._cli_path == str(real_cli)
+        mock_warning.assert_called_once_with(
+            "codex_cli_runtime.cli_wrapper_detected",
+            wrapper_path=str(wrapper),
+            hint="Searching PATH for the real Node.js codex CLI.",
+        )
+        mock_info.assert_any_call(
+            "codex_cli_runtime.cli_resolved_via_fallback",
+            fallback_path=str(real_cli),
+        )
 
     def test_build_command_uses_read_only_for_default_permission_mode(self) -> None:
         """Default permission mode keeps the runtime in read-only mode."""

--- a/tests/unit/orchestrator/test_codex_recursion_guard.py
+++ b/tests/unit/orchestrator/test_codex_recursion_guard.py
@@ -101,3 +101,28 @@ class TestCodexCliAdapterChildEnv:
         with patch.dict(os.environ, {"_OUROBOROS_DEPTH": "garbage"}):
             env = CodexCliLLMAdapter._build_child_env()
         assert env["_OUROBOROS_DEPTH"] == "1"
+
+
+class TestCodexChildEnvParity:
+    """Runtime/provider should share the same Codex child-env policy."""
+
+    def test_runtime_and_provider_build_identical_env(self) -> None:
+        runtime = _make_runtime()
+        runtime._child_session_env_keys = ("CODEX_THREAD_ID",)
+        runtime._max_ouroboros_depth = 5
+
+        with patch.dict(
+            os.environ,
+            {
+                "OUROBOROS_AGENT_RUNTIME": "codex",
+                "OUROBOROS_LLM_BACKEND": "codex",
+                "CODEX_THREAD_ID": "thread-123",
+                "CLAUDECODE": "1",
+                "_OUROBOROS_DEPTH": "1",
+                "PRESERVE_ME": "yes",
+            },
+        ):
+            runtime_env = runtime._build_child_env()
+            provider_env = CodexCliLLMAdapter._build_child_env()
+
+        assert runtime_env == provider_env

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1598,10 +1598,47 @@ class TestOrchestratorRunner:
         mock_create_llm_adapter.assert_called_once_with(
             backend="opencode",
             permission_mode="acceptEdits",
+            cli_path=None,
             cwd="/tmp/project",
             max_turns=1,
         )
         dependency_analyzer_cls.assert_called_once_with(llm_adapter=llm_adapter)
+
+    def test_build_dependency_analyzer_reuses_resolved_codex_cli_path(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Nested dependency analysis should inherit the runtime's resolved Codex CLI path."""
+        mock_adapter.runtime_backend = "codex"
+        mock_adapter.cli_path = "/tmp/real-codex"
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        llm_adapter = object()
+        dependency_analyzer_cls = MagicMock()
+
+        with (
+            patch(
+                "ouroboros.orchestrator.runner.create_llm_adapter",
+                return_value=llm_adapter,
+            ) as mock_create_llm_adapter,
+            patch(
+                "ouroboros.orchestrator.dependency_analyzer.DependencyAnalyzer",
+                dependency_analyzer_cls,
+            ),
+        ):
+            analyzer = runner._build_dependency_analyzer()
+
+        assert analyzer is dependency_analyzer_cls.return_value
+        mock_create_llm_adapter.assert_called_once_with(
+            backend="codex",
+            permission_mode="acceptEdits",
+            cli_path="/tmp/real-codex",
+            cwd="/tmp/project",
+            max_turns=1,
+        )
 
     @pytest.mark.asyncio
     async def test_execute_seed_uses_inherited_runtime_handle(

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -95,6 +96,18 @@ class _FakeProcess:
 class TestCodexCliLLMAdapter:
     """Tests for CodexCliLLMAdapter."""
 
+    @staticmethod
+    def _write_wrapper(path: Path) -> Path:
+        path.write_bytes(b"\xcf\xfa\xed\xfe")
+        path.chmod(0o755)
+        return path
+
+    @staticmethod
+    def _write_real_cli(path: Path) -> Path:
+        path.write_text("#!/usr/bin/env node\nconsole.log('codex')\n", encoding="utf-8")
+        path.chmod(0o755)
+        return path
+
     def test_build_prompt_preserves_system_and_roles(self) -> None:
         """Prompt builder keeps system instructions and conversation order."""
         adapter = CodexCliLLMAdapter(cli_path="codex", cwd="/tmp/project")
@@ -158,6 +171,31 @@ class TestCodexCliLLMAdapter:
 
         assert adapter._normalize_model("default") is None
         assert adapter._normalize_model(" o3 ") == "o3"
+
+    def test_resolve_cli_path_falls_back_from_wrapper(self, tmp_path: Path) -> None:
+        """Provider adapter should apply the same wrapper-safe fallback as runtime."""
+        wrapper = self._write_wrapper(tmp_path / "codex-wrapper")
+        real_dir = tmp_path / "bin"
+        real_dir.mkdir()
+        real_cli = self._write_real_cli(real_dir / "codex")
+
+        with (
+            patch.dict(os.environ, {"PATH": str(real_dir)}),
+            patch("ouroboros.providers.codex_cli_adapter.log.warning") as mock_warning,
+            patch("ouroboros.providers.codex_cli_adapter.log.info") as mock_info,
+        ):
+            adapter = CodexCliLLMAdapter(cli_path=wrapper)
+
+        assert adapter._cli_path == str(real_cli)
+        mock_warning.assert_called_once_with(
+            "codex_cli_adapter.cli_wrapper_detected",
+            wrapper_path=str(wrapper),
+            hint="Searching PATH for the real Node.js codex CLI.",
+        )
+        mock_info.assert_called_once_with(
+            "codex_cli_adapter.cli_resolved_via_fallback",
+            fallback_path=str(real_cli),
+        )
 
     def test_build_command_uses_read_only_by_default(self) -> None:
         """Default permission mode maps to a read-only sandbox."""


### PR DESCRIPTION
## Summary

- extract a shared `cli_policy` module for Codex CLI path resolution and child-process environment sanitation
- apply the shared policy to both `CodexCliRuntime` and `CodexCliLLMAdapter`
- pass the runtime's already-resolved Codex CLI path into nested dependency-analysis adapter construction so top-level and nested Codex calls converge on the same terminal binary
- add parity-focused tests for runtime/provider fallback behavior, child-env policy, and nested analyzer wiring

## Problem

Ouroboros had an inconsistency in how it launched Codex:

1. **Runtime path** (`CodexCliRuntime`) already recognized compiled wrapper binaries and fell back to the first real `codex` executable on `PATH`.
2. **Provider path** (`CodexCliLLMAdapter`) did **not** share that logic. It resolved `get_codex_cli_path()` directly and used the configured candidate as-is.

That left a missing parity point in nested execution flows.

A typical failure shape looked like this:

- top-level AC execution used the runtime path and correctly bypassed a wrapper binary
- nested provider-backed work (for example dependency analysis via `create_llm_adapter(...)`) could still resolve a different `codex` binary than the runtime had already selected
- the system therefore had two different Codex launch policies depending on which code path happened to fire

Even when the top-level execution was healthy, nested Codex calls could diverge into a different binary and a different subprocess environment.

## Why this fix is structured this way

This PR fixes the inconsistency at the policy boundary instead of patching a single callsite.

### Before
- wrapper-safe resolution logic lived only inside `CodexCliRuntime`
- child env sanitation was duplicated between runtime and provider code
- nested dependency-analysis calls rebuilt a provider adapter without reusing the runtime's resolved CLI path

### After
- `src/ouroboros/codex/cli_policy.py` owns the shared Codex launch policy:
  - wrapper-binary detection
  - fallback to the terminal `codex` binary
  - shared child-process environment sanitation
- both runtime and provider paths use the same policy
- `OrchestratorRunner._build_dependency_analyzer()` reuses the runtime's resolved `cli_path` when constructing the nested provider adapter

This keeps the fix architectural rather than tactical:

> one Codex launch policy, reused everywhere

## Design details

### 1. Shared wrapper-safe resolution
`resolve_codex_cli_path(...)` now centralizes the existing runtime behavior:

- inspect the configured/explicit candidate
- treat compiled binaries as wrapper candidates
- fall back to the first non-wrapper `codex` on `PATH`
- preserve the same structured logging (`cli_wrapper_detected`, `cli_resolved_via_fallback`, `cli_no_fallback`)

### 2. Shared child env policy
`build_codex_child_env(...)` now centralizes the recursion-prevention behavior:

- strip Ouroboros MCP env markers
- strip inherited Codex session markers
- strip `CLAUDECODE`
- increment `_OUROBOROS_DEPTH`
- preserve caller-specific exception behavior through an injected error factory

### 3. Nested analyzer parity
`OrchestratorRunner` now passes the runtime's resolved `cli_path` into `create_llm_adapter(...)` for dependency analysis. That prevents nested provider calls from drifting back to a different configured binary after the runtime has already resolved the correct terminal CLI.

## Why this matters

This change makes Codex invocation behavior deterministic across:

- top-level runtime execution
- provider-backed nested calls
- dependency-analysis paths that create fresh Codex adapters mid-run

It removes a class of bugs where the system could look healthy at the top level but still diverge in deeper execution phases.

## Test plan

### Focused parity and regression tests
- `PYTHONPATH=src ./.venv/bin/pytest -q tests/unit/orchestrator/test_codex_cli_runtime.py tests/unit/orchestrator/test_codex_recursion_guard.py tests/unit/orchestrator/test_runner.py tests/unit/providers/test_codex_cli_adapter.py`
- `PYTHONPATH=src ./.venv/bin/pytest -q tests/unit/codex/test_cli_policy.py tests/unit/providers/test_codex_cli_adapter.py::TestCodexCliLLMAdapter::test_resolve_cli_path_falls_back_from_wrapper tests/unit/orchestrator/test_codex_cli_runtime.py::TestCodexCliRuntime::test_resolve_cli_path_falls_back_from_wrapper tests/unit/orchestrator/test_runner.py::TestOrchestratorRunner::test_build_dependency_analyzer_reuses_resolved_codex_cli_path`
- `PYTHONPATH=src ./.venv/bin/pytest -q tests/unit/orchestrator/test_runtime_factory.py`

### Static checks
- `PYTHONPATH=src ./.venv/bin/ruff check src/ouroboros/codex/cli_policy.py src/ouroboros/orchestrator/codex_cli_runtime.py src/ouroboros/providers/codex_cli_adapter.py src/ouroboros/orchestrator/runner.py tests/unit/codex/test_cli_policy.py tests/unit/orchestrator/test_codex_cli_runtime.py tests/unit/orchestrator/test_codex_recursion_guard.py tests/unit/orchestrator/test_runner.py tests/unit/providers/test_codex_cli_adapter.py`
- `PYTHONPATH=src ./.venv/bin/mypy src/ouroboros/codex/cli_policy.py src/ouroboros/orchestrator/codex_cli_runtime.py src/ouroboros/providers/codex_cli_adapter.py src/ouroboros/orchestrator/runner.py`

### Smoke validation
- runtime/provider smoke parity check with a compiled wrapper candidate + real terminal `codex` script confirming both paths resolve to the same final binary

## Notes

I reviewed the current open PR list before opening this. The existing open PRs are focused on ambiguity milestones, inherited tool filtering, startup performance, and other unrelated areas; I did not find another open PR addressing Codex runtime/provider launch parity.
