### PR TITLE
fix(orchestrator): validate dependencies before external satisfaction check (#401)

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1674,13 +1674,15 @@ class ParallelACExecutor:
                     if ac_idx < 0 or ac_idx >= total_acs:
                         continue
 
-                    if ac_idx in external_completed:
-                        externally_satisfied.append(ac_idx)
-                        continue
-
+                    # Always validate dependencies first — even externally
+                    # satisfied ACs must be blocked if their upstream
+                    # dependencies failed, because the "satisfied" state may
+                    # be stale relative to the current execution.
                     deps = execution_plan.get_dependencies(ac_idx)
                     if any(dep in failed_indices or dep in blocked_indices for dep in deps):
                         blocked.append(ac_idx)
+                    elif ac_idx in external_completed:
+                        externally_satisfied.append(ac_idx)
                     else:
                         executable.append(ac_idx)
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -790,6 +790,69 @@ class TestParallelACExecutor:
         assert "abc1234" in result.results[0].final_message
         executor._execute_ac_batch.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_externally_satisfied_ac_blocked_when_dependency_failed(self) -> None:
+        """Externally satisfied ACs must be BLOCKED when an upstream dep failed.
+
+        Regression guard for #401: a stale --skip-completed marker must never
+        bypass dependency validation. If AC0 fails and AC1 (which depends on
+        AC0) is flagged externally_satisfied, AC1 must be BLOCKED — not
+        SATISFIED_EXTERNALLY — because the supposed satisfied state is stale
+        relative to the current failed run.
+        """
+        seed = _make_seed("AC 0 foundation", "AC 1 dependent flow")
+        dependency_graph = DependencyGraph(
+            nodes=(
+                ACNode(index=0, content=seed.acceptance_criteria[0], depends_on=()),
+                ACNode(index=1, content=seed.acceptance_criteria[1], depends_on=(0,)),
+            ),
+            execution_levels=((0,), (1,)),
+        )
+        executor = _make_executor()
+        executed_batches: list[list[int]] = []
+
+        async def fake_execute_ac_batch(**kwargs: Any) -> list[ACExecutionResult]:
+            batch_indices = list(kwargs["batch_indices"])
+            executed_batches.append(batch_indices)
+            return [
+                ACExecutionResult(
+                    ac_index=ac_index,
+                    ac_content=seed.acceptance_criteria[ac_index],
+                    success=False,
+                    error="Foundation failed",
+                    outcome=ACExecutionOutcome.FAILED,
+                )
+                for ac_index in batch_indices
+            ]
+
+        executor._execute_ac_batch = fake_execute_ac_batch  # type: ignore[method-assign]
+
+        result = await executor.execute_parallel(
+            seed=seed,
+            execution_plan=dependency_graph.to_execution_plan(),
+            session_id="orch_stale_external_satisfied",
+            execution_id="exec_stale_external_satisfied",
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            externally_satisfied_acs={
+                1: {"reason": "Previously satisfied", "commit": "deadbeef"},
+            },
+        )
+
+        # Only AC0 should be executed (and fails). AC1 must NOT run even
+        # though it was flagged externally satisfied — its upstream dep failed.
+        assert executed_batches == [[0]]
+
+        ac1_result = next(r for r in result.results if r.ac_index == 1)
+        assert ac1_result.outcome == ACExecutionOutcome.BLOCKED
+        assert ac1_result.success is False
+        assert ac1_result.error == "Skipped: dependency failed"
+
+        assert result.externally_satisfied_count == 0
+        assert result.blocked_count == 1
+        assert result.failure_count == 1
+
     def test_verification_report_emits_depth_warning_feedback_metadata(self) -> None:
         """Verification report should expose depth warnings as structured metadata."""
         parallel_result = ParallelExecutionResult(


### PR DESCRIPTION
## Summary
- **Bug**: In `execute_parallel()`, ACs marked as externally satisfied (e.g. from checkpoint recovery or evolve-cycle carry-over) bypassed dependency validation entirely. If an upstream AC had failed, the externally satisfied downstream AC would still be treated as PASS — a false positive.
- **Fix**: Dependency validation now runs first for ALL ACs. Only if dependencies are healthy does external satisfaction take effect. If upstream deps failed/blocked, the AC is blocked regardless of its external status.
- **Scope**: Surgical change to a single loop in `ParallelACExecutor.execute_parallel()` (~30 lines added).

## Test plan
- [x] Existing test suite passes (34/34 relevant tests pass; 2 pre-existing unrelated failures in decomposition depth tests)
- [ ] Manual verification: execute a seed where AC2 depends on AC1, AC2 is externally satisfied, but AC1 fails — AC2 should now be BLOCKED instead of false-positive PASS

Fixes #401