### PR TITLE
feat(tui): improve event subscription, activity display, and tree sync

### DIFF
--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -192,9 +192,7 @@ class OuroborosTUI(App[None]):
             return False
         if self._execution_id != context.execution_id:
             return False
-        if context.session_id and self._state.session_id != context.session_id:
-            return False
-        return True
+        return not (context.session_id and self._state.session_id != context.session_id)
 
     def _iter_subscription_sources(
         self, context: _EventSubscriptionContext
@@ -257,9 +255,7 @@ class OuroborosTUI(App[None]):
         if self._event_store is None or not context.execution_id:
             return
 
-        last_row_ids = {
-            source: 0 for source in self._iter_subscription_sources(context)
-        }
+        last_row_ids = dict.fromkeys(self._iter_subscription_sources(context), 0)
 
         while self._is_subscription_active(context):
             try:

--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual.app import App
@@ -46,6 +47,15 @@ from ouroboros.tui.screens.session_selector import SessionSelectorScreen
 if TYPE_CHECKING:
     from ouroboros.events.base import BaseEvent
     from ouroboros.persistence.event_store import EventStore
+
+
+@dataclass(frozen=True)
+class _EventSubscriptionContext:
+    """Immutable polling context for a single monitored execution/session."""
+
+    execution_id: str
+    session_id: str = ""
+    generation: int = 0
 
 
 class OuroborosTUI(App[None]):
@@ -122,6 +132,8 @@ class OuroborosTUI(App[None]):
         self._execution_id: str | None = execution_id
         self._state = TUIState()
         self._subscription_task: asyncio.Task[None] | None = None
+        self._subscription_generation = 0
+        self._poll_interval_seconds = 0.5
         self._is_paused = False
         self._pause_callback: Any | None = None
         self._resume_callback: Any | None = None
@@ -158,76 +170,116 @@ class OuroborosTUI(App[None]):
     def _start_event_subscription(self) -> None:
         """Start background task for event subscription."""
         # Skip if no event loop (e.g., during testing) or no event store
-        if self._event_store is None:
+        if self._event_store is None or not self._execution_id:
             return
         try:
             asyncio.get_running_loop()
         except RuntimeError:
             return  # No event loop running
+        self._subscription_generation += 1
+        context = _EventSubscriptionContext(
+            execution_id=self._execution_id,
+            session_id=self._state.session_id,
+            generation=self._subscription_generation,
+        )
         if self._subscription_task is not None:
             self._subscription_task.cancel()
-        self._subscription_task = asyncio.create_task(self._subscribe_to_events())
+        self._subscription_task = asyncio.create_task(self._subscribe_to_events(context))
 
-    async def _subscribe_to_events(self) -> None:
+    def _is_subscription_active(self, context: _EventSubscriptionContext) -> bool:
+        """Return True when the polling task still matches the active context."""
+        if self._subscription_generation != context.generation:
+            return False
+        if self._execution_id != context.execution_id:
+            return False
+        if context.session_id and self._state.session_id != context.session_id:
+            return False
+        return True
+
+    def _iter_subscription_sources(
+        self, context: _EventSubscriptionContext
+    ) -> tuple[tuple[str, str], ...]:
+        """Return the active aggregates that should feed the HUD."""
+        sources: list[tuple[str, str]] = [("execution", context.execution_id)]
+        if context.session_id:
+            sources.insert(0, ("session", context.session_id))
+        return tuple(sources)
+
+    def _process_subscription_event(self, event: BaseEvent) -> None:
+        """Forward a subscribed event into TUI state and installed screens."""
+        self._state.add_log(
+            "info",
+            "tui.events",
+            f"Received: {event.type}",
+            {"aggregate_id": event.aggregate_id},
+        )
+        # Also forward to logs screen
+        try:
+            logs_screen = self.get_screen("logs")
+            if logs_screen and hasattr(logs_screen, "add_log"):
+                logs_screen.add_log(
+                    "info",
+                    "tui.events",
+                    f"Received: {event.type}",
+                    {"aggregate_id": event.aggregate_id},
+                )
+        except Exception:
+            pass
+
+        message = create_message_from_event(event)
+        if message is not None:
+            self.post_message(message)
+            self._update_state_from_event(event)
+
+        # Forward raw event to debug screen
+        try:
+            debug_screen = self.get_screen("debug")
+            if debug_screen and hasattr(debug_screen, "add_raw_event"):
+                debug_screen.add_raw_event(
+                    {
+                        "type": event.type,
+                        "aggregate_type": event.aggregate_type,
+                        "aggregate_id": event.aggregate_id,
+                        "data": event.data,
+                        "timestamp": str(event.timestamp),
+                    }
+                )
+        except Exception:
+            pass  # Screen might not be installed yet
+
+    async def _subscribe_to_events(self, context: _EventSubscriptionContext) -> None:
         """Subscribe to EventStore for live updates.
 
         Uses incremental fetching via get_events_after() to avoid replaying
         the full event history on every poll cycle. This keeps each poll at
         O(new_events) instead of O(total_events).
         """
-        if self._event_store is None or self._execution_id is None:
+        if self._event_store is None or not context.execution_id:
             return
 
-        last_row_id = 0
-        poll_interval = 0.5
+        last_row_ids = {
+            source: 0 for source in self._iter_subscription_sources(context)
+        }
 
-        while True:
+        while self._is_subscription_active(context):
             try:
-                await asyncio.sleep(poll_interval)
-                new_events, last_row_id = await self._event_store.get_events_after(
-                    "execution", self._execution_id, last_row_id
-                )
-                for event in new_events:
-                    # Log event reception
-                    self._state.add_log(
-                        "info",
-                        "tui.events",
-                        f"Received: {event.type}",
-                        {"aggregate_id": event.aggregate_id},
+                new_events: list[BaseEvent] = []
+                for source in self._iter_subscription_sources(context):
+                    aggregate_type, aggregate_id = source
+                    events, last_row_ids[source] = await self._event_store.get_events_after(
+                        aggregate_type,
+                        aggregate_id,
+                        last_row_ids[source],
                     )
-                    # Also forward to logs screen
-                    try:
-                        logs_screen = self.get_screen("logs")
-                        if logs_screen and hasattr(logs_screen, "add_log"):
-                            logs_screen.add_log(
-                                "info",
-                                "tui.events",
-                                f"Received: {event.type}",
-                                {"aggregate_id": event.aggregate_id},
-                            )
-                    except Exception:
-                        pass
+                    new_events.extend(events)
 
-                    message = create_message_from_event(event)
-                    if message is not None:
-                        self.post_message(message)
-                        self._update_state_from_event(event)
+                if new_events:
+                    for event in sorted(new_events, key=lambda item: (item.timestamp, item.id)):
+                        if not self._is_subscription_active(context):
+                            break
+                        self._process_subscription_event(event)
 
-                    # Forward raw event to debug screen
-                    try:
-                        debug_screen = self.get_screen("debug")
-                        if debug_screen and hasattr(debug_screen, "add_raw_event"):
-                            debug_screen.add_raw_event(
-                                {
-                                    "type": event.type,
-                                    "aggregate_type": event.aggregate_type,
-                                    "aggregate_id": event.aggregate_id,
-                                    "data": event.data,
-                                    "timestamp": str(event.timestamp),
-                                }
-                            )
-                    except Exception:
-                        pass  # Screen might not be installed yet
+                await asyncio.sleep(self._poll_interval_seconds)
 
             except asyncio.CancelledError:
                 break
@@ -241,6 +293,7 @@ class OuroborosTUI(App[None]):
                         )
                 except Exception:
                     pass
+                await asyncio.sleep(self._poll_interval_seconds)
 
     def _update_state_from_event(self, event: BaseEvent) -> None:
         """Update internal state from an event."""
@@ -325,6 +378,20 @@ class OuroborosTUI(App[None]):
         self._state.execution_id = execution_id
         self._state.session_id = session_id
         self._state.status = "running"
+        self._state.current_phase = ""
+        self._state.iteration = 0
+        self._state.goal_drift = 0.0
+        self._state.constraint_drift = 0.0
+        self._state.ontology_drift = 0.0
+        self._state.combined_drift = 0.0
+        self._state.total_tokens = 0
+        self._state.total_cost_usd = 0.0
+        self._state.is_paused = False
+        self._state.ac_tree = {}
+        self._state.logs = []
+        self._state.active_tools.clear()
+        self._state.tool_history.clear()
+        self._state.thinking.clear()
         self._state.add_log("info", "tui.main", f"Monitoring execution: {execution_id}")
         # Forward to logs screen
         try:
@@ -333,6 +400,7 @@ class OuroborosTUI(App[None]):
                 logs_screen.add_log("info", "tui.main", f"Monitoring execution: {execution_id}")
         except Exception:
             pass
+        self._notify_ac_tree_updated()
         self._start_event_subscription()
 
     def action_show_selector(self) -> None:
@@ -376,16 +444,29 @@ class OuroborosTUI(App[None]):
         nodes = self._state.ac_tree.get("nodes", {})
         parent_ac_id = f"ac_{message.ac_index}"
         sub_task_id = message.sub_task_id
+        existing_node = nodes.get(sub_task_id, {})
 
         # Add or update subtask node
-        nodes[sub_task_id] = {
+        subtask_node = {
             "id": sub_task_id,
-            "content": message.content,
+            "content": message.content or existing_node.get("content", ""),
             "status": message.status,
-            "depth": 2,
+            "depth": existing_node.get("depth", 2),
+            "parent_id": parent_ac_id,
             "is_atomic": True,
-            "children_ids": [],
+            "children_ids": existing_node.get("children_ids", []),
         }
+        if message.current_tool_activity:
+            subtask_node["current_tool_activity"] = dict(message.current_tool_activity)
+        elif existing_node.get("current_tool_activity") is not None:
+            subtask_node["current_tool_activity"] = existing_node["current_tool_activity"]
+
+        if message.last_update:
+            subtask_node["last_update"] = dict(message.last_update)
+        elif existing_node.get("last_update") is not None:
+            subtask_node["last_update"] = existing_node["last_update"]
+
+        nodes[sub_task_id] = subtask_node
 
         # Update parent's children_ids (add if not present)
         if parent_ac_id in nodes:

--- a/src/ouroboros/tui/events.py
+++ b/src/ouroboros/tui/events.py
@@ -385,6 +385,8 @@ class SubtaskUpdated(Message):
         sub_task_id: Unique sub-task ID.
         content: Sub-task description.
         status: Sub-task status (executing, completed, failed).
+        current_tool_activity: Latest normalized tool-activity payload for the Sub-AC.
+        last_update: Latest runtime artifact snapshot associated with the Sub-AC.
     """
 
     def __init__(
@@ -395,6 +397,8 @@ class SubtaskUpdated(Message):
         sub_task_id: str,
         content: str,
         status: str,
+        current_tool_activity: dict[str, Any] | None = None,
+        last_update: dict[str, Any] | None = None,
     ) -> None:
         """Initialize SubtaskUpdated message."""
         super().__init__()
@@ -404,6 +408,10 @@ class SubtaskUpdated(Message):
         self.sub_task_id = sub_task_id
         self.content = content
         self.status = status
+        self.current_tool_activity = (
+            dict(current_tool_activity) if isinstance(current_tool_activity, dict) else {}
+        )
+        self.last_update = dict(last_update) if isinstance(last_update, dict) else {}
 
 
 class LineageSelected(Message):
@@ -699,18 +707,21 @@ def create_message_from_event(event: BaseEvent) -> Message | None:
             tokens_this_phase=data.get("tokens_this_phase", 0),
         )
 
-    elif event_type.startswith("decomposition.ac."):
+    elif event_type.startswith("decomposition.ac.") or event_type in {
+        "ac.decomposition.completed",
+        "ac.marked_atomic",
+    }:
         status = "pending"
-        if "completed" in event_type:
-            status = "completed"
+        if event_type in {"ac.decomposition.completed", "decomposition.ac.completed"}:
+            status = "decomposed"
         elif "started" in event_type:
             status = "executing"
-        elif "marked_atomic" in event_type:
+        elif event_type in {"ac.marked_atomic", "decomposition.ac.marked_atomic"}:
             status = "atomic"
 
         return ACUpdated(
-            execution_id=event.aggregate_id,
-            ac_id=data.get("ac_id", ""),
+            execution_id=data.get("execution_id", event.aggregate_id),
+            ac_id=data.get("ac_id", event.aggregate_id),
             status=status,
             depth=data.get("depth", 0),
             is_atomic=data.get("is_atomic", False),
@@ -794,6 +805,8 @@ def create_message_from_event(event: BaseEvent) -> Message | None:
             sub_task_id=data.get("sub_task_id", ""),
             content=data.get("content", ""),
             status=data.get("status", "pending"),
+            current_tool_activity=data.get("current_tool_activity"),
+            last_update=data.get("last_update"),
         )
 
     elif event_type == "execution.tool.started":

--- a/src/ouroboros/tui/screens/dashboard_v3.py
+++ b/src/ouroboros/tui/screens/dashboard_v3.py
@@ -28,6 +28,7 @@ Layout:
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from textual.app import ComposeResult
@@ -76,6 +77,11 @@ STATUS_ICONS = {
     "complete": "[bold green]●[/]",
     "failed": "[bold red]✖[/]",
     "cancelled": "[bold yellow]⊘[/]",
+}
+
+_TOOL_ACTIVITY_FALLBACK_LABELS = {
+    "missing": "working",
+    "unavailable": "working",
 }
 
 
@@ -459,7 +465,7 @@ class SelectableACTree(Static):
                 label += "..."
 
             # P2: Show inline tool activity for executing nodes
-            activity = self._active_tools.get(child_id)
+            activity = self._active_tools.get(child_id) or self._activity_from_node(child_data)
             if activity and status in ("executing", "running"):
                 label += f"\n     [dim italic]{activity}[/]"
 
@@ -489,6 +495,81 @@ class SelectableACTree(Static):
         """Clear inline tool activity for a node."""
         self._active_tools.pop(ac_id, None)
         self._rebuild_tree()
+
+    @staticmethod
+    def _activity_from_node(node: Mapping[str, Any]) -> str:
+        """Derive compact inline activity text from a node payload."""
+        status = str(node.get("status", "")).strip().lower()
+        if status not in {"executing", "running"}:
+            return ""
+
+        summary = SelectableACTree._summarize_tool_activity(node.get("current_tool_activity"))
+        if summary:
+            return summary
+
+        summary = SelectableACTree._summarize_tool_activity(node.get("tool_activity"))
+        if summary:
+            return summary
+
+        summary = SelectableACTree._summarize_tool_activity(node.get("last_update"))
+        if summary:
+            return summary
+
+        for key in ("tool_activity_summary", "tool_detail"):
+            value = node.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+        return ""
+
+    @staticmethod
+    def _summarize_tool_activity(raw_activity: object) -> str:
+        """Reduce runtime activity payloads into a single readable line."""
+        if not isinstance(raw_activity, Mapping):
+            return ""
+
+        message_type = str(raw_activity.get("message_type", "")).strip().lower()
+        runtime_status = str(raw_activity.get("runtime_status", "")).strip().lower()
+        if (
+            raw_activity.get("tool_result") is not None
+            or message_type in {"tool_result", "tool_result_chunk", "tool_completed"}
+            or runtime_status in {"completed", "failed", "cancelled", "paused"}
+        ):
+            return ""
+
+        for key in ("summary", "tool_detail", "activity_detail", "detail"):
+            value = raw_activity.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+        tool_name = ""
+        for key in ("tool_name", "current_tool", "active_tool", "tool"):
+            value = raw_activity.get(key)
+            if isinstance(value, str) and value.strip():
+                tool_name = value.strip()
+                break
+
+        tool_input = raw_activity.get("tool_input")
+        if not isinstance(tool_input, Mapping):
+            tool_input = raw_activity.get("input")
+
+        path_hint = ""
+        if isinstance(tool_input, Mapping):
+            for key in ("file_path", "path", "target", "uri"):
+                value = tool_input.get(key)
+                if isinstance(value, str) and value.strip():
+                    path_hint = value.strip()
+                    break
+
+        if tool_name and path_hint:
+            return f"{tool_name} {path_hint}"
+        if tool_name:
+            return tool_name
+
+        state = raw_activity.get("state")
+        if isinstance(state, str):
+            return _TOOL_ACTIVITY_FALLBACK_LABELS.get(state.strip().lower(), "")
+        return ""
 
     def on_tree_node_selected(self, event: Tree.NodeSelected[dict[str, Any]]) -> None:
         if event.node.data:

--- a/src/ouroboros/tui/screens/dashboard_v3.py
+++ b/src/ouroboros/tui/screens/dashboard_v3.py
@@ -27,8 +27,8 @@ Layout:
 
 from __future__ import annotations
 
-import contextlib
 from collections.abc import Mapping
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 from textual.app import ComposeResult

--- a/src/ouroboros/tui/widgets/ac_tree.py
+++ b/src/ouroboros/tui/widgets/ac_tree.py
@@ -113,6 +113,7 @@ class ACTreeWidget(Widget):
         self._node_map: dict[str, TreeNode[str]] = {}
         # Internal data cache to avoid triggering reactive watch
         self._tree_data_cache: dict[str, Any] = {}
+        self._pending_recompose = False
 
         super().__init__(name=name, id=id, classes=classes)
         self.tree_data = tree_data or {}
@@ -187,7 +188,7 @@ class ACTreeWidget(Widget):
 
         # Build label with status icon
         status_icon = STATUS_ICONS.get(status, "[ ]")
-        if is_atomic:
+        if is_atomic and status in {"atomic", "pending"}:
             status_icon = STATUS_ICONS["atomic"]
 
         # Highlight current AC
@@ -246,9 +247,17 @@ class ACTreeWidget(Widget):
         # Sync internal cache
         self._tree_data_cache = new_data
 
+        if self._pending_recompose:
+            self._pending_recompose = False
+            self.refresh(recompose=True)
+            return
+
         # Only recompose if tree doesn't exist (initial build or was cleared)
         if self._tree_widget is None or not self._node_map:
             self.refresh(recompose=True)
+            return
+
+        self._sync_existing_nodes(new_data)
 
     def watch_current_ac_id(self, new_id: str) -> None:
         """React to current_ac_id changes.
@@ -286,12 +295,52 @@ class ACTreeWidget(Widget):
             current_ac_id: Optional new current AC ID.
             force_rebuild: If True, force full recompose instead of incremental update.
         """
-        if force_rebuild:
+        if force_rebuild or self._tree_structure_changed(tree_data):
             self._node_map.clear()
+            self._pending_recompose = True
 
         self.tree_data = tree_data
         if current_ac_id is not None:
             self.current_ac_id = current_ac_id
+
+    def _tree_structure_changed(self, new_data: dict[str, Any]) -> bool:
+        """Return True when node membership or parent/child edges changed."""
+        if self._tree_widget is None or not self._node_map:
+            return False
+
+        old_data = self._tree_data_cache or self.tree_data
+        old_nodes = old_data.get("nodes")
+        new_nodes = new_data.get("nodes")
+        if not isinstance(old_nodes, dict) or not isinstance(new_nodes, dict):
+            return True
+
+        if old_data.get("root_id") != new_data.get("root_id"):
+            return True
+
+        if set(old_nodes) != set(new_nodes):
+            return True
+
+        for node_id, new_node in new_nodes.items():
+            old_node = old_nodes.get(node_id)
+            if not isinstance(old_node, dict) or not isinstance(new_node, dict):
+                return True
+            if list(old_node.get("children_ids", [])) != list(new_node.get("children_ids", [])):
+                return True
+
+        return False
+
+    def _sync_existing_nodes(self, tree_data: dict[str, Any]) -> None:
+        """Patch labels in-place when only node content/status changed."""
+        nodes = tree_data.get("nodes")
+        if not isinstance(nodes, dict):
+            return
+
+        for node_id, tree_node in self._node_map.items():
+            node_data = nodes.get(node_id)
+            if not isinstance(node_data, dict):
+                continue
+            is_current = node_id == self.current_ac_id
+            tree_node.set_label(self._format_node_label(node_data, is_current))
 
     def update_node_status(self, ac_id: str, status: str) -> None:
         """Update status of a single node without recompose.

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ouroboros.tui.app import OuroborosTUI
+from ouroboros.events.base import BaseEvent
+from ouroboros.persistence.event_store import EventStore
+from ouroboros.tui.app import OuroborosTUI, _EventSubscriptionContext
 from ouroboros.tui.events import (
     CostUpdated,
     DriftUpdated,
@@ -14,8 +18,20 @@ from ouroboros.tui.events import (
     PauseRequested,
     PhaseChanged,
     ResumeRequested,
+    SubtaskUpdated,
     TUIState,
 )
+
+
+@pytest.fixture
+async def memory_event_store() -> AsyncIterator[EventStore]:
+    """Provide an initialized in-memory event store."""
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    try:
+        yield store
+    finally:
+        await store.close()
 
 
 class TestOuroborosTUIConstruction:
@@ -67,6 +83,29 @@ class TestOuroborosTUIState:
         assert app.state.execution_id == "exec_123"
         assert app.state.session_id == "sess_456"
         assert app.state.status == "running"
+
+    def test_set_execution_resets_stale_hud_state(self) -> None:
+        """Switching executions should clear HUD state from the previous context."""
+        app = OuroborosTUI()
+        app.state.current_phase = "deliver"
+        app.state.iteration = 4
+        app.state.total_tokens = 999
+        app.state.ac_tree = {"nodes": {"ac_1": {"id": "ac_1"}}}
+        app.state.active_tools["ac_1"] = {"tool_name": "Edit"}
+        app.state.tool_history["ac_1"] = [{"tool_name": "Read"}]
+        app.state.thinking["ac_1"] = "stale thought"
+
+        app.set_execution("exec_fresh", "sess_fresh")
+
+        assert app.state.execution_id == "exec_fresh"
+        assert app.state.session_id == "sess_fresh"
+        assert app.state.current_phase == ""
+        assert app.state.iteration == 0
+        assert app.state.total_tokens == 0
+        assert app.state.ac_tree == {}
+        assert app.state.active_tools == {}
+        assert app.state.tool_history == {}
+        assert app.state.thinking == {}
 
     def test_update_ac_tree(self) -> None:
         """Test updating AC tree data."""
@@ -185,6 +224,61 @@ class TestOuroborosTUIMessageHandlers:
         assert app.state.total_tokens == 10000
         assert app.state.total_cost_usd == 0.05
 
+    def test_on_subtask_updated_preserves_runtime_activity_on_tree_node(self) -> None:
+        """Sub-AC runtime snapshots should remain attached to the rendered tree node."""
+        app = OuroborosTUI()
+        app.state.ac_tree = {
+            "root_id": "root",
+            "nodes": {
+                "root": {
+                    "id": "root",
+                    "content": "Acceptance Criteria",
+                    "children_ids": ["ac_1"],
+                },
+                "ac_1": {
+                    "id": "ac_1",
+                    "content": "Composite AC",
+                    "status": "executing",
+                    "children_ids": [],
+                },
+            },
+        }
+
+        app.on_subtask_updated(
+            SubtaskUpdated(
+                execution_id="exec_123",
+                ac_index=1,
+                sub_task_index=1,
+                sub_task_id="ac_1_sub_1",
+                content="Patch the event bridge",
+                status="executing",
+                current_tool_activity={
+                    "message_type": "tool",
+                    "tool_name": "Edit",
+                    "tool_input": {"file_path": "src/ouroboros/tui/events.py"},
+                },
+                last_update={
+                    "message_type": "tool",
+                    "tool_name": "Edit",
+                    "tool_input": {"file_path": "src/ouroboros/tui/events.py"},
+                },
+            )
+        )
+
+        subtask_node = app.state.ac_tree["nodes"]["ac_1_sub_1"]
+        assert subtask_node["parent_id"] == "ac_1"
+        assert subtask_node["current_tool_activity"] == {
+            "message_type": "tool",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/ouroboros/tui/events.py"},
+        }
+        assert subtask_node["last_update"] == {
+            "message_type": "tool",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/ouroboros/tui/events.py"},
+        }
+        assert app.state.ac_tree["nodes"]["ac_1"]["children_ids"] == ["ac_1_sub_1"]
+
     def test_on_pause_requested(self) -> None:
         """Test handling PauseRequested message."""
         app = OuroborosTUI()
@@ -284,10 +378,104 @@ class TestOuroborosTUIEventSubscription:
     """Tests for event store subscription."""
 
     @pytest.mark.asyncio
+    async def test_subscription_reads_active_session_events(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Session aggregate events should update HUD state for the active context."""
+        await memory_event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="sess_active",
+                data={"execution_id": "exec_active"},
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                type="workflow.progress.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_active",
+                data={
+                    "execution_id": "exec_active",
+                    "current_phase": "deliver",
+                    "completed_count": 1,
+                    "total_count": 2,
+                    "acceptance_criteria": [
+                        {"index": 1, "content": "First criterion", "status": "completed"},
+                        {"index": 2, "content": "Second criterion", "status": "in_progress"},
+                    ],
+                },
+            )
+        )
+
+        app = OuroborosTUI(event_store=memory_event_store)
+        app._poll_interval_seconds = 0.01
+        app.set_execution("exec_active", "sess_active")
+        await asyncio.sleep(0.03)
+
+        await memory_event_store.append(
+            BaseEvent(
+                type="orchestrator.session.completed",
+                aggregate_type="session",
+                aggregate_id="sess_active",
+                data={"execution_id": "exec_active"},
+            )
+        )
+        await asyncio.sleep(0.03)
+
+        assert app.state.execution_id == "exec_active"
+        assert app.state.session_id == "sess_active"
+        assert app.state.status == "completed"
+
+        if app._subscription_task is not None:
+            app._subscription_task.cancel()
+            await app._subscription_task
+
+    @pytest.mark.asyncio
+    async def test_subscription_task_drops_stale_context_parameters(self) -> None:
+        """A running poller must not start listening to a new context implicitly."""
+
+        class RecordingEventStore:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, str, int]] = []
+
+            async def get_events_after(
+                self,
+                aggregate_type: str,
+                aggregate_id: str,
+                last_row_id: int = 0,
+            ) -> tuple[list[BaseEvent], int]:
+                self.calls.append((aggregate_type, aggregate_id, last_row_id))
+                return [], last_row_id
+
+        event_store = RecordingEventStore()
+        app = OuroborosTUI(event_store=event_store)  # type: ignore[arg-type]
+        app._poll_interval_seconds = 0.01
+        app._execution_id = "exec_old"
+        app.state.session_id = "sess_old"
+        app._subscription_generation = 1
+        context = _EventSubscriptionContext(
+            execution_id="exec_old",
+            session_id="sess_old",
+            generation=1,
+        )
+
+        task = asyncio.create_task(app._subscribe_to_events(context))
+        await asyncio.sleep(0.03)
+        app._execution_id = "exec_new"
+        app.state.session_id = "sess_new"
+        await asyncio.wait_for(task, timeout=0.1)
+
+        assert task.done()
+        assert ("session", "sess_new", 0) not in event_store.calls
+        assert ("execution", "exec_new", 0) not in event_store.calls
+        assert any(call[:2] == ("session", "sess_old") for call in event_store.calls)
+        assert any(call[:2] == ("execution", "exec_old") for call in event_store.calls)
+
+    @pytest.mark.asyncio
     async def test_update_state_from_event_session_started(self) -> None:
         """Test state update from session started event."""
-        from ouroboros.events.base import BaseEvent
-
         app = OuroborosTUI()
         event = BaseEvent(
             type="orchestrator.session.started",
@@ -305,8 +493,6 @@ class TestOuroborosTUIEventSubscription:
     @pytest.mark.asyncio
     async def test_update_state_from_event_phase_completed(self) -> None:
         """Test state update from phase completed event."""
-        from ouroboros.events.base import BaseEvent
-
         app = OuroborosTUI()
         event = BaseEvent(
             type="execution.phase.completed",
@@ -323,8 +509,6 @@ class TestOuroborosTUIEventSubscription:
     @pytest.mark.asyncio
     async def test_update_state_from_event_drift_measured(self) -> None:
         """Test state update from drift measured event."""
-        from ouroboros.events.base import BaseEvent
-
         app = OuroborosTUI()
         event = BaseEvent(
             type="observability.drift.measured",

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -12,6 +12,7 @@ from ouroboros.tui.events import (
     PauseRequested,
     PhaseChanged,
     ResumeRequested,
+    SubtaskUpdated,
     TUIState,
     WorkflowProgressUpdated,
     create_message_from_event,
@@ -386,18 +387,58 @@ class TestCreateMessageFromEvent:
     def test_ac_event(self) -> None:
         """Test converting AC-related events."""
         event = BaseEvent(
-            type="decomposition.ac.marked_atomic",
-            aggregate_type="execution",
-            aggregate_id="exec_123",
-            data={"ac_id": "ac_abc", "depth": 1, "is_atomic": True},
+            type="ac.marked_atomic",
+            aggregate_type="ac_decomposition",
+            aggregate_id="ac_abc",
+            data={"execution_id": "exec_123", "depth": 1, "is_atomic": True},
         )
 
         msg = create_message_from_event(event)
 
         assert isinstance(msg, ACUpdated)
+        assert msg.execution_id == "exec_123"
         assert msg.ac_id == "ac_abc"
         assert msg.status == "atomic"
         assert msg.is_atomic is True
+
+    def test_subtask_event_preserves_runtime_activity_payload(self) -> None:
+        """Live Sub-AC events should keep tool activity attached for the dashboard."""
+        event = BaseEvent(
+            type="execution.subtask.updated",
+            aggregate_type="execution",
+            aggregate_id="exec_123",
+            data={
+                "ac_index": 1,
+                "sub_task_index": 2,
+                "sub_task_id": "ac_1_sub_2",
+                "content": "Patch the event bridge",
+                "status": "executing",
+                "current_tool_activity": {
+                    "message_type": "tool",
+                    "tool_name": "Edit",
+                    "tool_input": {"file_path": "src/ouroboros/tui/events.py"},
+                },
+                "last_update": {
+                    "message_type": "tool",
+                    "tool_name": "Edit",
+                    "tool_input": {"file_path": "src/ouroboros/tui/events.py"},
+                },
+            },
+        )
+
+        msg = create_message_from_event(event)
+
+        assert isinstance(msg, SubtaskUpdated)
+        assert msg.current_tool_activity == {
+            "message_type": "tool",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/ouroboros/tui/events.py"},
+        }
+        assert msg.last_update == {
+            "message_type": "tool",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/ouroboros/tui/events.py"},
+        }
 
     def test_cost_updated_event(self) -> None:
         """Test converting cost.updated event."""

--- a/tests/unit/tui/test_widgets.py
+++ b/tests/unit/tui/test_widgets.py
@@ -1,5 +1,7 @@
 """Unit tests for TUI widgets."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from ouroboros.tui.widgets.ac_progress import ACProgressItem, ACProgressWidget
@@ -263,6 +265,120 @@ class TestACTreeWidget:
 
         assert widget._node_map == {}
 
+    def test_update_tree_recomposes_when_subtask_changes_tree_shape(self) -> None:
+        """New Sub-AC nodes should force a rebuild so the rendered tree stays in sync."""
+        initial_tree = {
+            "root_id": "root",
+            "nodes": {
+                "root": {
+                    "id": "root",
+                    "content": "Acceptance Criteria",
+                    "children_ids": ["ac_1"],
+                },
+                "ac_1": {
+                    "id": "ac_1",
+                    "content": "Composite AC",
+                    "status": "executing",
+                    "children_ids": [],
+                },
+            },
+        }
+        updated_tree = {
+            "root_id": "root",
+            "nodes": {
+                **initial_tree["nodes"],
+                "ac_1": {
+                    "id": "ac_1",
+                    "content": "Composite AC",
+                    "status": "executing",
+                    "children_ids": ["ac_1_sub_1"],
+                },
+                "ac_1_sub_1": {
+                    "id": "ac_1_sub_1",
+                    "content": "Draft migration plan",
+                    "status": "executing",
+                    "is_atomic": True,
+                    "children_ids": [],
+                },
+            },
+        }
+
+        widget = ACTreeWidget(tree_data=initial_tree)
+        widget._tree_widget = MagicMock()
+        widget._tree_data_cache = initial_tree
+        widget._node_map = {"root": MagicMock(), "ac_1": MagicMock()}
+        widget.refresh = MagicMock()
+
+        widget.update_tree(updated_tree)
+
+        assert any(
+            call.kwargs.get("recompose") is True for call in widget.refresh.call_args_list
+        )
+        assert widget._node_map == {}
+
+    def test_update_tree_syncs_existing_labels_for_rapid_subtask_status_changes(self) -> None:
+        """Status-only Sub-AC updates should patch the rendered labels without a full rebuild."""
+        initial_tree = {
+            "root_id": "root",
+            "nodes": {
+                "root": {
+                    "id": "root",
+                    "content": "Acceptance Criteria",
+                    "children_ids": ["ac_1"],
+                },
+                "ac_1": {
+                    "id": "ac_1",
+                    "content": "Composite AC",
+                    "status": "executing",
+                    "children_ids": ["ac_1_sub_1"],
+                },
+                "ac_1_sub_1": {
+                    "id": "ac_1_sub_1",
+                    "content": "Draft migration plan",
+                    "status": "executing",
+                    "is_atomic": True,
+                    "children_ids": [],
+                },
+            },
+        }
+        updated_tree = {
+            "root_id": "root",
+            "nodes": {
+                **initial_tree["nodes"],
+                "ac_1_sub_1": {
+                    "id": "ac_1_sub_1",
+                    "content": "Draft migration plan",
+                    "status": "completed",
+                    "is_atomic": True,
+                    "children_ids": [],
+                },
+            },
+        }
+
+        root_node = MagicMock()
+        ac_node = MagicMock()
+        subtask_node = MagicMock()
+
+        widget = ACTreeWidget(tree_data=initial_tree)
+        widget._tree_widget = MagicMock()
+        widget._tree_data_cache = initial_tree
+        widget._node_map = {
+            "root": root_node,
+            "ac_1": ac_node,
+            "ac_1_sub_1": subtask_node,
+        }
+        widget.refresh = MagicMock()
+
+        widget.update_tree(updated_tree)
+
+        assert not any(
+            call.kwargs.get("recompose") is True for call in widget.refresh.call_args_list
+        )
+        subtask_node.set_label.assert_called_once()
+        rendered_label = subtask_node.set_label.call_args[0][0]
+        assert "[green][OK][/green]" in rendered_label
+        assert "Draft migration plan" in rendered_label
+
     def test_update_node_status(self) -> None:
         """Test updating a node's status."""
         tree_data = {
@@ -325,6 +441,20 @@ class TestACTreeWidget:
         label = widget._format_node_label(node_data)
 
         assert "[blue][A][/blue]" in label
+
+    def test_format_node_label_atomic_subtask_keeps_runtime_status_icon(self) -> None:
+        """Atomic Sub-ACs should still surface live execution status changes."""
+        widget = ACTreeWidget()
+        node_data = {
+            "status": "completed",
+            "content": "Atomic subtask",
+            "is_atomic": True,
+        }
+
+        label = widget._format_node_label(node_data)
+
+        assert "[green][OK][/green]" in label
+        assert "[blue][A][/blue]" not in label
 
     def test_format_node_label_current(self) -> None:
         """Test formatting label for current AC."""

--- a/tests/unit/tui/test_widgets.py
+++ b/tests/unit/tui/test_widgets.py
@@ -311,9 +311,7 @@ class TestACTreeWidget:
 
         widget.update_tree(updated_tree)
 
-        assert any(
-            call.kwargs.get("recompose") is True for call in widget.refresh.call_args_list
-        )
+        assert any(call.kwargs.get("recompose") is True for call in widget.refresh.call_args_list)
         assert widget._node_map == {}
 
     def test_update_tree_syncs_existing_labels_for_rapid_subtask_status_changes(self) -> None:


### PR DESCRIPTION
## Summary
- **Event subscription**: Generation-based `_EventSubscriptionContext` prevents stale polling tasks; multi-source polling (execution + session aggregates) simultaneously
- **SubtaskUpdated**: Now carries `current_tool_activity` and `last_update` fields for richer Sub-AC state
- **Dashboard**: `_activity_from_node()` extracts inline tool activity for executing Sub-ACs (e.g., `Edit interview.py`)
- **AC tree widget**: `_sync_existing_nodes()` does incremental label updates instead of full recompose when only content/status changed

## Test plan
- [ ] `uv run pytest tests/unit/tui/` passes (196 tests)
- [ ] TUI shows current tool activity inline for executing Sub-ACs
- [ ] Switching executions resets all state properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)