### PR TITLE
feat(cli): add 'ooo resume' to recover in-flight sessions after MCP disconnect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ When the user types any of these commands, read the corresponding SKILL.md file 
 | `ooo pm` or `ooo pm ...` | Read `skills/pm/SKILL.md` and follow it |
 | `ooo brownfield` or `ooo brownfield ...` | Read `skills/brownfield/SKILL.md` and follow it |
 | `ooo publish` or `ooo publish ...` | Read `skills/publish/SKILL.md` and follow it |
+| `ooo resume` | Read `skills/resume/SKILL.md` and follow it |
 
 **Important**: Do NOT use the Skill tool. Read the file with the Read tool and execute its instructions directly.
 

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: resume
+description: "List in-flight sessions and re-attach after MCP disconnect"
+---
+
+# /ouroboros:resume
+
+Recover in-flight sessions after an unexpected MCP server disconnect.
+
+## Usage
+
+```
+ooo resume
+```
+
+**Trigger keywords:** "resume session", "re-attach", "mcp disconnected", "lost session", "in-flight"
+
+## How It Works
+
+`ooo resume` reads the EventStore directly (no MCP server required) and lists
+every session that is still in a `running` or `paused` state. You can then
+pick one from the interactive prompt to receive re-attach instructions.
+
+## Instructions
+
+When the user invokes this skill:
+
+1. Run the CLI command:
+
+   ```
+   ouroboros resume
+   ```
+
+   This reads `~/.ouroboros/ouroboros.db` directly — the MCP server does **not**
+   need to be running.
+
+2. If sessions are listed, enter the number corresponding to the session you
+   want to re-attach to. The command will print the `exec_id`.
+
+3. Re-attach using:
+
+   ```
+   ooo status <exec_id>
+   ```
+
+## Fallback (No sessions found)
+
+If the command reports "No in-flight sessions found", the execution either
+completed, failed, or was already cancelled. Check with:
+
+```
+ouroboros status executions
+```
+
+## Example
+
+```
+User: ooo resume
+
+┌─────────────────────── In-Flight Sessions ───────────────────────┐
+│  #  Session ID          Execution ID        Status    Started    │
+│  1  sess-abc123         exec-xyz789         running   2026-04-15 │
+└───────────────────────────────────────────────────────────────────┘
+
+Enter number to re-attach (1-1), or 'q' to quit: 1
+
+╭─ Re-attach ──────────────────────────────────────────╮
+│ Session selected: sess-abc123                        │
+│ Execution ID:     exec-xyz789                        │
+│                                                      │
+│ Re-attach by running:                                │
+│                                                      │
+│     ooo status exec-xyz789                           │
+╰──────────────────────────────────────────────────────╯
+```
+
+## Next Steps
+
+After re-attaching:
+- `ooo status <exec_id>` — Check current execution status and drift
+- `ooo evaluate` — Evaluate results once execution completes
+- `ooo cancel execution <exec_id>` — Cancel if the session is stuck

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -46,11 +46,17 @@ When the user invokes this skill:
 
 3. Pick the right re-attach path:
 
-   - **Inspect only** (no execution resumes):
+   - **Inspect only** (read-only interactive monitor):
 
      ```
-     ouroboros status execution <exec_id>
+     ouroboros tui monitor
      ```
+
+     Launches the TUI and lets you pick the session to inspect. The
+     `ouroboros status execution <exec_id>` command is *registered* but its
+     handler is still a placeholder in `src/ouroboros/cli/commands/status.py`
+     (it only prints "Would show details for execution: …"), so it is
+     intentionally not surfaced here. Follow-up tracked as a separate issue.
 
    - **Resume execution** (requires the original seed file):
 
@@ -70,10 +76,10 @@ When the user invokes this skill:
 
 If the command reports "No in-flight sessions found", the execution either
 completed, failed, was cancelled, or the EventStore has never been created.
-Check with:
+To browse historical sessions interactively, use the TUI monitor:
 
 ```
-ouroboros status executions
+ouroboros tui monitor
 ```
 
 ## Example
@@ -92,8 +98,8 @@ Enter number to re-attach (1-1), or 'q' to quit: 1
 │ Session ID:   sess-abc123                                                  │
 │ Execution ID: exec-xyz789                                                  │
 │                                                                            │
-│ Inspect (read-only status):                                                │
-│     ouroboros status execution exec-xyz789                                 │
+│ Inspect (read-only interactive monitor):                                   │
+│     ouroboros tui monitor                                                  │
 │                                                                            │
 │ Resume execution (requires the original seed file):                        │
 │     ouroboros run workflow --orchestrator --resume sess-abc123 seed-001    │
@@ -104,7 +110,7 @@ Enter number to re-attach (1-1), or 'q' to quit: 1
 
 After you have the identifiers:
 
-- `ouroboros status execution <exec_id>` — inspect current execution status
+- `ouroboros tui monitor` — launch the TUI and pick the session to inspect
 - `ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>` — resume execution
 - `ooo evaluate` — evaluate results once the execution completes
 - `ooo cancel execution <exec_id>` — cancel if the session is stuck

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -40,7 +40,7 @@ When the user invokes this skill:
 3. Re-attach using:
 
    ```
-   ooo status <exec_id>
+   ouroboros status execution <exec_id>
    ```
 
 ## Fallback (No sessions found)
@@ -70,13 +70,13 @@ Enter number to re-attach (1-1), or 'q' to quit: 1
 │                                                      │
 │ Re-attach by running:                                │
 │                                                      │
-│     ooo status exec-xyz789                           │
+│     ouroboros status execution exec-xyz789             │
 ╰──────────────────────────────────────────────────────╯
 ```
 
 ## Next Steps
 
 After re-attaching:
-- `ooo status <exec_id>` — Check current execution status and drift
+- `ouroboros status execution <exec_id>` — Check current execution status and drift
 - `ooo evaluate` — Evaluate results once execution completes
 - `ooo cancel execution <exec_id>` — Cancel if the session is stuck

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: resume
-description: "List in-flight sessions and re-attach after MCP disconnect"
+description: "List in-flight sessions and show the commands needed to re-attach after MCP disconnect"
 ---
 
 # /ouroboros:resume
@@ -11,6 +11,7 @@ Recover in-flight sessions after an unexpected MCP server disconnect.
 
 ```
 ooo resume
+ooo resume --all
 ```
 
 **Trigger keywords:** "resume session", "re-attach", "mcp disconnected", "lost session", "in-flight"
@@ -18,8 +19,13 @@ ooo resume
 ## How It Works
 
 `ooo resume` reads the EventStore directly (no MCP server required) and lists
-every session that is still in a `running` or `paused` state. You can then
-pick one from the interactive prompt to receive re-attach instructions.
+every session that is still in a `running` or `paused` state. The command is
+strictly read-only — it never creates the data directory, never writes
+schema, and never appends events. Its job is to surface the identifiers you
+need to re-attach.
+
+- `ooo resume` shows the 20 most recent active sessions.
+- `ooo resume --all` shows every active session.
 
 ## Instructions
 
@@ -34,19 +40,37 @@ When the user invokes this skill:
    This reads `~/.ouroboros/ouroboros.db` directly — the MCP server does **not**
    need to be running.
 
-2. If sessions are listed, enter the number corresponding to the session you
-   want to re-attach to. The command will print the `exec_id`.
+2. If sessions are listed, enter the number of the session you want to work
+   with. The command prints both the `session_id` and the `exec_id`, along
+   with the two re-attach paths.
 
-3. Re-attach using:
+3. Pick the right re-attach path:
 
-   ```
-   ouroboros status execution <exec_id>
-   ```
+   - **Inspect only** (no execution resumes):
+
+     ```
+     ouroboros status execution <exec_id>
+     ```
+
+   - **Resume execution** (requires the original seed file):
+
+     ```
+     ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>
+     ```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Success — sessions listed, or no sessions found |
+| `1`  | Invalid user selection (non-numeric or out-of-range) |
+| `2`  | EventStore exists but could not be opened or read |
 
 ## Fallback (No sessions found)
 
 If the command reports "No in-flight sessions found", the execution either
-completed, failed, or was already cancelled. Check with:
+completed, failed, was cancelled, or the EventStore has never been created.
+Check with:
 
 ```
 ouroboros status executions
@@ -64,19 +88,23 @@ User: ooo resume
 
 Enter number to re-attach (1-1), or 'q' to quit: 1
 
-╭─ Re-attach ──────────────────────────────────────────╮
-│ Session selected: sess-abc123                        │
-│ Execution ID:     exec-xyz789                        │
-│                                                      │
-│ Re-attach by running:                                │
-│                                                      │
-│     ouroboros status execution exec-xyz789             │
-╰──────────────────────────────────────────────────────╯
+╭─ Re-attach ────────────────────────────────────────────────────────────────╮
+│ Session ID:   sess-abc123                                                  │
+│ Execution ID: exec-xyz789                                                  │
+│                                                                            │
+│ Inspect (read-only status):                                                │
+│     ouroboros status execution exec-xyz789                                 │
+│                                                                            │
+│ Resume execution (requires the original seed file):                        │
+│     ouroboros run workflow --orchestrator --resume sess-abc123 seed-001    │
+╰────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Next Steps
 
-After re-attaching:
-- `ouroboros status execution <exec_id>` — Check current execution status and drift
-- `ooo evaluate` — Evaluate results once execution completes
-- `ooo cancel execution <exec_id>` — Cancel if the session is stuck
+After you have the identifiers:
+
+- `ouroboros status execution <exec_id>` — inspect current execution status
+- `ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>` — resume execution
+- `ooo evaluate` — evaluate results once the execution completes
+- `ooo cancel execution <exec_id>` — cancel if the session is stuck

--- a/src/ouroboros/cli/commands/resume.py
+++ b/src/ouroboros/cli/commands/resume.py
@@ -1,14 +1,19 @@
 """Resume command for Ouroboros.
 
-List in-flight sessions directly from the EventStore (no MCP dependency)
-and surface the exec_id so the user can re-attach with
-`ouroboros status execution <exec_id>`.
+List in-flight sessions directly from the EventStore (no MCP dependency).
+The command is intentionally read-only: it never creates the data directory,
+never writes schema, and never appends events. Its only job is to surface the
+identifiers a user needs to re-attach (inspect with ``ouroboros status
+execution <exec_id>`` or resume execution with
+``ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>``).
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
+from pathlib import Path
+from typing import Annotated
 
 import typer
 
@@ -23,64 +28,128 @@ app = typer.Typer(
 )
 
 
-async def _get_event_store():
-    """Create and initialize an EventStore instance.
+# Default cap on rows shown when many stale sessions accumulate. The user can
+# opt into the full list with ``--all``.
+DEFAULT_DISPLAY_LIMIT = 20
 
