### PR TITLE
docs(claude-code): clarify Pro and Max plan support in runtime guide

### DIFF
--- a/docs/runtime-guides/claude-code.md
+++ b/docs/runtime-guides/claude-code.md
@@ -60,7 +60,7 @@ The orchestrator uses `claude-agent-sdk` which connects directly to your authent
 
 ## Claude Code-Specific Strengths
 
-- **Zero API key management** -- uses your Max Plan subscription directly
+- **Zero API key management** -- uses your Pro or Max Plan subscription directly
 - **Rich tool access** -- full suite of file, shell, and search tools via Claude Code
 - **Session continuity** -- resume interrupted workflows with `--resume`
 

--- a/docs/runtime-guides/claude-code.md
+++ b/docs/runtime-guides/claude-code.md
@@ -5,7 +5,7 @@ doc_metadata:
 
 # Running Ouroboros with Claude Code
 
-Ouroboros can use **Claude Code** as a runtime backend, leveraging your **Claude Code Max Plan** subscription to execute workflows without requiring a separate API key.
+Ouroboros can use **Claude Code** as a runtime backend, leveraging your **Claude Code Pro or Max Plan** subscription to execute workflows without requiring a separate API key.
 
 > For installation and first-run onboarding, see [Getting Started](../getting-started.md).
 
@@ -17,7 +17,7 @@ Ouroboros can use **Claude Code** as a runtime backend, leveraging your **Claude
 
 ## Prerequisites
 
-- Claude Code CLI installed and authenticated (Max Plan)
+- Claude Code CLI installed and authenticated (Pro or Max Plan)
 - Python >= 3.12
 - Ouroboros installed (see [Getting Started](../getting-started.md) for install options)
 
@@ -39,7 +39,7 @@ When using the `--orchestrator` CLI flag, Claude Code is the default runtime bac
 ```
 +-----------------+     +------------------+     +-----------------+
 |   Seed YAML     | --> |   Orchestrator   | --> |  Claude Code    |
-|  (your task)    |     |   (adapter.py)   |     |  (Max Plan)     |
+|  (your task)    |     |   (adapter.py)   |     |  (Pro/Max Plan) |
 +-----------------+     +------------------+     +-----------------+
                                 |
                                 v
@@ -121,8 +121,9 @@ The database will be created automatically at `~/.ouroboros/ouroboros.db`.
 
 ## Cost
 
-Using Claude Code as the runtime backend with a Max Plan means:
+Using Claude Code as the runtime backend with a Pro or Max Plan means:
 - **No additional API costs** -- uses your subscription
 - Execution time varies by task complexity
 - Typical simple tasks: 15-30 seconds
 - Complex multi-file tasks: 1-3 minutes
+> **Note:** Pro plan ($20/month) works but has lower usage limits. For long agentic workflows, **Max plan is recommended** to avoid hitting limits mid-session.


### PR DESCRIPTION
## Summary
`docs/runtime-guides/claude-code.md` mentions only **Max Plan** in all 
subscription-related references, implying Pro plan is unsupported. 
This is inaccurate — Pro plan works with no API key required.

## Problem
Four locations reference Max Plan exclusively:
- Intro: `leveraging your **Claude Code Max Plan** subscription`
- Prerequisites: `authenticated (Max Plan)`
- Architecture diagram: `Claude Code (Max Plan)`
- Cost section: `Using Claude Code as the runtime backend with a Max Plan`

## Verification
Tested on **Claude Pro plan ($20/month)** via the Claude Code plugin:
- Authentication works without an API key
- `ooo interview` (Phase 0) completes successfully
- Usage limits are consumed significantly faster than Max plan

## Changes
Updated all four references to reflect that both Pro and Max plans are 
supported. Added a note that Pro plan works but is best suited for the 
interview phase (Phase 0), while Max is recommended for full workflow 
execution (Phase 2+).

## References
- [Anthropic Help Center: Using Claude Code with your Pro or Max plan](https://support.claude.com/en/articles/11145838-using-claude-code-with-your-pro-or-max-plan)

## Checklist
- [x] Documentation only — no code changes
- [x] Verified on Pro plan via Claude Code plugin