### PR TITLE
fix(interview): cap initial context prompt

### DIFF
--- a/src/ouroboros/bigbang/ambiguity.py
+++ b/src/ouroboros/bigbang/ambiguity.py
@@ -18,7 +18,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 import structlog
 
-from ouroboros.bigbang.interview import InterviewState
+from ouroboros.bigbang.interview import InterviewState, prompt_safe_initial_context
 from ouroboros.config import get_clarification_model
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
@@ -463,7 +463,7 @@ class AmbiguityScorer:
         Returns:
             Formatted context string.
         """
-        parts = [f"Initial Context: {state.initial_context}"]
+        parts = [f"Initial Context: {prompt_safe_initial_context(state)}"]
 
         for round_data in state.rounds:
             parts.append(f"\nQ: {round_data.question}")

--- a/src/ouroboros/bigbang/ambiguity.py
+++ b/src/ouroboros/bigbang/ambiguity.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 import structlog
 
 from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
     InterviewState,
     initial_context_summary_missing,
     prompt_safe_initial_context,
@@ -478,6 +479,8 @@ class AmbiguityScorer:
         parts = [f"Initial Context: {prompt_safe_initial_context(state)}"]
 
         for round_data in state.rounds:
+            if round_data.question == INITIAL_CONTEXT_SUMMARY_QUESTION:
+                continue
             parts.append(f"\nQ: {round_data.question}")
             if round_data.user_response:
                 parts.append(f"A: {round_data.user_response}")

--- a/src/ouroboros/bigbang/ambiguity.py
+++ b/src/ouroboros/bigbang/ambiguity.py
@@ -18,7 +18,11 @@ from typing import Any
 from pydantic import BaseModel, Field
 import structlog
 
-from ouroboros.bigbang.interview import InterviewState, prompt_safe_initial_context
+from ouroboros.bigbang.interview import (
+    InterviewState,
+    initial_context_summary_missing,
+    prompt_safe_initial_context,
+)
 from ouroboros.config import get_clarification_model
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
@@ -321,6 +325,14 @@ class AmbiguityScorer:
 
         # Use brownfield flag from state if available
         is_brownfield = is_brownfield or getattr(state, "is_brownfield", False)
+
+        if initial_context_summary_missing(state):
+            return Result.err(
+                ProviderError(
+                    "Initial context summary required before ambiguity scoring",
+                    details={"interview_id": state.interview_id},
+                )
+            )
 
         # Build the context from interview
         context = self._build_interview_context(state)

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -820,10 +820,9 @@ class InterviewEngine:
         """
         messages: list[Message] = []
 
-        if state.current_round_number == 1:
-            overflow = self._initial_context_overflow_message(state.initial_context)
-            if overflow:
-                messages.append(Message(role=MessageRole.USER, content=overflow))
+        overflow = self._initial_context_overflow_message(state.initial_context)
+        if overflow:
+            messages.append(Message(role=MessageRole.USER, content=overflow))
 
         for round_data in state.rounds:
             messages.append(Message(role=MessageRole.ASSISTANT, content=round_data.question))

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -235,6 +235,9 @@ class InterviewEngine:
     model: str = field(default_factory=get_clarification_model)
     temperature: float = 0.7
     max_tokens: int = 512
+    _MAX_SYSTEM_PROMPT_CHARS = 3500
+    _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
+    _MAX_INITIAL_CONTEXT_OVERFLOW_CHARS = 1200
 
     def __post_init__(self) -> None:
         """Ensure state directory exists."""
@@ -536,6 +539,8 @@ class InterviewEngine:
 
         base_prompt = load_agent_prompt("socratic-interviewer")
 
+        prompt_initial_context = self._initial_context_for_system_prompt(state.initial_context)
+
         # For first round, add explicit instruction to start directly with a question
         if state.current_round_number == 1:
             dynamic_header = (
@@ -544,13 +549,13 @@ class InterviewEngine:
                 f'Do NOT introduce yourself. Do NOT say "I\'ll conduct" or "Let me ask". '
                 f"Just ask a specific, clarifying question immediately.\n\n"
                 f"This is {round_info}. Your ONLY job is to ask questions that reduce ambiguity.\n\n"
-                f"Initial context: {state.initial_context}\n"
+                f"Initial context: {prompt_initial_context}\n"
             )
         else:
             dynamic_header = (
                 f"You are an expert requirements engineer conducting a Socratic interview.\n\n"
                 f"This is {round_info}. Your ONLY job is to ask questions that reduce ambiguity.\n\n"
-                f"Initial context: {state.initial_context}\n"
+                f"Initial context: {prompt_initial_context}\n"
             )
 
         # Answer prefix hints — always present so the question generator
@@ -575,31 +580,48 @@ class InterviewEngine:
 
         perspective_panel = self._build_perspective_panel_prompt(state)
 
-        # Cap total system prompt to prevent Agent SDK CLI empty responses.
-        # The bundled CLI can fail silently when the prompt exceeds ~5,000 chars.
-        _MAX_SYSTEM_PROMPT_CHARS = 4800
         _OVERHEAD = 20  # newlines, ellipsis, separators
 
-        # Budget for base_prompt after accounting for other sections
-        base_budget = (
-            _MAX_SYSTEM_PROMPT_CHARS - len(dynamic_header) - len(perspective_panel) - _OVERHEAD
-        )
-        if base_budget < 0:
-            # Header + panel already exceed budget — truncate both proportionally
-            total = len(dynamic_header) + len(perspective_panel)
-            ratio = max(0.0, (_MAX_SYSTEM_PROMPT_CHARS - _OVERHEAD) / total) if total > 0 else 0.0
-            dynamic_header = dynamic_header[: int(len(dynamic_header) * ratio)]
-            perspective_panel = perspective_panel[: int(len(perspective_panel) * ratio)]
+        # Preserve the dynamic header first; it contains the capped initial
+        # context and first-turn instructions. Trim the optional panel/base
+        # prompt before falling back to hard-truncating the header.
+        available_after_header = self._MAX_SYSTEM_PROMPT_CHARS - len(dynamic_header) - _OVERHEAD
+        if available_after_header <= 0:
+            dynamic_header = dynamic_header[: self._MAX_SYSTEM_PROMPT_CHARS - _OVERHEAD]
+            perspective_panel = ""
             base_budget = 0
+        elif len(perspective_panel) > available_after_header:
+            perspective_panel = perspective_panel[:available_after_header]
+            base_budget = 0
+        else:
+            base_budget = available_after_header - len(perspective_panel)
 
         trimmed_base = base_prompt[:base_budget] if base_budget < len(base_prompt) else base_prompt
         full_prompt = f"{dynamic_header}\n{trimmed_base}\n\n{perspective_panel}"
 
         # Hard-truncate as final safety net
-        if len(full_prompt) > _MAX_SYSTEM_PROMPT_CHARS:
-            full_prompt = full_prompt[:_MAX_SYSTEM_PROMPT_CHARS]
+        if len(full_prompt) > self._MAX_SYSTEM_PROMPT_CHARS:
+            full_prompt = full_prompt[: self._MAX_SYSTEM_PROMPT_CHARS]
 
         return full_prompt
+
+    def _initial_context_for_system_prompt(self, initial_context: str) -> str:
+        """Return the initial context portion safe to embed in system prompt."""
+        if len(initial_context) <= self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS:
+            return initial_context
+        return (
+            initial_context[: self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS]
+            + "\n\n[Initial context continues in the first user message.]"
+        )
+
+    def _initial_context_overflow_message(self, initial_context: str) -> str:
+        """Return overflow initial context as user-message content for round one."""
+        if len(initial_context) <= self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS:
+            return ""
+        overflow = initial_context[self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS :]
+        if len(overflow) > self._MAX_INITIAL_CONTEXT_OVERFLOW_CHARS:
+            overflow = overflow[: self._MAX_INITIAL_CONTEXT_OVERFLOW_CHARS] + "..."
+        return f"Additional initial context omitted from the system prompt:\n{overflow}"
 
     def _build_ambiguity_snapshot_prompt(self, state: InterviewState) -> str:
         """Build prompt context from the latest ambiguity snapshot."""
