### PR TITLE
fix(setup): propagate OpenCode plugin setup failure

### DIFF
--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -888,7 +888,7 @@ def _cleanup_plugin_artifacts() -> None:
             pass  # best effort
 
 
-def _setup_opencode(opencode_path: str, mode: str = "plugin") -> None:
+def _setup_opencode(opencode_path: str, mode: str = "plugin") -> bool:
     """Configure Ouroboros for the OpenCode runtime.
 
     mode (mutually exclusive — pick one, run setup twice if you deliberately want both):
@@ -900,6 +900,10 @@ def _setup_opencode(opencode_path: str, mode: str = "plugin") -> None:
     Wiring both at once wastes tokens: an Ouroboros MCP tool called inside a
     subprocess-driven ``opencode run`` would also trigger the globally
     registered plugin, causing duplicate subagent dispatch. Choose one.
+
+    Returns:
+        True when setup completed; False when plugin-mode setup failed before
+        config was persisted.
     """
     if mode not in ("plugin", "subprocess"):
         raise ValueError(f"Invalid opencode mode: {mode!r} (expected 'plugin' or 'subprocess')")
@@ -944,7 +948,7 @@ def _setup_opencode(opencode_path: str, mode: str = "plugin") -> None:
 
         print_success(f"Configured OpenCode subprocess runtime (CLI: {opencode_path})")
         print_info(f"Config saved to: {config_path}")
-        return
+        return True
 
     # mode == "plugin" — install plugin/MCP entries FIRST, only persist config
     # if ALL steps succeed (fail-closed).  Without this, a failed bridge install
@@ -964,10 +968,10 @@ def _setup_opencode(opencode_path: str, mode: str = "plugin") -> None:
             failed.append("plugin entry registration")
         print_error(
             f"Plugin-mode setup incomplete — failed: {', '.join(failed)}. "
-            "Re-run 'ouroboros setup opencode --runtime opencode --opencode-mode plugin' "
+            "Re-run 'ouroboros setup --runtime opencode --opencode-mode plugin' "
             "after fixing the issues above."
         )
-        return
+        return False
 
     # All installs succeeded — now safe to persist config.
     # Plugin mode still needs runtime_backend=opencode so the MCP server's
@@ -993,6 +997,7 @@ def _setup_opencode(opencode_path: str, mode: str = "plugin") -> None:
         yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
 
     print_success("Installed OpenCode bridge plugin and registered MCP entry")
+    return True
 
 
 # ── Brownfield repo helpers ──────────────────────────────────────
@@ -1300,7 +1305,8 @@ def setup(
             if mode not in ("plugin", "subprocess"):
                 print_error(f"Invalid selection: {pick!r}")
                 raise typer.Exit(1)
-        _setup_opencode(opencode_path, mode=mode)
+        if not _setup_opencode(opencode_path, mode=mode):
+            raise typer.Exit(1)
     elif selected in ("hermes", "hermes_cli"):
         hermes_path = available.get("hermes")
         if not hermes_path:

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -5,9 +5,16 @@ CI runners (GitHub Actions) set ``XDG_CONFIG_HOME=/home/runner/.config``.
 only patch ``Path.home`` leak into the runner's real config directory.
 Clearing the env vars here forces the ``Path.home()`` fallback path, which
 the tests then patch to ``tmp_path``.
+
+Most existing CLI tests assert the Linux OpenCode path
+``~/.config/opencode``.  Force that platform in the test environment so the
+same assertions hold on macOS developer machines, where production code
+correctly uses ``~/Library/Application Support/OpenCode``.
 """
 
 from __future__ import annotations
+
+import sys
 
 import pytest
 
@@ -17,3 +24,4 @@ def _isolate_opencode_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear env vars that bypass Path.home() in opencode_config_dir()."""
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typer.testing import CliRunner
 import yaml
 
 import ouroboros.cli.commands.setup as setup_cmd
@@ -1642,6 +1643,65 @@ class TestOpenCodeSetupConfigYaml:
         result = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         mock_claude.assert_not_called()
         assert result["orchestrator"]["opencode_mode"] == "plugin"
+
+    def test_plugin_setup_failure_returns_false_without_persisting_config(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Plugin setup failure must not be reported as a completed helper run."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._install_opencode_bridge_plugin", return_value=False
+            ),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry", return_value=True),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_plugin_entry", return_value=True),
+        ):
+            from ouroboros.cli.commands.setup import _setup_opencode
+
+            assert _setup_opencode("/usr/bin/opencode", mode="plugin") is False
+
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {}
+
+    def test_plugin_setup_failure_exits_before_success_banner(self, tmp_path: Path) -> None:
+        """Top-level setup must propagate plugin setup failure to exit status."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("{}", encoding="utf-8")
+
+        runner = CliRunner()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_runtimes",
+                return_value={
+                    "claude": None,
+                    "codex": None,
+                    "opencode": "/usr/bin/opencode",
+                    "hermes": None,
+                },
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._install_opencode_bridge_plugin", return_value=False
+            ),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry", return_value=True),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_plugin_entry", return_value=True),
+        ):
+            result = runner.invoke(
+                setup_cmd.app,
+                ["--runtime", "opencode", "--non-interactive"],
+            )
+
+        assert result.exit_code == 1
+        assert "Plugin-mode setup incomplete" in result.output
+        assert "Setup complete!" not in result.output
 
 
 class TestOpenCodeModePersisted:


### PR DESCRIPTION
## Summary
- Propagate failed OpenCode plugin-mode setup to the top-level CLI exit path so it no longer prints `Setup complete!` after an incomplete bridge/MCP/plugin registration.
- Correct the retry command shown in the plugin setup failure message.
- Stabilize CLI OpenCode config tests on macOS by forcing Linux path semantics in the CLI test fixture.

## Verification
- `uv run pytest tests/unit/cli/test_setup.py tests/unit/cli/test_bridge_plugin_hardening.py tests/unit/cli/test_bridge_plugin_lifecycle.py tests/unit/mcp/tools/test_round5_fixes.py tests/unit/mcp/tools/test_handler_subagent_wiring.py -q` -> 174 passed
- `uv run ruff check src/ouroboros/cli/commands/setup.py tests/unit/cli/conftest.py tests/unit/cli/test_setup.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `bun test` in `src/ouroboros/opencode/plugin` -> 90 passed
- `bunx tsc --noEmit` in `src/ouroboros/opencode/plugin` -> passed