### PR TITLE
feat(evaluate): add ouroboros_checklist_verify MCP tool (#366 part 2)

### DIFF
--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -26,6 +26,7 @@ from ouroboros.mcp.tools.authoring_handlers import (
 )
 from ouroboros.mcp.tools.channel_workflow_handler import ChannelWorkflowHandler
 from ouroboros.mcp.tools.evaluation_handlers import (
+    ChecklistVerifyHandler,
     EvaluateHandler,
     LateralThinkHandler,
     MeasureDriftHandler,
@@ -186,6 +187,18 @@ def evaluate_handler(*, llm_backend: str | None = None) -> EvaluateHandler:
     return EvaluateHandler(llm_backend=llm_backend)
 
 
+def checklist_verify_handler(
+    *,
+    evaluate_handler: EvaluateHandler | None = None,
+    llm_backend: str | None = None,
+) -> ChecklistVerifyHandler:
+    """Create a ChecklistVerifyHandler instance."""
+    return ChecklistVerifyHandler(
+        evaluate_handler=evaluate_handler,
+        llm_backend=llm_backend,
+    )
+
+
 def evolve_step_handler() -> EvolveStepHandler:
     """Create an EvolveStepHandler instance."""
     return EvolveStepHandler()
@@ -226,6 +239,7 @@ OuroborosToolHandlers = tuple[
     | MeasureDriftHandler
     | InterviewHandler
     | EvaluateHandler
+    | ChecklistVerifyHandler
     | LateralThinkHandler
     | EvolveStepHandler
     | StartEvolveStepHandler
@@ -265,6 +279,7 @@ def get_ouroboros_tools(
     job_result = JobResultHandler()
     interview = InterviewHandler(llm_backend=llm_backend)
     generate_seed = GenerateSeedHandler(llm_backend=llm_backend)
+    evaluate = EvaluateHandler(llm_backend=llm_backend)
     return (
         execute_seed,
         start_execute,
@@ -278,7 +293,8 @@ def get_ouroboros_tools(
         generate_seed,
         MeasureDriftHandler(),
         interview,
-        EvaluateHandler(llm_backend=llm_backend),
+        evaluate,
+        ChecklistVerifyHandler(evaluate_handler=evaluate, llm_backend=llm_backend),
         LateralThinkHandler(),
         EvolveStepHandler(),
         StartEvolveStepHandler(),

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -862,6 +862,199 @@ class EvaluateHandler:
 
 
 @dataclass
+class ChecklistVerifyHandler:
+    """Handler for the ``ouroboros_checklist_verify`` tool (#366).
+
+    Given a seed (containing ``acceptance_criteria``) and an execution
+    artifact, this handler routes each AC through the Stage 2 evaluation
+    pipeline and returns an aggregated checklist.  It is intentionally
+    thin — it composes ``EvaluateHandler`` rather than reimplementing
+    pipeline orchestration, so it stays in sync with any future changes
+    to the main evaluator.
+
+    Why this is a separate tool instead of a flag on ``ouroboros_execute_seed``:
+
+    - ``ExecuteSeed`` is already complex (background execution, resume,
+      delegation) and has a stable public contract.  Adding a retry
+      loop inside it would entangle with Ralph mode and the Job system.
+    - This tool lets the *caller* (a human, a ``/ralph`` loop, or a
+      channel workflow) decide when and how to retry.  No decisions
+      are hidden inside background tasks.
+    - It is opt-in: existing callers are unaffected.
+    """
+
+    evaluate_handler: EvaluateHandler | None = field(default=None, repr=False)
+    llm_backend: str | None = field(default=None, repr=False)
+
+    @property
+    def definition(self) -> MCPToolDefinition:
+        """Return the tool definition."""
+        return MCPToolDefinition(
+            name="ouroboros_checklist_verify",
+            description=(
+                "Verify that a Run artifact satisfies every acceptance criterion "
+                "in a Seed.  Returns a per-AC checklist (pass/fail with evidence "
+                "and failure reasons) plus ready-to-use run_feedback strings the "
+                "caller can inject into a re-run prompt.  Does NOT automatically "
+                "re-execute — the caller (Ralph, workflow, or human) decides."
+            ),
+            parameters=(
+                MCPToolParameter(
+                    name="session_id",
+                    type=ToolInputType.STRING,
+                    description="The execution session ID being verified",
+                    required=True,
+                ),
+                MCPToolParameter(
+                    name="seed_content",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "Seed YAML containing acceptance_criteria, goal, constraints. "
+                        "The seed's acceptance_criteria list is evaluated in full."
+                    ),
+                    required=True,
+                ),
+                MCPToolParameter(
+                    name="artifact",
+                    type=ToolInputType.STRING,
+                    description="The Run output/artifact to verify against the seed's ACs",
+                    required=True,
+                ),
+                MCPToolParameter(
+                    name="artifact_type",
+                    type=ToolInputType.STRING,
+                    description="Type of artifact: code, docs, config. Default: code",
+                    required=False,
+                    default="code",
+                    enum=("code", "docs", "config"),
+                ),
+                MCPToolParameter(
+                    name="working_dir",
+                    type=ToolInputType.STRING,
+                    description="Project working directory (for language auto-detection).",
+                    required=False,
+                ),
+            ),
+        )
+
+    async def handle(
+        self,
+        arguments: dict[str, Any],
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Verify the seed's full AC list against the artifact."""
+        session_id = arguments.get("session_id")
+        if not session_id:
+            return Result.err(
+                MCPToolError(
+                    "session_id is required",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        seed_content = arguments.get("seed_content")
+        if not seed_content:
+            return Result.err(
+                MCPToolError(
+                    "seed_content is required",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        artifact = arguments.get("artifact")
+        if not artifact:
+            return Result.err(
+                MCPToolError(
+                    "artifact is required",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        # Extract acceptance criteria from seed.
+        try:
+            seed_dict = yaml.safe_load(seed_content)
+            seed = Seed.from_dict(seed_dict)
+        except yaml.YAMLError as exc:
+            log.warning("mcp.tool.checklist_verify.yaml_error", error=str(exc))
+            return Result.err(
+                MCPToolError(
+                    f"Failed to parse seed YAML: {exc}",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+        except (ValidationError, PydanticValidationError) as exc:
+            log.warning("mcp.tool.checklist_verify.seed_validation_error", error=str(exc))
+            return Result.err(
+                MCPToolError(
+                    f"Seed validation failed: {exc}",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        acceptance_criteria = tuple(
+            text.strip() for text in seed.acceptance_criteria if text and text.strip()
+        )
+        if not acceptance_criteria:
+            return Result.err(
+                MCPToolError(
+                    "Seed has no acceptance_criteria — cannot build checklist.",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        # Delegate to EvaluateHandler in multi-AC mode.  Re-using the
+        # evaluator means language detection, artifact bundling, event
+        # logging, and LLM backend handling stay consistent.
+        evaluator = self.evaluate_handler or EvaluateHandler(llm_backend=self.llm_backend)
+
+        evaluate_args = {
+            "session_id": session_id,
+            "artifact": artifact,
+            "seed_content": seed_content,
+            "acceptance_criteria": list(acceptance_criteria),
+            "artifact_type": arguments.get("artifact_type", "code"),
+        }
+        if "working_dir" in arguments:
+            evaluate_args["working_dir"] = arguments["working_dir"]
+
+        log.info(
+            "mcp.tool.checklist_verify.started",
+            session_id=session_id,
+            ac_count=len(acceptance_criteria),
+        )
+
+        result = await evaluator.handle(evaluate_args)
+
+        if result.is_err:
+            log.warning(
+                "mcp.tool.checklist_verify.evaluate_failed",
+                session_id=session_id,
+                error=str(result.error),
+            )
+            return result
+
+        # Augment the MCP result meta so callers can distinguish the
+        # verify path from a plain multi-AC evaluate call.
+        meta = dict(result.value.meta or {})
+        meta["checklist_verify"] = True
+        meta["seed_goal"] = seed.goal
+        augmented = MCPToolResult(
+            content=result.value.content,
+            is_error=result.value.is_error,
+            meta=meta,
+        )
+
+        log.info(
+            "mcp.tool.checklist_verify.completed",
+            session_id=session_id,
+            all_passed=meta.get("final_approved"),
+            passed_count=meta.get("passed_count"),
+            ac_count=meta.get("ac_count"),
+        )
+
+        return Result.ok(augmented)
+
+
+@dataclass
 class LateralThinkHandler:
     """Handler for the lateral_think tool.
 

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -417,8 +417,14 @@ class EvaluateHandler:
                 except Exception:
                     pass  # Best-effort enrichment
 
-            # Use acceptance_criterion or derive from seed
-            current_ac = acceptance_criterion or "Verify execution output meets requirements"
+            # Use acceptance_criterion or derive from seed.
+            # When a 1-item acceptance_criteria list was provided (e.g. from
+            # ChecklistVerifyHandler forwarding a seed with a single AC),
+            # honour it instead of falling back to the generic default.
+            if len(acceptance_criteria) == 1:
+                current_ac = acceptance_criteria[0]
+            else:
+                current_ac = acceptance_criterion or "Verify execution output meets requirements"
 
             # Evaluation reads multiple spec files (one Read call per AC).
             # Use a dedicated adapter with a higher turn budget — the shared

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -279,6 +279,17 @@ class EvaluateHandler:
                     required=False,
                 ),
                 MCPToolParameter(
+                    name="acceptance_criteria",
+                    type=ToolInputType.ARRAY,
+                    description=(
+                        "Multiple acceptance criteria for checklist evaluation. "
+                        "When two or more items are provided, each AC is evaluated "
+                        "independently and the results are aggregated into a "
+                        "pass/fail checklist (#366). Overrides acceptance_criterion."
+                    ),
+                    required=False,
+                ),
+                MCPToolParameter(
                     name="artifact_type",
                     type=ToolInputType.STRING,
                     description="Type of artifact: code, docs, config. Default: code",
@@ -349,13 +360,25 @@ class EvaluateHandler:
 
         seed_content = arguments.get("seed_content")
         acceptance_criterion = arguments.get("acceptance_criterion")
+        acceptance_criteria_raw = arguments.get("acceptance_criteria")
         artifact_type = arguments.get("artifact_type", "code")
         trigger_consensus = arguments.get("trigger_consensus", False)
+
+        # Normalize the optional multi-AC list (#366): filter out empty/blank
+        # entries so callers can safely pass `[""]` or an accidental null.
+        acceptance_criteria: tuple[str, ...] = ()
+        if isinstance(acceptance_criteria_raw, list):
+            acceptance_criteria = tuple(
+                str(item).strip()
+                for item in acceptance_criteria_raw
+                if isinstance(item, (str, int, float)) and str(item).strip()
+            )
 
         log.info(
             "mcp.tool.evaluate",
             session_id=session_id,
             has_seed=seed_content is not None,
+            multi_ac_count=len(acceptance_criteria),
             trigger_consensus=trigger_consensus,
         )
 
@@ -440,6 +463,33 @@ class EvaluateHandler:
                 )
                 artifact_bundle = None
 
+            mechanical_config = build_mechanical_config(working_dir)
+            config = PipelineConfig(
+                mechanical=mechanical_config,
+                semantic=SemanticConfig(model=get_semantic_model(self.llm_backend)),
+            )
+            pipeline = EvaluationPipeline(llm_adapter, config)
+
+            # Multi-AC checklist path (#366):
+            # When the caller provides >= 2 acceptance criteria we run the
+            # pipeline once per AC and aggregate the results into a
+            # checklist.  Single-AC callers keep the original single-pass
+            # behaviour — no extra cost or behaviour change for them.
+            if len(acceptance_criteria) >= 2:
+                return await self._handle_multi_ac(
+                    session_id=session_id,
+                    seed_id=seed_id,
+                    acceptance_criteria=acceptance_criteria,
+                    artifact=artifact,
+                    artifact_type=artifact_type,
+                    goal=goal,
+                    constraints=constraints,
+                    trigger_consensus=trigger_consensus,
+                    artifact_bundle=artifact_bundle,
+                    pipeline=pipeline,
+                    working_dir=working_dir,
+                )
+
             context = EvaluationContext(
                 execution_id=session_id,
                 seed_id=seed_id,
@@ -451,12 +501,6 @@ class EvaluateHandler:
                 trigger_consensus=trigger_consensus,
                 artifact_bundle=artifact_bundle,
             )
-            mechanical_config = build_mechanical_config(working_dir)
-            config = PipelineConfig(
-                mechanical=mechanical_config,
-                semantic=SemanticConfig(model=get_semantic_model(self.llm_backend)),
-            )
-            pipeline = EvaluationPipeline(llm_adapter, config)
             result = await pipeline.evaluate(context)
 
             if result.is_err:
@@ -537,6 +581,144 @@ class EvaluateHandler:
         finally:
             if owns_event_store and store is not None:
                 await store.close()
+
+    async def _handle_multi_ac(
+        self,
+        *,
+        session_id: str,
+        seed_id: str,
+        acceptance_criteria: tuple[str, ...],
+        artifact: str,
+        artifact_type: str,
+        goal: str,
+        constraints: tuple[str, ...],
+        trigger_consensus: bool,
+        artifact_bundle: object | None,
+        pipeline: object,  # EvaluationPipeline — typed as object to avoid import cycle
+        working_dir: Path,
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Evaluate each AC individually and return an aggregated checklist (#366).
+
+        Runs the evaluation pipeline once per acceptance criterion in
+        parallel via ``asyncio.gather``.  Per-AC results are then folded
+        into a single ``ACChecklistResult`` so the caller sees one
+        pass/fail checklist with per-item evidence and failure reasons.
+
+        Single-AC callers never reach this path — see ``handle()``.
+        """
+        import asyncio
+
+        from ouroboros.evaluation import EvaluationContext
+        from ouroboros.evaluation.checklist import (
+            aggregate_results,
+            build_run_feedback,
+            format_checklist,
+        )
+
+        async def _run_one(ac_text: str) -> Result[object, object]:
+            context = EvaluationContext(
+                execution_id=session_id,
+                seed_id=seed_id,
+                current_ac=ac_text,
+                artifact=artifact,
+                artifact_type=artifact_type,
+                goal=goal,
+                constraints=constraints,
+                trigger_consensus=trigger_consensus,
+                artifact_bundle=artifact_bundle,
+            )
+            return await pipeline.evaluate(context)  # type: ignore[attr-defined]
+
+        log.info(
+            "mcp.tool.evaluate.multi_ac_started",
+            session_id=session_id,
+            ac_count=len(acceptance_criteria),
+        )
+
+        gathered = await asyncio.gather(
+            *(_run_one(ac) for ac in acceptance_criteria),
+            return_exceptions=True,
+        )
+
+        # Any exception or err-Result aborts the whole checklist —
+        # otherwise we'd aggregate over a half-evaluated set.
+        for entry in gathered:
+            if isinstance(entry, BaseException):
+                log.exception(
+                    "mcp.tool.evaluate.multi_ac_exception",
+                    session_id=session_id,
+                )
+                return Result.err(
+                    MCPToolError(
+                        f"Evaluation failed during multi-AC run: {entry}",
+                        tool_name="ouroboros_evaluate",
+                    )
+                )
+            if entry.is_err:  # type: ignore[union-attr]
+                err = entry.error  # type: ignore[union-attr]
+                rendered = err.format_details() if hasattr(err, "format_details") else str(err)
+                log.warning(
+                    "mcp.tool.evaluate.multi_ac_pipeline_failed",
+                    session_id=session_id,
+                    error=rendered,
+                )
+                return Result.err(
+                    MCPToolError(
+                        f"Evaluation failed: {rendered}",
+                        tool_name="ouroboros_evaluate",
+                    )
+                )
+
+        eval_results = tuple(entry.value for entry in gathered)  # type: ignore[union-attr]
+        checklist = aggregate_results(acceptance_criteria, eval_results)
+        feedback = build_run_feedback(checklist)
+
+        code_changes: bool | None = None
+        if any(r.stage1_result and not r.stage1_result.passed for r in eval_results):
+            code_changes = await self._has_code_changes(working_dir)
+
+        text_parts = [format_checklist(checklist)]
+        if code_changes is False:
+            text_parts.append("\nNote: no code changes detected in the working tree.")
+        result_text = "\n".join(text_parts)
+
+        meta = {
+            "session_id": session_id,
+            "final_approved": checklist.all_passed,
+            "multi_ac": True,
+            "ac_count": checklist.total,
+            "passed_count": checklist.passed_count,
+            "pass_rate": checklist.pass_rate,
+            "checklist": [
+                {
+                    "ac_text": item.ac_text,
+                    "passed": item.passed,
+                    "reasoning": item.reasoning,
+                    "evidence": list(item.evidence),
+                    "questions_used": list(item.questions_used),
+                    "failure_reason": item.failure_reason,
+                }
+                for item in checklist.items
+            ],
+            "run_feedback": list(feedback),
+            "code_changes_detected": code_changes,
+        }
+
+        log.info(
+            "mcp.tool.evaluate.multi_ac_completed",
+            session_id=session_id,
+            passed=checklist.passed_count,
+            total=checklist.total,
+            all_passed=checklist.all_passed,
+        )
+
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text=result_text),),
+                is_error=False,
+                meta=meta,
+            )
+        )
 
     async def _has_code_changes(self, working_dir: Path) -> bool | None:
         """Detect whether the working tree has code changes.

--- a/tests/unit/mcp/tools/test_checklist_verify.py
+++ b/tests/unit/mcp/tools/test_checklist_verify.py
@@ -1,0 +1,279 @@
+"""Unit tests for ChecklistVerifyHandler (#366 part 2)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.evaluation_handlers import (
+    ChecklistVerifyHandler,
+    EvaluateHandler,
+)
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+VALID_SEED_WITH_MULTI_AC = """
+goal: Add a payment module
+constraints:
+  - Must integrate with Stripe
+acceptance_criteria:
+  - Charge succeeds
+  - Webhook signature verified
+  - Refund path covered
+ontology_schema:
+  name: Payment
+  description: Payment module
+  fields:
+    - name: provider
+      field_type: string
+      description: Provider name
+evaluation_principles: []
+exit_conditions: []
+metadata:
+  seed_id: seed-pay-1
+  version: "1.0.0"
+  created_at: "2024-01-01T00:00:00Z"
+  ambiguity_score: 0.15
+  interview_id: null
+"""
+
+
+VALID_SEED_NO_AC = """
+goal: Empty goal
+constraints: []
+acceptance_criteria: []
+ontology_schema:
+  name: Empty
+  description: empty
+  fields:
+    - name: x
+      field_type: string
+      description: x
+evaluation_principles: []
+exit_conditions: []
+metadata:
+  seed_id: seed-empty
+  version: "1.0.0"
+  created_at: "2024-01-01T00:00:00Z"
+  ambiguity_score: 0.1
+  interview_id: null
+"""
+
+
+class TestChecklistVerifyDefinition:
+    """Tool definition exposes the right parameters."""
+
+    def test_name_and_required_parameters(self) -> None:
+        handler = ChecklistVerifyHandler()
+        defn = handler.definition
+        assert defn.name == "ouroboros_checklist_verify"
+
+        names = {p.name for p in defn.parameters}
+        assert {"session_id", "seed_content", "artifact"} <= names
+
+        required = {p.name for p in defn.parameters if p.required}
+        assert required == {"session_id", "seed_content", "artifact"}
+
+
+class TestChecklistVerifyArgumentValidation:
+    """Missing required arguments produce actionable errors."""
+
+    async def test_missing_session_id(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+        assert "session_id is required" in str(result.error)
+
+    async def test_missing_seed_content(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+        assert "seed_content is required" in str(result.error)
+
+    async def test_missing_artifact(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+            }
+        )
+        assert result.is_err
+        assert "artifact is required" in str(result.error)
+
+    async def test_invalid_yaml(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": "not: valid: yaml: : :",
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+        # Accept either YAML parse error or seed validation error —
+        # both are surfaced as MCP errors, which is the contract.
+        assert any(
+            needle in str(result.error)
+            for needle in ("Failed to parse seed YAML", "Seed validation failed")
+        )
+
+    async def test_seed_with_no_acceptance_criteria(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_NO_AC,
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+        assert "no acceptance_criteria" in str(result.error)
+
+
+class TestChecklistVerifyDelegation:
+    """Delegates to EvaluateHandler with the seed's AC list."""
+
+    async def test_delegates_with_full_ac_list(self) -> None:
+        """ChecklistVerify forwards every AC to EvaluateHandler.handle()."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="Acceptance Criteria Checklist [ALL PASSED]",
+                        ),
+                    ),
+                    is_error=False,
+                    meta={
+                        "multi_ac": True,
+                        "final_approved": True,
+                        "passed_count": 3,
+                        "ac_count": 3,
+                        "pass_rate": 1.0,
+                    },
+                )
+            )
+        )
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "def pay(): ...",
+            }
+        )
+
+        assert result.is_ok
+        # Verify the inner call received all ACs.
+        mock_evaluate.handle.assert_awaited_once()
+        call_args = mock_evaluate.handle.await_args.args[0]
+        assert call_args["session_id"] == "s1"
+        assert call_args["artifact"] == "def pay(): ..."
+        assert call_args["acceptance_criteria"] == [
+            "Charge succeeds",
+            "Webhook signature verified",
+            "Refund path covered",
+        ]
+        # seed_content must be forwarded so EvaluateHandler can pull goal/constraints
+        assert call_args["seed_content"] == VALID_SEED_WITH_MULTI_AC
+
+    async def test_augments_meta_with_verify_flag(self) -> None:
+        """Response meta gets checklist_verify=True and seed_goal."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                    is_error=False,
+                    meta={"multi_ac": True, "final_approved": True},
+                )
+            )
+        )
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "x",
+            }
+        )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["checklist_verify"] is True
+        assert meta["seed_goal"] == "Add a payment module"
+        # Underlying evaluate meta still present
+        assert meta["multi_ac"] is True
+
+    async def test_evaluate_failure_propagates(self) -> None:
+        """When EvaluateHandler returns Err, ChecklistVerify returns the same err."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(return_value=Result.err(ValueError("pipeline exploded")))
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+
+    async def test_forwards_working_dir_when_provided(self) -> None:
+        """Optional working_dir is forwarded to the evaluator."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                    is_error=False,
+                    meta={"multi_ac": True, "final_approved": True},
+                )
+            )
+        )
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "x",
+                "working_dir": "/tmp/proj",
+            }
+        )
+
+        assert result.is_ok
+        call_args = mock_evaluate.handle.await_args.args[0]
+        assert call_args["working_dir"] == "/tmp/proj"
+
+
+class TestChecklistVerifyRegistered:
+    """The handler is wired into the default tool set."""
+
+    def test_registered_in_ouroboros_tools(self) -> None:
+        from ouroboros.mcp.tools.definitions import OUROBOROS_TOOLS
+
+        names = {h.definition.name for h in OUROBOROS_TOOLS}
+        assert "ouroboros_checklist_verify" in names
+
+    def test_factory_returns_handler(self) -> None:
+        from ouroboros.mcp.tools.definitions import checklist_verify_handler
+
+        handler = checklist_verify_handler(llm_backend="litellm")
+        assert isinstance(handler, ChecklistVerifyHandler)
+        assert handler.llm_backend == "litellm"

--- a/tests/unit/mcp/tools/test_checklist_verify.py
+++ b/tests/unit/mcp/tools/test_checklist_verify.py
@@ -37,6 +37,30 @@ metadata:
 """
 
 
+VALID_SEED_WITH_SINGLE_AC = """
+goal: Add a logging module
+constraints:
+  - Must use structured logging
+acceptance_criteria:
+  - Log output is JSON-formatted
+ontology_schema:
+  name: Logging
+  description: Logging module
+  fields:
+    - name: format
+      field_type: string
+      description: Log format
+evaluation_principles: []
+exit_conditions: []
+metadata:
+  seed_id: seed-log-1
+  version: "1.0.0"
+  created_at: "2024-01-01T00:00:00Z"
+  ambiguity_score: 0.15
+  interview_id: null
+"""
+
+
 VALID_SEED_NO_AC = """
 goal: Empty goal
 constraints: []
@@ -189,6 +213,44 @@ class TestChecklistVerifyDelegation:
         ]
         # seed_content must be forwarded so EvaluateHandler can pull goal/constraints
         assert call_args["seed_content"] == VALID_SEED_WITH_MULTI_AC
+
+    async def test_single_ac_seed_delegates_correctly(self) -> None:
+        """A seed with exactly one AC must forward that AC, not the fallback string."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="Evaluation Results",
+                        ),
+                    ),
+                    is_error=False,
+                    meta={
+                        "final_approved": True,
+                        "session_id": "s1",
+                    },
+                )
+            )
+        )
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_SINGLE_AC,
+                "artifact": "import structlog; log = structlog.get_logger()",
+            }
+        )
+
+        assert result.is_ok
+        # Verify the inner call received exactly the one AC from the seed.
+        mock_evaluate.handle.assert_awaited_once()
+        call_args = mock_evaluate.handle.await_args.args[0]
+        assert call_args["acceptance_criteria"] == ["Log output is JSON-formatted"]
+        # seed_content forwarded so EvaluateHandler can extract goal/constraints
+        assert call_args["seed_content"] == VALID_SEED_WITH_SINGLE_AC
 
     async def test_augments_meta_with_verify_flag(self) -> None:
         """Response meta gets checklist_verify=True and seed_goal."""

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -768,7 +768,9 @@ class TestOuroborosTools:
 
     def test_ouroboros_tools_contains_all_handlers(self) -> None:
         """OUROBOROS_TOOLS contains all standard handlers."""
-        assert len(OUROBOROS_TOOLS) == 23
+        from ouroboros.mcp.tools.evaluation_handlers import ChecklistVerifyHandler
+
+        assert len(OUROBOROS_TOOLS) == 24
 
         handler_types = {type(h) for h in OUROBOROS_TOOLS}
         assert ACTreeHUDHandler in handler_types
@@ -784,6 +786,7 @@ class TestOuroborosTools:
         assert MeasureDriftHandler in handler_types
         assert InterviewHandler in handler_types
         assert EvaluateHandler in handler_types
+        assert ChecklistVerifyHandler in handler_types
         assert LateralThinkHandler in handler_types
         assert EvolveStepHandler in handler_types
         assert StartEvolveStepHandler in handler_types
@@ -806,7 +809,7 @@ class TestOuroborosTools:
     def test_get_ouroboros_tools_can_inject_runtime_backend(self) -> None:
         """Tool factory can build execute_seed with a specific runtime backend."""
         tools = get_ouroboros_tools(runtime_backend="codex")
-        assert len(tools) == 23
+        assert len(tools) == 24
         execute_handler = next(h for h in tools if isinstance(h, ExecuteSeedHandler))
         assert execute_handler.agent_runtime_backend == "codex"
 

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -130,6 +130,45 @@ class TestMultiACRoutingBoundary:
         # Single-AC path — no multi_ac flag in meta.
         assert result.value.meta.get("multi_ac") is not True
 
+    async def test_single_item_list_ac_is_used_as_current_ac(self) -> None:
+        """A 1-element acceptance_criteria list must be used as current_ac.
+
+        Regression test: before the fix, a 1-item list was silently
+        ignored and the evaluation ran against the fallback string
+        'Verify execution output meets requirements'.
+        """
+        captured_contexts: list[object] = []
+        mock_pipeline = AsyncMock()
+
+        async def _capture_evaluate(context: object) -> object:
+            captured_contexts.append(context)
+            return Result.ok(_passing_eval("s1"))
+
+        mock_pipeline.evaluate = AsyncMock(side_effect=_capture_evaluate)
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criteria": ["Log output is JSON-formatted"],
+                }
+            )
+
+        assert result.is_ok
+        assert len(captured_contexts) == 1
+        ctx = captured_contexts[0]
+        # The actual AC text must be used, not the generic fallback.
+        assert ctx.current_ac == "Log output is JSON-formatted"
+
     async def test_two_passing_acs_produce_all_passed_checklist(self) -> None:
         """Two ACs both passing → meta.final_approved True, checklist populated."""
         mock_pipeline = self._install_pipeline_mock([_passing_eval("s1"), _passing_eval("s1")])

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -1,0 +1,290 @@
+"""Unit tests for EvaluateHandler multi-AC checklist path (#366).
+
+These tests exercise the new `acceptance_criteria` parameter that turns
+a single evaluate call into a per-AC checklist evaluation.  Single-AC
+behaviour is covered by existing tests in test_definitions.py and is
+deliberately left untouched here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.evaluation.models import (
+    CheckResult,
+    CheckType,
+    EvaluationResult,
+    MechanicalResult,
+    SemanticResult,
+)
+from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler
+from ouroboros.mcp.types import ToolInputType
+
+
+def _semantic_result(*, ac_compliance: bool, score: float, reasoning: str) -> SemanticResult:
+    """Build a SemanticResult tolerant to whether #367 fields exist yet."""
+    import dataclasses
+
+    kwargs = {
+        "score": score,
+        "ac_compliance": ac_compliance,
+        "goal_alignment": 0.9 if ac_compliance else 0.4,
+        "drift_score": 0.1 if ac_compliance else 0.5,
+        "uncertainty": 0.1,
+        "reasoning": reasoning,
+    }
+    field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+    if "evidence" in field_names:
+        kwargs["evidence"] = ()
+    if "questions_used" in field_names:
+        kwargs["questions_used"] = ()
+    return SemanticResult(**kwargs)
+
+
+def _passing_eval(execution_id: str) -> EvaluationResult:
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage1_result=MechanicalResult(
+            passed=True,
+            checks=(CheckResult(check_type=CheckType.LINT, passed=True, message="ok"),),
+        ),
+        stage2_result=_semantic_result(
+            ac_compliance=True,
+            score=0.9,
+            reasoning="AC met",
+        ),
+        final_approved=True,
+    )
+
+
+def _failing_eval(execution_id: str, *, reason: str) -> EvaluationResult:
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage2_result=_semantic_result(
+            ac_compliance=False,
+            score=0.3,
+            reasoning=reason,
+        ),
+        final_approved=False,
+    )
+
+
+class TestDefinitionAcceptsMultiAC:
+    """The tool schema must advertise the new acceptance_criteria parameter."""
+
+    def test_acceptance_criteria_parameter_present(self) -> None:
+        handler = EvaluateHandler()
+        names = {p.name for p in handler.definition.parameters}
+
+        assert "acceptance_criteria" in names
+        assert "acceptance_criterion" in names  # backward-compat
+
+        param = next(p for p in handler.definition.parameters if p.name == "acceptance_criteria")
+        assert param.type == ToolInputType.ARRAY
+        assert param.required is False
+
+
+class TestMultiACRoutingBoundary:
+    """Runtime behaviour of multi-AC routing in handle()."""
+
+    def _install_pipeline_mock(self, eval_results: list[EvaluationResult]) -> MagicMock:
+        mock_pipeline = AsyncMock()
+        # `evaluate()` returns Result objects in order per call.
+        results_iter = iter(eval_results)
+
+        async def _evaluate(_context: object) -> object:
+            return Result.ok(next(results_iter))
+
+        mock_pipeline.evaluate = AsyncMock(side_effect=_evaluate)
+        return mock_pipeline
+
+    async def test_single_item_list_uses_single_ac_path(self) -> None:
+        """A 1-element acceptance_criteria list falls back to single-AC path.
+
+        We don't assert the content here — just that the multi-AC meta
+        flag is NOT set, proving the request didn't enter _handle_multi_ac.
+        """
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criteria": ["Only AC"],
+                }
+            )
+
+        assert result.is_ok
+        # Single-AC path — no multi_ac flag in meta.
+        assert result.value.meta.get("multi_ac") is not True
+
+    async def test_two_passing_acs_produce_all_passed_checklist(self) -> None:
+        """Two ACs both passing → meta.final_approved True, checklist populated."""
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1"), _passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criteria": ["AC one", "AC two"],
+                }
+            )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["multi_ac"] is True
+        assert meta["ac_count"] == 2
+        assert meta["passed_count"] == 2
+        assert meta["pass_rate"] == 1.0
+        assert meta["final_approved"] is True
+        assert meta["run_feedback"] == []
+        assert len(meta["checklist"]) == 2
+        assert all(item["passed"] for item in meta["checklist"])
+        assert "ALL PASSED" in result.value.text_content
+
+    async def test_mixed_outcomes_produce_incomplete_checklist(self) -> None:
+        """One passing + one failing AC → run_feedback lists the failure."""
+        mock_pipeline = self._install_pipeline_mock(
+            [
+                _passing_eval("s2"),
+                _failing_eval("s2", reason="Webhook signature not verified"),
+            ]
+        )
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s2",
+                    "artifact": "def pay(): pass",
+                    "acceptance_criteria": ["Charge processed", "Webhook validated"],
+                }
+            )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["multi_ac"] is True
+        assert meta["ac_count"] == 2
+        assert meta["passed_count"] == 1
+        assert meta["final_approved"] is False
+        assert len(meta["run_feedback"]) == 1
+        assert "Webhook validated" in meta["run_feedback"][0]
+        assert "INCOMPLETE" in result.value.text_content
+        assert "[ ] 2. Webhook validated" in result.value.text_content
+
+    async def test_empty_strings_in_list_are_filtered(self) -> None:
+        """Whitespace/empty entries in acceptance_criteria are ignored.
+
+        Two valid ACs after filtering must still take the multi-AC path.
+        """
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s3"), _passing_eval("s3")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s3",
+                    "artifact": "x",
+                    "acceptance_criteria": ["  ", "Valid AC one", "", "Valid AC two"],
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta["multi_ac"] is True
+        assert result.value.meta["ac_count"] == 2
+
+    async def test_multi_ac_pipeline_error_propagates(self) -> None:
+        """If any AC evaluation errors, the whole handle() returns err."""
+        mock_pipeline = AsyncMock()
+        calls = [
+            Result.ok(_passing_eval("s4")),
+            Result.err(ValueError("semantic stage exploded")),
+        ]
+        mock_pipeline.evaluate = AsyncMock(side_effect=calls)
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s4",
+                    "artifact": "x",
+                    "acceptance_criteria": ["AC1", "AC2"],
+                }
+            )
+
+        assert result.is_err
+        assert "Evaluation failed" in str(result.error)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "not-a-list", 42],
+)
+class TestMultiACParameterTolerance:
+    """Non-list / empty values for acceptance_criteria fall back to single-AC."""
+
+    async def test_invalid_value_falls_back(self, value: object) -> None:
+        mock_pipeline = AsyncMock()
+        mock_pipeline.evaluate = AsyncMock(return_value=Result.ok(_passing_eval("s5")))
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s5",
+                    "artifact": "x",
+                    "acceptance_criteria": value,
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta.get("multi_ac") is not True


