### PR TITLE
fix(seed): provide defaults for ontology_schema and metadata

### DIFF
--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -229,7 +229,10 @@ class Seed(BaseModel, frozen=True):
 
     # Structure
     ontology_schema: OntologySchema = Field(
-        ...,
+        default_factory=lambda: OntologySchema(
+            name="default",
+            description="Workflow output schema",
+        ),
         description="Schema defining the structure of workflow outputs",
     )
 
@@ -247,7 +250,7 @@ class Seed(BaseModel, frozen=True):
 
     # Metadata
     metadata: SeedMetadata = Field(
-        ...,
+        default_factory=SeedMetadata,
         description="Generation metadata (version, timestamp, etc.)",
     )
 


### PR DESCRIPTION
## Summary
- Ralph (`ooo ralph`) inline-generates a seed YAML and passes it to `ouroboros_start_evolve_step`, which calls `Seed.from_dict()` for validation. A minimal YAML (goal + acceptance_criteria) failed because `Seed.ontology_schema` and `Seed.metadata` were marked as required (`Field(...)`), causing a wasted round trip and a retry with an expanded YAML.
- Give both fields sensible `default_factory` values so a minimal seed parses on the first call. Any explicit values supplied in the YAML still take precedence, so existing full seeds are unaffected.

## Test plan
- [x] `uv run pytest tests/unit/core/test_seed.py` — 39 passed
- [x] Manual check: minimal YAML (`goal` + `acceptance_criteria` only) now parses via `Seed.from_dict()` and yields a usable default `ontology_schema` / `metadata`.
- [ ] Follow-up: run a real `ooo ralph` iteration to confirm the retry cycle is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)