### PR TITLE
feat(evaluate): expose Socratic questions and evidence in Stage 2 output (#367)

### DIFF
--- a/src/ouroboros/agents/semantic-evaluator.md
+++ b/src/ouroboros/agents/semantic-evaluator.md
@@ -7,7 +7,9 @@ You must respond ONLY with a valid JSON object in the following exact format:
     "goal_alignment": <float between 0.0 and 1.0>,
     "drift_score": <float between 0.0 and 1.0>,
     "uncertainty": <float between 0.0 and 1.0>,
-    "reasoning": "<string explaining your evaluation>"
+    "reasoning": "<string explaining your evaluation>",
+    "questions_used": ["<socratic or ontology-gap question>", "..."],
+    "evidence": ["<concrete evidence inspected>", "..."]
 }
 
 Evaluation criteria:
@@ -17,6 +19,8 @@ Evaluation criteria:
 - drift_score: How much the implementation drifts from intent (0.0 = no drift, 1.0 = complete drift)
 - uncertainty: Your confidence level in this evaluation (0.0 = certain, 1.0 = very uncertain)
 - reasoning: Brief explanation of your evaluation
+- questions_used: the concrete Socratic / ontology-gap questions you asked to verify the artifact (visible to the user as anti-reward-hacking transparency)
+- evidence: the concrete evidence from the artifact or source files that supports the verdict (visible to the user)
 
 Be strict but fair. A passing artifact should have:
 - ac_compliance = true

--- a/src/ouroboros/evaluation/models.py
+++ b/src/ouroboros/evaluation/models.py
@@ -113,6 +113,12 @@ class SemanticResult:
         reward_hacking_risk: Suspicion that the artifact games the
             evaluator rather than solving the real task (0.0-1.0).
             Distinct from drift_score.
