### PR TITLE
fix(security): sanitize CheckpointStore seed_id to prevent path traversal

### DIFF
--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 from typing import Any
 
 from ouroboros.core.errors import PersistenceError
@@ -166,6 +167,63 @@ class CheckpointStore:
         This method is idempotent - safe to call multiple times.
         """
         self._base_path.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _sanitize_seed_id(seed_id: str) -> str:
+        """Sanitize seed_id to prevent path traversal attacks.
+
+        Strips null bytes, removes path separators and parent-directory
+        sequences, and enforces a maximum length of 255 characters.
+
+        Args:
+            seed_id: Raw seed identifier.
+
+        Returns:
+            Sanitized seed identifier safe for use in filenames.
+
+        Raises:
+            ValueError: If seed_id is empty or becomes empty after sanitization.
+        """
+        if not seed_id:
+            raise ValueError("seed_id must not be empty")
+
+        # Strip null bytes
+        sanitized = seed_id.replace("\x00", "")
+
+        # Remove parent-directory traversal sequences before stripping separators
+        # so that inputs like "x/../../PWNED" are neutralised.
+        sanitized = sanitized.replace("..", "")
+
+        # Replace path separators with underscores
+        sanitized = re.sub(r"[/\\]", "_", sanitized)
+
+        # Limit length to 255 characters (common filesystem limit)
+        sanitized = sanitized[:255]
+
+        # Final check: must still be non-empty after sanitization
+        if not sanitized or not sanitized.strip():
+            raise ValueError(
+                f"seed_id is empty after sanitization (original: {seed_id!r})"
+            )
+
+        return sanitized
+
+    def _validate_path_containment(self, path: Path) -> None:
+        """Verify that *path* is inside the checkpoint base directory.
+
+        Args:
+            path: Resolved path to validate.
+
+        Raises:
+            ValueError: If path escapes the base directory.
+        """
+        resolved = path.resolve()
+        base_resolved = self._base_path.resolve()
+        # Use os.path so the check works on all platforms.
+        if not str(resolved).startswith(str(base_resolved) + os.sep) and resolved != base_resolved:
+            raise ValueError(
+                f"Path traversal detected: {resolved} is outside {base_resolved}"
+            )
 
     def save(self, checkpoint: CheckpointData) -> Result[None, PersistenceError]:
         """Save checkpoint to disk.
@@ -327,17 +385,26 @@ class CheckpointStore:
     def _get_checkpoint_path(self, seed_id: str, level: int = 0) -> Path:
         """Get file path for checkpoint at specific rollback level.
 
+        The seed_id is sanitized to prevent path traversal, and the
+        resulting path is validated to stay within the base directory.
+
         Args:
             seed_id: Seed identifier.
             level: Rollback level (0=current, 1-3=previous).
 
         Returns:
             Path to checkpoint file.
+
+        Raises:
+            ValueError: If seed_id is invalid or path escapes base directory.
         """
-        filename = f"checkpoint_{seed_id}.json"
+        safe_id = self._sanitize_seed_id(seed_id)
+        filename = f"checkpoint_{safe_id}.json"
         if level > 0:
-            filename = f"checkpoint_{seed_id}.json.{level}"
-        return self._base_path / filename
+            filename = f"checkpoint_{safe_id}.json.{level}"
+        path = self._base_path / filename
+        self._validate_path_containment(path)
+        return path
 
 
 class PeriodicCheckpointer:

--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -202,9 +202,7 @@ class CheckpointStore:
 
         # Final check: must still be non-empty after sanitization
         if not sanitized or not sanitized.strip():
-            raise ValueError(
-                f"seed_id is empty after sanitization (original: {seed_id!r})"
-            )
+            raise ValueError(f"seed_id is empty after sanitization (original: {seed_id!r})")
 
         return sanitized
 
@@ -221,9 +219,7 @@ class CheckpointStore:
         base_resolved = self._base_path.resolve()
         # Use os.path so the check works on all platforms.
         if not str(resolved).startswith(str(base_resolved) + os.sep) and resolved != base_resolved:
