### PR TITLE
perf(evaluate): deduplicate Stage 1 in multi-AC checklist path

### DIFF
--- a/src/ouroboros/evaluation/pipeline.py
+++ b/src/ouroboros/evaluation/pipeline.py
@@ -106,6 +106,19 @@ class EvaluationPipeline:
                 lint/build/test once and share the outcome across parallel
                 semantic evaluations.
 
+                INVARIANT: Stage 1 checks (lint, build, test, static
+                analysis, coverage) must be AC-agnostic — they verify
+                project-wide code quality, not AC-specific behavior.  The
+                multi-AC checklist path (``_handle_multi_ac`` in
+                ``EvaluateHandler``, introduced in #385) relies on this
+                invariant to run Stage 1 exactly once across all ACs and
+                share the result via this parameter.
+
+                If future Stage 1 additions become AC-specific (e.g.
+                AC-tagged test filtering or per-AC coverage thresholds),
+                this dedup becomes incorrect and the multi-AC caller must
+                be updated to run Stage 1 per AC again.
+
         Returns:
             Result containing EvaluationResult or error
         """

--- a/src/ouroboros/evaluation/pipeline.py
+++ b/src/ouroboros/evaluation/pipeline.py
@@ -21,6 +21,7 @@ from ouroboros.evaluation.models import (
     CheckType,
     EvaluationContext,
     EvaluationResult,
+    MechanicalResult,
 )
 from ouroboros.evaluation.semantic import SemanticConfig, SemanticEvaluator
 from ouroboros.evaluation.trigger import (
@@ -91,23 +92,39 @@ class EvaluationPipeline:
         self,
         context: EvaluationContext,
         trigger_context: TriggerContext | None = None,
+        *,
+        stage1_result: MechanicalResult | None = None,
     ) -> Result[EvaluationResult, ProviderError | ValidationError]:
         """Run the evaluation pipeline.
 
         Args:
             context: Evaluation context with artifact
             trigger_context: Optional pre-populated trigger context
+            stage1_result: Pre-computed Stage 1 result.  When provided,
+                Stage 1 mechanical verification is skipped and this result
+                is reused.  This allows multi-AC callers to run
+                lint/build/test once and share the outcome across parallel
+                semantic evaluations.
 
         Returns:
             Result containing EvaluationResult or error
         """
         events: list[BaseEvent] = []
-        stage1_result = None
         stage2_result = None
         stage3_result = None
 
         # Stage 1: Mechanical Verification
-        if self._config.stage1_enabled:
+        # When a pre-computed result is injected, skip re-running the
+        # AC-agnostic lint/build/test checks.
+        if stage1_result is not None:
+            if not stage1_result.passed:
+                return self._build_result(
+                    context.execution_id,
+                    events,
+                    stage1_result=stage1_result,
+                    final_approved=False,
+                )
+        elif self._config.stage1_enabled:
             result = await self._mechanical.verify(
                 context.execution_id,
                 checks=[

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -612,10 +612,15 @@ class EvaluateHandler:
     ) -> Result[MCPToolResult, MCPServerError]:
         """Evaluate each AC individually and return an aggregated checklist (#366).
 
-        Runs the evaluation pipeline once per acceptance criterion in
-        parallel via ``asyncio.gather``.  Per-AC results are then folded
-        into a single ``ACChecklistResult`` so the caller sees one
-        pass/fail checklist with per-item evidence and failure reasons.
+        Stage 1 (mechanical verification — lint/build/test) is AC-agnostic,
+        so we run it exactly once via the first AC's full pipeline call and
+        inject the result into the remaining per-AC evaluations.  Only
+        Stage 2+ (semantic evaluation) is parallelized per AC via
+        ``asyncio.gather``.
+
+        Per-AC results are then folded into a single ``ACChecklistResult``
+        so the caller sees one pass/fail checklist with per-item evidence
+        and failure reasons.
 
         Single-AC callers never reach this path — see ``handle()``.
         """
@@ -628,6 +633,39 @@ class EvaluateHandler:
             format_checklist,
         )
 
+        log.info(
+            "mcp.tool.evaluate.multi_ac_started",
+            session_id=session_id,
+            ac_count=len(acceptance_criteria),
+        )
+
+        # --- Stage 1: run once via the first AC's full pipeline call ---
+        first_context = EvaluationContext(
+            execution_id=session_id,
+            seed_id=seed_id,
+            current_ac=acceptance_criteria[0],
+            artifact=artifact,
+            artifact_type=artifact_type,
+            goal=goal,
+            constraints=constraints,
+            trigger_consensus=trigger_consensus,
+            artifact_bundle=artifact_bundle,
+        )
+        first_result = await pipeline.evaluate(first_context)  # type: ignore[attr-defined]
+        if first_result.is_err:
+            err = first_result.error
+            rendered = err.format_details() if hasattr(err, "format_details") else str(err)
+            return Result.err(
+                MCPToolError(
+                    f"Evaluation failed: {rendered}",
+                    tool_name="ouroboros_evaluate",
+                )
+            )
+
+        # Extract Stage 1 result to share with remaining ACs.
+        shared_stage1 = first_result.value.stage1_result
+
+        # --- Stage 2+: parallelize remaining ACs (Stage 1 injected) ---
         async def _run_one(ac_text: str) -> Result[object, object]:
             context = EvaluationContext(
                 execution_id=session_id,
@@ -640,18 +678,16 @@ class EvaluateHandler:
                 trigger_consensus=trigger_consensus,
                 artifact_bundle=artifact_bundle,
             )
-            return await pipeline.evaluate(context)  # type: ignore[attr-defined]
+            return await pipeline.evaluate(  # type: ignore[attr-defined]
+                context,
+                stage1_result=shared_stage1,
+            )
 
-        log.info(
-            "mcp.tool.evaluate.multi_ac_started",
-            session_id=session_id,
-            ac_count=len(acceptance_criteria),
-        )
-
-        gathered = await asyncio.gather(
-            *(_run_one(ac) for ac in acceptance_criteria),
+        remaining_gathered = await asyncio.gather(
+            *(_run_one(ac) for ac in acceptance_criteria[1:]),
             return_exceptions=True,
         )
+        gathered = (first_result, *remaining_gathered)
 
         # Any exception or err-Result aborts the whole checklist —
         # otherwise we'd aggregate over a half-evaluated set.

--- a/tests/unit/evaluation/test_pipeline_stage1_reuse.py
+++ b/tests/unit/evaluation/test_pipeline_stage1_reuse.py
@@ -1,0 +1,190 @@
+"""Pipeline-level regression tests for stage1_result= reuse (#422).
+
+These tests exercise the real EvaluationPipeline.evaluate() method —
+not handler-level mocks — to ensure future Stage 1 changes cannot
+break the shared-result invariant silently.
+
+Requested by @Q00 in PR #422 review.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.evaluation.models import (
+    CheckResult,
+    CheckType,
+    EvaluationContext,
+    MechanicalResult,
+    SemanticResult,
+)
+from ouroboros.evaluation.pipeline import EvaluationPipeline, PipelineConfig
+
+
+def _make_context(*, execution_id: str = "test-exec") -> EvaluationContext:
+    """Build a minimal EvaluationContext for testing."""
+    return EvaluationContext(
+        execution_id=execution_id,
+        seed_id="seed-1",
+        current_ac="Test AC",
+        artifact="def f(): pass",
+        artifact_type="code",
+        goal="Test goal",
+        constraints=(),
+        trigger_consensus=False,
+    )
+
+
+def _passing_stage1() -> MechanicalResult:
+    return MechanicalResult(
+        passed=True,
+        checks=(CheckResult(check_type=CheckType.LINT, passed=True, message="ok"),),
+    )
+
+
+def _failing_stage1() -> MechanicalResult:
+    return MechanicalResult(
+        passed=False,
+        checks=(CheckResult(check_type=CheckType.LINT, passed=False, message="lint failed"),),
+    )
+
+
+def _passing_semantic() -> SemanticResult:
+    return SemanticResult(
+        score=0.9,
+        ac_compliance=True,
+        goal_alignment=0.9,
+        drift_score=0.1,
+        uncertainty=0.1,
+        reasoning="AC met",
+        reward_hacking_risk=0.0,
+        questions_used=(),
+        evidence=(),
+    )
+
+
+class TestStage1ResultReuse:
+    """Verify the stage1_result= parameter on EvaluationPipeline.evaluate()."""
+
+    @pytest.fixture()
+    def mock_llm(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture()
+    def pipeline(self, mock_llm: AsyncMock) -> EvaluationPipeline:
+        return EvaluationPipeline(mock_llm, PipelineConfig())
+
+    async def test_injected_passing_stage1_skips_mechanical_verify(
+        self, pipeline: EvaluationPipeline
+    ) -> None:
+        """When stage1_result is provided and passing, MechanicalVerifier.verify
+        must NOT be called, and Stage 2 should proceed.
+        """
+        stage1 = _passing_stage1()
+        semantic_return = (_passing_semantic(), [])
+
+        with (
+            patch(
+                "ouroboros.evaluation.mechanical.MechanicalVerifier.verify",
+                new_callable=AsyncMock,
+            ) as mock_verify,
+            patch(
+                "ouroboros.evaluation.semantic.SemanticEvaluator.evaluate",
+                new_callable=AsyncMock,
+                return_value=Result.ok(semantic_return),
+            ) as mock_semantic,
+        ):
+            result = await pipeline.evaluate(
+                _make_context(),
+                stage1_result=stage1,
+            )
+
+        mock_verify.assert_not_called()
+        mock_semantic.assert_called_once()
+        assert result.is_ok
+        assert result.value.final_approved is True
+        assert result.value.stage1_result is stage1
+
+    async def test_no_stage1_result_calls_mechanical_verify(
+        self, pipeline: EvaluationPipeline
+    ) -> None:
+        """When stage1_result is None (default), MechanicalVerifier.verify
+        MUST be called.
+        """
+        mech_return = (_passing_stage1(), [])
+        semantic_return = (_passing_semantic(), [])
+
+        with (
+            patch(
+                "ouroboros.evaluation.mechanical.MechanicalVerifier.verify",
+                new_callable=AsyncMock,
+                return_value=Result.ok(mech_return),
+            ) as mock_verify,
+            patch(
+                "ouroboros.evaluation.semantic.SemanticEvaluator.evaluate",
+                new_callable=AsyncMock,
+                return_value=Result.ok(semantic_return),
+            ),
+        ):
+            result = await pipeline.evaluate(_make_context())
+
+        mock_verify.assert_called_once()
+        assert result.is_ok
+        assert result.value.final_approved is True
+
+    async def test_injected_failing_stage1_causes_early_exit(
+        self, pipeline: EvaluationPipeline
+    ) -> None:
+        """When stage1_result is provided and failing, pipeline exits early
+        with final_approved=False and SemanticEvaluator.evaluate is NOT called.
+        """
+        stage1 = _failing_stage1()
+
+        with (
+            patch(
+                "ouroboros.evaluation.mechanical.MechanicalVerifier.verify",
+                new_callable=AsyncMock,
+            ) as mock_verify,
+            patch(
+                "ouroboros.evaluation.semantic.SemanticEvaluator.evaluate",
+                new_callable=AsyncMock,
+            ) as mock_semantic,
+        ):
+            result = await pipeline.evaluate(
+                _make_context(),
+                stage1_result=stage1,
+            )
+
+        mock_verify.assert_not_called()
+        mock_semantic.assert_not_called()
+        assert result.is_ok
+        assert result.value.final_approved is False
+        assert result.value.stage1_result is stage1
+
+    async def test_injected_passing_stage1_allows_stage2(
+        self, pipeline: EvaluationPipeline
+    ) -> None:
+        """When stage1_result is provided and passing, Stage 2
+        (SemanticEvaluator.evaluate) MUST be called.
+        """
+        stage1 = _passing_stage1()
+        semantic_return = (_passing_semantic(), [])
+
+        with (
+            patch(
+                "ouroboros.evaluation.semantic.SemanticEvaluator.evaluate",
+                new_callable=AsyncMock,
+                return_value=Result.ok(semantic_return),
+            ) as mock_semantic,
+        ):
+            result = await pipeline.evaluate(
+                _make_context(),
+                stage1_result=stage1,
+            )
+
+        mock_semantic.assert_called_once()
+        assert result.is_ok
+        assert result.value.stage2_result is not None

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -95,7 +95,7 @@ class TestMultiACRoutingBoundary:
         # `evaluate()` returns Result objects in order per call.
         results_iter = iter(eval_results)
 
-        async def _evaluate(_context: object) -> object:
+        async def _evaluate(_context: object, **_kwargs: object) -> object:
             return Result.ok(next(results_iter))
 
         mock_pipeline.evaluate = AsyncMock(side_effect=_evaluate)


### PR DESCRIPTION
## Summary

Rebase of #422 onto current `main` to resolve the "cannot be rebased due to conflicts" state. Original author: @shaun0927.

GitHub's `Rebase and merge` button failed because #422 contained earlier commits (the per-AC aggregator and multi-AC handler) that had already landed on `main` via separate merges (#384 / #385). Replaying those commits onto the updated `main` caused conflicts even though `Create a merge commit` would have worked.

## Commits (3 cherry-picked from #422)

- `e5925bb0` perf(evaluate): deduplicate Stage 1 in multi-AC checklist path (from `5b3859f0`)
- `220b88c2` docs(evaluate): document AC-agnostic invariant for Stage 1 dedup (from `480ba9ff`)
- `b763775c` test(evaluate): add pipeline-level regression for stage1_result reuse (from `86695251`)

Skipped (already in `main` via other merges):
- `e128ad82` — per-AC checklist aggregator → landed as #384
- `f8334155` — wire checklist into EvaluateHandler → landed as #385 (`a2a64594`)
- `5d17a831` — 1-item AC fix → equivalent logic already on main (`665a7359`); empty after resolution

## What this adds

- `EvaluationPipeline.evaluate(..., stage1_result: MechanicalResult | None = None)` — new kwarg to inject a pre-computed Stage 1 result, skipping re-execution.
- `_handle_multi_ac` now runs Stage 1 **once** on the first AC, then reuses its result for the remaining per-AC Stage 2+ evaluations in parallel. Previously Stage 1 ran N times for N ACs.
- Docstring codifies the "Stage 1 must remain AC-agnostic" invariant so future contributors don't silently break the dedup.
- Pipeline-level regression test exercises `stage1_result` reuse directly (not via handler mocks).

## Test plan

- [x] `uv run pytest tests/unit/evaluation/test_pipeline_stage1_reuse.py tests/unit/mcp/tools/test_evaluate_multi_ac.py` — 15 passed.
- [ ] CI full suite

Closes #422. Refs #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)