### PR DESCRIPTION
## Summary

- New MCP tool **`ouroboros_checklist_verify`** that verifies a Run artifact against **every** acceptance criterion from its Seed in one call
- Returns a per-AC pass/fail checklist with evidence + failure reasons, plus pre-built `run_feedback` strings for re-run prompts
- Does NOT auto-retry — the caller (Ralph, channel workflow, human) decides
- Registered in `OUROBOROS_TOOLS` (24 tools total, up from 23)
- `checklist_verify_handler` factory function exposed in `definitions`

## Why this design (and not \"auto-retry inside ExecuteSeed\")

`ExecuteSeedHandler` is already very complex — background execution via `_background_tasks`, session resume, inherited runtime/tool context, delegation through `StartExecuteSeedHandler`. Adding an auto-retry loop inside it would:

1. **Entangle with Ralph mode** — Ralph is already the \"persistent loop until verification passes\" mechanism. A second loop inside ExecuteSeed would nest awkwardly or conflict outright.
2. **Hide decisions inside background tasks** — users couldn't control when retries happen, how many, or whether they happen at all.
3. **Break existing integration tests** — ExecuteSeed has a stable public contract that channel workflows and the Job system depend on.

Instead this PR adds a separate, composable tool:

- **The caller decides when and how to retry.** Ralph naturally integrates — its verification step can simply call `ouroboros_checklist_verify` and loop.
- **Strictly opt-in.** Nothing changes for existing callers of `ouroboros_execute_seed` or `ouroboros_evaluate`.
- **Keeps single responsibility.** ExecuteSeed runs. Evaluate grades. ChecklistVerify produces the composite quality gate.