-            raise ValueError(
-                f"Path traversal detected: {resolved} is outside {base_resolved}"
-            )
+            raise ValueError(f"Path traversal detected: {resolved} is outside {base_resolved}")
 
     def save(self, checkpoint: CheckpointData) -> Result[None, PersistenceError]:
         """Save checkpoint to disk.

--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -168,15 +168,30 @@ class CheckpointStore:
         """
         self._base_path.mkdir(parents=True, exist_ok=True)
 
+    # Filename components used by _get_checkpoint_path:
+    #   "checkpoint_" + <seed> + ".json"         (level 0)
+    #   "checkpoint_" + <seed> + ".json.N"       (level 1-3)
+    # file_lock appends ".lock", so worst-case basename is:
+    #   "checkpoint_" + <seed> + ".json.N.lock"
+    _FILENAME_PREFIX = "checkpoint_"
+    _FILENAME_SUFFIX_WORST = ".json.0.lock"  # longest possible basename suffix
+    _MAX_SEED_LEN = 255 - len(_FILENAME_PREFIX) - len(_FILENAME_SUFFIX_WORST)  # 232
+    # When truncating, reserve space for a collision-resistant hash suffix.
+    _HASH_SUFFIX_LEN = 8  # hex chars from SHA-256
+
     @staticmethod
-    def _sanitize_seed_id(seed_id: str) -> str:
+    def _sanitize_seed_id(seed_id: str, *, max_len: int | None = None) -> str:
         """Sanitize seed_id to prevent path traversal attacks.
 
         Strips null bytes, removes path separators and parent-directory
-        sequences, and enforces a maximum length of 255 characters.
+        sequences, and caps length so that the **full** checkpoint
+        filename (prefix + seed + suffix) stays within the 255-byte
+        filesystem limit.  When truncation is needed a SHA-256 hash
+        fragment is appended to keep the mapping collision-resistant.
 
         Args:
             seed_id: Raw seed identifier.
+            max_len: Override for maximum sanitized length (used in tests).
 
         Returns:
             Sanitized seed identifier safe for use in filenames.
@@ -186,6 +201,8 @@ class CheckpointStore:
         """
         if not seed_id:
             raise ValueError("seed_id must not be empty")
+
+        budget = max_len if max_len is not None else CheckpointStore._MAX_SEED_LEN
 
         # Strip null bytes
         sanitized = seed_id.replace("\x00", "")
@@ -197,8 +214,14 @@ class CheckpointStore:
         # Replace path separators with underscores
         sanitized = re.sub(r"[/\\]", "_", sanitized)
 
-        # Limit length to 255 characters (common filesystem limit)
-        sanitized = sanitized[:255]
+        # Cap length to the remaining filename budget.
+        # When truncation is required, append a hash suffix for collision resistance.
+        if len(sanitized) > budget:
+            hash_hex = hashlib.sha256(sanitized.encode()).hexdigest()[
+                : CheckpointStore._HASH_SUFFIX_LEN
+            ]
+            truncated_len = budget - CheckpointStore._HASH_SUFFIX_LEN - 1  # 1 for "_"
+            sanitized = f"{sanitized[:truncated_len]}_{hash_hex}"
 
         # Final check: must still be non-empty after sanitization
         if not sanitized or not sanitized.strip():

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -208,6 +208,116 @@ class TestCheckpointStore:
         )
 
 