-    Returns:
-        Initialized EventStore.
+# Exit code surfaced when the EventStore exists but is unreadable. Pinned so
+# users/scripts can branch on it (distinct from the happy "no sessions" path
+# which exits 0).
+EXIT_CORRUPTED_DB = 2
+
+
+def _default_db_path() -> str:
+    """Return the canonical SQLite path used by the running CLI."""
+    return os.path.expanduser("~/.ouroboros/ouroboros.db")
+
+
+async def _get_event_store(db_path: str | None = None):
+    """Open the EventStore read-only.
+
+    Returns ``None`` if the database file does not exist. Intentionally does
+    not create ``~/.ouroboros/`` or run ``metadata.create_all`` — this command
+    is a recovery tool and must not mutate user state.
     """
     from ouroboros.persistence.event_store import EventStore
 
-    db_path = os.path.expanduser("~/.ouroboros/ouroboros.db")
-    os.makedirs(os.path.dirname(db_path), exist_ok=True)
-    event_store = EventStore(f"sqlite+aiosqlite:///{db_path}")
-    await event_store.initialize()
+    resolved = db_path or _default_db_path()
+    if not Path(resolved).exists():
+        return None
+
+    event_store = EventStore(f"sqlite+aiosqlite:///{resolved}")
+    try:
+        await event_store.initialize(create_schema=False)
+    except Exception:
+        # Ensure the partially constructed engine is disposed before we bail
+        # out — otherwise the outer ``finally`` cannot close it (the variable
+        # was never bound in the caller).
+        try:
+            await event_store.close()
+        finally:
+            raise
     return event_store
 
 
-async def _get_in_flight_sessions(event_store) -> list:
-    """Return all running or paused session trackers.
+def _is_active_snapshot(snapshot) -> bool:
+    """Return True when a snapshot is plausibly running or paused.
 
-    Args:
-        event_store: Initialized EventStore instance.
+    Terminal ``status_event_type`` values short-circuit the expensive replay.
+    Non-terminal or progress-only snapshots fall through to reconstruction.
+    """
+    terminal = {
+        "orchestrator.session.completed",
+        "orchestrator.session.failed",
+        "orchestrator.session.cancelled",
+    }
+    return snapshot.status_event_type not in terminal
 
-    Returns:
-        List of SessionTracker objects for in-flight sessions.
+
+async def _get_in_flight_sessions(event_store, limit: int | None = DEFAULT_DISPLAY_LIMIT) -> list:
+    """Return running or paused session trackers, most-recent-first.
+
+    Uses ``get_session_activity_snapshots`` to narrow candidates without
+    replaying every event for every session, then reconstructs only the
+    snapshots whose latest status is non-terminal.
     """
     from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 
     repo = SessionRepository(event_store)
-    session_events = await event_store.get_all_sessions()
 
+    try:
+        snapshots = await event_store.get_session_activity_snapshots()
+    except AttributeError:
+        # Older EventStore builds may lack the snapshot helper. Fall back to
+        # the full replay path so the command still works.
+        return await _get_in_flight_sessions_fallback(event_store)
+
+    candidates = [s for s in snapshots if _is_active_snapshot(s)]
+
+    def _activity_key(snapshot) -> str:
+        return str(snapshot.last_activity or snapshot.start_time or "")
+
+    candidates.sort(key=_activity_key, reverse=True)
+
+    in_flight: list = []
+    for snapshot in candidates:
+        result = await repo.reconstruct_session(snapshot.session_id)
+        if result.is_err:
+            continue
+        tracker = result.value
+        if tracker.status in (SessionStatus.RUNNING, SessionStatus.PAUSED):
+            in_flight.append(tracker)
+            if limit is not None and len(in_flight) >= limit:
+                break
+
+    return in_flight
+
+
+async def _get_in_flight_sessions_fallback(event_store) -> list:
+    """Legacy path: replay every session. Retained only for API compatibility."""
+    from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+
+    repo = SessionRepository(event_store)
+    session_events = await event_store.get_all_sessions()
     if not session_events:
         return []
 
     seen: set[str] = set()
     in_flight: list = []
-
     for event in session_events:
         session_id = event.aggregate_id
         if session_id in seen:
             continue
         seen.add(session_id)
-
         result = await repo.reconstruct_session(session_id)
         if result.is_err:
             continue
-
         tracker = result.value
         if tracker.status in (SessionStatus.RUNNING, SessionStatus.PAUSED):
             in_flight.append(tracker)
-
     return in_flight
 
 
 def _display_sessions(sessions: list) -> None:
-    """Render in-flight sessions in a numbered table.
-
-    Args:
-        sessions: List of SessionTracker objects.
-    """
+    """Render in-flight sessions in a numbered table."""
     table = create_table("In-Flight Sessions")
     table.add_column("#", style="bold", no_wrap=True, justify="right")
     table.add_column("Session ID", style="cyan", no_wrap=True)
@@ -104,19 +173,69 @@ def _display_sessions(sessions: list) -> None:
     print_table(table)
 
 
-async def _interactive_resume() -> None:
-    """List in-flight sessions and prompt the user to pick one to re-attach."""
-    try:
-        event_store = await _get_event_store()
-    except Exception as exc:  # noqa: BLE001
-        print_error(f"Failed to open EventStore: {exc}")
-        return
+def _format_reattach_guidance(tracker) -> str:
+    """Build the post-selection guidance block.
+
+    Prints two commands, matching the real CLI contracts:
+
+    - Inspect:   ``ouroboros status execution <exec_id>``
+    - Resume:    ``ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>``
+
+    ``run workflow --resume`` takes a *session_id* (not an execution_id) and
+    also requires the seed file, so both identifiers are surfaced explicitly.
+    """
+    exec_id = tracker.execution_id or "<unknown>"
+    seed_hint = tracker.seed_id or "<seed.yaml>"
+
+    inspect_line = f"ouroboros status execution {exec_id}"
+    resume_line = f"ouroboros run workflow --orchestrator --resume {tracker.session_id} {seed_hint}"
+
+    lines = [
+        f"Session ID:   [bold cyan]{tracker.session_id}[/]",
+        f"Execution ID: [bold cyan]{exec_id}[/]",
+        "",
+        "[bold]Inspect[/] (read-only status):",
+        f"    {inspect_line}",
+        "",
+        "[bold]Resume execution[/] (requires the original seed file):",
+        f"    {resume_line}",
+    ]
+    if not tracker.seed_id:
+        lines.append(
+            "[dim]Seed ID was not recorded for this session — replace "
+            "<seed.yaml> with the original seed path.[/]"
+        )
+    return "\n".join(lines)
+
+
+async def _interactive_resume(show_all: bool = False) -> int:
+    """List in-flight sessions and prompt the user to pick one to re-attach.
+
+    Returns the integer exit code the CLI should emit so callers can pin
+    distinct codes for missing DB vs. corrupted DB vs. happy path.
+    """
+    limit = None if show_all else DEFAULT_DISPLAY_LIMIT
 
     try:
-        sessions = await _get_in_flight_sessions(event_store)
-    except Exception as exc:  # noqa: BLE001
-        print_error(f"Failed to read EventStore: {exc}")
-        return
+        event_store = await _get_event_store()
+    except Exception as exc:  # noqa: BLE001 — surface any open error verbatim
+        print_error(f"Failed to open EventStore: {exc}")
+        return EXIT_CORRUPTED_DB
+
+    if event_store is None:
+        print_info("No in-flight sessions found.", "Resume")
+        console.print(
+            "[dim]EventStore does not exist yet. "
+            "Sessions appear here after the MCP server has started at least one run.[/]"
+        )
+        return 0
+
+    try:
+        try:
+            sessions = await _get_in_flight_sessions(event_store, limit=limit)
+        except Exception as exc:  # noqa: BLE001
+            print_error(f"Failed to read EventStore: {exc}")
+            return EXIT_CORRUPTED_DB
     finally:
         await event_store.close()
 
@@ -125,7 +244,7 @@ async def _interactive_resume() -> None:
         console.print(
             "[dim]Sessions appear here when the MCP server was disconnected mid-execution.[/]"
         )
-        return
+        return 0
 
     _display_sessions(sessions)
     console.print()
@@ -137,48 +256,64 @@ async def _interactive_resume() -> None:
 
     if choice.strip().lower() == "q":
         print_info("No session selected.", "Resume")
-        return
+        return 0
 
     try:
         index = int(choice) - 1
     except ValueError:
         print_error(f"Invalid selection: {choice!r}")
-        raise typer.Exit(1)
+        return 1
 
     if index < 0 or index >= len(sessions):
         print_error(f"Selection out of range: {choice}. Expected 1-{len(sessions)}.")
-        raise typer.Exit(1)
+        return 1
 
     selected = sessions[index]
-    exec_id = selected.execution_id or selected.session_id
-
-    print_success(
-        f"Session selected: [bold]{selected.session_id}[/]\n"
-        f"Execution ID:     [bold cyan]{exec_id}[/]\n\n"
-        "Re-attach by running:\n\n"
-        f"    ouroboros status execution {exec_id}",
-        "Re-attach",
-    )
+    print_success(_format_reattach_guidance(selected), "Re-attach")
+    return 0
 
 
 @app.callback(invoke_without_command=True)
-def resume(ctx: typer.Context) -> None:
+def resume(
+    ctx: typer.Context,
+    show_all: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            "-a",
+            help=(
+                f"Show every in-flight session instead of the most recent {DEFAULT_DISPLAY_LIMIT}."
+            ),
+        ),
+    ] = False,
+) -> None:
     """List in-flight sessions and get re-attach instructions.
 
-    Reads the EventStore directly — no MCP server required. Use this
-    command after an unexpected MCP disconnect to recover the execution ID
-    and re-attach with:
+    Reads the EventStore directly — no MCP server required. Use this command
+    after an unexpected MCP disconnect to recover the session/execution IDs
+    and re-attach.
 
+    Re-attach paths surfaced after selection:
+
+        # Inspect
         ouroboros status execution <exec_id>
+
+        # Resume execution (requires the original seed file)
+        ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>
 
     Examples:
 
         # Interactive: list in-flight sessions and pick one
         ouroboros resume
