### PR TITLE
fix(mcp): cancel linked job runner tasks

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,7 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.runner import request_cancellation
+from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
 
@@ -434,12 +434,18 @@ class JobManager:
         if snapshot.links.session_id:
             await request_cancellation(snapshot.links.session_id)
 
+        local_task_cancelled = False
         task = self._tasks.get(job_id)
         if task is not None:
             task.cancel()
+            local_task_cancelled = True
         runner_task = self._runner_tasks.get(job_id)
         if runner_task is not None and not runner_task.done():
             runner_task.cancel()
+            local_task_cancelled = True
+
+        if snapshot.links.session_id and local_task_cancelled:
+            await clear_cancellation(snapshot.links.session_id)
 
         return await self.get_snapshot(job_id)
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -431,8 +431,10 @@ class JobManager:
             return snapshot
 
         linked_session_repo: SessionRepository | None = None
+        linked_session_exists = False
         linked_session_started = False
         linked_session_owned_by_current_process = False
+        linked_session_inspection_failed = False
         linked_session_terminal = False
         if snapshot.links.session_id:
             try:
@@ -440,6 +442,7 @@ class JobManager:
                 session_result = await linked_session_repo.reconstruct_session(
                     snapshot.links.session_id
                 )
+                linked_session_exists = session_result.is_ok
                 terminal_events = await self._event_store.query_events(
                     aggregate_id=snapshot.links.session_id,
                     limit=10,
@@ -459,6 +462,7 @@ class JobManager:
                     for event in terminal_events
                 )
             except Exception:
+                linked_session_inspection_failed = True
                 linked_session_terminal = False
             linked_session_started = is_holder_alive(snapshot.links.session_id)
             linked_session_owned_by_current_process = is_owned_by_current_process(
@@ -471,17 +475,18 @@ class JobManager:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
                 if linked_session_started and not linked_session_owned_by_current_process:
-                    repo = linked_session_repo or SessionRepository(self._event_store)
-                    cancel_result = await repo.mark_cancelled(
-                        snapshot.links.session_id,
-                        reason="Background job cancelled",
-                        cancelled_by="mcp_job_manager",
-                    )
-                    if cancel_result.is_err:
-                        raise ValueError(
-                            "Failed to mark linked session cancelled: "
-                            f"{cancel_result.error.message}"
+                    if linked_session_exists and not linked_session_inspection_failed:
+                        repo = linked_session_repo or SessionRepository(self._event_store)
+                        cancel_result = await repo.mark_cancelled(
+                            snapshot.links.session_id,
+                            reason="Background job cancelled",
+                            cancelled_by="mcp_job_manager",
                         )
+                        if cancel_result.is_err:
+                            raise ValueError(
+                                "Failed to mark linked session cancelled: "
+                                f"{cancel_result.error.message}"
+                            )
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -466,6 +466,8 @@ class JobManager:
         if snapshot.links.session_id:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
+            if linked_session_started:
+                return await self.get_snapshot(job_id)
 
         task = self._tasks.get(job_id)
         if task is not None and not task.done():

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,7 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.runner import request_cancellation
+from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
 
@@ -431,6 +431,7 @@ class JobManager:
 
         linked_session_repo: SessionRepository | None = None
         linked_session_started = False
+        linked_session_terminal = False
         if snapshot.links.session_id:
             linked_session_repo = SessionRepository(self._event_store)
             session_result = await linked_session_repo.reconstruct_session(
@@ -446,7 +447,7 @@ class JobManager:
                 SessionStatus.CANCELLED,
             }
             linked_session_started = session_result.is_ok
-            if linked_session_terminal or any(
+            linked_session_terminal = linked_session_terminal or any(
                 event.type
                 in {
                     "orchestrator.session.completed",
@@ -454,18 +455,13 @@ class JobManager:
                     "orchestrator.session.cancelled",
                 }
                 for event in terminal_events
-            ):
-                return snapshot
+            )
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
         if snapshot.links.session_id:
-            await request_cancellation(snapshot.links.session_id)
-            if linked_session_started:
-                runner_task = self._runner_tasks.get(job_id)
-                if runner_task is not None and not runner_task.done():
-                    runner_task.cancel()
-            return await self.get_snapshot(job_id)
+            if not linked_session_terminal:
+                await request_cancellation(snapshot.links.session_id)
 
         task = self._tasks.get(job_id)
         if task is not None and not task.done():
@@ -473,6 +469,8 @@ class JobManager:
         runner_task = self._runner_tasks.get(job_id)
         if runner_task is not None and not runner_task.done():
             runner_task.cancel()
+        if snapshot.links.session_id and not linked_session_started:
+            await clear_cancellation(snapshot.links.session_id)
 
         return await self.get_snapshot(job_id)
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -440,15 +440,11 @@ class JobManager:
                 aggregate_id=snapshot.links.session_id,
                 limit=10,
             )
-            linked_session_terminal = (
-                session_result.is_ok
-                and session_result.value.status
-                in {
-                    SessionStatus.COMPLETED,
-                    SessionStatus.FAILED,
-                    SessionStatus.CANCELLED,
-                }
-            )
+            linked_session_terminal = session_result.is_ok and session_result.value.status in {
+                SessionStatus.COMPLETED,
+                SessionStatus.FAILED,
+                SessionStatus.CANCELLED,
+            }
             linked_session_started = session_result.is_ok
             if linked_session_terminal or any(
                 event.type

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -437,7 +437,7 @@ class JobManager:
 
         local_task_cancelled = False
         task = self._tasks.get(job_id)
-        if task is not None:
+        if task is not None and not task.done():
             task.cancel()
             local_task_cancelled = True
         runner_task = self._runner_tasks.get(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,7 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.heartbeat import is_holder_alive
+from ouroboros.orchestrator.heartbeat import is_holder_alive, is_owned_by_current_process
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
@@ -432,6 +432,7 @@ class JobManager:
 
         linked_session_repo: SessionRepository | None = None
         linked_session_started = False
+        linked_session_owned_by_current_process = False
         linked_session_terminal = False
         if snapshot.links.session_id:
             try:
@@ -460,12 +461,27 @@ class JobManager:
             except Exception:
                 linked_session_terminal = False
             linked_session_started = is_holder_alive(snapshot.links.session_id)
+            linked_session_owned_by_current_process = is_owned_by_current_process(
+                snapshot.links.session_id
+            )
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
         if snapshot.links.session_id:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
+                if linked_session_started and not linked_session_owned_by_current_process:
+                    repo = linked_session_repo or SessionRepository(self._event_store)
+                    cancel_result = await repo.mark_cancelled(
+                        snapshot.links.session_id,
+                        reason="Background job cancelled",
+                        cancelled_by="mcp_job_manager",
+                    )
+                    if cancel_result.is_err:
+                        raise ValueError(
+                            "Failed to mark linked session cancelled: "
+                            f"{cancel_result.error.message}"
+                        )
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -466,8 +466,6 @@ class JobManager:
         if snapshot.links.session_id:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
-            if linked_session_started:
-                return await self.get_snapshot(job_id)
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,6 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
@@ -446,7 +447,6 @@ class JobManager:
                 SessionStatus.FAILED,
                 SessionStatus.CANCELLED,
             }
-            linked_session_started = session_result.is_ok
             linked_session_terminal = linked_session_terminal or any(
                 event.type
                 in {
@@ -456,6 +456,7 @@ class JobManager:
                 }
                 for event in terminal_events
             )
+            linked_session_started = is_holder_alive(snapshot.links.session_id)
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -432,6 +432,7 @@ class JobManager:
             return snapshot
 
         linked_session_repo: SessionRepository | None = None
+        linked_session_reconstructed = False
         linked_session_started = False
         linked_session_owned_by_current_process = False
         linked_session_terminal = False
@@ -440,6 +441,7 @@ class JobManager:
             session_result = await linked_session_repo.reconstruct_session(
                 snapshot.links.session_id
             )
+            linked_session_reconstructed = session_result.is_ok
             linked_session_terminal = session_result.is_ok and session_result.value.status in {
                 SessionStatus.COMPLETED,
                 SessionStatus.FAILED,
@@ -473,8 +475,8 @@ class JobManager:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
                 should_persist_linked_cancel = (
-                    linked_session_started and not linked_session_owned_by_current_process
-                )
+                    linked_session_reconstructed or linked_session_started
+                ) and (not linked_session_started or not linked_session_owned_by_current_process)
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -445,6 +445,15 @@ class JobManager:
             local_task_cancelled = True
 
         if snapshot.links.session_id and local_task_cancelled:
+            repo = SessionRepository(self._event_store)
+            await repo.mark_cancelled(
+                snapshot.links.session_id,
+                reason="Background job cancelled",
+                cancelled_by="mcp_job_manager",
+            )
+            from ouroboros.orchestrator.heartbeat import release as release_session_lock
+
+            release_session_lock(snapshot.links.session_id)
             await clear_cancellation(snapshot.links.session_id)
 
         return await self.get_snapshot(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -474,9 +474,9 @@ class JobManager:
         if snapshot.links.session_id:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
-                should_persist_linked_cancel = (
-                    linked_session_reconstructed
-                ) and (not linked_session_started or not linked_session_owned_by_current_process)
+                should_persist_linked_cancel = linked_session_reconstructed and (
+                    not linked_session_started or not linked_session_owned_by_current_process
+                )
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -434,28 +434,31 @@ class JobManager:
         linked_session_started = False
         linked_session_terminal = False
         if snapshot.links.session_id:
-            linked_session_repo = SessionRepository(self._event_store)
-            session_result = await linked_session_repo.reconstruct_session(
-                snapshot.links.session_id
-            )
-            terminal_events = await self._event_store.query_events(
-                aggregate_id=snapshot.links.session_id,
-                limit=10,
-            )
-            linked_session_terminal = session_result.is_ok and session_result.value.status in {
-                SessionStatus.COMPLETED,
-                SessionStatus.FAILED,
-                SessionStatus.CANCELLED,
-            }
-            linked_session_terminal = linked_session_terminal or any(
-                event.type
-                in {
-                    "orchestrator.session.completed",
-                    "orchestrator.session.failed",
-                    "orchestrator.session.cancelled",
+            try:
+                linked_session_repo = SessionRepository(self._event_store)
+                session_result = await linked_session_repo.reconstruct_session(
+                    snapshot.links.session_id
+                )
+                terminal_events = await self._event_store.query_events(
+                    aggregate_id=snapshot.links.session_id,
+                    limit=10,
+                )
+                linked_session_terminal = session_result.is_ok and session_result.value.status in {
+                    SessionStatus.COMPLETED,
+                    SessionStatus.FAILED,
+                    SessionStatus.CANCELLED,
                 }
-                for event in terminal_events
-            )
+                linked_session_terminal = linked_session_terminal or any(
+                    event.type
+                    in {
+                        "orchestrator.session.completed",
+                        "orchestrator.session.failed",
+                        "orchestrator.session.cancelled",
+                    }
+                    for event in terminal_events
+                )
+            except Exception:
+                linked_session_terminal = False
             linked_session_started = is_holder_alive(snapshot.links.session_id)
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -480,7 +480,7 @@ class JobManager:
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)
-        if task is not None and not task.done():
+        if snapshot.links.session_id is None and task is not None and not task.done():
             task.cancel()
             cancelled_tasks.append(task)
         runner_task = self._runner_tasks.get(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,8 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.events import create_execution_terminal_event
-from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
+from ouroboros.orchestrator.runner import request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
 
@@ -431,6 +430,7 @@ class JobManager:
             return snapshot
 
         linked_session_repo: SessionRepository | None = None
+        linked_session_started = False
         if snapshot.links.session_id:
             linked_session_repo = SessionRepository(self._event_store)
             session_result = await linked_session_repo.reconstruct_session(
@@ -440,7 +440,7 @@ class JobManager:
                 aggregate_id=snapshot.links.session_id,
                 limit=10,
             )
-            if (
+            linked_session_terminal = (
                 session_result.is_ok
                 and session_result.value.status
                 in {
@@ -448,7 +448,9 @@ class JobManager:
                     SessionStatus.FAILED,
                     SessionStatus.CANCELLED,
                 }
-            ) or any(
+            )
+            linked_session_started = session_result.is_ok
+            if linked_session_terminal or any(
                 event.type
                 in {
                     "orchestrator.session.completed",
@@ -461,45 +463,20 @@ class JobManager:
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
-        local_task_cancelled = False
+        if snapshot.links.session_id:
+            await request_cancellation(snapshot.links.session_id)
+            if linked_session_started:
+                runner_task = self._runner_tasks.get(job_id)
+                if runner_task is not None and not runner_task.done():
+                    runner_task.cancel()
+            return await self.get_snapshot(job_id)
+
         task = self._tasks.get(job_id)
         if task is not None and not task.done():
             task.cancel()
-            local_task_cancelled = True
         runner_task = self._runner_tasks.get(job_id)
         if runner_task is not None and not runner_task.done():
             runner_task.cancel()
-            local_task_cancelled = True
-
-        if snapshot.links.session_id and not local_task_cancelled:
-            await request_cancellation(snapshot.links.session_id)
-
-        if snapshot.links.session_id and local_task_cancelled:
-            repo = linked_session_repo or SessionRepository(self._event_store)
-            cancel_result = await repo.mark_cancelled(
-                snapshot.links.session_id,
-                reason="Background job cancelled",
-                cancelled_by="mcp_job_manager",
-            )
-            if cancel_result.is_err:
-                await clear_cancellation(snapshot.links.session_id)
-                raise ValueError(
-                    f"Failed to mark linked session cancelled: {cancel_result.error.message}"
-                )
-
-            from ouroboros.orchestrator.heartbeat import release_if_owned_by_current_process
-
-            release_if_owned_by_current_process(snapshot.links.session_id)
-            if snapshot.links.execution_id:
-                await self._event_store.append(
-                    create_execution_terminal_event(
-                        execution_id=snapshot.links.execution_id,
-                        session_id=snapshot.links.session_id,
-                        status="cancelled",
-                        error_message="Background job cancelled",
-                    )
-                )
-            await clear_cancellation(snapshot.links.session_id)
 
         return await self.get_snapshot(job_id)
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -475,7 +475,7 @@ class JobManager:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
                 should_persist_linked_cancel = (
-                    linked_session_reconstructed or linked_session_started
+                    linked_session_reconstructed
                 ) and (not linked_session_started or not linked_session_owned_by_current_process)
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
@@ -492,6 +492,11 @@ class JobManager:
         if snapshot.links.session_id and should_persist_linked_cancel:
             repo = linked_session_repo or SessionRepository(self._event_store)
             latest_session = await repo.reconstruct_session(snapshot.links.session_id)
+            if latest_session.is_err:
+                raise ValueError(
+                    "Failed to inspect linked session before cancellation: "
+                    f"{latest_session.error.message}"
+                )
             latest_terminal = latest_session.is_ok and latest_session.value.status in {
                 SessionStatus.COMPLETED,
                 SessionStatus.FAILED,

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -432,7 +432,6 @@ class JobManager:
             return snapshot
 
         linked_session_repo: SessionRepository | None = None
-        linked_session_exists = False
         linked_session_started = False
         linked_session_owned_by_current_process = False
         linked_session_terminal = False
@@ -441,7 +440,6 @@ class JobManager:
             session_result = await linked_session_repo.reconstruct_session(
                 snapshot.links.session_id
             )
-            linked_session_exists = session_result.is_ok
             linked_session_terminal = session_result.is_ok and session_result.value.status in {
                 SessionStatus.COMPLETED,
                 SessionStatus.FAILED,
@@ -475,9 +473,7 @@ class JobManager:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
                 should_persist_linked_cancel = (
-                    linked_session_exists
-                    and linked_session_started
-                    and not linked_session_owned_by_current_process
+                    linked_session_started and not linked_session_owned_by_current_process
                 )
 
         cancelled_tasks: list[asyncio.Task[Any]] = []

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,6 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.events import create_execution_terminal_event
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
@@ -454,6 +455,15 @@ class JobManager:
             from ouroboros.orchestrator.heartbeat import release as release_session_lock
 
             release_session_lock(snapshot.links.session_id)
+            if snapshot.links.execution_id:
+                await self._event_store.append(
+                    create_execution_terminal_event(
+                        execution_id=snapshot.links.execution_id,
+                        session_id=snapshot.links.session_id,
+                        status="cancelled",
+                        error_message="Background job cancelled",
+                    )
+                )
             await clear_cancellation(snapshot.links.session_id)
 
         return await self.get_snapshot(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -466,30 +466,11 @@ class JobManager:
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
+        should_persist_linked_cancel = False
         if snapshot.links.session_id:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
-                if linked_session_exists and linked_session_started:
-                    repo = linked_session_repo or SessionRepository(self._event_store)
-                    cancel_result = await repo.mark_cancelled(
-                        snapshot.links.session_id,
-                        reason="Background job cancelled",
-                        cancelled_by="mcp_job_manager",
-                    )
-                    if cancel_result.is_err:
-                        raise ValueError(
-                            "Failed to mark linked session cancelled: "
-                            f"{cancel_result.error.message}"
-                        )
-                    if snapshot.links.execution_id:
-                        await self._event_store.append(
-                            create_execution_terminal_event(
-                                execution_id=snapshot.links.execution_id,
-                                session_id=snapshot.links.session_id,
-                                status="cancelled",
-                                error_message="Background job cancelled",
-                            )
-                        )
+                should_persist_linked_cancel = linked_session_exists and linked_session_started
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)
@@ -502,6 +483,33 @@ class JobManager:
             cancelled_tasks.append(runner_task)
         if cancelled_tasks:
             await asyncio.wait(cancelled_tasks, timeout=5)
+        if snapshot.links.session_id and should_persist_linked_cancel:
+            repo = linked_session_repo or SessionRepository(self._event_store)
+            latest_session = await repo.reconstruct_session(snapshot.links.session_id)
+            latest_terminal = latest_session.is_ok and latest_session.value.status in {
+                SessionStatus.COMPLETED,
+                SessionStatus.FAILED,
+                SessionStatus.CANCELLED,
+            }
+            if not latest_terminal:
+                cancel_result = await repo.mark_cancelled(
+                    snapshot.links.session_id,
+                    reason="Background job cancelled",
+                    cancelled_by="mcp_job_manager",
+                )
+                if cancel_result.is_err:
+                    raise ValueError(
+                        f"Failed to mark linked session cancelled: {cancel_result.error.message}"
+                    )
+                if snapshot.links.execution_id:
+                    await self._event_store.append(
+                        create_execution_terminal_event(
+                            execution_id=snapshot.links.execution_id,
+                            session_id=snapshot.links.session_id,
+                            status="cancelled",
+                            error_message="Background job cancelled",
+                        )
+                    )
         if (
             snapshot.links.session_id
             and not linked_session_started

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.events import create_execution_terminal_event
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
-from ouroboros.orchestrator.session import SessionRepository
+from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
 
 
@@ -430,6 +430,35 @@ class JobManager:
         if snapshot.is_terminal:
             return snapshot
 
+        linked_session_repo: SessionRepository | None = None
+        if snapshot.links.session_id:
+            linked_session_repo = SessionRepository(self._event_store)
+            session_result = await linked_session_repo.reconstruct_session(
+                snapshot.links.session_id
+            )
+            terminal_events = await self._event_store.query_events(
+                aggregate_id=snapshot.links.session_id,
+                limit=10,
+            )
+            if (
+                session_result.is_ok
+                and session_result.value.status
+                in {
+                    SessionStatus.COMPLETED,
+                    SessionStatus.FAILED,
+                    SessionStatus.CANCELLED,
+                }
+            ) or any(
+                event.type
+                in {
+                    "orchestrator.session.completed",
+                    "orchestrator.session.failed",
+                    "orchestrator.session.cancelled",
+                }
+                for event in terminal_events
+            ):
+                return snapshot
+
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
         local_task_cancelled = False
@@ -446,7 +475,7 @@ class JobManager:
             await request_cancellation(snapshot.links.session_id)
 
         if snapshot.links.session_id and local_task_cancelled:
-            repo = SessionRepository(self._event_store)
+            repo = linked_session_repo or SessionRepository(self._event_store)
             cancel_result = await repo.mark_cancelled(
                 snapshot.links.session_id,
                 reason="Background job cancelled",

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -432,9 +432,6 @@ class JobManager:
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
-        if snapshot.links.session_id:
-            await request_cancellation(snapshot.links.session_id)
-
         local_task_cancelled = False
         task = self._tasks.get(job_id)
         if task is not None and not task.done():
@@ -444,6 +441,9 @@ class JobManager:
         if runner_task is not None and not runner_task.done():
             runner_task.cancel()
             local_task_cancelled = True
+
+        if snapshot.links.session_id and not local_task_cancelled:
+            await request_cancellation(snapshot.links.session_id)
 
         if snapshot.links.session_id and local_task_cancelled:
             repo = SessionRepository(self._event_store)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,6 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.events import create_execution_terminal_event
 from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
@@ -468,7 +469,7 @@ class JobManager:
         if snapshot.links.session_id:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
-                if linked_session_exists:
+                if linked_session_exists and linked_session_started:
                     repo = linked_session_repo or SessionRepository(self._event_store)
                     cancel_result = await repo.mark_cancelled(
                         snapshot.links.session_id,
@@ -479,6 +480,15 @@ class JobManager:
                         raise ValueError(
                             "Failed to mark linked session cancelled: "
                             f"{cancel_result.error.message}"
+                        )
+                    if snapshot.links.execution_id:
+                        await self._event_store.append(
+                            create_execution_terminal_event(
+                                execution_id=snapshot.links.execution_id,
+                                session_id=snapshot.links.session_id,
+                                status="cancelled",
+                                error_message="Background job cancelled",
+                            )
                         )
 
         cancelled_tasks: list[asyncio.Task[Any]] = []

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -433,13 +433,13 @@ class JobManager:
 
         if snapshot.links.session_id:
             await request_cancellation(snapshot.links.session_id)
-        else:
-            task = self._tasks.get(job_id)
-            if task is not None:
-                task.cancel()
-            runner_task = self._runner_tasks.get(job_id)
-            if runner_task is not None and not runner_task.done():
-                runner_task.cancel()
+
+        task = self._tasks.get(job_id)
+        if task is not None:
+            task.cancel()
+        runner_task = self._runner_tasks.get(job_id)
+        if runner_task is not None and not runner_task.done():
+            runner_task.cancel()
 
         return await self.get_snapshot(job_id)
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,7 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.heartbeat import is_holder_alive, is_owned_by_current_process
+from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
@@ -433,25 +433,23 @@ class JobManager:
         linked_session_repo: SessionRepository | None = None
         linked_session_exists = False
         linked_session_started = False
-        linked_session_owned_by_current_process = False
-        linked_session_inspection_failed = False
         linked_session_terminal = False
         if snapshot.links.session_id:
+            linked_session_repo = SessionRepository(self._event_store)
+            session_result = await linked_session_repo.reconstruct_session(
+                snapshot.links.session_id
+            )
+            linked_session_exists = session_result.is_ok
+            linked_session_terminal = session_result.is_ok and session_result.value.status in {
+                SessionStatus.COMPLETED,
+                SessionStatus.FAILED,
+                SessionStatus.CANCELLED,
+            }
             try:
-                linked_session_repo = SessionRepository(self._event_store)
-                session_result = await linked_session_repo.reconstruct_session(
-                    snapshot.links.session_id
-                )
-                linked_session_exists = session_result.is_ok
                 terminal_events = await self._event_store.query_events(
                     aggregate_id=snapshot.links.session_id,
                     limit=10,
                 )
-                linked_session_terminal = session_result.is_ok and session_result.value.status in {
-                    SessionStatus.COMPLETED,
-                    SessionStatus.FAILED,
-                    SessionStatus.CANCELLED,
-                }
                 linked_session_terminal = linked_session_terminal or any(
                     event.type
                     in {
@@ -462,31 +460,26 @@ class JobManager:
                     for event in terminal_events
                 )
             except Exception:
-                linked_session_inspection_failed = True
-                linked_session_terminal = False
+                pass
             linked_session_started = is_holder_alive(snapshot.links.session_id)
-            linked_session_owned_by_current_process = is_owned_by_current_process(
-                snapshot.links.session_id
-            )
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
         if snapshot.links.session_id:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
-                if linked_session_started and not linked_session_owned_by_current_process:
-                    if linked_session_exists and not linked_session_inspection_failed:
-                        repo = linked_session_repo or SessionRepository(self._event_store)
-                        cancel_result = await repo.mark_cancelled(
-                            snapshot.links.session_id,
-                            reason="Background job cancelled",
-                            cancelled_by="mcp_job_manager",
+                if linked_session_exists:
+                    repo = linked_session_repo or SessionRepository(self._event_store)
+                    cancel_result = await repo.mark_cancelled(
+                        snapshot.links.session_id,
+                        reason="Background job cancelled",
+                        cancelled_by="mcp_job_manager",
+                    )
+                    if cancel_result.is_err:
+                        raise ValueError(
+                            "Failed to mark linked session cancelled: "
+                            f"{cancel_result.error.message}"
                         )
-                        if cancel_result.is_err:
-                            raise ValueError(
-                                "Failed to mark linked session cancelled: "
-                                f"{cancel_result.error.message}"
-                            )
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -447,14 +447,20 @@ class JobManager:
 
         if snapshot.links.session_id and local_task_cancelled:
             repo = SessionRepository(self._event_store)
-            await repo.mark_cancelled(
+            cancel_result = await repo.mark_cancelled(
                 snapshot.links.session_id,
                 reason="Background job cancelled",
                 cancelled_by="mcp_job_manager",
             )
-            from ouroboros.orchestrator.heartbeat import release as release_session_lock
+            if cancel_result.is_err:
+                await clear_cancellation(snapshot.links.session_id)
+                raise ValueError(
+                    f"Failed to mark linked session cancelled: {cancel_result.error.message}"
+                )
 
-            release_session_lock(snapshot.links.session_id)
+            from ouroboros.orchestrator.heartbeat import release_if_owned_by_current_process
+
+            release_if_owned_by_current_process(snapshot.links.session_id)
             if snapshot.links.execution_id:
                 await self._event_store.append(
                     create_execution_terminal_event(

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -469,13 +469,22 @@ class JobManager:
             if linked_session_started:
                 return await self.get_snapshot(job_id)
 
+        cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)
         if task is not None and not task.done():
             task.cancel()
+            cancelled_tasks.append(task)
         runner_task = self._runner_tasks.get(job_id)
         if runner_task is not None and not runner_task.done():
             runner_task.cancel()
-        if snapshot.links.session_id and not linked_session_started:
+            cancelled_tasks.append(runner_task)
+        if cancelled_tasks:
+            await asyncio.wait(cancelled_tasks, timeout=5)
+        if (
+            snapshot.links.session_id
+            and not linked_session_started
+            and not is_holder_alive(snapshot.links.session_id)
+        ):
             await clear_cancellation(snapshot.links.session_id)
 
         return await self.get_snapshot(job_id)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.events import create_execution_terminal_event
-from ouroboros.orchestrator.heartbeat import is_holder_alive
+from ouroboros.orchestrator.heartbeat import is_holder_alive, is_owned_by_current_process
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
@@ -434,6 +434,7 @@ class JobManager:
         linked_session_repo: SessionRepository | None = None
         linked_session_exists = False
         linked_session_started = False
+        linked_session_owned_by_current_process = False
         linked_session_terminal = False
         if snapshot.links.session_id:
             linked_session_repo = SessionRepository(self._event_store)
@@ -463,6 +464,9 @@ class JobManager:
             except Exception:
                 pass
             linked_session_started = is_holder_alive(snapshot.links.session_id)
+            linked_session_owned_by_current_process = is_owned_by_current_process(
+                snapshot.links.session_id
+            )
 
         await self.update_status(job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested")
 
@@ -470,7 +474,11 @@ class JobManager:
         if snapshot.links.session_id:
             if not linked_session_terminal:
                 await request_cancellation(snapshot.links.session_id)
-                should_persist_linked_cancel = linked_session_exists and linked_session_started
+                should_persist_linked_cancel = (
+                    linked_session_exists
+                    and linked_session_started
+                    and not linked_session_owned_by_current_process
+                )
 
         cancelled_tasks: list[asyncio.Task[Any]] = []
         task = self._tasks.get(job_id)

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -122,6 +122,14 @@ def release_if_owned_by_current_process(session_id: str) -> bool:
         return False
     if pid != os.getpid():
         return False
+    if len(parts) > 1 and parts[1] != "None":
+        try:
+            recorded_start = float(parts[1])
+        except ValueError:
+            return False
+        current_start = _get_process_start_time(pid)
+        if current_start is not None and abs(current_start - recorded_start) > 2.0:
+            return False
 
     release(session_id)
     return True

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -109,6 +109,15 @@ def release(session_id: str) -> None:
 
 def release_if_owned_by_current_process(session_id: str) -> bool:
     """Release a session lock only when the current process owns it."""
+    if not is_owned_by_current_process(session_id):
+        return False
+
+    release(session_id)
+    return True
+
+
+def is_owned_by_current_process(session_id: str) -> bool:
+    """Return True when the current process owns the session lock."""
     path = lock_path(session_id)
     try:
         content = path.read_text().strip()
@@ -131,7 +140,6 @@ def release_if_owned_by_current_process(session_id: str) -> bool:
         if current_start is not None and abs(current_start - recorded_start) > 2.0:
             return False
 
-    release(session_id)
     return True
 
 

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -107,6 +107,26 @@ def release(session_id: str) -> None:
         pass
 
 
+def release_if_owned_by_current_process(session_id: str) -> bool:
+    """Release a session lock only when the current process owns it."""
+    path = lock_path(session_id)
+    try:
+        content = path.read_text().strip()
+    except OSError:
+        return False
+
+    parts = content.split(":", 1)
+    try:
+        pid = int(parts[0])
+    except ValueError:
+        return False
+    if pid != os.getpid():
+        return False
+
+    release(session_id)
+    return True
+
+
 def is_holder_alive(session_id: str) -> bool:
     """Check if the lock holder for a session is still alive.
 

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1621,14 +1621,18 @@ class OrchestratorRunner:
 
                 return await self._execute_parallel(**parallel_kwargs)
         except asyncio.CancelledError:
-            if session_registered:
+            if session_registered and await is_cancellation_requested(tracker.session_id):
                 return await self._handle_cancellation(
                     session_id=tracker.session_id,
                     execution_id=exec_id,
                     messages_processed=0,
                     start_time=start_time,
                 )
-            await clear_cancellation(tracker.session_id)
+            self._cleanup_pre_execution_state(
+                exec_id,
+                tracker.session_id,
+                session_registered=session_registered,
+            )
             raise
         except Exception as e:
             self._cleanup_pre_execution_state(
@@ -1896,12 +1900,17 @@ class OrchestratorRunner:
             )
 
         except asyncio.CancelledError:
-            return await self._handle_cancellation(
-                session_id=tracker.session_id,
-                execution_id=exec_id,
-                messages_processed=messages_processed,
-                start_time=start_time,
-            )
+            if await is_cancellation_requested(tracker.session_id):
+                return await self._handle_cancellation(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    messages_processed=messages_processed,
+                    start_time=start_time,
+                )
+            self._unregister_session(exec_id, tracker.session_id)
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            raise
         except Exception as e:
             log.exception(
                 "orchestrator.runner.execute_failed",

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1373,7 +1373,8 @@ class OrchestratorRunner:
         # Only mark cancelled if not already in a terminal state
         session_result = await self._session_repo.reconstruct_session(session_id)
         _terminal = {SessionStatus.COMPLETED, SessionStatus.FAILED, SessionStatus.CANCELLED}
-        if session_result.is_ok and session_result.value.status not in _terminal:
+        session_already_terminal = session_result.is_ok and session_result.value.status in _terminal
+        if not session_already_terminal:
             cancel_result = await self._session_repo.mark_cancelled(
                 session_id,
                 reason="Cancellation detected during execution",
@@ -1386,16 +1387,16 @@ class OrchestratorRunner:
                     error=str(cancel_result.error),
                 )
 
-        # Mirror cancellation into execution stream for TUI.
-        await self._event_store.append(
-            create_execution_terminal_event(
-                execution_id=execution_id,
-                session_id=session_id,
-                status="cancelled",
-                error_message="Execution cancelled by external request",
-                messages_processed=messages_processed,
+            # Mirror cancellation into execution stream for TUI.
+            await self._event_store.append(
+                create_execution_terminal_event(
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    status="cancelled",
+                    error_message="Execution cancelled by external request",
+                    messages_processed=messages_processed,
+                )
             )
-        )
 
         # Display cancellation notice
         self._console.print(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1336,6 +1336,24 @@ class OrchestratorRunner:
             )
             return False
 
+    async def _check_startup_cancellation(self, session_id: str) -> bool:
+        """Check cancellation before normal message-loop checkpoints exist."""
+        if await is_cancellation_requested(session_id):
+            return True
+        try:
+            events = await self._event_store.query_events(
+                aggregate_id=session_id,
+                event_type="orchestrator.session.cancelled",
+                limit=1,
+            )
+            return len(events) > 0
+        except Exception:
+            log.warning(
+                "orchestrator.runner.startup_cancellation_check_failed",
+                session_id=session_id,
+            )
+            return False
+
     async def _handle_cancellation(
         self,
         session_id: str,
@@ -1572,7 +1590,7 @@ class OrchestratorRunner:
             # Register session for cancellation tracking
             self._register_session(exec_id, tracker.session_id)
             session_registered = True
-            if await is_cancellation_requested(tracker.session_id):
+            if await self._check_startup_cancellation(tracker.session_id):
                 return await self._handle_cancellation(
                     session_id=tracker.session_id,
                     execution_id=exec_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1380,7 +1380,7 @@ class OrchestratorRunner:
                 reason="Cancellation detected during execution",
                 cancelled_by="runner",
             )
-            if cancel_result.is_err:
+            if cancel_result is not None and cancel_result.is_err:
                 log.warning(
                     "orchestrator.runner.mark_cancelled_failed",
                     session_id=session_id,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1531,6 +1531,13 @@ class OrchestratorRunner:
             # Register session for cancellation tracking
             self._register_session(exec_id, tracker.session_id)
             session_registered = True
+            if await is_cancellation_requested(tracker.session_id):
+                return await self._handle_cancellation(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    messages_processed=0,
+                    start_time=start_time,
+                )
 
             # Build prompts with strategy
             strategy = get_strategy(seed.task_type)
@@ -1574,6 +1581,16 @@ class OrchestratorRunner:
                     parallel_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
 
                 return await self._execute_parallel(**parallel_kwargs)
+        except asyncio.CancelledError:
+            if session_registered:
+                return await self._handle_cancellation(
+                    session_id=tracker.session_id,
+                    execution_id=exec_id,
+                    messages_processed=0,
+                    start_time=start_time,
+                )
+            await clear_cancellation(tracker.session_id)
+            raise
         except Exception as e:
             self._cleanup_pre_execution_state(
                 exec_id,
@@ -1839,6 +1856,13 @@ class OrchestratorRunner:
                 )
             )
 
+        except asyncio.CancelledError:
+            return await self._handle_cancellation(
+                session_id=tracker.session_id,
+                execution_id=exec_id,
+                messages_processed=messages_processed,
+                start_time=start_time,
+            )
         except Exception as e:
             log.exception(
                 "orchestrator.runner.execute_failed",

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1380,6 +1380,27 @@ class OrchestratorRunner:
             summary = {"terminal_status": terminal_status.value, **self._task_summary()}
             if terminal_status == SessionStatus.CANCELLED:
                 summary["cancelled"] = True
+            try:
+                execution_terminal_events = await self._event_store.query_events(
+                    aggregate_id=execution_id,
+                    event_type="execution.terminal",
+                    limit=1,
+                )
+            except Exception:
+                execution_terminal_events = []
+            if not execution_terminal_events:
+                await self._event_store.append(
+                    create_execution_terminal_event(
+                        execution_id=execution_id,
+                        session_id=session_id,
+                        status=terminal_status.value,
+                        summary=summary if terminal_status == SessionStatus.COMPLETED else None,
+                        error_message=(
+                            final_message if terminal_status != SessionStatus.COMPLETED else None
+                        ),
+                        messages_processed=messages_processed,
+                    )
+                )
             return Result.ok(
                 OrchestratorResult(
                     success=terminal_status == SessionStatus.COMPLETED,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -461,7 +461,9 @@ class OrchestratorRunner:
             execution_id: Execution ID to remove.
             session_id: Session ID to remove.
         """
-        from ouroboros.orchestrator.heartbeat import release as release_lock
+        from ouroboros.orchestrator.heartbeat import (
+            release_if_owned_by_current_process as release_lock,
+        )
 
         self._active_sessions.pop(execution_id, None)
         release_lock(session_id)

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1374,29 +1374,46 @@ class OrchestratorRunner:
         session_result = await self._session_repo.reconstruct_session(session_id)
         _terminal = {SessionStatus.COMPLETED, SessionStatus.FAILED, SessionStatus.CANCELLED}
         session_already_terminal = session_result.is_ok and session_result.value.status in _terminal
-        if not session_already_terminal:
-            cancel_result = await self._session_repo.mark_cancelled(
-                session_id,
-                reason="Cancellation detected during execution",
-                cancelled_by="runner",
-            )
-            if cancel_result is not None and cancel_result.is_err:
-                log.warning(
-                    "orchestrator.runner.mark_cancelled_failed",
+        if session_already_terminal:
+            terminal_status = session_result.value.status
+            final_message = f"Execution already {terminal_status.value}"
+            summary = {"terminal_status": terminal_status.value, **self._task_summary()}
+            if terminal_status == SessionStatus.CANCELLED:
+                summary["cancelled"] = True
+            return Result.ok(
+                OrchestratorResult(
+                    success=terminal_status == SessionStatus.COMPLETED,
                     session_id=session_id,
-                    error=str(cancel_result.error),
-                )
-
-            # Mirror cancellation into execution stream for TUI.
-            await self._event_store.append(
-                create_execution_terminal_event(
                     execution_id=execution_id,
-                    session_id=session_id,
-                    status="cancelled",
-                    error_message="Execution cancelled by external request",
+                    summary=summary,
                     messages_processed=messages_processed,
+                    final_message=final_message,
+                    duration_seconds=duration,
                 )
             )
+
+        cancel_result = await self._session_repo.mark_cancelled(
+            session_id,
+            reason="Cancellation detected during execution",
+            cancelled_by="runner",
+        )
+        if cancel_result is not None and cancel_result.is_err:
+            log.warning(
+                "orchestrator.runner.mark_cancelled_failed",
+                session_id=session_id,
+                error=str(cancel_result.error),
+            )
+
+        # Mirror cancellation into execution stream for TUI.
+        await self._event_store.append(
+            create_execution_terminal_event(
+                execution_id=execution_id,
+                session_id=session_id,
+                status="cancelled",
+                error_message="Execution cancelled by external request",
+                messages_processed=messages_processed,
+            )
+        )
 
         # Display cancellation notice
         self._console.print(

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -65,9 +65,14 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
         await manager.cancel_job(started.job_id)
         await asyncio.wait_for(process.wait(), timeout=5)
         snapshot = await manager.get_snapshot(started.job_id)
+        cancellation_events = await store.query_events(
+            aggregate_id=session_id,
+            event_type="orchestrator.session.cancelled",
+        )
 
         assert process.returncode is not None
         assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+        assert cancellation_events
         assert await is_cancellation_requested(session_id) is False
     finally:
         process = process_holder.get("process")

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -1,0 +1,73 @@
+"""Regression tests for background job cancellation terminating subprocesses."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.persistence.event_store import EventStore
+
+
+def _build_store(tmp_path: Path) -> EventStore:
+    return EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+
+
+@pytest.mark.asyncio
+async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -> None:
+    """Cancelling a linked session job must cancel its runner and child process."""
+    store = _build_store(tmp_path)
+    manager = JobManager(store)
+    process_started = asyncio.Event()
+    process_holder: dict[str, asyncio.subprocess.Process] = {}
+
+    async def _runner() -> MCPToolResult:
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import time; time.sleep(60)",
+        )
+        process_holder["process"] = process
+        process_started.set()
+        try:
+            await process.wait()
+        except asyncio.CancelledError:
+            if process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5)
+                except TimeoutError:
+                    process.kill()
+                    await asyncio.wait_for(process.wait(), timeout=5)
+            raise
+        return MCPToolResult(
+            content=(MCPContentItem(type=ContentType.TEXT, text="finished"),),
+            is_error=False,
+        )
+
+    try:
+        started = await manager.start_job(
+            job_type="linked-session-process",
+            initial_message="queued",
+            runner=_runner(),
+            links=JobLinks(session_id="orch_cancel_123", execution_id="exec_cancel_123"),
+        )
+        await asyncio.wait_for(process_started.wait(), timeout=5)
+        process = process_holder["process"]
+
+        await manager.cancel_job(started.job_id)
+        await asyncio.wait_for(process.wait(), timeout=5)
+        snapshot = await manager.get_snapshot(started.job_id)
+
+        assert process.returncode is not None
+        assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+    finally:
+        process = process_holder.get("process")
+        if process is not None and process.returncode is None:
+            process.kill()
+            await process.wait()
+        await store.close()

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -10,6 +10,7 @@ import pytest
 
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.persistence.event_store import EventStore
 
 
@@ -20,6 +21,8 @@ def _build_store(tmp_path: Path) -> EventStore:
 @pytest.mark.asyncio
 async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -> None:
     """Cancelling a linked session job must cancel its runner and child process."""
+    session_id = "orch_cancel_123"
+    await clear_cancellation(session_id)
     store = _build_store(tmp_path)
     manager = JobManager(store)
     process_started = asyncio.Event()
@@ -54,7 +57,7 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
             job_type="linked-session-process",
             initial_message="queued",
             runner=_runner(),
-            links=JobLinks(session_id="orch_cancel_123", execution_id="exec_cancel_123"),
+            links=JobLinks(session_id=session_id, execution_id="exec_cancel_123"),
         )
         await asyncio.wait_for(process_started.wait(), timeout=5)
         process = process_holder["process"]
@@ -65,9 +68,11 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
 
         assert process.returncode is not None
         assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+        assert await is_cancellation_requested(session_id) is False
     finally:
         process = process_holder.get("process")
         if process is not None and process.returncode is None:
             process.kill()
             await process.wait()
+        await clear_cancellation(session_id)
         await store.close()

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -69,10 +69,16 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
             aggregate_id=session_id,
             event_type="orchestrator.session.cancelled",
         )
+        terminal_events = await store.query_events(
+            aggregate_id="exec_cancel_123",
+            event_type="execution.terminal",
+        )
 
         assert process.returncode is not None
         assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
         assert cancellation_events
+        assert terminal_events
+        assert terminal_events[0].data["status"] == "cancelled"
         assert await is_cancellation_requested(session_id) is False
     finally:
         process = process_holder.get("process")

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -10,6 +10,8 @@ import pytest
 
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
+from ouroboros.orchestrator.heartbeat import release as release_session_lock
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
@@ -63,6 +65,7 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
             session_id=session_id,
         )
         assert create_result.is_ok
+        acquire_session_lock(session_id)
 
         started = await manager.start_job(
             job_type="linked-session-process",
@@ -92,6 +95,7 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
         assert not terminal_events
         assert await is_cancellation_requested(session_id) is True
     finally:
+        release_session_lock(session_id)
         process = process_holder.get("process")
         if process is not None and process.returncode is None:
             process.kill()

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -21,7 +21,7 @@ def _build_store(tmp_path: Path) -> EventStore:
 
 @pytest.mark.asyncio
 async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -> None:
-    """Precreated linked sessions stop local subprocesses without terminalizing sessions."""
+    """Precreated linked sessions stop local subprocesses and persist cancellation."""
     session_id = "orch_cancel_123"
     execution_id = "exec_cancel_123"
     await clear_cancellation(session_id)
@@ -88,8 +88,10 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
 
         assert process.returncode is not None
         assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
-        assert not cancellation_events
-        assert not terminal_events
+        assert cancellation_events
+        assert cancellation_events[-1].data["cancelled_by"] == "mcp_job_manager"
+        assert terminal_events
+        assert terminal_events[-1].data["status"] == "cancelled"
         assert await is_cancellation_requested(session_id) is False
     finally:
         process = process_holder.get("process")

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 from pathlib import Path
+import sys
 
 import pytest
 

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -10,9 +10,8 @@ import pytest
 
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
-from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
-from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
+from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
 
 
@@ -22,10 +21,10 @@ def _build_store(tmp_path: Path) -> EventStore:
 
 @pytest.mark.asyncio
 async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -> None:
-    """Cancelling a linked session job must cancel its runner and child process."""
+    """Started linked sessions may cancel the runner without synthesizing terminal state."""
     session_id = "orch_cancel_123"
+    execution_id = "exec_cancel_123"
     await clear_cancellation(session_id)
-    acquire_session_lock(session_id)
     store = _build_store(tmp_path)
     manager = JobManager(store)
     process_started = asyncio.Event()
@@ -56,34 +55,42 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
         )
 
     try:
+        await store.initialize()
+        repo = SessionRepository(store)
+        create_result = await repo.create_session(
+            execution_id=execution_id,
+            seed_id="seed_cancel_123",
+            session_id=session_id,
+        )
+        assert create_result.is_ok
+
         started = await manager.start_job(
             job_type="linked-session-process",
             initial_message="queued",
             runner=_runner(),
-            links=JobLinks(session_id=session_id, execution_id="exec_cancel_123"),
+            links=JobLinks(session_id=session_id, execution_id=execution_id),
         )
         await asyncio.wait_for(process_started.wait(), timeout=5)
         process = process_holder["process"]
 
         await manager.cancel_job(started.job_id)
         await asyncio.wait_for(process.wait(), timeout=5)
+        await asyncio.sleep(0.05)
         snapshot = await manager.get_snapshot(started.job_id)
         cancellation_events = await store.query_events(
             aggregate_id=session_id,
             event_type="orchestrator.session.cancelled",
         )
         terminal_events = await store.query_events(
-            aggregate_id="exec_cancel_123",
+            aggregate_id=execution_id,
             event_type="execution.terminal",
         )
 
         assert process.returncode is not None
         assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
-        assert cancellation_events
-        assert terminal_events
-        assert terminal_events[0].data["status"] == "cancelled"
-        assert is_holder_alive(session_id) is False
-        assert await is_cancellation_requested(session_id) is False
+        assert not cancellation_events
+        assert not terminal_events
+        assert await is_cancellation_requested(session_id) is True
     finally:
         process = process_holder.get("process")
         if process is not None and process.returncode is None:

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -10,8 +10,6 @@ import pytest
 
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
-from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
-from ouroboros.orchestrator.heartbeat import release as release_session_lock
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
@@ -23,7 +21,7 @@ def _build_store(tmp_path: Path) -> EventStore:
 
 @pytest.mark.asyncio
 async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -> None:
-    """Started linked sessions may cancel the runner without synthesizing terminal state."""
+    """Precreated linked sessions stop local subprocesses without terminalizing sessions."""
     session_id = "orch_cancel_123"
     execution_id = "exec_cancel_123"
     await clear_cancellation(session_id)
@@ -65,7 +63,6 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
             session_id=session_id,
         )
         assert create_result.is_ok
-        acquire_session_lock(session_id)
 
         started = await manager.start_job(
             job_type="linked-session-process",
@@ -93,9 +90,8 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
         assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
         assert not cancellation_events
         assert not terminal_events
-        assert await is_cancellation_requested(session_id) is True
+        assert await is_cancellation_requested(session_id) is False
     finally:
-        release_session_lock(session_id)
         process = process_holder.get("process")
         if process is not None and process.returncode is None:
             process.kill()

--- a/tests/integration/test_cancel_subprocess_termination.py
+++ b/tests/integration/test_cancel_subprocess_termination.py
@@ -10,6 +10,8 @@ import pytest
 
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
+from ouroboros.orchestrator.heartbeat import is_holder_alive
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.persistence.event_store import EventStore
 
@@ -23,6 +25,7 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
     """Cancelling a linked session job must cancel its runner and child process."""
     session_id = "orch_cancel_123"
     await clear_cancellation(session_id)
+    acquire_session_lock(session_id)
     store = _build_store(tmp_path)
     manager = JobManager(store)
     process_started = asyncio.Event()
@@ -79,6 +82,7 @@ async def test_cancel_job_terminates_linked_session_subprocess(tmp_path: Path) -
         assert cancellation_events
         assert terminal_events
         assert terminal_events[0].data["status"] == "cancelled"
+        assert is_holder_alive(session_id) is False
         assert await is_cancellation_requested(session_id) is False
     finally:
         process = process_holder.get("process")

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -160,14 +160,24 @@ class TestJobManager:
         finally:
             await store.close()
 
-    async def test_cancel_job_skips_linked_session_already_terminal(self, tmp_path) -> None:
+    async def test_cancel_job_stops_task_when_linked_session_already_terminal(
+        self, tmp_path
+    ) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
+        session_id = "orch_terminal_123"
+        execution_id = "exec_terminal_123"
+        await clear_cancellation(session_id)
+        runner_cancelled = asyncio.Event()
 
         try:
 
             async def _runner() -> MCPToolResult:
-                await asyncio.sleep(10)
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    runner_cancelled.set()
+                    raise
                 return MCPToolResult(
                     content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
                     is_error=False,
@@ -177,25 +187,29 @@ class TestJobManager:
                 job_type="terminal-session-race",
                 initial_message="queued",
                 runner=_runner(),
-                links=JobLinks(session_id="orch_terminal_123", execution_id="exec_terminal_123"),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
             )
             repo = SessionRepository(store)
-            mark_result = await repo.mark_completed("orch_terminal_123")
+            mark_result = await repo.mark_completed(session_id)
             assert mark_result.is_ok
 
-            await manager.cancel_job(started.job_id)
+            snapshot = await manager.cancel_job(started.job_id)
+            await asyncio.wait_for(runner_cancelled.wait(), timeout=1)
             session_cancelled = await store.query_events(
-                aggregate_id="orch_terminal_123",
+                aggregate_id=session_id,
                 event_type="orchestrator.session.cancelled",
             )
             execution_cancelled = await store.query_events(
-                aggregate_id="exec_terminal_123",
+                aggregate_id=execution_id,
                 event_type="execution.terminal",
             )
 
+            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert await is_cancellation_requested(session_id) is False
             assert not session_cancelled
             assert not any(event.data.get("status") == "cancelled" for event in execution_cancelled)
         finally:
+            await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()
 
@@ -223,6 +237,7 @@ class TestJobManager:
                 runner=_runner(),
                 links=JobLinks(session_id=session_id, execution_id=execution_id),
             )
+            runner_task = manager._runner_tasks[started.job_id]
 
             snapshot = await manager.cancel_job(started.job_id)
             session_cancelled = await store.query_events(
@@ -233,13 +248,13 @@ class TestJobManager:
                 aggregate_id=execution_id,
                 event_type="execution.terminal",
             )
-            runner_task = manager._runner_tasks[started.job_id]
+            await asyncio.sleep(0)
 
             assert snapshot.status == JobStatus.CANCEL_REQUESTED
-            assert await is_cancellation_requested(session_id) is True
+            assert await is_cancellation_requested(session_id) is False
             assert not session_cancelled
             assert not terminal_events
-            assert runner_task.done() is False
+            assert runner_task.done() is True
         finally:
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -225,6 +225,7 @@ class TestJobManager:
         session_id = "orch_pending_123"
         execution_id = "exec_pending_123"
         await clear_cancellation(session_id)
+        lock_path(session_id).unlink(missing_ok=True)
 
         try:
 
@@ -413,6 +414,15 @@ class TestJobManager:
         await clear_cancellation(session_id)
 
         try:
+            await store.initialize()
+            repo = SessionRepository(store)
+            create_result = await repo.create_session(
+                execution_id=execution_id,
+                seed_id="seed_inspection_fail_123",
+                session_id=session_id,
+            )
+            assert create_result.is_ok
+            lock_path(session_id).write_text("1")
 
             async def _runner() -> MCPToolResult:
                 await asyncio.sleep(10)
@@ -436,11 +446,17 @@ class TestJobManager:
             ):
                 snapshot = await manager.cancel_job(started.job_id)
             await asyncio.sleep(0)
+            session_cancelled = await store.query_events(
+                aggregate_id=session_id,
+                event_type="orchestrator.session.cancelled",
+            )
 
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert runner_task.done() is True
-            assert await is_cancellation_requested(session_id) is False
+            assert await is_cancellation_requested(session_id) is True
+            assert not session_cancelled
         finally:
+            lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -302,10 +302,20 @@ class TestJobManager:
 
             snapshot = await manager.cancel_job(started.job_id)
             await asyncio.sleep(0)
+            session_cancelled = await store.query_events(
+                aggregate_id=session_id,
+                event_type="orchestrator.session.cancelled",
+            )
+            execution_cancelled = await store.query_events(
+                aggregate_id=execution_id,
+                event_type="execution.terminal",
+            )
 
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert await is_cancellation_requested(session_id) is False
             assert runner_task.done() is True
+            assert session_cancelled
+            assert execution_cancelled[-1].data["status"] == "cancelled"
         finally:
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -353,7 +353,7 @@ class TestJobManager:
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert await is_cancellation_requested(session_id) is True
         finally:
-            release_session_lock(session_id)
+            lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()
@@ -406,7 +406,7 @@ class TestJobManager:
             assert execution_cancelled
             assert execution_cancelled[-1].data["status"] == "cancelled"
         finally:
-            lock_path(session_id).unlink(missing_ok=True)
+            release_session_lock(session_id)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()
@@ -470,7 +470,7 @@ class TestJobManager:
             assert execution_cancelled
             assert execution_cancelled[-1].data["status"] == "cancelled"
         finally:
-            lock_path(session_id).unlink(missing_ok=True)
+            release_session_lock(session_id)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()
@@ -533,10 +533,8 @@ class TestJobManager:
             assert await is_cancellation_requested(session_id) is True
             assert runner_cancelled.is_set() is True
             assert runner_task.done() is True
-            assert session_cancelled
-            assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
-            assert terminal_events
-            assert terminal_events[-1].data["status"] == "cancelled"
+            assert not session_cancelled
+            assert not terminal_events
         finally:
             release_session_lock(session_id)
             await clear_cancellation(session_id)
@@ -562,7 +560,7 @@ class TestJobManager:
                 session_id=session_id,
             )
             assert create_result.is_ok
-            acquire_session_lock(session_id)
+            lock_path(session_id).write_text("1")
 
             async def _runner() -> MCPToolResult:
                 try:
@@ -595,7 +593,7 @@ class TestJobManager:
 
             assert runner_cancelled.is_set() is True
         finally:
-            release_session_lock(session_id)
+            lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock, patch
 
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
@@ -10,7 +11,7 @@ from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
 from ouroboros.orchestrator.heartbeat import release as release_session_lock
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.orchestrator.session import SessionRepository
-from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.event_store import EventStore, PersistenceError
 
 
 def _build_store(tmp_path) -> EventStore:
@@ -302,6 +303,48 @@ class TestJobManager:
             assert snapshot.status == JobStatus.CANCEL_REQUESTED
             assert await is_cancellation_requested(session_id) is False
             assert runner_task.done() is True
+        finally:
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_stops_task_when_linked_session_inspection_fails(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_inspection_fail_123"
+        execution_id = "exec_inspection_fail_123"
+        await clear_cancellation(session_id)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                await asyncio.sleep(10)
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="inspection-fail-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+            runner_task = manager._runner_tasks[started.job_id]
+
+            with patch.object(
+                store,
+                "query_events",
+                new=AsyncMock(side_effect=PersistenceError("query failed")),
+            ):
+                snapshot = await manager.cancel_job(started.job_id)
+            await asyncio.sleep(0)
+
+            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert runner_task.done() is True
+            assert await is_cancellation_requested(session_id) is False
         finally:
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore, PersistenceError
 
 
@@ -158,6 +159,45 @@ class TestJobManager:
             assert not session_cancelled
             assert not any(event.data.get("status") == "cancelled" for event in execution_cancelled)
         finally:
+            await store.close()
+
+    async def test_cancel_job_skips_linked_session_already_terminal(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                await asyncio.sleep(10)
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="terminal-session-race",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_terminal_123", execution_id="exec_terminal_123"),
+            )
+            repo = SessionRepository(store)
+            mark_result = await repo.mark_completed("orch_terminal_123")
+            assert mark_result.is_ok
+
+            await manager.cancel_job(started.job_id)
+            session_cancelled = await store.query_events(
+                aggregate_id="orch_terminal_123",
+                event_type="orchestrator.session.cancelled",
+            )
+            execution_cancelled = await store.query_events(
+                aggregate_id="exec_terminal_123",
+                event_type="execution.terminal",
+            )
+
+            assert not session_cancelled
+            assert not any(event.data.get("status") == "cancelled" for event in execution_cancelled)
+        finally:
+            await _cancel_manager_tasks(manager)
             await store.close()
 
     async def test_cancel_job_errors_when_linked_session_cancel_persist_fails(

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -411,6 +411,52 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_cancel_job_persists_cross_process_cancel_when_reconstruct_fails(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_reconstruct_fail_123"
+        execution_id = "exec_reconstruct_fail_123"
+        await clear_cancellation(session_id)
+
+        try:
+            await store.initialize()
+            lock_path(session_id).write_text("1")
+
+            async def _runner() -> MCPToolResult:
+                await asyncio.sleep(10)
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="reconstruct-fail-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+
+            with patch(
+                "ouroboros.mcp.job_manager.SessionRepository.reconstruct_session",
+                new=AsyncMock(return_value=Result.err(PersistenceError("replay failed"))),
+            ):
+                snapshot = await manager.cancel_job(started.job_id)
+            session_cancelled = await store.query_events(
+                aggregate_id=session_id,
+                event_type="orchestrator.session.cancelled",
+            )
+
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+            assert session_cancelled
+            assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
+        finally:
+            lock_path(session_id).unlink(missing_ok=True)
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_cancel_job_stops_task_when_linked_session_inspection_fails(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -421,7 +421,7 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_cancel_job_persists_cross_process_cancel_when_reconstruct_fails(
+    async def test_cancel_job_does_not_persist_cross_process_cancel_when_reconstruct_fails(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -429,13 +429,18 @@ class TestJobManager:
         session_id = "orch_reconstruct_fail_123"
         execution_id = "exec_reconstruct_fail_123"
         await clear_cancellation(session_id)
+        runner_cancelled = asyncio.Event()
 
         try:
             await store.initialize()
             lock_path(session_id).write_text("1")
 
             async def _runner() -> MCPToolResult:
-                await asyncio.sleep(10)
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    runner_cancelled.set()
+                    raise
                 return MCPToolResult(
                     content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
                     is_error=False,
@@ -459,8 +464,86 @@ class TestJobManager:
             )
 
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
-            assert session_cancelled
-            assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
+            assert runner_cancelled.is_set() is True
+            assert not session_cancelled
+        finally:
+            lock_path(session_id).unlink(missing_ok=True)
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_errors_before_persist_when_latest_reconstruct_fails(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_latest_reconstruct_fail_123"
+        execution_id = "exec_latest_reconstruct_fail_123"
+        await clear_cancellation(session_id)
+        runner_cancelled = asyncio.Event()
+
+        try:
+            await store.initialize()
+            repo = SessionRepository(store)
+            create_result = await repo.create_session(
+                execution_id=execution_id,
+                seed_id="seed_latest_reconstruct_fail_123",
+                session_id=session_id,
+            )
+            assert create_result.is_ok
+            lock_path(session_id).write_text("1")
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    runner_cancelled.set()
+                    raise
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="latest-reconstruct-fail-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+
+            original_reconstruct = SessionRepository.reconstruct_session
+            call_count = 0
+
+            async def _reconstruct_once_then_fail(self, target_session_id):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return await original_reconstruct(self, target_session_id)
+                return Result.err(PersistenceError("replay failed"))
+
+            with patch(
+                "ouroboros.mcp.job_manager.SessionRepository.reconstruct_session",
+                new=_reconstruct_once_then_fail,
+            ):
+                try:
+                    await manager.cancel_job(started.job_id)
+                except ValueError as exc:
+                    assert "Failed to inspect linked session before cancellation" in str(exc)
+                else:
+                    raise AssertionError("cancel_job should fail when latest inspect fails")
+
+            session_cancelled = await store.query_events(
+                aggregate_id=session_id,
+                event_type="orchestrator.session.cancelled",
+            )
+            execution_cancelled = await store.query_events(
+                aggregate_id=execution_id,
+                event_type="execution.terminal",
+            )
+
+            assert runner_cancelled.is_set() is True
+            assert not session_cancelled
+            assert not execution_cancelled
         finally:
             lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -441,7 +441,7 @@ class TestJobManager:
             runner_task = manager._runner_tasks[started.job_id]
 
             snapshot = await manager.cancel_job(started.job_id)
-            await asyncio.sleep(0.05)
+            await asyncio.wait_for(runner_cancelled.wait(), timeout=1)
             session_cancelled = await store.query_events(
                 aggregate_id=session_id,
                 event_type="orchestrator.session.cancelled",
@@ -453,8 +453,8 @@ class TestJobManager:
 
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert await is_cancellation_requested(session_id) is True
-            assert runner_cancelled.is_set() is False
-            assert runner_task.done() is False
+            assert runner_cancelled.is_set() is True
+            assert runner_task.done() is True
             assert not session_cancelled
             assert not terminal_events
         finally:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -207,7 +207,7 @@ class TestJobManager:
                 event_type="execution.terminal",
             )
 
-            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert await is_cancellation_requested(session_id) is False
             assert not session_cancelled
             assert not any(event.data.get("status") == "cancelled" for event in execution_cancelled)
@@ -253,7 +253,7 @@ class TestJobManager:
             )
             await asyncio.sleep(0)
 
-            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert await is_cancellation_requested(session_id) is False
             assert not session_cancelled
             assert not terminal_events
@@ -300,10 +300,57 @@ class TestJobManager:
             snapshot = await manager.cancel_job(started.job_id)
             await asyncio.sleep(0)
 
-            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert await is_cancellation_requested(session_id) is False
             assert runner_task.done() is True
         finally:
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_preserves_signal_when_runner_starts_during_cancel(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_start_race_123"
+        execution_id = "exec_start_race_123"
+        await clear_cancellation(session_id)
+
+        try:
+            await store.initialize()
+            repo = SessionRepository(store)
+            create_result = await repo.create_session(
+                execution_id=execution_id,
+                seed_id="seed_start_race_123",
+                session_id=session_id,
+            )
+            assert create_result.is_ok
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    acquire_session_lock(session_id)
+                    raise
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="start-race-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+
+            snapshot = await manager.cancel_job(started.job_id)
+
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+            assert await is_cancellation_requested(session_id) is True
+        finally:
+            release_session_lock(session_id)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()
@@ -342,7 +389,7 @@ class TestJobManager:
                 snapshot = await manager.cancel_job(started.job_id)
             await asyncio.sleep(0)
 
-            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert runner_task.done() is True
             assert await is_cancellation_requested(session_id) is False
         finally:
@@ -404,7 +451,7 @@ class TestJobManager:
                 event_type="execution.terminal",
             )
 
-            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert await is_cancellation_requested(session_id) is True
             assert runner_cancelled.is_set() is False
             assert runner_task.done() is False

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -454,7 +454,8 @@ class TestJobManager:
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert runner_task.done() is True
             assert await is_cancellation_requested(session_id) is True
-            assert not session_cancelled
+            assert session_cancelled
+            assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
         finally:
             lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)
@@ -519,7 +520,8 @@ class TestJobManager:
             assert await is_cancellation_requested(session_id) is True
             assert runner_cancelled.is_set() is True
             assert runner_task.done() is True
-            assert not session_cancelled
+            assert session_cancelled
+            assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
             assert not terminal_events
         finally:
             release_session_lock(session_id)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -394,10 +394,16 @@ class TestJobManager:
                 aggregate_id=session_id,
                 event_type="orchestrator.session.cancelled",
             )
+            execution_cancelled = await store.query_events(
+                aggregate_id=execution_id,
+                event_type="execution.terminal",
+            )
 
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert session_cancelled
             assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
+            assert execution_cancelled
+            assert execution_cancelled[-1].data["status"] == "cancelled"
         finally:
             lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)
@@ -450,12 +456,18 @@ class TestJobManager:
                 aggregate_id=session_id,
                 event_type="orchestrator.session.cancelled",
             )
+            execution_cancelled = await store.query_events(
+                aggregate_id=execution_id,
+                event_type="execution.terminal",
+            )
 
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
             assert runner_task.done() is True
             assert await is_cancellation_requested(session_id) is True
             assert session_cancelled
             assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
+            assert execution_cancelled
+            assert execution_cancelled[-1].data["status"] == "cancelled"
         finally:
             lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)
@@ -522,7 +534,8 @@ class TestJobManager:
             assert runner_task.done() is True
             assert session_cancelled
             assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
-            assert not terminal_events
+            assert terminal_events
+            assert terminal_events[-1].data["status"] == "cancelled"
         finally:
             release_session_lock(session_id)
             await clear_cancellation(session_id)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, patch
 
+from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
@@ -536,6 +537,63 @@ class TestJobManager:
             assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
             assert terminal_events
             assert terminal_events[-1].data["status"] == "cancelled"
+        finally:
+            release_session_lock(session_id)
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_stops_task_when_persisting_linked_cancel_fails(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_mark_fail_123"
+        execution_id = "exec_mark_fail_123"
+        await clear_cancellation(session_id)
+        runner_cancelled = asyncio.Event()
+
+        try:
+            await store.initialize()
+            repo = SessionRepository(store)
+            create_result = await repo.create_session(
+                execution_id=execution_id,
+                seed_id="seed_mark_fail_123",
+                session_id=session_id,
+            )
+            assert create_result.is_ok
+            acquire_session_lock(session_id)
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    runner_cancelled.set()
+                    raise
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="mark-fail-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+
+            with patch(
+                "ouroboros.mcp.job_manager.SessionRepository.mark_cancelled",
+                new=AsyncMock(return_value=Result.err(PersistenceError("write failed"))),
+            ):
+                try:
+                    await manager.cancel_job(started.job_id)
+                except ValueError as exc:
+                    assert "Failed to mark linked session cancelled" in str(exc)
+                else:
+                    raise AssertionError("cancel_job should fail when session cancel does")
+
+            assert runner_cancelled.is_set() is True
         finally:
             release_session_lock(session_id)
             await clear_cancellation(session_id)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
+from ouroboros.orchestrator.heartbeat import lock_path
 from ouroboros.orchestrator.heartbeat import release as release_session_lock
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.orchestrator.session import SessionRepository
@@ -351,6 +352,53 @@ class TestJobManager:
             assert await is_cancellation_requested(session_id) is True
         finally:
             release_session_lock(session_id)
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_persists_cross_process_linked_cancellation(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_cross_process_123"
+        execution_id = "exec_cross_process_123"
+        await clear_cancellation(session_id)
+
+        try:
+            await store.initialize()
+            repo = SessionRepository(store)
+            create_result = await repo.create_session(
+                execution_id=execution_id,
+                seed_id="seed_cross_process_123",
+                session_id=session_id,
+            )
+            assert create_result.is_ok
+            lock_path(session_id).write_text("1")
+
+            async def _runner() -> MCPToolResult:
+                await asyncio.sleep(10)
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="cross-process-session-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+
+            snapshot = await manager.cancel_job(started.job_id)
+            session_cancelled = await store.query_events(
+                aggregate_id=session_id,
+                event_type="orchestrator.session.cancelled",
+            )
+
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+            assert session_cancelled
+            assert session_cancelled[-1].data["cancelled_by"] == "mcp_job_manager"
+        finally:
+            lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -105,3 +105,42 @@ class TestJobManager:
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
         finally:
             await store.close()
+
+    async def test_cancel_job_does_not_mark_linked_session_when_task_already_done(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="done"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="race-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_done_123", execution_id="exec_done_123"),
+            )
+            task = manager._tasks[started.job_id]
+            await task
+
+            snapshot = await manager.cancel_job(started.job_id)
+            session_cancelled = await store.query_events(
+                aggregate_id="orch_done_123",
+                event_type="orchestrator.session.cancelled",
+            )
+            execution_cancelled = await store.query_events(
+                aggregate_id="exec_done_123",
+                event_type="execution.terminal",
+            )
+
+            assert snapshot.is_terminal
+            assert not session_cancelled
+            assert not any(event.data.get("status") == "cancelled" for event in execution_cancelled)
+        finally:
+            await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock, patch
 
+from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
-from ouroboros.persistence.event_store import EventStore
+from ouroboros.persistence.event_store import EventStore, PersistenceError
 
 
 def _build_store(tmp_path) -> EventStore:
@@ -142,5 +144,47 @@ class TestJobManager:
             assert snapshot.is_terminal
             assert not session_cancelled
             assert not any(event.data.get("status") == "cancelled" for event in execution_cancelled)
+        finally:
+            await store.close()
+
+    async def test_cancel_job_errors_when_linked_session_cancel_persist_fails(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                await asyncio.sleep(10)
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="persist-fail-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_fail_123", execution_id="exec_fail_123"),
+            )
+
+            failed = Result.err(PersistenceError("write failed"))
+            with patch(
+                "ouroboros.mcp.job_manager.SessionRepository.mark_cancelled",
+                new=AsyncMock(return_value=failed),
+            ):
+                try:
+                    await manager.cancel_job(started.job_id)
+                except ValueError as exc:
+                    assert "Failed to mark linked session cancelled" in str(exc)
+                else:
+                    raise AssertionError("cancel_job should fail when session cancel does")
+
+            terminal_events = await store.query_events(
+                aggregate_id="exec_fail_123",
+                event_type="execution.terminal",
+            )
+            assert not terminal_events
         finally:
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -350,7 +350,9 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_cancel_job_cancels_started_linked_runner_task(self, tmp_path) -> None:
+    async def test_cancel_job_requests_cancellation_for_started_linked_runner(
+        self, tmp_path
+    ) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
         session_id = "orch_started_123"
@@ -389,9 +391,10 @@ class TestJobManager:
                 runner=_runner(),
                 links=JobLinks(session_id=session_id, execution_id=execution_id),
             )
+            runner_task = manager._runner_tasks[started.job_id]
 
             snapshot = await manager.cancel_job(started.job_id)
-            await asyncio.wait_for(runner_cancelled.wait(), timeout=1)
+            await asyncio.sleep(0.05)
             session_cancelled = await store.query_events(
                 aggregate_id=session_id,
                 event_type="orchestrator.session.cancelled",
@@ -403,6 +406,8 @@ class TestJobManager:
 
             assert snapshot.status == JobStatus.CANCEL_REQUESTED
             assert await is_cancellation_requested(session_id) is True
+            assert runner_cancelled.is_set() is False
+            assert runner_task.done() is False
             assert not session_cancelled
             assert not terminal_events
         finally:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -6,6 +6,8 @@ import asyncio
 
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
+from ouroboros.orchestrator.heartbeat import release as release_session_lock
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
@@ -260,6 +262,51 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_cancel_job_clears_precreated_unstarted_session_cancellation(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_precreated_123"
+        execution_id = "exec_precreated_123"
+        await clear_cancellation(session_id)
+
+        try:
+            await store.initialize()
+            repo = SessionRepository(store)
+            create_result = await repo.create_session(
+                execution_id=execution_id,
+                seed_id="seed_precreated_123",
+                session_id=session_id,
+            )
+            assert create_result.is_ok
+
+            async def _runner() -> MCPToolResult:
+                await asyncio.sleep(10)
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="precreated-session-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+            runner_task = manager._runner_tasks[started.job_id]
+
+            snapshot = await manager.cancel_job(started.job_id)
+            await asyncio.sleep(0)
+
+            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert await is_cancellation_requested(session_id) is False
+            assert runner_task.done() is True
+        finally:
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_cancel_job_cancels_started_linked_runner_task(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
@@ -277,6 +324,7 @@ class TestJobManager:
                 session_id=session_id,
             )
             assert create_result.is_ok
+            acquire_session_lock(session_id)
 
             async def _runner() -> MCPToolResult:
                 try:
@@ -315,6 +363,7 @@ class TestJobManager:
             assert not session_cancelled
             assert not terminal_events
         finally:
+            release_session_lock(session_id)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -16,6 +16,19 @@ def _build_store(tmp_path) -> EventStore:
     return EventStore(f"sqlite+aiosqlite:///{db_path}")
 
 
+async def _cancel_manager_tasks(manager: JobManager) -> None:
+    tasks = [
+        *manager._tasks.values(),
+        *manager._runner_tasks.values(),
+        *manager._monitors.values(),
+    ]
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
 class TestJobManager:
     """Test background job lifecycle behavior."""
 
@@ -187,4 +200,5 @@ class TestJobManager:
             )
             assert not terminal_events
         finally:
+            await _cancel_manager_tasks(manager)
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
 
-from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.orchestrator.session import SessionRepository
-from ouroboros.persistence.event_store import EventStore, PersistenceError
+from ouroboros.persistence.event_store import EventStore
 
 
 def _build_store(tmp_path) -> EventStore:
@@ -200,11 +199,14 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_cancel_job_errors_when_linked_session_cancel_persist_fails(
+    async def test_cancel_job_requests_linked_session_cancellation_without_start_event(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
+        session_id = "orch_pending_123"
+        execution_id = "exec_pending_123"
+        await clear_cancellation(session_id)
 
         try:
 
@@ -216,29 +218,88 @@ class TestJobManager:
                 )
 
             started = await manager.start_job(
-                job_type="persist-fail-test",
+                job_type="pending-session-test",
                 initial_message="queued",
                 runner=_runner(),
-                links=JobLinks(session_id="orch_fail_123", execution_id="exec_fail_123"),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
             )
 
-            failed = Result.err(PersistenceError("write failed"))
-            with patch(
-                "ouroboros.mcp.job_manager.SessionRepository.mark_cancelled",
-                new=AsyncMock(return_value=failed),
-            ):
-                try:
-                    await manager.cancel_job(started.job_id)
-                except ValueError as exc:
-                    assert "Failed to mark linked session cancelled" in str(exc)
-                else:
-                    raise AssertionError("cancel_job should fail when session cancel does")
-
+            snapshot = await manager.cancel_job(started.job_id)
+            session_cancelled = await store.query_events(
+                aggregate_id=session_id,
+                event_type="orchestrator.session.cancelled",
+            )
             terminal_events = await store.query_events(
-                aggregate_id="exec_fail_123",
+                aggregate_id=execution_id,
                 event_type="execution.terminal",
             )
+            runner_task = manager._runner_tasks[started.job_id]
+
+            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert await is_cancellation_requested(session_id) is True
+            assert not session_cancelled
+            assert not terminal_events
+            assert runner_task.done() is False
+        finally:
+            await clear_cancellation(session_id)
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_cancels_started_linked_runner_task(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        session_id = "orch_started_123"
+        execution_id = "exec_started_123"
+        await clear_cancellation(session_id)
+        runner_cancelled = asyncio.Event()
+
+        try:
+            await store.initialize()
+            repo = SessionRepository(store)
+            create_result = await repo.create_session(
+                execution_id=execution_id,
+                seed_id="seed_started_123",
+                session_id=session_id,
+            )
+            assert create_result.is_ok
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    runner_cancelled.set()
+                    return MCPToolResult(
+                        content=(MCPContentItem(type=ContentType.TEXT, text="cancelled"),),
+                        is_error=False,
+                    )
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="started-session-test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id=session_id, execution_id=execution_id),
+            )
+
+            snapshot = await manager.cancel_job(started.job_id)
+            await asyncio.wait_for(runner_cancelled.wait(), timeout=1)
+            session_cancelled = await store.query_events(
+                aggregate_id=session_id,
+                event_type="orchestrator.session.cancelled",
+            )
+            terminal_events = await store.query_events(
+                aggregate_id=execution_id,
+                event_type="execution.terminal",
+            )
+
+            assert snapshot.status == JobStatus.CANCEL_REQUESTED
+            assert await is_cancellation_requested(session_id) is True
+            assert not session_cancelled
             assert not terminal_events
         finally:
+            await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
             await store.close()

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -727,6 +727,7 @@ class TestInFlightCancellationGraceful:
                 )
             )
             await asyncio.wait_for(stream_started.wait(), timeout=1)
+            await request_cancellation("sess_task_cancel")
             task.cancel()
             result = await asyncio.wait_for(task, timeout=1)
 
@@ -788,6 +789,7 @@ class TestInFlightCancellationGraceful:
                 )
             )
             await asyncio.wait_for(stream_started.wait(), timeout=1)
+            await request_cancellation("sess_terminal_cancel")
             task.cancel()
             result = await asyncio.wait_for(task, timeout=1)
 
@@ -804,6 +806,62 @@ class TestInFlightCancellationGraceful:
         assert not [event for event in terminal_events if event.data.get("status") == "cancelled"]
         assert terminal_events
         assert terminal_events[-1].data["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_task_cancellation_without_request_propagates_without_terminalizing(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        sample_seed: Any,
+    ) -> None:
+        """Unrelated task cancellation does not mutate session terminal state."""
+        stream_started = asyncio.Event()
+        tracker = SessionTracker.create(
+            "exec_unrequested_cancel",
+            sample_seed.metadata.seed_id,
+            session_id="sess_unrequested_cancel",
+        )
+
+        async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            stream_started.set()
+            await asyncio.sleep(10)
+            yield AgentMessage(type="result", content="Done", data={"subtype": "success"})
+
+        mock_adapter.execute_task = mock_execute
+
+        with (
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                new=AsyncMock(return_value=Result.ok(tracker)),
+            ),
+            patch.object(
+                runner._session_repo,
+                "mark_cancelled",
+                new=AsyncMock(return_value=Result.ok(None)),
+            ) as mark_cancelled_mock,
+        ):
+            task = asyncio.create_task(
+                runner.execute_precreated_session(
+                    sample_seed,
+                    tracker,
+                    parallel=False,
+                )
+            )
+            await asyncio.wait_for(stream_started.wait(), timeout=1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout=1)
+
+        assert "exec_unrequested_cancel" not in runner.active_sessions
+        mark_cancelled_mock.assert_not_awaited()
+        terminal_events = [
+            call.args[0]
+            for call in mock_event_store.append.await_args_list
+            if call.args and getattr(call.args[0], "type", "") == "execution.terminal"
+        ]
+        assert not terminal_events
 
     @pytest.mark.asyncio
     async def test_cancellation_mid_stream_preserves_partial_results(

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -30,7 +30,7 @@ from ouroboros.orchestrator.runner import (
     is_cancellation_requested,
     request_cancellation,
 )
-from ouroboros.orchestrator.session import SessionTracker
+from ouroboros.orchestrator.session import SessionStatus, SessionTracker
 
 # =============================================================================
 # Fixtures
@@ -743,6 +743,63 @@ class TestInFlightCancellationGraceful:
         ]
         assert terminal_events
         assert terminal_events[-1].data["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_task_cancellation_preserves_existing_terminal_execution_state(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        sample_seed: Any,
+    ) -> None:
+        """Cancelling the wrapper after session terminal state does not emit cancelled terminal."""
+        stream_started = asyncio.Event()
+        tracker = SessionTracker.create(
+            "exec_terminal_cancel",
+            sample_seed.metadata.seed_id,
+            session_id="sess_terminal_cancel",
+        )
+        completed_tracker = tracker.with_status(SessionStatus.COMPLETED)
+
+        async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            stream_started.set()
+            await asyncio.sleep(10)
+            yield AgentMessage(type="result", content="Done", data={"subtype": "success"})
+
+        mock_adapter.execute_task = mock_execute
+
+        with (
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                new=AsyncMock(return_value=Result.ok(completed_tracker)),
+            ),
+            patch.object(
+                runner._session_repo,
+                "mark_cancelled",
+                new=AsyncMock(return_value=Result.ok(None)),
+            ) as mark_cancelled_mock,
+        ):
+            task = asyncio.create_task(
+                runner.execute_precreated_session(
+                    sample_seed,
+                    tracker,
+                    parallel=False,
+                )
+            )
+            await asyncio.wait_for(stream_started.wait(), timeout=1)
+            task.cancel()
+            result = await asyncio.wait_for(task, timeout=1)
+
+        assert result.is_ok
+        assert result.value.success is False
+        mark_cancelled_mock.assert_not_awaited()
+        terminal_events = [
+            call.args[0]
+            for call in mock_event_store.append.await_args_list
+            if call.args and getattr(call.args[0], "type", "") == "execution.terminal"
+        ]
+        assert not [event for event in terminal_events if event.data.get("status") == "cancelled"]
 
     @pytest.mark.asyncio
     async def test_cancellation_mid_stream_preserves_partial_results(

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -792,7 +792,9 @@ class TestInFlightCancellationGraceful:
             result = await asyncio.wait_for(task, timeout=1)
 
         assert result.is_ok
-        assert result.value.success is False
+        assert result.value.success is True
+        assert result.value.summary["terminal_status"] == "completed"
+        assert "cancelled" not in result.value.summary
         mark_cancelled_mock.assert_not_awaited()
         terminal_events = [
             call.args[0]

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -802,6 +802,8 @@ class TestInFlightCancellationGraceful:
             if call.args and getattr(call.args[0], "type", "") == "execution.terminal"
         ]
         assert not [event for event in terminal_events if event.data.get("status") == "cancelled"]
+        assert terminal_events
+        assert terminal_events[-1].data["status"] == "completed"
 
     @pytest.mark.asyncio
     async def test_cancellation_mid_stream_preserves_partial_results(

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -685,6 +685,66 @@ class TestInFlightCancellationGraceful:
         assert "exec_unreg" not in runner.active_sessions
 
     @pytest.mark.asyncio
+    async def test_task_cancellation_uses_runner_cleanup(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        sample_seed: Any,
+    ) -> None:
+        """Async task cancellation follows the same cleanup path as cooperative cancel."""
+        stream_started = asyncio.Event()
+        tracker = SessionTracker.create(
+            "exec_task_cancel",
+            sample_seed.metadata.seed_id,
+            session_id="sess_task_cancel",
+        )
+
+        async def mock_execute(*args: Any, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            stream_started.set()
+            await asyncio.sleep(10)
+            yield AgentMessage(type="result", content="Done", data={"subtype": "success"})
+
+        mock_adapter.execute_task = mock_execute
+
+        with (
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                new=AsyncMock(return_value=Result.ok(tracker)),
+            ),
+            patch.object(
+                runner._session_repo,
+                "mark_cancelled",
+                new=AsyncMock(return_value=Result.ok(None)),
+            ) as mark_cancelled_mock,
+        ):
+            task = asyncio.create_task(
+                runner.execute_precreated_session(
+                    sample_seed,
+                    tracker,
+                    parallel=False,
+                )
+            )
+            await asyncio.wait_for(stream_started.wait(), timeout=1)
+            task.cancel()
+            result = await asyncio.wait_for(task, timeout=1)
+
+        assert result.is_ok
+        assert result.value.success is False
+        assert result.value.summary["cancelled"] is True
+        assert "exec_task_cancel" not in runner.active_sessions
+        assert await is_cancellation_requested("sess_task_cancel") is False
+        mark_cancelled_mock.assert_awaited_once()
+        terminal_events = [
+            call.args[0]
+            for call in mock_event_store.append.await_args_list
+            if call.args and getattr(call.args[0], "type", "") == "execution.terminal"
+        ]
+        assert terminal_events
+        assert terminal_events[-1].data["status"] == "cancelled"
+
+    @pytest.mark.asyncio
     async def test_cancellation_mid_stream_preserves_partial_results(
         self,
         runner: OrchestratorRunner,

--- a/tests/unit/orchestrator/test_inflight_cancellation.py
+++ b/tests/unit/orchestrator/test_inflight_cancellation.py
@@ -746,6 +746,23 @@ class TestInFlightCancellationGraceful:
         assert terminal_events[-1].data["status"] == "cancelled"
 
     @pytest.mark.asyncio
+    async def test_startup_cancellation_checks_persisted_events(
+        self,
+        runner: OrchestratorRunner,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Startup cancellation sees cross-process persisted cancel events."""
+        from ouroboros.orchestrator.events import create_session_cancelled_event
+
+        mock_event_store.query_events = AsyncMock(
+            return_value=[
+                create_session_cancelled_event("sess_startup_cancel", "Cancelled elsewhere")
+            ]
+        )
+
+        assert await runner._check_startup_cancellation("sess_startup_cancel") is True
+
+    @pytest.mark.asyncio
     async def test_task_cancellation_preserves_existing_terminal_execution_state(
         self,
         runner: OrchestratorRunner,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2672,9 +2672,10 @@ class TestCancellationPolling:
 
         mock_adapter.execute_task = mock_execute
 
-        # Return no cancellation initially, then return a cancellation event
+        # Return no cancellation at startup, then return a cancellation event
+        # at the first periodic message-loop checkpoint.
         cancel_event = create_session_cancelled_event("session_123", "User requested")
-        mock_event_store.query_events = AsyncMock(return_value=[cancel_event])
+        mock_event_store.query_events = AsyncMock(side_effect=[[], [cancel_event]])
 
         async def mock_create_session(*args: Any, **kwargs: Any):
             return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))


### PR DESCRIPTION
## Summary

- Fixes #341 by making `ouroboros_cancel_job` cancel the in-process job task even when the job is linked to an orchestration session.
- Preserves the existing session cancellation signal while ensuring `CancelledError` reaches runtime subprocess cleanup immediately.
- Adds an integration regression test with a real child process so cancelled jobs cannot leave CLI subprocesses alive.

## Changes

- `JobManager.cancel_job()` now always cancels tracked job/runner tasks after persisting `cancel_requested`.
- Linked session jobs still call `request_cancellation(session_id)` for runner/event-store visibility.
- New integration test starts a Python subprocess through a linked job and asserts it exits after `cancel_job()`.

## Tests

- `uv run pytest tests/integration/test_cancel_subprocess_termination.py`
- `uv run pytest tests/unit/mcp/test_job_manager.py::TestJobManager::test_cancel_job_cancels_non_session_task`