+class TestCheckpointStorePathTraversal:
+    """Test that path traversal attacks via seed_id are blocked."""
+
+    def test_traversal_with_slashes_is_sanitized(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """seed_id with path separators is sanitized to underscores."""
+        cp = CheckpointData.create("x/../../PWNED", "phase1", {"a": 1})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+        # ".." removed -> "x/__/PWNED", slashes -> underscores -> "x___PWNED"
+        expected = checkpoint_store._base_path / "checkpoint_x___PWNED.json"
+        assert expected.exists()
+
+    def test_traversal_with_backslashes_is_sanitized(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """seed_id with backslash separators is sanitized."""
+        cp = CheckpointData.create("x\\..\\..\\PWNED", "phase1", {"a": 1})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+        # ".." removed -> "x\\\\" , backslashes -> underscores -> "x___PWNED"
+        expected = checkpoint_store._base_path / "checkpoint_x___PWNED.json"
+        assert expected.exists()
+
+    def test_traversal_does_not_escape_base_dir(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """No checkpoint file is created outside the base directory."""
+        cp = CheckpointData.create("../../../etc/passwd", "phase1", {})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+        # Ensure nothing was written outside the checkpoint dir
+        import os
+
+        for entry in checkpoint_store._base_path.parent.iterdir():
+            if entry != checkpoint_store._base_path:
+                assert "passwd" not in entry.name
+
+    def test_normal_seed_id_still_works(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """Normal seed_ids without traversal patterns work correctly."""
+        cp = CheckpointData.create("my-seed-123", "phase1", {"step": 1})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+
+        load_result = checkpoint_store.load("my-seed-123")
+        assert load_result.is_ok
+        assert load_result.value.seed_id == "my-seed-123"
+
+    def test_empty_seed_id_raises_value_error(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """Empty seed_id raises ValueError."""
+        with pytest.raises(ValueError, match="seed_id must not be empty"):
+            checkpoint_store._get_checkpoint_path("")
+
+    def test_null_byte_seed_id_raises_value_error(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """seed_id consisting only of null bytes raises ValueError."""
+        with pytest.raises(ValueError, match="empty after sanitization"):
+            checkpoint_store._get_checkpoint_path("\x00\x00")
+
+    def test_dot_dot_only_seed_id_raises_value_error(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """seed_id that is purely '..' sequences raises ValueError."""
+        with pytest.raises(ValueError, match="empty after sanitization"):
+            checkpoint_store._get_checkpoint_path("..")
+
+    def test_seed_id_with_null_bytes_stripped(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """Null bytes are stripped but remaining content is preserved."""
+        cp = CheckpointData.create("seed\x00id", "phase1", {"a": 1})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+        expected = checkpoint_store._base_path / "checkpoint_seedid.json"
+        assert expected.exists()
+
+    def test_long_seed_id_is_truncated(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """seed_id longer than 255 chars is truncated."""
+        long_id = "a" * 300
+        path = checkpoint_store._get_checkpoint_path(long_id)
+        # The seed portion in the filename should be at most 255 chars
+        assert len(long_id[:255]) == 255
+        assert path.name == f"checkpoint_{'a' * 255}.json"
+
+    def test_load_with_traversal_seed_id(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """load() with a traversal seed_id is safely handled."""
+        # Save with a traversal-attempt seed_id
+        cp = CheckpointData.create("x/../secret", "phase1", {"a": 1})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+
+        # Load with the same traversal-attempt seed_id -- sanitized consistently
+        load_result = checkpoint_store.load("x/../secret")
+        assert load_result.is_ok
+        assert load_result.value.phase == "phase1"
+        # File lives inside the base directory with sanitized name
+        expected = checkpoint_store._base_path / "checkpoint_x__secret.json"
+        assert expected.exists()
+
+
 class TestCheckpointStoreRollback:
     """Test checkpoint rollback functionality."""
 

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -277,13 +277,67 @@ class TestCheckpointStorePathTraversal:
         expected = checkpoint_store._base_path / "checkpoint_seedid.json"
         assert expected.exists()
 
-    def test_long_seed_id_is_truncated(self, checkpoint_store: CheckpointStore) -> None:
-        """seed_id longer than 255 chars is truncated."""
+    def test_long_seed_id_is_truncated_within_filename_budget(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """seed_id is capped so the full filename never exceeds 255 bytes."""
         long_id = "a" * 300
         path = checkpoint_store._get_checkpoint_path(long_id)
-        # The seed portion in the filename should be at most 255 chars
-        assert len(long_id[:255]) == 255
-        assert path.name == f"checkpoint_{'a' * 255}.json"
+        # The full basename must fit in 255 bytes for any rollback level
+        assert len(path.name) <= 255
+        # The sanitized seed portion is at most _MAX_SEED_LEN (237)
+        seed_part = path.name.removeprefix("checkpoint_").removesuffix(".json")
+        assert len(seed_part) <= CheckpointStore._MAX_SEED_LEN
+        # With rollback suffix the basename still fits
+        path_with_level = checkpoint_store._get_checkpoint_path(long_id, level=3)
+        assert len(path_with_level.name) <= 255
+
+    def test_long_seed_id_has_hash_suffix_for_collision_resistance(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """Truncated seed ids include a hash suffix to avoid collisions."""
+        import hashlib
+
+        long_id = "a" * 300
+        sanitized = CheckpointStore._sanitize_seed_id(long_id)
+        # Must end with _<8-hex-char hash>
+        assert "_" in sanitized
+        hash_suffix = sanitized.rsplit("_", 1)[-1]
+        assert len(hash_suffix) == CheckpointStore._HASH_SUFFIX_LEN
+        # Verify the hash is derived from the full (pre-truncation) sanitized id
+        expected_hash = hashlib.sha256(long_id.encode()).hexdigest()[
+            : CheckpointStore._HASH_SUFFIX_LEN
+        ]
+        assert hash_suffix == expected_hash
+
+    def test_long_seed_id_write_and_read_roundtrip(self, checkpoint_store: CheckpointStore) -> None:
+        """Regression: a checkpoint with a very long seed_id can be written and read back."""
+        long_id = "b" * 300
+        cp = CheckpointData.create(long_id, "phase1", {"step": 42})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+
+        # The file must actually exist on disk
+        path = checkpoint_store._get_checkpoint_path(long_id)
+        assert path.exists(), f"checkpoint file was not created: {path}"
+        assert len(path.name) <= 255
+
+        # Read it back via load (which re-sanitizes the seed_id identically)
+        load_result = checkpoint_store.load(long_id)
+        assert load_result.is_ok
+        assert load_result.value.phase == "phase1"
+        assert load_result.value.state == {"step": 42}
+
+    def test_long_seed_id_different_ids_do_not_collide(
+        self, checkpoint_store: CheckpointStore
+    ) -> None:
+        """Two long seed_ids that share a 228-char prefix map to different files."""
+        prefix = "x" * 228
+        id_a = prefix + "a" * 72
+        id_b = prefix + "b" * 72
+        path_a = checkpoint_store._get_checkpoint_path(id_a)
+        path_b = checkpoint_store._get_checkpoint_path(id_b)
+        assert path_a != path_b, "distinct long seed_ids must not collide"
 
     def test_load_with_traversal_seed_id(self, checkpoint_store: CheckpointStore) -> None:
         """load() with a traversal seed_id is safely handled."""

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -211,9 +211,7 @@ class TestCheckpointStore:
 class TestCheckpointStorePathTraversal:
     """Test that path traversal attacks via seed_id are blocked."""
 
-    def test_traversal_with_slashes_is_sanitized(
-        self, checkpoint_store: CheckpointStore
-    ) -> None:
+    def test_traversal_with_slashes_is_sanitized(self, checkpoint_store: CheckpointStore) -> None:
         """seed_id with path separators is sanitized to underscores."""
         cp = CheckpointData.create("x/../../PWNED", "phase1", {"a": 1})
         result = checkpoint_store.save(cp)
@@ -233,23 +231,18 @@ class TestCheckpointStorePathTraversal:
         expected = checkpoint_store._base_path / "checkpoint_x___PWNED.json"
         assert expected.exists()
 
-    def test_traversal_does_not_escape_base_dir(
-        self, checkpoint_store: CheckpointStore
-    ) -> None:
+    def test_traversal_does_not_escape_base_dir(self, checkpoint_store: CheckpointStore) -> None:
         """No checkpoint file is created outside the base directory."""
         cp = CheckpointData.create("../../../etc/passwd", "phase1", {})
         result = checkpoint_store.save(cp)
         assert result.is_ok
         # Ensure nothing was written outside the checkpoint dir
-        import os
 
         for entry in checkpoint_store._base_path.parent.iterdir():
             if entry != checkpoint_store._base_path:
                 assert "passwd" not in entry.name
 
-    def test_normal_seed_id_still_works(
-        self, checkpoint_store: CheckpointStore
-    ) -> None:
+    def test_normal_seed_id_still_works(self, checkpoint_store: CheckpointStore) -> None:
         """Normal seed_ids without traversal patterns work correctly."""
         cp = CheckpointData.create("my-seed-123", "phase1", {"step": 1})
         result = checkpoint_store.save(cp)
@@ -259,16 +252,12 @@ class TestCheckpointStorePathTraversal:
         assert load_result.is_ok
         assert load_result.value.seed_id == "my-seed-123"
 
-    def test_empty_seed_id_raises_value_error(
-        self, checkpoint_store: CheckpointStore
-    ) -> None:
+    def test_empty_seed_id_raises_value_error(self, checkpoint_store: CheckpointStore) -> None:
         """Empty seed_id raises ValueError."""
         with pytest.raises(ValueError, match="seed_id must not be empty"):
             checkpoint_store._get_checkpoint_path("")
 
-    def test_null_byte_seed_id_raises_value_error(
-        self, checkpoint_store: CheckpointStore
-    ) -> None:
+    def test_null_byte_seed_id_raises_value_error(self, checkpoint_store: CheckpointStore) -> None:
         """seed_id consisting only of null bytes raises ValueError."""
         with pytest.raises(ValueError, match="empty after sanitization"):
             checkpoint_store._get_checkpoint_path("\x00\x00")
@@ -280,9 +269,7 @@ class TestCheckpointStorePathTraversal:
         with pytest.raises(ValueError, match="empty after sanitization"):
             checkpoint_store._get_checkpoint_path("..")
 
-    def test_seed_id_with_null_bytes_stripped(
-        self, checkpoint_store: CheckpointStore
-    ) -> None:
+    def test_seed_id_with_null_bytes_stripped(self, checkpoint_store: CheckpointStore) -> None:
         """Null bytes are stripped but remaining content is preserved."""
         cp = CheckpointData.create("seed\x00id", "phase1", {"a": 1})
         result = checkpoint_store.save(cp)
@@ -290,9 +277,7 @@ class TestCheckpointStorePathTraversal:
         expected = checkpoint_store._base_path / "checkpoint_seedid.json"
         assert expected.exists()
 
-    def test_long_seed_id_is_truncated(
-        self, checkpoint_store: CheckpointStore
-    ) -> None:
+    def test_long_seed_id_is_truncated(self, checkpoint_store: CheckpointStore) -> None:
         """seed_id longer than 255 chars is truncated."""
         long_id = "a" * 300
         path = checkpoint_store._get_checkpoint_path(long_id)
@@ -300,9 +285,7 @@ class TestCheckpointStorePathTraversal:
         assert len(long_id[:255]) == 255
         assert path.name == f"checkpoint_{'a' * 255}.json"
 
-    def test_load_with_traversal_seed_id(
-        self, checkpoint_store: CheckpointStore
-    ) -> None:
+    def test_load_with_traversal_seed_id(self, checkpoint_store: CheckpointStore) -> None:
         """load() with a traversal seed_id is safely handled."""
         # Save with a traversal-attempt seed_id
         cp = CheckpointData.create("x/../secret", "phase1", {"a": 1})


### PR DESCRIPTION
## Summary

- **Fixes #397** — `CheckpointStore._get_checkpoint_path()` directly interpolated `seed_id` into filenames without sanitization, allowing crafted IDs like `x/../../PWNED` to read, write, or delete files outside the checkpoint directory.
- Adds `_sanitize_seed_id()` static method that strips null bytes, removes `..` traversal sequences, replaces `/` and `\` with underscores, limits length to 255 chars, and raises `ValueError` for empty results.
- Adds `_validate_path_containment()` that verifies the resolved checkpoint path stays within `self._base_path`.
- Both guards are applied in `_get_checkpoint_path()`, which is used by `save()`, `load()`, and all rollback operations.

## Test plan

- [x] Path traversal with forward slashes is sanitized (file stays in base dir)
- [x] Path traversal with backslashes is sanitized
- [x] No file is created outside the checkpoint directory
- [x] Normal seed_ids continue to work (save + load roundtrip)
- [x] Empty seed_id raises `ValueError`
- [x] Null-byte-only seed_id raises `ValueError`
- [x] `..`-only seed_id raises `ValueError`
- [x] Null bytes are stripped but remaining content preserved
- [x] Seed IDs longer than 255 chars are truncated
- [x] `load()` with traversal seed_id resolves consistently with `save()`
- [x] All 34 existing + new tests pass
- [x] `ruff check` passes clean