### PR TITLE
fix(interview): add post-close guard to _emit_event_bg (#388)

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -545,6 +545,7 @@ class InterviewHandler:
         self._owns_event_store = self.event_store is None
         self._event_store = self.event_store or EventStore()
         self._initialized = False
+        self._closed = False
         self._bg_tasks: set[asyncio.Task] = set()
 
     async def _ensure_initialized(self) -> None:
@@ -568,6 +569,7 @@ class InterviewHandler:
 
     async def close(self) -> None:
         """Drain pending event tasks, then close the event store if owned."""
+        self._closed = True
         await self._drain_bg_tasks()
         if self._owns_event_store:
             await self._event_store.close()
@@ -583,6 +585,8 @@ class InterviewHandler:
 
     def _emit_event_bg(self, event: Any) -> None:
         """Fire-and-forget event emission — non-blocking on the hot path."""
+        if self._closed:
+            return
         task = asyncio.create_task(self._emit_event(event))
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -2569,3 +2569,35 @@ class TestInterviewHandlerDrain:
 
         assert len(handler._bg_tasks) == 0
         mock_store.close.assert_awaited_once()
+
+    async def test_emit_event_bg_after_close_is_noop(self) -> None:
+        """_emit_event_bg() after close() must not create tasks or re-initialize."""
+        mock_store = AsyncMock()
+        handler = InterviewHandler(event_store=mock_store)
+        handler._owns_event_store = True
+
+        await handler.close()
+        assert handler._closed is True
+
+        # Reset the mock to track post-close calls only
+        mock_store.initialize.reset_mock()
+        mock_store.append.reset_mock()
+
+        handler._emit_event_bg({"type": "late_event"})
+
+        # Give any accidentally created tasks a chance to run
+        await asyncio.sleep(0.05)
+
+        assert len(handler._bg_tasks) == 0
+        mock_store.initialize.assert_not_awaited()
+        mock_store.append.assert_not_awaited()
+
+    async def test_close_sets_closed_flag(self) -> None:
+        """close() must set _closed before draining tasks."""
+        mock_store = AsyncMock()
+        handler = InterviewHandler(event_store=mock_store)
+        handler._owns_event_store = True
+
+        assert handler._closed is False
+        await handler.close()
+        assert handler._closed is True


### PR DESCRIPTION
## Summary

- Add `_closed` flag to `InterviewHandler`, set `True` at the start of `close()`
- Guard `_emit_event_bg()` with early return when `_closed` is set
- Prevent fire-and-forget event tasks from re-initializing a closed EventStore
- Add 2 regression tests for post-close safety

## Problem

PR #347 (v0.28.6) converted all event emissions to fire-and-forget via `_emit_event_bg()`. However, there is no guard preventing calls after `close()`:

1. `close()` drains tasks, closes EventStore, sets `_initialized = False`
2. A late `_emit_event_bg()` call creates a new asyncio task
3. The task calls `_ensure_initialized()`, sees `_initialized == False`
4. **Re-initializes the already-closed EventStore** → potential DB corruption

PoC test confirmed: `EventStore.initialize()` is called 1 time after `close()` without this fix.

## Fix

```python
def __post_init__(self):
    ...
    self._closed = False

async def close(self):
    self._closed = True          # ← set BEFORE draining
    await self._drain_bg_tasks()
    ...

def _emit_event_bg(self, event):
    if self._closed:             # ← guard
        return
    ...
```

## Test plan

- [x] Existing 3 drain tests pass
- [x] New `test_emit_event_bg_after_close_is_noop` — verifies no task creation, no re-init
- [x] New `test_close_sets_closed_flag` — verifies flag lifecycle
- [x] `PYTHONPATH=src pytest tests/unit/mcp/tools/test_definitions.py::TestInterviewHandlerDrain -v` — 5/5 passed

Closes #388 (part 1 — post-close guard). Event ordering (part 2) tracked separately.