### PR TITLE
refactor(evaluate): run Stage 1 once in multi-AC checklist path

### DIFF
--- a/src/ouroboros/evaluation/checklist.py
+++ b/src/ouroboros/evaluation/checklist.py
@@ -1,0 +1,240 @@
+"""Per-AC checklist aggregation for evaluation pipeline (#366).
+
+The evaluation pipeline already evaluates one acceptance criterion at a time
+via ``EvaluationContext.current_ac``.  Orchestration layers
+(``parallel_executor``, ``runner``) already dispatch one evaluation per AC.
+
+What was missing is a lightweight, reusable aggregator that:
+
+1. Collects individual ``EvaluationResult`` objects into a single
+   checklist view (pass/fail per AC, evidence, questions used).
+2. Computes aggregate metrics the user can read at a glance
+   (pass rate, failed items, overall verdict).
+3. Generates actionable feedback for the Run stage when items fail.
+
+This module is **purely additive**.  Nothing in the evaluation pipeline
+is required to use it — existing callers remain unchanged.  Callers that
+want the checklist view simply pass their collected results through
+``aggregate_results``.
+
+Ties in with Phase 1 (#363) milestones: when the interview reaches the
+READY milestone (ambiguity <= 0.2), every AC from that Seed should pass
+when routed through this checklist.  That is the concrete quality gate
+the milestones promise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.evaluation.models import EvaluationResult
+
+
+@dataclass(frozen=True, slots=True)
+class ACCheckItem:
+    """Per-AC checklist entry.
+
+    Attributes:
+        ac_text: The acceptance criterion as written in the Seed.
+        passed: True when the evaluation pipeline approved this AC.
+        reasoning: Evaluator's explanation (from Stage 2 reasoning).
+        evidence: Concrete evidence the evaluator relied on (#367 field).
+        questions_used: Socratic questions the evaluator asked (#367 field).
+        failure_reason: Human-readable reason when ``passed`` is False.
+            This is the feedback a Run re-attempt should address.
+    """
+
+    ac_text: str
+    passed: bool
+    reasoning: str = ""
+    evidence: tuple[str, ...] = ()
+    questions_used: tuple[str, ...] = ()
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ACChecklistResult:
+    """Aggregated checklist across multiple AC evaluations.
+
+    Attributes:
+        items: Per-AC entries in the same order they were provided.
+        total: Total number of AC items.
+        passed_count: Number of items with ``passed == True``.
+    """
+
+    items: tuple[ACCheckItem, ...]
+    total: int
+    passed_count: int
+
+    @property
+    def failed_items(self) -> tuple[ACCheckItem, ...]:
+        """Return only items whose evaluation did not pass."""
+        return tuple(item for item in self.items if not item.passed)
+
+    @property
+    def all_passed(self) -> bool:
+        """True when every AC passed. Empty checklist returns False.
+
+        An empty checklist is treated as "not ready" — a Seed with zero
+        ACs is definitionally incomplete (see Phase 1 milestone READY
+        criteria), so we refuse to mark it complete.
+        """
+        return self.total > 0 and self.passed_count == self.total
+
+    @property
+    def pass_rate(self) -> float:
+        """Ratio of passed items to total (0.0 for empty checklist)."""
+        if self.total == 0:
+            return 0.0
+        return self.passed_count / self.total
+
+
+def _evaluation_passed(result: EvaluationResult) -> bool:
+    """Return True when an EvaluationResult represents an overall pass."""
+    return result.final_approved
+
+
+def _derive_failure_reason(result: EvaluationResult) -> str | None:
+    """Extract a concise failure reason from an EvaluationResult."""
+    if result.final_approved:
+        return None
+    reason = result.failure_reason
+    if reason:
+        return reason
+    # Fallback: Stage 2 reasoning if available.
+    if result.stage2_result and result.stage2_result.reasoning:
+        return result.stage2_result.reasoning
+    return "Evaluation did not approve this AC."
+
+
+def _extract_stage2_fields(
+    result: EvaluationResult,
+) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    """Pull reasoning / evidence / questions_used from Stage 2, if present."""
+    if result.stage2_result is None:
+        return "", (), ()
+    s2 = result.stage2_result
+    return (
+        s2.reasoning,
+        getattr(s2, "evidence", ()),
+        getattr(s2, "questions_used", ()),
+    )
+
+
+def aggregate_results(
+    ac_texts: tuple[str, ...],
+    results: tuple[EvaluationResult, ...],
+) -> ACChecklistResult:
+    """Aggregate per-AC EvaluationResult objects into a checklist.
+
+    Args:
+        ac_texts: The acceptance criteria, in the same order their
+            evaluations were performed.
+        results: Parallel evaluation results, one per AC.
+
+    Returns:
+        Aggregated ``ACChecklistResult``.
+
+    Raises:
+        ValueError: If ``ac_texts`` and ``results`` have different lengths.
+    """
+    if len(ac_texts) != len(results):
+        msg = (
+            f"ac_texts and results must be the same length "
+            f"(got {len(ac_texts)} ACs vs {len(results)} results)"
+        )
+        raise ValueError(msg)
+
+    items: list[ACCheckItem] = []
+    for ac, result in zip(ac_texts, results, strict=True):
+        passed = _evaluation_passed(result)
+        reasoning, evidence, questions_used = _extract_stage2_fields(result)
+        items.append(
+            ACCheckItem(
+                ac_text=ac,
+                passed=passed,
+                reasoning=reasoning,
+                evidence=evidence,
+                questions_used=questions_used,
+                failure_reason=_derive_failure_reason(result),
+            )
+        )
+
+    passed_count = sum(1 for item in items if item.passed)
+    return ACChecklistResult(
+        items=tuple(items),
+        total=len(items),
+        passed_count=passed_count,
+    )
+
+
+def format_checklist(checklist: ACChecklistResult) -> str:
+    """Render a human-readable checklist for display to the user.
+
+    Output is intentionally plain text so callers can embed it in MCP
+    responses, CLI output, or TUI panels without extra formatting.
+
+    Args:
+        checklist: Aggregated checklist to render.
+
+    Returns:
+        Multi-line string suitable for direct display.
+    """
+    lines: list[str] = []
+    header_status = "ALL PASSED" if checklist.all_passed else "INCOMPLETE"
+    lines.append(
+        f"Acceptance Criteria Checklist [{header_status}] "
+        f"({checklist.passed_count}/{checklist.total} passed, "
+        f"{checklist.pass_rate:.0%})"
+    )
+    lines.append("=" * 60)
+
+    for index, item in enumerate(checklist.items, start=1):
+        marker = "[x]" if item.passed else "[ ]"
+        lines.append(f"{marker} {index}. {item.ac_text}")
+        if not item.passed and item.failure_reason:
+            lines.append(f"    Reason: {item.failure_reason}")
+        if item.questions_used:
+            lines.append("    Questions Used:")
+            for question in item.questions_used:
+                lines.append(f"      - {question}")
+        if item.evidence:
+            lines.append("    Evidence:")
+            for evidence in item.evidence:
+                lines.append(f"      - {evidence}")
+
+    if not checklist.all_passed and checklist.failed_items:
+        lines.append("")
+        lines.append("Next Steps:")
+        lines.append(f"  {len(checklist.failed_items)} AC(s) need to be re-addressed in Run.")
+
+    return "\n".join(lines)
+
+
+def build_run_feedback(checklist: ACChecklistResult) -> tuple[str, ...]:
+    """Build structured feedback to hand back to the Run stage.
+
+    Only failed items contribute feedback.  Each entry identifies the
+    AC text and the specific failure reason so the Run re-attempt can
+    target the gap instead of regenerating everything.
+
+    Args:
+        checklist: Aggregated checklist.
+
+    Returns:
+        Tuple of feedback strings, one per failed AC.
+    """
+    feedback: list[str] = []
+    for item in checklist.failed_items:
+        reason = item.failure_reason or "Evaluation did not approve this AC."
+        feedback.append(f"AC not met: {item.ac_text} — {reason}")
+    return tuple(feedback)
+
+
+__all__ = [
+    "ACCheckItem",
+    "ACChecklistResult",
+    "aggregate_results",
+    "build_run_feedback",
+    "format_checklist",
+]

--- a/src/ouroboros/evaluation/pipeline.py
+++ b/src/ouroboros/evaluation/pipeline.py
@@ -21,6 +21,7 @@ from ouroboros.evaluation.models import (
     CheckType,
     EvaluationContext,
     EvaluationResult,
+    MechanicalResult,
 )
 from ouroboros.evaluation.semantic import SemanticConfig, SemanticEvaluator
 from ouroboros.evaluation.trigger import (
@@ -87,27 +88,74 @@ class EvaluationPipeline:
         self._consensus = ConsensusEvaluator(llm_adapter, self._config.consensus)
         self._trigger = ConsensusTrigger(self._config.trigger)
 
+    async def run_stage1(
+        self,
+        context: EvaluationContext,
+    ) -> Result[
+        tuple[MechanicalResult | None, list[BaseEvent]],
+        ProviderError | ValidationError,
+    ]:
+        """Run Stage 1 (mechanical verification) in isolation.
+
+        Returns ``(MechanicalResult, events)`` or ``(None, [])`` when
+        Stage 1 is disabled.  Callers can feed the result into
+        :meth:`evaluate` via ``stage1_result`` to avoid re-running
+        the AC-agnostic lint/build/test checks in multi-AC loops.
+        """
+        if not self._config.stage1_enabled:
+            return Result.ok((None, []))
+
+        result = await self._mechanical.verify(
+            context.execution_id,
+            checks=[
+                CheckType.LINT,
+                CheckType.BUILD,
+                CheckType.TEST,
+                CheckType.STATIC,
+                CheckType.COVERAGE,
+            ],
+        )
+        if result.is_err:
+            return Result.err(result.error)
+
+        stage1_result, stage1_events = result.value
+        return Result.ok((stage1_result, list(stage1_events)))
+
     async def evaluate(
         self,
         context: EvaluationContext,
         trigger_context: TriggerContext | None = None,
+        *,
+        stage1_result: MechanicalResult | None = None,
     ) -> Result[EvaluationResult, ProviderError | ValidationError]:
         """Run the evaluation pipeline.
 
         Args:
             context: Evaluation context with artifact
             trigger_context: Optional pre-populated trigger context
+            stage1_result: Pre-computed Stage 1 result.  When provided,
+                Stage 1 is skipped and this result is reused.  Pass the
+                output of :meth:`run_stage1` to avoid re-running
+                mechanical verification in multi-AC loops.
 
         Returns:
             Result containing EvaluationResult or error
         """
         events: list[BaseEvent] = []
-        stage1_result = None
         stage2_result = None
         stage3_result = None
 
         # Stage 1: Mechanical Verification
-        if self._config.stage1_enabled:
+        # When a pre-computed result is injected, skip re-running.
+        if stage1_result is not None:
+            if not stage1_result.passed:
+                return self._build_result(
+                    context.execution_id,
+                    events,
+                    stage1_result=stage1_result,
+                    final_approved=False,
+                )
+        elif self._config.stage1_enabled:
             result = await self._mechanical.verify(
                 context.execution_id,
                 checks=[
@@ -124,7 +172,6 @@ class EvaluationPipeline:
             stage1_result, stage1_events = result.value
             events.extend(stage1_events)
 
-            # If Stage 1 fails, stop here
             if not stage1_result.passed:
                 return self._build_result(
                     context.execution_id,

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -628,6 +628,81 @@ class EvaluateHandler:
             format_checklist,
         )
 
+        log.info(
+            "mcp.tool.evaluate.multi_ac_started",
+            session_id=session_id,
+            ac_count=len(acceptance_criteria),
+        )
+
+        # Run Stage 1 (mechanical verification) once.  Lint/build/test
+        # results are project-wide and AC-agnostic, so sharing them
+        # across per-AC evaluations avoids N redundant runs.
+        stage1_ctx = EvaluationContext(
+            execution_id=session_id,
+            seed_id=seed_id,
+            current_ac=acceptance_criteria[0],
+            artifact=artifact,
+            artifact_type=artifact_type,
+            goal=goal,
+            constraints=constraints,
+            trigger_consensus=trigger_consensus,
+            artifact_bundle=artifact_bundle,
+        )
+        stage1_pre = await pipeline.run_stage1(stage1_ctx)  # type: ignore[attr-defined]
+        if stage1_pre.is_err:
+            return Result.err(
+                MCPToolError(
+                    f"Stage 1 mechanical verification failed: {stage1_pre.error}",
+                    tool_name="ouroboros_evaluate",
+                )
+            )
+        pre_stage1_result, _ = stage1_pre.value
+
+        # If Stage 1 failed, short-circuit before per-AC semantic runs.
+        if pre_stage1_result is not None and not pre_stage1_result.passed:
+            from ouroboros.evaluation.models import EvaluationResult as _ER
+
+            fail = _ER(
+                execution_id=session_id,
+                stage1_result=pre_stage1_result,
+                final_approved=False,
+            )
+            fail_results = tuple(fail for _ in acceptance_criteria)
+            checklist = aggregate_results(acceptance_criteria, fail_results)
+            feedback = build_run_feedback(checklist)
+            code_changes = await self._has_code_changes(working_dir)
+            text = format_checklist(checklist)
+            if code_changes is False:
+                text += "\nNote: no code changes detected in the working tree."
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text=text),),
+                    is_error=False,
+                    meta={
+                        "session_id": session_id,
+                        "final_approved": False,
+                        "multi_ac": True,
+                        "ac_count": checklist.total,
+                        "passed_count": 0,
+                        "pass_rate": 0.0,
+                        "checklist": [
+                            {
+                                "ac_text": item.ac_text,
+                                "passed": item.passed,
+                                "reasoning": item.reasoning,
+                                "evidence": list(item.evidence),
+                                "questions_used": list(item.questions_used),
+                                "failure_reason": item.failure_reason,
+                            }
+                            for item in checklist.items
+                        ],
+                        "run_feedback": list(feedback),
+                        "code_changes_detected": code_changes,
+                    },
+                )
+            )
+
+        # Stage 2+3 per-AC in parallel, injecting the shared Stage 1 result.
         async def _run_one(ac_text: str) -> Result[object, object]:
             context = EvaluationContext(
                 execution_id=session_id,
@@ -640,13 +715,10 @@ class EvaluateHandler:
                 trigger_consensus=trigger_consensus,
                 artifact_bundle=artifact_bundle,
             )
-            return await pipeline.evaluate(context)  # type: ignore[attr-defined]
-
-        log.info(
-            "mcp.tool.evaluate.multi_ac_started",
-            session_id=session_id,
-            ac_count=len(acceptance_criteria),
-        )
+            return await pipeline.evaluate(  # type: ignore[attr-defined]
+                context,
+                stage1_result=pre_stage1_result,
+            )
 
         gathered = await asyncio.gather(
             *(_run_one(ac) for ac in acceptance_criteria),

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -279,6 +279,17 @@ class EvaluateHandler:
                     required=False,
                 ),
                 MCPToolParameter(
+                    name="acceptance_criteria",
+                    type=ToolInputType.ARRAY,
+                    description=(
+                        "Multiple acceptance criteria for checklist evaluation. "
+                        "When two or more items are provided, each AC is evaluated "
+                        "independently and the results are aggregated into a "
+                        "pass/fail checklist (#366). Overrides acceptance_criterion."
+                    ),
+                    required=False,
+                ),
+                MCPToolParameter(
                     name="artifact_type",
                     type=ToolInputType.STRING,
                     description="Type of artifact: code, docs, config. Default: code",
@@ -349,13 +360,25 @@ class EvaluateHandler:
 
         seed_content = arguments.get("seed_content")
         acceptance_criterion = arguments.get("acceptance_criterion")
+        acceptance_criteria_raw = arguments.get("acceptance_criteria")
         artifact_type = arguments.get("artifact_type", "code")
         trigger_consensus = arguments.get("trigger_consensus", False)
+
+        # Normalize the optional multi-AC list (#366): filter out empty/blank
+        # entries so callers can safely pass `[""]` or an accidental null.
+        acceptance_criteria: tuple[str, ...] = ()
+        if isinstance(acceptance_criteria_raw, list):
+            acceptance_criteria = tuple(
+                str(item).strip()
+                for item in acceptance_criteria_raw
+                if isinstance(item, (str, int, float)) and str(item).strip()
+            )
 
         log.info(
             "mcp.tool.evaluate",
             session_id=session_id,
             has_seed=seed_content is not None,
+            multi_ac_count=len(acceptance_criteria),
             trigger_consensus=trigger_consensus,
         )
 
@@ -440,6 +463,33 @@ class EvaluateHandler:
                 )
                 artifact_bundle = None
 
+            mechanical_config = build_mechanical_config(working_dir)
+            config = PipelineConfig(
+                mechanical=mechanical_config,
+                semantic=SemanticConfig(model=get_semantic_model(self.llm_backend)),
+            )
+            pipeline = EvaluationPipeline(llm_adapter, config)
+
+            # Multi-AC checklist path (#366):
+            # When the caller provides >= 2 acceptance criteria we run the
+            # pipeline once per AC and aggregate the results into a
+            # checklist.  Single-AC callers keep the original single-pass
+            # behaviour — no extra cost or behaviour change for them.
+            if len(acceptance_criteria) >= 2:
+                return await self._handle_multi_ac(
+                    session_id=session_id,
+                    seed_id=seed_id,
+                    acceptance_criteria=acceptance_criteria,
+                    artifact=artifact,
+                    artifact_type=artifact_type,
+                    goal=goal,
+                    constraints=constraints,
+                    trigger_consensus=trigger_consensus,
+                    artifact_bundle=artifact_bundle,
+                    pipeline=pipeline,
+                    working_dir=working_dir,
+                )
+
             context = EvaluationContext(
                 execution_id=session_id,
                 seed_id=seed_id,
@@ -451,12 +501,6 @@ class EvaluateHandler:
                 trigger_consensus=trigger_consensus,
                 artifact_bundle=artifact_bundle,
             )
-            mechanical_config = build_mechanical_config(working_dir)
-            config = PipelineConfig(
-                mechanical=mechanical_config,
-                semantic=SemanticConfig(model=get_semantic_model(self.llm_backend)),
-            )
-            pipeline = EvaluationPipeline(llm_adapter, config)
             result = await pipeline.evaluate(context)
 
             if result.is_err:
@@ -537,6 +581,144 @@ class EvaluateHandler:
         finally:
             if owns_event_store and store is not None:
                 await store.close()
+
+    async def _handle_multi_ac(
+        self,
+        *,
+        session_id: str,
+        seed_id: str,
+        acceptance_criteria: tuple[str, ...],
+        artifact: str,
+        artifact_type: str,
+        goal: str,
+        constraints: tuple[str, ...],
+        trigger_consensus: bool,
+        artifact_bundle: object | None,
+        pipeline: object,  # EvaluationPipeline — typed as object to avoid import cycle
+        working_dir: Path,
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Evaluate each AC individually and return an aggregated checklist (#366).
+
+        Runs the evaluation pipeline once per acceptance criterion in
+        parallel via ``asyncio.gather``.  Per-AC results are then folded
+        into a single ``ACChecklistResult`` so the caller sees one
+        pass/fail checklist with per-item evidence and failure reasons.
+
+        Single-AC callers never reach this path — see ``handle()``.
+        """
+        import asyncio
+
+        from ouroboros.evaluation import EvaluationContext
+        from ouroboros.evaluation.checklist import (
+            aggregate_results,
+            build_run_feedback,
+            format_checklist,
+        )
+
+        async def _run_one(ac_text: str) -> Result[object, object]:
+            context = EvaluationContext(
+                execution_id=session_id,
+                seed_id=seed_id,
+                current_ac=ac_text,
+                artifact=artifact,
+                artifact_type=artifact_type,
+                goal=goal,
+                constraints=constraints,
+                trigger_consensus=trigger_consensus,
+                artifact_bundle=artifact_bundle,
+            )
+            return await pipeline.evaluate(context)  # type: ignore[attr-defined]
+
+        log.info(
+            "mcp.tool.evaluate.multi_ac_started",
+            session_id=session_id,
+            ac_count=len(acceptance_criteria),
+        )
+
+        gathered = await asyncio.gather(
+            *(_run_one(ac) for ac in acceptance_criteria),
+            return_exceptions=True,
+        )
+
+        # Any exception or err-Result aborts the whole checklist —
+        # otherwise we'd aggregate over a half-evaluated set.
+        for entry in gathered:
+            if isinstance(entry, BaseException):
+                log.exception(
+                    "mcp.tool.evaluate.multi_ac_exception",
+                    session_id=session_id,
+                )
+                return Result.err(
+                    MCPToolError(
+                        f"Evaluation failed during multi-AC run: {entry}",
+                        tool_name="ouroboros_evaluate",
+                    )
+                )
+            if entry.is_err:  # type: ignore[union-attr]
+                err = entry.error  # type: ignore[union-attr]
+                rendered = err.format_details() if hasattr(err, "format_details") else str(err)
+                log.warning(
+                    "mcp.tool.evaluate.multi_ac_pipeline_failed",
+                    session_id=session_id,
+                    error=rendered,
+                )
+                return Result.err(
+                    MCPToolError(
+                        f"Evaluation failed: {rendered}",
+                        tool_name="ouroboros_evaluate",
+                    )
+                )
+
+        eval_results = tuple(entry.value for entry in gathered)  # type: ignore[union-attr]
+        checklist = aggregate_results(acceptance_criteria, eval_results)
+        feedback = build_run_feedback(checklist)
+
+        code_changes: bool | None = None
+        if any(r.stage1_result and not r.stage1_result.passed for r in eval_results):
+            code_changes = await self._has_code_changes(working_dir)
+
+        text_parts = [format_checklist(checklist)]
+        if code_changes is False:
+            text_parts.append("\nNote: no code changes detected in the working tree.")
+        result_text = "\n".join(text_parts)
+
+        meta = {
+            "session_id": session_id,
+            "final_approved": checklist.all_passed,
+            "multi_ac": True,
+            "ac_count": checklist.total,
+            "passed_count": checklist.passed_count,
+            "pass_rate": checklist.pass_rate,
+            "checklist": [
+                {
+                    "ac_text": item.ac_text,
+                    "passed": item.passed,
+                    "reasoning": item.reasoning,
+                    "evidence": list(item.evidence),
+                    "questions_used": list(item.questions_used),
+                    "failure_reason": item.failure_reason,
+                }
+                for item in checklist.items
+            ],
+            "run_feedback": list(feedback),
+            "code_changes_detected": code_changes,
+        }
+
+        log.info(
+            "mcp.tool.evaluate.multi_ac_completed",
+            session_id=session_id,
+            passed=checklist.passed_count,
+            total=checklist.total,
+            all_passed=checklist.all_passed,
+        )
+
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text=result_text),),
+                is_error=False,
+                meta=meta,
+            )
+        )
 
     async def _has_code_changes(self, working_dir: Path) -> bool | None:
         """Detect whether the working tree has code changes.

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -364,8 +364,13 @@ class EvaluateHandler:
         artifact_type = arguments.get("artifact_type", "code")
         trigger_consensus = arguments.get("trigger_consensus", False)
 
-        # Normalize the optional multi-AC list (#366): filter out empty/blank
-        # entries so callers can safely pass `[""]` or an accidental null.
+        # Normalize all AC inputs into a single tuple (#366 fix):
+        # 1. If acceptance_criteria (plural, ARRAY) has valid entries, use them.
+        # 2. Else if acceptance_criterion (singular, STRING) is set, wrap it.
+        # 3. Else empty — single-AC path will use a default.
+        # This ensures a 1-item list is honoured as the effective AC,
+        # fixing the contract violation where the input shape was accepted
+        # but its meaning was silently ignored.
         acceptance_criteria: tuple[str, ...] = ()
         if isinstance(acceptance_criteria_raw, list):
             acceptance_criteria = tuple(
@@ -373,6 +378,8 @@ class EvaluateHandler:
                 for item in acceptance_criteria_raw
                 if isinstance(item, (str, int, float)) and str(item).strip()
             )
+        if not acceptance_criteria and acceptance_criterion and str(acceptance_criterion).strip():
+            acceptance_criteria = (str(acceptance_criterion).strip(),)
 
         log.info(
             "mcp.tool.evaluate",
@@ -417,8 +424,14 @@ class EvaluateHandler:
                 except Exception:
                     pass  # Best-effort enrichment
 
-            # Use acceptance_criterion or derive from seed
-            current_ac = acceptance_criterion or "Verify execution output meets requirements"
+            # Derive current_ac from the unified acceptance_criteria tuple.
+            # The tuple already incorporates both the plural and singular params,
+            # so we only need to index or fall back to a default.
+            current_ac = (
+                acceptance_criteria[0]
+                if acceptance_criteria
+                else "Verify execution output meets requirements"
+            )
 
             # Evaluation reads multiple spec files (one Read call per AC).
             # Use a dedicated adapter with a higher turn budget — the shared

--- a/tests/unit/evaluation/test_checklist.py
+++ b/tests/unit/evaluation/test_checklist.py
@@ -1,0 +1,392 @@
+"""Unit tests for the per-AC checklist aggregator (#366)."""
+
+import pytest
+
+from ouroboros.evaluation.checklist import (
+    ACCheckItem,
+    ACChecklistResult,
+    aggregate_results,
+    build_run_feedback,
+    format_checklist,
+)
+from ouroboros.evaluation.models import (
+    CheckResult,
+    CheckType,
+    EvaluationResult,
+    MechanicalResult,
+    SemanticResult,
+)
+
+
+def _build_semantic_result(
+    *,
+    score: float,
+    ac_compliance: bool,
+    goal_alignment: float,
+    drift_score: float,
+    uncertainty: float,
+    reasoning: str,
+    evidence: tuple[str, ...] = (),
+    questions_used: tuple[str, ...] = (),
+) -> SemanticResult:
+    """Build a SemanticResult, tolerating codebases without #367 fields.
+
+    This keeps the checklist tests runnable both on branches where
+    ``questions_used``/``evidence`` already exist on ``SemanticResult``
+    (PR #383) and on branches where they do not (plain main).
+    """
+    kwargs = {
+        "score": score,
+        "ac_compliance": ac_compliance,
+        "goal_alignment": goal_alignment,
+        "drift_score": drift_score,
+        "uncertainty": uncertainty,
+        "reasoning": reasoning,
+    }
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+    if "evidence" in field_names:
+        kwargs["evidence"] = evidence
+    if "questions_used" in field_names:
+        kwargs["questions_used"] = questions_used
+    return SemanticResult(**kwargs)
+
+
+def _passing_evaluation(
+    *,
+    execution_id: str = "exec",
+    reasoning: str = "",
+    evidence: tuple[str, ...] = (),
+    questions_used: tuple[str, ...] = (),
+) -> EvaluationResult:
+    """Build an EvaluationResult that passes end-to-end."""
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage1_result=MechanicalResult(
+            passed=True,
+            checks=(
+                CheckResult(
+                    check_type=CheckType.LINT,
+                    passed=True,
+                    message="ok",
+                ),
+            ),
+        ),
+        stage2_result=_build_semantic_result(
+            score=0.9,
+            ac_compliance=True,
+            goal_alignment=0.95,
+            drift_score=0.05,
+            uncertainty=0.1,
+            reasoning=reasoning,
+            evidence=evidence,
+            questions_used=questions_used,
+        ),
+        final_approved=True,
+    )
+
+
+def _failing_evaluation(
+    *,
+    execution_id: str = "exec",
+    reasoning: str = "Stage 2 found a gap",
+) -> EvaluationResult:
+    """Build an EvaluationResult that fails at Stage 2."""
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage2_result=_build_semantic_result(
+            score=0.4,
+            ac_compliance=False,
+            goal_alignment=0.5,
+            drift_score=0.5,
+            uncertainty=0.3,
+            reasoning=reasoning,
+        ),
+        final_approved=False,
+    )
+
+
+class TestACCheckItem:
+    """Tests for ACCheckItem dataclass."""
+
+    def test_defaults(self) -> None:
+        """ACCheckItem has sensible defaults for optional fields."""
+        item = ACCheckItem(ac_text="User can login", passed=True)
+
+        assert item.ac_text == "User can login"
+        assert item.passed is True
+        assert item.reasoning == ""
+        assert item.evidence == ()
+        assert item.questions_used == ()
+        assert item.failure_reason is None
+
+    def test_with_evidence_and_questions(self) -> None:
+        """ACCheckItem preserves evidence and question tuples."""
+        item = ACCheckItem(
+            ac_text="Login must be secure",
+            passed=True,
+            reasoning="Uses bcrypt",
+            evidence=("src/auth.py:42",),
+            questions_used=("Does it reject empty passwords?",),
+        )
+
+        assert item.evidence == ("src/auth.py:42",)
+        assert item.questions_used == ("Does it reject empty passwords?",)
+
+
+class TestACChecklistResultProperties:
+    """Tests for ACChecklistResult computed properties."""
+
+    def test_empty_checklist_is_not_all_passed(self) -> None:
+        """An empty checklist is treated as 'not ready', never as all-passed."""
+        checklist = ACChecklistResult(items=(), total=0, passed_count=0)
+
+        assert checklist.all_passed is False
+        assert checklist.pass_rate == 0.0
+        assert checklist.failed_items == ()
+
+    def test_all_passed_true_when_every_item_passes(self) -> None:
+        """all_passed True when passed_count == total and total > 0."""
+        items = (
+            ACCheckItem(ac_text="AC1", passed=True),
+            ACCheckItem(ac_text="AC2", passed=True),
+        )
+        checklist = ACChecklistResult(items=items, total=2, passed_count=2)
+
+        assert checklist.all_passed is True
+        assert checklist.pass_rate == 1.0
+        assert checklist.failed_items == ()
+
+    def test_partial_pass_rate(self) -> None:
+        """pass_rate is a plain ratio."""
+        items = (
+            ACCheckItem(ac_text="AC1", passed=True),
+            ACCheckItem(ac_text="AC2", passed=False, failure_reason="bad"),
+            ACCheckItem(ac_text="AC3", passed=True),
+            ACCheckItem(ac_text="AC4", passed=False),
+        )
+        checklist = ACChecklistResult(items=items, total=4, passed_count=2)
+
+        assert checklist.pass_rate == 0.5
+        assert checklist.all_passed is False
+        assert len(checklist.failed_items) == 2
+
+
+class TestAggregateResults:
+    """Tests for aggregate_results()."""
+
+    def test_length_mismatch_raises(self) -> None:
+        """Mismatched ac_texts and results tuples raise ValueError."""
+        with pytest.raises(ValueError, match="same length"):
+            aggregate_results(
+                ac_texts=("AC1", "AC2"),
+                results=(_passing_evaluation(),),
+            )
+
+    def test_empty_inputs_produce_empty_checklist(self) -> None:
+        """Empty inputs produce an empty (and not-ready) checklist."""
+        checklist = aggregate_results(ac_texts=(), results=())
+
+        assert checklist.total == 0
+        assert checklist.all_passed is False
+
+    def test_all_passing_produces_all_passed_checklist(self) -> None:
+        """When every result is final_approved, checklist is all-passed."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _passing_evaluation(execution_id="e2"),
+        )
+        checklist = aggregate_results(
+            ac_texts=("AC1", "AC2"),
+            results=results,
+        )
+
+        assert checklist.total == 2
+        assert checklist.passed_count == 2
+        assert checklist.all_passed is True
+        assert all(item.failure_reason is None for item in checklist.items)
+
+    def test_mixed_outcomes_capture_failure_reason(self) -> None:
+        """Failing items record a failure_reason derived from Stage 2 reasoning."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _failing_evaluation(
+                execution_id="e2",
+                reasoning="Webhook signature validation missing",
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Charge processed", "Webhook handled"),
+            results=results,
+        )
+
+        assert checklist.passed_count == 1
+        assert checklist.all_passed is False
+        failed = checklist.failed_items
+        assert len(failed) == 1
+        assert failed[0].ac_text == "Webhook handled"
+        assert failed[0].failure_reason is not None
+        assert "AC non-compliance" in failed[0].failure_reason or (
+            "Webhook signature" in (failed[0].failure_reason or "")
+        )
+
+    def test_preserves_evidence_and_questions(self) -> None:
+        """Stage 2 evidence and questions_used carry through to checklist items.
+
+        Only meaningful once #367 (PR #383) lands and ``SemanticResult``
+        exposes those fields.  On earlier code the aggregator falls back
+        to empty tuples — we skip instead of asserting, because the
+        behaviour is provably correct for that code state.
+        """
+        import dataclasses
+
+        field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+        if "evidence" not in field_names or "questions_used" not in field_names:
+            pytest.skip("SemanticResult does not yet carry #367 fields")
+
+        results = (
+            _passing_evaluation(
+                execution_id="e1",
+                reasoning="Bcrypt verified",
+                evidence=("src/auth.py:42", "tests/test_auth.py covers empty pwd"),
+                questions_used=("Does it reject empty passwords?",),
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Login must be secure",),
+            results=results,
+        )
+
+        item = checklist.items[0]
+        assert item.evidence == (
+            "src/auth.py:42",
+            "tests/test_auth.py covers empty pwd",
+        )
+        assert item.questions_used == ("Does it reject empty passwords?",)
+
+    def test_preserves_input_order(self) -> None:
+        """Items appear in the exact order provided."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _failing_evaluation(execution_id="e2"),
+            _passing_evaluation(execution_id="e3"),
+        )
+        checklist = aggregate_results(
+            ac_texts=("first", "second", "third"),
+            results=results,
+        )
+
+        assert [item.ac_text for item in checklist.items] == [
+            "first",
+            "second",
+            "third",
+        ]
+
+
+class TestFormatChecklist:
+    """Tests for format_checklist()."""
+
+    def test_format_all_passed(self) -> None:
+        """All-passed checklist renders with ALL PASSED header and [x] markers."""
+        results = (_passing_evaluation(),)
+        checklist = aggregate_results(
+            ac_texts=("Login works",),
+            results=results,
+        )
+
+        output = format_checklist(checklist)
+
+        assert "ALL PASSED" in output
+        assert "(1/1 passed, 100%)" in output
+        assert "[x] 1. Login works" in output
+
+    def test_format_incomplete_includes_next_steps(self) -> None:
+        """Failing checklist includes INCOMPLETE, [ ] marker, and Next Steps."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _failing_evaluation(
+                execution_id="e2",
+                reasoning="Missing signature check",
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Charge processed", "Webhook validated"),
+            results=results,
+        )
+
+        output = format_checklist(checklist)
+
+        assert "INCOMPLETE" in output
+        assert "(1/2 passed, 50%)" in output
+        assert "[x] 1. Charge processed" in output
+        assert "[ ] 2. Webhook validated" in output
+        assert "Next Steps:" in output
+
+    def test_format_renders_evidence_and_questions(self) -> None:
+        """Evidence and questions_used render under each item when present.
+
+        Only meaningful once #367 (PR #383) exposes those fields.
+        """
+        import dataclasses
+
+        field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+        if "evidence" not in field_names or "questions_used" not in field_names:
+            pytest.skip("SemanticResult does not yet carry #367 fields")
+
+        results = (
+            _passing_evaluation(
+                reasoning="ok",
+                evidence=("src/auth.py:42",),
+                questions_used=("Does it reject empty passwords?",),
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Login works",),
+            results=results,
+        )
+
+        output = format_checklist(checklist)
+
+        assert "Questions Used:" in output
+        assert "Does it reject empty passwords?" in output
+        assert "Evidence:" in output
+        assert "src/auth.py:42" in output
+
+
+class TestBuildRunFeedback:
+    """Tests for build_run_feedback()."""
+
+    def test_empty_when_all_passed(self) -> None:
+        """No feedback when everything passed."""
+        results = (_passing_evaluation(),)
+        checklist = aggregate_results(
+            ac_texts=("Login works",),
+            results=results,
+        )
+
+        assert build_run_feedback(checklist) == ()
+
+    def test_feedback_per_failed_item(self) -> None:
+        """Each failed item produces one feedback string."""
+        results = (
+            _passing_evaluation(execution_id="e1"),
+            _failing_evaluation(
+                execution_id="e2",
+                reasoning="Missing signature check",
+            ),
+            _failing_evaluation(
+                execution_id="e3",
+                reasoning="Refund path not implemented",
+            ),
+        )
+        checklist = aggregate_results(
+            ac_texts=("Charge processed", "Webhook validated", "Refund works"),
+            results=results,
+        )
+
+        feedback = build_run_feedback(checklist)
+
+        assert len(feedback) == 2
+        assert any("Webhook validated" in entry for entry in feedback)
+        assert any("Refund works" in entry for entry in feedback)

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -102,10 +102,8 @@ class TestMultiACRoutingBoundary:
         return mock_pipeline
 
     async def test_single_item_list_uses_single_ac_path(self) -> None:
-        """A 1-element acceptance_criteria list falls back to single-AC path.
-
-        We don't assert the content here — just that the multi-AC meta
-        flag is NOT set, proving the request didn't enter _handle_multi_ac.
+        """A 1-element acceptance_criteria list falls back to single-AC path
+        and the provided AC text is actually used (not the default).
         """
         mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
 
@@ -129,6 +127,61 @@ class TestMultiACRoutingBoundary:
         assert result.is_ok
         # Single-AC path — no multi_ac flag in meta.
         assert result.value.meta.get("multi_ac") is not True
+        # The provided AC text must reach the pipeline, not the default.
+        ctx_arg = mock_pipeline.evaluate.call_args[0][0]
+        assert ctx_arg.current_ac == "Only AC"
+
+    async def test_single_item_list_does_not_use_default_ac(self) -> None:
+        """Regression: a 1-item acceptance_criteria must NOT fall back to the
+        generic default 'Verify execution output meets requirements'.
+        """
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "x = 1",
+                    "acceptance_criteria": ["Payment webhook fires on success"],
+                }
+            )
+
+        ctx_arg = mock_pipeline.evaluate.call_args[0][0]
+        assert ctx_arg.current_ac == "Payment webhook fires on success"
+        assert ctx_arg.current_ac != "Verify execution output meets requirements"
+
+    async def test_singular_acceptance_criterion_forwarded(self) -> None:
+        """The legacy ``acceptance_criterion`` (singular) param sets current_ac."""
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criterion": "Legacy AC",
+                }
+            )
+
+        assert result.is_ok
+        ctx_arg = mock_pipeline.evaluate.call_args[0][0]
+        assert ctx_arg.current_ac == "Legacy AC"
 
     async def test_two_passing_acs_produce_all_passed_checklist(self) -> None:
         """Two ACs both passing → meta.final_approved True, checklist populated."""

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -95,10 +95,12 @@ class TestMultiACRoutingBoundary:
         # `evaluate()` returns Result objects in order per call.
         results_iter = iter(eval_results)
 
-        async def _evaluate(_context: object) -> object:
+        async def _evaluate(_context: object, **kwargs: object) -> object:
             return Result.ok(next(results_iter))
 
         mock_pipeline.evaluate = AsyncMock(side_effect=_evaluate)
+        # run_stage1 returns (None, []) — Stage 1 disabled / passed.
+        mock_pipeline.run_stage1 = AsyncMock(return_value=Result.ok((None, [])))
         return mock_pipeline
 
     async def test_single_item_list_uses_single_ac_path(self) -> None:
@@ -284,6 +286,7 @@ class TestMultiACRoutingBoundary:
     async def test_multi_ac_pipeline_error_propagates(self) -> None:
         """If any AC evaluation errors, the whole handle() returns err."""
         mock_pipeline = AsyncMock()
+        mock_pipeline.run_stage1 = AsyncMock(return_value=Result.ok((None, [])))
         calls = [
             Result.ok(_passing_eval("s4")),
             Result.err(ValueError("semantic stage exploded")),

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -1,0 +1,290 @@
+"""Unit tests for EvaluateHandler multi-AC checklist path (#366).
+
+These tests exercise the new `acceptance_criteria` parameter that turns
+a single evaluate call into a per-AC checklist evaluation.  Single-AC
+behaviour is covered by existing tests in test_definitions.py and is
+deliberately left untouched here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.evaluation.models import (
+    CheckResult,
+    CheckType,
+    EvaluationResult,
+    MechanicalResult,
+    SemanticResult,
+)
+from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler
+from ouroboros.mcp.types import ToolInputType
+
+
+def _semantic_result(*, ac_compliance: bool, score: float, reasoning: str) -> SemanticResult:
+    """Build a SemanticResult tolerant to whether #367 fields exist yet."""
+    import dataclasses
+
+    kwargs = {
+        "score": score,
+        "ac_compliance": ac_compliance,
+        "goal_alignment": 0.9 if ac_compliance else 0.4,
+        "drift_score": 0.1 if ac_compliance else 0.5,
+        "uncertainty": 0.1,
+        "reasoning": reasoning,
+    }
+    field_names = {f.name for f in dataclasses.fields(SemanticResult)}
+    if "evidence" in field_names:
+        kwargs["evidence"] = ()
+    if "questions_used" in field_names:
+        kwargs["questions_used"] = ()
+    return SemanticResult(**kwargs)
+
+
+def _passing_eval(execution_id: str) -> EvaluationResult:
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage1_result=MechanicalResult(
+            passed=True,
+            checks=(CheckResult(check_type=CheckType.LINT, passed=True, message="ok"),),
+        ),
+        stage2_result=_semantic_result(
+            ac_compliance=True,
+            score=0.9,
+            reasoning="AC met",
+        ),
+        final_approved=True,
+    )
+
+
+def _failing_eval(execution_id: str, *, reason: str) -> EvaluationResult:
+    return EvaluationResult(
+        execution_id=execution_id,
+        stage2_result=_semantic_result(
+            ac_compliance=False,
+            score=0.3,
+            reasoning=reason,
+        ),
+        final_approved=False,
+    )
+
+
+class TestDefinitionAcceptsMultiAC:
+    """The tool schema must advertise the new acceptance_criteria parameter."""
+
+    def test_acceptance_criteria_parameter_present(self) -> None:
+        handler = EvaluateHandler()
+        names = {p.name for p in handler.definition.parameters}
+
+        assert "acceptance_criteria" in names
+        assert "acceptance_criterion" in names  # backward-compat
+
+        param = next(p for p in handler.definition.parameters if p.name == "acceptance_criteria")
+        assert param.type == ToolInputType.ARRAY
+        assert param.required is False
+
+
+class TestMultiACRoutingBoundary:
+    """Runtime behaviour of multi-AC routing in handle()."""
+
+    def _install_pipeline_mock(self, eval_results: list[EvaluationResult]) -> MagicMock:
+        mock_pipeline = AsyncMock()
+        # `evaluate()` returns Result objects in order per call.
+        results_iter = iter(eval_results)
+
+        async def _evaluate(_context: object) -> object:
+            return Result.ok(next(results_iter))
+
+        mock_pipeline.evaluate = AsyncMock(side_effect=_evaluate)
+        return mock_pipeline
+
+    async def test_single_item_list_uses_single_ac_path(self) -> None:
+        """A 1-element acceptance_criteria list falls back to single-AC path.
+
+        We don't assert the content here — just that the multi-AC meta
+        flag is NOT set, proving the request didn't enter _handle_multi_ac.
+        """
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criteria": ["Only AC"],
+                }
+            )
+
+        assert result.is_ok
+        # Single-AC path — no multi_ac flag in meta.
+        assert result.value.meta.get("multi_ac") is not True
+
+    async def test_two_passing_acs_produce_all_passed_checklist(self) -> None:
+        """Two ACs both passing → meta.final_approved True, checklist populated."""
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s1"), _passing_eval("s1")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criteria": ["AC one", "AC two"],
+                }
+            )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["multi_ac"] is True
+        assert meta["ac_count"] == 2
+        assert meta["passed_count"] == 2
+        assert meta["pass_rate"] == 1.0
+        assert meta["final_approved"] is True
+        assert meta["run_feedback"] == []
+        assert len(meta["checklist"]) == 2
+        assert all(item["passed"] for item in meta["checklist"])
+        assert "ALL PASSED" in result.value.text_content
+
+    async def test_mixed_outcomes_produce_incomplete_checklist(self) -> None:
+        """One passing + one failing AC → run_feedback lists the failure."""
+        mock_pipeline = self._install_pipeline_mock(
+            [
+                _passing_eval("s2"),
+                _failing_eval("s2", reason="Webhook signature not verified"),
+            ]
+        )
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s2",
+                    "artifact": "def pay(): pass",
+                    "acceptance_criteria": ["Charge processed", "Webhook validated"],
+                }
+            )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["multi_ac"] is True
+        assert meta["ac_count"] == 2
+        assert meta["passed_count"] == 1
+        assert meta["final_approved"] is False
+        assert len(meta["run_feedback"]) == 1
+        assert "Webhook validated" in meta["run_feedback"][0]
+        assert "INCOMPLETE" in result.value.text_content
+        assert "[ ] 2. Webhook validated" in result.value.text_content
+
+    async def test_empty_strings_in_list_are_filtered(self) -> None:
+        """Whitespace/empty entries in acceptance_criteria are ignored.
+
+        Two valid ACs after filtering must still take the multi-AC path.
+        """
+        mock_pipeline = self._install_pipeline_mock([_passing_eval("s3"), _passing_eval("s3")])
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s3",
+                    "artifact": "x",
+                    "acceptance_criteria": ["  ", "Valid AC one", "", "Valid AC two"],
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta["multi_ac"] is True
+        assert result.value.meta["ac_count"] == 2
+
+    async def test_multi_ac_pipeline_error_propagates(self) -> None:
+        """If any AC evaluation errors, the whole handle() returns err."""
+        mock_pipeline = AsyncMock()
+        calls = [
+            Result.ok(_passing_eval("s4")),
+            Result.err(ValueError("semantic stage exploded")),
+        ]
+        mock_pipeline.evaluate = AsyncMock(side_effect=calls)
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s4",
+                    "artifact": "x",
+                    "acceptance_criteria": ["AC1", "AC2"],
+                }
+            )
+
+        assert result.is_err
+        assert "Evaluation failed" in str(result.error)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "not-a-list", 42],
+)
+class TestMultiACParameterTolerance:
+    """Non-list / empty values for acceptance_criteria fall back to single-AC."""
+
+    async def test_invalid_value_falls_back(self, value: object) -> None:
+        mock_pipeline = AsyncMock()
+        mock_pipeline.evaluate = AsyncMock(return_value=Result.ok(_passing_eval("s5")))
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s5",
+                    "artifact": "x",
+                    "acceptance_criteria": value,
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta.get("multi_ac") is not True


