### PR TITLE
fix(security): add path validation and size limit to _extract_public_api

### DIFF
--- a/src/ouroboros/orchestrator/level_context.py
+++ b/src/ouroboros/orchestrator/level_context.py
@@ -8,7 +8,9 @@ through file system exploration.
 Usage:
     from ouroboros.orchestrator.level_context import extract_level_context
 
-    context = extract_level_context(results, level_num=0)
+    context = extract_level_context(
+        results, level_num=0, workspace_root="/path/to/session/workspace"
+    )
     prompt_text = context.to_prompt_text()
 """
 
@@ -39,7 +41,7 @@ _MAX_FILE_SIZE_BYTES = 1_048_576
 _MAX_FILES_FOR_API = 20
 
 
-def _extract_public_api(file_path: str) -> list[str]:
+def _extract_public_api(file_path: str, workspace_root: str) -> list[str]:
     """Extract public API signatures from a source file.
 
     Reads the file and extracts top-level public definitions:
@@ -47,12 +49,27 @@ def _extract_public_api(file_path: str) -> list[str]:
     - TypeScript/JS: exported functions/classes/interfaces/types
     - Go: exported (capitalized) func/type signatures
 
+    Args:
+        file_path: Path to the source file to scan.
+        workspace_root: Required workspace directory. Files whose resolved
+            path falls outside this root are rejected (defence in depth against
+            callers that forget to pre-filter). May be passed raw or already
+            resolved — this function applies realpath() internally.
+
     Returns list of signature strings like:
         ["class UserService", "def get_user(id: str) -> User"]
     """
+    if not workspace_root:
+        # Required sentinel — empty root means reject everything.
+        return []
     try:
+        resolved_root = os.path.realpath(workspace_root)
         # Resolve symlinks to prevent symlink-based path traversal
         resolved = os.path.realpath(file_path)
+        # Defence-in-depth: reject paths outside the workspace root even if
+        # callers skipped their own containment check.
+        if resolved != resolved_root and not resolved.startswith(resolved_root + os.sep):
+            return []
         # Check file size before reading to avoid memory exhaustion
         if os.path.getsize(resolved) > _MAX_FILE_SIZE_BYTES:
             return []
@@ -110,22 +127,27 @@ def _extract_public_api(file_path: str) -> list[str]:
 
 def _build_public_api_summary(
     files_modified: tuple[str, ...],
-    workspace_root: str | None = None,
+    *,
+    workspace_root: str,
 ) -> str:
     """Build a public API summary across all modified files.
 
     Args:
         files_modified: Tuple of file paths to scan.
-        workspace_root: If provided, only files whose realpath falls within
-            this directory are processed (prevents path-traversal reads).
+        workspace_root: Required workspace directory. Only files whose
+            realpath falls within this directory are processed. Passing an
+            empty string or a path outside any expected tree will cause all
+            files to be rejected — there is no bypass path.
 
     Returns a compact string like:
         user_service.py: class UserService, def get_user(id: str) -> User;
         models.py: class User
     """
-    resolved_root: str | None = None
-    if workspace_root is not None:
-        resolved_root = os.path.realpath(workspace_root)
+    if not workspace_root:
+        # Explicitly reject empty paths: a missing workspace would be a
+        # containment bypass if silently treated as "/" or CWD.
+        return ""
+    resolved_root = os.path.realpath(workspace_root)
 
     parts: list[str] = []
     processed = 0
@@ -135,14 +157,10 @@ def _build_public_api_summary(
         if not os.path.isfile(file_path):
             continue
         # Path containment check: skip files outside workspace
-        if resolved_root is not None:
-            resolved_file = os.path.realpath(file_path)
-            if (
-                not resolved_file.startswith(resolved_root + os.sep)
-                and resolved_file != resolved_root
-            ):
-                continue
-        sigs = _extract_public_api(file_path)
+        resolved_file = os.path.realpath(file_path)
+        if not resolved_file.startswith(resolved_root + os.sep) and resolved_file != resolved_root:
+            continue
+        sigs = _extract_public_api(file_path, resolved_root)
         processed += 1
         if sigs:
             basename = os.path.basename(file_path)
@@ -282,7 +300,8 @@ def build_context_prompt(level_contexts: list[LevelContext]) -> str:
 def extract_level_context(
     ac_results: list[tuple[int, str, bool, tuple[AgentMessage, ...], str]],
     level_num: int,
-    workspace_root: str | None = None,
+    *,
+    workspace_root: str,
 ) -> LevelContext:
     """Extract context from completed AC results in a level.
 
