### PR TITLE
fix(evaluate): refine node-* presets against package.json before running

### DIFF
--- a/src/ouroboros/evaluation/languages.py
+++ b/src/ouroboros/evaluation/languages.py
@@ -10,8 +10,10 @@ Usage:
 """
 
 from dataclasses import dataclass
+import json
 import os
 from pathlib import Path
+import re
 import shlex
 from typing import Any
 
@@ -195,6 +197,183 @@ def _resolve_maven_command(working_dir: Path) -> str:
     return "mvn"
 
 
+_ESLINT_CONFIG_FILES: tuple[str, ...] = (
+    "eslint.config.js",
+    "eslint.config.mjs",
+    "eslint.config.cjs",
+    "eslint.config.ts",
+    ".eslintrc.js",
+    ".eslintrc.cjs",
+    ".eslintrc.json",
+    ".eslintrc.yaml",
+    ".eslintrc.yml",
+    ".eslintrc",
+)
+
+_BIOME_CONFIG_FILES: tuple[str, ...] = ("biome.json", "biome.jsonc")
+
+# Tokens in a `scripts.test` value that indicate a specific runner is expected.
+# When a token is present but its package is not declared in dependencies,
+# the script is considered misconfigured and the test check is skipped.
+_TEST_RUNNER_TOKENS: tuple[tuple[str, str], ...] = (
+    ("vitest", "vitest"),
+    ("jest", "jest"),
+    ("mocha", "mocha"),
+    ("ava", "ava"),
+    ("playwright", "@playwright/test"),
+)
+
+_TEST_RUNNER_TOKEN_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(tok) for tok, _ in _TEST_RUNNER_TOKENS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+def _read_package_json(working_dir: Path) -> dict[str, Any] | None:
+    """Read and parse ``package.json`` safely.
+
+    Returns None when the file is absent or invalid; never raises.
+    """
+    path = working_dir / "package.json"
+    if not path.is_file():
+        return None
+    try:
+        with open(path, "rb") as handle:
+            data = json.loads(handle.read())
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("node_preset.package_json_parse_error", path=str(path), error=str(exc))
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _has_eslint_config(working_dir: Path, pkg: dict[str, Any]) -> bool:
+    if any((working_dir / name).exists() for name in _ESLINT_CONFIG_FILES):
+        return True
+    return "eslintConfig" in pkg
+
+
+def _has_biome_config(working_dir: Path) -> bool:
+    return any((working_dir / name).exists() for name in _BIOME_CONFIG_FILES)
+
+
+def _declares_dependency(pkg: dict[str, Any], name: str) -> bool:
+    for key in (
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ):
+        section = pkg.get(key)
+        if isinstance(section, dict) and name in section:
+            return True
+    return False
+
+
+def _refine_node_lint(
+    working_dir: Path,
+    pkg: dict[str, Any],
+    fallback: tuple[str, ...] | None,
+) -> tuple[str, ...] | None:
+    """Return a safe lint command, or None to skip.
+
+    A lint script is only trusted when:
+    - ``scripts.lint`` is defined in package.json, and
+    - the referenced tool (eslint/biome) has a config file available.
+    """
+    scripts = pkg.get("scripts")
+    if not isinstance(scripts, dict):
+        return None
+    lint_script = scripts.get("lint")
+    if not isinstance(lint_script, str) or not lint_script.strip():
+        return None
+    lower = lint_script.lower()
+    if "eslint" in lower and not _has_eslint_config(working_dir, pkg):
+        log.info("node_preset.lint_skipped", reason="eslint_config_missing")
+        return None
+    if "biome" in lower and not _has_biome_config(working_dir):
+        log.info("node_preset.lint_skipped", reason="biome_config_missing")
+        return None
+    return fallback
+
+
+def _refine_node_test(
+    pkg: dict[str, Any],
+    fallback: tuple[str, ...] | None,
+) -> tuple[str, ...] | None:
+    """Return a safe test command, or None to skip.
+
+    A test script is only trusted when:
+    - ``scripts.test`` is defined and is not the npm "no test specified" stub, and
+    - any referenced runner (vitest/jest/mocha/…) is declared in dependencies.
+    """
+    scripts = pkg.get("scripts")
+    if not isinstance(scripts, dict):
+        return None
+    test_script = scripts.get("test")
+    if not isinstance(test_script, str) or not test_script.strip():
+        return None
+    lower = test_script.lower()
+    if "no test specified" in lower:
+        log.info("node_preset.test_skipped", reason="npm_stub")
+        return None
+    for match in _TEST_RUNNER_TOKEN_PATTERN.finditer(test_script):
+        token = match.group(1).lower()
+        for tok, dep_name in _TEST_RUNNER_TOKENS:
+            if tok == token and not _declares_dependency(pkg, dep_name):
+                log.info(
+                    "node_preset.test_skipped",
+                    reason="runner_not_declared",
+                    runner=token,
+                )
+                return None
+    return fallback
+
+
+def _refine_node_build(
+    working_dir: Path,
+    pkg: dict[str, Any],
+    fallback: tuple[str, ...] | None,
+) -> tuple[str, ...] | None:
+    """Return a safe build command, or None to skip.
+
+    Keeps ``scripts.build`` when declared. When no build script is available
+    but a ``tsconfig.json`` is present, falls back to a type-check-only
+    compile via ``npx tsc --noEmit`` so TypeScript projects still get build
+    verification.
+    """
+    scripts = pkg.get("scripts")
+    if isinstance(scripts, dict):
+        build_script = scripts.get("build")
+        if isinstance(build_script, str) and build_script.strip():
+            return fallback
+    if (working_dir / "tsconfig.json").exists():
+        return ("npx", "--no-install", "tsc", "--noEmit")
+    return None
+
+
+def _refine_node_preset(working_dir: Path, preset: LanguagePreset) -> LanguagePreset:
+    """Refine a node-* preset against the actual project manifest.
+
+    Returns a new ``LanguagePreset`` where any command the project cannot
+    reliably execute is replaced with ``None`` (skipped). Stage 1 is meant
+    to be a zero-cost, zero-false-positive sanity gate; it is better to skip
+    a check than to run the wrong tool and report a phantom failure.
+    """
+    pkg = _read_package_json(working_dir)
+    if pkg is None:
+        return preset
+    return LanguagePreset(
+        name=preset.name,
+        lint_command=_refine_node_lint(working_dir, pkg, preset.lint_command),
+        build_command=_refine_node_build(working_dir, pkg, preset.build_command),
+        test_command=_refine_node_test(pkg, preset.test_command),
+        static_command=preset.static_command,
+        coverage_command=preset.coverage_command,
+    )
+
+
 def _load_project_overrides(working_dir: Path) -> dict[str, Any] | None:
     """Load .ouroboros/mechanical.toml if it exists.
 
