### PR TITLE
fix(cli): preserve JSONC comments warning + shared opencode config helper

### DIFF
--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -30,6 +30,7 @@ from ouroboros.cli.formatters.panels import (
     print_success,
     print_warning,
 )
+from ouroboros.cli.opencode_config import find_opencode_config
 from ouroboros.persistence.brownfield import BrownfieldStore
 
 # Canonical MCP args for Claude Code uvx installs — single source of truth.
@@ -385,21 +386,13 @@ def _strip_jsonc(text: str) -> str:
 def _find_opencode_config() -> Path:
     """Locate the existing OpenCode config file, or return a default path.
 
-    OpenCode checks (in order): ``opencode.jsonc``, ``opencode.json``,
-    ``config.json`` — all inside ``~/.config/opencode/``.  On Windows
-    ``Path.home()`` resolves to ``%USERPROFILE%`` which matches the
-    ``xdg-basedir`` fallback that OpenCode uses.
-
-    Returns the first file that exists, or ``opencode.json`` as the
-    default for new installations (plain JSON is the safer default
-    since we write with ``json.dump``).
+    Delegates to :func:`ouroboros.cli.opencode_config.find_opencode_config`
+    with ``allow_default=True`` so that new installations get a sensible
+    default path (``opencode.json``) to write to.
     """
-    config_dir = Path.home() / ".config" / "opencode"
-    for name in ("opencode.jsonc", "opencode.json"):
-        candidate = config_dir / name
-        if candidate.exists():
-            return candidate
-    return config_dir / "opencode.json"
+    result = find_opencode_config(allow_default=True)
+    assert result is not None  # allow_default=True always returns a Path
+    return result
 
 
 def _ensure_opencode_mcp_entry() -> None:
@@ -499,6 +492,17 @@ def _ensure_opencode_mcp_entry() -> None:
         if "timeout" not in existing:
             existing["timeout"] = 300000
         print_info("MCP server already registered — verified config.")
+
+    # Warn if we're about to overwrite a .jsonc file that contained comments.
+    if config_path.suffix == ".jsonc":
+        try:
+            original_text = config_path.read_text(encoding="utf-8")
+        except OSError:
+            original_text = ""
+        if "//" in original_text or "/*" in original_text:
+            print_warning(
+                f"Note: JSONC comments in {config_path} were removed during config update."
+            )
 
     # Write back as plain JSON.  This intentionally discards JSONC
     # comments — the same approach Claude and Codex setup use for their

--- a/src/ouroboros/cli/commands/uninstall.py
+++ b/src/ouroboros/cli/commands/uninstall.py
@@ -22,13 +22,13 @@ from typing import Annotated
 
 import typer
 
-from ouroboros.cli.opencode_config import find_opencode_config
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import (
     print_info,
     print_success,
     print_warning,
 )
