### PR TITLE
fix(build): remove redundant opencode plugin force-include causing wheel duplicates

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -70,6 +70,18 @@ jobs:
           print(f'Runtime version: {v}')
           assert 'dev' in v or 'unknown' not in v, f'Unexpected version: {v}'
           "
+          # Packaging contract: opencode bridge assets must be reachable via
+          # importlib.resources in the installed wheel. Guards against
+          # regressions where hatch include rules stop shipping non-Python
+          # assets (see PR #462).
+          python -c "
+          from importlib.resources import files
+          root = files('ouroboros.opencode.plugin')
+          required = ['ouroboros-bridge.ts', 'package.json', 'tsconfig.json']
+          missing = [n for n in required if not (root / n).is_file()]
+          assert not missing, f'Missing opencode plugin assets in wheel: {missing}'
+          print('opencode plugin assets present:', required)
+          "
 
       - name: Publish to PyPI
         if: steps.check.outputs.skip == 'false'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ packages = ["src/ouroboros"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "skills" = "ouroboros/skills"
-"src/ouroboros/opencode/plugin" = "ouroboros/opencode/plugin"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,14 +52,18 @@ version-file = "src/ouroboros/_version.py"
 exclude = [
     "/.smoke-home",
     "**/node_modules",
-    # opencode bridge assets are shipped via force-include below so the
-    # packaging contract is explicit. Exclude them from the `packages=`
-    # sweep to avoid duplicate ZIP local headers (PyPI rejects those).
-    "src/ouroboros/opencode/plugin/**",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ouroboros"]
+# Scoped to wheel only: prevent the `packages=` sweep from shipping these
+# assets, so the force-include below is the single source of truth and we
+# avoid duplicate ZIP local headers (PyPI rejects those). The sdist keeps
+# the files at their natural source path so rebuilds from sdist reproduce
+# the same wheel via this same config.
+exclude = [
+    "src/ouroboros/opencode/plugin/**",
+]
 
 [tool.hatch.build.targets.wheel.force-include]
 "skills" = "ouroboros/skills"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ version-file = "src/ouroboros/_version.py"
 exclude = [
     "/.smoke-home",
     "**/node_modules",
+    # opencode bridge assets are shipped via force-include below so the
+    # packaging contract is explicit. Exclude them from the `packages=`
+    # sweep to avoid duplicate ZIP local headers (PyPI rejects those).
+    "src/ouroboros/opencode/plugin/**",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -59,6 +63,10 @@ packages = ["src/ouroboros"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "skills" = "ouroboros/skills"
+# Explicit inclusion so `importlib.resources.files("ouroboros.opencode.plugin")`
+# reliably finds ouroboros-bridge.ts / package.json / tsconfig.json in the
+# installed wheel, independent of hatchling's implicit asset handling.
+"src/ouroboros/opencode/plugin" = "ouroboros/opencode/plugin"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- PyPI dev-publish has been failing (e.g. [run 24700587826](https://github.com/Q00/ouroboros/actions/runs/24700587826)) with `400 Invalid distribution file. ZIP archive not accepted: Duplicate filename in local headers.`
- Root cause: `src/ouroboros/opencode/plugin/` is shipped twice — once via `packages = ["src/ouroboros"]` (hatchling treats it as a package because of `__init__.py`) and again via an explicit `force-include` pointing to the same wheel target. Every file in that directory ended up with two ZIP local headers, which PyPI now rejects.
- Fix: drop the redundant `force-include` line. The `skills` entry stays because that directory lives at the repo root, outside `src/ouroboros/`.

## Verification
Built the wheel locally before and after:

| | duplicate local headers | opencode/plugin files shipped |
|---|---|---|
| before | 6 files x 2 | 6 |
| after | 0 | 6 |

```
$ uv build --wheel
Successfully built dist/ouroboros_ai-0.28.9.dev78-py3-none-any.whl
# no "Duplicate name" warnings
Local-header duplicates: {}
Total local-header entries: 309
```

All six files (`__init__.py`, `opencode-plugin.d.ts`, `ouroboros-bridge.ts`, `ouroboros-bridge.test.ts`, `package.json`, `tsconfig.json`) remain in the wheel at `ouroboros/opencode/plugin/`.

## Test plan
- [x] `uv build --wheel` emits no `Duplicate name` warnings
- [x] Parsed ZIP local headers — 0 duplicates
- [x] All opencode plugin assets still present in the wheel
- [ ] Confirm Dev Publish workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)