## How it composes with prior PRs

```
PR #384 checklist module         → adds ACChecklistResult, aggregate_results, format_checklist
PR #385 multi-AC evaluate path   → adds acceptance_criteria param to ouroboros_evaluate
PR #386 (this)                   → thin delegation tool that pulls ACs from the Seed
                                    and routes through the multi-AC evaluate path
```

`ChecklistVerifyHandler.handle()` does exactly one non-trivial thing: parse the Seed, extract its `acceptance_criteria` tuple, and delegate to `EvaluateHandler.handle()` with `acceptance_criteria=[...]`. All pipeline logic stays in the main evaluator.

## Depends on

- #384 (`feat/evaluate-per-ac-checklist`) — the checklist module
- #385 (`feat/evaluate-handler-checklist-integration`) — the multi-AC evaluate routing

Both are cherry-picked onto this branch so the PR is self-contained, but ideally those land first for a clean history.

## Response shape

Same shape as `ouroboros_evaluate` multi-AC, plus two extra meta fields:

```json
{
  \"meta\": {
    \"checklist_verify\": true,
    \"seed_goal\": \"Add a payment module\",
    \"multi_ac\": true,
    \"ac_count\": 3,
    \"passed_count\": 2,
    \"pass_rate\": 0.67,
    \"final_approved\": false,
    \"checklist\": [...per-AC details...],
    \"run_feedback\": [\"AC not met: Webhook signature verified — ...\"]
  }
}
```

## Test plan

- [x] 12 new tests in `tests/unit/mcp/tools/test_checklist_verify.py`:
  - Definition shape (name + required params)
  - Argument validation: missing session/seed/artifact, invalid YAML, Seed with no ACs
  - Delegation: forwards full AC list to `EvaluateHandler`, forwards `working_dir`, propagates failures
  - Meta augmentation: adds `checklist_verify` and `seed_goal`
  - Registry: wired into `OUROBOROS_TOOLS`, factory function works
- [x] Updated `test_ouroboros_tools_contains_all_handlers` for new count + handler
- [x] 844 passed, 2 skipped — no regressions across `tests/unit/mcp/` and `tests/unit/evaluation/`
- [x] ruff check + format clean