+
+        # Show every stale active session, not just the 20 most recent
+        ouroboros resume --all
     """
     if ctx.invoked_subcommand is not None:
         return
-    asyncio.run(_interactive_resume())
+    exit_code = asyncio.run(_interactive_resume(show_all=show_all))
+    if exit_code != 0:
+        raise typer.Exit(exit_code)
 
 
 __all__ = ["app"]

--- a/src/ouroboros/cli/commands/resume.py
+++ b/src/ouroboros/cli/commands/resume.py
@@ -2,9 +2,11 @@
 
 List in-flight sessions directly from the EventStore (no MCP dependency).
 The command is intentionally read-only: it never creates the data directory,
-never writes schema, and never appends events. Its only job is to surface the
-identifiers a user needs to re-attach (inspect with ``ouroboros status
-execution <exec_id>`` or resume execution with
+never writes schema, and never appends events. Read-only is enforced at the
+SQLite connection layer via ``EventStore(..., read_only=True)`` so even
+unexpected write paths fail fast with ``attempt to write a readonly
+database``. Its only job is to surface the identifiers a user needs to
+re-attach (inspect with ``ouroboros tui monitor`` or resume execution with
 ``ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>``).
 """
 
@@ -48,7 +50,10 @@ async def _get_event_store(db_path: str | None = None):
 
     Returns ``None`` if the database file does not exist. Intentionally does
     not create ``~/.ouroboros/`` or run ``metadata.create_all`` — this command
-    is a recovery tool and must not mutate user state.
+    is a recovery tool and must not mutate user state. Read-only is enforced
+    at the SQLite connection layer via ``EventStore(..., read_only=True)``
+    so any accidental write path raises
+    ``sqlite3.OperationalError: attempt to write a readonly database``.
     """
     from ouroboros.persistence.event_store import EventStore
 
@@ -56,9 +61,12 @@ async def _get_event_store(db_path: str | None = None):
     if not Path(resolved).exists():
         return None
 
-    event_store = EventStore(f"sqlite+aiosqlite:///{resolved}")
+    event_store = EventStore(
+        f"sqlite+aiosqlite:///{resolved}",
+        read_only=True,
+    )
     try:
-        await event_store.initialize(create_schema=False)
+        await event_store.initialize()
     except Exception:
         # Ensure the partially constructed engine is disposed before we bail
         # out — otherwise the outer ``finally`` cannot close it (the variable
@@ -178,23 +186,28 @@ def _format_reattach_guidance(tracker) -> str:
 
     Prints two commands, matching the real CLI contracts:
 
-    - Inspect:   ``ouroboros status execution <exec_id>``
+    - Inspect:   ``ouroboros tui monitor`` (functional TUI; select the session)
     - Resume:    ``ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>``
 
     ``run workflow --resume`` takes a *session_id* (not an execution_id) and
     also requires the seed file, so both identifiers are surfaced explicitly.
+
+    Note: ``ouroboros status execution <exec_id>`` is *registered* but its
+    implementation is still a placeholder (see src/ouroboros/cli/commands/status.py),
+    so we deliberately do not surface it as an inspection path — it would
+    print misleading "Would show details" output.
     """
     exec_id = tracker.execution_id or "<unknown>"
     seed_hint = tracker.seed_id or "<seed.yaml>"
 