@@ -356,6 +535,9 @@ def build_mechanical_config(
     """
     # Start with auto-detected preset
     preset = detect_language(working_dir)
+
+    if preset and preset.name.startswith("node-"):
+        preset = _refine_node_preset(working_dir, preset)
 
     build_command = preset.build_command if preset else None
     test_command = preset.test_command if preset else None

--- a/tests/unit/evaluation/test_languages.py
+++ b/tests/unit/evaluation/test_languages.py
@@ -1,5 +1,6 @@
 """Tests for language detection and mechanical config building."""
 
+import json
 from pathlib import Path
 
 from ouroboros.evaluation.languages import (
@@ -7,6 +8,11 @@ from ouroboros.evaluation.languages import (
     build_mechanical_config,
     detect_language,
 )
+
+
+def _write_package_json(path: Path, data: dict[str, object]) -> None:
+    """Write ``package.json`` at ``path`` with the given dict body."""
+    (path / "package.json").write_text(json.dumps(data))
 
 
 class TestDetectLanguage:
@@ -323,6 +329,173 @@ class TestBuildMechanicalConfig:
         (tmp_path / "build.zig").touch()
         config = build_mechanical_config(tmp_path)
         assert config.build_command == ("zig", "build")
+
+
+class TestNodePresetRefinement:
+    """Node presets must be refined against the actual package manifest.
+
+    Stage 1 favors skipping over running the wrong tool: a missing lint
+    script, a misconfigured test runner, or a stale build script must
+    downgrade to ``None`` (skip) rather than produce a phantom failure.
+    """
+
+    def _with_lockfile(self, tmp_path: Path, manifest: dict[str, object]) -> Path:
+        _write_package_json(tmp_path, manifest)
+        (tmp_path / "package-lock.json").touch()
+        return tmp_path
+
+    def test_empty_scripts_skips_lint_and_test(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"name": "x", "version": "0.0.0"})
+        config = build_mechanical_config(tmp_path)
+        assert config.lint_command is None
+        assert config.test_command is None
+
+    def test_lint_script_without_eslint_config_is_skipped(self, tmp_path: Path) -> None:
+        self._with_lockfile(
+            tmp_path,
+            {"scripts": {"lint": "eslint ."}},
+        )
+        config = build_mechanical_config(tmp_path)
+        assert config.lint_command is None
+
+    def test_lint_script_with_eslint_config_file_is_kept(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"scripts": {"lint": "eslint ."}})
+        (tmp_path / "eslint.config.js").touch()
+        config = build_mechanical_config(tmp_path)
+        assert config.lint_command == ("npm", "run", "lint")
+
+    def test_lint_script_with_legacy_eslintrc_is_kept(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"scripts": {"lint": "eslint ."}})
+        (tmp_path / ".eslintrc.json").touch()
+        config = build_mechanical_config(tmp_path)
+        assert config.lint_command == ("npm", "run", "lint")
+
+    def test_lint_script_with_package_json_eslint_config_is_kept(self, tmp_path: Path) -> None:
+        self._with_lockfile(
+            tmp_path,
+            {
+                "scripts": {"lint": "eslint ."},
+                "eslintConfig": {"root": True},
+            },
+        )
+        config = build_mechanical_config(tmp_path)
+        assert config.lint_command == ("npm", "run", "lint")
+
+    def test_biome_lint_without_config_is_skipped(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"scripts": {"lint": "biome check ."}})
+        config = build_mechanical_config(tmp_path)
+        assert config.lint_command is None
+
+    def test_biome_lint_with_config_is_kept(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"scripts": {"lint": "biome check ."}})
+        (tmp_path / "biome.json").touch()
+        config = build_mechanical_config(tmp_path)
+        assert config.lint_command == ("npm", "run", "lint")
+
+    def test_test_script_referencing_vitest_without_dep_is_skipped(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"scripts": {"test": "vitest run"}})
+        config = build_mechanical_config(tmp_path)
+        assert config.test_command is None
+
+    def test_test_script_referencing_vitest_with_dep_is_kept(self, tmp_path: Path) -> None:
+        self._with_lockfile(
+            tmp_path,
+            {
+                "scripts": {"test": "vitest run"},
+                "devDependencies": {"vitest": "^1.0.0"},
+            },
+        )
+        config = build_mechanical_config(tmp_path)
+        assert config.test_command == ("npm", "test")
+
+    def test_test_script_with_npm_stub_is_skipped(self, tmp_path: Path) -> None:
+        self._with_lockfile(
+            tmp_path,
+            {
+                "scripts": {
+                    "test": 'echo "Error: no test specified" && exit 1',
+                },
+            },
+        )
+        config = build_mechanical_config(tmp_path)
+        assert config.test_command is None
+
+    def test_test_script_using_node_test_is_kept(self, tmp_path: Path) -> None:
+        """Native ``node --test`` needs no extra runner dependency."""
+        self._with_lockfile(
+            tmp_path,
+            {"scripts": {"test": "node --test tests/*.test.js"}},
+        )
+        config = build_mechanical_config(tmp_path)
+        assert config.test_command == ("npm", "test")
+
+    def test_jest_without_dep_is_skipped(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"scripts": {"test": "jest"}})
+        config = build_mechanical_config(tmp_path)
+        assert config.test_command is None
+
+    def test_build_script_present_is_kept(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"scripts": {"build": "tsc -p ."}})
+        config = build_mechanical_config(tmp_path)
+        assert config.build_command == ("npm", "run", "build")
+
+    def test_build_falls_back_to_tsc_noemit_when_tsconfig_exists(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"name": "x"})
+        (tmp_path / "tsconfig.json").touch()
+        config = build_mechanical_config(tmp_path)
+        assert config.build_command == ("npx", "--no-install", "tsc", "--noEmit")
+
+    def test_build_skipped_without_script_or_tsconfig(self, tmp_path: Path) -> None:
+        self._with_lockfile(tmp_path, {"name": "x"})
+        config = build_mechanical_config(tmp_path)
+        assert config.build_command is None
+
+    def test_invalid_package_json_preserves_preset(self, tmp_path: Path) -> None:
+        """Malformed ``package.json`` must not crash; keep the raw preset."""
+        (tmp_path / "package.json").write_text("{not valid json")
+        (tmp_path / "package-lock.json").touch()
+        config = build_mechanical_config(tmp_path)
+        # With refinement bypassed, preset commands survive unchanged.
+        assert config.lint_command == ("npm", "run", "lint")
+        assert config.test_command == ("npm", "test")
+        assert config.build_command == ("npm", "run", "build")
+
+    def test_refinement_runs_for_all_node_variants(self, tmp_path: Path) -> None:
+        """pnpm/yarn/bun presets must share the refinement behavior."""
+        cases = [
+            ("pnpm-lock.yaml", "node-pnpm", ("pnpm", "lint"), ("pnpm", "test")),
+            ("yarn.lock", "node-yarn", ("yarn", "lint"), ("yarn", "test")),
+            ("bun.lockb", "node-bun", ("bun", "lint"), ("bun", "test")),
+        ]
+        for lockfile, _name, lint_cmd, test_cmd in cases:
+            d = tmp_path / lockfile.replace(".", "_")
+            d.mkdir()
+            _write_package_json(
+                d,
+                {
+                    "scripts": {"lint": "eslint .", "test": "vitest run"},
+                    "devDependencies": {"vitest": "^1.0.0"},
+                },
+            )
+            (d / lockfile).touch()
+            (d / "eslint.config.js").touch()
+            config = build_mechanical_config(d)
+            assert config.lint_command == lint_cmd, lockfile
+            assert config.test_command == test_cmd, lockfile
+
+    def test_toml_override_still_wins_over_refinement(self, tmp_path: Path) -> None:
+        """``.ouroboros/mechanical.toml`` remains the authoritative escape hatch."""
+        self._with_lockfile(
+            tmp_path,
+            {"scripts": {"test": "vitest run"}},  # no dep -> refinement skips
+        )
+        ouroboros_dir = tmp_path / ".ouroboros"
+        ouroboros_dir.mkdir()
+        (ouroboros_dir / "mechanical.toml").write_text(
+            'test = "node --test tests"\n',
+        )
+        config = build_mechanical_config(tmp_path)
+        assert config.test_command == ("node", "--test", "tests")
 
 
 class TestLanguagePresetCommands:


### PR DESCRIPTION
## Summary

- Stage 1 ran `npm run lint` / `npm test` / `npm run build` blindly for every node project. When `scripts.lint` pointed to `eslint` without a config (exit 254) or `scripts.test` pointed to `vitest` without the dep, evaluation rejected perfectly good code for a tooling mismatch — not a real defect.
- Stage 1 is supposed to be a zero-cost, zero-false-positive gate. This PR makes node preset detection honor the actual manifest so misconfigured scripts downgrade to **skip**, not **fail**.

## Behavior

After language detection, `_refine_node_preset` inspects `package.json`:

| Check | Kept when… | Skipped when… | Fallback |
|---|---|---|---|
| lint | `scripts.lint` exists AND referenced tool (eslint/biome) has a config file (or `eslintConfig` in package.json) | script missing; tool config missing | — |
| test | `scripts.test` exists AND referenced runner (vitest/jest/mocha/ava/playwright) is in deps | script missing; npm "no test specified" stub; runner token without dep | — |
| build | `scripts.build` exists | — | `npx --no-install tsc --noEmit` when `tsconfig.json` exists |

`.ouroboros/mechanical.toml` remains the authoritative escape hatch (covered by a test).

## Test plan

- [x] `uv run pytest tests/unit/evaluation/` — 267 passed
- [x] `uv run pytest tests/ --ignore=tests/unit/mcp --ignore=tests/integration/mcp --ignore=tests/e2e` — 3963 passed, 2 skipped (pre-existing)
- [x] `uv run mypy src/ouroboros/evaluation/languages.py` — clean
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] 17 new unit tests cover: empty scripts, eslint with/without config (flat + legacy `.eslintrc` + `eslintConfig`), biome with/without config, vitest/jest without dep, npm stub, `node --test` without a dep requirement, tsconfig build fallback, all four package managers (npm/pnpm/yarn/bun), malformed `package.json`, `.ouroboros/mechanical.toml` still overrides refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)