### PR TITLE
fix(mcp): route validate_transport error to stderr (#408)

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -191,7 +191,9 @@ async def _run_mcp_server(
     try:
         transport = validate_transport(transport)
     except ValueError:
-        _stderr_console.print(f"[red]Invalid transport {transport!r}. Must be 'stdio' or 'sse'.[/red]")
+        _stderr_console.print(
+            f"[red]Invalid transport {transport!r}. Must be 'stdio' or 'sse'.[/red]"
+        )
         raise typer.Exit(code=1)
 
     # Create EventStore with custom path if provided

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -17,7 +17,7 @@ from typing import Annotated
 from rich.console import Console
 import typer
 
-from ouroboros.cli.formatters.panels import print_error, print_info, print_success
+from ouroboros.cli.formatters.panels import print_info, print_success
 
 # PID file for detecting stale instances
 _PID_DIR = Path.home() / ".ouroboros"
@@ -191,7 +191,7 @@ async def _run_mcp_server(
     try:
         transport = validate_transport(transport)
     except ValueError:
-        print_error(f"Invalid transport {transport!r}. Must be 'stdio' or 'sse'.")
+        _stderr_console.print(f"[red]Invalid transport {transport!r}. Must be 'stdio' or 'sse'.[/red]")
         raise typer.Exit(code=1)
 
     # Create EventStore with custom path if provided

--- a/tests/unit/cli/test_mcp_validate_transport_stderr.py
+++ b/tests/unit/cli/test_mcp_validate_transport_stderr.py
@@ -9,15 +9,14 @@ These tests ensure the invariant holds so it cannot be accidentally broken.
 
 from __future__ import annotations
 
-import os
-import subprocess
-import sys
-from pathlib import Path
+import asyncio
+from unittest.mock import patch
 
 import pytest
+import typer
 
+from ouroboros.cli.commands.mcp import _run_mcp_server, _stderr_console
 from ouroboros.mcp.server.adapter import validate_transport
-
 
 # ---------------------------------------------------------------------------
 # Unit: validate_transport rejects bad values and accepts good ones
@@ -31,7 +30,10 @@ def test_validate_transport_rejects_invalid(bad_transport: str) -> None:
         validate_transport(bad_transport)
 
 
-@pytest.mark.parametrize("good_transport,expected", [("stdio", "stdio"), ("sse", "sse"), ("STDIO", "stdio"), ("SSE", "sse")])
+@pytest.mark.parametrize(
+    "good_transport,expected",
+    [("stdio", "stdio"), ("sse", "sse"), ("STDIO", "stdio"), ("SSE", "sse")],
+)
 def test_validate_transport_accepts_valid(good_transport: str, expected: str) -> None:
     """validate_transport must accept and lowercase known transports."""
     assert validate_transport(good_transport) == expected
@@ -48,8 +50,6 @@ def test_stderr_console_is_configured_for_stderr() -> None:
     This is the critical invariant: in stdio mode, stdout is the JSON-RPC
     channel, so all human-readable diagnostics must go to stderr.
     """
-    from ouroboros.cli.commands.mcp import _stderr_console
-
     assert _stderr_console.stderr is True, (
         "_stderr_console must be created with stderr=True to avoid "
         "corrupting the JSON-RPC channel on stdout"
@@ -57,50 +57,63 @@ def test_stderr_console_is_configured_for_stderr() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Integration: subprocess test ensuring stdout stays clean
+# Integration: invalid transport writes diagnostic to stderr and exits non-zero
 # ---------------------------------------------------------------------------
 
-# Locate the ``src/`` directory for the current source tree so the subprocess
-# picks up the same code the test suite is running against (important when
-# the repo is checked out in a worktree separate from the editable install).
-_SRC_DIR = str(Path(__file__).resolve().parents[3] / "src")
 
-
-def test_invalid_transport_keeps_stdout_clean_subprocess() -> None:
+def test_invalid_transport_keeps_stdout_clean(capfd, monkeypatch) -> None:
     """stdout must stay empty when an invalid transport is passed.
 
-    Uses a real subprocess so stdout and stderr are truly separate,
-    unlike typer's CliRunner which mixes the streams.  This is the
-    definitive regression test for JSON-RPC corruption prevention.
+    Uses pytest's ``capfd`` fixture to capture real file-descriptor output
+    (what a subprocess or MCP client would actually see), without relying on
+    an out-of-process test which is fragile in CI (env leakage, editable
+    install path, shell profile loading, etc.).
+
+    The definitive regression guard for JSON-RPC corruption prevention:
+    in stdio mode, any byte on stdout corrupts the protocol, so invalid
+    transport diagnostics must go to stderr only.
     """
-    env = os.environ.copy()
-    # Ensure the subprocess loads the source tree under test.
-    env["PYTHONPATH"] = _SRC_DIR + os.pathsep + env.get("PYTHONPATH", "")
+    # Ensure the nested-guard sentinel is clear so we exercise the real
+    # validate_transport path (not the early `typer.Exit(0)` shortcut).
+    monkeypatch.delenv("_OUROBOROS_NESTED", raising=False)
 
-    result = subprocess.run(
-        [
-            sys.executable, "-c",
-            "import sys; sys.argv = ['ouroboros', 'mcp', 'serve', '--transport', 'INVALID']; "
-            "from ouroboros.cli.main import app; app()",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        env=env,
-    )
+    # Drain any pre-existing buffered output from prior test logging so the
+    # capture below only reflects bytes emitted by _run_mcp_server.
+    capfd.readouterr()
 
-    # Command must exit with non-zero code
-    assert result.returncode != 0, (
-        f"Expected non-zero exit code for invalid transport, got {result.returncode}"
-    )
+    # Patch _ensure_shell_env to a no-op: it can spawn a login shell which is
+    # slow and irrelevant to this regression and may also emit diagnostics.
+    with patch("ouroboros.cli.commands.mcp._ensure_shell_env", lambda **_: None):
+        with pytest.raises(typer.Exit) as excinfo:
+            asyncio.run(_run_mcp_server("localhost", 8080, "INVALID"))
 
-    # stdout must be empty -- any bytes here would corrupt JSON-RPC in stdio mode
-    assert result.stdout.strip() == "", (
-        f"stdout must be empty to prevent JSON-RPC corruption but contained: "
-        f"{result.stdout!r}"
+    # The invalid-transport path must signal failure
+    assert excinfo.value.exit_code == 1
+
+    captured = capfd.readouterr()
+
+    # stdout must be empty — any bytes here would corrupt JSON-RPC in stdio mode
+    assert captured.out == "", (
+        f"stdout must be empty to prevent JSON-RPC corruption but contained: {captured.out!r}"
     )
 
     # stderr must contain the diagnostic
-    assert "Invalid transport" in result.stderr, (
-        f"Expected 'Invalid transport' in stderr but got: {result.stderr!r}"
+    assert "Invalid transport" in captured.err, (
+        f"Expected 'Invalid transport' in stderr but got: {captured.err!r}"
     )
+
+
+def test_stderr_console_print_does_not_leak_to_stdout(capfd) -> None:
+    """_stderr_console.print output must land on stderr, never stdout.
+
+    Complements the integration test above: this directly exercises the
+    console configuration so any regression in how ``_stderr_console`` is
+    constructed will be caught even if the command-level flow changes.
+    """
+    capfd.readouterr()  # drain
+
+    _stderr_console.print("[red]Invalid transport: http[/red]")
+
+    captured = capfd.readouterr()
+    assert captured.out == "", f"stdout must be clean but got: {captured.out!r}"
+    assert "Invalid transport" in captured.err

--- a/tests/unit/cli/test_mcp_validate_transport_stderr.py
+++ b/tests/unit/cli/test_mcp_validate_transport_stderr.py
@@ -1,0 +1,106 @@
+"""Regression test: invalid transport errors go to stderr, not stdout.
+
+In stdio mode stdout is the JSON-RPC channel.  If validation errors leak
+to stdout they corrupt the protocol.  The fix in mcp.py routes all
+human-readable output through ``_stderr_console`` (``Console(stderr=True)``).
+
+These tests ensure the invariant holds so it cannot be accidentally broken.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ouroboros.mcp.server.adapter import validate_transport
+
+
+# ---------------------------------------------------------------------------
+# Unit: validate_transport rejects bad values and accepts good ones
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_transport", ["http", "ws", "grpc", "invalid", "", "BOGUS"])
+def test_validate_transport_rejects_invalid(bad_transport: str) -> None:
+    """validate_transport must raise ValueError for unknown transports."""
+    with pytest.raises(ValueError, match="Invalid transport"):
+        validate_transport(bad_transport)
+
+
+@pytest.mark.parametrize("good_transport,expected", [("stdio", "stdio"), ("sse", "sse"), ("STDIO", "stdio"), ("SSE", "sse")])
+def test_validate_transport_accepts_valid(good_transport: str, expected: str) -> None:
+    """validate_transport must accept and lowercase known transports."""
+    assert validate_transport(good_transport) == expected
+
+
+# ---------------------------------------------------------------------------
+# Configuration: _stderr_console must write to stderr, not stdout
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_console_is_configured_for_stderr() -> None:
+    """The module-level _stderr_console must write to stderr, not stdout.
+
+    This is the critical invariant: in stdio mode, stdout is the JSON-RPC
+    channel, so all human-readable diagnostics must go to stderr.
+    """
+    from ouroboros.cli.commands.mcp import _stderr_console
+
+    assert _stderr_console.stderr is True, (
+        "_stderr_console must be created with stderr=True to avoid "
+        "corrupting the JSON-RPC channel on stdout"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: subprocess test ensuring stdout stays clean
+# ---------------------------------------------------------------------------
+
+# Locate the ``src/`` directory for the current source tree so the subprocess
+# picks up the same code the test suite is running against (important when
+# the repo is checked out in a worktree separate from the editable install).
+_SRC_DIR = str(Path(__file__).resolve().parents[3] / "src")
+
+
+def test_invalid_transport_keeps_stdout_clean_subprocess() -> None:
+    """stdout must stay empty when an invalid transport is passed.
+
+    Uses a real subprocess so stdout and stderr are truly separate,
+    unlike typer's CliRunner which mixes the streams.  This is the
+    definitive regression test for JSON-RPC corruption prevention.
+    """
+    env = os.environ.copy()
+    # Ensure the subprocess loads the source tree under test.
+    env["PYTHONPATH"] = _SRC_DIR + os.pathsep + env.get("PYTHONPATH", "")
+
+    result = subprocess.run(
+        [
+            sys.executable, "-c",
+            "import sys; sys.argv = ['ouroboros', 'mcp', 'serve', '--transport', 'INVALID']; "
+            "from ouroboros.cli.main import app; app()",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+
+    # Command must exit with non-zero code
+    assert result.returncode != 0, (
+        f"Expected non-zero exit code for invalid transport, got {result.returncode}"
+    )
+
+    # stdout must be empty -- any bytes here would corrupt JSON-RPC in stdio mode
+    assert result.stdout.strip() == "", (
+        f"stdout must be empty to prevent JSON-RPC corruption but contained: "
+        f"{result.stdout!r}"
+    )
+
+    # stderr must contain the diagnostic
+    assert "Invalid transport" in result.stderr, (
+        f"Expected 'Invalid transport' in stderr but got: {result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

v0.28.2 moved error output in `serve()` to `_stderr_console` to prevent JSON-RPC channel corruption in stdio mode, but missed one call site in `_run_mcp_server()`:

- **Line 194**: `print_error()` (stdout) → `_stderr_console.print()` (stderr) for transport validation errors
- Removed unused `print_error` import (only `print_info` and `print_success` remain, used safely in the SSE branch)

Closes #408

## Test plan

- [x] Verified `print_error` is no longer called from any stdio-reachable code path
- [x] 825 MCP-related tests pass
- [x] `print_info`/`print_success` remain in SSE branch only (lines 274-277, 292) where stdout is safe