### PR TITLE
fix(mcp): reject transport hostnames that resolve to local/private IPs

### DIFF
--- a/src/ouroboros/mcp/types.py
+++ b/src/ouroboros/mcp/types.py
@@ -125,11 +125,18 @@ def _validate_transport_url(url: str, transport: str) -> None:
     # Strip IPv6 brackets (urlparse already does, but be defensive).
     host_literal = hostname.strip("[]")
 
+    # Normalize canonical DNS form before matching known loopback names: DNS is
+    # case-insensitive and a single trailing dot marks an absolute FQDN, so
+    # ``LOCALHOST.`` and ``localhost`` denote the same host.  ``urlparse``
+    # already lowercases, but it does not strip the trailing dot, which let
+    # variants like ``http://localhost./`` slip past the well-known check.
+    host_literal = host_literal.rstrip(".") or host_literal
+
     # Check for well-known loopback hostnames before attempting IP parsing.
     # These bypass the IP-literal checks because they are DNS names, but
     # they resolve to loopback addresses and must be blocked unless the
     # dev escape hatch is enabled.
-    if host_literal in _LOOPBACK_HOSTNAMES:
+    if host_literal.lower() in _LOOPBACK_HOSTNAMES:
         if allow_local:
             return
         msg = (

--- a/src/ouroboros/mcp/types.py
+++ b/src/ouroboros/mcp/types.py
@@ -86,12 +86,25 @@ def _validate_transport_url(url: str, transport: str) -> None:
         * URLs carrying userinfo (``user:pass@host``) used for credential
           smuggling / host confusion.
         * URLs with an empty hostname (e.g. bare ``http://``).
-        * Literal IPs resolving to loopback, link-local, or private ranges,
-          unless the ``OUROBOROS_ALLOW_LOCAL_TRANSPORT=1`` dev escape is set.
+        * Well-known canonical loopback hostnames (``localhost`` and its
+          trailing-dot / mixed-case variants).
+        * Literal IPs inside loopback, link-local, private, multicast,
+          reserved, or unspecified ranges.
+        * DNS hostnames whose ``getaddrinfo()`` result resolves to any
+          address in those same blocked ranges (e.g. ``*.nip.io`` aliases,
+          DNS rebinding targets, metadata-IP aliases).
 
-    DNS resolution is intentionally out of scope for this static validation;
-    runtime code that follows redirects should be hardened separately (the
-    adapter sets ``follow_redirects=False``).
+    The ``OUROBOROS_ALLOW_LOCAL_TRANSPORT=1`` dev escape re-enables every
+    range above for local development only.
+
+    Boundary note: two distinct normalizations are used here. Canonical
+    matching against ``_LOOPBACK_HOSTNAMES`` uses a ``rstrip('.').lower()``
+    form so that ``LOCALHOST.``/``localhost.``/``localhost`` are recognized
+    as the same name. The DNS / IP-literal checks, however, resolve the
+    exact host the MCP client will connect to (the unmodified value
+    returned by ``urllib.parse``, minus IPv6 brackets), because a stripped
+    trailing dot can change how some resolvers answer. Canonicalization is
+    for identity matching, not for picking the lookup target.
 
     Args:
         url: The transport URL to validate.
@@ -122,21 +135,27 @@ def _validate_transport_url(url: str, transport: str) -> None:
 
     allow_local = os.environ.get(_ALLOW_LOCAL_TRANSPORT_ENV, "0") == "1"
 
-    # Strip IPv6 brackets (urlparse already does, but be defensive).
-    host_literal = hostname.strip("[]")
+    # ``lookup_host`` is the exact host the HTTP client will dial. ``urlparse``
+    # has already stripped IPv6 brackets and lowercased the hostname, but we
+    # defensively re-strip brackets in case a future parser change preserves
+    # them. This value is passed verbatim to ``ipaddress.ip_address()`` and to
+    # ``getaddrinfo()`` so DNS resolution sees exactly what the client will.
+    lookup_host = hostname.strip("[]")
 
-    # Normalize canonical DNS form before matching known loopback names: DNS is
-    # case-insensitive and a single trailing dot marks an absolute FQDN, so
-    # ``LOCALHOST.`` and ``localhost`` denote the same host.  ``urlparse``
-    # already lowercases, but it does not strip the trailing dot, which let
-    # variants like ``http://localhost./`` slip past the well-known check.
-    host_literal = host_literal.rstrip(".") or host_literal
+    # ``canonical_host`` collapses DNS-equivalent spellings (trailing dot,
+    # case) into a single form used *only* for well-known-name matching. DNS
+    # is case-insensitive, and a single trailing dot marks an absolute FQDN,
+    # so ``LOCALHOST.``/``localhost.``/``localhost`` must all hit the
+    # loopback guard. ``urlparse`` already lowercases, but it does not strip
+    # the trailing dot, which let variants like ``http://localhost./`` slip
+    # past the well-known check in earlier versions.
+    canonical_host = (lookup_host.rstrip(".") or lookup_host).lower()
 
     # Check for well-known loopback hostnames before attempting IP parsing.
     # These bypass the IP-literal checks because they are DNS names, but
     # they resolve to loopback addresses and must be blocked unless the
     # dev escape hatch is enabled.
-    if host_literal.lower() in _LOOPBACK_HOSTNAMES:
+    if canonical_host in _LOOPBACK_HOSTNAMES:
         if allow_local:
             return
         msg = (
@@ -145,10 +164,15 @@ def _validate_transport_url(url: str, transport: str) -> None:
         )
         raise ValueError(msg)
 
+    # Use the un-normalized ``lookup_host`` for IP parsing and DNS resolution
+    # so the check matches exactly what the HTTP client will connect to. A
+    # resolver may answer differently for ``localhost.`` (absolute) vs
+    # ``localhost`` (search-list), so stripping the trailing dot here would
+    # break the boundary with the runtime connect path.
     try:
-        ip = ipaddress.ip_address(host_literal)
+        ip = ipaddress.ip_address(lookup_host)
     except ValueError:
-        blocked_ips = _resolved_blocked_transport_ips(host_literal)
+        blocked_ips = _resolved_blocked_transport_ips(lookup_host)
         if not blocked_ips or allow_local:
             return
         msg = (

--- a/src/ouroboros/mcp/types.py
+++ b/src/ouroboros/mcp/types.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 import ipaddress
 import os
+import socket
 from typing import Any
 from urllib.parse import urlparse
 
@@ -24,6 +25,50 @@ _ALLOW_LOCAL_TRANSPORT_ENV = "OUROBOROS_ALLOW_LOCAL_TRANSPORT"
 # ``ipaddress.ip_address()`` check (they raise ``ValueError`` because they are
 # not IP literals), so we must block them explicitly.
 _LOOPBACK_HOSTNAMES = frozenset({"localhost"})
+
+
+def _is_blocked_transport_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Return True when an IP literal should be rejected for MCP transport use."""
+    return (
+        ip.is_loopback
+        or ip.is_link_local
+        or ip.is_private
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolved_blocked_transport_ips(hostname: str) -> tuple[str, ...]:
+    """Resolve *hostname* and return any blocked IPs it maps to.
+
+    Static hostname validation is not enough because public DNS aliases can
+    legally resolve to private or loopback literals (for example ``nip.io``).
+    This helper resolves the hostname once at validation time and records any
+    IPs that fall inside the blocked transport ranges.
+
+    Resolution failures are treated as inconclusive rather than fatal so the
+    validator does not reject legitimate-but-currently-unresolvable hostnames.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except OSError:
+        return ()
+
+    blocked: list[str] = []
+    for info in infos:
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        addr = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(addr.strip("[]"))
+        except ValueError:
+            continue
+        if _is_blocked_transport_ip(ip):
+            blocked.append(str(ip))
+
+    return tuple(dict.fromkeys(blocked))
 
 
 def _validate_transport_url(url: str, transport: str) -> None:
@@ -96,21 +141,24 @@ def _validate_transport_url(url: str, transport: str) -> None:
     try:
         ip = ipaddress.ip_address(host_literal)
     except ValueError:
-        # Not an IP literal -- a DNS name. Static validation ends here.
-        return
+        blocked_ips = _resolved_blocked_transport_ips(host_literal)
+        if not blocked_ips or allow_local:
+            return
+        msg = (
+            "Transport URL hostname resolves to loopback/link-local/private IP(s): "
+            f"{', '.join(blocked_ips)} for {hostname}. "
+            f"Set {_ALLOW_LOCAL_TRANSPORT_ENV}=1 for local dev."
+        )
+        raise ValueError(msg)
 
     if allow_local:
         return
 
-    if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_multicast:
+    if _is_blocked_transport_ip(ip):
         msg = (
             f"Transport URL points to loopback/link-local/private IP: "
             f"{hostname}. Set {_ALLOW_LOCAL_TRANSPORT_ENV}=1 for local dev."
         )
-        raise ValueError(msg)
-
-    if ip.is_reserved or ip.is_unspecified:
-        msg = f"Transport URL points to reserved/unspecified IP: {hostname}"
         raise ValueError(msg)
 
 

--- a/tests/unit/mcp/test_types.py
+++ b/tests/unit/mcp/test_types.py
@@ -297,6 +297,13 @@ class TestMCPServerConfigSSRFHardening:
             "http://localhost:3000/",
             "http://localhost:8080/sse",
             "https://localhost/",
+            # Canonical FQDN form: a trailing dot marks an absolute DNS name
+            # and must be treated as identical to "localhost".  Without
+            # normalization these slipped past the well-known loopback check
+            # and fell through to DNS resolution.
+            "http://localhost./",
+            "http://localhost.:3000/",
+            "https://LOCALHOST./",
         ],
     )
     def test_rejects_localhost(self, url: str, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/mcp/test_types.py
+++ b/tests/unit/mcp/test_types.py
@@ -1,5 +1,7 @@
 """Tests for MCP types."""
 
+import socket
+
 import pytest
 
 from ouroboros.mcp.types import (
@@ -316,6 +318,96 @@ class TestMCPServerConfigSSRFHardening:
             url="http://localhost:3000/",
         )
         assert config.url == "http://localhost:3000/"
+
+    def test_rejects_hostname_resolving_to_loopback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Public-looking hostnames that resolve to loopback are rejected."""
+        monkeypatch.delenv("OUROBOROS_ALLOW_LOCAL_TRANSPORT", raising=False)
+
+        def _fake_getaddrinfo(host: str, *_args, **_kwargs):
+            assert host == "127.0.0.1.nip.io"
+            return [
+                (
+                    2,
+                    1,
+                    6,
+                    "",
+                    ("127.0.0.1", 0),
+                )
+            ]
+
+        monkeypatch.setattr("ouroboros.mcp.types.socket.getaddrinfo", _fake_getaddrinfo)
+
+        with pytest.raises(ValueError, match="hostname resolves to loopback/link-local/private"):
+            MCPServerConfig(
+                name="test",
+                transport=TransportType.HTTP,
+                url="http://127.0.0.1.nip.io/",
+            )
+
+    def test_rejects_hostname_resolving_to_metadata_ip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hostnames resolving to link-local metadata IPs are rejected."""
+        monkeypatch.delenv("OUROBOROS_ALLOW_LOCAL_TRANSPORT", raising=False)
+
+        def _fake_getaddrinfo(host: str, *_args, **_kwargs):
+            assert host == "metadata.example.test"
+            return [
+                (
+                    2,
+                    1,
+                    6,
+                    "",
+                    ("169.254.169.254", 0),
+                )
+            ]
+
+        monkeypatch.setattr("ouroboros.mcp.types.socket.getaddrinfo", _fake_getaddrinfo)
+
+        with pytest.raises(ValueError, match="169.254.169.254"):
+            MCPServerConfig(
+                name="test",
+                transport=TransportType.HTTP,
+                url="http://metadata.example.test/latest/meta-data/",
+            )
+
+    def test_hostname_resolution_failure_is_inconclusive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resolution failures stay non-fatal to preserve existing DNS behavior."""
+        monkeypatch.delenv("OUROBOROS_ALLOW_LOCAL_TRANSPORT", raising=False)
+
+        def _fake_getaddrinfo(_host: str, *_args, **_kwargs):
+            raise socket.gaierror("unresolvable")
+
+        monkeypatch.setattr("ouroboros.mcp.types.socket.getaddrinfo", _fake_getaddrinfo)
+
+        config = MCPServerConfig(
+            name="test",
+            transport=TransportType.HTTP,
+            url="http://future-host.example.test/",
+        )
+        assert config.url == "http://future-host.example.test/"
+
+    def test_hostname_resolution_escape_hatch_allows_local_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The dev escape hatch still permits aliases that resolve locally."""
+        monkeypatch.setenv("OUROBOROS_ALLOW_LOCAL_TRANSPORT", "1")
+
+        def _fake_getaddrinfo(_host: str, *_args, **_kwargs):
+            return [(2, 1, 6, "", ("127.0.0.1", 0))]
+
+        monkeypatch.setattr("ouroboros.mcp.types.socket.getaddrinfo", _fake_getaddrinfo)
+
+        config = MCPServerConfig(
+            name="test",
+            transport=TransportType.HTTP,
+            url="http://127.0.0.1.nip.io/",
+        )
+        assert config.url == "http://127.0.0.1.nip.io/"
 
 
 class TestMCPToolParameter:

--- a/tests/unit/mcp/test_types.py
+++ b/tests/unit/mcp/test_types.py
@@ -326,9 +326,7 @@ class TestMCPServerConfigSSRFHardening:
         )
         assert config.url == "http://localhost:3000/"
 
-    def test_rejects_hostname_resolving_to_loopback(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_rejects_hostname_resolving_to_loopback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Public-looking hostnames that resolve to loopback are rejected."""
         monkeypatch.delenv("OUROBOROS_ALLOW_LOCAL_TRANSPORT", raising=False)
 
@@ -415,6 +413,69 @@ class TestMCPServerConfigSSRFHardening:
             url="http://127.0.0.1.nip.io/",
         )
         assert config.url == "http://127.0.0.1.nip.io/"
+
+    def test_dns_lookup_uses_unnormalized_host_for_trailing_dot(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: DNS resolution must use the exact host the client dials.
+
+        Canonical matching against ``_LOOPBACK_HOSTNAMES`` collapses the
+        trailing-dot/case variants of ``localhost`` into a single form for
+        identity matching. But for hosts that *don't* hit the canonical
+        loopback set and fall through to DNS, the resolver must see the
+        original host (trailing dot preserved) because an absolute FQDN
+        (``example.com.``) and a relative name (``example.com``) can give
+        different answers under some resolver configurations.
+        """
+        monkeypatch.delenv("OUROBOROS_ALLOW_LOCAL_TRANSPORT", raising=False)
+
+        seen_hosts: list[str] = []
+
+        def _fake_getaddrinfo(host: str, *_args, **_kwargs):
+            seen_hosts.append(host)
+            return [(2, 1, 6, "", ("127.0.0.1", 0))]
+
+        monkeypatch.setattr("ouroboros.mcp.types.socket.getaddrinfo", _fake_getaddrinfo)
+
+        with pytest.raises(ValueError, match="hostname resolves to loopback/link-local/private"):
+            MCPServerConfig(
+                name="test",
+                transport=TransportType.HTTP,
+                url="http://127.0.0.1.nip.io./",
+            )
+
+        # The resolver must have been handed the trailing-dot form, not the
+        # canonicalized (stripped) form, so the lookup matches exactly what
+        # the HTTP client will connect to.
+        assert seen_hosts == ["127.0.0.1.nip.io."]
+
+    def test_canonical_match_does_not_short_circuit_non_loopback_aliases(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A host whose canonical form is not ``localhost`` still gets DNS-checked.
+
+        Guards against a regression where the canonical/lookup split is
+        collapsed back into a single normalized string and DNS is skipped
+        when the canonical form does not equal a well-known loopback name.
+        """
+        monkeypatch.delenv("OUROBOROS_ALLOW_LOCAL_TRANSPORT", raising=False)
+
+        seen_hosts: list[str] = []
+
+        def _fake_getaddrinfo(host: str, *_args, **_kwargs):
+            seen_hosts.append(host)
+            return [(2, 1, 6, "", ("10.0.0.5", 0))]
+
+        monkeypatch.setattr("ouroboros.mcp.types.socket.getaddrinfo", _fake_getaddrinfo)
+
+        with pytest.raises(ValueError, match="hostname resolves to loopback/link-local/private"):
+            MCPServerConfig(
+                name="test",
+                transport=TransportType.HTTP,
+                url="http://internal.example.test./",
+            )
+
+        assert seen_hosts == ["internal.example.test."]
 
 
 class TestMCPToolParameter:


### PR DESCRIPTION
## Summary

Closes #446.

This is a narrow follow-up hardening pass after #419.

The MCP transport validator now resolves non-IP hostnames once and rejects them when they map to blocked address classes (loopback, link-local, private, reserved, or unspecified IPs).

## Problem

`_validate_transport_url()` already blocks:

- non-HTTP schemes
- literal local/private IPs
- `localhost`
- userinfo / empty-host cases

But for any other hostname it currently returns early after `ipaddress.ip_address()` fails, which means public-looking DNS aliases to local/private targets still pass validation.

Concrete examples on current `main`:

- `http://127.0.0.1.nip.io/` resolves to `127.0.0.1` and is accepted
- a hostname resolving to `169.254.169.254` is accepted unless the caller uses a literal IP

This keeps the validator in the same problem family already addressed by #402 / #419, just one level narrower: the hardening is complete for literals but not for hostname aliases.

## What changed

### `src/ouroboros/mcp/types.py`

- add `_is_blocked_transport_ip()` to centralize the blocked-address predicate
- add `_resolved_blocked_transport_ips()` to resolve hostnames with `socket.getaddrinfo()`
- for non-IP hostnames:
  - resolve once
  - reject if any resolved address is loopback / link-local / private / reserved / unspecified
- keep `OUROBOROS_ALLOW_LOCAL_TRANSPORT=1` as the local-dev escape hatch
- keep DNS resolution failures non-fatal so temporarily unresolvable public hosts do not become invalid configs

### `tests/unit/mcp/test_types.py`

Add regression coverage for:

- hostname alias resolving to loopback
- hostname alias resolving to `169.254.169.254`
- DNS resolution failure staying non-fatal
- escape hatch still allowing intentional local aliases

## Scope / non-goals

This PR is intentionally narrow.

It does **not** claim to solve every DNS-rebinding or TOCTOU case. The goal is to close the obvious hostname-alias gap while preserving the existing connect-time redirect hardening and the local-development override.

## Test plan

- [x] `ruff check src/ouroboros/mcp/types.py tests/unit/mcp/test_types.py`
- [x] `PYTHONPATH=src pytest tests/unit/mcp/test_types.py -q`
- [x] `PYTHONPATH=src pytest tests/unit/mcp/test_types.py tests/unit/mcp/client/test_adapter_transport_lifecycle.py -q`
- [x] Manual runtime repro: `127.0.0.1.nip.io` accepted on current `main`, blocked with this patch
- [x] Manual runtime repro: mocked hostname resolving to `169.254.169.254` is blocked with this patch

## Why this shape matches recent merged fixes

Recent merged hardening PRs in this area (#419, #423) have been:

- small and surgical
- explicit about the exact boundary being fixed
- paired with focused regression tests
- careful not to over-claim broader security guarantees

This PR follows the same pattern.