-    inspect_line = f"ouroboros status execution {exec_id}"
+    inspect_line = "ouroboros tui monitor"
     resume_line = f"ouroboros run workflow --orchestrator --resume {tracker.session_id} {seed_hint}"
 
     lines = [
         f"Session ID:   [bold cyan]{tracker.session_id}[/]",
         f"Execution ID: [bold cyan]{exec_id}[/]",
         "",
-        "[bold]Inspect[/] (read-only status):",
+        "[bold]Inspect[/] (read-only interactive monitor):",
         f"    {inspect_line}",
         "",
         "[bold]Resume execution[/] (requires the original seed file):",
@@ -295,8 +308,9 @@ def resume(
 
     Re-attach paths surfaced after selection:
 
-        # Inspect
-        ouroboros status execution <exec_id>
+        # Inspect (interactive monitor — the `status execution` placeholder is
+        # not wired up yet)
+        ouroboros tui monitor
 
         # Resume execution (requires the original seed file)
         ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>

--- a/src/ouroboros/cli/commands/resume.py
+++ b/src/ouroboros/cli/commands/resume.py
@@ -1,0 +1,183 @@
+"""Resume command for Ouroboros.
+
+List in-flight sessions directly from the EventStore (no MCP dependency)
+and surface the exec_id so the user can re-attach with `ooo status`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import typer
+
+from ouroboros.cli.formatters import console
+from ouroboros.cli.formatters.panels import print_error, print_info, print_success
+from ouroboros.cli.formatters.tables import create_table, print_table
+
+app = typer.Typer(
+    name="resume",
+    help="List in-flight sessions and re-attach after MCP disconnect.",
+    invoke_without_command=True,
+)
+
+
+async def _get_event_store():
+    """Create and initialize an EventStore instance.
+
+    Returns:
+        Initialized EventStore.
+    """
+    from ouroboros.persistence.event_store import EventStore
+
+    db_path = os.path.expanduser("~/.ouroboros/ouroboros.db")
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    event_store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+    await event_store.initialize()
+    return event_store
+
+
+async def _get_in_flight_sessions(event_store) -> list:
+    """Return all running or paused session trackers.
+
+    Args:
+        event_store: Initialized EventStore instance.
+
+    Returns:
+        List of SessionTracker objects for in-flight sessions.
+    """
+    from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+
+    repo = SessionRepository(event_store)
+    session_events = await event_store.get_all_sessions()
+
+    if not session_events:
+        return []
+
+    seen: set[str] = set()
+    in_flight: list = []
+
+    for event in session_events:
+        session_id = event.aggregate_id
+        if session_id in seen:
+            continue
+        seen.add(session_id)
+
+        result = await repo.reconstruct_session(session_id)
+        if result.is_err:
+            continue
+
+        tracker = result.value
+        if tracker.status in (SessionStatus.RUNNING, SessionStatus.PAUSED):
+            in_flight.append(tracker)
+
+    return in_flight
+
+
+def _display_sessions(sessions: list) -> None:
+    """Render in-flight sessions in a numbered table.
+
+    Args:
+        sessions: List of SessionTracker objects.
+    """
+    table = create_table("In-Flight Sessions")
+    table.add_column("#", style="bold", no_wrap=True, justify="right")
+    table.add_column("Session ID", style="cyan", no_wrap=True)
+    table.add_column("Execution ID", style="dim")
+    table.add_column("Seed ID", style="dim")
+    table.add_column("Status", justify="center")
+    table.add_column("Started", style="dim")
+
+    for idx, tracker in enumerate(sessions, 1):
+        status = tracker.status.value
+        status_style = "success" if status == "running" else "warning"
+        table.add_row(
+            str(idx),
+            tracker.session_id,
+            tracker.execution_id or "-",
+            tracker.seed_id or "-",
+            f"[{status_style}]{status}[/]",
+            tracker.start_time.isoformat(),
+        )
+
+    print_table(table)
+
+
+async def _interactive_resume() -> None:
+    """List in-flight sessions and prompt the user to pick one to re-attach."""
+    try:
+        event_store = await _get_event_store()
+    except Exception as exc:  # noqa: BLE001
+        print_error(f"Failed to open EventStore: {exc}")
+        return
+
+    try:
+        sessions = await _get_in_flight_sessions(event_store)
+    except Exception as exc:  # noqa: BLE001
+        print_error(f"Failed to read EventStore: {exc}")
+        return
+    finally:
+        await event_store.close()
+
+    if not sessions:
+        print_info("No in-flight sessions found.", "Resume")
+        console.print(
+            "[dim]Sessions appear here when the MCP server was disconnected mid-execution.[/]"
+        )
+        return
+
+    _display_sessions(sessions)
+    console.print()
+
+    choice = typer.prompt(
+        f"Enter number to re-attach (1-{len(sessions)}), or 'q' to quit",
+        default="q",
+    )
+
+    if choice.strip().lower() == "q":
+        print_info("No session selected.", "Resume")
+        return
+
+    try:
+        index = int(choice) - 1
+    except ValueError:
+        print_error(f"Invalid selection: {choice!r}")
+        raise typer.Exit(1)
+
+    if index < 0 or index >= len(sessions):
+        print_error(f"Selection out of range: {choice}. Expected 1-{len(sessions)}.")
+        raise typer.Exit(1)
+
+    selected = sessions[index]
+    exec_id = selected.execution_id or selected.session_id
+
+    print_success(
+        f"Session selected: [bold]{selected.session_id}[/]\n"
+        f"Execution ID:     [bold cyan]{exec_id}[/]\n\n"
+        "Re-attach by running:\n\n"
+        f"    ooo status {exec_id}",
+        "Re-attach",
+    )
+
+
+@app.callback(invoke_without_command=True)
+def resume(ctx: typer.Context) -> None:
+    """List in-flight sessions and get re-attach instructions.
+
+    Reads the EventStore directly — no MCP server required. Use this
+    command after an unexpected MCP disconnect to recover the execution ID
+    and re-attach with:
+
+        ooo status <exec_id>
+
+    Examples:
+
+        # Interactive: list in-flight sessions and pick one
+        ouroboros resume
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+    asyncio.run(_interactive_resume())
+
+
+__all__ = ["app"]

--- a/src/ouroboros/cli/commands/resume.py
+++ b/src/ouroboros/cli/commands/resume.py
@@ -1,7 +1,8 @@
 """Resume command for Ouroboros.
 
 List in-flight sessions directly from the EventStore (no MCP dependency)
-and surface the exec_id so the user can re-attach with `ooo status`.
+and surface the exec_id so the user can re-attach with
+`ouroboros status execution <exec_id>`.
 """
 
 from __future__ import annotations
@@ -155,7 +156,7 @@ async def _interactive_resume() -> None:
         f"Session selected: [bold]{selected.session_id}[/]\n"
         f"Execution ID:     [bold cyan]{exec_id}[/]\n\n"
         "Re-attach by running:\n\n"
-        f"    ooo status {exec_id}",
+        f"    ouroboros status execution {exec_id}",
         "Re-attach",
     )
 
@@ -168,7 +169,7 @@ def resume(ctx: typer.Context) -> None:
     command after an unexpected MCP disconnect to recover the execution ID
     and re-attach with:
 
-        ooo status <exec_id>
+        ouroboros status execution <exec_id>
 
     Examples:
 

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -21,6 +21,7 @@ from ouroboros.cli.commands import (
     init,
     mcp,
     pm,
+    resume,
     run,
     setup,
     status,
@@ -48,6 +49,7 @@ app.add_typer(setup.app, name="setup")
 app.add_typer(detect.app, name="detect")
 app.add_typer(tui.app, name="tui")
 app.add_typer(pm.app, name="pm")
+app.add_typer(resume.app, name="resume")
 app.add_typer(uninstall.app, name="uninstall")
 
 

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -90,20 +90,63 @@ class EventStore:
         await store.close()
     """
 
-    def __init__(self, database_url: str | None = None) -> None:
+    def __init__(
+        self,
+        database_url: str | None = None,
+        *,
+        read_only: bool = False,
+    ) -> None:
         """Initialize EventStore with database URL.
 
         Args:
             database_url: SQLAlchemy database URL.
                          For async SQLite: "sqlite+aiosqlite:///path/to/db.sqlite"
                          If not provided, defaults to ~/.ouroboros/ouroboros.db
+            read_only: When True, open the underlying SQLite database in true
+                read-only mode by rewriting the URL into the ``file:<path>?mode=ro&uri=true``
+                form and passing ``connect_args={"uri": True}`` to aiosqlite.
+                This enforces the read-only contract at the connection layer
+                so *any* accidental write path (including library/future code
+                paths we don't control) fails fast with
+                ``sqlite3.OperationalError: attempt to write a readonly database``.
+                Callers that opt in should also skip schema creation by calling
+                ``initialize(create_schema=False)`` — this is the default when
+                ``read_only=True``. ``read_only`` is a no-op for non-SQLite URLs.
         """
         if database_url is None:
             db_path = Path.home() / ".ouroboros" / "ouroboros.db"
-            db_path.parent.mkdir(parents=True, exist_ok=True)
+            if not read_only:
+                db_path.parent.mkdir(parents=True, exist_ok=True)
             database_url = f"sqlite+aiosqlite:///{db_path}"
+
+        self._read_only = read_only
+        if read_only:
+            database_url = self._coerce_to_readonly_url(database_url)
         self._database_url = database_url
         self._engine: AsyncEngine | None = None
+
+    @staticmethod
+    def _coerce_to_readonly_url(database_url: str) -> str:
+        """Rewrite a plain aiosqlite URL into a ``mode=ro`` URI form.
+
+        Leaves non-SQLite URLs untouched. Already-URI forms (starting with
+        ``file:``) are returned as-is so explicit callers keep full control.
+        """
+        prefix = "sqlite+aiosqlite:///"
+        if not database_url.startswith(prefix):
+            return database_url
+
+        path_part = database_url[len(prefix) :]
+        if path_part.startswith("file:"):
+            # Caller already provided a URI form — respect it verbatim.
+            return database_url
+
+        # ``:memory:`` has no filesystem and cannot be opened read-only
+        # meaningfully; leave it alone.
+        if path_part in (":memory:", ""):
+            return database_url
+
+        return f"{prefix}file:{path_part}?mode=ro&uri=true"
 
     def _raise_invalid_append_input(
         self,
@@ -133,36 +176,60 @@ class EventStore:
             details=details,
         )
 
-    async def initialize(self, *, create_schema: bool = True) -> None:
+    async def initialize(self, *, create_schema: bool | None = None) -> None:
         """Initialize the database connection and create tables if needed.
 
         This method is idempotent - calling it multiple times is safe.
 
         Args:
-            create_schema: When True (default) run ``metadata.create_all`` so
-                missing tables are created. Read-only consumers (for example
-                diagnostic CLI commands that must not mutate the store) can
-                pass ``False`` to skip schema creation entirely.
+            create_schema: When True run ``metadata.create_all`` so missing
+                tables are created. Read-only consumers (for example diagnostic
+                CLI commands that must not mutate the store) can pass ``False``
+                to skip schema creation entirely. When ``None`` (default), the
+                value follows ``read_only``: stores constructed with
+                ``read_only=True`` skip schema creation and all others create
+                it, preserving the prior default behaviour.
 
         For aiosqlite, uses StaticPool (default) which maintains a single
         connection. This avoids connection accumulation while supporting
         :memory: databases in tests.
         """
+        if create_schema is None:
+            create_schema = not self._read_only
+
+        if self._read_only and create_schema:
+            raise PersistenceError(
+                "Cannot create schema on a read-only EventStore.",
+                operation="initialize",
+                details={"read_only": True},
+            )
+
         if self._engine is None:
+            connect_args: dict[str, object] = {"timeout": 30}
+            if self._read_only:
+                # aiosqlite forwards unknown kwargs to sqlite3.connect — the
+                # ``uri=True`` flag is what turns the ``file:...?mode=ro`` form
+                # into a real read-only connection.
+                connect_args["uri"] = True
+
             self._engine = create_async_engine(
                 self._database_url,
                 echo=False,
-                connect_args={"timeout": 30},
+                connect_args=connect_args,
             )
 
-            # Enable WAL mode and set busy timeout on every new connection
-            @event.listens_for(self._engine.sync_engine, "connect")
-            def _set_sqlite_pragmas(dbapi_conn, _connection_record):
-                cursor = dbapi_conn.cursor()
-                cursor.execute("PRAGMA journal_mode=WAL")
-                cursor.execute("PRAGMA synchronous=NORMAL")
-                cursor.execute("PRAGMA busy_timeout=30000")
-                cursor.close()
+            # Enable WAL mode and set busy timeout on every new connection.
+            # Skipped for read-only consumers: ``PRAGMA journal_mode=WAL`` is
+            # itself a write and would trip SQLite's read-only guard.
+            if not self._read_only:
+
+                @event.listens_for(self._engine.sync_engine, "connect")
+                def _set_sqlite_pragmas(dbapi_conn, _connection_record):
+                    cursor = dbapi_conn.cursor()
+                    cursor.execute("PRAGMA journal_mode=WAL")
+                    cursor.execute("PRAGMA synchronous=NORMAL")
+                    cursor.execute("PRAGMA busy_timeout=30000")
+                    cursor.close()
 
         # Create all tables defined in metadata (skipped for read-only consumers)
         if create_schema:

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -133,10 +133,16 @@ class EventStore:
             details=details,
         )
 
-    async def initialize(self) -> None:
+    async def initialize(self, *, create_schema: bool = True) -> None:
         """Initialize the database connection and create tables if needed.
 
         This method is idempotent - calling it multiple times is safe.
+
+        Args:
+            create_schema: When True (default) run ``metadata.create_all`` so
+                missing tables are created. Read-only consumers (for example
+                diagnostic CLI commands that must not mutate the store) can
+                pass ``False`` to skip schema creation entirely.
 
         For aiosqlite, uses StaticPool (default) which maintains a single
         connection. This avoids connection accumulation while supporting
@@ -158,9 +164,10 @@ class EventStore:
                 cursor.execute("PRAGMA busy_timeout=30000")
                 cursor.close()
 
-        # Create all tables defined in metadata
-        async with self._engine.begin() as conn:
-            await conn.run_sync(metadata.create_all)
+        # Create all tables defined in metadata (skipped for read-only consumers)
+        if create_schema:
+            async with self._engine.begin() as conn:
+                await conn.run_sync(metadata.create_all)
 
     async def append(self, event: BaseEvent) -> None:
         """Append an event to the store.

--- a/tests/unit/cli/test_doc_commands.py
+++ b/tests/unit/cli/test_doc_commands.py
@@ -1,0 +1,187 @@
+"""Contract tests for documented CLI command strings.
+
+User-facing documentation (skills, README, CLAUDE.md, in-code re-attach
+guidance) routinely prints runnable command strings. When a command string
+drifts from the installed argparse/typer tree — either the subcommand
+vanishes, is renamed, or an option is removed — users follow stale guidance
+into "unknown command" errors.
+
+These tests walk the command strings we actually print to users and assert
+each one parses cleanly under the installed CLI tree. We rely on ``--help``
+to prove syntactic acceptance without executing side effects (no DB writes,
+no MCP spin-up, no seed file required).
+
+Scope:
+
+- Every command line emitted by ``resume._format_reattach_guidance``.
+- Every ``ouroboros ...`` directive documented in ``skills/resume/SKILL.md``.
+- The bare ``ouroboros`` entrypoints listed in the CLAUDE.md ``ooo`` table
+  that correspond to a real CLI subcommand (plugin-only skills such as
+  ``ooo welcome`` are not CLI commands and are skipped).
+
+If you add a new documented command string, add it here too. The test is
+deliberately strict: it ignores nothing, because the whole point is to catch
+the kind of drift flagged in PR #433's bot review (the ``ooo`` skill
+surfaces pointing at a placeholder ``status execution`` handler).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.cli.commands.resume import _format_reattach_guidance
+from ouroboros.cli.main import app as root_app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_runner = CliRunner()
+
+
+def _make_tracker(
+    session_id: str = "sess-abc123",
+    execution_id: str | None = "exec-xyz789",
+    seed_id: str | None = "seed-001",
+) -> MagicMock:
+    """Return a minimal SessionTracker-like mock for guidance rendering."""
+    from ouroboros.orchestrator.session import SessionStatus
+
+    tracker = MagicMock()
+    tracker.session_id = session_id
+    tracker.execution_id = execution_id
+    tracker.seed_id = seed_id
+    tracker.status = SessionStatus("running")
+    from datetime import UTC, datetime
+
+    tracker.start_time = datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC)
+    return tracker
+
+
+def _assert_command_parses(argv: list[str]) -> None:
+    """Invoke ``argv + ['--help']`` and assert Typer accepted the chain.
+
+    Appending ``--help`` gives us a zero-side-effect proof that every
+    subcommand in the chain exists and every option is recognised.
+    """
+    result = _runner.invoke(root_app, [*argv, "--help"])
+    assert result.exit_code == 0, (
+        f"documented command string `ouroboros {' '.join(argv)}` did not parse:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1) Commands printed by `resume._format_reattach_guidance`
+# ---------------------------------------------------------------------------
+
+
+class TestReattachGuidanceCommandsAreReal:
+    """Every command string emitted by the re-attach panel must be real."""
+
+    def test_inspect_command_parses(self) -> None:
+        """``ouroboros tui monitor`` must be a real subcommand chain."""
+        tracker = _make_tracker()
+        output = _format_reattach_guidance(tracker)
+        assert "ouroboros tui monitor" in output, (
+            "inspect guidance must surface `ouroboros tui monitor`"
+        )
+        _assert_command_parses(["tui", "monitor"])
+
+    def test_resume_command_parses(self) -> None:
+        """The ``run workflow --orchestrator --resume`` chain must parse."""
+        tracker = _make_tracker()
+        output = _format_reattach_guidance(tracker)
+        assert "ouroboros run workflow --orchestrator --resume" in output
+        # --orchestrator and --resume must both be accepted by run workflow.
+        result = _runner.invoke(root_app, ["run", "workflow", "--help"])
+        assert result.exit_code == 0
+        assert "--orchestrator" in result.output
+        assert "--resume" in result.output
+
+    def test_guidance_does_not_point_at_placeholder(self) -> None:
+        """Must NOT surface ``ouroboros status execution`` (placeholder handler).
+
+        ``src/ouroboros/cli/commands/status.py:execution`` only prints
+        "Would show details for execution: …". Surfacing it misleads users
+        into thinking they can inspect an execution when they can't.
+        """
+        tracker = _make_tracker()
+        output = _format_reattach_guidance(tracker)
+        assert "ouroboros status execution" not in output
+
+
+# ---------------------------------------------------------------------------
+# 2) Every `ouroboros ...` directive in skills/resume/SKILL.md
+# ---------------------------------------------------------------------------
+
+
+# NB: these are the *user-facing* directives intended to be run verbatim.
+# Placeholder forms (with ``<angle brackets>``) are rewritten to concrete
+# stubs so the argparse tree can actually see each token. The goal is to
+# verify the subcommand chain + options, not the argument values.
+SKILL_RESUME_COMMANDS: list[list[str]] = [
+    # Primary command the skill tells users to run.
+    ["resume"],
+    # Inspect (read-only) path printed after session selection.
+    ["tui", "monitor"],
+    # Resume execution path printed after session selection.
+    # --resume takes a session_id; the seed file is a positional arg.
+    ["run", "workflow", "--orchestrator", "--resume", "sess-abc123", "seed.yaml"],
+]
+
+
+@pytest.mark.parametrize("argv", SKILL_RESUME_COMMANDS)
+def test_skill_resume_commands_parse(argv: list[str]) -> None:
+    """Every runnable ``ouroboros ...`` string in the resume skill parses."""
+    # For the seed-file positional, ``--help`` suffices to verify the chain
+    # accepts the shape; we don't need the file to exist.
+    _assert_command_parses(argv)
+
+
+# ---------------------------------------------------------------------------
+# 3) Real CLI subcommands listed under the CLAUDE.md ooo table
+# ---------------------------------------------------------------------------
+
+
+# The CLAUDE.md ooo table maps `ooo <verb>` to a SKILL.md file. Most verbs
+# are Claude-Code skills (no CLI equivalent — e.g. ``ooo welcome``). The
+# ones below are verbs whose SKILL.md genuinely shells out to ``ouroboros
+# <verb>``, so the CLI subcommand must exist. If a verb here disappears
+# from the CLI but stays in CLAUDE.md, users following the skill will hit
+# "No such command".
+CLAUDE_MD_BACKED_BY_CLI: list[list[str]] = [
+    ["run", "--help"],
+    ["init", "--help"],
+    ["config", "--help"],
+    ["status", "--help"],
+    ["cancel", "--help"],
+    ["mcp", "--help"],
+    ["setup", "--help"],
+    ["tui", "--help"],
+    ["pm", "--help"],
+    ["resume", "--help"],
+    ["uninstall", "--help"],
+]
+
+
+@pytest.mark.parametrize("argv", CLAUDE_MD_BACKED_BY_CLI)
+def test_claude_md_cli_subcommands_exist(argv: list[str]) -> None:
+    """Every ``ouroboros <verb>`` referenced from skill guidance must resolve."""
+    result = _runner.invoke(root_app, argv)
+    assert result.exit_code == 0, (
+        f"CLAUDE.md-referenced CLI `ouroboros {' '.join(argv[:-1])}` is missing:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4) Cancel guidance (the resume skill's "Next Steps" block points at it)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_execution_subcommand_parses() -> None:
+    """``ooo cancel execution <exec_id>`` resolves to real ``cancel execution``."""
+    _assert_command_parses(["cancel", "execution"])

--- a/tests/unit/cli/test_resume.py
+++ b/tests/unit/cli/test_resume.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+import sqlite3
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import OperationalError
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands.resume import (
     EXIT_CORRUPTED_DB,
     _format_reattach_guidance,
+    _get_event_store,
     _get_in_flight_sessions,
     _is_active_snapshot,
     app,
@@ -284,10 +287,20 @@ class TestFormatReattachGuidance:
         output = _format_reattach_guidance(tracker)
         assert "ouroboros run workflow --orchestrator --resume sess-abc123 seed-001" in output
 
-    def test_inspect_command_uses_execution_id(self) -> None:
+    def test_inspect_command_points_at_tui_monitor(self) -> None:
+        """Inspect guidance must point at a *functional* command.
+
+        ``ouroboros status execution <id>`` is registered but its handler is
+        still a placeholder (src/ouroboros/cli/commands/status.py) — it would
+        print "Would show details for execution: ..." instead of doing
+        anything useful. ``ouroboros tui monitor`` is the real working
+        inspection path today, so the guidance points there until
+        ``status execution`` is implemented.
+        """
         tracker = _make_tracker()
         output = _format_reattach_guidance(tracker)
-        assert "ouroboros status execution exec-xyz789" in output
+        assert "ouroboros tui monitor" in output
+        assert "ouroboros status execution" not in output
 
     def test_surfaces_both_identifiers(self) -> None:
         tracker = _make_tracker()
@@ -490,12 +503,158 @@ class TestResumeCLIWithSessions:
         result = self._invoke_with_sessions("99\n")
         assert result.exit_code == 1
 
-    def test_status_hint_included_in_output(self) -> None:
-        """The output suggests `ouroboros status execution <exec_id>` for inspection."""
+    def test_inspect_hint_points_at_functional_command(self) -> None:
+        """Inspect hint must be a *working* command (``tui monitor``).
+
+        Pinned contract: the resume output must not direct users at the
+        placeholder ``status execution`` handler (Finding #2).
+        """
         result = self._invoke_with_sessions("1\n")
-        assert "ouroboros status execution" in result.output
+        assert "ouroboros tui monitor" in result.output
+        assert "ouroboros status execution" not in result.output
 
     def test_resume_hint_matches_run_workflow_contract(self) -> None:
         """The output surfaces `ouroboros run workflow --orchestrator --resume <session_id>`."""
         result = self._invoke_with_sessions("1\n")
         assert "ouroboros run workflow --orchestrator --resume sess-abc123" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Read-only enforcement at the SQLite connection layer
+# ---------------------------------------------------------------------------
+
+
+class TestResumeConnectionIsReadOnly:
+    """Pin the core contract: ``resume`` opens the DB in true read-only mode.
+
+    The earlier ``create_schema=False`` guard only skipped schema creation —
+    the underlying SQLite connection was still read-write, so a future code
+    path (or a library bug) could mutate the user's DB. These tests enforce
+    the contract at the connection layer via the
+    ``EventStore(..., read_only=True)`` URI form ``mode=ro&uri=true``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cannot_insert_through_opened_event_store(self, tmp_path: Path) -> None:
+        """Any INSERT against the opened connection must raise OperationalError."""
+        # Seed a real on-disk SQLite file with the schema so the read-only
+        # connection has something to refuse writes against.
+        db_path = tmp_path / "ouroboros.db"
+        from sqlalchemy import text
+
+        from ouroboros.persistence.event_store import EventStore
+
+        # Bootstrap schema via a separate RW store, then close it cleanly.
+        bootstrap = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await bootstrap.initialize()
+        await bootstrap.close()
+
+        event_store = await _get_event_store(str(db_path))
+        assert event_store is not None
+        try:
+            with pytest.raises(OperationalError) as excinfo:
+                async with event_store._engine.begin() as conn:  # type: ignore[union-attr]
+                    # Raw SQL — we don't care *which* write we attempt, only
+                    # that the connection refuses every write. ``DELETE FROM
+                    # events`` is trivially valid against the bootstrapped
+                    # schema, so a failure here proves the connection itself
+                    # is read-only (not a schema mismatch).
+                    await conn.execute(text("DELETE FROM events"))
+            assert "readonly database" in str(excinfo.value).lower()
+        finally:
+            await event_store.close()
+
+    @pytest.mark.asyncio
+    async def test_database_url_uses_readonly_uri_form(self, tmp_path: Path) -> None:
+        """The constructed URL must include ``mode=ro`` and ``uri=true``."""
+        db_path = tmp_path / "ouroboros.db"
+        from ouroboros.persistence.event_store import EventStore
+
+        bootstrap = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await bootstrap.initialize()
+        await bootstrap.close()
+
+        event_store = await _get_event_store(str(db_path))
+        assert event_store is not None
+        try:
+            url = event_store._database_url  # type: ignore[attr-defined]
+            assert "mode=ro" in url
+            assert "uri=true" in url
+        finally:
+            await event_store.close()
+
+    @pytest.mark.asyncio
+    async def test_raw_sqlite_write_is_blocked(self, tmp_path: Path) -> None:
+        """Belt-and-braces: even a raw sqlite3 connect over the URI refuses writes.
+
+        Guards against someone later swapping in a non-aiosqlite driver that
+        ignores our connect_args — the URI itself carries ``mode=ro``.
+        """
+        db_path = tmp_path / "ouroboros.db"
+        from ouroboros.persistence.event_store import EventStore
+
+        bootstrap = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await bootstrap.initialize()
+        await bootstrap.close()
+
+        event_store = EventStore(
+            f"sqlite+aiosqlite:///{db_path}",
+            read_only=True,
+        )
+        try:
+            # Extract the ``file:...`` path from the rewritten URL so we can
+            # hand it to sqlite3.connect directly, bypassing aiosqlite.
+            url = event_store._database_url  # type: ignore[attr-defined]
+            prefix = "sqlite+aiosqlite:///"
+            assert url.startswith(prefix)
+            raw_uri = url[len(prefix) :]
+
+            with sqlite3.connect(raw_uri, uri=True) as conn:
+                with pytest.raises(sqlite3.OperationalError) as excinfo:
+                    conn.execute("DELETE FROM events")
+                assert "readonly" in str(excinfo.value).lower()
+        finally:
+            await event_store.close()
+
+
+# ---------------------------------------------------------------------------
+# Printed guidance is parseable by the installed CLI
+# ---------------------------------------------------------------------------
+
+
+class TestResumeGuidanceIsCallable:
+    """The printed next-step commands must be syntactically accepted by the CLI.
+
+    We don't *execute* the happy path (it would require a real seed file and
+    an MCP server), but ``--help`` on the parsed subcommand chain proves that
+    the command string is one the installed CLI actually understands — i.e.
+    we don't ship guidance that points at a non-existent command again
+    (Finding #2).
+    """
+
+    def test_tui_monitor_subcommand_chain_is_valid(self) -> None:
+        """``ouroboros tui monitor --help`` must succeed."""
+        from ouroboros.cli.main import app as root_app
+
+        result = CliRunner().invoke(root_app, ["tui", "monitor", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "monitor" in result.output.lower() or "tui" in result.output.lower()
+
+    def test_run_workflow_resume_subcommand_chain_is_valid(self) -> None:
+        """``ouroboros run workflow --help`` must list ``--resume`` and ``--orchestrator``."""
+        from ouroboros.cli.main import app as root_app
+
+        result = CliRunner().invoke(root_app, ["run", "workflow", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--resume" in result.output
+        assert "--orchestrator" in result.output
+
+    def test_status_execution_is_not_surfaced_as_guidance(self) -> None:
+        """``status execution`` is a placeholder — guidance must not point there.
+
+        This pins Finding #2 (the printed re-attach hint used to claim
+        ``ouroboros status execution <id>`` but that handler is still
+        unimplemented — see src/ouroboros/cli/commands/status.py).
+        """
+        tracker = _make_tracker()
+        assert "status execution" not in _format_reattach_guidance(tracker)

--- a/tests/unit/cli/test_resume.py
+++ b/tests/unit/cli/test_resume.py
@@ -9,7 +9,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
-from ouroboros.cli.commands.resume import _get_in_flight_sessions, app
+from ouroboros.cli.commands.resume import (
+    EXIT_CORRUPTED_DB,
+    _format_reattach_guidance,
+    _get_in_flight_sessions,
+    _is_active_snapshot,
+    app,
+)
 
 runner = CliRunner()
 
@@ -24,8 +30,8 @@ _SESSION_REPO_PATH = "ouroboros.orchestrator.session.SessionRepository"
 
 def _make_tracker(
     session_id: str = "sess-abc123",
-    execution_id: str = "exec-xyz789",
-    seed_id: str = "seed-001",
+    execution_id: str | None = "exec-xyz789",
+    seed_id: str | None = "seed-001",
     status_value: str = "running",
 ) -> MagicMock:
     """Return a minimal SessionTracker-like mock."""
@@ -40,10 +46,54 @@ def _make_tracker(
     return tracker
 
 
-def _make_event(aggregate_id: str) -> MagicMock:
-    event = MagicMock()
-    event.aggregate_id = aggregate_id
-    return event
+def _make_snapshot(
+    session_id: str = "sess-abc123",
+    status_event_type: str | None = None,
+    last_activity: str = "2026-04-15T12:00:00+00:00",
+    start_time: str = "2026-04-15T12:00:00+00:00",
+) -> MagicMock:
+    """Return a minimal SessionActivitySnapshot-like mock."""
+    snapshot = MagicMock()
+    snapshot.session_id = session_id
+    snapshot.execution_id = "exec-xyz789"
+    snapshot.seed_id = "seed-001"
+    snapshot.status_event_type = status_event_type
+    snapshot.last_activity = last_activity
+    snapshot.start_time = start_time
+    snapshot.runtime_status = None
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Snapshot filtering
+# ---------------------------------------------------------------------------
+
+
+class TestIsActiveSnapshot:
+    """The terminal short-circuit must match the orchestrator.session.* contract."""
+
+    @pytest.mark.parametrize(
+        "terminal",
+        [
+            "orchestrator.session.completed",
+            "orchestrator.session.failed",
+            "orchestrator.session.cancelled",
+        ],
+    )
+    def test_terminal_status_is_inactive(self, terminal: str) -> None:
+        assert _is_active_snapshot(_make_snapshot(status_event_type=terminal)) is False
+
+    @pytest.mark.parametrize(
+        "active",
+        [
+            None,
+            "orchestrator.session.paused",
+            "orchestrator.session.started",
+            "orchestrator.progress.updated",
+        ],
+    )
+    def test_non_terminal_status_is_active(self, active: str | None) -> None:
+        assert _is_active_snapshot(_make_snapshot(status_event_type=active)) is True
 
 
 # ---------------------------------------------------------------------------
@@ -52,16 +102,16 @@ def _make_event(aggregate_id: str) -> MagicMock:
 
 
 class TestGetInFlightSessions:
-    """Tests for the _get_in_flight_sessions helper."""
+    """Tests for the _get_in_flight_sessions helper (snapshot-first path)."""
 
     @pytest.mark.asyncio
     async def test_returns_running_sessions(self) -> None:
         """Running sessions are returned."""
         tracker = _make_tracker(status_value="running")
-        event = _make_event("sess-abc123")
+        snapshot = _make_snapshot()
 
         event_store = AsyncMock()
-        event_store.get_all_sessions.return_value = [event]
+        event_store.get_session_activity_snapshots.return_value = [snapshot]
 
         ok_result = MagicMock()
         ok_result.is_err = False
@@ -77,10 +127,13 @@ class TestGetInFlightSessions:
     async def test_returns_paused_sessions(self) -> None:
         """Paused sessions are also returned."""
         tracker = _make_tracker(status_value="paused")
-        event = _make_event("sess-paused")
+        snapshot = _make_snapshot(
+            session_id="sess-paused",
+            status_event_type="orchestrator.session.paused",
+        )
 
         event_store = AsyncMock()
-        event_store.get_all_sessions.return_value = [event]
+        event_store.get_session_activity_snapshots.return_value = [snapshot]
 
         ok_result = MagicMock()
         ok_result.is_err = False
@@ -93,14 +146,30 @@ class TestGetInFlightSessions:
         assert result == [tracker]
 
     @pytest.mark.asyncio
+    async def test_short_circuits_terminal_snapshots(self) -> None:
+        """Snapshots with terminal status_event_type skip reconstruct entirely."""
+        snapshot = _make_snapshot(status_event_type="orchestrator.session.completed")
+
+        event_store = AsyncMock()
+        event_store.get_session_activity_snapshots.return_value = [snapshot]
+
+        with patch(_SESSION_REPO_PATH, autospec=True) as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.reconstruct_session = AsyncMock()
+            result = await _get_in_flight_sessions(event_store)
+
+        mock_repo.reconstruct_session.assert_not_called()
+        assert result == []
+
+    @pytest.mark.asyncio
     async def test_excludes_terminal_sessions(self) -> None:
-        """Completed / failed / cancelled sessions are not returned."""
+        """Even if snapshot lets it through, reconstructed terminal status is dropped."""
         for status in ("completed", "failed", "cancelled"):
             tracker = _make_tracker(status_value=status)
-            event = _make_event(f"sess-{status}")
+            snapshot = _make_snapshot(session_id=f"sess-{status}")
 
             event_store = AsyncMock()
-            event_store.get_all_sessions.return_value = [event]
+            event_store.get_session_activity_snapshots.return_value = [snapshot]
 
             ok_result = MagicMock()
             ok_result.is_err = False
@@ -116,7 +185,7 @@ class TestGetInFlightSessions:
     async def test_empty_event_store_returns_empty_list(self) -> None:
         """No sessions in the DB → empty list."""
         event_store = AsyncMock()
-        event_store.get_all_sessions.return_value = []
+        event_store.get_session_activity_snapshots.return_value = []
 
         with patch(_SESSION_REPO_PATH, autospec=True):
             result = await _get_in_flight_sessions(event_store)
@@ -124,32 +193,73 @@ class TestGetInFlightSessions:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_deduplicates_session_events(self) -> None:
-        """If the same session_id appears more than once, reconstruct is called once."""
-        tracker = _make_tracker(status_value="running")
-        events = [_make_event("sess-dup"), _make_event("sess-dup")]
+    async def test_sorts_most_recent_first(self) -> None:
+        """Multiple active sessions surface newest-first by last_activity."""
+        tracker_old = _make_tracker(session_id="sess-old")
+        tracker_new = _make_tracker(session_id="sess-new")
+
+        snapshot_old = _make_snapshot(
+            session_id="sess-old",
+            last_activity="2026-04-10T00:00:00+00:00",
+        )
+        snapshot_new = _make_snapshot(
+            session_id="sess-new",
+            last_activity="2026-04-16T00:00:00+00:00",
+        )
 
         event_store = AsyncMock()
-        event_store.get_all_sessions.return_value = events
+        event_store.get_session_activity_snapshots.return_value = [snapshot_old, snapshot_new]
 
-        ok_result = MagicMock()
-        ok_result.is_err = False
-        ok_result.value = tracker
+        by_id = {"sess-old": tracker_old, "sess-new": tracker_new}
+
+        async def _reconstruct(session_id):
+            ok = MagicMock()
+            ok.is_err = False
+            ok.value = by_id[session_id]
+            return ok
 
         with patch(_SESSION_REPO_PATH, autospec=True) as MockRepo:
-            mock_repo = MockRepo.return_value
-            mock_repo.reconstruct_session = AsyncMock(return_value=ok_result)
+            MockRepo.return_value.reconstruct_session = AsyncMock(side_effect=_reconstruct)
             result = await _get_in_flight_sessions(event_store)
 
-        mock_repo.reconstruct_session.assert_called_once_with("sess-dup")
-        assert result == [tracker]
+        assert [t.session_id for t in result] == ["sess-new", "sess-old"]
+
+    @pytest.mark.asyncio
+    async def test_respects_display_limit(self) -> None:
+        """When more than `limit` sessions are active, only the top N are returned."""
+        snapshots = [
+            _make_snapshot(
+                session_id=f"sess-{i:02d}",
+                last_activity=f"2026-04-15T12:{i:02d}:00+00:00",
+            )
+            for i in range(25)
+        ]
+        trackers = {
+            s.session_id: _make_tracker(session_id=s.session_id, status_value="running")
+            for s in snapshots
+        }
+
+        event_store = AsyncMock()
+        event_store.get_session_activity_snapshots.return_value = snapshots
+
+        async def _reconstruct(session_id):
+            ok = MagicMock()
+            ok.is_err = False
+            ok.value = trackers[session_id]
+            return ok
+
+        with patch(_SESSION_REPO_PATH, autospec=True) as MockRepo:
+            MockRepo.return_value.reconstruct_session = AsyncMock(side_effect=_reconstruct)
+            result = await _get_in_flight_sessions(event_store, limit=5)
+
+        assert len(result) == 5
 
     @pytest.mark.asyncio
     async def test_skips_sessions_that_fail_to_reconstruct(self) -> None:
         """If a session cannot be reconstructed, it is silently skipped."""
-        event = _make_event("sess-broken")
+        snapshot = _make_snapshot(session_id="sess-broken")
         event_store = AsyncMock()
-        event_store.get_all_sessions.return_value = [event]
+        event_store.get_session_activity_snapshots.return_value = [snapshot]
 
         err_result = MagicMock()
         err_result.is_err = True
@@ -162,6 +272,94 @@ class TestGetInFlightSessions:
 
 
 # ---------------------------------------------------------------------------
+# Re-attach output contract
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReattachGuidance:
+    """The printed guidance must match the real CLI contracts."""
+
+    def test_resume_command_points_at_run_workflow(self) -> None:
+        tracker = _make_tracker()
+        output = _format_reattach_guidance(tracker)
+        assert "ouroboros run workflow --orchestrator --resume sess-abc123 seed-001" in output
+
+    def test_inspect_command_uses_execution_id(self) -> None:
+        tracker = _make_tracker()
+        output = _format_reattach_guidance(tracker)
+        assert "ouroboros status execution exec-xyz789" in output
+
+    def test_surfaces_both_identifiers(self) -> None:
+        tracker = _make_tracker()
+        output = _format_reattach_guidance(tracker)
+        assert "sess-abc123" in output
+        assert "exec-xyz789" in output
+
+    def test_missing_execution_id_falls_back_safely(self) -> None:
+        tracker = _make_tracker(execution_id=None)
+        output = _format_reattach_guidance(tracker)
+        assert "<unknown>" in output
+        assert "ouroboros run workflow --orchestrator --resume sess-abc123" in output
+
+    def test_missing_seed_id_surfaces_placeholder(self) -> None:
+        tracker = _make_tracker(seed_id=None)
+        output = _format_reattach_guidance(tracker)
+        assert "<seed.yaml>" in output
+        assert "Seed ID was not recorded" in output
+
+
+# ---------------------------------------------------------------------------
+# Read-only guarantee — missing DB must NOT create anything
+# ---------------------------------------------------------------------------
+
+
+class TestResumeReadOnly:
+    """Verify the command never mutates the filesystem when the DB is absent."""
+
+    def test_missing_db_does_not_create_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With HOME pointed at a fresh tmp_path, no ~/.ouroboros/ must appear."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        # Sanity: directory does not exist beforehand.
+        ouroboros_dir = fake_home / ".ouroboros"
+        assert not ouroboros_dir.exists()
+
+        result = runner.invoke(app, [], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert "No in-flight sessions" in result.output
+        assert not ouroboros_dir.exists(), (
+            f"resume must not create {ouroboros_dir}; found: "
+            f"{list(ouroboros_dir.iterdir()) if ouroboros_dir.exists() else 'n/a'}"
+        )
+
+    def test_missing_db_does_not_create_schema(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Even if the dir exists, the DB file must not be created."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        (fake_home / ".ouroboros").mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        db_file = fake_home / ".ouroboros" / "ouroboros.db"
+        assert not db_file.exists()
+
+        result = runner.invoke(app, [], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert not db_file.exists(), "resume must not create the SQLite file"
+
+
+# ---------------------------------------------------------------------------
 # CLI integration — empty state
 # ---------------------------------------------------------------------------
 
@@ -169,12 +367,12 @@ class TestGetInFlightSessions:
 class TestResumeCLIEmpty:
     """Tests for the `ouroboros resume` command with no sessions."""
 
-    def _invoke_with_empty_store(self, tmp_path: Path) -> object:
+    def _invoke_with_empty_store(self) -> object:
         event_store = AsyncMock()
-        event_store.get_all_sessions.return_value = []
+        event_store.get_session_activity_snapshots.return_value = []
         event_store.close = AsyncMock()
 
-        async def _fake_get_event_store():
+        async def _fake_get_event_store(db_path=None):
             return event_store
 
         with (
@@ -186,14 +384,13 @@ class TestResumeCLIEmpty:
         ):
             return runner.invoke(app, [], catch_exceptions=False)
 
-    def test_exit_code_zero_when_no_sessions(self, tmp_path: Path) -> None:
-        result = self._invoke_with_empty_store(tmp_path)
+    def test_exit_code_zero_when_no_sessions(self) -> None:
+        result = self._invoke_with_empty_store()
         assert result.exit_code == 0
 
-    def test_no_crash_when_no_sessions(self, tmp_path: Path) -> None:
-        """Command must not raise or crash when the DB is empty."""
-        result = self._invoke_with_empty_store(tmp_path)
-        assert "No in-flight sessions" in result.output or result.exit_code == 0
+    def test_message_printed_when_no_sessions(self) -> None:
+        result = self._invoke_with_empty_store()
+        assert "No in-flight sessions" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -204,10 +401,10 @@ class TestResumeCLIEmpty:
 class TestResumeCLICorrupted:
     """Tests for graceful handling of a bad or missing EventStore."""
 
-    def test_handles_corrupted_db_gracefully(self) -> None:
-        """If the EventStore raises during initialization, the command handles it."""
+    def test_corrupted_db_returns_pinned_exit_code(self) -> None:
+        """If the EventStore raises during initialization, exit with EXIT_CORRUPTED_DB."""
 
-        async def _raise():
+        async def _raise(db_path=None):
             raise Exception("database disk image is malformed")
 
         with patch(
@@ -216,15 +413,17 @@ class TestResumeCLICorrupted:
         ):
             result = runner.invoke(app, [], catch_exceptions=False)
 
-        assert result.exit_code in (0, 1)
+        assert result.exit_code == EXIT_CORRUPTED_DB
+        assert "Failed to open EventStore" in result.output
+        assert "database disk image is malformed" in result.output
 
-    def test_handles_get_all_sessions_exception(self) -> None:
-        """If get_all_sessions raises mid-flight, error is surfaced without crash."""
+    def test_get_all_sessions_exception_returns_pinned_exit_code(self) -> None:
+        """If snapshot query raises mid-flight, exit with EXIT_CORRUPTED_DB."""
         event_store = AsyncMock()
-        event_store.get_all_sessions.side_effect = Exception("DB locked")
+        event_store.get_session_activity_snapshots.side_effect = Exception("DB locked")
         event_store.close = AsyncMock()
 
-        async def _fake_get_event_store():
+        async def _fake_get_event_store(db_path=None):
             return event_store
 
         with patch(
@@ -233,7 +432,8 @@ class TestResumeCLICorrupted:
         ):
             result = runner.invoke(app, [], catch_exceptions=False)
 
-        assert result.exit_code in (0, 1)
+        assert result.exit_code == EXIT_CORRUPTED_DB
+        assert "Failed to read EventStore" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -246,10 +446,10 @@ class TestResumeCLIWithSessions:
 
     def _build_mocks(self) -> tuple:
         tracker = _make_tracker()
-        event = _make_event("sess-abc123")
+        snapshot = _make_snapshot()
 
         event_store = AsyncMock()
-        event_store.get_all_sessions.return_value = [event]
+        event_store.get_session_activity_snapshots.return_value = [snapshot]
         event_store.close = AsyncMock()
 
         ok_result = MagicMock()
@@ -261,7 +461,7 @@ class TestResumeCLIWithSessions:
     def _invoke_with_sessions(self, input_text: str) -> object:
         tracker, event_store, ok_result = self._build_mocks()
 
-        async def _fake_get_event_store():
+        async def _fake_get_event_store(db_path=None):
             return event_store
 
         with (
@@ -291,6 +491,11 @@ class TestResumeCLIWithSessions:
         assert result.exit_code == 1
 
     def test_status_hint_included_in_output(self) -> None:
-        """The output suggests `ouroboros status execution <exec_id>` for re-attachment."""
+        """The output suggests `ouroboros status execution <exec_id>` for inspection."""
         result = self._invoke_with_sessions("1\n")
         assert "ouroboros status execution" in result.output
+
+    def test_resume_hint_matches_run_workflow_contract(self) -> None:
+        """The output surfaces `ouroboros run workflow --orchestrator --resume <session_id>`."""
+        result = self._invoke_with_sessions("1\n")
+        assert "ouroboros run workflow --orchestrator --resume sess-abc123" in result.output

--- a/tests/unit/cli/test_resume.py
+++ b/tests/unit/cli/test_resume.py
@@ -291,6 +291,6 @@ class TestResumeCLIWithSessions:
         assert result.exit_code == 1
 
     def test_status_hint_included_in_output(self) -> None:
-        """The output suggests `ooo status <exec_id>` for re-attachment."""
+        """The output suggests `ouroboros status execution <exec_id>` for re-attachment."""
         result = self._invoke_with_sessions("1\n")
-        assert "ooo status" in result.output
+        assert "ouroboros status execution" in result.output

--- a/tests/unit/cli/test_resume.py
+++ b/tests/unit/cli/test_resume.py
@@ -1,0 +1,296 @@
+"""Unit tests for the resume command."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.cli.commands.resume import _get_in_flight_sessions, app
+
+runner = CliRunner()
+
+# Patch target for SessionRepository — imported lazily inside the function
+_SESSION_REPO_PATH = "ouroboros.orchestrator.session.SessionRepository"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tracker(
+    session_id: str = "sess-abc123",
+    execution_id: str = "exec-xyz789",
+    seed_id: str = "seed-001",
+    status_value: str = "running",
+) -> MagicMock:
+    """Return a minimal SessionTracker-like mock."""
+    from ouroboros.orchestrator.session import SessionStatus
+
+    tracker = MagicMock()
+    tracker.session_id = session_id
+    tracker.execution_id = execution_id
+    tracker.seed_id = seed_id
+    tracker.status = SessionStatus(status_value)
+    tracker.start_time = datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC)
+    return tracker
+
+
+def _make_event(aggregate_id: str) -> MagicMock:
+    event = MagicMock()
+    event.aggregate_id = aggregate_id
+    return event
+
+
+# ---------------------------------------------------------------------------
+# _get_in_flight_sessions
+# ---------------------------------------------------------------------------
+
+
+class TestGetInFlightSessions:
+    """Tests for the _get_in_flight_sessions helper."""
+
+    @pytest.mark.asyncio
+    async def test_returns_running_sessions(self) -> None:
+        """Running sessions are returned."""
+        tracker = _make_tracker(status_value="running")
+        event = _make_event("sess-abc123")
+
+        event_store = AsyncMock()
+        event_store.get_all_sessions.return_value = [event]
+
+        ok_result = MagicMock()
+        ok_result.is_err = False
+        ok_result.value = tracker
+
+        with patch(_SESSION_REPO_PATH, autospec=True) as MockRepo:
+            MockRepo.return_value.reconstruct_session = AsyncMock(return_value=ok_result)
+            result = await _get_in_flight_sessions(event_store)
+
+        assert result == [tracker]
+
+    @pytest.mark.asyncio
+    async def test_returns_paused_sessions(self) -> None:
+        """Paused sessions are also returned."""
+        tracker = _make_tracker(status_value="paused")
+        event = _make_event("sess-paused")
+
+        event_store = AsyncMock()
+        event_store.get_all_sessions.return_value = [event]
+
+        ok_result = MagicMock()
+        ok_result.is_err = False
+        ok_result.value = tracker
+
+        with patch(_SESSION_REPO_PATH, autospec=True) as MockRepo:
+            MockRepo.return_value.reconstruct_session = AsyncMock(return_value=ok_result)
+            result = await _get_in_flight_sessions(event_store)
+
+        assert result == [tracker]
+
+    @pytest.mark.asyncio
+    async def test_excludes_terminal_sessions(self) -> None:
+        """Completed / failed / cancelled sessions are not returned."""
+        for status in ("completed", "failed", "cancelled"):
+            tracker = _make_tracker(status_value=status)
+            event = _make_event(f"sess-{status}")
+
+            event_store = AsyncMock()
+            event_store.get_all_sessions.return_value = [event]
+
+            ok_result = MagicMock()
+            ok_result.is_err = False
+            ok_result.value = tracker
+
+            with patch(_SESSION_REPO_PATH, autospec=True) as MockRepo:
+                MockRepo.return_value.reconstruct_session = AsyncMock(return_value=ok_result)
+                result = await _get_in_flight_sessions(event_store)
+
+            assert result == [], f"Expected empty list for status={status!r}"
+
+    @pytest.mark.asyncio
+    async def test_empty_event_store_returns_empty_list(self) -> None:
+        """No sessions in the DB → empty list."""
+        event_store = AsyncMock()
+        event_store.get_all_sessions.return_value = []
+
+        with patch(_SESSION_REPO_PATH, autospec=True):
+            result = await _get_in_flight_sessions(event_store)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_session_events(self) -> None:
+        """If the same session_id appears more than once, reconstruct is called once."""
+        tracker = _make_tracker(status_value="running")
+        events = [_make_event("sess-dup"), _make_event("sess-dup")]
+
+        event_store = AsyncMock()
+        event_store.get_all_sessions.return_value = events
+
+        ok_result = MagicMock()
+        ok_result.is_err = False
+        ok_result.value = tracker
+
+        with patch(_SESSION_REPO_PATH, autospec=True) as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.reconstruct_session = AsyncMock(return_value=ok_result)
+            result = await _get_in_flight_sessions(event_store)
+
+        mock_repo.reconstruct_session.assert_called_once_with("sess-dup")
+        assert result == [tracker]
+
+    @pytest.mark.asyncio
+    async def test_skips_sessions_that_fail_to_reconstruct(self) -> None:
+        """If a session cannot be reconstructed, it is silently skipped."""
+        event = _make_event("sess-broken")
+        event_store = AsyncMock()
+        event_store.get_all_sessions.return_value = [event]
+
+        err_result = MagicMock()
+        err_result.is_err = True
+
+        with patch(_SESSION_REPO_PATH, autospec=True) as MockRepo:
+            MockRepo.return_value.reconstruct_session = AsyncMock(return_value=err_result)
+            result = await _get_in_flight_sessions(event_store)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — empty state
+# ---------------------------------------------------------------------------
+
+
+class TestResumeCLIEmpty:
+    """Tests for the `ouroboros resume` command with no sessions."""
+
+    def _invoke_with_empty_store(self, tmp_path: Path) -> object:
+        event_store = AsyncMock()
+        event_store.get_all_sessions.return_value = []
+        event_store.close = AsyncMock()
+
+        async def _fake_get_event_store():
+            return event_store
+
+        with (
+            patch(
+                "ouroboros.cli.commands.resume._get_event_store",
+                side_effect=_fake_get_event_store,
+            ),
+            patch(_SESSION_REPO_PATH, autospec=True),
+        ):
+            return runner.invoke(app, [], catch_exceptions=False)
+
+    def test_exit_code_zero_when_no_sessions(self, tmp_path: Path) -> None:
+        result = self._invoke_with_empty_store(tmp_path)
+        assert result.exit_code == 0
+
+    def test_no_crash_when_no_sessions(self, tmp_path: Path) -> None:
+        """Command must not raise or crash when the DB is empty."""
+        result = self._invoke_with_empty_store(tmp_path)
+        assert "No in-flight sessions" in result.output or result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — corrupted / missing DB
+# ---------------------------------------------------------------------------
+
+
+class TestResumeCLICorrupted:
+    """Tests for graceful handling of a bad or missing EventStore."""
+
+    def test_handles_corrupted_db_gracefully(self) -> None:
+        """If the EventStore raises during initialization, the command handles it."""
+
+        async def _raise():
+            raise Exception("database disk image is malformed")
+
+        with patch(
+            "ouroboros.cli.commands.resume._get_event_store",
+            side_effect=_raise,
+        ):
+            result = runner.invoke(app, [], catch_exceptions=False)
+
+        assert result.exit_code in (0, 1)
+
+    def test_handles_get_all_sessions_exception(self) -> None:
+        """If get_all_sessions raises mid-flight, error is surfaced without crash."""
+        event_store = AsyncMock()
+        event_store.get_all_sessions.side_effect = Exception("DB locked")
+        event_store.close = AsyncMock()
+
+        async def _fake_get_event_store():
+            return event_store
+
+        with patch(
+            "ouroboros.cli.commands.resume._get_event_store",
+            side_effect=_fake_get_event_store,
+        ):
+            result = runner.invoke(app, [], catch_exceptions=False)
+
+        assert result.exit_code in (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — sessions present, user selects one
+# ---------------------------------------------------------------------------
+
+
+class TestResumeCLIWithSessions:
+    """Tests for interactive session selection."""
+
+    def _build_mocks(self) -> tuple:
+        tracker = _make_tracker()
+        event = _make_event("sess-abc123")
+
+        event_store = AsyncMock()
+        event_store.get_all_sessions.return_value = [event]
+        event_store.close = AsyncMock()
+
+        ok_result = MagicMock()
+        ok_result.is_err = False
+        ok_result.value = tracker
+
+        return tracker, event_store, ok_result
+
+    def _invoke_with_sessions(self, input_text: str) -> object:
+        tracker, event_store, ok_result = self._build_mocks()
+
+        async def _fake_get_event_store():
+            return event_store
+
+        with (
+            patch(
+                "ouroboros.cli.commands.resume._get_event_store",
+                side_effect=_fake_get_event_store,
+            ),
+            patch(_SESSION_REPO_PATH, autospec=True) as MockRepo,
+        ):
+            MockRepo.return_value.reconstruct_session = AsyncMock(return_value=ok_result)
+            return runner.invoke(app, [], input=input_text, catch_exceptions=False)
+
+    def test_lists_sessions_and_shows_exec_id(self) -> None:
+        """When a session is selected, the exec_id is printed."""
+        result = self._invoke_with_sessions("1\n")
+        assert result.exit_code == 0
+        assert "exec-xyz789" in result.output
+
+    def test_quit_exits_cleanly(self) -> None:
+        """Entering 'q' exits with code 0 and no crash."""
+        result = self._invoke_with_sessions("q\n")
+        assert result.exit_code == 0
+
+    def test_invalid_selection_exits_with_error(self) -> None:
+        """An out-of-range number exits with code 1."""
+        result = self._invoke_with_sessions("99\n")
+        assert result.exit_code == 1
+
+    def test_status_hint_included_in_output(self) -> None:
+        """The output suggests `ooo status <exec_id>` for re-attachment."""
+        result = self._invoke_with_sessions("1\n")
+        assert "ooo status" in result.output


### PR DESCRIPTION
## Summary

Closes #430 · Refs #387

When the MCP server disconnects during long-running seed execution, users previously had no way to re-attach to the in-flight session. `ooo seed` would start a fresh interview, discarding interview answers and execution progress.

This adds a standalone CLI command that reads the SQLite EventStore directly (no MCP dependency), lists non-terminal sessions, and prompts the user to pick one to re-attach to via `ooo status <exec_id>`.

## Changes

- **New**: `src/ouroboros/cli/commands/resume.py` — reads `~/.ouroboros/ouroboros.db` directly, renders a Rich table of running/paused sessions, interactive picker that surfaces `exec_id` for `ooo status` re-attachment
- **New**: `skills/resume/SKILL.md` — skill documentation
- **New**: `tests/unit/cli/test_resume.py` — 14 tests (empty state, corrupted DB, selection flow, quit, out-of-range input)
- **Updated**: `src/ouroboros/cli/main.py` — registered the new `resume` subcommand
- **Updated**: `CLAUDE.md` — added `ooo resume` to the ooo commands table

## Test plan

- [x] `ruff format --check .` and `ruff check .` pass
- [x] `mypy src/ouroboros/cli/commands/resume.py` passes
- [x] `pytest tests/unit/cli/test_resume.py` — 14 tests pass
- [x] `pytest tests/unit/cli/` — 411 tests pass (no regression)
- [ ] Manual: run `ooo resume` with 0, 1, and multiple in-flight sessions
- [ ] Manual: run `ooo resume` with a corrupted DB path → graceful error

## Design notes

- **No MCP dependency by design**: the whole point is that this works when the MCP server is unreachable.
- **Read-only**: `resume` never modifies the EventStore or creates events.
- **Doesn't auto-reconnect**: just surfaces the `exec_id` and suggests the next command. Keeps this PR focused and reviewable; auto-reconnect flow can be a follow-up.