### PR TITLE
fix(providers): respect OUROBOROS_SKIP_VERSION_CHECK env override

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -425,6 +425,7 @@ All environment variables have higher priority than the corresponding `config.ya
 | `OUROBOROS_CLI_PATH` | `orchestrator.cli_path` | Path to the Claude CLI binary. |
 | `OUROBOROS_CODEX_CLI_PATH` | `orchestrator.codex_cli_path` | Path to the Codex CLI binary. |
 | `OUROBOROS_OPENCODE_CLI_PATH` | `orchestrator.opencode_cli_path` | Path to the OpenCode CLI binary. |
+| `OUROBOROS_SKIP_VERSION_CHECK` | *(none)* | Controls the Claude Agent SDK per-call version compatibility check. Defaults to `"1"` (skip the check, saving ~0.3-0.8 s per LLM call). Set to `"0"` to re-enable the check for debugging version-mismatch issues. Maps to `CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK` internally. |
 
 ### LLM Flow
 

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -566,7 +566,11 @@ class ClaudeCodeAdapter:
             # to verify version compatibility.  This is advisory-only — version
             # mismatches surface naturally as API errors — and saves ~0.3-0.8 s
             # latency on every LLM call.
-            "CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK": "1",
+            # Honour OUROBOROS_SKIP_VERSION_CHECK if the user/operator sets it
+            # (e.g. "0" to re-enable the check for debugging).
+            "CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK": os.environ.get(
+                "OUROBOROS_SKIP_VERSION_CHECK", "1"
+            ),
         }
         if claudecode_present:
             env_overrides["CLAUDECODE"] = ""

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -271,13 +271,16 @@ class TestAdapterOverheadReductions:
 
         sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
 
-        with patch.dict(
-            "sys.modules",
-            {
-                "claude_agent_sdk": sdk_module,
-                "claude_agent_sdk._errors": sdk_module._errors,
-            },
-        ), patch.dict("os.environ", {}, clear=False):
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "claude_agent_sdk": sdk_module,
+                    "claude_agent_sdk._errors": sdk_module._errors,
+                },
+            ),
+            patch.dict("os.environ", {}, clear=False),
+        ):
             # Ensure the override var is NOT set
             os.environ.pop("OUROBOROS_SKIP_VERSION_CHECK", None)
             await adapter._execute_single_request("test prompt", config)
@@ -304,13 +307,16 @@ class TestAdapterOverheadReductions:
 
         sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
 
-        with patch.dict(
-            "sys.modules",
-            {
-                "claude_agent_sdk": sdk_module,
-                "claude_agent_sdk._errors": sdk_module._errors,
-            },
-        ), patch.dict("os.environ", {"OUROBOROS_SKIP_VERSION_CHECK": "0"}):
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "claude_agent_sdk": sdk_module,
+                    "claude_agent_sdk._errors": sdk_module._errors,
+                },
+            ),
+            patch.dict("os.environ", {"OUROBOROS_SKIP_VERSION_CHECK": "0"}),
+        ):
             await adapter._execute_single_request("test prompt", config)
 
         options_call_kwargs = mock_options_cls.call_args.kwargs

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -8,6 +8,7 @@ being embedded as XML in the user prompt.
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -253,8 +254,8 @@ class TestAdapterOverheadReductions:
     """Test per-call overhead optimizations in ClaudeCodeAdapter."""
 
     @pytest.mark.asyncio
-    async def test_version_check_skip_env_is_set(self) -> None:
-        """CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK=1 is passed to ClaudeAgentOptions."""
+    async def test_version_check_skip_env_defaults_to_one(self) -> None:
+        """CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK defaults to '1' when OUROBOROS_SKIP_VERSION_CHECK is unset."""
         adapter = ClaudeCodeAdapter()
         config = CompletionConfig(model="claude-sonnet-4-6")
 
@@ -276,12 +277,45 @@ class TestAdapterOverheadReductions:
                 "claude_agent_sdk": sdk_module,
                 "claude_agent_sdk._errors": sdk_module._errors,
             },
-        ):
+        ), patch.dict("os.environ", {}, clear=False):
+            # Ensure the override var is NOT set
+            os.environ.pop("OUROBOROS_SKIP_VERSION_CHECK", None)
             await adapter._execute_single_request("test prompt", config)
 
         options_call_kwargs = mock_options_cls.call_args.kwargs
         env = options_call_kwargs.get("env", {})
         assert env.get("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK") == "1"
+
+    @pytest.mark.asyncio
+    async def test_version_check_skip_env_respects_override(self) -> None:
+        """OUROBOROS_SKIP_VERSION_CHECK=0 disables the SDK version-check skip."""
+        adapter = ClaudeCodeAdapter()
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ), patch.dict("os.environ", {"OUROBOROS_SKIP_VERSION_CHECK": "0"}):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        env = options_call_kwargs.get("env", {})
+        assert env.get("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK") == "0"
 
     def test_initial_backoff_is_half_second(self) -> None:
         """_INITIAL_BACKOFF_SECONDS should be 0.5 for interactive responsiveness."""


### PR DESCRIPTION
## Summary

- `CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK` was unconditionally hardcoded to `"1"` in `ClaudeCodeAdapter`, giving users no way to re-enable the SDK version check for debugging
- Now reads from the `OUROBOROS_SKIP_VERSION_CHECK` environment variable, defaulting to `"1"` (skip) to preserve existing behavior
- Setting `OUROBOROS_SKIP_VERSION_CHECK=0` lets users/operators restore the version check when diagnosing version-mismatch issues

Fixes #407

## Test plan

- [x] Existing test updated: verifies default behavior (`CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK` is `"1"` when `OUROBOROS_SKIP_VERSION_CHECK` is unset)
- [x] New test added: verifies `OUROBOROS_SKIP_VERSION_CHECK=0` propagates as `CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK=0`
- [x] Full test suite for `test_claude_code_adapter.py` passes (33/33)