@@ -797,6 +819,11 @@ class InterviewEngine:
             List of messages representing the conversation.
         """
         messages: list[Message] = []
+
+        if state.current_round_number == 1:
+            overflow = self._initial_context_overflow_message(state.initial_context)
+            if overflow:
+                messages.append(Message(role=MessageRole.USER, content=overflow))
 
         for round_data in state.rounds:
             messages.append(Message(role=MessageRole.ASSISTANT, content=round_data.question))

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -237,7 +237,6 @@ class InterviewEngine:
     max_tokens: int = 512
     _MAX_SYSTEM_PROMPT_CHARS = 3500
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
-    _MAX_INITIAL_CONTEXT_OVERFLOW_CHARS = 1200
 
     def __post_init__(self) -> None:
         """Ensure state directory exists."""
@@ -619,8 +618,6 @@ class InterviewEngine:
         if len(initial_context) <= self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS:
             return ""
         overflow = initial_context[self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS :]
-        if len(overflow) > self._MAX_INITIAL_CONTEXT_OVERFLOW_CHARS:
-            overflow = overflow[: self._MAX_INITIAL_CONTEXT_OVERFLOW_CHARS] + "..."
         return f"Additional initial context omitted from the system prompt:\n{overflow}"
 
     def _build_ambiguity_snapshot_prompt(self, state: InterviewState) -> str:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -49,6 +49,7 @@ INITIAL_CONTEXT_SUMMARY_REQUIRED = (
     "recorded yet. Ask the user to provide a concise summary before scoring or "
     "generating a seed.]"
 )
+PROMPT_SAFE_CONTEXT_TRUNCATION_NOTICE = "\n\n[Context truncated for prompt safety.]"
 
 
 class InterviewPerspective(StrEnum):
@@ -212,8 +213,21 @@ def prompt_safe_initial_context(state: InterviewState) -> str:
         return state.initial_context
     for round_data in reversed(state.rounds):
         if round_data.question == INITIAL_CONTEXT_SUMMARY_QUESTION and round_data.user_response:
-            return round_data.user_response
+            return _truncate_prompt_safe_context(round_data.user_response)
     return INITIAL_CONTEXT_SUMMARY_REQUIRED
+
+
+def _truncate_prompt_safe_context(context: str) -> str:
+    """Cap prompt context while leaving an explicit truncation marker."""
+    if len(context) <= MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS:
+        return context
+
+    content_budget = MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS - len(
+        PROMPT_SAFE_CONTEXT_TRUNCATION_NOTICE
+    )
+    if content_budget <= 0:
+        return context[:MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS]
+    return context[:content_budget] + PROMPT_SAFE_CONTEXT_TRUNCATION_NOTICE
 
 
 def initial_context_summary_missing(state: InterviewState) -> bool:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -237,6 +237,7 @@ class InterviewEngine:
     max_tokens: int = 512
     _MAX_SYSTEM_PROMPT_CHARS = 3500
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
+    _MAX_INITIAL_CONTEXT_TOTAL_CHARS = 3500
 
     def __post_init__(self) -> None:
         """Ensure state directory exists."""
@@ -272,6 +273,18 @@ class InterviewEngine:
         is_valid, error_msg = InputValidator.validate_initial_context(initial_context)
         if not is_valid:
             return Result.err(ValidationError(error_msg, field="initial_context"))
+        if len(initial_context) > self._MAX_INITIAL_CONTEXT_TOTAL_CHARS:
+            return Result.err(
+                ValidationError(
+                    (
+                        "initial_context is too long for safe interview prompt generation "
+                        f"({len(initial_context)} chars > "
+                        f"{self._MAX_INITIAL_CONTEXT_TOTAL_CHARS}). Provide a shorter "
+                        "summary or store the full document in a file and reference its path."
+                    ),
+                    field="initial_context",
+                )
+            )
 
         if interview_id is None:
             interview_id = f"interview_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}"
@@ -317,6 +330,18 @@ class InterviewEngine:
                     "Interview is already complete",
                     field="status",
                     value=state.status,
+                )
+            )
+        if len(state.initial_context) > self._MAX_INITIAL_CONTEXT_TOTAL_CHARS:
+            return Result.err(
+                ValidationError(
+                    (
+                        "Interview initial_context is too long for safe prompt generation "
+                        f"({len(state.initial_context)} chars > "
+                        f"{self._MAX_INITIAL_CONTEXT_TOTAL_CHARS}). Resume with a shorter "
+                        "summary or reference the full document by file path."
+                    ),
+                    field="initial_context",
                 )
             )
 

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -214,6 +214,8 @@ def prompt_safe_initial_context(state: InterviewState) -> str:
     for round_data in reversed(state.rounds):
         if round_data.question == INITIAL_CONTEXT_SUMMARY_QUESTION and round_data.user_response:
             return _truncate_prompt_safe_context(round_data.user_response)
+    if state.is_complete:
+        return _truncate_prompt_safe_context(state.initial_context)
     return INITIAL_CONTEXT_SUMMARY_REQUIRED
 
 

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -240,6 +240,12 @@ class InterviewEngine:
     _MIN_SYSTEM_PROMPT_CHARS = 1200
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
     _MAX_INITIAL_CONTEXT_TOTAL_CHARS = 3500
+    _INITIAL_CONTEXT_SUMMARY_QUESTION = (
+        "Your saved initial context is too long to safely send to the interview "
+        "model without risking CLI prompt failure. Please reply with a concise "
+        "summary of the full context, including goals, constraints, and success "
+        "criteria. I will use that summary for the next interview question."
+    )
 
     def __post_init__(self) -> None:
         """Ensure state directory exists."""
@@ -275,18 +281,6 @@ class InterviewEngine:
         is_valid, error_msg = InputValidator.validate_initial_context(initial_context)
         if not is_valid:
             return Result.err(ValidationError(error_msg, field="initial_context"))
-        if len(initial_context) > self._MAX_INITIAL_CONTEXT_TOTAL_CHARS:
-            return Result.err(
-                ValidationError(
-                    (
-                        "initial_context is too long for safe interview prompt generation "
-                        f"({len(initial_context)} chars > "
-                        f"{self._MAX_INITIAL_CONTEXT_TOTAL_CHARS}). Provide a shorter "
-                        "summary or store the full document in a file and reference its path."
-                    ),
-                    field="initial_context",
-                )
-            )
 
         if interview_id is None:
             interview_id = f"interview_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}"
@@ -334,29 +328,31 @@ class InterviewEngine:
                     value=state.status,
                 )
             )
-        if len(state.initial_context) > self._MAX_INITIAL_CONTEXT_TOTAL_CHARS:
-            return Result.err(
-                ValidationError(
-                    (
-                        "Interview initial_context is too long for safe prompt generation "
-                        f"({len(state.initial_context)} chars > "
-                        f"{self._MAX_INITIAL_CONTEXT_TOTAL_CHARS}). Resume with a shorter "
-                        "summary or reference the full document by file path."
-                    ),
-                    field="initial_context",
-                )
-            )
+        effective_initial_context = self._effective_initial_context(state)
+        if effective_initial_context is None:
+            return Result.ok(self._INITIAL_CONTEXT_SUMMARY_QUESTION)
 
         # Build the context from previous rounds
-        conversation_history = self._build_conversation_history(state)
+        conversation_history = self._build_conversation_history(
+            state,
+            initial_context=effective_initial_context,
+        )
+        conversation_history = self._trim_messages_to_budget(
+            conversation_history,
+            max_chars=self._MAX_TOTAL_PROMPT_CHARS - self._MIN_SYSTEM_PROMPT_CHARS,
+        )
 
         # Generate next question
         history_chars = sum(len(message.content) for message in conversation_history)
-        system_prompt_budget = max(
-            self._MIN_SYSTEM_PROMPT_CHARS,
-            min(self._MAX_SYSTEM_PROMPT_CHARS, self._MAX_TOTAL_PROMPT_CHARS - history_chars),
+        system_prompt_budget = min(
+            self._MAX_SYSTEM_PROMPT_CHARS,
+            self._MAX_TOTAL_PROMPT_CHARS - history_chars,
         )
-        system_prompt = self._build_system_prompt(state, max_chars=system_prompt_budget)
+        system_prompt = self._build_system_prompt(
+            state,
+            initial_context=effective_initial_context,
+            max_chars=system_prompt_budget,
+        )
         messages = [
             Message(role=MessageRole.SYSTEM, content=system_prompt),
             *conversation_history,
@@ -555,11 +551,18 @@ class InterviewEngine:
                 )
             )
 
-    def _build_system_prompt(self, state: InterviewState, max_chars: int | None = None) -> str:
+    def _build_system_prompt(
+        self,
+        state: InterviewState,
+        initial_context: str | None = None,
+        max_chars: int | None = None,
+    ) -> str:
         """Build the system prompt for question generation.
 
         Args:
             state: Current interview state.
+            initial_context: Optional prompt-safe context to use instead of
+                ``state.initial_context``.
             max_chars: Optional cap for the returned system prompt. When omitted,
                 uses the standard system-prompt cap.
 
@@ -573,7 +576,10 @@ class InterviewEngine:
 
         base_prompt = load_agent_prompt("socratic-interviewer")
 
-        prompt_initial_context = self._initial_context_for_system_prompt(state.initial_context)
+        context_for_prompt = (
+            initial_context if initial_context is not None else state.initial_context
+        )
+        prompt_initial_context = self._initial_context_for_system_prompt(context_for_prompt)
 
         # For first round, add explicit instruction to start directly with a question
         if state.current_round_number == 1:
@@ -654,6 +660,18 @@ class InterviewEngine:
             return ""
         overflow = initial_context[self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS :]
         return f"Additional initial context omitted from the system prompt:\n{overflow}"
+
+    def _effective_initial_context(self, state: InterviewState) -> str | None:
+        """Return prompt-safe initial context, or None when a summary is needed."""
+        if len(state.initial_context) <= self._MAX_INITIAL_CONTEXT_TOTAL_CHARS:
+            return state.initial_context
+        for round_data in reversed(state.rounds):
+            if (
+                round_data.question == self._INITIAL_CONTEXT_SUMMARY_QUESTION
+                and round_data.user_response
+            ):
+                return round_data.user_response
+        return None
 
     def _build_ambiguity_snapshot_prompt(self, state: InterviewState) -> str:
         """Build prompt context from the latest ambiguity snapshot."""
@@ -838,7 +856,11 @@ class InterviewEngine:
     # Cap each user response to keep the total prompt within safe limits.
     _MAX_USER_RESPONSE_CHARS = 800
 
-    def _build_conversation_history(self, state: InterviewState) -> list[Message]:
+    def _build_conversation_history(
+        self,
+        state: InterviewState,
+        initial_context: str | None = None,
+    ) -> list[Message]:
         """Build conversation history from completed rounds.
 
         Long user responses are truncated to prevent Agent SDK CLI from
@@ -846,17 +868,24 @@ class InterviewEngine:
 
         Args:
             state: Current interview state.
+            initial_context: Prompt-safe initial context to use for overflow
+                instead of ``state.initial_context``.
 
         Returns:
             List of messages representing the conversation.
         """
         messages: list[Message] = []
+        context_for_prompt = (
+            initial_context if initial_context is not None else state.initial_context
+        )
 
-        overflow = self._initial_context_overflow_message(state.initial_context)
+        overflow = self._initial_context_overflow_message(context_for_prompt)
         if overflow:
             messages.append(Message(role=MessageRole.USER, content=overflow))
 
         for round_data in state.rounds:
+            if round_data.question == self._INITIAL_CONTEXT_SUMMARY_QUESTION:
+                continue
             messages.append(Message(role=MessageRole.ASSISTANT, content=round_data.question))
             if round_data.user_response:
                 response = round_data.user_response
@@ -865,6 +894,30 @@ class InterviewEngine:
                 messages.append(Message(role=MessageRole.USER, content=response))
 
         return messages
