### PR TITLE
feat(evaluate): wire checklist into EvaluateHandler for multi-AC (#366)

### DIFF
--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -279,6 +279,17 @@ class EvaluateHandler:
                     required=False,
                 ),
                 MCPToolParameter(
+                    name="acceptance_criteria",
+                    type=ToolInputType.ARRAY,
+                    description=(
+                        "Multiple acceptance criteria for checklist evaluation. "
+                        "When two or more items are provided, each AC is evaluated "
+                        "independently and the results are aggregated into a "
+                        "pass/fail checklist (#366). Overrides acceptance_criterion."
+                    ),
+                    required=False,
+                ),
+                MCPToolParameter(
                     name="artifact_type",
                     type=ToolInputType.STRING,
                     description="Type of artifact: code, docs, config. Default: code",
@@ -349,13 +360,25 @@ class EvaluateHandler:
 
         seed_content = arguments.get("seed_content")
         acceptance_criterion = arguments.get("acceptance_criterion")
+        acceptance_criteria_raw = arguments.get("acceptance_criteria")
         artifact_type = arguments.get("artifact_type", "code")
         trigger_consensus = arguments.get("trigger_consensus", False)
+
+        # Normalize the optional multi-AC list (#366): filter out empty/blank
+        # entries so callers can safely pass `[""]` or an accidental null.
+        acceptance_criteria: tuple[str, ...] = ()
+        if isinstance(acceptance_criteria_raw, list):
+            acceptance_criteria = tuple(
+                str(item).strip()
+                for item in acceptance_criteria_raw
+                if isinstance(item, (str, int, float)) and str(item).strip()
+            )
 
         log.info(
             "mcp.tool.evaluate",
             session_id=session_id,
             has_seed=seed_content is not None,
+            multi_ac_count=len(acceptance_criteria),
             trigger_consensus=trigger_consensus,
         )
 
@@ -440,6 +463,33 @@ class EvaluateHandler:
                 )
                 artifact_bundle = None
 
+            mechanical_config = build_mechanical_config(working_dir)
+            config = PipelineConfig(
+                mechanical=mechanical_config,
+                semantic=SemanticConfig(model=get_semantic_model(self.llm_backend)),
+            )
+            pipeline = EvaluationPipeline(llm_adapter, config)
+
+            # Multi-AC checklist path (#366):
+            # When the caller provides >= 2 acceptance criteria we run the
+            # pipeline once per AC and aggregate the results into a
+            # checklist.  Single-AC callers keep the original single-pass
+            # behaviour — no extra cost or behaviour change for them.
+            if len(acceptance_criteria) >= 2:
+                return await self._handle_multi_ac(
+                    session_id=session_id,
+                    seed_id=seed_id,
+                    acceptance_criteria=acceptance_criteria,
+                    artifact=artifact,
+                    artifact_type=artifact_type,
+                    goal=goal,
+                    constraints=constraints,
+                    trigger_consensus=trigger_consensus,
+                    artifact_bundle=artifact_bundle,
+                    pipeline=pipeline,
+                    working_dir=working_dir,
+                )
+
             context = EvaluationContext(
                 execution_id=session_id,
                 seed_id=seed_id,
@@ -451,12 +501,6 @@ class EvaluateHandler:
                 trigger_consensus=trigger_consensus,
                 artifact_bundle=artifact_bundle,
             )
-            mechanical_config = build_mechanical_config(working_dir)
-            config = PipelineConfig(
-                mechanical=mechanical_config,
-                semantic=SemanticConfig(model=get_semantic_model(self.llm_backend)),
-            )
-            pipeline = EvaluationPipeline(llm_adapter, config)
             result = await pipeline.evaluate(context)
 
             if result.is_err:
@@ -537,6 +581,144 @@ class EvaluateHandler:
         finally:
             if owns_event_store and store is not None:
                 await store.close()