+        questions_used: Socratic / ontology-gap questions the evaluator
+            actually asked while verifying the artifact.  Exposing these
+            to the user is an anti-reward-hacking mechanism (#367) —
+            the evaluator has to show its work.
+        evidence: Concrete evidence (file snippets, behavior observations,
+            etc.) the evaluator relied on when deciding the verdict.
     """
 
     score: float
@@ -122,6 +128,8 @@ class SemanticResult:
     uncertainty: float
     reasoning: str
     reward_hacking_risk: float = 0.0
+    questions_used: tuple[str, ...] = ()
+    evidence: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         """Validate score ranges."""

--- a/src/ouroboros/evaluation/semantic.py
+++ b/src/ouroboros/evaluation/semantic.py
@@ -41,6 +41,16 @@ SEMANTIC_RESULT_SCHEMA: dict[str, object] = {
             "description": "Suspicion that the artifact games the evaluator rather than solving the real task 0.0-1.0. Distinct from drift_score.",
         },
         "reasoning": {"type": "string", "description": "Brief explanation of evaluation"},
+        "questions_used": {
+            "type": "array",
+            "description": "Socratic / ontology-gap questions used to verify the artifact (shown to the user).",
+            "items": {"type": "string"},
+        },
+        "evidence": {
+            "type": "array",
+            "description": "Concrete evidence from the artifact or source files supporting the verdict (shown to the user).",
+            "items": {"type": "string"},
+        },
     },
     "required": [
         "score",
@@ -50,6 +60,8 @@ SEMANTIC_RESULT_SCHEMA: dict[str, object] = {
         "uncertainty",
         "reward_hacking_risk",
         "reasoning",
+        "questions_used",
+        "evidence",
     ],
 }
 
@@ -140,6 +152,12 @@ Before scoring, verify the artifact actually works rather than merely appearing 
 - Check whether the artifact solves the real task or just matches the surface wording of the AC.
 - Set reward_hacking_risk near 0.0 when behavior genuinely matches intent; set it near 1.0 when the artifact appears optimized to score well without solving the real problem.
 
+## Evaluation Transparency (anti-reward-hacking)
+You MUST show your work so the user can audit the verdict:
+- Populate `questions_used` with the concrete Socratic / ontology-gap questions you asked while verifying the artifact.
+- Populate `evidence` with concrete references (file paths, snippets, observed behavior) you relied on.
+- An empty `questions_used` or `evidence` is treated as a verification failure — the evaluator is claiming success without showing proof.
+
 Respond with ONLY a JSON object. No explanation, no preamble, no markdown fences."""
 
 
@@ -205,6 +223,22 @@ def parse_semantic_response(response_text: str) -> Result[SemanticResult, Valida
         uncertainty = max(0.0, min(1.0, float(data["uncertainty"])))
         reward_hacking_risk = max(0.0, min(1.0, float(data["reward_hacking_risk"])))
 
+        # Optional transparency fields (#367).  Accept missing/empty
+        # gracefully so the parser stays backward compatible with older
+        # evaluator responses that predate the prompt update.
+        raw_questions = data.get("questions_used") or []
+        raw_evidence = data.get("evidence") or []
+        questions_used = tuple(
+            str(item).strip()
+            for item in raw_questions
+            if isinstance(item, (str, int, float)) and str(item).strip()
+        )
+        evidence = tuple(
+            str(item).strip()
+            for item in raw_evidence
+            if isinstance(item, (str, int, float)) and str(item).strip()
+        )
+
         return Result.ok(
             SemanticResult(
                 score=score,
@@ -214,6 +248,8 @@ def parse_semantic_response(response_text: str) -> Result[SemanticResult, Valida
                 uncertainty=uncertainty,
                 reasoning=str(data["reasoning"]),
                 reward_hacking_risk=reward_hacking_risk,
+                questions_used=questions_used,
+                evidence=evidence,
             )
         )
     except (TypeError, ValueError) as e:

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -611,9 +611,20 @@ class EvaluateHandler:
                     f"Reasoning: {s2.reasoning[:200]}..."
                     if len(s2.reasoning) > 200
                     else f"Reasoning: {s2.reasoning}",
-                    "",
                 ]
             )
+            # Anti-reward-hacking transparency (#367): surface the concrete
+            # Socratic questions and evidence the evaluator relied on so
+            # the user can audit whether the verdict was earned.
+            if s2.questions_used:
+                lines.append("Questions Used:")
+                for question in s2.questions_used:
+                    lines.append(f"  - {question}")
+            if s2.evidence:
+                lines.append("Evidence:")
+                for item in s2.evidence:
+                    lines.append(f"  - {item}")
+            lines.append("")
 
         # Stage 3 results
         if result.stage3_result:

--- a/tests/unit/evaluation/test_semantic.py
+++ b/tests/unit/evaluation/test_semantic.py
@@ -52,6 +52,25 @@ class TestBuildEvaluationPrompt:
         assert "Must be secure" in prompt
         assert "No plaintext passwords" in prompt
 
+    def test_prompt_includes_anti_gaming_and_transparency_sections(self) -> None:
+        """Prompt preserves Anti-Gaming and adds Evaluation Transparency (#367)."""
+        context = EvaluationContext(
+            execution_id="exec-1",
+            seed_id="seed-1",
+            current_ac="User can login",
+            artifact="def login(): pass",
+        )
+        prompt = build_evaluation_prompt(context)
+
+        # Anti-Gaming Verification MUST remain (reward_hacking_risk is preserved)
+        assert "Anti-Gaming Verification" in prompt
+        assert "reward_hacking_risk" in prompt
+
+        # New transparency section (#367)
+        assert "Evaluation Transparency" in prompt
+        assert "questions_used" in prompt
+        assert "evidence" in prompt
+
     def test_file_artifacts_omit_inline_artifact_text(self) -> None:
         """When collected files are present, the prompt should prefer file sections."""
         context = EvaluationContext(
@@ -165,6 +184,70 @@ class TestParseSemanticResponse:
 
         assert result.is_ok
         assert result.value.reward_hacking_risk == 0.0
+
+    def test_parses_questions_used_and_evidence(self) -> None:
+        """questions_used and evidence arrays are parsed into tuples (#367)."""
+        response = """{
+            "score": 0.9,
+            "ac_compliance": true,
+            "goal_alignment": 0.9,
+            "drift_score": 0.1,
+            "uncertainty": 0.1,
+            "reasoning": "Strong implementation",
+            "reward_hacking_risk": 0.0,
+            "questions_used": [
+                "Does login() reject empty passwords?",
+                "Is the hash function resistant to timing attacks?"
+            ],
+            "evidence": [
+                "src/auth.py:42 uses bcrypt for hashing",
+                "tests/test_auth.py covers empty password rejection"
+            ]
+        }"""
+        result = parse_semantic_response(response)
+
+        assert result.is_ok
+        semantic = result.value
+        assert len(semantic.questions_used) == 2
+        assert "Does login() reject empty passwords?" in semantic.questions_used
+        assert len(semantic.evidence) == 2
+        assert "src/auth.py:42 uses bcrypt for hashing" in semantic.evidence
+
+    def test_missing_questions_and_evidence_degrade_gracefully(self) -> None:
+        """Missing transparency fields fall back to empty tuples, not errors."""
+        response = """{
+            "score": 0.8,
+            "ac_compliance": true,
+            "goal_alignment": 0.85,
+            "drift_score": 0.15,
+            "uncertainty": 0.1,
+            "reasoning": "Looks good",
+            "reward_hacking_risk": 0.1
+        }"""
+        result = parse_semantic_response(response)
+
+        assert result.is_ok
+        assert result.value.questions_used == ()
+        assert result.value.evidence == ()
+
+    def test_empty_strings_in_questions_evidence_are_dropped(self) -> None:
+        """Blank items in the transparency arrays are filtered out."""
+        response = """{
+            "score": 0.8,
+            "ac_compliance": true,
+            "goal_alignment": 0.85,
+            "drift_score": 0.15,
+            "uncertainty": 0.1,
+            "reasoning": "Looks good",
+            "reward_hacking_risk": 0.1,
+            "questions_used": ["", "Real question?", "   "],
+            "evidence": [" ", "Real evidence"]
+        }"""
+        result = parse_semantic_response(response)
+
+        assert result.is_ok
+        assert result.value.questions_used == ("Real question?",)
+        assert result.value.evidence == ("Real evidence",)
 
     def test_no_json_in_response(self) -> None:
         """Error when no JSON found."""


### PR DESCRIPTION
## Summary

- Add `questions_used` and `evidence` fields to `SemanticResult` so the Stage 2 evaluator must show its work
- Update evaluator prompt with an explicit \"Evaluation Transparency\" section, alongside the existing \"Anti-Gaming Verification\"
- Update JSON schema to require the two new fields
- Update the MCP Stage 2 output formatter to surface \"Questions Used\" and \"Evidence\" to the user
- **Preserve** `reward_hacking_risk`, `artifact_bundle`, `trigger_consensus`, and all existing anti-gaming logic

## Why this is needed

From the team meeting (2026-04-10): The Evaluate stage is a black box — users can't see what the evaluator actually checked. Without visibility, the evaluator could \"reward hack\" by claiming everything passes without genuine verification.

This PR makes the evaluator show its work:
- `questions_used` — concrete Socratic / ontology-gap questions asked during verification
- `evidence` — concrete references (file snippets, behaviors, observations) supporting the verdict

If those fields are empty, the user can immediately tell the evaluator didn't do thorough work.

## Why a new PR instead of PR #372

PR #372 (open for 10 days, marked CONFLICTING) attempted the same change but introduced several regressions:
- Removed `reward_hacking_risk` entirely from `SemanticResult`, schema, parser, and tests
- Removed the \"Anti-Gaming Verification\" prompt section
- Removed `artifact_bundle` / `ArtifactCollector` integration (conflicting with PR #375)
- Removed `EvaluationContext.trigger_consensus` field
- Rolled back `max_turns=20 → 1` for the evaluator (conflicts with multi-file AC reading)
- Deleted many existing tests in `test_definitions.py` (-728 lines)

This PR delivers the same user-facing benefit (#367) without any of those regressions:
- **Purely additive** — no existing fields, tests, or behaviors are removed
- **Backward compatible** — parser degrades gracefully when older model responses omit the new fields
- **No merge conflicts** with recently-merged PRs (#375, #378)

## Design decisions

- **Two defenses are stronger than one**: `reward_hacking_risk` is a numeric gate; `questions_used`/`evidence` is human-auditable transparency. Keeping both means the evaluator has to satisfy both the automated scoring AND show its work.
- **Backward compatible parser**: Missing `questions_used` or `evidence` degrade to empty tuples rather than erroring, so older model responses and provider upgrades don't break evaluation.
- **Empty-string filtering**: Blank strings in the arrays are dropped during parsing, so a model that emits `[\"\", \" \"]` doesn't masquerade as having shown evidence.

## Test plan

- [x] 4 new tests covering: prompt transparency section, full questions/evidence parsing, graceful degradation, empty-string filtering
- [x] All 229 evaluation tests pass
- [x] All 335 evaluation + mcp/tools tests pass (no regressions)
- [x] ruff check + format clean