### PR TITLE
fix(orchestrator): narrow exception scope in _build_dependency_analyzer

### DIFF
--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -593,7 +593,7 @@ class OrchestratorRunner:
                 cwd=self._effective_cwd(),
                 max_turns=1,
             )
-        except Exception as exc:
+        except (RuntimeError, ImportError, ConnectionError, OSError, ValueError) as exc:
             log.warning(
                 "orchestrator.runner.dependency_analysis_llm_unavailable",
                 backend=backend,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1640,6 +1640,61 @@ class TestOrchestratorRunner:
             max_turns=1,
         )
 
+    def test_build_dependency_analyzer_catches_expected_exceptions(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """RuntimeError from create_llm_adapter is caught and returns a no-LLM analyzer."""
+        from ouroboros.orchestrator.dependency_analyzer import DependencyAnalyzer
+
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        with patch(
+            "ouroboros.orchestrator.runner.create_llm_adapter",
+            side_effect=RuntimeError("CLI not found"),
+        ):
+            analyzer = runner._build_dependency_analyzer()
+
+        assert isinstance(analyzer, DependencyAnalyzer)
+
+    def test_build_dependency_analyzer_does_not_catch_type_error(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """TypeError from create_llm_adapter propagates uncaught (programming error)."""
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        with (
+            patch(
+                "ouroboros.orchestrator.runner.create_llm_adapter",
+                side_effect=TypeError("unexpected keyword argument"),
+            ),
+            pytest.raises(TypeError),
+        ):
+            runner._build_dependency_analyzer()
+
+    def test_build_dependency_analyzer_does_not_catch_attribute_error(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """AttributeError from create_llm_adapter propagates uncaught (programming error)."""
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        with (
+            patch(
+                "ouroboros.orchestrator.runner.create_llm_adapter",
+                side_effect=AttributeError("object has no attribute"),
+            ),
+            pytest.raises(AttributeError),
+        ):
+            runner._build_dependency_analyzer()
+
     @pytest.mark.asyncio
     async def test_execute_seed_uses_inherited_runtime_handle(
         self,


### PR DESCRIPTION
## Summary

Fixes #410 — `_build_dependency_analyzer` in `runner.py` catches `Exception` when calling `create_llm_adapter`, which masks programming errors like `TypeError` and `AttributeError`.

Changed `except Exception` to `except (RuntimeError, ImportError, ConnectionError, OSError, ValueError)` — only catching expected operational failures while letting programming errors propagate.

`ValueError` was added because `resolve_llm_backend` raises it for unsupported backend names.

## Changes

| File | Change |
|------|--------|
| `src/ouroboros/orchestrator/runner.py` | Narrowed `except` clause (1 line) |
| `tests/unit/orchestrator/test_runner.py` | 3 new tests: `RuntimeError` caught, `TypeError`/`AttributeError` propagate |

## Test plan

- [ ] `pytest tests/unit/orchestrator/test_runner.py` — all runner tests pass
- [ ] Verify `TypeError` from a bad `create_llm_adapter` call propagates instead of being silently caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)