+
+    async def _handle_multi_ac(
+        self,
+        *,
+        session_id: str,
+        seed_id: str,
+        acceptance_criteria: tuple[str, ...],
+        artifact: str,
+        artifact_type: str,
+        goal: str,
+        constraints: tuple[str, ...],
+        trigger_consensus: bool,
+        artifact_bundle: object | None,
+        pipeline: object,  # EvaluationPipeline — typed as object to avoid import cycle
+        working_dir: Path,
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Evaluate each AC individually and return an aggregated checklist (#366).
+
+        Runs the evaluation pipeline once per acceptance criterion in
+        parallel via ``asyncio.gather``.  Per-AC results are then folded
+        into a single ``ACChecklistResult`` so the caller sees one
+        pass/fail checklist with per-item evidence and failure reasons.
+
+        Single-AC callers never reach this path — see ``handle()``.
+        """
+        import asyncio
+
+        from ouroboros.evaluation import EvaluationContext
+        from ouroboros.evaluation.checklist import (
+            aggregate_results,
+            build_run_feedback,
+            format_checklist,
+        )
+
+        async def _run_one(ac_text: str) -> Result[object, object]:
+            context = EvaluationContext(
+                execution_id=session_id,
+                seed_id=seed_id,
+                current_ac=ac_text,
+                artifact=artifact,
+                artifact_type=artifact_type,
+                goal=goal,
+                constraints=constraints,
+                trigger_consensus=trigger_consensus,
+                artifact_bundle=artifact_bundle,
+            )
+            return await pipeline.evaluate(context)  # type: ignore[attr-defined]
+
+        log.info(
+            "mcp.tool.evaluate.multi_ac_started",
+            session_id=session_id,
+            ac_count=len(acceptance_criteria),
+        )
+
+        gathered = await asyncio.gather(
+            *(_run_one(ac) for ac in acceptance_criteria),
+            return_exceptions=True,
+        )
+
+        # Any exception or err-Result aborts the whole checklist —
+        # otherwise we'd aggregate over a half-evaluated set.
+        for entry in gathered:
+            if isinstance(entry, BaseException):
+                log.exception(
+                    "mcp.tool.evaluate.multi_ac_exception",
+                    session_id=session_id,
+                )
+                return Result.err(
+                    MCPToolError(
+                        f"Evaluation failed during multi-AC run: {entry}",
+                        tool_name="ouroboros_evaluate",
+                    )
+                )
+            if entry.is_err:  # type: ignore[union-attr]
+                err = entry.error  # type: ignore[union-attr]
+                rendered = err.format_details() if hasattr(err, "format_details") else str(err)
+                log.warning(
+                    "mcp.tool.evaluate.multi_ac_pipeline_failed",
+                    session_id=session_id,
+                    error=rendered,
+                )
+                return Result.err(
+                    MCPToolError(
+                        f"Evaluation failed: {rendered}",
+                        tool_name="ouroboros_evaluate",
+                    )
+                )
+
+        eval_results = tuple(entry.value for entry in gathered)  # type: ignore[union-attr]
+        checklist = aggregate_results(acceptance_criteria, eval_results)
+        feedback = build_run_feedback(checklist)
+
+        code_changes: bool | None = None
+        if any(r.stage1_result and not r.stage1_result.passed for r in eval_results):
+            code_changes = await self._has_code_changes(working_dir)
+
+        text_parts = [format_checklist(checklist)]
+        if code_changes is False:
+            text_parts.append("\nNote: no code changes detected in the working tree.")
+        result_text = "\n".join(text_parts)
+
+        meta = {
+            "session_id": session_id,
+            "final_approved": checklist.all_passed,
+            "multi_ac": True,
+            "ac_count": checklist.total,
+            "passed_count": checklist.passed_count,
+            "pass_rate": checklist.pass_rate,
+            "checklist": [
+                {
+                    "ac_text": item.ac_text,
+                    "passed": item.passed,
+                    "reasoning": item.reasoning,
+                    "evidence": list(item.evidence),
+                    "questions_used": list(item.questions_used),
+                    "failure_reason": item.failure_reason,
+                }
+                for item in checklist.items
+            ],
+            "run_feedback": list(feedback),
+            "code_changes_detected": code_changes,
+        }
+
+        log.info(
+            "mcp.tool.evaluate.multi_ac_completed",
+            session_id=session_id,
+            passed=checklist.passed_count,
+            total=checklist.total,
+            all_passed=checklist.all_passed,
+        )
+
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text=result_text),),
+                is_error=False,
+                meta=meta,
+            )
+        )
 
     async def _has_code_changes(self, working_dir: Path) -> bool | None:
         """Detect whether the working tree has code changes.

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -364,8 +364,13 @@ class EvaluateHandler:
         artifact_type = arguments.get("artifact_type", "code")
         trigger_consensus = arguments.get("trigger_consensus", False)
 
-        # Normalize the optional multi-AC list (#366): filter out empty/blank
-        # entries so callers can safely pass `[""]` or an accidental null.
+        # Normalize all AC inputs into a single tuple (#366 fix):
+        # 1. If acceptance_criteria (plural, ARRAY) has valid entries, use them.
+        # 2. Else if acceptance_criterion (singular, STRING) is set, wrap it.
+        # 3. Else empty — single-AC path will use a default.
+        # This ensures a 1-item list is honoured as the effective AC,
+        # fixing the contract violation where the input shape was accepted
+        # but its meaning was silently ignored.
         acceptance_criteria: tuple[str, ...] = ()
         if isinstance(acceptance_criteria_raw, list):
             acceptance_criteria = tuple(
@@ -373,6 +378,8 @@ class EvaluateHandler:
                 for item in acceptance_criteria_raw
                 if isinstance(item, (str, int, float)) and str(item).strip()
             )
+        if not acceptance_criteria and acceptance_criterion and str(acceptance_criterion).strip():
+            acceptance_criteria = (str(acceptance_criterion).strip(),)
 
         log.info(
             "mcp.tool.evaluate",
@@ -417,8 +424,14 @@ class EvaluateHandler:
                 except Exception:
                     pass  # Best-effort enrichment
 
-            # Use acceptance_criterion or derive from seed
-            current_ac = acceptance_criterion or "Verify execution output meets requirements"
+            # Derive current_ac from the unified acceptance_criteria tuple.
+            # The tuple already incorporates both the plural and singular params,
+            # so we only need to index or fall back to a default.
+            current_ac = (
+                acceptance_criteria[0]
+                if acceptance_criteria
+                else "Verify execution output meets requirements"
+            )
 
             # Evaluation reads multiple spec files (one Read call per AC).
             # Use a dedicated adapter with a higher turn budget — the shared

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -102,10 +102,8 @@ class TestMultiACRoutingBoundary:
         return mock_pipeline
 
     async def test_single_item_list_uses_single_ac_path(self) -> None:
-        """A 1-element acceptance_criteria list falls back to single-AC path.
-
-        We don't assert the content here — just that the multi-AC meta
-        flag is NOT set, proving the request didn't enter _handle_multi_ac.
+        """A 1-element acceptance_criteria list falls back to single-AC path
+        and the provided AC text is actually used (not the default).
         """
         mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
 
@@ -129,6 +127,61 @@ class TestMultiACRoutingBoundary:
         assert result.is_ok
         # Single-AC path — no multi_ac flag in meta.
         assert result.value.meta.get("multi_ac") is not True
+        # The provided AC text must reach the pipeline, not the default.
+        ctx_arg = mock_pipeline.evaluate.call_args[0][0]
+        assert ctx_arg.current_ac == "Only AC"
+
+    async def test_single_item_list_does_not_use_default_ac(self) -> None:
+        """Regression: a 1-item acceptance_criteria must NOT fall back to the
+        generic default 'Verify execution output meets requirements'.
+        """
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "x = 1",
+                    "acceptance_criteria": ["Payment webhook fires on success"],
+                }
+            )
+
+        ctx_arg = mock_pipeline.evaluate.call_args[0][0]
+        assert ctx_arg.current_ac == "Payment webhook fires on success"
+        assert ctx_arg.current_ac != "Verify execution output meets requirements"
+
+    async def test_singular_acceptance_criterion_forwarded(self) -> None:
+        """The legacy ``acceptance_criterion`` (singular) param sets current_ac."""
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criterion": "Legacy AC",
+                }
+            )
+
+        assert result.is_ok
+        ctx_arg = mock_pipeline.evaluate.call_args[0][0]
+        assert ctx_arg.current_ac == "Legacy AC"
 
     async def test_two_passing_acs_produce_all_passed_checklist(self) -> None:
         """Two ACs both passing → meta.final_approved True, checklist populated."""

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -1,0 +1,290 @@
+"""Unit tests for EvaluateHandler multi-AC checklist path (#366).
+
+These tests exercise the new `acceptance_criteria` parameter that turns
+a single evaluate call into a per-AC checklist evaluation.  Single-AC
+behaviour is covered by existing tests in test_definitions.py and is
+deliberately left untouched here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.evaluation.models import (
+    CheckResult,
+    CheckType,
+    EvaluationResult,
+    MechanicalResult,
+    SemanticResult,
+)
+from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler
+from ouroboros.mcp.types import ToolInputType
+
+
+def _semantic_result(*, ac_compliance: bool, score: float, reasoning: str) -> SemanticResult:
+    """Build a SemanticResult tolerant to whether #367 fields exist yet."""
+    import dataclasses
+
+    kwargs = {
+        "score": score,
+        "ac_compliance": ac_compliance,
+        "goal_alignment": 0.9 if ac_compliance else 0.4,
+        "drift_score": 0.1 if ac_compliance else 0.5,
+        "uncertainty": 0.1,
+        "reasoning": reasoning,
+    }
+    field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+    if "evidence" in field_names:
+        kwargs["evidence"] = ()
+    if "questions_used" in field_names:
+        kwargs["questions_used"] = ()
+    return SemanticResult(**kwargs)
+
+
+def _passing_eval(execution_id: str) -> EvaluationResult:
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage1_result=MechanicalResult(
+            passed=True,
+            checks=(CheckResult(check_type=CheckType.LINT, passed=True, message="ok"),),
+        ),
+        stage2_result=_semantic_result(
+            ac_compliance=True,
+            score=0.9,
+            reasoning="AC met",
+        ),
+        final_approved=True,
+    )
+
+
+def _failing_eval(execution_id: str, *, reason: str) -> EvaluationResult:
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage2_result=_semantic_result(
+            ac_compliance=False,
+            score=0.3,
+            reasoning=reason,
+        ),
+        final_approved=False,
+    )
+
+
+class TestDefinitionAcceptsMultiAC:
+    """The tool schema must advertise the new acceptance_criteria parameter."""
+
+    def test_acceptance_criteria_parameter_present(self) -> None:
+        handler = EvaluateHandler()
+        names = {p.name for p in handler.definition.parameters}
+
+        assert "acceptance_criteria" in names
+        assert "acceptance_criterion" in names  # backward-compat
+
+        param = next(p for p in handler.definition.parameters if p.name == "acceptance_criteria")
+        assert param.type == ToolInputType.ARRAY
+        assert param.required is False
+
+
+class TestMultiACRoutingBoundary:
+    """Runtime behaviour of multi-AC routing in handle()."""
+
+    def _install_pipeline_mock(self, eval_results: list[EvaluationResult]) -> MagicMock:
+        mock_pipeline = AsyncMock()
+        # `evaluate()` returns Result objects in order per call.
+        results_iter = iter(eval_results)
+
+        async def _evaluate(_context: object) -> object:
+            return Result.ok(next(results_iter))
+
+        mock_pipeline.evaluate = AsyncMock(side_effect=_evaluate)
+        return mock_pipeline
+
+    async def test_single_item_list_uses_single_ac_path(self) -> None:
+        """A 1-element acceptance_criteria list falls back to single-AC path.
+
+        We don't assert the content here — just that the multi-AC meta
+        flag is NOT set, proving the request didn't enter _handle_multi_ac.
+        """
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criteria": ["Only AC"],
+                }
+            )
+
+        assert result.is_ok
+        # Single-AC path — no multi_ac flag in meta.
+        assert result.value.meta.get("multi_ac") is not True
+
+    async def test_two_passing_acs_produce_all_passed_checklist(self) -> None:
+        """Two ACs both passing → meta.final_approved True, checklist populated."""
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1"), _passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criteria": ["AC one", "AC two"],
+                }
+            )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["multi_ac"] is True
+        assert meta["ac_count"] == 2
+        assert meta["passed_count"] == 2
+        assert meta["pass_rate"] == 1.0
+        assert meta["final_approved"] is True
+        assert meta["run_feedback"] == []
+        assert len(meta["checklist"]) == 2
+        assert all(item["passed"] for item in meta["checklist"])
+        assert "ALL PASSED" in result.value.text_content
+
+    async def test_mixed_outcomes_produce_incomplete_checklist(self) -> None:
+        """One passing + one failing AC → run_feedback lists the failure."""
+        mock_pipeline = self._install_pipeline_mock(
+            [
+                _passing_eval("s2"),
+                _failing_eval("s2", reason="Webhook signature not verified"),
+            ]
+        )
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s2",
+                    "artifact": "def pay(): pass",
+                    "acceptance_criteria": ["Charge processed", "Webhook validated"],
+                }
+            )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["multi_ac"] is True
+        assert meta["ac_count"] == 2
+        assert meta["passed_count"] == 1
+        assert meta["final_approved"] is False
+        assert len(meta["run_feedback"]) == 1
+        assert "Webhook validated" in meta["run_feedback"][0]
+        assert "INCOMPLETE" in result.value.text_content
+        assert "[ ] 2. Webhook validated" in result.value.text_content
+
+    async def test_empty_strings_in_list_are_filtered(self) -> None:
+        """Whitespace/empty entries in acceptance_criteria are ignored.
+
+        Two valid ACs after filtering must still take the multi-AC path.
+        """
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s3"), _passing_eval("s3")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s3",
+                    "artifact": "x",
+                    "acceptance_criteria": ["  ", "Valid AC one", "", "Valid AC two"],
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta["multi_ac"] is True
+        assert result.value.meta["ac_count"] == 2
+
+    async def test_multi_ac_pipeline_error_propagates(self) -> None:
+        """If any AC evaluation errors, the whole handle() returns err."""
+        mock_pipeline = AsyncMock()
+        calls = [
+            Result.ok(_passing_eval("s4")),
+            Result.err(ValueError("semantic stage exploded")),
+        ]
+        mock_pipeline.evaluate = AsyncMock(side_effect=calls)
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s4",
+                    "artifact": "x",
+                    "acceptance_criteria": ["AC1", "AC2"],
+                }
+            )
+
+        assert result.is_err
+        assert "Evaluation failed" in str(result.error)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "not-a-list", 42],
+)
+class TestMultiACParameterTolerance:
+    """Non-list / empty values for acceptance_criteria fall back to single-AC."""
+
+    async def test_invalid_value_falls_back(self, value: object) -> None:
+        mock_pipeline = AsyncMock()
+        mock_pipeline.evaluate = AsyncMock(return_value=Result.ok(_passing_eval("s5")))
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s5",
+                    "artifact": "x",
+                    "acceptance_criteria": value,
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta.get("multi_ac") is not True