+
+    def _trim_messages_to_budget(
+        self,
+        messages: list[Message],
+        *,
+        max_chars: int,
+    ) -> list[Message]:
+        """Keep the newest conversation messages within a character budget."""
+        if sum(len(message.content) for message in messages) <= max_chars:
+            return messages
+
+        retained: list[Message] = []
+        used_chars = 0
+        for message in reversed(messages):
+            remaining = max_chars - used_chars
+            if remaining <= 0:
+                break
+            if len(message.content) <= remaining:
+                retained.append(message)
+                used_chars += len(message.content)
+            else:
+                retained.append(Message(role=message.role, content=message.content[-remaining:]))
+                break
+        return list(reversed(retained))
 
     async def complete_interview(
         self, state: InterviewState

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -37,6 +37,18 @@ DEFAULT_INTERVIEW_ROUNDS = 10  # Reference value for prompts (not enforced)
 
 # Legacy alias for backward compatibility
 MAX_INTERVIEW_ROUNDS = DEFAULT_INTERVIEW_ROUNDS
+MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS = 3500
+INITIAL_CONTEXT_SUMMARY_QUESTION = (
+    "Your saved initial context is too long to safely send to the interview "
+    "model without risking CLI prompt failure. Please reply with a concise "
+    "summary of the full context, including goals, constraints, and success "
+    "criteria. I will use that summary for the next interview question."
+)
+INITIAL_CONTEXT_SUMMARY_REQUIRED = (
+    "[Initial context exceeds the prompt-safe size and no user summary has been "
+    "recorded yet. Ask the user to provide a concise summary before scoring or "
+    "generating a seed.]"
+)
 
 
 class InterviewPerspective(StrEnum):
@@ -194,6 +206,16 @@ class InterviewState(BaseModel):
         self.mark_updated()
 
 
+def prompt_safe_initial_context(state: InterviewState) -> str:
+    """Return initial context safe for LLM prompts across interview consumers."""
+    if len(state.initial_context) <= MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS:
+        return state.initial_context
+    for round_data in reversed(state.rounds):
+        if round_data.question == INITIAL_CONTEXT_SUMMARY_QUESTION and round_data.user_response:
+            return round_data.user_response
+    return INITIAL_CONTEXT_SUMMARY_REQUIRED
+
+
 @dataclass
 class InterviewEngine:
     """Engine for conducting interactive requirement interviews.
@@ -239,13 +261,8 @@ class InterviewEngine:
     _MAX_SYSTEM_PROMPT_CHARS = 3500
     _MIN_SYSTEM_PROMPT_CHARS = 1200
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
-    _MAX_INITIAL_CONTEXT_TOTAL_CHARS = 3500
-    _INITIAL_CONTEXT_SUMMARY_QUESTION = (
-        "Your saved initial context is too long to safely send to the interview "
-        "model without risking CLI prompt failure. Please reply with a concise "
-        "summary of the full context, including goals, constraints, and success "
-        "criteria. I will use that summary for the next interview question."
-    )
+    _MAX_INITIAL_CONTEXT_TOTAL_CHARS = MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
+    _INITIAL_CONTEXT_SUMMARY_QUESTION = INITIAL_CONTEXT_SUMMARY_QUESTION
 
     def __post_init__(self) -> None:
         """Ensure state directory exists."""
@@ -663,15 +680,10 @@ class InterviewEngine:
 
     def _effective_initial_context(self, state: InterviewState) -> str | None:
         """Return prompt-safe initial context, or None when a summary is needed."""
-        if len(state.initial_context) <= self._MAX_INITIAL_CONTEXT_TOTAL_CHARS:
-            return state.initial_context
-        for round_data in reversed(state.rounds):
-            if (
-                round_data.question == self._INITIAL_CONTEXT_SUMMARY_QUESTION
-                and round_data.user_response
-            ):
-                return round_data.user_response
-        return None
+        context = prompt_safe_initial_context(state)
+        if context == INITIAL_CONTEXT_SUMMARY_REQUIRED:
+            return None
+        return context
 
     def _build_ambiguity_snapshot_prompt(self, state: InterviewState) -> str:
         """Build prompt context from the latest ambiguity snapshot."""

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -359,9 +359,15 @@ class InterviewEngine:
             state,
             initial_context=effective_initial_context,
         )
+        preserve_prefix_messages = (
+            1
+            if len(effective_initial_context) > self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS
+            else 0
+        )
         conversation_history = self._trim_messages_to_budget(
             conversation_history,
             max_chars=self._MAX_TOTAL_PROMPT_CHARS - self._MIN_SYSTEM_PROMPT_CHARS,
+            preserve_prefix_messages=preserve_prefix_messages,
         )
 
         # Generate next question
@@ -917,14 +923,35 @@ class InterviewEngine:
         messages: list[Message],
         *,
         max_chars: int,
+        preserve_prefix_messages: int = 0,
     ) -> list[Message]:
-        """Keep the newest conversation messages within a character budget."""
+        """Keep durable prefix messages plus newest conversation within a budget."""
         if sum(len(message.content) for message in messages) <= max_chars:
             return messages
 
+        prefix = messages[:preserve_prefix_messages]
+        remaining_messages = messages[preserve_prefix_messages:]
+        prefix_chars = sum(len(message.content) for message in prefix)
+        if prefix_chars >= max_chars:
+            retained_prefix: list[Message] = []
+            used_prefix_chars = 0
+            for message in prefix:
+                remaining = max_chars - used_prefix_chars
+                if remaining <= 0:
+                    break
+                if len(message.content) <= remaining:
+                    retained_prefix.append(message)
+                    used_prefix_chars += len(message.content)
+                else:
+                    retained_prefix.append(
+                        Message(role=message.role, content=message.content[:remaining])
+                    )
+                    break
+            return retained_prefix
+
         retained: list[Message] = []
-        used_chars = 0
-        for message in reversed(messages):
+        used_chars = prefix_chars
+        for message in reversed(remaining_messages):
             remaining = max_chars - used_chars
             if remaining <= 0:
                 break
@@ -934,7 +961,7 @@ class InterviewEngine:
             else:
                 retained.append(Message(role=message.role, content=message.content[-remaining:]))
                 break
-        return list(reversed(retained))
+        return [*prefix, *reversed(retained)]
 
     async def complete_interview(
         self, state: InterviewState

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -360,9 +360,7 @@ class InterviewEngine:
             initial_context=effective_initial_context,
         )
         preserve_prefix_messages = (
-            1
-            if len(effective_initial_context) > self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS
-            else 0
+            1 if len(effective_initial_context) > self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS else 0
         )
         conversation_history = self._trim_messages_to_budget(
             conversation_history,

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -216,6 +216,11 @@ def prompt_safe_initial_context(state: InterviewState) -> str:
     return INITIAL_CONTEXT_SUMMARY_REQUIRED
 
 
+def initial_context_summary_missing(state: InterviewState) -> bool:
+    """Return True when a long initial context still needs a user summary."""
+    return prompt_safe_initial_context(state) == INITIAL_CONTEXT_SUMMARY_REQUIRED
+
+
 @dataclass
 class InterviewEngine:
     """Engine for conducting interactive requirement interviews.

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -235,7 +235,9 @@ class InterviewEngine:
     model: str = field(default_factory=get_clarification_model)
     temperature: float = 0.7
     max_tokens: int = 512
+    _MAX_TOTAL_PROMPT_CHARS = 4800
     _MAX_SYSTEM_PROMPT_CHARS = 3500
+    _MIN_SYSTEM_PROMPT_CHARS = 1200
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
     _MAX_INITIAL_CONTEXT_TOTAL_CHARS = 3500
 
@@ -349,7 +351,12 @@ class InterviewEngine:
         conversation_history = self._build_conversation_history(state)
 
         # Generate next question
-        system_prompt = self._build_system_prompt(state)
+        history_chars = sum(len(message.content) for message in conversation_history)
+        system_prompt_budget = max(
+            self._MIN_SYSTEM_PROMPT_CHARS,
+            min(self._MAX_SYSTEM_PROMPT_CHARS, self._MAX_TOTAL_PROMPT_CHARS - history_chars),
+        )
+        system_prompt = self._build_system_prompt(state, max_chars=system_prompt_budget)
         messages = [
             Message(role=MessageRole.SYSTEM, content=system_prompt),
             *conversation_history,
@@ -548,17 +555,20 @@ class InterviewEngine:
                 )
             )
 
-    def _build_system_prompt(self, state: InterviewState) -> str:
+    def _build_system_prompt(self, state: InterviewState, max_chars: int | None = None) -> str:
         """Build the system prompt for question generation.
 
         Args:
             state: Current interview state.
+            max_chars: Optional cap for the returned system prompt. When omitted,
+                uses the standard system-prompt cap.
 
         Returns:
             The system prompt.
         """
         from ouroboros.agents.loader import load_agent_prompt
 
+        max_prompt_chars = max_chars or self._MAX_SYSTEM_PROMPT_CHARS
         round_info = f"Round {state.current_round_number}"
 
         base_prompt = load_agent_prompt("socratic-interviewer")
@@ -609,9 +619,9 @@ class InterviewEngine:
         # Preserve the dynamic header first; it contains the capped initial
         # context and first-turn instructions. Trim the optional panel/base
         # prompt before falling back to hard-truncating the header.
-        available_after_header = self._MAX_SYSTEM_PROMPT_CHARS - len(dynamic_header) - _OVERHEAD
+        available_after_header = max_prompt_chars - len(dynamic_header) - _OVERHEAD
         if available_after_header <= 0:
-            dynamic_header = dynamic_header[: self._MAX_SYSTEM_PROMPT_CHARS - _OVERHEAD]
+            dynamic_header = dynamic_header[: max_prompt_chars - _OVERHEAD]
             perspective_panel = ""
             base_budget = 0
         elif len(perspective_panel) > available_after_header:
@@ -624,8 +634,8 @@ class InterviewEngine:
         full_prompt = f"{dynamic_header}\n{trimmed_base}\n\n{perspective_panel}"
 
         # Hard-truncate as final safety net
