### PR TITLE
fix(deps): add missing anyio dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "aiosqlite>=0.20.0,<1.0.0",
+    "anyio>=4.0.0,<5.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "prompt-toolkit>=3.0.0,<4.0.0",
     "pyyaml>=6.0.0,<7.0.0",


### PR DESCRIPTION
## Summary
- `parallel_executor.py` imports `anyio` for Semaphore, task groups, and CancelScope but `anyio` was not declared in `pyproject.toml`
- This caused `ModuleNotFoundError: No module named 'anyio'` when running `ouroboros tui monitor` from PyPI

## Test plan
- [ ] `uvx --from 'ouroboros-ai[tui]' ouroboros tui monitor` starts without ImportError
- [ ] `uv run pytest tests/unit/orchestrator/test_parallel_executor.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)