### PR DESCRIPTION
## Summary

- Add a new `acceptance_criteria` (ARRAY) parameter to the `ouroboros_evaluate` MCP tool
- When 2+ ACs are provided, fan out one evaluation per AC via `asyncio.gather`, then aggregate through the checklist module (#366 part 1)
- Return a rendered checklist as text and a structured `checklist` + `run_feedback` in `meta`
- Preserve the existing single-AC path unchanged — 1-element lists and callers that don't pass `acceptance_criteria` keep the original behaviour

## Why this is needed

The checklist aggregator from PR #384 exists but has no callable surface — users can't exercise the per-AC view without writing Python directly. This PR plumbs the aggregator into the MCP boundary so:

1. **Users see the whole picture in one call**: \"3 of 5 ACs pass, here are the 2 that failed and exactly why.\"
2. **Run stage gets targeted feedback**: `meta.run_feedback` provides pre-built feedback strings for each failed AC, ready to be injected into a re-attempt prompt.
3. **Ouroboros Physics principle**: the MCP server (Python) now **enforces** the checklist semantics deterministically. An LLM cannot decide to skip the per-AC fan-out — the MCP does it itself.

## Depends on

- #384 (`feat/evaluate-per-ac-checklist`) — provides the checklist module this PR wires in. This PR includes PR #384's commit via cherry-pick so it can be reviewed and merged independently, but ideally #384 lands first.

## Design decisions

- **Single-AC path untouched**: backward compatibility is the top priority. Existing tests and callers pass through without any change.
- **Fan-out via `asyncio.gather`**: AC evaluations are independent, so we evaluate them in parallel. This keeps the total latency close to single-AC.
- **Fail-fast on pipeline error**: if any AC's pipeline evaluation returns `Err`, the whole call returns `Err`. A partial checklist would mislead the Run stage about what actually failed.
- **Blank-entry filtering**: whitespace-only or empty strings in `acceptance_criteria` are dropped during normalization. Callers can safely pass the list from their own data sources without defensive cleanup.
- **Structured meta + text render**: we give the caller both a human-readable checklist (text) and machine-readable data (`meta.checklist`, `meta.run_feedback`) so both humans and tooling can consume it.

## Response shape for multi-AC calls

```json
{
  \"text\": \"Acceptance Criteria Checklist [INCOMPLETE] (1/2 passed, 50%)\\n...\",
  \"meta\": {
    \"multi_ac\": true,
    \"ac_count\": 2,
    \"passed_count\": 1,
    \"pass_rate\": 0.5,
    \"final_approved\": false,
    \"checklist\": [
      {\"ac_text\": \"Charge processed\", \"passed\": true, \"reasoning\": \"...\", ...},
      {\"ac_text\": \"Webhook validated\", \"passed\": false, \"failure_reason\": \"...\", ...}
    ],
    \"run_feedback\": [\"AC not met: Webhook validated — ...\"]
  }
}
```

## Test plan

- [x] 9 new tests in `tests/unit/mcp/tools/test_evaluate_multi_ac.py`:
  - Parameter schema exposes `acceptance_criteria` as ARRAY
  - 1-element list → single-AC path (no `multi_ac` meta flag)
  - 2 passing ACs → `ALL PASSED`, `final_approved=True`, `run_feedback=[]`
  - Mixed outcomes → `INCOMPLETE`, per-AC `failure_reason`, `run_feedback` populated
  - Whitespace/empty entries filtered out
  - Pipeline error propagates as handler error (no partial checklist)
  - Invalid parameter values (None, non-list, int) fall back to single-AC
- [x] 663 passed, 2 skipped — no regressions across `tests/unit/mcp/tools/` and `tests/unit/evaluation/`
- [x] ruff check + format clean