### PR TITLE
feat(evaluate): add ouroboros_checklist_verify MCP tool (#366 part 2)

### DIFF
--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -26,6 +26,7 @@ from ouroboros.mcp.tools.authoring_handlers import (
 )
 from ouroboros.mcp.tools.channel_workflow_handler import ChannelWorkflowHandler
 from ouroboros.mcp.tools.evaluation_handlers import (
+    ChecklistVerifyHandler,
     EvaluateHandler,
     LateralThinkHandler,
     MeasureDriftHandler,
@@ -186,6 +187,18 @@ def evaluate_handler(*, llm_backend: str | None = None) -> EvaluateHandler:
     return EvaluateHandler(llm_backend=llm_backend)
 
 
+def checklist_verify_handler(
+    *,
+    evaluate_handler: EvaluateHandler | None = None,
+    llm_backend: str | None = None,
+) -> ChecklistVerifyHandler:
+    """Create a ChecklistVerifyHandler instance."""
+    return ChecklistVerifyHandler(
+        evaluate_handler=evaluate_handler,
+        llm_backend=llm_backend,
+    )
+
+
 def evolve_step_handler() -> EvolveStepHandler:
     """Create an EvolveStepHandler instance."""
     return EvolveStepHandler()
@@ -226,6 +239,7 @@ OuroborosToolHandlers = tuple[
     | MeasureDriftHandler
     | InterviewHandler
     | EvaluateHandler
+    | ChecklistVerifyHandler
     | LateralThinkHandler
     | EvolveStepHandler
     | StartEvolveStepHandler
@@ -265,6 +279,7 @@ def get_ouroboros_tools(
     job_result = JobResultHandler()
     interview = InterviewHandler(llm_backend=llm_backend)
     generate_seed = GenerateSeedHandler(llm_backend=llm_backend)
+    evaluate = EvaluateHandler(llm_backend=llm_backend)
     return (
         execute_seed,
         start_execute,
@@ -278,7 +293,8 @@ def get_ouroboros_tools(
         generate_seed,
         MeasureDriftHandler(),
         interview,
-        EvaluateHandler(llm_backend=llm_backend),
+        evaluate,
+        ChecklistVerifyHandler(evaluate_handler=evaluate, llm_backend=llm_backend),
         LateralThinkHandler(),
         EvolveStepHandler(),
         StartEvolveStepHandler(),

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -875,6 +875,199 @@ class EvaluateHandler:
 
 
 @dataclass
+class ChecklistVerifyHandler:
+    """Handler for the ``ouroboros_checklist_verify`` tool (#366).
+
+    Given a seed (containing ``acceptance_criteria``) and an execution
+    artifact, this handler routes each AC through the Stage 2 evaluation
+    pipeline and returns an aggregated checklist.  It is intentionally
+    thin — it composes ``EvaluateHandler`` rather than reimplementing
+    pipeline orchestration, so it stays in sync with any future changes
+    to the main evaluator.
+
+    Why this is a separate tool instead of a flag on ``ouroboros_execute_seed``:
+
+    - ``ExecuteSeed`` is already complex (background execution, resume,
+      delegation) and has a stable public contract.  Adding a retry
+      loop inside it would entangle with Ralph mode and the Job system.
+    - This tool lets the *caller* (a human, a ``/ralph`` loop, or a
+      channel workflow) decide when and how to retry.  No decisions
+      are hidden inside background tasks.
+    - It is opt-in: existing callers are unaffected.
+    """
+
+    evaluate_handler: EvaluateHandler | None = field(default=None, repr=False)
+    llm_backend: str | None = field(default=None, repr=False)
+
+    @property
+    def definition(self) -> MCPToolDefinition:
+        """Return the tool definition."""
+        return MCPToolDefinition(
+            name="ouroboros_checklist_verify",
+            description=(
+                "Verify that a Run artifact satisfies every acceptance criterion "
+                "in a Seed.  Returns a per-AC checklist (pass/fail with evidence "
+                "and failure reasons) plus ready-to-use run_feedback strings the "
+                "caller can inject into a re-run prompt.  Does NOT automatically "
+                "re-execute — the caller (Ralph, workflow, or human) decides."
+            ),
+            parameters=(
+                MCPToolParameter(
+                    name="session_id",
+                    type=ToolInputType.STRING,
+                    description="The execution session ID being verified",
+                    required=True,
+                ),
+                MCPToolParameter(
+                    name="seed_content",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "Seed YAML containing acceptance_criteria, goal, constraints. "
+                        "The seed's acceptance_criteria list is evaluated in full."
+                    ),
+                    required=True,
+                ),
+                MCPToolParameter(
+                    name="artifact",
+                    type=ToolInputType.STRING,
+                    description="The Run output/artifact to verify against the seed's ACs",
+                    required=True,
+                ),
+                MCPToolParameter(
+                    name="artifact_type",
+                    type=ToolInputType.STRING,
+                    description="Type of artifact: code, docs, config. Default: code",
+                    required=False,
+                    default="code",
+                    enum=("code", "docs", "config"),
+                ),
+                MCPToolParameter(
+                    name="working_dir",
+                    type=ToolInputType.STRING,
+                    description="Project working directory (for language auto-detection).",
+                    required=False,
+                ),
+            ),
+        )
+
+    async def handle(
+        self,
+        arguments: dict[str, Any],
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Verify the seed's full AC list against the artifact."""
+        session_id = arguments.get("session_id")
+        if not session_id:
+            return Result.err(
+                MCPToolError(
+                    "session_id is required",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        seed_content = arguments.get("seed_content")
+        if not seed_content:
+            return Result.err(
+                MCPToolError(
+                    "seed_content is required",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        artifact = arguments.get("artifact")
+        if not artifact:
+            return Result.err(
+                MCPToolError(
+                    "artifact is required",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        # Extract acceptance criteria from seed.
+        try:
+            seed_dict = yaml.safe_load(seed_content)
+            seed = Seed.from_dict(seed_dict)
+        except yaml.YAMLError as exc:
+            log.warning("mcp.tool.checklist_verify.yaml_error", error=str(exc))
+            return Result.err(
+                MCPToolError(
+                    f"Failed to parse seed YAML: {exc}",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+        except (ValidationError, PydanticValidationError) as exc:
+            log.warning("mcp.tool.checklist_verify.seed_validation_error", error=str(exc))
+            return Result.err(
+                MCPToolError(
+                    f"Seed validation failed: {exc}",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        acceptance_criteria = tuple(
+            text.strip() for text in seed.acceptance_criteria if text and text.strip()
+        )
+        if not acceptance_criteria:
+            return Result.err(
+                MCPToolError(
+                    "Seed has no acceptance_criteria — cannot build checklist.",
+                    tool_name="ouroboros_checklist_verify",
+                )
+            )
+
+        # Delegate to EvaluateHandler in multi-AC mode.  Re-using the
+        # evaluator means language detection, artifact bundling, event
+        # logging, and LLM backend handling stay consistent.
+        evaluator = self.evaluate_handler or EvaluateHandler(llm_backend=self.llm_backend)
+
+        evaluate_args = {
+            "session_id": session_id,
+            "artifact": artifact,
+            "seed_content": seed_content,
+            "acceptance_criteria": list(acceptance_criteria),
+            "artifact_type": arguments.get("artifact_type", "code"),
+        }
+        if "working_dir" in arguments:
+            evaluate_args["working_dir"] = arguments["working_dir"]
+
+        log.info(
+            "mcp.tool.checklist_verify.started",
+            session_id=session_id,
+            ac_count=len(acceptance_criteria),
+        )
+
+        result = await evaluator.handle(evaluate_args)
+
+        if result.is_err:
+            log.warning(
+                "mcp.tool.checklist_verify.evaluate_failed",
+                session_id=session_id,
+                error=str(result.error),
+            )
+            return result
+
+        # Augment the MCP result meta so callers can distinguish the
+        # verify path from a plain multi-AC evaluate call.
+        meta = dict(result.value.meta or {})
+        meta["checklist_verify"] = True
+        meta["seed_goal"] = seed.goal
+        augmented = MCPToolResult(
+            content=result.value.content,
+            is_error=result.value.is_error,
+            meta=meta,
+        )
+
+        log.info(
+            "mcp.tool.checklist_verify.completed",
+            session_id=session_id,
+            all_passed=meta.get("final_approved"),
+            passed_count=meta.get("passed_count"),
+            ac_count=meta.get("ac_count"),
+        )
+
+        return Result.ok(augmented)
+
+
+@dataclass
 class LateralThinkHandler:
     """Handler for the lateral_think tool.
 

--- a/tests/unit/mcp/tools/test_checklist_verify.py
+++ b/tests/unit/mcp/tools/test_checklist_verify.py
@@ -1,0 +1,279 @@
+"""Unit tests for ChecklistVerifyHandler (#366 part 2)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.evaluation_handlers import (
+    ChecklistVerifyHandler,
+    EvaluateHandler,
+)
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+VALID_SEED_WITH_MULTI_AC = """
+goal: Add a payment module
+constraints:
+  - Must integrate with Stripe
+acceptance_criteria:
+  - Charge succeeds
+  - Webhook signature verified
+  - Refund path covered
+ontology_schema:
+  name: Payment
+  description: Payment module
+  fields:
+    - name: provider
+      field_type: string
+      description: Provider name
+evaluation_principles: []
+exit_conditions: []
+metadata:
+  seed_id: seed-pay-1
+  version: "1.0.0"
+  created_at: "2024-01-01T00:00:00Z"
+  ambiguity_score: 0.15
+  interview_id: null
+"""
+
+
+VALID_SEED_NO_AC = """
+goal: Empty goal
+constraints: []
+acceptance_criteria: []
+ontology_schema:
+  name: Empty
+  description: empty
+  fields:
+    - name: x
+      field_type: string
+      description: x
+evaluation_principles: []
+exit_conditions: []
+metadata:
+  seed_id: seed-empty
+  version: "1.0.0"
+  created_at: "2024-01-01T00:00:00Z"
+  ambiguity_score: 0.1
+  interview_id: null
+"""
+
+
+class TestChecklistVerifyDefinition:
+    """Tool definition exposes the right parameters."""
+
+    def test_name_and_required_parameters(self) -> None:
+        handler = ChecklistVerifyHandler()
+        defn = handler.definition
+        assert defn.name == "ouroboros_checklist_verify"
+
+        names = {p.name for p in defn.parameters}
+        assert {"session_id", "seed_content", "artifact"} <= names
+
+        required = {p.name for p in defn.parameters if p.required}
+        assert required == {"session_id", "seed_content", "artifact"}
+
+
+class TestChecklistVerifyArgumentValidation:
+    """Missing required arguments produce actionable errors."""
+
+    async def test_missing_session_id(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+        assert "session_id is required" in str(result.error)
+
+    async def test_missing_seed_content(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+        assert "seed_content is required" in str(result.error)
+
+    async def test_missing_artifact(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+            }
+        )
+        assert result.is_err
+        assert "artifact is required" in str(result.error)
+
+    async def test_invalid_yaml(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": "not: valid: yaml: : :",
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+        # Accept either YAML parse error or seed validation error —
+        # both are surfaced as MCP errors, which is the contract.
+        assert any(
+            needle in str(result.error)
+            for needle in ("Failed to parse seed YAML", "Seed validation failed")
+        )
+
+    async def test_seed_with_no_acceptance_criteria(self) -> None:
+        handler = ChecklistVerifyHandler()
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_NO_AC,
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+        assert "no acceptance_criteria" in str(result.error)
+
+
+class TestChecklistVerifyDelegation:
+    """Delegates to EvaluateHandler with the seed's AC list."""
+
+    async def test_delegates_with_full_ac_list(self) -> None:
+        """ChecklistVerify forwards every AC to EvaluateHandler.handle()."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="Acceptance Criteria Checklist [ALL PASSED]",
+                        ),
+                    ),
+                    is_error=False,
+                    meta={
+                        "multi_ac": True,
+                        "final_approved": True,
+                        "passed_count": 3,
+                        "ac_count": 3,
+                        "pass_rate": 1.0,
+                    },
+                )
+            )
+        )
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "def pay(): ...",
+            }
+        )
+
+        assert result.is_ok
+        # Verify the inner call received all ACs.
+        mock_evaluate.handle.assert_awaited_once()
+        call_args = mock_evaluate.handle.await_args.args[0]
+        assert call_args["session_id"] == "s1"
+        assert call_args["artifact"] == "def pay(): ..."
+        assert call_args["acceptance_criteria"] == [
+            "Charge succeeds",
+            "Webhook signature verified",
+            "Refund path covered",
+        ]
+        # seed_content must be forwarded so EvaluateHandler can pull goal/constraints
+        assert call_args["seed_content"] == VALID_SEED_WITH_MULTI_AC
+
+    async def test_augments_meta_with_verify_flag(self) -> None:
+        """Response meta gets checklist_verify=True and seed_goal."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                    is_error=False,
+                    meta={"multi_ac": True, "final_approved": True},
+                )
+            )
+        )
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "x",
+            }
+        )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["checklist_verify"] is True
+        assert meta["seed_goal"] == "Add a payment module"
+        # Underlying evaluate meta still present
+        assert meta["multi_ac"] is True
+
+    async def test_evaluate_failure_propagates(self) -> None:
+        """When EvaluateHandler returns Err, ChecklistVerify returns the same err."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(return_value=Result.err(ValueError("pipeline exploded")))
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "x",
+            }
+        )
+        assert result.is_err
+
+    async def test_forwards_working_dir_when_provided(self) -> None:
+        """Optional working_dir is forwarded to the evaluator."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                    is_error=False,
+                    meta={"multi_ac": True, "final_approved": True},
+                )
+            )
+        )
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_MULTI_AC,
+                "artifact": "x",
+                "working_dir": "/tmp/proj",
+            }
+        )
+
+        assert result.is_ok
+        call_args = mock_evaluate.handle.await_args.args[0]
+        assert call_args["working_dir"] == "/tmp/proj"
+
+
+class TestChecklistVerifyRegistered:
+    """The handler is wired into the default tool set."""
+
+    def test_registered_in_ouroboros_tools(self) -> None:
+        from ouroboros.mcp.tools.definitions import OUROBOROS_TOOLS
+
+        names = {h.definition.name for h in OUROBOROS_TOOLS}
+        assert "ouroboros_checklist_verify" in names
+
+    def test_factory_returns_handler(self) -> None:
+        from ouroboros.mcp.tools.definitions import checklist_verify_handler
+
+        handler = checklist_verify_handler(llm_backend="litellm")
+        assert isinstance(handler, ChecklistVerifyHandler)
+        assert handler.llm_backend == "litellm"

--- a/tests/unit/mcp/tools/test_checklist_verify.py
+++ b/tests/unit/mcp/tools/test_checklist_verify.py
@@ -37,6 +37,30 @@ metadata:
 """
 
 
+VALID_SEED_WITH_SINGLE_AC = """
+goal: Add a logging module
+constraints:
+  - Must use structured logging
+acceptance_criteria:
+  - Log output is JSON-formatted
+ontology_schema:
+  name: Logging
+  description: Logging module
+  fields:
+    - name: format
+      field_type: string
+      description: Log format
+evaluation_principles: []
+exit_conditions: []
+metadata:
+  seed_id: seed-log-1
+  version: "1.0.0"
+  created_at: "2024-01-01T00:00:00Z"
+  ambiguity_score: 0.15
+  interview_id: null
+"""
+
+
 VALID_SEED_NO_AC = """
 goal: Empty goal
 constraints: []
@@ -189,6 +213,44 @@ class TestChecklistVerifyDelegation:
         ]
         # seed_content must be forwarded so EvaluateHandler can pull goal/constraints
         assert call_args["seed_content"] == VALID_SEED_WITH_MULTI_AC
+
+    async def test_single_ac_seed_delegates_correctly(self) -> None:
+        """A seed with exactly one AC must forward that AC, not the fallback string."""
+        mock_evaluate = MagicMock(spec=EvaluateHandler)
+        mock_evaluate.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="Evaluation Results",
+                        ),
+                    ),
+                    is_error=False,
+                    meta={
+                        "final_approved": True,
+                        "session_id": "s1",
+                    },
+                )
+            )
+        )
+        handler = ChecklistVerifyHandler(evaluate_handler=mock_evaluate)
+
+        result = await handler.handle(
+            {
+                "session_id": "s1",
+                "seed_content": VALID_SEED_WITH_SINGLE_AC,
+                "artifact": "import structlog; log = structlog.get_logger()",
+            }
+        )
+
+        assert result.is_ok
+        # Verify the inner call received exactly the one AC from the seed.
+        mock_evaluate.handle.assert_awaited_once()
+        call_args = mock_evaluate.handle.await_args.args[0]
+        assert call_args["acceptance_criteria"] == ["Log output is JSON-formatted"]
+        # seed_content forwarded so EvaluateHandler can extract goal/constraints
+        assert call_args["seed_content"] == VALID_SEED_WITH_SINGLE_AC
 
     async def test_augments_meta_with_verify_flag(self) -> None:
         """Response meta gets checklist_verify=True and seed_goal."""

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -768,7 +768,9 @@ class TestOuroborosTools:
 
     def test_ouroboros_tools_contains_all_handlers(self) -> None:
         """OUROBOROS_TOOLS contains all standard handlers."""
-        assert len(OUROBOROS_TOOLS) == 23
+        from ouroboros.mcp.tools.evaluation_handlers import ChecklistVerifyHandler
+
+        assert len(OUROBOROS_TOOLS) == 24
 
         handler_types = {type(h) for h in OUROBOROS_TOOLS}
         assert ACTreeHUDHandler in handler_types
@@ -784,6 +786,7 @@ class TestOuroborosTools:
         assert MeasureDriftHandler in handler_types
         assert InterviewHandler in handler_types
         assert EvaluateHandler in handler_types
+        assert ChecklistVerifyHandler in handler_types
         assert LateralThinkHandler in handler_types
         assert EvolveStepHandler in handler_types
         assert StartEvolveStepHandler in handler_types
@@ -806,7 +809,7 @@ class TestOuroborosTools:
     def test_get_ouroboros_tools_can_inject_runtime_backend(self) -> None:
         """Tool factory can build execute_seed with a specific runtime backend."""
         tools = get_ouroboros_tools(runtime_backend="codex")
-        assert len(tools) == 23
+        assert len(tools) == 24
         execute_handler = next(h for h in tools if isinstance(h, ExecuteSeedHandler))
         assert execute_handler.agent_runtime_backend == "codex"
 

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -183,6 +183,45 @@ class TestMultiACRoutingBoundary:
         ctx_arg = mock_pipeline.evaluate.call_args[0][0]
         assert ctx_arg.current_ac == "Legacy AC"
 
+    async def test_single_item_list_ac_is_used_as_current_ac(self) -> None:
+        """A 1-element acceptance_criteria list must be used as current_ac.
+
+        Regression test: before the fix, a 1-item list was silently
+        ignored and the evaluation ran against the fallback string
+        'Verify execution output meets requirements'.
+        """
+        captured_contexts: list[object] = []
+        mock_pipeline = AsyncMock()
+
+        async def _capture_evaluate(context: object) -> object:
+            captured_contexts.append(context)
+            return Result.ok(_passing_eval("s1"))
+
+        mock_pipeline.evaluate = AsyncMock(side_effect=_capture_evaluate)
+
+        with (
+            patch("ouroboros.evaluation.EvaluationPipeline") as MockPipeline,
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=AsyncMock(initialize=AsyncMock()),
+            ),
+        ):
+            MockPipeline.return_value = mock_pipeline
+            handler = EvaluateHandler()
+            result = await handler.handle(
+                {
+                    "session_id": "s1",
+                    "artifact": "def f(): pass",
+                    "acceptance_criteria": ["Log output is JSON-formatted"],
+                }
+            )
+
+        assert result.is_ok
+        assert len(captured_contexts) == 1
+        ctx = captured_contexts[0]
+        # The actual AC text must be used, not the generic fallback.
+        assert ctx.current_ac == "Log output is JSON-formatted"
+
     async def test_two_passing_acs_produce_all_passed_checklist(self) -> None:
         """Two ACs both passing → meta.final_approved True, checklist populated."""
         mock_pipeline = self._install_pipeline_mock([_passing_eval("s1"), _passing_eval("s1")])


### PR DESCRIPTION
## Summary

Rebase of #386 onto current `main` to resolve merge conflicts. Original author: @shaun0927.

Commits (2 cherry-picked from #386; the first PR commit was already in `main` as #385 / a2a64594 and skipped):

- `07876f69` feat(evaluate): add `ouroboros_checklist_verify` MCP tool (#366 part 2)
- `38cc272e` fix(evaluate): honour 1-item acceptance_criteria in single-AC path

## Why a new branch

PR #386 had a conflict in `src/ouroboros/mcp/tools/evaluation_handlers.py` against current `main` (main already had a unified `acceptance_criteria` normalization path from #404 / #409 area). Rather than force-push the contributor's branch, this PR brings the novel `ChecklistVerifyHandler` + its tests across cleanly. Conflict resolution kept `main`'s unified `current_ac = acceptance_criteria[0]` derivation — strictly equivalent to the incoming 1-item fix.

## What's new (vs. main)

- `ChecklistVerifyHandler` — new MCP tool `ouroboros_checklist_verify` that parses a seed, extracts its `acceptance_criteria`, and delegates to `EvaluateHandler` in multi-AC mode. Returns per-AC checklist + `run_feedback`.
- Registered in `OUROBOROS_TOOLS` (24 tools total).
- `checklist_verify_handler` factory in `definitions`.

## Test plan

- [x] `uv run pytest tests/unit/mcp/tools/test_checklist_verify.py tests/unit/mcp/tools/test_evaluate_multi_ac.py` — 25 passed.
- [ ] CI full suite

Closes #386. Refs #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)