@@ -290,7 +309,10 @@ def extract_level_context(
         ac_results: List of (ac_index, ac_content, success, messages, final_message)
             tuples from the completed level.
         level_num: Level number for tracking.
-        workspace_root: If provided, restricts file reads to this directory tree.
+        workspace_root: Required workspace directory that bounds all file
+            reads performed while building public-API summaries. Callers that
+            do not have a session workspace MUST pass an explicit sentinel
+            (e.g., ``os.getcwd()`` or a temp dir) — there is no silent bypass.
 
     Returns:
         LevelContext with summaries of completed work.

--- a/src/ouroboros/orchestrator/level_context.py
+++ b/src/ouroboros/orchestrator/level_context.py
@@ -33,6 +33,10 @@ _MAX_KEY_OUTPUT_CHARS = 200
 _MAX_LEVEL_CONTEXT_CHARS = 2000
 # Maximum characters for public API summary per AC
 _MAX_PUBLIC_API_CHARS = 500
+# Maximum file size (bytes) to read for API extraction (1 MB)
+_MAX_FILE_SIZE_BYTES = 1_048_576
+# Maximum number of files to process for public API summary
+_MAX_FILES_FOR_API = 20
 
 
 def _extract_public_api(file_path: str) -> list[str]:
@@ -47,7 +51,12 @@ def _extract_public_api(file_path: str) -> list[str]:
         ["class UserService", "def get_user(id: str) -> User"]
     """
     try:
-        with open(file_path) as f:
+        # Resolve symlinks to prevent symlink-based path traversal
+        resolved = os.path.realpath(file_path)
+        # Check file size before reading to avoid memory exhaustion
+        if os.path.getsize(resolved) > _MAX_FILE_SIZE_BYTES:
+            return []
+        with open(resolved) as f:
             content = f.read()
     except (OSError, UnicodeDecodeError):
         return []
@@ -99,18 +108,39 @@ def _extract_public_api(file_path: str) -> list[str]:
     return signatures
 
 
-def _build_public_api_summary(files_modified: tuple[str, ...]) -> str:
+def _build_public_api_summary(
+    files_modified: tuple[str, ...],
+    workspace_root: str | None = None,
+) -> str:
     """Build a public API summary across all modified files.
+
+    Args:
+        files_modified: Tuple of file paths to scan.
+        workspace_root: If provided, only files whose realpath falls within
+            this directory are processed (prevents path-traversal reads).
 
     Returns a compact string like:
         user_service.py: class UserService, def get_user(id: str) -> User;
         models.py: class User
     """
+    resolved_root: str | None = None
+    if workspace_root is not None:
+        resolved_root = os.path.realpath(workspace_root)
+
     parts: list[str] = []
+    processed = 0
     for file_path in files_modified:
+        if processed >= _MAX_FILES_FOR_API:
+            break
         if not os.path.isfile(file_path):
             continue
+        # Path containment check: skip files outside workspace
+        if resolved_root is not None:
+            resolved_file = os.path.realpath(file_path)
+            if not resolved_file.startswith(resolved_root + os.sep) and resolved_file != resolved_root:
+                continue
         sigs = _extract_public_api(file_path)
+        processed += 1
         if sigs:
             basename = os.path.basename(file_path)
             parts.append(f"{basename}: {', '.join(sigs)}")
@@ -249,6 +279,7 @@ def build_context_prompt(level_contexts: list[LevelContext]) -> str:
 def extract_level_context(
     ac_results: list[tuple[int, str, bool, tuple[AgentMessage, ...], str]],
     level_num: int,
+    workspace_root: str | None = None,
 ) -> LevelContext:
     """Extract context from completed AC results in a level.
 
@@ -256,6 +287,7 @@ def extract_level_context(
         ac_results: List of (ac_index, ac_content, success, messages, final_message)
             tuples from the completed level.
         level_num: Level number for tracking.
+        workspace_root: If provided, restricts file reads to this directory tree.
 
     Returns:
         LevelContext with summaries of completed work.
@@ -281,7 +313,11 @@ def extract_level_context(
             key_output = final_message[-_MAX_KEY_OUTPUT_CHARS:].strip()
 
         sorted_files = tuple(sorted(files_modified))
-        public_api = _build_public_api_summary(sorted_files) if success else ""
+        public_api = (
+            _build_public_api_summary(sorted_files, workspace_root=workspace_root)
+            if success
+            else ""
+        )
 
         summaries.append(
             ACContextSummary(

--- a/src/ouroboros/orchestrator/level_context.py
+++ b/src/ouroboros/orchestrator/level_context.py
@@ -137,7 +137,10 @@ def _build_public_api_summary(
         # Path containment check: skip files outside workspace
         if resolved_root is not None:
             resolved_file = os.path.realpath(file_path)
-            if not resolved_file.startswith(resolved_root + os.sep) and resolved_file != resolved_root:
+            if (
+                not resolved_file.startswith(resolved_root + os.sep)
+                and resolved_file != resolved_root
+            ):
                 continue
         sigs = _extract_public_api(file_path)
         processed += 1

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1886,7 +1886,11 @@ class ParallelACExecutor:
                         for r in stage_ac_results
                         if r.ac_index in executable
                     ]
-                    level_ctx = extract_level_context(level_ac_data, level_num)
+                    level_ctx = extract_level_context(
+                        level_ac_data,
+                        level_num,
+                        workspace_root=self._task_cwd,
+                    )
 
                     # Coordinator: detect and resolve file conflicts (Approach A)
                     level_ac_results = [r for r in stage_ac_results if r.ac_index in executable]

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -31,6 +31,7 @@ import asyncio
 from dataclasses import replace
 from datetime import UTC, datetime
 import json
+import os
 import platform
 import re
 import subprocess
@@ -1886,10 +1887,15 @@ class ParallelACExecutor:
                         for r in stage_ac_results
                         if r.ac_index in executable
                     ]
+                    # workspace_root is required: fall back through
+                    # adapter working directory, then process cwd. Never None.
+                    workspace_root = (
+                        self._task_cwd or self._adapter.working_directory or os.getcwd()
+                    )
                     level_ctx = extract_level_context(
                         level_ac_data,
                         level_num,
-                        workspace_root=self._task_cwd,
+                        workspace_root=workspace_root,
                     )
 
                     # Coordinator: detect and resolve file conflicts (Approach A)

--- a/tests/unit/orchestrator/test_level_context.py
+++ b/tests/unit/orchestrator/test_level_context.py
@@ -225,25 +225,25 @@ class TestBuildContextPrompt:
 class TestExtractLevelContext:
     """Tests for extract_level_context function."""
 
-    def test_extract_from_empty_results(self) -> None:
+    def test_extract_from_empty_results(self, tmp_path: object) -> None:
         """Test extraction from empty result list."""
-        ctx = extract_level_context([], level_num=0)
+        ctx = extract_level_context([], level_num=0, workspace_root=str(tmp_path))
         assert ctx.level_number == 0
         assert ctx.completed_acs == ()
 
-    def test_extract_basic_context(self) -> None:
+    def test_extract_basic_context(self, tmp_path: object) -> None:
         """Test extracting context from simple AC results."""
         results = [
             (0, "Create the model", True, (), "Model created successfully"),
         ]
-        ctx = extract_level_context(results, level_num=1)
+        ctx = extract_level_context(results, level_num=1, workspace_root=str(tmp_path))
         assert ctx.level_number == 1
         assert len(ctx.completed_acs) == 1
         assert ctx.completed_acs[0].ac_index == 0
         assert ctx.completed_acs[0].success is True
         assert "Model created" in ctx.completed_acs[0].key_output
 
-    def test_extract_tools_and_files(self) -> None:
+    def test_extract_tools_and_files(self, tmp_path: object) -> None:
         """Test that tools and modified files are extracted from messages."""
         messages = (
             AgentMessage(type="tool", content="", tool_name="Read"),
@@ -264,7 +264,7 @@ class TestExtractLevelContext:
         results = [
             (0, "Implement feature", True, messages, "Feature implemented"),
         ]
-        ctx = extract_level_context(results, level_num=0)
+        ctx = extract_level_context(results, level_num=0, workspace_root=str(tmp_path))
         summary = ctx.completed_acs[0]
 
         assert "Bash" in summary.tools_used
@@ -274,29 +274,29 @@ class TestExtractLevelContext:
         assert "src/main.py" in summary.files_modified
         assert "src/utils.py" in summary.files_modified
 
-    def test_extract_truncates_key_output(self) -> None:
+    def test_extract_truncates_key_output(self, tmp_path: object) -> None:
         """Test that key_output is truncated to max chars."""
         long_output = "x" * 500
         results = [
             (0, "Big task", True, (), long_output),
         ]
-        ctx = extract_level_context(results, level_num=0)
+        ctx = extract_level_context(results, level_num=0, workspace_root=str(tmp_path))
         assert len(ctx.completed_acs[0].key_output) <= 200
 
-    def test_extract_multiple_acs(self) -> None:
+    def test_extract_multiple_acs(self, tmp_path: object) -> None:
         """Test extracting context from multiple ACs."""
         results = [
             (0, "AC zero", True, (), "Done zero"),
             (1, "AC one", False, (), "Failed one"),
             (2, "AC two", True, (), "Done two"),
         ]
-        ctx = extract_level_context(results, level_num=0)
+        ctx = extract_level_context(results, level_num=0, workspace_root=str(tmp_path))
         assert len(ctx.completed_acs) == 3
         assert ctx.completed_acs[0].success is True
         assert ctx.completed_acs[1].success is False
         assert ctx.completed_acs[2].success is True
 
-    def test_extract_notebook_edit_file_tracking(self) -> None:
+    def test_extract_notebook_edit_file_tracking(self, tmp_path: object) -> None:
         """Test that NotebookEdit file paths are tracked alongside Write/Edit."""
         messages = (
             AgentMessage(
@@ -315,7 +315,7 @@ class TestExtractLevelContext:
         results = [
             (0, "Update notebook and code", True, messages, "Done"),
         ]
-        ctx = extract_level_context(results, level_num=0)
+        ctx = extract_level_context(results, level_num=0, workspace_root=str(tmp_path))
         summary = ctx.completed_acs[0]
         assert "notebooks/analysis.ipynb" in summary.files_modified
         assert "src/main.py" in summary.files_modified
@@ -453,7 +453,7 @@ class TestExtractPublicApi:
             "async def create_user(name: str, email: str) -> User:\n"
             "    pass\n"
         )
-        sigs = _extract_public_api(str(p))
+        sigs = _extract_public_api(str(p), str(tmp_path))
         assert "class UserService" in sigs
         assert "def get_user(id: str) -> User" in sigs
         assert any("async def create_user" in s for s in sigs)
@@ -473,7 +473,7 @@ class TestExtractPublicApi:
             "def public_fn() -> str:\n"
             "    pass\n"
         )
-        sigs = _extract_public_api(str(p))
+        sigs = _extract_public_api(str(p), str(tmp_path))
         assert len(sigs) == 1
         assert "public_fn" in sigs[0]
 
@@ -490,7 +490,7 @@ class TestExtractPublicApi:
             ") -> dict[str, Any]:\n"
             "    pass\n"
         )
-        sigs = _extract_public_api(str(p))
+        sigs = _extract_public_api(str(p), str(tmp_path))
         assert len(sigs) == 1
         assert "arg1: str" in sigs[0]
         assert "arg2: int" in sigs[0]
@@ -516,7 +516,7 @@ class TestExtractPublicApi:
             "\n"
             "function privateHelper() {}\n"
         )
-        sigs = _extract_public_api(str(p))
+        sigs = _extract_public_api(str(p), str(tmp_path))
         assert any("getUser" in s for s in sigs)
         assert any("UserController" in s for s in sigs)
         assert any("UserDTO" in s for s in sigs)
@@ -538,14 +538,16 @@ class TestExtractPublicApi:
             "\n"
             "func privateHelper() {}\n"
         )
-        sigs = _extract_public_api(str(p))
+        sigs = _extract_public_api(str(p), str(tmp_path))
         assert any("GetUser" in s for s in sigs)
         assert any("UserService" in s for s in sigs)
         assert not any("privateHelper" in s for s in sigs)
 
-    def test_nonexistent_file(self) -> None:
+    def test_nonexistent_file(self, tmp_path: object) -> None:
         """Test that nonexistent files return empty list."""
-        assert _extract_public_api("/nonexistent/file.py") == []
+        # Point both file and workspace inside tmp_path so rejection is
+        # driven by OSError from getsize(), not by containment.
+        assert _extract_public_api(str(tmp_path) + "/nonexistent.py", str(tmp_path)) == []
 
     def test_unsupported_extension(self, tmp_path: object) -> None:
         """Test that unsupported file types return empty list."""
@@ -553,7 +555,7 @@ class TestExtractPublicApi:
 
         p = pathlib.Path(str(tmp_path)) / "data.json"
         p.write_text('{"key": "value"}')
-        assert _extract_public_api(str(p)) == []
+        assert _extract_public_api(str(p), str(tmp_path)) == []
 
     def test_file_exceeding_size_limit_returns_empty(self, tmp_path: object) -> None:
         """Test that files larger than _MAX_FILE_SIZE_BYTES are skipped."""
@@ -562,7 +564,7 @@ class TestExtractPublicApi:
         p = pathlib.Path(str(tmp_path)) / "huge.py"
         # Write a file just over the limit
         p.write_text("class Big:\n    pass\n" + "x" * (_MAX_FILE_SIZE_BYTES + 1))
-        assert _extract_public_api(str(p)) == []
+        assert _extract_public_api(str(p), str(tmp_path)) == []
 
     def test_file_within_size_limit_is_read(self, tmp_path: object) -> None:
         """Test that files within _MAX_FILE_SIZE_BYTES are read normally."""
@@ -570,7 +572,7 @@ class TestExtractPublicApi:
 
         p = pathlib.Path(str(tmp_path)) / "small.py"
         p.write_text("class Small:\n    pass\n")
-        sigs = _extract_public_api(str(p))
+        sigs = _extract_public_api(str(p), str(tmp_path))
         assert "class Small" in sigs
 
     def test_symlink_resolved_before_read(self, tmp_path: object) -> None:
@@ -582,7 +584,7 @@ class TestExtractPublicApi:
         link = pathlib.Path(str(tmp_path)) / "link.py"
         link.symlink_to(real_file)
 
-        sigs = _extract_public_api(str(link))
+        sigs = _extract_public_api(str(link), str(tmp_path))
         assert "class RealClass" in sigs
 
     def test_symlink_to_large_file_returns_empty(self, tmp_path: object) -> None:
@@ -594,7 +596,7 @@ class TestExtractPublicApi:
         link = pathlib.Path(str(tmp_path)) / "link_to_huge.py"
         link.symlink_to(real_file)
 
-        assert _extract_public_api(str(link)) == []
+        assert _extract_public_api(str(link), str(tmp_path)) == []
 
 
 class TestBuildPublicApiSummary:
@@ -609,7 +611,10 @@ class TestBuildPublicApiSummary:
         p2 = pathlib.Path(str(tmp_path)) / "service.py"
         p2.write_text("def get_user(id: str) -> User:\n    pass\n")
 
-        summary = _build_public_api_summary((str(p1), str(p2)))
+        summary = _build_public_api_summary(
+            (str(p1), str(p2)),
+            workspace_root=str(tmp_path),
+        )
         assert "models.py:" in summary
         assert "service.py:" in summary
         assert "class User" in summary
@@ -623,12 +628,18 @@ class TestBuildPublicApiSummary:
         lines = [f"def function_{i}(arg: str) -> str:\n    pass\n" for i in range(100)]
         p.write_text("\n".join(lines))
 
-        summary = _build_public_api_summary((str(p),))
+        summary = _build_public_api_summary(
+            (str(p),),
+            workspace_root=str(tmp_path),
+        )
         assert len(summary) <= 500
 
-    def test_summary_skips_missing_files(self) -> None:
+    def test_summary_skips_missing_files(self, tmp_path: object) -> None:
         """Test that missing files are silently skipped."""
-        summary = _build_public_api_summary(("/nonexistent/a.py", "/nonexistent/b.py"))
+        summary = _build_public_api_summary(
+            (str(tmp_path) + "/nonexistent/a.py", str(tmp_path) + "/nonexistent/b.py"),
+            workspace_root=str(tmp_path),
+        )
         assert summary == ""
 
     def test_workspace_root_rejects_outside_files(self, tmp_path: object) -> None:
@@ -698,15 +709,31 @@ class TestBuildPublicApiSummary:
         finally:
             pathlib.Path(outside_path).unlink(missing_ok=True)
 
-    def test_no_workspace_root_allows_all_files(self, tmp_path: object) -> None:
-        """Test that without workspace_root, all valid files are processed."""
+    def test_empty_workspace_root_rejects_all_files(self, tmp_path: object) -> None:
+        """Test that an empty workspace_root yields an empty summary.
+
+        Regression guard for the previous ``workspace_root=None`` default
+        which silently disabled path containment. The contract is now: no
+        workspace, no reads — there is no silent bypass.
+        """
         import pathlib
 
         p = pathlib.Path(str(tmp_path)) / "anywhere.py"
         p.write_text("class Anywhere:\n    pass\n")
 
-        summary = _build_public_api_summary((str(p),), workspace_root=None)
-        assert "class Anywhere" in summary
+        summary = _build_public_api_summary((str(p),), workspace_root="")
+        assert summary == ""
+
+    def test_workspace_root_is_required_kwarg(self, tmp_path: object) -> None:
+        """Test that workspace_root has no default (callers MUST pass it)."""
+        import pathlib
+
+        p = pathlib.Path(str(tmp_path)) / "x.py"
+        p.write_text("class X:\n    pass\n")
+
+        with pytest.raises(TypeError):
+            # mypy: keep the check narrow — this is a runtime contract guard.
+            _build_public_api_summary((str(p),))  # type: ignore[call-arg]
 
     def test_file_cap_limits_processed_files(self, tmp_path: object) -> None:
         """Test that at most _MAX_FILES_FOR_API files are processed."""
@@ -719,7 +746,10 @@ class TestBuildPublicApiSummary:
             p.write_text(f"class Class{i}:\n    pass\n")
             paths.append(str(p))
 
-        summary = _build_public_api_summary(tuple(paths))
+        summary = _build_public_api_summary(
+            tuple(paths),
+            workspace_root=str(workspace),
+        )
         # Count how many distinct "mod_N.py:" entries appear
         import re as _re
 

--- a/tests/unit/orchestrator/test_level_context.py
+++ b/tests/unit/orchestrator/test_level_context.py
@@ -7,6 +7,8 @@ import pytest
 from ouroboros.orchestrator.adapter import AgentMessage
 from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict
 from ouroboros.orchestrator.level_context import (
+    _MAX_FILE_SIZE_BYTES,
+    _MAX_FILES_FOR_API,
     ACContextSummary,
     LevelContext,
     _build_public_api_summary,
@@ -553,6 +555,47 @@ class TestExtractPublicApi:
         p.write_text('{"key": "value"}')
         assert _extract_public_api(str(p)) == []
 
+    def test_file_exceeding_size_limit_returns_empty(self, tmp_path: object) -> None:
+        """Test that files larger than _MAX_FILE_SIZE_BYTES are skipped."""
+        import pathlib
+
+        p = pathlib.Path(str(tmp_path)) / "huge.py"
+        # Write a file just over the limit
+        p.write_text("class Big:\n    pass\n" + "x" * (_MAX_FILE_SIZE_BYTES + 1))
+        assert _extract_public_api(str(p)) == []
+
+    def test_file_within_size_limit_is_read(self, tmp_path: object) -> None:
+        """Test that files within _MAX_FILE_SIZE_BYTES are read normally."""
+        import pathlib
+
+        p = pathlib.Path(str(tmp_path)) / "small.py"
+        p.write_text("class Small:\n    pass\n")
+        sigs = _extract_public_api(str(p))
+        assert "class Small" in sigs
+
+    def test_symlink_resolved_before_read(self, tmp_path: object) -> None:
+        """Test that symlinks are resolved via realpath before reading."""
+        import pathlib
+
+        real_file = pathlib.Path(str(tmp_path)) / "real.py"
+        real_file.write_text("class RealClass:\n    pass\n")
+        link = pathlib.Path(str(tmp_path)) / "link.py"
+        link.symlink_to(real_file)
+
+        sigs = _extract_public_api(str(link))
+        assert "class RealClass" in sigs
+
+    def test_symlink_to_large_file_returns_empty(self, tmp_path: object) -> None:
+        """Test that symlinks to oversized files are rejected after resolution."""
+        import pathlib
+
+        real_file = pathlib.Path(str(tmp_path)) / "huge_real.py"
+        real_file.write_text("class Big:\n    pass\n" + "x" * (_MAX_FILE_SIZE_BYTES + 1))
+        link = pathlib.Path(str(tmp_path)) / "link_to_huge.py"
+        link.symlink_to(real_file)
+
+        assert _extract_public_api(str(link)) == []
+
 
 class TestBuildPublicApiSummary:
     """Tests for _build_public_api_summary."""
@@ -587,6 +630,101 @@ class TestBuildPublicApiSummary:
         """Test that missing files are silently skipped."""
         summary = _build_public_api_summary(("/nonexistent/a.py", "/nonexistent/b.py"))
         assert summary == ""
+
+    def test_workspace_root_rejects_outside_files(self, tmp_path: object) -> None:
+        """Test that files outside workspace_root are skipped."""
+        import pathlib
+        import tempfile
+
+        workspace = pathlib.Path(str(tmp_path)) / "project"
+        workspace.mkdir()
+        inside = workspace / "service.py"
+        inside.write_text("class InsideService:\n    pass\n")
+
+        # Create a file outside the workspace
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+            f.write("class OutsideService:\n    pass\n")
+            outside_path = f.name
+
+        try:
+            summary = _build_public_api_summary(
+                (str(inside), outside_path),
+                workspace_root=str(workspace),
+            )
+            assert "InsideService" in summary
+            assert "OutsideService" not in summary
+        finally:
+            pathlib.Path(outside_path).unlink(missing_ok=True)
+
+    def test_workspace_root_allows_inside_files(self, tmp_path: object) -> None:
+        """Test that files inside workspace_root are processed normally."""
+        import pathlib
+
+        workspace = pathlib.Path(str(tmp_path)) / "project"
+        workspace.mkdir()
+        f = workspace / "models.py"
+        f.write_text("class User:\n    pass\n")
+
+        summary = _build_public_api_summary(
+            (str(f),),
+            workspace_root=str(workspace),
+        )
+        assert "class User" in summary
+
+    def test_workspace_root_rejects_symlink_escape(self, tmp_path: object) -> None:
+        """Test that symlinks pointing outside workspace are rejected."""
+        import pathlib
+        import tempfile
+
+        workspace = pathlib.Path(str(tmp_path)) / "project"
+        workspace.mkdir()
+
+        # Create a file outside the workspace
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
+            f.write("class EscapedClass:\n    pass\n")
+            outside_path = f.name
+
+        # Symlink inside workspace pointing outside
+        link = workspace / "sneaky.py"
+        link.symlink_to(outside_path)
+
+        try:
+            summary = _build_public_api_summary(
+                (str(link),),
+                workspace_root=str(workspace),
+            )
+            assert "EscapedClass" not in summary
+            assert summary == ""
+        finally:
+            pathlib.Path(outside_path).unlink(missing_ok=True)
+
+    def test_no_workspace_root_allows_all_files(self, tmp_path: object) -> None:
+        """Test that without workspace_root, all valid files are processed."""
+        import pathlib
+
+        p = pathlib.Path(str(tmp_path)) / "anywhere.py"
+        p.write_text("class Anywhere:\n    pass\n")
+
+        summary = _build_public_api_summary((str(p),), workspace_root=None)
+        assert "class Anywhere" in summary
+
+    def test_file_cap_limits_processed_files(self, tmp_path: object) -> None:
+        """Test that at most _MAX_FILES_FOR_API files are processed."""
+        import pathlib
+
+        workspace = pathlib.Path(str(tmp_path))
+        paths: list[str] = []
+        for i in range(_MAX_FILES_FOR_API + 5):
+            p = workspace / f"mod_{i}.py"
+            p.write_text(f"class Class{i}:\n    pass\n")
+            paths.append(str(p))
+
+        summary = _build_public_api_summary(tuple(paths))
+        # Count how many distinct "mod_N.py:" entries appear
+        import re as _re
+
+        file_entries = _re.findall(r"mod_\d+\.py:", summary)
+        assert len(file_entries) <= _MAX_FILES_FOR_API
 
 
 class TestPromptTextWithPublicApi:


### PR DESCRIPTION
## Summary

- **File size check**: `_extract_public_api()` now checks `os.path.getsize()` against a 1 MB limit (`_MAX_FILE_SIZE_BYTES`) before reading, preventing memory exhaustion from oversized files.
- **Symlink resolution**: `os.path.realpath()` is called before any file read, preventing symlink-based path traversal attacks.
- **Workspace containment**: `_build_public_api_summary()` accepts an optional `workspace_root` parameter; files whose resolved path falls outside the workspace are skipped.
- **File count cap**: At most `_MAX_FILES_FOR_API` (20) files are processed per summary call, bounding resource usage.
- **Caller wiring**: `extract_level_context()` accepts and forwards `workspace_root`; `ParallelACExecutor` passes `self._task_cwd` as the workspace root.

Closes #399

## Test plan

- [x] File exceeding size limit returns empty list
- [x] File within size limit is read normally
- [x] Symlink resolution works (reads through symlink)
- [x] Symlink to oversized file is rejected after resolution
- [x] Path containment rejects files outside workspace_root
- [x] Path containment allows files inside workspace_root
- [x] Symlink escape (symlink inside workspace pointing outside) is rejected
- [x] No workspace_root allows all files (backward compatibility)
- [x] File cap limits processed files to _MAX_FILES_FOR_API
- [x] All 46 tests pass (`uv run pytest tests/unit/orchestrator/test_level_context.py -v`)