-        if len(full_prompt) > self._MAX_SYSTEM_PROMPT_CHARS:
-            full_prompt = full_prompt[: self._MAX_SYSTEM_PROMPT_CHARS]
+        if len(full_prompt) > max_prompt_chars:
+            full_prompt = full_prompt[:max_prompt_chars]
 
         return full_prompt
 
@@ -639,7 +649,7 @@ class InterviewEngine:
         )
 
     def _initial_context_overflow_message(self, initial_context: str) -> str:
-        """Return overflow initial context as user-message content for round one."""
+        """Return overflow initial context as durable user-message content."""
         if len(initial_context) <= self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS:
             return ""
         overflow = initial_context[self._MAX_INITIAL_CONTEXT_SYSTEM_CHARS :]

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -168,18 +168,31 @@ class InterviewState(BaseModel):
         return self.status == InterviewStatus.COMPLETED
 
     @property
+    def needs_initial_context_summary(self) -> bool:
+        """True when oversized initial context has no recorded summary."""
+        if len(self.initial_context) <= MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS:
+            return False
+        return not any(
+            round_data.question == INITIAL_CONTEXT_SUMMARY_QUESTION
+            and bool(round_data.user_response)
+            for round_data in self.rounds
+        )
+
+    @property
     def can_reopen(self) -> bool:
         """True when a completed interview should be reopenable.
 
-        A completed interview is reopenable only when its stored ambiguity
-        score exceeds the seed-generation threshold — i.e. it was completed
-        prematurely and is now in a deadlock (can't generate seed, can't
-        resume).
+        A completed interview is reopenable when it is missing a required
+        long-context summary, or when its stored ambiguity score exceeds the
+        seed-generation threshold — i.e. it was completed prematurely and is
+        now in a deadlock (can't generate seed, can't resume).
         """
