### PR TITLE
fix(pm): restore timestamp fallback, footer for legacy seeds, and deduplicate brownfield path (#406)

### DIFF
--- a/src/ouroboros/bigbang/pm_document.py
+++ b/src/ouroboros/bigbang/pm_document.py
@@ -89,6 +89,7 @@ def generate_pm_markdown(seed: PMSeed) -> str:
         lines.append(f"*Created At: {seed.created_at}*")
     else:
         from datetime import UTC, datetime
+
         lines.append(f"*Generated: {datetime.now(UTC).strftime('%Y-%m-%d %H:%M UTC')}*")
     lines.append("")
 

--- a/src/ouroboros/bigbang/pm_document.py
+++ b/src/ouroboros/bigbang/pm_document.py
@@ -87,7 +87,10 @@ def generate_pm_markdown(seed: PMSeed) -> str:
     lines.append("")
     if seed.created_at:
         lines.append(f"*Created At: {seed.created_at}*")
-        lines.append("")
+    else:
+        from datetime import UTC, datetime
+        lines.append(f"*Generated: {datetime.now(UTC).strftime('%Y-%m-%d %H:%M UTC')}*")
+    lines.append("")
 
     # Goal
     lines.append("## Goal")
@@ -151,7 +154,8 @@ def generate_pm_markdown(seed: PMSeed) -> str:
             name = repo.get("name") or repo.get("path") or "Unknown"
             desc = repo.get("desc", "")
             path = repo.get("path") or ""
-            if path:
+            is_name_from_path = not repo.get("name") and path
+            if path and not is_name_from_path:
                 lines.append(f"- **{name}** (`{path}`)")
             else:
                 lines.append(f"- **{name}**")
@@ -463,7 +467,11 @@ class PMDocumentGenerator:
                 name = repo.get("name") or repo.get("path") or "Unknown"
                 path = repo.get("path") or ""
                 desc = repo.get("desc", "")
-                label = f"{name} ({path})" if path else name
+                is_name_from_path = not repo.get("name") and path
+                if path and not is_name_from_path:
+                    label = f"{name} ({path})"
+                else:
+                    label = name
                 parts.append(f"- {label}{f' — {desc}' if desc else ''}")
             parts.append("")
 

--- a/src/ouroboros/bigbang/pm_seed.py
+++ b/src/ouroboros/bigbang/pm_seed.py
@@ -196,7 +196,7 @@ class PMSeed:
                 pass  # Preserve as raw dict if Seed import/parse fails
 
         return cls(
-            pm_id=data.get("pm_id", ""),
+            pm_id=data.get("pm_id") or f"pm_seed_{uuid4().hex[:12]}",
             product_name=data.get("product_name", ""),
             goal=data.get("goal", ""),
             user_stories=stories,

--- a/tests/unit/bigbang/test_pm_document_generator.py
+++ b/tests/unit/bigbang/test_pm_document_generator.py
@@ -326,13 +326,15 @@ class TestPMDocumentGeneratorPrompt:
         assert "**Interview ID:** int_abc" in prompt
 
     def test_prompt_brownfield_repo_empty_name_uses_path(self):
-        """Prompt builder falls back to path when brownfield repo name is empty."""
+        """Prompt builder falls back to path when brownfield repo name is empty, without duplicate."""
         seed = _make_seed(
             brownfield_repos=({"name": "", "path": "/repo/path", "desc": "desc"},),
         )
         prompt = PMDocumentGenerator._build_generation_prompt(seed)
 
-        assert "/repo/path (/repo/path)" in prompt
+        # Name falls back to path, so parenthetical path is NOT shown
+        assert "/repo/path" in prompt
+        assert "/repo/path (/repo/path)" not in prompt
         assert "desc" in prompt
 
     def test_prompt_brownfield_repo_none_name_uses_path(self):

--- a/tests/unit/bigbang/test_pm_document_writer.py
+++ b/tests/unit/bigbang/test_pm_document_writer.py
@@ -176,11 +176,13 @@ class TestGeneratePrdMarkdown:
         assert "1. **As a** admin" in md
         assert "2. **As a** dev" in md
 
-    def test_omits_empty_created_at(self):
-        """Created At is omitted when empty or None."""
+    def test_fallback_generated_timestamp_when_created_at_empty(self):
+        """Shows Generated timestamp when created_at is empty."""
         seed = PMSeed(pm_id="pm_1", product_name="Test", goal="A goal", created_at="")
         md = generate_pm_markdown(seed)
         assert "Created At" not in md
+        assert "*Generated:" in md
+        assert "UTC*" in md
 
     def test_omits_empty_interview_id(self):
         """Interview ID is omitted when empty or None."""
@@ -198,13 +200,15 @@ class TestGeneratePrdMarkdown:
         assert "*Interview ID: int_abc*" in footer
 
     def test_brownfield_repo_empty_name_falls_back_to_path(self):
-        """Brownfield repo with empty name falls back to path."""
+        """Brownfield repo with empty name falls back to path without duplicate."""
         seed = _make_seed(
             brownfield_repos=({"name": "", "path": "/repo/path", "desc": "desc"},),
         )
         md = generate_pm_markdown(seed)
         assert "**/repo/path**" in md
-        assert "(`/repo/path`)" in md
+        # When name falls back to path, the parenthetical path is NOT shown
+        assert "(`/repo/path`)" not in md
+        assert "/repo/path (/repo/path)" not in md
 
     def test_brownfield_repo_missing_path_renders_cleanly(self):
         """Brownfield repo with missing path renders without empty backticks."""


### PR DESCRIPTION
## Summary

Fixes three regressions introduced by #314 (v0.28.2) in PM document generation:

- **Timestamp fallback**: `generate_pm_markdown()` now falls back to `*Generated: YYYY-MM-DD HH:MM UTC*` when `seed.created_at` is empty (legacy seeds from `from_dict()`), preventing documents with no timestamp at all
- **Footer for legacy seeds**: `PMSeed.from_dict()` now generates a UUID for `pm_id` when the key is missing or empty, preventing the entire footer (including `---` separator) from vanishing
- **Brownfield duplicate path**: When `repo["name"]` is empty and falls back to `path`, the parenthetical `(path)` is now skipped to prevent `/repo/path (/repo/path)` duplication in both `generate_pm_markdown()` and `_build_generation_prompt()`

Closes #406

## Test plan

- [x] `test_fallback_generated_timestamp_when_created_at_empty` — verifies `*Generated:*` appears when `created_at` is empty
- [x] `test_footer_contains_both_pm_id_and_interview_id` — verifies footer renders with auto-generated pm_id
- [x] `test_brownfield_repo_empty_name_falls_back_to_path` — verifies no duplicate path display
- [x] `test_prompt_brownfield_repo_empty_name_uses_path` — same for prompt builder
- [x] All 61 existing PM tests pass