### PR TITLE
fix(codex): delegate _which() to shutil.which for cross-platform support (#391)

### DIFF
--- a/src/ouroboros/codex/cli_policy.py
+++ b/src/ouroboros/codex/cli_policy.py
@@ -139,12 +139,14 @@ def build_codex_child_env(
 
 
 def _which(name: str) -> str | None:
-    """Small local ``which`` helper to keep path resolution pure/testable."""
-    for directory in os.environ.get("PATH", "").split(os.pathsep):
-        candidate = os.path.join(directory, name)
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    return None
+    """Locate an executable on ``PATH``, delegating to :func:`shutil.which`.
+
+    Using the stdlib implementation ensures correct behavior on all
+    platforms, including Windows ``PATHEXT`` resolution.
+    """
+    import shutil
+
+    return shutil.which(name)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- Replace custom `_which()` implementation in `cli_policy.py` with delegation to `shutil.which()`
- Restores Windows PATHEXT support that was lost when PR #381 introduced the custom helper

## Problem

PR #381 (v0.28.6) extracted a shared `cli_policy.py` module with a custom `_which()`:

```python
def _which(name: str) -> str | None:
    for directory in os.environ.get("PATH", "").split(os.pathsep):
        candidate = os.path.join(directory, name)
        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
            return candidate
    return None
```

This does **not** handle Windows `PATHEXT` (`.exe`, `.cmd`, `.bat`), so `_which("codex")` cannot find `codex.exe` on Windows. The **provider path** (`CodexCliLLMAdapter`) previously used `shutil.which()` directly, so this is a regression for Windows users.

## Fix

```python
def _which(name: str) -> str | None:
    import shutil
    return shutil.which(name)
```

`shutil.which()` handles PATHEXT, CWD-on-PATH (Windows), and is the stdlib standard for executable resolution.

## Test plan

- [x] `TestResolveCodexCliPath::test_falls_back_from_wrapper_to_real_cli` — passes
- [x] `TestResolveCodexCliPath::test_keeps_wrapper_when_no_real_cli_exists` — passes
- [x] `TestBuildCodexChildEnv` tests — pass
- [x] All 4 cli_policy tests pass

Closes #391