### PR TITLE
fix(interview): restore backward-compatible ambiguity display format (#390)

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -691,9 +691,7 @@ class InterviewHandler:
 
         score_line = ""
         if score is not None:
-            score_line = (
-                f"(ambiguity: {score.overall_score:.2f}) Ready for Seed generation.\n"
-            )
+            score_line = f"(ambiguity: {score.overall_score:.2f}) Ready for Seed generation.\n"
 
         return Result.ok(
             MCPToolResult(

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -171,12 +171,15 @@ def _milestone_for_score(score: AmbiguityScore | None) -> str | None:
 
 
 def _format_question_with_ambiguity(question: str, score: AmbiguityScore | None) -> str:
-    """Attach the current ambiguity score to a question for display."""
+    """Attach the current ambiguity score to a question for display.
+
+    The text format uses ``(ambiguity: <score>)`` without the milestone
+    label to preserve backward compatibility with downstream consumers
+    that parse the score via regex.  Milestone data is available in the
+    structured ``meta.milestone`` field of the MCP response.
+    """
     if score is None:
         return question
-    milestone_label = _milestone_for_score(score)
-    if milestone_label:
-        return f"(ambiguity: {score.overall_score:.2f} [{milestone_label}]) {question}"
     return f"(ambiguity: {score.overall_score:.2f}) {question}"
 
 
@@ -688,9 +691,8 @@ class InterviewHandler:
 
         score_line = ""
         if score is not None:
-            ms_label = _milestone_for_score(score)
             score_line = (
-                f"(ambiguity: {score.overall_score:.2f} [{ms_label}]) Ready for Seed generation.\n"
+                f"(ambiguity: {score.overall_score:.2f}) Ready for Seed generation.\n"
             )
 
         return Result.ok(

--- a/tests/unit/mcp/tools/test_channel_workflow_handler.py
+++ b/tests/unit/mcp/tools/test_channel_workflow_handler.py
@@ -23,7 +23,7 @@ class FakeInterviewHandler(InterviewHandler):
                     content=(
                         MCPContentItem(
                             type=ContentType.TEXT,
-                            text="Session sess_1\n\n(ambiguity: 0.80 [initial]) What should this do?",
+                            text="Session sess_1\n\n(ambiguity: 0.80) What should this do?",
                         ),
                     ),
                     is_error=False,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1968,9 +1968,7 @@ class TestInterviewHandlerCwd:
         assert state.status == InterviewStatus.COMPLETED
         assert result.value.meta["completed"] is True
         assert result.value.meta["ambiguity_score"] == 0.18
-        assert (
-            "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
-        )
+        assert "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
         mock_engine.ask_next_question.assert_not_called()
 
 

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1973,9 +1973,7 @@ class TestInterviewHandlerCwd:
         assert result.value.meta["completed"] is True
         assert result.value.meta["ambiguity_score"] == 0.18
         assert result.value.meta["milestone"] == "ready"
-        assert (
-            "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
-        )
+        assert "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
         mock_engine.ask_next_question.assert_not_called()
 
 

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1627,7 +1627,7 @@ class TestInterviewHandlerCwd:
         assert result.is_ok
         assert state.ambiguity_score == 0.44
         assert state.ambiguity_breakdown is not None
-        assert "(ambiguity: 0.44 [initial]) Next question?" in result.value.content[0].text
+        assert "(ambiguity: 0.44) Next question?" in result.value.content[0].text
 
     async def test_interview_handle_done_completes_without_new_question(self) -> None:
         """Explicit completion signals should stop the interview instead of asking again."""
@@ -1969,7 +1969,7 @@ class TestInterviewHandlerCwd:
         assert result.value.meta["completed"] is True
         assert result.value.meta["ambiguity_score"] == 0.18
         assert (
-            "(ambiguity: 0.18 [ready]) Ready for Seed generation." in result.value.content[0].text
+            "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
         )
         mock_engine.ask_next_question.assert_not_called()
 

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1628,6 +1628,7 @@ class TestInterviewHandlerCwd:
         assert state.ambiguity_score == 0.44
         assert state.ambiguity_breakdown is not None
         assert "(ambiguity: 0.44) Next question?" in result.value.content[0].text
+        assert result.value.meta["milestone"] == "initial"
 
     async def test_interview_handle_done_completes_without_new_question(self) -> None:
         """Explicit completion signals should stop the interview instead of asking again."""
@@ -1690,6 +1691,7 @@ class TestInterviewHandlerCwd:
         assert state.ambiguity_score == 0.14
         mock_engine.ask_next_question.assert_not_called()
         assert result.value.meta["completed"] is True
+        assert result.value.meta["milestone"] == "ready"
 
     async def test_interview_handle_done_refuses_when_component_floors_fail(self) -> None:
         """Low ambiguity alone should not allow completion when weak dimensions remain."""
@@ -1768,6 +1770,7 @@ class TestInterviewHandlerCwd:
         assert result.is_ok
         assert state.status == InterviewStatus.IN_PROGRESS
         assert result.value.meta["seed_ready"] is False
+        assert result.value.meta["milestone"] == "ready"
         assert "completion floors are unmet" in result.value.content[0].text
         mock_engine.complete_interview.assert_not_called()
         mock_engine.ask_next_question.assert_not_called()
@@ -1846,6 +1849,7 @@ class TestInterviewHandlerCwd:
         assert result.is_ok
         assert state.status == InterviewStatus.COMPLETED
         assert result.value.meta["completed"] is True
+        assert result.value.meta["milestone"] == "ready"
         mock_score.assert_called_once()
         mock_engine.complete_interview.assert_called_once()
         mock_engine.ask_next_question.assert_not_called()
@@ -1968,7 +1972,10 @@ class TestInterviewHandlerCwd:
         assert state.status == InterviewStatus.COMPLETED
         assert result.value.meta["completed"] is True
         assert result.value.meta["ambiguity_score"] == 0.18
-        assert "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
+        assert result.value.meta["milestone"] == "ready"
+        assert (
+            "(ambiguity: 0.18) Ready for Seed generation." in result.value.content[0].text
+        )
         mock_engine.ask_next_question.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- Remove `[milestone]` label from the MCP response text format
- Restore backward-compatible `(ambiguity: 0.44)` format (without inline milestone)
- Milestone data remains available in the structured `meta.milestone` field

## Problem

PR #380 (v0.28.6) changed the text format from:
```
(ambiguity: 0.44) Next question?
```
to:
```
(ambiguity: 0.44 [initial]) Next question?
```

This breaks any downstream consumer that extracts the ambiguity score via regex:
```python
# Common pattern — now broken:
match = re.search(r'\(ambiguity:\s+([\d.]+)\)', text)
```

The `[milestone]` text between the score and closing `)` causes regex match failure. This is a silent breaking change with no semver bump.

## Fix

Keep milestone in `meta` (structured, safe for programmatic access) and restore plain text format:

| Field | Before (broken) | After (fixed) |
|-------|-----------------|---------------|
| `content[0].text` | `(ambiguity: 0.44 [initial]) Q?` | `(ambiguity: 0.44) Q?` |
| `meta.milestone` | `"initial"` | `"initial"` (unchanged) |
| `meta.ambiguity_score` | `0.44` | `0.44` (unchanged) |

## Test plan

- [x] `test_interview_handle_clears_stored_ambiguity_after_new_answer` — passes with restored format
- [x] All 19 channel_workflow_handler tests — pass
- [x] Test assertions updated from `[initial]`/`[ready]` back to plain format

Closes #390