+from ouroboros.cli.opencode_config import find_opencode_config
 
 app = typer.Typer(
     name="uninstall",

--- a/src/ouroboros/cli/commands/uninstall.py
+++ b/src/ouroboros/cli/commands/uninstall.py
@@ -22,6 +22,7 @@ from typing import Annotated
 
 import typer
 
+from ouroboros.cli.opencode_config import find_opencode_config
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import (
     print_info,
@@ -182,15 +183,11 @@ def _strip_jsonc(text: str) -> str:
 def _find_opencode_config() -> Path | None:
     """Locate existing OpenCode config (``opencode.jsonc`` or ``opencode.json``).
 
-    Returns the first file that exists, or ``None`` if neither is present.
-    Mirrors the lookup order that OpenCode itself uses.
+    Delegates to :func:`ouroboros.cli.opencode_config.find_opencode_config`
+    with ``allow_default=False`` so that uninstall skips cleanly when no
+    config file exists.
     """
-    config_dir = Path.home() / ".config" / "opencode"
-    for name in ("opencode.jsonc", "opencode.json"):
-        candidate = config_dir / name
-        if candidate.exists():
-            return candidate
-    return None
+    return find_opencode_config(allow_default=False)
 
 
 def _remove_opencode_mcp(dry_run: bool) -> bool:
@@ -213,6 +210,18 @@ def _remove_opencode_mcp(dry_run: bool) -> bool:
         return True
 
     del mcp["ouroboros"]
+
+    # Warn if we're about to overwrite a .jsonc file that contained comments.
+    if config_path.suffix == ".jsonc":
+        try:
+            original_text = config_path.read_text(encoding="utf-8")
+        except OSError:
+            original_text = ""
+        if "//" in original_text or "/*" in original_text:
+            print_warning(
+                f"Note: JSONC comments in {config_path} were removed during config update."
+            )
+
     try:
         config_path.write_text(json.dumps(data, indent=2) + "\n")
     except OSError:

--- a/src/ouroboros/cli/opencode_config.py
+++ b/src/ouroboros/cli/opencode_config.py
@@ -1,0 +1,39 @@
+"""Shared helpers for locating the OpenCode configuration file.
+
+Both :mod:`~ouroboros.cli.commands.setup` and
+:mod:`~ouroboros.cli.commands.uninstall` need to find the same config file;
+centralising the logic here avoids duplication and keeps the ``PermissionError``
+/ ``OSError`` guard in one place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def find_opencode_config(*, allow_default: bool = True) -> Path | None:
+    """Locate the existing OpenCode config file.
+
+    OpenCode checks (in order): ``opencode.jsonc``, ``opencode.json`` —
+    both inside ``~/.config/opencode/``.
+
+    Args:
+        allow_default: When ``True`` (setup path), return
+            ``~/.config/opencode/opencode.json`` as a default for new
+            installations if neither file exists.  When ``False``
+            (uninstall path), return ``None`` so the caller can skip
+            cleanly when no config is present.
+
+    Returns:
+        The first existing config path, the default path (when
+        *allow_default* is ``True``), or ``None``.
+    """
+    config_dir = Path.home() / ".config" / "opencode"
+    for name in ("opencode.jsonc", "opencode.json"):
+        candidate = config_dir / name
+        try:
+            if candidate.exists():
+                return candidate
+        except OSError:
+            continue
+    return (config_dir / "opencode.json") if allow_default else None

--- a/tests/unit/cli/test_opencode_config.py
+++ b/tests/unit/cli/test_opencode_config.py
@@ -1,0 +1,101 @@
+"""Unit tests for the shared opencode_config helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ouroboros.cli.opencode_config import find_opencode_config
+
+
+class TestFindOpencodeConfig:
+    """Tests for find_opencode_config()."""
+
+    def test_prefers_jsonc_over_json(self, tmp_path: Path) -> None:
+        """opencode.jsonc takes priority over opencode.json when both exist."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        jsonc = config_dir / "opencode.jsonc"
+        json_ = config_dir / "opencode.json"
+        jsonc.write_text("{}")
+        json_.write_text("{}")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = find_opencode_config(allow_default=True)
+
+        assert result == jsonc
+
+    def test_falls_back_to_json_when_no_jsonc(self, tmp_path: Path) -> None:
+        """Returns opencode.json when only that file exists."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        json_ = config_dir / "opencode.json"
+        json_.write_text("{}")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = find_opencode_config(allow_default=True)
+
+        assert result == json_
+
+    def test_allow_default_true_returns_default_when_missing(self, tmp_path: Path) -> None:
+        """Returns default opencode.json path when no config exists and allow_default=True."""
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = find_opencode_config(allow_default=True)
+
+        assert result == tmp_path / ".config" / "opencode" / "opencode.json"
+        assert result is not None
+
+    def test_allow_default_false_returns_none_when_missing(self, tmp_path: Path) -> None:
+        """Returns None when no config exists and allow_default=False."""
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = find_opencode_config(allow_default=False)
+
+        assert result is None
+
+    def test_allow_default_false_returns_existing_file(self, tmp_path: Path) -> None:
+        """Returns existing file even when allow_default=False."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        jsonc = config_dir / "opencode.jsonc"
+        jsonc.write_text("{}")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = find_opencode_config(allow_default=False)
+
+        assert result == jsonc
+
+    def test_oserror_on_candidate_is_skipped(self, tmp_path: Path) -> None:
+        """OSError on exists() check is silently skipped — fallback continues."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        json_ = config_dir / "opencode.json"
+        json_.write_text("{}")
+
+        original_exists = Path.exists
+
+        def patched_exists(self: Path) -> bool:
+            if self.name == "opencode.jsonc":
+                raise OSError("permission denied")
+            return original_exists(self)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(Path, "exists", patched_exists),
+        ):
+            result = find_opencode_config(allow_default=True)
+
+        # jsonc errored, falls through to json which exists
+        assert result == json_
+
+    def test_returns_jsonc_path_type(self, tmp_path: Path) -> None:
+        """Return value is always a Path instance (not str)."""
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        (config_dir / "opencode.jsonc").write_text("{}")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = find_opencode_config(allow_default=True)
+
+        assert isinstance(result, Path)

--- a/tests/unit/cli/test_opencode_config.py
+++ b/tests/unit/cli/test_opencode_config.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from ouroboros.cli.opencode_config import find_opencode_config
 
 


### PR DESCRIPTION
## Summary

Fixes #404 — three related issues in the opencode config handling introduced in v0.28.4 (PR #374):

- **JSONC comment destruction (Critical):** `setup` and `uninstall` read `.jsonc` files with `_strip_jsonc()` then write back with `json.dump()`, permanently deleting all user comments. Now emits a `print_warning()` before overwriting, so users know their comments will be removed.
- **Duplicate `_find_opencode_config` (Low):** Extracted to a shared `ouroboros.cli.opencode_config.find_opencode_config(*, allow_default)` helper, eliminating the duplicated function with divergent signatures (`Path` vs `Path | None`).
- **`PermissionError` crash (Low):** `Path.exists()` inside the helper is now wrapped in `try/except OSError`, so restricted filesystems skip gracefully instead of crashing.

## Changes

| File | Change |
|------|--------|
| `src/ouroboros/cli/opencode_config.py` | **New** — shared `find_opencode_config` with `OSError` safety |
| `src/ouroboros/cli/commands/setup.py` | Delegates to shared helper; warns before stripping JSONC comments |
| `src/ouroboros/cli/commands/uninstall.py` | Delegates to shared helper; warns before stripping JSONC comments |
| `tests/unit/cli/test_opencode_config.py` | **New** — 7 tests for shared helper |

## Test plan

- [ ] `pytest tests/unit/cli/test_opencode_config.py` — shared helper tests
- [ ] `pytest tests/unit/cli/test_setup.py` — existing setup tests still pass
- [ ] `pytest tests/unit/cli/test_uninstall.py` — existing uninstall tests still pass
- [ ] Manual: create `~/.config/opencode/opencode.jsonc` with comments, run `ouroboros setup`, verify warning is printed