### PR DESCRIPTION
## Summary

- **`EvaluationPipeline.run_stage1()`** — new public method that runs mechanical verification (lint/build/test) in isolation and returns `(MechanicalResult, events)`
- **`EvaluationPipeline.evaluate(stage1_result=...)`** — accepts a pre-computed Stage 1 result, skipping re-execution when provided
- **`_handle_multi_ac`** — now calls `run_stage1()` once, short-circuits on failure, then parallelizes only Stage 2 (semantic evaluation) per AC via `asyncio.gather`

## Why

The multi-AC checklist path (#366) previously ran the full pipeline per AC:

```
Before:  AC1 → [Stage1 + Stage2 + Stage3]  }
         AC2 → [Stage1 + Stage2 + Stage3]  } parallel — Stage 1 runs N times
         AC3 → [Stage1 + Stage2 + Stage3]  }

After:   [Stage 1] once
          ├→ AC1 → [Stage2 + Stage3]  }
          ├→ AC2 → [Stage2 + Stage3]  } parallel — Stage 1 shared
          └→ AC3 → [Stage2 + Stage3]  }
```

Stage 1 checks (lint, build, test, static analysis, coverage) are project-wide and AC-agnostic — the result is identical regardless of which AC is being evaluated. Duplicating them wastes compute and wall-clock time proportional to AC count.

This was flagged as a design concern in the PR #385 review by the maintainer:

> *"the implementation parallelizes the full EvaluationPipeline.evaluate() per AC, which duplicates Stage 1 mechanical verification for every AC instead of only parallelizing AC-specific semantic evaluation. That may be acceptable temporarily, but it is the wrong execution layer for this feature."*

## Depends on

- #385 (`feat/evaluate-handler-checklist-integration`) — must land first

## Backward compatibility

- `evaluate()` without `stage1_result` behaves identically to before — the parameter is keyword-only with `None` default
- `run_stage1()` is purely additive — no existing callers are affected
- Single-AC callers never reach `_handle_multi_ac` and are unaffected

## Test plan

- [x] Existing multi-AC tests updated to mock `run_stage1` → 25 passed, 2 skipped
- [x] No regressions in `test_checklist.py` or `test_evaluation_handler.py`
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)