### PR TITLE
feat(evaluate): add per-AC checklist aggregator (#366)

### DIFF
--- a/src/ouroboros/evaluation/checklist.py
+++ b/src/ouroboros/evaluation/checklist.py
@@ -1,0 +1,240 @@
+"""Per-AC checklist aggregation for evaluation pipeline (#366).
+
+The evaluation pipeline already evaluates one acceptance criterion at a time
+via ``EvaluationContext.current_ac``.  Orchestration layers
+(``parallel_executor``, ``runner``) already dispatch one evaluation per AC.
+
+What was missing is a lightweight, reusable aggregator that:
+
+1. Collects individual ``EvaluationResult`` objects into a single
+   checklist view (pass/fail per AC, evidence, questions used).
+2. Computes aggregate metrics the user can read at a glance
+   (pass rate, failed items, overall verdict).
+3. Generates actionable feedback for the Run stage when items fail.
+
+This module is **purely additive**.  Nothing in the evaluation pipeline
+is required to use it — existing callers remain unchanged.  Callers that
+want the checklist view simply pass their collected results through
+``aggregate_results``.
+
+Ties in with Phase 1 (#363) milestones: when the interview reaches the
+READY milestone (ambiguity <= 0.2), every AC from that Seed should pass
+when routed through this checklist.  That is the concrete quality gate
+the milestones promise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.evaluation.models import EvaluationResult
+
+
+@dataclass(frozen=True, slots=True)
+class ACCheckItem:
+    """Per-AC checklist entry.
+
+    Attributes:
+        ac_text: The acceptance criterion as written in the Seed.
+        passed: True when the evaluation pipeline approved this AC.
+        reasoning: Evaluator's explanation (from Stage 2 reasoning).
+        evidence: Concrete evidence the evaluator relied on (#367 field).
+        questions_used: Socratic questions the evaluator asked (#367 field).
+        failure_reason: Human-readable reason when ``passed`` is False.
+            This is the feedback a Run re-attempt should address.
+    """
+
+    ac_text: str
+    passed: bool
+    reasoning: str = ""
+    evidence: tuple[str, ...] = ()
+    questions_used: tuple[str, ...] = ()
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ACChecklistResult:
+    """Aggregated checklist across multiple AC evaluations.
+
+    Attributes:
+        items: Per-AC entries in the same order they were provided.
+        total: Total number of AC items.
+        passed_count: Number of items with ``passed == True``.
+    """
+
+    items: tuple[ACCheckItem, ...]
+    total: int
+    passed_count: int
+
+    @property
+    def failed_items(self) -> tuple[ACCheckItem, ...]:
+        """Return only items whose evaluation did not pass."""
+        return tuple(item for item in self.items if not item.passed)
+
+    @property
+    def all_passed(self) -> bool:
+        """True when every AC passed. Empty checklist returns False.
+
+        An empty checklist is treated as "not ready" — a Seed with zero
+        ACs is definitionally incomplete (see Phase 1 milestone READY
+        criteria), so we refuse to mark it complete.
+        """
+        return self.total > 0 and self.passed_count == self.total
+
+    @property
+    def pass_rate(self) -> float:
+        """Ratio of passed items to total (0.0 for empty checklist)."""
+        if self.total == 0:
+            return 0.0
+        return self.passed_count / self.total
+
+
+def _evaluation_passed(result: EvaluationResult) -> bool:
+    """Return True when an EvaluationResult represents an overall pass."""
+    return result.final_approved
+
+
+def _derive_failure_reason(result: EvaluationResult) -> str | None:
+    """Extract a concise failure reason from an EvaluationResult."""
+    if result.final_approved:
+        return None
+    reason = result.failure_reason
+    if reason:
+        return reason
+    # Fallback: Stage 2 reasoning if available.
+    if result.stage2_result and result.stage2_result.reasoning:
+        return result.stage2_result.reasoning
+    return "Evaluation did not approve this AC."
+
+
+def _extract_stage2_fields(
+    result: EvaluationResult,
+) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    """Pull reasoning / evidence / questions_used from Stage 2, if present."""
+    if result.stage2_result is None:
+        return "", (), ()
+    s2 = result.stage2_result
+    return (
+        s2.reasoning,
+        getattr(s2, "evidence", ()),
+        getattr(s2, "questions_used", ()),
+    )
+
+
+def aggregate_results(
+    ac_texts: tuple[str, ...],
+    results: tuple[EvaluationResult, ...],
+) -> ACChecklistResult:
+    """Aggregate per-AC EvaluationResult objects into a checklist.
+
+    Args:
+        ac_texts: The acceptance criteria, in the same order their
+            evaluations were performed.
+        results: Parallel evaluation results, one per AC.
+
+    Returns:
+        Aggregated ``ACChecklistResult``.
+
+    Raises:
+        ValueError: If ``ac_texts`` and ``results`` have different lengths.
+    """
+    if len(ac_texts) != len(results):
+        msg = (
+            f"ac_texts and results must be the same length "
+            f"(got {len(ac_texts)} ACs vs {len(results)} results)"
+        )
+        raise ValueError(msg)
+
+    items: list[ACCheckItem] = []
+    for ac, result in zip(ac_texts, results, strict=True):
+        passed = _evaluation_passed(result)
+        reasoning, evidence, questions_used = _extract_stage2_fields(result)
+        items.append(
+            ACCheckItem(
+                ac_text=ac,
+                passed=passed,
+                reasoning=reasoning,
+                evidence=evidence,
+                questions_used=questions_used,
+                failure_reason=_derive_failure_reason(result),
+            )
+        )
+
+    passed_count = sum(1 for item in items if item.passed)
+    return ACChecklistResult(
+        items=tuple(items),
+        total=len(items),
+        passed_count=passed_count,
+    )
+
+
+def format_checklist(checklist: ACChecklistResult) -> str:
+    """Render a human-readable checklist for display to the user.
+
+    Output is intentionally plain text so callers can embed it in MCP
+    responses, CLI output, or TUI panels without extra formatting.
+
+    Args:
+        checklist: Aggregated checklist to render.
+
+    Returns:
+        Multi-line string suitable for direct display.
+    """
+    lines: list[str] = []
+    header_status = "ALL PASSED" if checklist.all_passed else "INCOMPLETE"
+    lines.append(
+        f"Acceptance Criteria Checklist [{header_status}] "
+        f"({checklist.passed_count}/{checklist.total} passed, "
+        f"{checklist.pass_rate:.0%})"
+    )
+    lines.append("=" * 60)
+
+    for index, item in enumerate(checklist.items, start=1):
+        marker = "[x]" if item.passed else "[ ]"
+        lines.append(f"{marker} {index}. {item.ac_text}")
+        if not item.passed and item.failure_reason:
+            lines.append(f"    Reason: {item.failure_reason}")
+        if item.questions_used:
+            lines.append("    Questions Used:")
+            for question in item.questions_used:
+                lines.append(f"      - {question}")
+        if item.evidence:
+            lines.append("    Evidence:")
+            for evidence in item.evidence:
+                lines.append(f"      - {evidence}")
+
+    if not checklist.all_passed and checklist.failed_items:
+        lines.append("")
+        lines.append("Next Steps:")
+        lines.append(f"  {len(checklist.failed_items)} AC(s) need to be re-addressed in Run.")
+
+    return "\n".join(lines)
+
+
+def build_run_feedback(checklist: ACChecklistResult) -> tuple[str, ...]:
+    """Build structured feedback to hand back to the Run stage.
+
+    Only failed items contribute feedback.  Each entry identifies the
+    AC text and the specific failure reason so the Run re-attempt can
+    target the gap instead of regenerating everything.
+
+    Args:
+        checklist: Aggregated checklist.
+
+    Returns:
+        Tuple of feedback strings, one per failed AC.
+    """
+    feedback: list[str] = []
+    for item in checklist.failed_items:
+        reason = item.failure_reason or "Evaluation did not approve this AC."
+        feedback.append(f"AC not met: {item.ac_text} — {reason}")
+    return tuple(feedback)
+
+
+__all__ = [
+    "ACCheckItem",
+    "ACChecklistResult",
+    "aggregate_results",
+    "build_run_feedback",
+    "format_checklist",
+]

--- a/tests/unit/evaluation/test_checklist.py
+++ b/tests/unit/evaluation/test_checklist.py
@@ -1,0 +1,392 @@
+"""Unit tests for the per-AC checklist aggregator (#366)."""
+
+import pytest
+
+from ouroboros.evaluation.checklist import (
+    ACCheckItem,
+    ACChecklistResult,
+    aggregate_results,
+    build_run_feedback,
+    format_checklist,
+)
+from ouroboros.evaluation.models import (
+    CheckResult,
+    CheckType,
+    EvaluationResult,
+    MechanicalResult,
+    SemanticResult,
+)
+
+
+def _build_semantic_result(
+    *,
+    score: float,
+    ac_compliance: bool,
+    goal_alignment: float,
+    drift_score: float,
+    uncertainty: float,
+    reasoning: str,
+    evidence: tuple[str, ...] = (),
+    questions_used: tuple[str, ...] = (),
+) -> SemanticResult:
+    """Build a SemanticResult, tolerating codebases without #367 fields.
+
+    This keeps the checklist tests runnable both on branches where
+    ``questions_used``/``evidence`` already exist on ``SemanticResult``
+    (PR #383) and on branches where they do not (plain main).
+    """
+    kwargs = {
+        "score": score,
+        "ac_compliance": ac_compliance,
+        "goal_alignment": goal_alignment,
+        "drift_score": drift_score,
+        "uncertainty": uncertainty,
+        "reasoning": reasoning,
+    }
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+    if "evidence" in field_names:
+        kwargs["evidence"] = evidence
+    if "questions_used" in field_names:
+        kwargs["questions_used"] = questions_used
+    return SemanticResult(**kwargs)
+
+
+def _passing_evaluation(
+    *,
+    execution_id: str = "exec",
+    reasoning: str = "",
+    evidence: tuple[str, ...] = (),
+    questions_used: tuple[str, ...] = (),
+) -> EvaluationResult:
+    """Build an EvaluationResult that passes end-to-end."""
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage1_result=MechanicalResult(
+            passed=True,
+            checks=(
+                CheckResult(
+                    check_type=CheckType.LINT,
+                    passed=True,
+                    message="ok",
+                ),
+            ),
+        ),
+        stage2_result=_build_semantic_result(
+            score=0.9,
+            ac_compliance=True,
+            goal_alignment=0.95,
+            drift_score=0.05,
+            uncertainty=0.1,
+            reasoning=reasoning,
+            evidence=evidence,
+            questions_used=questions_used,
+        ),
+        final_approved=True,
+    )
+
+
+def _failing_evaluation(
+    *,
+    execution_id: str = "exec",
+    reasoning: str = "Stage 2 found a gap",
+) -> EvaluationResult:
+    """Build an EvaluationResult that fails at Stage 2."""
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage2_result=_build_semantic_result(
+            score=0.4,
+            ac_compliance=False,
+            goal_alignment=0.5,
+            drift_score=0.5,
+            uncertainty=0.3,
+            reasoning=reasoning,
+        ),
+        final_approved=False,
+    )
+
+
+class TestACCheckItem:
+    """Tests for ACCheckItem dataclass."""
+
+    def test_defaults(self) -> None:
+        """ACCheckItem has sensible defaults for optional fields."""
+        item = ACCheckItem(ac_text="User can login", passed=True)
+
+        assert item.ac_text == "User can login"
+        assert item.passed is True
+        assert item.reasoning == ""
+        assert item.evidence == ()
+        assert item.questions_used == ()
+        assert item.failure_reason is None
+
+    def test_with_evidence_and_questions(self) -> None:
+        """ACCheckItem preserves evidence and question tuples."""
+        item = ACCheckItem(
+            ac_text="Login must be secure",
+            passed=True,
+            reasoning="Uses bcrypt",
+            evidence=("src/auth.py:42",),
+            questions_used=("Does it reject empty passwords?",),
+        )
+
+        assert item.evidence == ("src/auth.py:42",)
+        assert item.questions_used == ("Does it reject empty passwords?",)
+
+
+class TestACChecklistResultProperties:
+    """Tests for ACChecklistResult computed properties."""
+
+    def test_empty_checklist_is_not_all_passed(self) -> None:
+        """An empty checklist is treated as 'not ready', never as all-passed."""
+        checklist = ACChecklistResult(items=(), total=0, passed_count=0)
+
+        assert checklist.all_passed is False
+        assert checklist.pass_rate == 0.0
+        assert checklist.failed_items == ()
+
+    def test_all_passed_true_when_every_item_passes(self) -> None:
+        """all_passed True when passed_count == total and total > 0."""
+        items = (
+            ACCheckItem(ac_text="AC1", passed=True),
+            ACCheckItem(ac_text="AC2", passed=True),
+        )
+        checklist = ACChecklistResult(items=items, total=2, passed_count=2)
+
+        assert checklist.all_passed is True
+        assert checklist.pass_rate == 1.0
+        assert checklist.failed_items == ()
+
+    def test_partial_pass_rate(self) -> None:
+        """pass_rate is a plain ratio."""
+        items = (
+            ACCheckItem(ac_text="AC1", passed=True),
+            ACCheckItem(ac_text="AC2", passed=False, failure_reason="bad"),
+            ACCheckItem(ac_text="AC3", passed=True),
+            ACCheckItem(ac_text="AC4", passed=False),
+        )
+        checklist = ACChecklistResult(items=items, total=4, passed_count=2)
+
+        assert checklist.pass_rate == 0.5
+        assert checklist.all_passed is False
+        assert len(checklist.failed_items) == 2
+
+
+class TestAggregateResults:
+    """Tests for aggregate_results()."""
+
+    def test_length_mismatch_raises(self) -> None:
+        """Mismatched ac_texts and results tuples raise ValueError."""
+        with pytest.raises(ValueError, match="same length"):
+            aggregate_results(
+                ac_texts=("AC1", "AC2"),
+                results=(_passing_evaluation(),),
+            )
+
+    def test_empty_inputs_produce_empty_checklist(self) -> None:
+        """Empty inputs produce an empty (and not-ready) checklist."""
+        checklist = aggregate_results(ac_texts=(), results=())
+
+        assert checklist.total == 0
+        assert checklist.all_passed is False
+
+    def test_all_passing_produces_all_passed_checklist(self) -> None:
+        """When every result is final_approved, checklist is all-passed."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _passing_evaluation(execution_id="e2"),
+        )
+        checklist = aggregate_results(
+            ac_texts=("AC1", "AC2"),
+            results=results,
+        )
+
+        assert checklist.total == 2
+        assert checklist.passed_count == 2
+        assert checklist.all_passed is True
+        assert all(item.failure_reason is None for item in checklist.items)
+
+    def test_mixed_outcomes_capture_failure_reason(self) -> None:
+        """Failing items record a failure_reason derived from Stage 2 reasoning."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _failing_evaluation(
+                execution_id="e2",
+                reasoning="Webhook signature validation missing",
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Charge processed", "Webhook handled"),
+            results=results,
+        )
+
+        assert checklist.passed_count == 1
+        assert checklist.all_passed is False
+        failed = checklist.failed_items
+        assert len(failed) == 1
+        assert failed[0].ac_text == "Webhook handled"
+        assert failed[0].failure_reason is not None
+        assert "AC non-compliance" in failed[0].failure_reason or (
+            "Webhook signature" in (failed[0].failure_reason or "")
+        )
+
+    def test_preserves_evidence_and_questions(self) -> None:
+        """Stage 2 evidence and questions_used carry through to checklist items.
+
+        Only meaningful once #367 (PR #383) lands and ``SemanticResult``
+        exposes those fields.  On earlier code the aggregator falls back
+        to empty tuples — we skip instead of asserting, because the
+        behaviour is provably correct for that code state.
+        """
+        import dataclasses
+
+        field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+        if "evidence" not in field_names or "questions_used" not in field_names:
+            pytest.skip("SemanticResult does not yet carry #367 fields")
+
+        results = (
+            _passing_evaluation(
+                execution_id="e1",
+                reasoning="Bcrypt verified",
+                evidence=("src/auth.py:42", "tests/test_auth.py covers empty pwd"),
+                questions_used=("Does it reject empty passwords?",),
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Login must be secure",),
+            results=results,
+        )
+
+        item = checklist.items[0]
+        assert item.evidence == (
+            "src/auth.py:42",
+            "tests/test_auth.py covers empty pwd",
+        )
+        assert item.questions_used == ("Does it reject empty passwords?",)
+
+    def test_preserves_input_order(self) -> None:
+        """Items appear in the exact order provided."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _failing_evaluation(execution_id="e2"),
+            _passing_evaluation(execution_id="e3"),
+        )
+        checklist = aggregate_results(
+            ac_texts=("first", "second", "third"),
+            results=results,
+        )
+
+        assert [item.ac_text for item in checklist.items] == [
+            "first",
+            "second",
+            "third",
+        ]
+
+
+class TestFormatChecklist:
+    """Tests for format_checklist()."""
+
+    def test_format_all_passed(self) -> None:
+        """All-passed checklist renders with ALL PASSED header and [x] markers."""
+        results = (_passing_evaluation(),)
+        checklist = aggregate_results(
+            ac_texts=("Login works",),
+            results=results,
+        )
+
+        output = format_checklist(checklist)
+
+        assert "ALL PASSED" in output
+        assert "(1/1 passed, 100%)" in output
+        assert "[x] 1. Login works" in output
+
+    def test_format_incomplete_includes_next_steps(self) -> None:
+        """Failing checklist includes INCOMPLETE, [ ] marker, and Next Steps."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _failing_evaluation(
+                execution_id="e2",
+                reasoning="Missing signature check",
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Charge processed", "Webhook validated"),
+            results=results,
+        )
+
+        output = format_checklist(checklist)
+
+        assert "INCOMPLETE" in output
+        assert "(1/2 passed, 50%)" in output
+        assert "[x] 1. Charge processed" in output
+        assert "[ ] 2. Webhook validated" in output
+        assert "Next Steps:" in output
+
+    def test_format_renders_evidence_and_questions(self) -> None:
+        """Evidence and questions_used render under each item when present.
+
+        Only meaningful once #367 (PR #383) exposes those fields.
+        """
+        import dataclasses
+
+        field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+        if "evidence" not in field_names or "questions_used" not in field_names:
+            pytest.skip("SemanticResult does not yet carry #367 fields")
+
+        results = (
+            _passing_evaluation(
+                reasoning="ok",
+                evidence=("src/auth.py:42",),
+                questions_used=("Does it reject empty passwords?",),
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Login works",),
+            results=results,
+        )
+
+        output = format_checklist(checklist)
+
+        assert "Questions Used:" in output
+        assert "Does it reject empty passwords?" in output
+        assert "Evidence:" in output
+        assert "src/auth.py:42" in output
+
+
+class TestBuildRunFeedback:
+    """Tests for build_run_feedback()."""
+
+    def test_empty_when_all_passed(self) -> None:
+        """No feedback when everything passed."""
+        results = (_passing_evaluation(),)
+        checklist = aggregate_results(
+            ac_texts=("Login works",),
+            results=results,
+        )
+
+        assert build_run_feedback(checklist) == ()
+
+    def test_feedback_per_failed_item(self) -> None:
+        """Each failed item produces one feedback string."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _failing_evaluation(
+                execution_id="e2",
+                reasoning="Missing signature check",
+            ),
+            _failing_evaluation(
+                execution_id="e3",
+                reasoning="Refund path not implemented",
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Charge processed", "Webhook validated", "Refund works"),
+            results=results,
+        )
+
+        feedback = build_run_feedback(checklist)
+
+        assert len(feedback) == 2
+        assert any("Webhook validated" in entry for entry in feedback)
+        assert any("Refund works" in entry for entry in feedback)


### PR DESCRIPTION
## Summary

- Add a new module `ouroboros.evaluation.checklist` with:
  - `ACCheckItem` — per-AC state (text, passed, reasoning, evidence, questions_used, failure_reason)
  - `ACChecklistResult` — aggregated view with `all_passed`, `pass_rate`, `failed_items`
  - `aggregate_results(ac_texts, results)` — builds a checklist from parallel AC evaluation results
  - `format_checklist(checklist)` — plain-text rendering with `[x]` / `[ ]` markers and Next Steps
  - `build_run_feedback(checklist)` — extracts per-AC feedback for Run re-attempts
- 16 unit tests covering construction, aggregation, ordering, formatting, and feedback generation

## Why this is needed

From the team meeting (2026-04-10):

> \"까고 다시 만들고 까고 다시 만들고\" — evaluation should feed specific AC failures back to Run so the next attempt targets the gap.

Today's evaluation pipeline produces pass/fail verdicts for each AC individually, and orchestration already dispatches one evaluation per AC. **What is missing** is a single aggregated view the user (and Run stage) can act on:

- \"3 of 5 ACs pass, here are the 2 that failed and why\"
- \"Here is the exact feedback to send back to Run for each failure\"
- \"The checklist is incomplete until every AC passes — this is the quality gate the milestones promise\"

This PR adds exactly that view, as a small reusable module.

## Design decisions

- **Purely additive**: this module does NOT modify `SemanticResult`, `EvaluationContext`, `EvaluationResult`, or any existing orchestration path. Existing callers remain unchanged. The aggregator is opt-in — callers route results through it when they want the checklist view.
- **Empty checklist is not ready**: `all_passed` returns `False` for a zero-AC checklist. A Seed with no ACs is definitionally incomplete (see Phase 1 READY milestone), and the gate must refuse to pass it.
- **Phase 1 tie-in** (#363 milestones, PRs #379/#380): when Interview reaches READY (ambiguity ≤ 0.2), every AC should pass when routed through this checklist. That is the concrete quality gate the milestones promise.
- **Forward-compatible with #367** (PR #383): the aggregator reads `questions_used` and `evidence` off `SemanticResult` via `getattr` so it works whether #367 has landed or not. Two tests skip gracefully on code that predates #367 and activate automatically once it lands.
- **Scope kept minimal**: wiring the checklist into `ExecuteSeed` / `EvaluateHandler` to drive automatic Run re-runs is deliberately left for a follow-up PR. Landing this aggregator first lets the data-layer change ship independently of orchestration changes.

## Relationship to #366

#366 has two parts:
1. A data-layer aggregator that turns per-AC results into a checklist with pass/fail/evidence/feedback. **This PR addresses part 1.**
2. Orchestration wiring that routes failed items back to Run automatically. **Part 2 follows in a separate PR** so this one can land without touching orchestration code.

## Test plan

- [x] 16 new tests in `tests/unit/evaluation/test_checklist.py` covering:
  - `ACCheckItem` defaults and optional fields
  - `ACChecklistResult` properties (empty, all-passed, partial)
  - `aggregate_results` length mismatch, empty, all-pass, mixed outcomes, preserved ordering
  - `format_checklist` all-passed render, incomplete render with Next Steps
  - `build_run_feedback` empty/per-failed-item behavior
- [x] Two tests skip gracefully when `SemanticResult` lacks `questions_used`/`evidence`; they activate once #367 (PR #383) merges.
- [x] 239 evaluation tests pass (237 + 2 skipped), no regressions
- [x] ruff check + format clean