### PR TITLE
fix(evaluate): align SEMANTIC_RESULT_SCHEMA required fields with parser (#389)

### DIFF
--- a/src/ouroboros/evaluation/semantic.py
+++ b/src/ouroboros/evaluation/semantic.py
@@ -58,10 +58,7 @@ SEMANTIC_RESULT_SCHEMA: dict[str, object] = {
         "goal_alignment",
         "drift_score",
         "uncertainty",
-        "reward_hacking_risk",
         "reasoning",
-        "questions_used",
-        "evidence",
     ],
 }
 


### PR DESCRIPTION
## Summary

- Remove `questions_used`, `evidence`, and `reward_hacking_risk` from `SEMANTIC_RESULT_SCHEMA`'s `required` list
- Aligns schema declaration with parser behavior — both now treat these fields as optional

## Problem

PR #383 (v0.28.6) added `questions_used` and `evidence` to the schema's `required` list, but the parser (`parse_semantic_response`) treats them as optional with graceful fallbacks:

```python
# Schema says REQUIRED:
"required": [..., "questions_used", "evidence"]

# Parser says OPTIONAL:
raw_questions = data.get("questions_used") or []  # ← graceful fallback
```

This schema is passed as `response_format: { type: "json_schema" }` to the LLM. **Providers with strict schema enforcement (OpenAI, Codex structured output) reject responses missing required fields before the parser ever runs**, making the graceful fallback dead code.

Additionally, `reward_hacking_risk` was already in the schema `required` list but handled as optional in the parser (defaults to `0.0` when missing).

### Divergence (3 fields):

| Field | Schema | Parser |
|-------|--------|--------|
| `reward_hacking_risk` | required | optional (defaults to 0.0) |
| `questions_used` | required | optional (defaults to []) |
| `evidence` | required | optional (defaults to []) |

## Fix

Remove the 3 optional fields from `required` to match parser behavior:

```python
"required": [
    "score", "ac_compliance", "goal_alignment",
    "drift_score", "uncertainty", "reasoning",
],
```

## Test plan

- [x] `test_missing_reward_hacking_risk_defaults_to_zero` — passes
- [x] `test_missing_questions_and_evidence_degrade_gracefully` — passes
- [x] `test_parses_questions_used_and_evidence` — passes
- [x] `test_empty_strings_in_questions_evidence_are_dropped` — passes
- [x] All 5 selected semantic tests pass

Closes #389