-        return (
-            self.is_complete
-            and self.ambiguity_score is not None
-            and self.ambiguity_score > self._SEED_READY_THRESHOLD
+        return self.is_complete and (
+            self.needs_initial_context_summary
+            or (
+                self.ambiguity_score is not None
+                and self.ambiguity_score > self._SEED_READY_THRESHOLD
+            )
         )
 
     def mark_updated(self) -> None:
@@ -214,8 +227,6 @@ def prompt_safe_initial_context(state: InterviewState) -> str:
     for round_data in reversed(state.rounds):
         if round_data.question == INITIAL_CONTEXT_SUMMARY_QUESTION and round_data.user_response:
             return _truncate_prompt_safe_context(round_data.user_response)
-    if state.is_complete:
-        return _truncate_prompt_safe_context(state.initial_context)
     return INITIAL_CONTEXT_SUMMARY_REQUIRED
 
 
@@ -358,6 +369,9 @@ class InterviewEngine:
         Returns:
             Result containing the next question or error.
         """
+        if state.is_complete and state.needs_initial_context_summary:
+            return Result.ok(self._INITIAL_CONTEXT_SUMMARY_QUESTION)
+
         if state.is_complete:
             return Result.err(
                 ValidationError(

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -29,9 +29,11 @@ from ouroboros.bigbang.brownfield import (
 )
 from ouroboros.bigbang.explore import CodebaseExplorer, format_explore_results
 from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
     MIN_ROUNDS_BEFORE_EARLY_EXIT,
     InterviewEngine,
     InterviewState,
+    prompt_safe_initial_context,
 )
 from ouroboros.bigbang.pm_seed import PMSeed, UserStory
 from ouroboros.bigbang.question_classifier import (
@@ -882,8 +884,13 @@ class PMInterviewEngine:
             Dict with completion metadata if the interview should end,
             or ``None`` if the interview should continue.
         """
-        # Count only answered rounds (exclude the pending unanswered round)
-        answered_rounds = sum(1 for r in state.rounds if r.user_response is not None)
+        # Count only substantive answered rounds (exclude pending and synthetic
+        # initial-context summary recovery rounds).
+        answered_rounds = sum(
+            1
+            for r in state.rounds
+            if r.user_response is not None and r.question != INITIAL_CONTEXT_SUMMARY_QUESTION
+        )
 
         # ── Ambiguity check (only after minimum rounds) ────────────────
         if answered_rounds < MIN_ROUNDS_BEFORE_EARLY_EXIT:
@@ -1101,9 +1108,11 @@ class PMInterviewEngine:
         Returns:
             Formatted context string.
         """
-        parts = [f"Initial Context: {state.initial_context}"]
+        parts = [f"Initial Context: {prompt_safe_initial_context(state)}"]
 
         for round_data in state.rounds:
+            if round_data.question == INITIAL_CONTEXT_SUMMARY_QUESTION:
+                continue
             parts.append(f"\nQ: {round_data.question}")
             if round_data.user_response:
                 parts.append(f"A: {round_data.user_response}")

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -33,6 +33,7 @@ from ouroboros.bigbang.interview import (
     MIN_ROUNDS_BEFORE_EARLY_EXIT,
     InterviewEngine,
     InterviewState,
+    initial_context_summary_missing,
     prompt_safe_initial_context,
 )
 from ouroboros.bigbang.pm_seed import PMSeed, UserStory
@@ -1000,6 +1001,15 @@ class PMInterviewEngine:
                 ValidationError(
                     "Cannot generate PM seed from incomplete interview — complete the interview first",
                     field="is_complete",
+                )
+            )
+
+        if initial_context_summary_missing(state):
+            return Result.err(
+                ValidationError(
+                    "Initial context summary required before PM seed generation",
+                    field="initial_context",
+                    details={"interview_id": state.interview_id},
                 )
             )
 

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -457,6 +457,8 @@ class PMInterviewEngine:
             return question_result
 
         question = question_result.value
+        if question == INITIAL_CONTEXT_SUMMARY_QUESTION:
+            return Result.ok(question)
 
         # Classify the question
         context = self._build_interview_context(state)
@@ -980,7 +982,12 @@ class PMInterviewEngine:
         Returns:
             Result containing PMSeed or error.
         """
-        if not state.rounds:
+        substantive_rounds = [
+            round_data
+            for round_data in state.rounds
+            if round_data.question != INITIAL_CONTEXT_SUMMARY_QUESTION and round_data.user_response
+        ]
+        if not substantive_rounds:
             return Result.err(
                 ValidationError(
                     "Cannot generate PM seed from empty interview",

--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -426,8 +426,8 @@ class PMInterviewEngine:
 
         original_build = self._original_build_system_prompt
 
-        def _pm_build_system_prompt(state: InterviewState) -> str:
-            base = original_build(state)
+        def _pm_build_system_prompt(state: InterviewState, *args, **kwargs) -> str:
+            base = original_build(state, *args, **kwargs)
             return self._pm_steering + "\n\n" + base
 
         self.inner._build_system_prompt = _pm_build_system_prompt  # type: ignore[assignment]

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -21,6 +21,7 @@ import yaml
 
 from ouroboros.bigbang.ambiguity import AMBIGUITY_THRESHOLD, AmbiguityScore
 from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
     InterviewState,
     initial_context_summary_missing,
     prompt_safe_initial_context,
@@ -428,6 +429,8 @@ PROJECT_TYPE: greenfield"""
         parts = [f"Initial Context: {prompt_safe_initial_context(state)}"]
 
         for round_data in state.rounds:
+            if round_data.question == INITIAL_CONTEXT_SUMMARY_QUESTION:
+                continue
             parts.append(f"\nQ: {round_data.question}")
             if round_data.user_response:
                 parts.append(f"A: {round_data.user_response}")

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -20,7 +20,7 @@ import structlog
 import yaml
 
 from ouroboros.bigbang.ambiguity import AMBIGUITY_THRESHOLD, AmbiguityScore
-from ouroboros.bigbang.interview import InterviewState
+from ouroboros.bigbang.interview import InterviewState, prompt_safe_initial_context
 from ouroboros.config import get_clarification_model
 from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.seed import (
@@ -412,7 +412,7 @@ PROJECT_TYPE: greenfield"""
         Returns:
             Formatted context string.
         """
-        parts = [f"Initial Context: {state.initial_context}"]
+        parts = [f"Initial Context: {prompt_safe_initial_context(state)}"]
 
         for round_data in state.rounds:
             parts.append(f"\nQ: {round_data.question}")

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -20,7 +20,11 @@ import structlog
 import yaml
 
 from ouroboros.bigbang.ambiguity import AMBIGUITY_THRESHOLD, AmbiguityScore
-from ouroboros.bigbang.interview import InterviewState, prompt_safe_initial_context
+from ouroboros.bigbang.interview import (
+    InterviewState,
+    initial_context_summary_missing,
+    prompt_safe_initial_context,
+)
 from ouroboros.config import get_clarification_model
 from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.seed import (
@@ -129,6 +133,15 @@ class SeedGenerator:
                         "threshold": AMBIGUITY_THRESHOLD,
                         "interview_id": state.interview_id,
                     },
+                )
+            )
+
+        if initial_context_summary_missing(state):
+            return Result.err(
+                ValidationError(
+                    "Initial context summary required before seed generation",
+                    field="initial_context",
+                    details={"interview_id": state.interview_id},
                 )
             )
 

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -725,6 +725,9 @@ class ClaudeCodeAdapter:
             raise
         except Exception as exc:
             stderr_tail = "\n".join(stderr_lines[-20:]) if stderr_lines else ""
+            error_message = f"Claude Agent SDK request failed: {exc}"
+            if stderr_tail and "Check stderr output for details" in str(exc):
+                error_message = f"{error_message}\nstderr tail:\n{stderr_tail}"
             log.exception(
                 "claude_code_adapter.sdk_request_failed",
                 error=str(exc),
@@ -736,7 +739,7 @@ class ClaudeCodeAdapter:
             )
             return Result.err(
                 ProviderError(
-                    message=f"Claude Agent SDK request failed: {exc}",
+                    message=error_message,
                     details={
                         "error_type": type(exc).__name__,
                         "session_id": session_id,

--- a/tests/unit/bigbang/test_ambiguity.py
+++ b/tests/unit/bigbang/test_ambiguity.py
@@ -407,6 +407,22 @@ class TestAmbiguityScorerScore:
         # Should have retried 3 times
         assert mock_adapter.complete.call_count == 3
 
+    async def test_score_requires_summary_for_large_initial_context(self) -> None:
+        """score fails explicitly when long initial_context has no summary."""
+        mock_adapter = MagicMock()
+        mock_adapter.complete = AsyncMock()
+        scorer = AmbiguityScorer(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_large_context",
+            initial_context=("A" * 4_000) + "TAIL_MARKER",
+        )
+
+        result = await scorer.score(state)
+
+        assert result.is_err
+        assert "summary required" in result.error.message
+        mock_adapter.complete.assert_not_called()
+
     async def test_score_provider_error_recovers_on_retry(self) -> None:
         """score recovers when provider error is transient."""
         mock_adapter = MagicMock()

--- a/tests/unit/bigbang/test_ambiguity.py
+++ b/tests/unit/bigbang/test_ambiguity.py
@@ -655,6 +655,30 @@ class TestAmbiguityScorerBuildInterviewContext:
 
         assert "Short project summary" in context
         assert "TAIL_MARKER" not in context
+        assert INITIAL_CONTEXT_SUMMARY_QUESTION not in context
+
+    def test_context_caps_oversized_initial_context_summary(self) -> None:
+        """_build_interview_context does not serialize oversized summary rounds raw."""
+        mock_adapter = MagicMock()
+        scorer = AmbiguityScorer(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_large_summary",
+            initial_context=("A" * 4_000) + "RAW_TAIL",
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                user_response=("B" * 4_000) + "SUMMARY_TAIL",
+            )
+        )
+
+        context = scorer._build_interview_context(state)
+
+        assert "Context truncated for prompt safety" in context
+        assert "RAW_TAIL" not in context
+        assert "SUMMARY_TAIL" not in context
+        assert INITIAL_CONTEXT_SUMMARY_QUESTION not in context
 
 
 class TestAmbiguityScorerParseResponse:

--- a/tests/unit/bigbang/test_ambiguity.py
+++ b/tests/unit/bigbang/test_ambiguity.py
@@ -424,12 +424,10 @@ class TestAmbiguityScorerScore:
         assert "summary required" in result.error.message
         mock_adapter.complete.assert_not_called()
 
-    async def test_score_uses_truncated_context_for_completed_legacy_interview(self) -> None:
-        """Completed long-context interviews without summaries remain scoreable."""
+    async def test_score_requires_summary_for_completed_large_initial_context(self) -> None:
+        """Completed long-context interviews still enforce summary before scoring."""
         mock_adapter = MagicMock()
-        mock_adapter.complete = AsyncMock(
-            return_value=Result.ok(create_mock_completion_response(create_valid_scoring_response()))
-        )
+        mock_adapter.complete = AsyncMock()
         scorer = AmbiguityScorer(llm_adapter=mock_adapter)
         state = InterviewState(
             interview_id="test_completed_large_context",
@@ -439,11 +437,9 @@ class TestAmbiguityScorerScore:
 
         result = await scorer.score(state)
 
-        assert result.is_ok
-        messages = mock_adapter.complete.call_args[0][0]
-        prompt_content = "\n".join(message.content for message in messages)
-        assert "Context truncated for prompt safety" in prompt_content
-        assert "TAIL_MARKER" not in prompt_content
+        assert result.is_err
+        assert "summary required" in result.error.message
+        mock_adapter.complete.assert_not_called()
 
     async def test_score_provider_error_recovers_on_retry(self) -> None:
         """score recovers when provider error is transient."""

--- a/tests/unit/bigbang/test_ambiguity.py
+++ b/tests/unit/bigbang/test_ambiguity.py
@@ -26,6 +26,7 @@ from ouroboros.bigbang.interview import (
     INITIAL_CONTEXT_SUMMARY_QUESTION,
     InterviewRound,
     InterviewState,
+    InterviewStatus,
 )
 from ouroboros.config.loader import get_clarification_model
 from ouroboros.core.errors import ProviderError
@@ -422,6 +423,27 @@ class TestAmbiguityScorerScore:
         assert result.is_err
         assert "summary required" in result.error.message
         mock_adapter.complete.assert_not_called()
+
+    async def test_score_uses_truncated_context_for_completed_legacy_interview(self) -> None:
+        """Completed long-context interviews without summaries remain scoreable."""
+        mock_adapter = MagicMock()
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(create_valid_scoring_response()))
+        )
+        scorer = AmbiguityScorer(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_completed_large_context",
+            initial_context=("A" * 4_000) + "TAIL_MARKER",
+            status=InterviewStatus.COMPLETED,
+        )
+
+        result = await scorer.score(state)
+
+        assert result.is_ok
+        messages = mock_adapter.complete.call_args[0][0]
+        prompt_content = "\n".join(message.content for message in messages)
+        assert "Context truncated for prompt safety" in prompt_content
+        assert "TAIL_MARKER" not in prompt_content
 
     async def test_score_provider_error_recovers_on_retry(self) -> None:
         """score recovers when provider error is transient."""

--- a/tests/unit/bigbang/test_ambiguity.py
+++ b/tests/unit/bigbang/test_ambiguity.py
@@ -22,7 +22,11 @@ from ouroboros.bigbang.ambiguity import (
     get_next_milestone,
     is_ready_for_seed,
 )
-from ouroboros.bigbang.interview import InterviewRound, InterviewState
+from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
+    InterviewRound,
+    InterviewState,
+)
 from ouroboros.config.loader import get_clarification_model
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
@@ -614,6 +618,27 @@ class TestAmbiguityScorerBuildInterviewContext:
         assert "A: Answer 1" in context
         assert "Q: Question 2?" in context
         assert "A: Answer 2" in context
+
+    def test_context_uses_prompt_safe_initial_context_summary(self) -> None:
+        """_build_interview_context avoids oversized raw initial_context."""
+        mock_adapter = MagicMock()
+        scorer = AmbiguityScorer(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_large_context",
+            initial_context=("A" * 4_000) + "TAIL_MARKER",
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                user_response="Short project summary",
+            )
+        )
+
+        context = scorer._build_interview_context(state)
+
+        assert "Short project summary" in context
+        assert "TAIL_MARKER" not in context
 
 
 class TestAmbiguityScorerParseResponse:

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -370,6 +370,33 @@ class TestInterviewEngineAskNextQuestion:
         assert "Additional initial context omitted" in messages[1].content
 
     @pytest.mark.asyncio
+    async def test_long_initial_context_overflow_remains_after_first_round(self) -> None:
+        """Overflow initial_context remains present in later stateless requests."""
+        mock_adapter = MagicMock()
+        mock_adapter.complete = AsyncMock(return_value=Result.ok(create_mock_completion_response()))
+
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_long_context_round_2",
+            initial_context="X" * 3500,
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question="What is the main goal?",
+                user_response="Ship the feature",
+            )
+        )
+
+        result = await engine.ask_next_question(state)
+
+        assert result.is_ok
+        messages = mock_adapter.complete.call_args[0][0]
+        assert len(messages[0].content) <= engine._MAX_SYSTEM_PROMPT_CHARS
+        assert messages[1].role == MessageRole.USER
+        assert "Additional initial context omitted" in messages[1].content
+
+    @pytest.mark.asyncio
     async def test_ask_question_with_history(self) -> None:
         """ask_next_question includes conversation history."""
         mock_adapter = MagicMock()

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -336,6 +336,40 @@ class TestInterviewEngineAskNextQuestion:
         assert "Build a task manager" in system_message.content
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("context_length", [2500, 3500])
+    async def test_long_initial_context_stays_below_cli_failure_cap(
+        self, context_length: int
+    ) -> None:
+        """Long initial_context is split so the system prompt stays below 3500 chars."""
+        mock_adapter = MagicMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+
+        async def _complete(messages, _config):
+            system_prompt = messages[0].content
+            if len(system_prompt) > engine._MAX_SYSTEM_PROMPT_CHARS:
+                return Result.err(
+                    ProviderError(
+                        "Command failed with exit code 1. Check stderr output for details"
+                    )
+                )
+            return Result.ok(create_mock_completion_response())
+
+        mock_adapter.complete = AsyncMock(side_effect=_complete)
+        state = InterviewState(
+            interview_id=f"test_long_context_{context_length}",
+            initial_context="X" * context_length,
+        )
+
+        result = await engine.ask_next_question(state)
+
+        assert result.is_ok
+        messages = mock_adapter.complete.call_args[0][0]
+        assert len(messages[0].content) <= engine._MAX_SYSTEM_PROMPT_CHARS
+        assert "Initial context continues in the first user message" in messages[0].content
+        assert messages[1].role == MessageRole.USER
+        assert "Additional initial context omitted" in messages[1].content
+
+    @pytest.mark.asyncio
     async def test_ask_question_with_history(self) -> None:
         """ask_next_question includes conversation history."""
         mock_adapter = MagicMock()
@@ -1023,7 +1057,7 @@ class TestSystemPromptBrownfield:
         assert "### architect" in prompt
 
     def test_system_prompt_hard_cap_enforced(self) -> None:
-        """Final prompt must never exceed _MAX_SYSTEM_PROMPT_CHARS (4800)."""
+        """Final prompt must never exceed _MAX_SYSTEM_PROMPT_CHARS (3500)."""
         mock_adapter = MagicMock()
         engine = InterviewEngine(llm_adapter=mock_adapter)
 
@@ -1037,10 +1071,10 @@ class TestSystemPromptBrownfield:
 
         prompt = engine._build_system_prompt(state)
 
-        assert len(prompt) <= 4800
+        assert len(prompt) <= engine._MAX_SYSTEM_PROMPT_CHARS
 
     def test_system_prompt_cap_when_header_and_panel_exceed_budget(self) -> None:
-        """Cap holds even when dynamic_header + perspective_panel alone exceed 4800."""
+        """Cap holds even when dynamic_header + perspective_panel alone exceed 3500."""
         mock_adapter = MagicMock()
         engine = InterviewEngine(llm_adapter=mock_adapter)
 
@@ -1055,4 +1089,4 @@ class TestSystemPromptBrownfield:
 
         prompt = engine._build_system_prompt(state)
 
-        assert len(prompt) <= 4800
+        assert len(prompt) <= engine._MAX_SYSTEM_PROMPT_CHARS

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -397,8 +397,8 @@ class TestInterviewEngineAskNextQuestion:
         assert "Additional initial context omitted" in messages[1].content
 
     @pytest.mark.asyncio
-    async def test_very_long_initial_context_overflow_is_not_truncated(self) -> None:
-        """Initial context beyond the system cap is moved without dropping the tail."""
+    async def test_very_long_initial_context_is_rejected_before_prompting(self) -> None:
+        """Very long initial_context fails explicitly instead of being truncated."""
         mock_adapter = MagicMock()
         mock_adapter.complete = AsyncMock(return_value=Result.ok(create_mock_completion_response()))
 
@@ -411,12 +411,23 @@ class TestInterviewEngineAskNextQuestion:
 
         result = await engine.ask_next_question(state)
 
-        assert result.is_ok
-        messages = mock_adapter.complete.call_args[0][0]
-        assert len(messages[0].content) <= engine._MAX_SYSTEM_PROMPT_CHARS
-        assert messages[1].role == MessageRole.USER
-        assert "TAIL_MARKER" in messages[1].content
-        assert not messages[1].content.endswith("...")
+        assert result.is_err
+        assert isinstance(result.error, ValidationError)
+        assert "too long for safe prompt generation" in result.error.message
+        mock_adapter.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_very_long_initial_context(self) -> None:
+        """start_interview refuses contexts that cannot be passed without loss."""
+        mock_adapter = MagicMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+
+        result = await engine.start_interview(("A" * 4_000) + "TAIL_MARKER")
+
+        assert result.is_err
+        assert isinstance(result.error, ValidationError)
+        assert result.error.field == "initial_context"
+        assert "too long for safe interview prompt generation" in result.error.message
 
     @pytest.mark.asyncio
     async def test_ask_question_with_history(self) -> None:

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -400,7 +400,7 @@ class TestInterviewEngineAskNextQuestion:
 
     @pytest.mark.asyncio
     async def test_very_long_initial_context_is_rejected_before_prompting(self) -> None:
-        """Very long initial_context fails explicitly instead of being truncated."""
+        """Persisted long initial_context asks for a summary instead of failing."""
         mock_adapter = MagicMock()
         mock_adapter.complete = AsyncMock(return_value=Result.ok(create_mock_completion_response()))
 
@@ -413,23 +413,46 @@ class TestInterviewEngineAskNextQuestion:
 
         result = await engine.ask_next_question(state)
 
-        assert result.is_err
-        assert isinstance(result.error, ValidationError)
-        assert "too long for safe prompt generation" in result.error.message
+        assert result.is_ok
+        assert "too long to safely send" in result.value
         mock_adapter.complete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_start_rejects_very_long_initial_context(self) -> None:
-        """start_interview refuses contexts that cannot be passed without loss."""
+    async def test_start_accepts_very_long_initial_context_for_summary_recovery(self) -> None:
+        """start_interview remains backward-compatible with security limits."""
         mock_adapter = MagicMock()
         engine = InterviewEngine(llm_adapter=mock_adapter)
 
         result = await engine.start_interview(("A" * 4_000) + "TAIL_MARKER")
 
-        assert result.is_err
-        assert isinstance(result.error, ValidationError)
-        assert result.error.field == "initial_context"
-        assert "too long for safe interview prompt generation" in result.error.message
+        assert result.is_ok
+        assert result.value.initial_context.endswith("TAIL_MARKER")
+
+    @pytest.mark.asyncio
+    async def test_long_history_stays_under_total_prompt_cap(self) -> None:
+        """Later rounds trim retained history so the full request stays safe."""
+        mock_adapter = MagicMock()
+        mock_adapter.complete = AsyncMock(return_value=Result.ok(create_mock_completion_response()))
+
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_long_history",
+            initial_context="X" * 3500,
+        )
+        for i in range(8):
+            state.rounds.append(
+                InterviewRound(
+                    round_number=i + 1,
+                    question=f"What detail matters next? {i}",
+                    user_response="Y" * 800,
+                )
+            )
+
+        result = await engine.ask_next_question(state)
+
+        assert result.is_ok
+        messages = mock_adapter.complete.call_args[0][0]
+        assert sum(len(message.content) for message in messages) <= engine._MAX_TOTAL_PROMPT_CHARS
 
     @pytest.mark.asyncio
     async def test_ask_question_with_history(self) -> None:

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -345,8 +345,8 @@ class TestInterviewEngineAskNextQuestion:
         engine = InterviewEngine(llm_adapter=mock_adapter)
 
         async def _complete(messages, _config):
-            system_prompt = messages[0].content
-            if len(system_prompt) > engine._MAX_SYSTEM_PROMPT_CHARS:
+            total_prompt_chars = sum(len(message.content) for message in messages)
+            if total_prompt_chars > engine._MAX_TOTAL_PROMPT_CHARS:
                 return Result.err(
                     ProviderError(
                         "Command failed with exit code 1. Check stderr output for details"
@@ -365,6 +365,7 @@ class TestInterviewEngineAskNextQuestion:
         assert result.is_ok
         messages = mock_adapter.complete.call_args[0][0]
         assert len(messages[0].content) <= engine._MAX_SYSTEM_PROMPT_CHARS
+        assert sum(len(message.content) for message in messages) <= engine._MAX_TOTAL_PROMPT_CHARS
         assert "Initial context continues in the first user message" in messages[0].content
         assert messages[1].role == MessageRole.USER
         assert "Additional initial context omitted" in messages[1].content
@@ -393,6 +394,7 @@ class TestInterviewEngineAskNextQuestion:
         assert result.is_ok
         messages = mock_adapter.complete.call_args[0][0]
         assert len(messages[0].content) <= engine._MAX_SYSTEM_PROMPT_CHARS
+        assert sum(len(message.content) for message in messages) <= engine._MAX_TOTAL_PROMPT_CHARS
         assert messages[1].role == MessageRole.USER
         assert "Additional initial context omitted" in messages[1].content
 

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -7,10 +7,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
     InterviewEngine,
     InterviewRound,
     InterviewState,
     InterviewStatus,
+    prompt_safe_initial_context,
 )
 from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.types import Result
@@ -414,7 +416,7 @@ class TestInterviewEngineAskNextQuestion:
         result = await engine.ask_next_question(state)
 
         assert result.is_ok
-        assert "too long to safely send" in result.value
+        assert result.value == INITIAL_CONTEXT_SUMMARY_QUESTION
         mock_adapter.complete.assert_not_called()
 
     @pytest.mark.asyncio
@@ -427,6 +429,22 @@ class TestInterviewEngineAskNextQuestion:
 
         assert result.is_ok
         assert result.value.initial_context.endswith("TAIL_MARKER")
+
+    def test_prompt_safe_initial_context_uses_summary_round(self) -> None:
+        """Shared prompt-safe context helper uses the recorded user summary."""
+        state = InterviewState(
+            interview_id="test_summary_context",
+            initial_context=("A" * 4_000) + "TAIL_MARKER",
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                user_response="Short project summary",
+            )
+        )
+
+        assert prompt_safe_initial_context(state) == "Short project summary"
 
     @pytest.mark.asyncio
     async def test_long_history_stays_under_total_prompt_cap(self) -> None:

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -468,19 +468,23 @@ class TestInterviewEngineAskNextQuestion:
         assert "ORIGINAL_TAIL" not in prompt_context
         assert "SUMMARY_TAIL" not in prompt_context
 
-    def test_prompt_safe_initial_context_caps_completed_legacy_context(self) -> None:
-        """Completed legacy interviews remain usable without a recorded summary."""
+    @pytest.mark.asyncio
+    async def test_completed_long_context_requests_summary_recovery(self) -> None:
+        """Completed long-context interviews can still ask for the required summary."""
+        mock_adapter = MagicMock()
+        mock_adapter.complete = AsyncMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
         state = InterviewState(
             interview_id="test_completed_legacy_context",
             initial_context=("A" * 4_000) + "ORIGINAL_TAIL",
             status=InterviewStatus.COMPLETED,
         )
 
-        prompt_context = prompt_safe_initial_context(state)
+        result = await engine.ask_next_question(state)
 
-        assert len(prompt_context) <= MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
-        assert "Context truncated for prompt safety" in prompt_context
-        assert "ORIGINAL_TAIL" not in prompt_context
+        assert result.is_ok
+        assert result.value == INITIAL_CONTEXT_SUMMARY_QUESTION
+        mock_adapter.complete.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_long_history_stays_under_total_prompt_cap(self) -> None:
@@ -644,6 +648,29 @@ class TestInterviewEngineRecordResponse:
 
         assert result.is_err
         assert isinstance(result.error, ValidationError)
+
+    @pytest.mark.asyncio
+    async def test_record_response_reopens_completed_long_context_for_summary(self) -> None:
+        """Completed long-context interviews can record the missing summary."""
+        mock_adapter = MagicMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+
+        state = InterviewState(
+            interview_id="test_completed_summary_repair",
+            initial_context=("A" * 4_000) + "ORIGINAL_TAIL",
+            status=InterviewStatus.COMPLETED,
+        )
+
+        result = await engine.record_response(
+            state,
+            user_response="Concise product summary",
+            question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+        )
+
+        assert result.is_ok
+        assert state.status == InterviewStatus.IN_PROGRESS
+        assert state.rounds[-1].question == INITIAL_CONTEXT_SUMMARY_QUESTION
+        assert prompt_safe_initial_context(state) == "Concise product summary"
 
     @pytest.mark.asyncio
     async def test_record_response_does_not_auto_complete(self) -> None:

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -397,6 +397,28 @@ class TestInterviewEngineAskNextQuestion:
         assert "Additional initial context omitted" in messages[1].content
 
     @pytest.mark.asyncio
+    async def test_very_long_initial_context_overflow_is_not_truncated(self) -> None:
+        """Initial context beyond the system cap is moved without dropping the tail."""
+        mock_adapter = MagicMock()
+        mock_adapter.complete = AsyncMock(return_value=Result.ok(create_mock_completion_response()))
+
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+        initial_context = ("A" * 49_990) + "TAIL_MARKER"
+        state = InterviewState(
+            interview_id="test_very_long_context",
+            initial_context=initial_context,
+        )
+
+        result = await engine.ask_next_question(state)
+
+        assert result.is_ok
+        messages = mock_adapter.complete.call_args[0][0]
+        assert len(messages[0].content) <= engine._MAX_SYSTEM_PROMPT_CHARS
+        assert messages[1].role == MessageRole.USER
+        assert "TAIL_MARKER" in messages[1].content
+        assert not messages[1].content.endswith("...")
+
+    @pytest.mark.asyncio
     async def test_ask_question_with_history(self) -> None:
         """ask_next_question includes conversation history."""
         mock_adapter = MagicMock()

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -8,6 +8,7 @@ import pytest
 
 from ouroboros.bigbang.interview import (
     INITIAL_CONTEXT_SUMMARY_QUESTION,
+    MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS,
     InterviewEngine,
     InterviewRound,
     InterviewState,
@@ -445,6 +446,27 @@ class TestInterviewEngineAskNextQuestion:
         )
 
         assert prompt_safe_initial_context(state) == "Short project summary"
+
+    def test_prompt_safe_initial_context_caps_long_summary_round(self) -> None:
+        """Shared prompt-safe context helper caps oversized recorded summaries."""
+        state = InterviewState(
+            interview_id="test_long_summary_context",
+            initial_context=("A" * 4_000) + "ORIGINAL_TAIL",
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                user_response=("B" * 4_000) + "SUMMARY_TAIL",
+            )
+        )
+
+        prompt_context = prompt_safe_initial_context(state)
+
+        assert len(prompt_context) <= MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
+        assert "Context truncated for prompt safety" in prompt_context
+        assert "ORIGINAL_TAIL" not in prompt_context
+        assert "SUMMARY_TAIL" not in prompt_context
 
     @pytest.mark.asyncio
     async def test_long_history_stays_under_total_prompt_cap(self) -> None:

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -455,7 +455,7 @@ class TestInterviewEngineAskNextQuestion:
         engine = InterviewEngine(llm_adapter=mock_adapter)
         state = InterviewState(
             interview_id="test_long_history",
-            initial_context="X" * 3500,
+            initial_context=("X" * 3489) + "TAIL_MARKER",
         )
         for i in range(8):
             state.rounds.append(
@@ -470,7 +470,10 @@ class TestInterviewEngineAskNextQuestion:
 
         assert result.is_ok
         messages = mock_adapter.complete.call_args[0][0]
+        prompt_content = "\n".join(message.content for message in messages)
         assert sum(len(message.content) for message in messages) <= engine._MAX_TOTAL_PROMPT_CHARS
+        assert "Additional initial context omitted" in prompt_content
+        assert "TAIL_MARKER" in prompt_content
 
     @pytest.mark.asyncio
     async def test_ask_question_with_history(self) -> None:

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -468,6 +468,20 @@ class TestInterviewEngineAskNextQuestion:
         assert "ORIGINAL_TAIL" not in prompt_context
         assert "SUMMARY_TAIL" not in prompt_context
 
+    def test_prompt_safe_initial_context_caps_completed_legacy_context(self) -> None:
+        """Completed legacy interviews remain usable without a recorded summary."""
+        state = InterviewState(
+            interview_id="test_completed_legacy_context",
+            initial_context=("A" * 4_000) + "ORIGINAL_TAIL",
+            status=InterviewStatus.COMPLETED,
+        )
+
+        prompt_context = prompt_safe_initial_context(state)
+
+        assert len(prompt_context) <= MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
+        assert "Context truncated for prompt safety" in prompt_context
+        assert "ORIGINAL_TAIL" not in prompt_context
+
     @pytest.mark.asyncio
     async def test_long_history_stays_under_total_prompt_cap(self) -> None:
         """Later rounds trim retained history so the full request stays safe."""

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
     InterviewEngine,
     InterviewRound,
     InterviewState,
@@ -667,6 +668,77 @@ class TestAskNextQuestion:
         assert result.output_type == ClassifierOutputType.DECIDE_LATER
         # Returned to user so they can choose to answer or defer
         assert result.question_for_pm == "How should we handle scaling?"
+
+
+class TestPMInterviewContext:
+    """Test PM interview context construction."""
+
+    def test_context_uses_prompt_safe_initial_context_and_skips_summary_round(
+        self, tmp_path: Path
+    ) -> None:
+        """PM contexts avoid raw oversized initial context and synthetic summary Q&A."""
+        engine = _make_engine(tmp_path=tmp_path)
+        state = InterviewState(
+            interview_id="test_pm_large_context",
+            initial_context=("A" * 4_000) + "RAW_TAIL",
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                    user_response=("B" * 4_000) + "SUMMARY_TAIL",
+                ),
+                InterviewRound(
+                    round_number=2,
+                    question="Who are the target users?",
+                    user_response="Small teams",
+                ),
+            ],
+        )
+
+        context = engine._build_interview_context(state)
+
+        assert "Context truncated for prompt safety" in context
+        assert "RAW_TAIL" not in context
+        assert "SUMMARY_TAIL" not in context
+        assert INITIAL_CONTEXT_SUMMARY_QUESTION not in context
+        assert "Who are the target users?" in context
+        assert "Small teams" in context
+
+
+class TestCheckCompletion:
+    """Test PM interview completion checks."""
+
+    @pytest.mark.asyncio
+    async def test_summary_round_does_not_count_toward_minimum_rounds(self, tmp_path: Path) -> None:
+        """Initial-context summary recovery is not a substantive PM answer."""
+        adapter = _make_adapter()
+        engine = _make_engine(adapter, tmp_path)
+        state = InterviewState(
+            interview_id="test_pm_summary_round_count",
+            initial_context=("A" * 4_000) + "RAW_TAIL",
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                    user_response="Concise product summary",
+                ),
+                InterviewRound(
+                    round_number=2,
+                    question="Who are the users?",
+                    user_response="Small teams",
+                ),
+                InterviewRound(
+                    round_number=3,
+                    question="What problem do they have?",
+                    user_response="Tracking work",
+                ),
+            ],
+        )
+
+        result = await engine.check_completion(state)
+
+        assert result is None
+        adapter.complete.assert_not_called()
 
 
 class TestRecordResponse:

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -1065,6 +1065,32 @@ class TestPMSeedGeneration:
         assert "empty interview" in result.error.message
         adapter.complete.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_large_context_without_summary_returns_summary_required(
+        self, tmp_path: Path
+    ) -> None:
+        """PM seed generation enforces the long-context summary requirement."""
+        adapter = _make_adapter()
+        engine = _make_engine(adapter, tmp_path)
+        state = InterviewState(
+            interview_id="test_pm_seed_missing_summary",
+            initial_context=("A" * 4_000) + "RAW_TAIL",
+            status=InterviewStatus.COMPLETED,
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question="Who are the target users?",
+                    user_response="Small teams",
+                ),
+            ],
+        )
+
+        result = await engine.generate_pm_seed(state)
+
+        assert result.is_err
+        assert "summary required" in result.error.message
+        adapter.complete.assert_not_called()
+
 
 class TestSavePMSeed:
     """Test PMSeed persistence."""

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -467,6 +467,25 @@ class TestAskNextQuestion:
         assert result.value == planning_q
 
     @pytest.mark.asyncio
+    async def test_initial_context_summary_question_bypasses_classification(
+        self, tmp_path: Path
+    ) -> None:
+        """Long-context recovery prompt is returned verbatim, not classified."""
+        adapter = _make_adapter()
+        engine = _make_engine(adapter, tmp_path)
+        state = InterviewState(
+            interview_id="test_pm_summary_recovery",
+            initial_context=("A" * 4_000) + "RAW_TAIL",
+        )
+
+        result = await engine.ask_next_question(state)
+
+        assert result.is_ok
+        assert result.value == INITIAL_CONTEXT_SUMMARY_QUESTION
+        adapter.complete.assert_not_called()
+        assert engine.classifications == []
+
+    @pytest.mark.asyncio
     async def test_deferred_question_returned_to_user(self, tmp_path: Path) -> None:
         """DEV-only questions marked as defer_to_dev are returned to the user."""
         adapter = _make_adapter()
@@ -1021,6 +1040,30 @@ class TestPMSeedGeneration:
 
         result = await engine.generate_pm_seed(state)
         assert result.is_err
+
+    @pytest.mark.asyncio
+    async def test_summary_only_interview_returns_empty_error(self, tmp_path: Path) -> None:
+        """Synthetic summary recovery alone is not substantive PM interview content."""
+        adapter = _make_adapter()
+        engine = _make_engine(adapter, tmp_path)
+        state = InterviewState(
+            interview_id="test_summary_only_pm_seed",
+            initial_context=("A" * 4_000) + "RAW_TAIL",
+            status=InterviewStatus.COMPLETED,
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                    user_response="Concise product summary",
+                ),
+            ],
+        )
+
+        result = await engine.generate_pm_seed(state)
+
+        assert result.is_err
+        assert "empty interview" in result.error.message
+        adapter.complete.assert_not_called()
 
 
 class TestSavePMSeed:

--- a/tests/unit/bigbang/test_pm_interview.py
+++ b/tests/unit/bigbang/test_pm_interview.py
@@ -431,6 +431,41 @@ class TestAskNextQuestion:
         assert engine.classifications[0].category == QuestionCategory.DEVELOPMENT
 
     @pytest.mark.asyncio
+    async def test_pm_steering_wrapper_accepts_prompt_budget_kwargs(self, tmp_path: Path) -> None:
+        """PM prompt wrapper remains compatible with InterviewEngine prompt budgeting."""
+        adapter = _make_adapter()
+        engine = _make_engine(adapter, tmp_path)
+        planning_q = "Who are the target users?"
+
+        adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(_mock_completion(planning_q)),
+                Result.ok(
+                    _mock_completion(
+                        json.dumps(
+                            {
+                                "category": "planning",
+                                "reframed_question": planning_q,
+                                "reasoning": "Target users are a PM concern",
+                                "defer_to_dev": False,
+                            }
+                        )
+                    )
+                ),
+            ]
+        )
+
+        state = InterviewState(
+            interview_id="test_pm_budget_kwargs",
+            initial_context=("A" * 3_489) + "TAIL_MARKER",
+        )
+
+        result = await engine.ask_next_question(state)
+
+        assert result.is_ok
+        assert result.value == planning_q
+
+    @pytest.mark.asyncio
     async def test_deferred_question_returned_to_user(self, tmp_path: Path) -> None:
         """DEV-only questions marked as defer_to_dev are returned to the user."""
         adapter = _make_adapter()

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -13,7 +13,11 @@ from ouroboros.bigbang.ambiguity import (
     ComponentScore,
     ScoreBreakdown,
 )
-from ouroboros.bigbang.interview import InterviewRound, InterviewState
+from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
+    InterviewRound,
+    InterviewState,
+)
 from ouroboros.bigbang.seed_generator import (
     SeedGenerator,
     load_seed,
@@ -449,6 +453,31 @@ class TestSeedGeneratorMetadata:
             assert seed.metadata.version == "1.0.0"
             assert seed.metadata.seed_id.startswith("seed_")
             assert seed.metadata.created_at is not None
+
+
+class TestSeedGeneratorInterviewContext:
+    """Test SeedGenerator._build_interview_context."""
+
+    def test_context_uses_prompt_safe_initial_context_summary(self) -> None:
+        """_build_interview_context avoids oversized raw initial_context."""
+        mock_adapter = AsyncMock()
+        generator = SeedGenerator(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_large_context",
+            initial_context=("A" * 4_000) + "TAIL_MARKER",
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                user_response="Short project summary",
+            )
+        )
+
+        context = generator._build_interview_context(state)
+
+        assert "Short project summary" in context
+        assert "TAIL_MARKER" not in context
 
 
 class TestSeedGeneratorErrorHandling:

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -280,34 +280,25 @@ class TestSeedGeneratorAmbiguityGating:
         assert "summary required" in result.error.message
 
     @pytest.mark.asyncio
-    async def test_generate_uses_truncated_context_for_completed_legacy_interview(
+    async def test_generate_requires_summary_for_completed_large_initial_context(
         self,
     ) -> None:
-        """Completed long-context interviews without summaries remain seedable."""
+        """Completed long-context interviews still enforce summary before seed generation."""
         mock_adapter = AsyncMock()
-        extraction_response = create_valid_extraction_response()
-        mock_adapter.complete = AsyncMock(
-            return_value=Result.ok(create_mock_completion_response(extraction_response))
-        )
         state = InterviewState(
             interview_id="test_completed_large_context",
             initial_context=("A" * 4_000) + "TAIL_MARKER",
             status=InterviewStatus.COMPLETED,
         )
         low_ambiguity = create_low_ambiguity_score()
+        generator = SeedGenerator(llm_adapter=mock_adapter)
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            generator = SeedGenerator(
-                llm_adapter=mock_adapter,
-                output_dir=Path(tmp_dir) / "seeds",
-            )
-            result = await generator.generate(state, low_ambiguity)
+        result = await generator.generate(state, low_ambiguity)
 
-        assert result.is_ok
-        messages = mock_adapter.complete.call_args[0][0]
-        prompt_content = "\n".join(message.content for message in messages)
-        assert "Context truncated for prompt safety" in prompt_content
-        assert "TAIL_MARKER" not in prompt_content
+        assert result.is_err
+        assert isinstance(result.error, ValidationError)
+        assert "summary required" in result.error.message
+        mock_adapter.complete.assert_not_called()
 
 
 class TestSeedGeneratorExtraction:

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -261,6 +261,23 @@ class TestSeedGeneratorAmbiguityGating:
             assert result.is_ok
             assert isinstance(result.value, Seed)
 
+    @pytest.mark.asyncio
+    async def test_generate_requires_summary_for_large_initial_context(self) -> None:
+        """SeedGenerator.generate() fails when long initial_context has no summary."""
+        mock_adapter = AsyncMock()
+        state = InterviewState(
+            interview_id="test_large_context",
+            initial_context=("A" * 4_000) + "TAIL_MARKER",
+        )
+        low_ambiguity = create_low_ambiguity_score()
+        generator = SeedGenerator(llm_adapter=mock_adapter)
+
+        result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_err
+        assert isinstance(result.error, ValidationError)
+        assert "summary required" in result.error.message
+
 
 class TestSeedGeneratorExtraction:
     """Test SeedGenerator requirement extraction."""

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -17,6 +17,7 @@ from ouroboros.bigbang.interview import (
     INITIAL_CONTEXT_SUMMARY_QUESTION,
     InterviewRound,
     InterviewState,
+    InterviewStatus,
 )
 from ouroboros.bigbang.seed_generator import (
     SeedGenerator,
@@ -277,6 +278,36 @@ class TestSeedGeneratorAmbiguityGating:
         assert result.is_err
         assert isinstance(result.error, ValidationError)
         assert "summary required" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_generate_uses_truncated_context_for_completed_legacy_interview(
+        self,
+    ) -> None:
+        """Completed long-context interviews without summaries remain seedable."""
+        mock_adapter = AsyncMock()
+        extraction_response = create_valid_extraction_response()
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+        state = InterviewState(
+            interview_id="test_completed_large_context",
+            initial_context=("A" * 4_000) + "TAIL_MARKER",
+            status=InterviewStatus.COMPLETED,
+        )
+        low_ambiguity = create_low_ambiguity_score()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            result = await generator.generate(state, low_ambiguity)
+
+        assert result.is_ok
+        messages = mock_adapter.complete.call_args[0][0]
+        prompt_content = "\n".join(message.content for message in messages)
+        assert "Context truncated for prompt safety" in prompt_content
+        assert "TAIL_MARKER" not in prompt_content
 
 
 class TestSeedGeneratorExtraction:

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -495,6 +495,30 @@ class TestSeedGeneratorInterviewContext:
 
         assert "Short project summary" in context
         assert "TAIL_MARKER" not in context
+        assert INITIAL_CONTEXT_SUMMARY_QUESTION not in context
+
+    def test_context_caps_oversized_initial_context_summary(self) -> None:
+        """_build_interview_context does not serialize oversized summary rounds raw."""
+        mock_adapter = AsyncMock()
+        generator = SeedGenerator(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_large_summary",
+            initial_context=("A" * 4_000) + "RAW_TAIL",
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                user_response=("B" * 4_000) + "SUMMARY_TAIL",
+            )
+        )
+
+        context = generator._build_interview_context(state)
+
+        assert "Context truncated for prompt safety" in context
+        assert "RAW_TAIL" not in context
+        assert "SUMMARY_TAIL" not in context
+        assert INITIAL_CONTEXT_SUMMARY_QUESTION not in context
 
 
 class TestSeedGeneratorErrorHandling:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -685,9 +685,7 @@ class TestErrorDiagnostics:
 
     @pytest.mark.asyncio
     async def test_sdk_exception_includes_stderr_in_details(self) -> None:
-        """SDK exception captures stderr lines in error details."""
-        import subprocess
-
+        """SDK exception captures stderr lines in error details and message."""
         adapter = ClaudeCodeAdapter()
         config = CompletionConfig(model="claude-sonnet-4-6")
 
@@ -706,7 +704,9 @@ class TestErrorDiagnostics:
                 captured_stderr["fn"]("fatal: SDK process died")
             if False:
                 yield
-            raise subprocess.CalledProcessError(1, "claude")
+            raise RuntimeError(
+                "Command failed with exit code 1. Check stderr output for details"
+            )
 
         sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=failing_query))
 
@@ -722,6 +722,8 @@ class TestErrorDiagnostics:
         assert result.is_err
         assert "stderr" in result.error.details
         assert "connection refused" in result.error.details["stderr"]
+        assert "stderr tail:" in result.error.message
+        assert "fatal: SDK process died" in result.error.message
 
     @pytest.mark.asyncio
     async def test_cancelled_error_is_not_swallowed(self) -> None:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -704,9 +704,7 @@ class TestErrorDiagnostics:
                 captured_stderr["fn"]("fatal: SDK process died")
             if False:
                 yield
-            raise RuntimeError(
-                "Command failed with exit code 1. Check stderr output for details"
-            )
+            raise RuntimeError("Command failed with exit code 1. Check stderr output for details")
 
         sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=failing_query))
 


### PR DESCRIPTION
## Summary

- Fixes #456 by lowering the interview system prompt ceiling and moving oversized initial_context overflow out of the system prompt.
- Adds stderr-tail diagnostics when the Claude Agent SDK emits the placeholder stderr failure message.
- Adds regression coverage for 2500/3500-character initial_context inputs and SDK stderr capture.

## Changes

- Cap interview system prompts at 3500 chars and initial_context-in-system at 1800 chars.
- Carry additional first-round initial_context into a user message with a bounded overflow budget.
- Preserve the dynamic interview header before trimming optional prompt sections.
- Include captured stderr in placeholder SDK failure messages.

## Tests

- `uv run pytest tests/unit/bigbang/test_interview.py::TestInterviewEngineAskNextQuestion::test_long_initial_context_stays_below_cli_failure_cap tests/unit/bigbang/test_interview.py::TestSystemPromptBrownfield::test_system_prompt_hard_cap_enforced tests/unit/bigbang/test_interview.py::TestSystemPromptBrownfield::test_system_prompt_cap_when_header_and_panel_exceed_budget tests/unit/providers/test_claude_code_adapter.py::TestErrorDiagnostics::test_sdk_exception_includes_stderr_in_details`