### PR TITLE
feat(cli): add 'ouroboros mcp doctor' diagnostic command

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -18,7 +18,7 @@ from rich.console import Console
 import typer
 
 from ouroboros.cli.commands.mcp_doctor import register_doctor_command
-from ouroboros.cli.formatters.panels import print_error, print_info, print_success
+from ouroboros.cli.formatters.panels import print_info, print_success
 
 # PID file for detecting stale instances
 _PID_DIR = Path.home() / ".ouroboros"

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -17,7 +17,8 @@ from typing import Annotated
 from rich.console import Console
 import typer
 
-from ouroboros.cli.formatters.panels import print_info, print_success
+from ouroboros.cli.commands.mcp_doctor import register_doctor_command
+from ouroboros.cli.formatters.panels import print_error, print_info, print_success
 
 # PID file for detecting stale instances
 _PID_DIR = Path.home() / ".ouroboros"
@@ -160,6 +161,8 @@ app = typer.Typer(
     help="MCP (Model Context Protocol) server commands.",
     no_args_is_help=True,
 )
+
+register_doctor_command(app)
 
 
 async def _run_mcp_server(

--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -4,7 +4,7 @@ Run ``ouroboros mcp doctor`` to check whether your environment is set up
 correctly for the MCP server.  Each check returns a :class:`CheckResult`
 with a pass/warn/fail status and an optional remediation hint.
 
-The ``--json`` flag emits a machine-readable JSON object suitable for
+The ``--json`` flag emits a machine-readable JSON array suitable for
 inclusion in bug reports or CI pipelines.  Exit code 1 is returned if any
 check has status ``fail``; 0 otherwise.
 """
@@ -252,6 +252,8 @@ def check_pid_file() -> CheckResult:
             message="No PID file (server not running or cleanly stopped)",
         )
 
+    _rm_cmd = "del" if platform.system() == "Windows" else "rm"
+
     try:
         raw = _PID_FILE.read_text(encoding="utf-8").strip()
         pid = int(raw)
@@ -260,7 +262,7 @@ def check_pid_file() -> CheckResult:
             name="pid_file",
             status="warn",
             message=f"PID file unreadable: {exc}",
-            remediation=f"Remove the stale file: rm {_PID_FILE}",
+            remediation=f"Remove the stale file: {_rm_cmd} {_PID_FILE}",
         )
 
     if _pid_is_alive(pid):
@@ -273,7 +275,7 @@ def check_pid_file() -> CheckResult:
         name="pid_file",
         status="warn",
         message=f"Stale PID file: process {pid} is not running",
-        remediation=f"Remove the stale file: rm {_PID_FILE}",
+        remediation=f"Remove the stale file: {_rm_cmd} {_PID_FILE}",
     )
 
 

--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -129,8 +129,30 @@ def check_mcp_import() -> CheckResult:
     )
 
 
+_CLAUDE_RUNTIME_BACKENDS = frozenset({"claude", "claude_code"})
+
+
+def _get_runtime_backend() -> str:
+    """Return the configured agent runtime backend, with a safe fallback."""
+    try:
+        from ouroboros.config.loader import get_agent_runtime_backend
+
+        return get_agent_runtime_backend()
+    except Exception:
+        return "claude"
+
+
 def check_claude_agent_sdk_import() -> CheckResult:
-    """Check that the ``claude`` extra (claude-agent-sdk) is installed."""
+    """Check that the ``claude`` extra (claude-agent-sdk) is installed.
+
+    The check is backend-aware: when the configured runtime is *not*
+    Claude-based (e.g. ``codex`` or ``opencode``), a missing
+    ``claude-agent-sdk`` is downgraded to **warn** instead of **fail**
+    because the package is not required for that backend.
+    """
+    runtime = _get_runtime_backend()
+    needs_claude = runtime in _CLAUDE_RUNTIME_BACKENDS
+
     try:
         import claude_agent_sdk  # noqa: F401
 
@@ -144,11 +166,18 @@ def check_claude_agent_sdk_import() -> CheckResult:
             message=f"claude-agent-sdk {version}",
         )
     except ImportError:
+        if needs_claude:
+            return CheckResult(
+                name="claude_agent_sdk_import",
+                status="fail",
+                message="claude-agent-sdk not importable",
+                remediation="pip install 'ouroboros-ai[claude]'  or  uv add 'ouroboros-ai[claude]'",
+            )
         return CheckResult(
             name="claude_agent_sdk_import",
-            status="fail",
-            message="claude-agent-sdk not importable",
-            remediation="pip install 'ouroboros-ai[claude]'  or  uv add 'ouroboros-ai[claude]'",
+            status="warn",
+            message=f"claude-agent-sdk not installed (not required for {runtime} runtime)",
+            remediation="Install if switching to Claude runtime: pip install 'ouroboros-ai[claude]'",
         )
 
 
@@ -313,7 +342,9 @@ def register_doctor_command(app: typer.Typer) -> None:
         """Run environment diagnostics for the MCP server.
 
         Checks Python version, installed extras (mcp, claude-agent-sdk,
-        litellm), EventStore health, and PID file liveness.  Exit code 1
+        litellm), EventStore health, and PID file liveness.  Backend-specific
+        extras are validated against the configured runtime so that non-Claude
+        setups (codex, opencode) do not produce false failures.  Exit code 1
         if any check fails.
 
         Examples:
@@ -349,6 +380,7 @@ def register_doctor_command(app: typer.Typer) -> None:
 __all__ = [
     "CheckResult",
     "Status",
+    "_CLAUDE_RUNTIME_BACKENDS",
     "check_python_version",
     "check_platform",
     "check_ouroboros_version",

--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -1,0 +1,359 @@
+"""MCP doctor subcommand — fast, read-only environment diagnostics.
+
+Run ``ouroboros mcp doctor`` to check whether your environment is set up
+correctly for the MCP server.  Each check returns a :class:`CheckResult`
+with a pass/warn/fail status and an optional remediation hint.
+
+The ``--json`` flag emits a machine-readable JSON object suitable for
+inclusion in bug reports or CI pipelines.  Exit code 1 is returned if any
+check has status ``fail``; 0 otherwise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import platform
+import sys
+from typing import Annotated, Literal
+
+from rich.console import Console
+import typer
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+Status = Literal["pass", "warn", "fail"]
+
+_SYMBOLS: dict[Status, str] = {
+    "pass": "[green]✓[/green]",
+    "warn": "[yellow]⚠[/yellow]",
+    "fail": "[red]✗[/red]",
+}
+
+
+@dataclass
+class CheckResult:
+    """Result of a single diagnostic check."""
+
+    name: str
+    status: Status
+    message: str
+    remediation: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Individual check functions
+# ---------------------------------------------------------------------------
+
+_PID_FILE = Path.home() / ".ouroboros" / "mcp-server.pid"
+_EVENT_STORE_PATH = Path.home() / ".ouroboros" / "ouroboros.db"
+_EVENT_STORE_WARN_BYTES = 500 * 1024 * 1024  # 500 MB
+
+
+def check_python_version() -> CheckResult:
+    """Require Python >= 3.12."""
+    major, minor, micro = sys.version_info[0], sys.version_info[1], sys.version_info[2]
+    version_str = f"{major}.{minor}.{micro}"
+    if (major, minor) >= (3, 12):
+        return CheckResult(
+            name="python_version",
+            status="pass",
+            message=f"Python {version_str}",
+        )
+    return CheckResult(
+        name="python_version",
+        status="fail",
+        message=f"Python {version_str} (need >= 3.12)",
+        remediation="Upgrade to Python 3.12 or newer: https://www.python.org/downloads/",
+    )
+
+
+def check_platform() -> CheckResult:
+    """Report platform/OS information (always passes)."""
+    info = f"{platform.system()} {platform.release()} ({platform.machine()})"
+    return CheckResult(
+        name="platform",
+        status="pass",
+        message=info,
+    )
+
+
+def check_ouroboros_version() -> CheckResult:
+    """Check that ouroboros-ai is installed and report its version."""
+    try:
+        version = importlib.metadata.version("ouroboros-ai")
+        return CheckResult(
+            name="ouroboros_version",
+            status="pass",
+            message=f"ouroboros-ai {version}",
+        )
+    except importlib.metadata.PackageNotFoundError:
+        return CheckResult(
+            name="ouroboros_version",
+            status="fail",
+            message="ouroboros-ai not found in installed packages",
+            remediation="pip install ouroboros-ai  or  uv add ouroboros-ai",
+        )
+
+
+def check_mcp_import() -> CheckResult:
+    """Check that the ``mcp`` extra is installed."""
+    try:
+        import mcp  # noqa: F401
+    except ImportError:
+        return CheckResult(
+            name="mcp_import",
+            status="fail",
+            message="mcp package not importable",
+            remediation="pip install 'ouroboros-ai[mcp]'  or  uv add 'ouroboros-ai[mcp]'",
+        )
+
+    try:
+        version = importlib.metadata.version("mcp")
+    except importlib.metadata.PackageNotFoundError:
+        # importable but no dist-info — treat as pass
+        return CheckResult(
+            name="mcp_import",
+            status="pass",
+            message="mcp (version unknown)",
+        )
+    return CheckResult(
+        name="mcp_import",
+        status="pass",
+        message=f"mcp {version}",
+    )
+
+
+def check_claude_agent_sdk_import() -> CheckResult:
+    """Check that the ``claude`` extra (claude-agent-sdk) is installed."""
+    try:
+        import claude_agent_sdk  # noqa: F401
+
+        try:
+            version = importlib.metadata.version("claude-agent-sdk")
+        except importlib.metadata.PackageNotFoundError:
+            version = "unknown"
+        return CheckResult(
+            name="claude_agent_sdk_import",
+            status="pass",
+            message=f"claude-agent-sdk {version}",
+        )
+    except ImportError:
+        return CheckResult(
+            name="claude_agent_sdk_import",
+            status="fail",
+            message="claude-agent-sdk not importable",
+            remediation="pip install 'ouroboros-ai[claude]'  or  uv add 'ouroboros-ai[claude]'",
+        )
+
+
+def check_litellm_import() -> CheckResult:
+    """Check that litellm is installed (warn if missing, not fail)."""
+    try:
+        import litellm  # noqa: F401
+
+        try:
+            version = importlib.metadata.version("litellm")
+        except importlib.metadata.PackageNotFoundError:
+            version = "unknown"
+        return CheckResult(
+            name="litellm_import",
+            status="pass",
+            message=f"litellm {version}",
+        )
+    except ImportError:
+        return CheckResult(
+            name="litellm_import",
+            status="warn",
+            message="litellm not installed (optional)",
+            remediation="pip install 'ouroboros-ai[litellm]'  or  uv add 'ouroboros-ai[litellm]'",
+        )
+
+
+def check_event_store() -> CheckResult:
+    """Check EventStore path existence and warn if it exceeds 500 MB."""
+    if not _EVENT_STORE_PATH.exists():
+        return CheckResult(
+            name="event_store",
+            status="pass",
+            message=f"{_EVENT_STORE_PATH} not found (will be created on first use)",
+        )
+    try:
+        size_bytes = _EVENT_STORE_PATH.stat().st_size
+    except OSError as exc:
+        return CheckResult(
+            name="event_store",
+            status="warn",
+            message=f"Cannot stat {_EVENT_STORE_PATH}: {exc}",
+        )
+
+    size_mb = size_bytes / (1024 * 1024)
+    if size_bytes > _EVENT_STORE_WARN_BYTES:
+        return CheckResult(
+            name="event_store",
+            status="warn",
+            message=f"{_EVENT_STORE_PATH} is {size_mb:.1f} MB (>500 MB)",
+            remediation=(
+                "Consider archiving or pruning old sessions. "
+                "The DB can be vacuumed with: sqlite3 ~/.ouroboros/ouroboros.db VACUUM;"
+            ),
+        )
+    return CheckResult(
+        name="event_store",
+        status="pass",
+        message=f"{_EVENT_STORE_PATH} ({size_mb:.1f} MB)",
+    )
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Return True if *pid* refers to a running process.
+
+    Handles Windows (where ``os.kill(pid, 0)`` raises ``OSError`` with
+    ``WinError 87`` instead of ``ProcessLookupError``) and POSIX.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we don't have permission to signal it.
+        return True
+    except OSError:
+        # Windows: signal 0 unsupported — fall back to a tasklist check.
+        if sys.platform == "win32":
+            try:
+                import subprocess
+
+                result = subprocess.run(
+                    ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                return str(pid) in result.stdout
+            except Exception:
+                return False
+        # Non-Windows, unknown OSError — assume stale.
+        return False
+
+
+def check_pid_file() -> CheckResult:
+    """Check the MCP server PID file for liveness."""
+    if not _PID_FILE.exists():
+        return CheckResult(
+            name="pid_file",
+            status="pass",
+            message="No PID file (server not running or cleanly stopped)",
+        )
+
+    try:
+        raw = _PID_FILE.read_text(encoding="utf-8").strip()
+        pid = int(raw)
+    except (ValueError, OSError) as exc:
+        return CheckResult(
+            name="pid_file",
+            status="warn",
+            message=f"PID file unreadable: {exc}",
+            remediation=f"Remove the stale file: rm {_PID_FILE}",
+        )
+
+    if _pid_is_alive(pid):
+        return CheckResult(
+            name="pid_file",
+            status="pass",
+            message=f"MCP server running (PID {pid})",
+        )
+    return CheckResult(
+        name="pid_file",
+        status="warn",
+        message=f"Stale PID file: process {pid} is not running",
+        remediation=f"Remove the stale file: rm {_PID_FILE}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ordered list of all checks
+# ---------------------------------------------------------------------------
+
+_ALL_CHECKS = [
+    check_python_version,
+    check_platform,
+    check_ouroboros_version,
+    check_mcp_import,
+    check_claude_agent_sdk_import,
+    check_litellm_import,
+    check_event_store,
+    check_pid_file,
+]
+
+
+# ---------------------------------------------------------------------------
+# Typer command
+# ---------------------------------------------------------------------------
+
+
+def register_doctor_command(app: typer.Typer) -> None:
+    """Register the ``doctor`` subcommand onto *app* (the ``mcp`` Typer app)."""
+
+    @app.command()
+    def doctor(
+        as_json: Annotated[
+            bool,
+            typer.Option("--json", help="Emit machine-readable JSON to stdout."),
+        ] = False,
+    ) -> None:
+        """Run environment diagnostics for the MCP server.
+
+        Checks Python version, installed extras (mcp, claude-agent-sdk,
+        litellm), EventStore health, and PID file liveness.  Exit code 1
+        if any check fails.
+
+        Examples:
+
+            # Human-readable output
+            ouroboros mcp doctor
+
+            # Machine-readable (for bug reports)
+            ouroboros mcp doctor --json
+        """
+        console = Console()
+        results: list[CheckResult] = [fn() for fn in _ALL_CHECKS]
+
+        if as_json:
+            payload = [asdict(r) for r in results]
+            print(json.dumps(payload, indent=2))
+        else:
+            console.print()
+            console.print("[bold]Ouroboros MCP Doctor[/bold]")
+            console.print()
+            for result in results:
+                symbol = _SYMBOLS[result.status]
+                console.print(f"  {symbol}  [bold]{result.name}[/bold]: {result.message}")
+                if result.remediation:
+                    console.print(f"      [dim]hint: {result.remediation}[/dim]")
+            console.print()
+
+        has_failure = any(r.status == "fail" for r in results)
+        if has_failure:
+            raise typer.Exit(code=1)
+
+
+__all__ = [
+    "CheckResult",
+    "Status",
+    "check_python_version",
+    "check_platform",
+    "check_ouroboros_version",
+    "check_mcp_import",
+    "check_claude_agent_sdk_import",
+    "check_litellm_import",
+    "check_event_store",
+    "check_pid_file",
+    "register_doctor_command",
+]

--- a/tests/unit/cli/test_mcp_doctor.py
+++ b/tests/unit/cli/test_mcp_doctor.py
@@ -155,6 +155,8 @@ class TestCheckMcpImport:
 
 
 class TestCheckClaudeAgentSdkImport:
+    """Tests for check_claude_agent_sdk_import — backend-aware behaviour."""
+
     def test_passes_when_importable(self):
         mock_sdk = MagicMock()
         with (
@@ -164,11 +166,44 @@ class TestCheckClaudeAgentSdkImport:
             result = check_claude_agent_sdk_import()
         assert result.status == "pass"
 
-    def test_fails_when_not_importable(self):
-        with patch("builtins.__import__", side_effect=_import_error_for("claude_agent_sdk")):
+    def test_fails_when_not_importable_on_claude_backend(self):
+        """Missing SDK on a Claude runtime is a hard fail."""
+        with (
+            patch(
+                "ouroboros.cli.commands.mcp_doctor._get_runtime_backend",
+                return_value="claude",
+            ),
+            patch("builtins.__import__", side_effect=_import_error_for("claude_agent_sdk")),
+        ):
             result = check_claude_agent_sdk_import()
         assert result.status == "fail"
         assert result.remediation != ""
+
+    def test_warns_when_not_importable_on_codex_backend(self):
+        """Missing SDK on a Codex runtime is only a warning, not a failure."""
+        with (
+            patch(
+                "ouroboros.cli.commands.mcp_doctor._get_runtime_backend",
+                return_value="codex",
+            ),
+            patch("builtins.__import__", side_effect=_import_error_for("claude_agent_sdk")),
+        ):
+            result = check_claude_agent_sdk_import()
+        assert result.status == "warn"
+        assert "codex" in result.message
+
+    def test_warns_when_not_importable_on_opencode_backend(self):
+        """Missing SDK on an OpenCode runtime is only a warning."""
+        with (
+            patch(
+                "ouroboros.cli.commands.mcp_doctor._get_runtime_backend",
+                return_value="opencode",
+            ),
+            patch("builtins.__import__", side_effect=_import_error_for("claude_agent_sdk")),
+        ):
+            result = check_claude_agent_sdk_import()
+        assert result.status == "warn"
+        assert "opencode" in result.message
 
     def test_passes_with_unknown_version(self):
         mock_sdk = MagicMock()
@@ -182,6 +217,32 @@ class TestCheckClaudeAgentSdkImport:
             result = check_claude_agent_sdk_import()
         assert result.status == "pass"
         assert "unknown" in result.message
+
+    def test_passes_when_importable_regardless_of_backend(self):
+        """If the SDK is installed, the check passes even on non-Claude backends."""
+        mock_sdk = MagicMock()
+        with (
+            patch(
+                "ouroboros.cli.commands.mcp_doctor._get_runtime_backend",
+                return_value="codex",
+            ),
+            patch.dict("sys.modules", {"claude_agent_sdk": mock_sdk}),
+            patch("importlib.metadata.version", return_value="0.5.0"),
+        ):
+            result = check_claude_agent_sdk_import()
+        assert result.status == "pass"
+
+    def test_fails_on_claude_code_backend(self):
+        """claude_code is also a Claude backend — missing SDK should fail."""
+        with (
+            patch(
+                "ouroboros.cli.commands.mcp_doctor._get_runtime_backend",
+                return_value="claude_code",
+            ),
+            patch("builtins.__import__", side_effect=_import_error_for("claude_agent_sdk")),
+        ):
+            result = check_claude_agent_sdk_import()
+        assert result.status == "fail"
 
 
 # ---------------------------------------------------------------------------
@@ -442,6 +503,22 @@ class TestDoctorCommand:
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert data[0]["status"] == "fail"
+
+    def test_exits_0_on_codex_backend_without_claude_sdk(self):
+        """On a Codex backend, missing claude-agent-sdk should not cause exit 1."""
+        app = _make_app()
+        warn_result = CheckResult(
+            name="claude_agent_sdk_import",
+            status="warn",
+            message="claude-agent-sdk not installed (not required for codex runtime)",
+        )
+        pass_result = CheckResult(name="mcp_import", status="pass", message="mcp 1.26.0")
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: pass_result, lambda: warn_result],
+        ):
+            result = runner.invoke(app, [])
+        assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_mcp_doctor.py
+++ b/tests/unit/cli/test_mcp_doctor.py
@@ -1,0 +1,480 @@
+"""Unit tests for ``ouroboros mcp doctor`` diagnostic command.
+
+Covers:
+- Each individual check function with a mocked environment
+- Overall exit-code logic (0 = all pass/warn, 1 = any fail)
+- JSON output format validation
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from ouroboros.cli.commands.mcp_doctor import (
+    CheckResult,
+    check_claude_agent_sdk_import,
+    check_event_store,
+    check_litellm_import,
+    check_mcp_import,
+    check_ouroboros_version,
+    check_pid_file,
+    check_platform,
+    check_python_version,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+runner = CliRunner()
+
+
+def _make_app():
+    """Return a fresh Typer app with the doctor command registered."""
+    import typer
+
+    from ouroboros.cli.commands.mcp_doctor import register_doctor_command
+
+    app = typer.Typer()
+    register_doctor_command(app)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# check_python_version
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPythonVersion:
+    def test_passes_on_312_or_newer(self):
+        with patch.object(sys, "version_info", (3, 12, 0, "final", 0)):
+            result = check_python_version()
+        assert result.status == "pass"
+        assert "3.12" in result.message
+
+    def test_passes_on_313(self):
+        with patch.object(sys, "version_info", (3, 13, 1, "final", 0)):
+            result = check_python_version()
+        assert result.status == "pass"
+
+    def test_fails_on_311(self):
+        with patch.object(sys, "version_info", (3, 11, 9, "final", 0)):
+            result = check_python_version()
+        assert result.status == "fail"
+        assert result.remediation != ""
+
+    def test_fails_on_310(self):
+        with patch.object(sys, "version_info", (3, 10, 0, "final", 0)):
+            result = check_python_version()
+        assert result.status == "fail"
+
+    def test_message_contains_version_string(self):
+        with patch.object(sys, "version_info", (3, 12, 5, "final", 0)):
+            result = check_python_version()
+        assert "3.12.5" in result.message
+
+
+# ---------------------------------------------------------------------------
+# check_platform
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPlatform:
+    def test_always_passes(self):
+        result = check_platform()
+        assert result.status == "pass"
+
+    def test_message_is_non_empty(self):
+        result = check_platform()
+        assert result.message.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# check_ouroboros_version
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOuroborosVersion:
+    def test_passes_when_installed(self):
+        with patch("importlib.metadata.version", return_value="0.28.4"):
+            result = check_ouroboros_version()
+        assert result.status == "pass"
+        assert "0.28.4" in result.message
+
+    def test_fails_when_not_installed(self):
+        with patch(
+            "importlib.metadata.version",
+            side_effect=importlib.metadata.PackageNotFoundError("ouroboros-ai"),
+        ):
+            result = check_ouroboros_version()
+        assert result.status == "fail"
+        assert result.remediation != ""
+
+
+# ---------------------------------------------------------------------------
+# check_mcp_import
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMcpImport:
+    def test_passes_when_importable(self):
+        mock_mcp = MagicMock()
+        with (
+            patch.dict("sys.modules", {"mcp": mock_mcp}),
+            patch("importlib.metadata.version", return_value="1.26.0"),
+        ):
+            result = check_mcp_import()
+        assert result.status == "pass"
+        assert "1.26.0" in result.message
+
+    def test_fails_when_not_importable(self):
+        with patch.dict("sys.modules", {"mcp": None}):
+            # Ensure import raises ImportError
+            with patch("builtins.__import__", side_effect=_import_error_for("mcp")):
+                result = check_mcp_import()
+        assert result.status == "fail"
+        assert result.remediation != ""
+
+    def test_passes_when_installed_returns_version(self):
+        # mcp is installed — check that version string is included in the message
+        result = check_mcp_import()
+        # mcp is an actual dependency of this project, so it should pass
+        assert result.status == "pass"
+        assert result.name == "mcp_import"
+
+
+# ---------------------------------------------------------------------------
+# check_claude_agent_sdk_import
+# ---------------------------------------------------------------------------
+
+
+class TestCheckClaudeAgentSdkImport:
+    def test_passes_when_importable(self):
+        mock_sdk = MagicMock()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": mock_sdk}),
+            patch("importlib.metadata.version", return_value="0.5.0"),
+        ):
+            result = check_claude_agent_sdk_import()
+        assert result.status == "pass"
+
+    def test_fails_when_not_importable(self):
+        with patch("builtins.__import__", side_effect=_import_error_for("claude_agent_sdk")):
+            result = check_claude_agent_sdk_import()
+        assert result.status == "fail"
+        assert result.remediation != ""
+
+    def test_passes_with_unknown_version(self):
+        mock_sdk = MagicMock()
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": mock_sdk}),
+            patch(
+                "importlib.metadata.version",
+                side_effect=importlib.metadata.PackageNotFoundError("claude-agent-sdk"),
+            ),
+        ):
+            result = check_claude_agent_sdk_import()
+        assert result.status == "pass"
+        assert "unknown" in result.message
+
+
+# ---------------------------------------------------------------------------
+# check_litellm_import
+# ---------------------------------------------------------------------------
+
+
+class TestCheckLitellmImport:
+    def test_passes_when_importable(self):
+        mock_litellm = MagicMock()
+        with (
+            patch.dict("sys.modules", {"litellm": mock_litellm}),
+            patch("importlib.metadata.version", return_value="1.80.0"),
+        ):
+            result = check_litellm_import()
+        assert result.status == "pass"
+
+    def test_warns_when_not_importable(self):
+        """litellm is optional — missing yields warn, not fail."""
+        with patch("builtins.__import__", side_effect=_import_error_for("litellm")):
+            result = check_litellm_import()
+        assert result.status == "warn"
+        assert result.remediation != ""
+
+    def test_does_not_fail_when_missing(self):
+        with patch("builtins.__import__", side_effect=_import_error_for("litellm")):
+            result = check_litellm_import()
+        assert result.status != "fail"
+
+
+# ---------------------------------------------------------------------------
+# check_event_store
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEventStore:
+    def test_passes_when_db_does_not_exist(self, tmp_path):
+        fake_path = tmp_path / "nonexistent.db"
+        with patch("ouroboros.cli.commands.mcp_doctor._EVENT_STORE_PATH", fake_path):
+            result = check_event_store()
+        assert result.status == "pass"
+        assert "not found" in result.message
+
+    def test_passes_when_db_small(self, tmp_path):
+        db = tmp_path / "ouroboros.db"
+        db.write_bytes(b"x" * 1024)  # 1 KB
+        with patch("ouroboros.cli.commands.mcp_doctor._EVENT_STORE_PATH", db):
+            result = check_event_store()
+        assert result.status == "pass"
+        assert "MB" in result.message
+
+    def test_warns_when_db_over_500mb(self, tmp_path):
+        db = tmp_path / "ouroboros.db"
+        db.write_bytes(b"x")
+        large_stat = MagicMock()
+        large_stat.st_size = 600 * 1024 * 1024  # 600 MB
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.return_value = True
+        mock_path.stat.return_value = large_stat
+        mock_path.__str__ = lambda _self: str(db)
+        with patch("ouroboros.cli.commands.mcp_doctor._EVENT_STORE_PATH", mock_path):
+            result = check_event_store()
+        assert result.status == "warn"
+        assert result.remediation != ""
+
+    def test_warns_when_stat_raises(self, tmp_path):
+        db = tmp_path / "ouroboros.db"
+        mock_path = MagicMock(spec=Path)
+        mock_path.exists.return_value = True
+        mock_path.stat.side_effect = OSError("permission denied")
+        mock_path.__str__ = lambda _self: str(db)
+        with patch("ouroboros.cli.commands.mcp_doctor._EVENT_STORE_PATH", mock_path):
+            result = check_event_store()
+        assert result.status == "warn"
+
+
+# ---------------------------------------------------------------------------
+# check_pid_file
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPidFile:
+    def test_passes_when_no_pid_file(self, tmp_path):
+        fake_pid = tmp_path / "mcp-server.pid"
+        with patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", fake_pid):
+            result = check_pid_file()
+        assert result.status == "pass"
+        assert "not running" in result.message.lower() or "no pid" in result.message.lower()
+
+    def test_passes_when_pid_alive(self, tmp_path):
+        fake_pid = tmp_path / "mcp-server.pid"
+        fake_pid.write_text("12345", encoding="utf-8")
+        with (
+            patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", fake_pid),
+            patch("ouroboros.cli.commands.mcp_doctor._pid_is_alive", return_value=True),
+        ):
+            result = check_pid_file()
+        assert result.status == "pass"
+        assert "12345" in result.message
+
+    def test_warns_when_pid_stale(self, tmp_path):
+        fake_pid = tmp_path / "mcp-server.pid"
+        fake_pid.write_text("99999", encoding="utf-8")
+        with (
+            patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", fake_pid),
+            patch("ouroboros.cli.commands.mcp_doctor._pid_is_alive", return_value=False),
+        ):
+            result = check_pid_file()
+        assert result.status == "warn"
+        assert result.remediation != ""
+
+    def test_warns_when_pid_file_unreadable(self, tmp_path):
+        fake_pid = tmp_path / "mcp-server.pid"
+        fake_pid.write_text("not_a_number", encoding="utf-8")
+        with patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", fake_pid):
+            result = check_pid_file()
+        assert result.status == "warn"
+        assert result.remediation != ""
+
+
+# ---------------------------------------------------------------------------
+# _pid_is_alive
+# ---------------------------------------------------------------------------
+
+
+class TestPidIsAlive:
+    def test_returns_true_when_process_exists(self):
+        from ouroboros.cli.commands.mcp_doctor import _pid_is_alive
+
+        with patch("os.kill", return_value=None):
+            assert _pid_is_alive(12345) is True
+
+    def test_returns_false_when_process_not_found(self):
+        from ouroboros.cli.commands.mcp_doctor import _pid_is_alive
+
+        with patch("os.kill", side_effect=ProcessLookupError):
+            assert _pid_is_alive(99999) is False
+
+    def test_returns_true_on_permission_error(self):
+        """PermissionError means process exists but we can't signal it."""
+        from ouroboros.cli.commands.mcp_doctor import _pid_is_alive
+
+        with patch("os.kill", side_effect=PermissionError):
+            assert _pid_is_alive(12345) is True
+
+    def test_returns_false_on_os_error_non_windows(self):
+        from ouroboros.cli.commands.mcp_doctor import _pid_is_alive
+
+        with (
+            patch("os.kill", side_effect=OSError("WinError 87")),
+            patch.object(sys, "platform", "linux"),
+        ):
+            assert _pid_is_alive(12345) is False
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: exit codes and JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorCommand:
+    def test_exits_0_when_all_pass(self):
+        app = _make_app()
+        all_pass = CheckResult(name="x", status="pass", message="ok")
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: all_pass],
+        ):
+            result = runner.invoke(app, [])
+        assert result.exit_code == 0
+
+    def test_exits_1_when_any_fail(self):
+        app = _make_app()
+        failing = CheckResult(name="x", status="fail", message="broken")
+        passing = CheckResult(name="y", status="pass", message="ok")
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: failing, lambda: passing],
+        ):
+            result = runner.invoke(app, [])
+        assert result.exit_code == 1
+
+    def test_exits_0_when_only_warn(self):
+        app = _make_app()
+        warning = CheckResult(name="x", status="warn", message="optional missing")
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: warning],
+        ):
+            result = runner.invoke(app, [])
+        assert result.exit_code == 0
+
+    def test_json_flag_emits_valid_json(self):
+        app = _make_app()
+        check_a = CheckResult(name="a", status="pass", message="good")
+        check_b = CheckResult(name="b", status="warn", message="maybe", remediation="fix it")
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: check_a, lambda: check_b],
+        ):
+            result = runner.invoke(app, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 2
+        assert data[0]["name"] == "a"
+        assert data[0]["status"] == "pass"
+        assert data[1]["remediation"] == "fix it"
+
+    def test_json_output_has_required_keys(self):
+        app = _make_app()
+        check_result = CheckResult(name="z", status="pass", message="ok")
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: check_result],
+        ):
+            result = runner.invoke(app, ["--json"])
+        data = json.loads(result.output)
+        for item in data:
+            assert "name" in item
+            assert "status" in item
+            assert "message" in item
+            assert "remediation" in item
+
+    def test_human_output_shows_symbols(self):
+        app = _make_app()
+        check_result = CheckResult(name="mcp", status="pass", message="mcp 1.26.0")
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: check_result],
+        ):
+            result = runner.invoke(app, [])
+        assert "mcp" in result.output
+
+    def test_human_output_shows_remediation(self):
+        app = _make_app()
+        check_result = CheckResult(
+            name="mcp_import",
+            status="fail",
+            message="not found",
+            remediation="pip install mcp",
+        )
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: check_result],
+        ):
+            result = runner.invoke(app, [])
+        assert "pip install mcp" in result.output
+
+    def test_json_fail_still_exits_1(self):
+        app = _make_app()
+        failing = CheckResult(name="x", status="fail", message="broken")
+        with patch(
+            "ouroboros.cli.commands.mcp_doctor._ALL_CHECKS",
+            [lambda: failing],
+        ):
+            result = runner.invoke(app, ["--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data[0]["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Sanity: mcp.py app still importable with doctor registered
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_app_importable():
+    from ouroboros.cli.commands.mcp import app
+
+    assert app is not None
+
+
+def test_doctor_command_registered():
+    from ouroboros.cli.commands.mcp import app
+
+    # Typer stores name=None at registration time; use callback name instead
+    callback_names = [cmd.callback.__name__ for cmd in app.registered_commands]
+    assert "doctor" in callback_names
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _import_error_for(module_name: str):
+    """Return a side_effect function that raises ImportError only for *module_name*."""
+    real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+    def _side_effect(name, *args, **kwargs):
+        if name == module_name or name.startswith(module_name + "."):
+            raise ImportError(f"No module named '{module_name}'")
+        return real_import(name, *args, **kwargs)
+
+    return _side_effect


### PR DESCRIPTION
## Summary

Rebase of #434 onto current `main` to resolve merge conflicts. Original author: @shaun0927.

## Commits (3 cherry-picked from #434 + 1 lint fixup)

- `44cfaa96` — `feat(cli): add ouroboros mcp doctor diagnostic command (#431)` (from `08b92e62`)
- `3295c60d` — `docs(cli): fix --json shape docs and add platform-specific PID hint` (from `2f70a55c`)
- `ad64b486` — `fix(cli): make mcp doctor backend-aware for non-Claude runtimes` (from `d8c093fe`)
- `ded8c770` — `style(cli): remove unused print_error import after rebase` (my cleanup so `ruff F401` passes)

## Conflict resolution

Conflict in `src/ouroboros/cli/commands/mcp.py` — the import block diverged because `main` had moved on. Kept the incoming `register_doctor_command` import and the `print_info, print_success` panel imports; dropped the stale `print_error` import (no call site in the merged state) in a follow-up commit.

## What this adds

- `ouroboros mcp doctor` subcommand: fast read-only diagnostics (Python version, platform, installed extras, EventStore health, stale PID file detection, backend-aware SDK import check).
- `--json` flag for machine-readable output.
- Backend-aware: downgrades the `claude_agent_sdk` import check to a warn when the active runtime is `codex` or `opencode`.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_mcp_doctor.py` — 45 passed.
- [x] `uv run ruff check src/` — clean.
- [ ] CI full suite

Closes #434. Closes #431. Refs #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)