### PR TITLE
feat(mcp): suggest lateral persona from stagnation

### DIFF
--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1459,7 +1459,17 @@ class LateralThinkHandler:
                     stagnation_pattern,
                     exclude_personas=tuple(excluded_personas),
                 )
-                persona_arg = (suggested or ThinkingPersona.CONTRARIAN).value
+                if suggested is None:
+                    return Result.err(
+                        MCPToolError(
+                            (
+                                "No available lateral thinking persona remains after "
+                                "applying failed_attempts exclusions"
+                            ),
+                            tool_name="ouroboros_lateral_think",
+                        )
+                    )
+                persona_arg = suggested.value
             else:
                 persona_arg = ThinkingPersona.CONTRARIAN.value
 

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1231,6 +1231,21 @@ class LateralThinkHandler:
                     ),
                 ),
                 MCPToolParameter(
+                    name="stagnation_pattern",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "Detected stagnation pattern used to suggest a persona when "
+                        "persona is omitted."
+                    ),
+                    required=False,
+                    enum=(
+                        "spinning",
+                        "oscillation",
+                        "no_drift",
+                        "diminishing_returns",
+                    ),
+                ),
+                MCPToolParameter(
                     name="personas",
                     type=ToolInputType.ARRAY,
                     description=(
@@ -1270,6 +1285,7 @@ class LateralThinkHandler:
             Result containing lateral thinking prompt(s) or error.
         """
         from ouroboros.resilience.lateral import LateralThinker, ThinkingPersona
+        from ouroboros.resilience.stagnation import StagnationPattern
 
         problem_context = arguments.get("problem_context")
         if not problem_context:
@@ -1294,7 +1310,8 @@ class LateralThinkHandler:
 
         # --- Parallel multi-persona dispatch path ---
         explicit_list = arguments.get("personas")
-        persona_arg = arguments.get("persona", "contrarian")
+        raw_persona_arg = arguments.get("persona")
+        persona_arg = str(raw_persona_arg).strip() if raw_persona_arg else ""
         dispatch_all = persona_arg == "all"
 
         if explicit_list or dispatch_all:
@@ -1413,6 +1430,39 @@ class LateralThinkHandler:
             )
 
         # --- Single-persona path ---
+        if not persona_arg:
+            stagnation_pattern_arg = arguments.get("stagnation_pattern")
+            if stagnation_pattern_arg:
+                try:
+                    stagnation_pattern = StagnationPattern(str(stagnation_pattern_arg))
+                except ValueError:
+                    return Result.err(
+                        MCPToolError(
+                            (
+                                f"Invalid stagnation_pattern: {stagnation_pattern_arg}. "
+                                "Must be one of: spinning, oscillation, no_drift, "
+                                "diminishing_returns"
+                            ),
+                            tool_name="ouroboros_lateral_think",
+                        )
+                    )
+
+                excluded_personas: list[ThinkingPersona] = []
+                for attempt in failed_attempts:
+                    try:
+                        excluded_personas.append(ThinkingPersona(attempt.strip().lower()))
+                    except ValueError:
+                        continue
+
+                thinker = LateralThinker()
+                suggested = thinker.suggest_persona_for_pattern(
+                    stagnation_pattern,
+                    exclude_personas=tuple(excluded_personas),
+                )
+                persona_arg = (suggested or ThinkingPersona.CONTRARIAN).value
+            else:
+                persona_arg = ThinkingPersona.CONTRARIAN.value
+
         try:
             persona = ThinkingPersona(persona_arg)
         except ValueError:

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1311,7 +1311,7 @@ class LateralThinkHandler:
         # --- Parallel multi-persona dispatch path ---
         explicit_list = arguments.get("personas")
         raw_persona_arg = arguments.get("persona")
-        if raw_persona_arg is None:
+        if explicit_list or raw_persona_arg is None:
             persona_arg = ""
         else:
             persona_arg = str(raw_persona_arg).strip()

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1457,17 +1457,11 @@ class LateralThinkHandler:
                         )
                     )
 
-                excluded_personas: list[ThinkingPersona] = []
-                for attempt in failed_attempts:
-                    try:
-                        excluded_personas.append(ThinkingPersona(attempt.strip().lower()))
-                    except ValueError:
-                        continue
+                from ouroboros.resilience.recovery import suggest_lateral_persona_for_pattern
 
-                thinker = LateralThinker()
-                suggested = thinker.suggest_persona_for_pattern(
+                suggested = suggest_lateral_persona_for_pattern(
                     stagnation_pattern,
-                    exclude_personas=tuple(excluded_personas),
+                    failed_attempts=failed_attempts,
                 )
                 if suggested is None:
                     return Result.err(

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1311,7 +1311,17 @@ class LateralThinkHandler:
         # --- Parallel multi-persona dispatch path ---
         explicit_list = arguments.get("personas")
         raw_persona_arg = arguments.get("persona")
-        persona_arg = str(raw_persona_arg).strip() if raw_persona_arg else ""
+        if raw_persona_arg is None:
+            persona_arg = ""
+        else:
+            persona_arg = str(raw_persona_arg).strip()
+            if not persona_arg:
+                return Result.err(
+                    MCPToolError(
+                        "persona cannot be blank",
+                        tool_name="ouroboros_lateral_think",
+                    )
+                )
         dispatch_all = persona_arg == "all"
 
         if explicit_list or dispatch_all:

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -87,6 +87,14 @@ from ouroboros.orchestrator.session import SessionRepository, SessionStatus, Ses
 from ouroboros.orchestrator.workflow_state import coerce_ac_marker_update
 from ouroboros.persistence.checkpoint import CheckpointStore
 from ouroboros.providers import create_llm_adapter
+from ouroboros.resilience.lateral import ThinkingPersona
+from ouroboros.resilience.recovery import (
+    RecoveryActionKind,
+    RecoveryPlanner,
+    RecoverySnapshot,
+    create_recovery_applied_event,
+    get_run_recovery_protocol_prompt,
+)
 
 if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
@@ -277,6 +285,7 @@ IMPORTANT: You are extending existing code, NOT creating a new project.
 
     ac_tracking = get_ac_tracking_prompt()
     strategy_fragment = strategy.get_system_prompt_fragment()
+    recovery_protocol = get_run_recovery_protocol_prompt()
 
     return f"""{strategy_fragment}
 
@@ -289,7 +298,9 @@ IMPORTANT: You are extending existing code, NOT creating a new project.
 ## Evaluation Principles
 {principles_text}
 
-{ac_tracking}"""
+{ac_tracking}
+
+{recovery_protocol}"""
 
 
 def build_task_prompt(
@@ -1599,23 +1610,32 @@ class OrchestratorRunner:
             last_tool: str | None = None
             last_completed_count = 0
             runtime_handle: RuntimeHandle | None = None
+            recovery_interventions_used = 0
+            recovery_personas: list[str] = []
 
             cancelled_result: Result[OrchestratorResult, OrchestratorError] | None = None
 
-            with Status(
-                f"[bold cyan]Executing: {seed.goal[:50]}...[/]",
-                console=self._console,
-                spinner="dots",
-            ) as status:
-                runtime_handle = self._seed_runtime_handle(
-                    self._inherited_runtime_handle, tool_catalog=tool_catalog
-                )
+            async def _consume_task_stream(
+                *,
+                prompt: str,
+                resume_handle: RuntimeHandle | None,
+                status: Any,
+            ) -> RuntimeHandle | None:
+                nonlocal cancelled_result
+                nonlocal final_message
+                nonlocal last_completed_count
+                nonlocal last_tool
+                nonlocal messages_processed
+                nonlocal success
+                nonlocal tracker
+
+                active_runtime_handle = resume_handle
                 async with aclosing(
                     self._adapter.execute_task(  # type: ignore[type-var]
-                        prompt=task_prompt,
+                        prompt=prompt,
                         tools=merged_tools,
                         system_prompt=system_prompt,
-                        resume_handle=runtime_handle,
+                        resume_handle=active_runtime_handle,
                     )
                 ) as message_stream:
                     async for message in message_stream:
@@ -1640,7 +1660,7 @@ class OrchestratorRunner:
                             tracker.session_id,
                         )
                         if message.resume_handle is not None:
-                            runtime_handle = message.resume_handle
+                            active_runtime_handle = message.resume_handle
 
                         # Update workflow state tracker
                         state_tracker.process_runtime_message(message)
@@ -1740,6 +1760,84 @@ class OrchestratorRunner:
                         if message.is_final:
                             final_message = message.content
                             success = not message.is_error
+
+                return active_runtime_handle
+
+            def _build_recovery_snapshot() -> RecoverySnapshot:
+                unfinished = [
+                    f"{ac.index}. {ac.content}"
+                    for ac in state_tracker.state.acceptance_criteria
+                    if ac.status.value != "completed"
+                ]
+                unfinished_text = "\n".join(unfinished[:5]) or "None"
+                problem_context = (
+                    f"Goal: {seed.goal}\n"
+                    f"Unfinished acceptance criteria:\n{unfinished_text}\n\n"
+                    f"Previous final message:\n{final_message[:1000]}"
+                )
+                current_approach = (
+                    "The first run attempted the seed normally and ended without "
+                    "satisfying the workflow. Continue from the current repository "
+                    "state, but avoid repeating the same failed path."
+                )
+                return RecoverySnapshot(
+                    problem_context=problem_context,
+                    current_approach=current_approach,
+                    messages_processed=messages_processed,
+                    completed_count=state_tracker.state.completed_count,
+                    total_count=state_tracker.state.total_count,
+                    final_error=final_message,
+                    used_personas=tuple(ThinkingPersona(persona) for persona in recovery_personas),
+                    interventions_used=recovery_interventions_used,
+                )
+
+            with Status(
+                f"[bold cyan]Executing: {seed.goal[:50]}...[/]",
+                console=self._console,
+                spinner="dots",
+            ) as status:
+                runtime_handle = self._seed_runtime_handle(
+                    self._inherited_runtime_handle, tool_catalog=tool_catalog
+                )
+                runtime_handle = await _consume_task_stream(
+                    prompt=task_prompt,
+                    resume_handle=runtime_handle,
+                    status=status,
+                )
+
+                if cancelled_result is None and not success and runtime_handle is not None:
+                    planner = RecoveryPlanner()
+                    recovery_action = planner.plan(_build_recovery_snapshot())
+                    if (
+                        recovery_action.kind == RecoveryActionKind.INJECT_LATERAL_DIRECTIVE
+                        and recovery_action.directive
+                        and recovery_action.persona is not None
+                    ):
+                        recovery_interventions_used += 1
+                        recovery_personas.append(recovery_action.persona.value)
+                        await self._event_store.append(
+                            create_recovery_applied_event(
+                                execution_id=exec_id,
+                                session_id=tracker.session_id,
+                                seed_id=seed.metadata.seed_id,
+                                action=recovery_action,
+                                messages_processed=messages_processed,
+                                completed_count=state_tracker.state.completed_count,
+                                total_count=state_tracker.state.total_count,
+                            )
+                        )
+                        status.stop()
+                        self._console.print(
+                            "[yellow]Recovery: "
+                            f"{recovery_action.pattern.value if recovery_action.pattern else 'unknown'} "
+                            f"-> {recovery_action.persona.value}[/yellow]"
+                        )
+                        status.start()
+                        runtime_handle = await _consume_task_stream(
+                            prompt=recovery_action.directive,
+                            resume_handle=runtime_handle,
+                            status=status,
+                        )
 
             # If cancelled, return the cancellation result now that the
             # generator has been properly closed via aclosing.

--- a/src/ouroboros/resilience/__init__.py
+++ b/src/ouroboros/resilience/__init__.py
@@ -8,6 +8,7 @@ Components:
 - ExecutionHistory: Tracks execution state for detection
 - LateralThinker: Generates alternative approaches via personas
 - ThinkingPersona: 5 personas for lateral thinking
+- RecoveryPlanner: Chooses bounded in-run recovery directives
 - Events: Stagnation and lateral thinking event types
 
 Story 4.1: Stagnation Detection (4 Patterns)
@@ -33,6 +34,16 @@ from ouroboros.resilience.lateral import (
     LateralThinkingSucceededEvent,
     PersonaStrategy,
     ThinkingPersona,
+)
+from ouroboros.resilience.recovery import (
+    RecoveryAction,
+    RecoveryActionKind,
+    RecoveryPlanner,
+    RecoverySnapshot,
+    coerce_failed_attempt_personas,
+    create_recovery_applied_event,
+    get_run_recovery_protocol_prompt,
+    suggest_lateral_persona_for_pattern,
 )
 from ouroboros.resilience.stagnation import (
     DiminishingReturnsDetectedEvent,
@@ -64,4 +75,13 @@ __all__ = [
     "LateralThinkingSucceededEvent",
     "LateralThinkingFailedEvent",
     "AllPersonasExhaustedEvent",
+    # Recovery planning
+    "RecoveryAction",
+    "RecoveryActionKind",
+    "RecoveryPlanner",
+    "RecoverySnapshot",
+    "coerce_failed_attempt_personas",
+    "create_recovery_applied_event",
+    "get_run_recovery_protocol_prompt",
+    "suggest_lateral_persona_for_pattern",
 ]

--- a/src/ouroboros/resilience/recovery.py
+++ b/src/ouroboros/resilience/recovery.py
@@ -1,0 +1,232 @@
+"""Recovery planning shared by run loops and lateral thinking tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.resilience.lateral import LateralThinker, ThinkingPersona
+from ouroboros.resilience.stagnation import StagnationPattern
+
+
+class RecoveryActionKind(StrEnum):
+    """Planner actions for a stalled or failed execution."""
+
+    CONTINUE = "continue"
+    INJECT_LATERAL_DIRECTIVE = "inject_lateral_directive"
+    STAGNATED = "stagnated"
+
+
+@dataclass(frozen=True, slots=True)
+class RecoverySnapshot:
+    """Execution state used to decide whether to intervene."""
+
+    problem_context: str
+    current_approach: str
+    messages_processed: int = 0
+    completed_count: int = 0
+    total_count: int = 0
+    final_error: str = ""
+    stagnation_pattern: StagnationPattern | None = None
+    failed_attempts: tuple[str, ...] = ()
+    used_personas: tuple[ThinkingPersona, ...] = ()
+    interventions_used: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryAction:
+    """A concrete recovery decision."""
+
+    kind: RecoveryActionKind
+    reason: str
+    pattern: StagnationPattern | None = None
+    persona: ThinkingPersona | None = None
+    directive: str = ""
+
+    @classmethod
+    def continue_(cls, reason: str) -> RecoveryAction:
+        """Return a no-op recovery action."""
+        return cls(kind=RecoveryActionKind.CONTINUE, reason=reason)
+
+    @classmethod
+    def stagnated(cls, reason: str, pattern: StagnationPattern | None = None) -> RecoveryAction:
+        """Return a terminal stagnation action."""
+        return cls(kind=RecoveryActionKind.STAGNATED, reason=reason, pattern=pattern)
+
+
+class RecoveryPlanner:
+    """Choose bounded lateral recovery actions for execution loops."""
+
+    def __init__(
+        self,
+        *,
+        lateral_thinker: LateralThinker | None = None,
+        max_interventions: int = 1,
+    ) -> None:
+        self._lateral_thinker = lateral_thinker or LateralThinker()
+        self._max_interventions = max_interventions
+
+    def plan(self, snapshot: RecoverySnapshot) -> RecoveryAction:
+        """Return the next recovery action for the supplied execution snapshot."""
+        if snapshot.interventions_used >= self._max_interventions:
+            return RecoveryAction.stagnated(
+                "Recovery intervention budget exhausted",
+                snapshot.stagnation_pattern,
+            )
+
+        pattern = snapshot.stagnation_pattern or self._infer_pattern(snapshot)
+        persona = suggest_lateral_persona_for_pattern(
+            pattern,
+            failed_attempts=snapshot.failed_attempts,
+            used_personas=snapshot.used_personas,
+            lateral_thinker=self._lateral_thinker,
+        )
+        if persona is None:
+            return RecoveryAction.stagnated(
+                "No available lateral thinking persona remains after exclusions",
+                pattern,
+            )
+
+        lateral_result = self._lateral_thinker.generate_alternative(
+            persona=persona,
+            problem_context=snapshot.problem_context,
+            current_approach=snapshot.current_approach,
+            failed_attempts=snapshot.failed_attempts,
+        )
+        if lateral_result.is_err:
+            return RecoveryAction.stagnated(str(lateral_result.error), pattern)
+
+        lateral = lateral_result.unwrap()
+        reason = self._reason_for(pattern, snapshot)
+        directive = (
+            "## Lateral Recovery Directive\n"
+            f"Detected pattern: {pattern.value}\n"
+            f"Selected persona: {persona.value}\n"
+            f"Reason: {reason}\n\n"
+            "Do not repeat the failed path. Continue the same task, but switch "
+            "strategy using the lateral prompt below. Produce a concrete patch "
+            "or verification step that advances the acceptance criteria.\n\n"
+            f"{lateral.prompt}"
+        )
+        return RecoveryAction(
+            kind=RecoveryActionKind.INJECT_LATERAL_DIRECTIVE,
+            reason=reason,
+            pattern=pattern,
+            persona=persona,
+            directive=directive,
+        )
+
+    @staticmethod
+    def _infer_pattern(snapshot: RecoverySnapshot) -> StagnationPattern:
+        if snapshot.final_error.strip():
+            return StagnationPattern.SPINNING
+        if (
+            snapshot.total_count
+            and snapshot.completed_count <= 0
+            and snapshot.messages_processed >= 10
+        ):
+            return StagnationPattern.NO_DRIFT
+        return StagnationPattern.DIMINISHING_RETURNS
+
+    @staticmethod
+    def _reason_for(pattern: StagnationPattern, snapshot: RecoverySnapshot) -> str:
+        if snapshot.final_error.strip():
+            return "The previous run ended in a final error without satisfying the seed."
+        if pattern == StagnationPattern.NO_DRIFT:
+            return "No acceptance criteria have completed after sustained execution."
+        if pattern == StagnationPattern.DIMINISHING_RETURNS:
+            return "Execution appears to be making weaker progress and needs a strategy shift."
+        if pattern == StagnationPattern.OSCILLATION:
+            return "Execution appears to be alternating between approaches."
+        return "Execution appears to be repeating an unproductive path."
+
+
+def coerce_failed_attempt_personas(
+    failed_attempts: tuple[str, ...],
+    *,
+    used_personas: tuple[ThinkingPersona, ...] = (),
+) -> tuple[ThinkingPersona, ...]:
+    """Convert failed attempt strings into persona exclusions."""
+    excluded: list[ThinkingPersona] = list(used_personas)
+    for attempt in failed_attempts:
+        try:
+            persona = ThinkingPersona(attempt.strip().lower())
+        except ValueError:
+            continue
+        if persona not in excluded:
+            excluded.append(persona)
+    return tuple(excluded)
+
+
+def suggest_lateral_persona_for_pattern(
+    pattern: StagnationPattern,
+    *,
+    failed_attempts: tuple[str, ...] = (),
+    used_personas: tuple[ThinkingPersona, ...] = (),
+    lateral_thinker: LateralThinker | None = None,
+) -> ThinkingPersona | None:
+    """Suggest a persona for a stagnation pattern with shared exclusion semantics."""
+    thinker = lateral_thinker or LateralThinker()
+    return thinker.suggest_persona_for_pattern(
+        pattern,
+        exclude_personas=coerce_failed_attempt_personas(
+            failed_attempts,
+            used_personas=used_personas,
+        ),
+    )
+
+
+def get_run_recovery_protocol_prompt() -> str:
+    """Return system prompt instructions for in-run self recovery."""
+    return """## Self-Recovery Protocol
+If you notice that the run is stalled, repeating the same failed edit, or making
+no acceptance-criterion progress, switch strategy before continuing:
+- spinning: stop retrying the same fix; isolate or bypass the blocker.
+- no_drift: gather the missing fact or inspect the source of truth.
+- diminishing_returns: simplify the task and remove unnecessary moving parts.
+- oscillation: choose one architecture and make the smallest coherent step.
+
+When you switch strategy, state the detected pattern and the new concrete next
+step briefly, then continue implementing and verifying the acceptance criteria."""
+
+
+def create_recovery_applied_event(
+    *,
+    execution_id: str,
+    session_id: str,
+    action: RecoveryAction,
+    seed_id: str | None = None,
+    messages_processed: int = 0,
+    completed_count: int = 0,
+    total_count: int = 0,
+) -> BaseEvent:
+    """Create an event recording an automatic recovery intervention."""
+    return BaseEvent(
+        type="resilience.recovery.applied",
+        aggregate_type="execution",
+        aggregate_id=execution_id,
+        data={
+            "session_id": session_id,
+            "seed_id": seed_id,
+            "kind": action.kind.value,
+            "pattern": action.pattern.value if action.pattern else None,
+            "persona": action.persona.value if action.persona else None,
+            "reason": action.reason,
+            "messages_processed": messages_processed,
+            "completed_count": completed_count,
+            "total_count": total_count,
+        },
+    )
+
+
+__all__ = [
+    "RecoveryAction",
+    "RecoveryActionKind",
+    "RecoveryPlanner",
+    "RecoverySnapshot",
+    "coerce_failed_attempt_personas",
+    "create_recovery_applied_event",
+    "get_run_recovery_protocol_prompt",
+    "suggest_lateral_persona_for_pattern",
+]

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -167,8 +167,8 @@ async def test_stagnation_pattern_excludes_known_failed_personas() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stagnation_pattern_falls_back_to_contrarian_when_all_excluded() -> None:
-    """When every suggested persona is excluded, contrarian remains the fallback."""
+async def test_stagnation_pattern_errors_when_all_personas_excluded() -> None:
+    """When every persona is excluded, the handler does not repeat one."""
     handler = LateralThinkHandler(
         agent_runtime_backend="opencode",
         opencode_mode="subprocess",
@@ -189,6 +189,5 @@ async def test_stagnation_pattern_falls_back_to_contrarian_when_all_excluded() -
         }
     )
 
-    assert result.is_ok, result
-    payload = result.unwrap()
-    assert payload.meta.get("persona") == "contrarian"
+    assert result.is_err
+    assert "No available lateral thinking persona remains" in str(result.error)

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -167,6 +167,29 @@ async def test_blank_persona_is_invalid(persona: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_personas_list_takes_precedence_over_blank_persona() -> None:
+    """Explicit personas list is honored even when persona is blank."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="subprocess",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "stuck on X",
+            "current_approach": "tried Y",
+            "persona": "",
+            "personas": ["hacker", "contrarian"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    assert payload.meta.get("dispatch_mode") == "inline_fallback"
+    assert payload.meta.get("persona_count") == 2
+
+
+@pytest.mark.asyncio
 async def test_stagnation_pattern_excludes_known_failed_personas() -> None:
     """failed_attempts persona names are excluded and unknown values are skipped."""
     handler = LateralThinkHandler(

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -145,6 +145,28 @@ async def test_stagnation_pattern_suggests_persona_when_persona_omitted() -> Non
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("persona", ["", "   "])
+async def test_blank_persona_is_invalid(persona: str) -> None:
+    """Blank persona values are invalid rather than treated as omitted."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="subprocess",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "progress is flat",
+            "current_approach": "rerun the same checks",
+            "stagnation_pattern": "no_drift",
+            "persona": persona,
+        }
+    )
+
+    assert result.is_err
+    assert "persona cannot be blank" in str(result.error)
+
+
+@pytest.mark.asyncio
 async def test_stagnation_pattern_excludes_known_failed_personas() -> None:
     """failed_attempts persona names are excluded and unknown values are skipped."""
     handler = LateralThinkHandler(

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -121,3 +121,74 @@ async def test_single_persona_path_unchanged() -> None:
     # Single-persona path returns inline text unconditionally.
     assert "_subagents" not in (payload.meta or {})
     assert payload.meta.get("persona") == "contrarian"
+
+
+@pytest.mark.asyncio
+async def test_stagnation_pattern_suggests_persona_when_persona_omitted() -> None:
+    """stagnation_pattern selects an affinity persona when persona is omitted."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="subprocess",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "progress is flat",
+            "current_approach": "rerun the same checks",
+            "stagnation_pattern": "no_drift",
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    assert payload.meta.get("persona") == "researcher"
+
+
+@pytest.mark.asyncio
+async def test_stagnation_pattern_excludes_known_failed_personas() -> None:
+    """failed_attempts persona names are excluded and unknown values are skipped."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="subprocess",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "same failure repeats",
+            "current_approach": "retry the same edit",
+            "stagnation_pattern": "spinning",
+            "failed_attempts": ["hacker", "not-a-persona"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    assert payload.meta.get("persona") == "contrarian"
+
+
+@pytest.mark.asyncio
+async def test_stagnation_pattern_falls_back_to_contrarian_when_all_excluded() -> None:
+    """When every suggested persona is excluded, contrarian remains the fallback."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="subprocess",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "progress is flat",
+            "current_approach": "tried every persona",
+            "stagnation_pattern": "no_drift",
+            "failed_attempts": [
+                "hacker",
+                "researcher",
+                "simplifier",
+                "architect",
+                "contrarian",
+            ],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    assert payload.meta.get("persona") == "contrarian"

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -108,6 +108,13 @@ class TestBuildSystemPrompt:
         assert "completeness" in prompt
         assert "All requirements are met" in prompt
 
+    def test_includes_self_recovery_protocol(self, sample_seed: Seed) -> None:
+        """Run prompts should tell agents how to change strategy when stuck."""
+        prompt = build_system_prompt(sample_seed)
+        assert "Self-Recovery Protocol" in prompt
+        assert "spinning" in prompt
+        assert "no acceptance-criterion progress" in prompt
+
     def test_handles_empty_constraints(self) -> None:
         """Test handling seed with no constraints."""
         seed = Seed(
@@ -253,6 +260,77 @@ class TestOrchestratorRunner:
         assert result.value.success is True
         # Parallel executor: 3 ACs × 3 messages each = 9 total
         assert result.value.messages_processed == 9
+
+    @pytest.mark.asyncio
+    async def test_execute_seed_retries_once_with_lateral_recovery_directive(
+        self,
+        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Sequential run failures should get one same-session lateral recovery retry."""
+        runtime_handle = RuntimeHandle(
+            backend="opencode",
+            native_session_id="oc-session-recovery",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+        )
+        prompts: list[str] = []
+        resume_handles: list[RuntimeHandle | None] = []
+
+        async def mock_execute(prompt: str, **kwargs: Any) -> AsyncIterator[AgentMessage]:
+            prompts.append(prompt)
+            resume_handles.append(kwargs.get("resume_handle"))
+            if len(prompts) == 1:
+                yield AgentMessage(
+                    type="assistant",
+                    content="Trying the original path",
+                    resume_handle=runtime_handle,
+                )
+                yield AgentMessage(
+                    type="result",
+                    content="Tests still fail",
+                    data={"subtype": "error"},
+                    resume_handle=runtime_handle,
+                )
+                return
+
+            yield AgentMessage(
+                type="result",
+                content="[TASK_COMPLETE] Recovered",
+                data={"subtype": "success"},
+                resume_handle=runtime_handle,
+            )
+
+        mock_adapter.execute_task = mock_execute
+
+        async def mock_create_session(*args: Any, **kwargs: Any):
+            return Result.ok(SessionTracker.create("exec", sample_seed.metadata.seed_id))
+
+        async def mock_mark_completed(*args: Any, **kwargs: Any):
+            return Result.ok(None)
+
+        with (
+            patch.object(runner._session_repo, "create_session", mock_create_session),
+            patch.object(runner._session_repo, "mark_completed", mock_mark_completed),
+        ):
+            result = await runner.execute_seed(sample_seed, parallel=False)
+
+        assert result.is_ok
+        assert result.value.success is True
+        assert len(prompts) == 2
+        assert "Lateral Recovery Directive" in prompts[1]
+        assert "Selected persona: hacker" in prompts[1]
+        assert resume_handles[1] == runtime_handle
+
+        recovery_event = next(
+            call.args[0]
+            for call in mock_event_store.append.await_args_list
+            if getattr(call.args[0], "type", None) == "resilience.recovery.applied"
+        )
+        assert recovery_event.data["pattern"] == "spinning"
+        assert recovery_event.data["persona"] == "hacker"
 
     @pytest.mark.asyncio
     async def test_prepare_session_forwards_seed_goal(

--- a/tests/unit/resilience/test_recovery.py
+++ b/tests/unit/resilience/test_recovery.py
@@ -1,0 +1,71 @@
+"""Unit tests for run recovery planning."""
+
+from __future__ import annotations
+
+from ouroboros.resilience.lateral import ThinkingPersona
+from ouroboros.resilience.recovery import (
+    RecoveryActionKind,
+    RecoveryPlanner,
+    RecoverySnapshot,
+    suggest_lateral_persona_for_pattern,
+)
+from ouroboros.resilience.stagnation import StagnationPattern
+
+
+def test_suggest_lateral_persona_skips_failed_attempt_names() -> None:
+    persona = suggest_lateral_persona_for_pattern(
+        StagnationPattern.NO_DRIFT,
+        failed_attempts=("researcher", "not-a-persona"),
+    )
+
+    assert persona == ThinkingPersona.ARCHITECT
+
+
+def test_recovery_planner_injects_lateral_directive_for_failure() -> None:
+    planner = RecoveryPlanner()
+
+    action = planner.plan(
+        RecoverySnapshot(
+            problem_context="Goal: fix tests\nPrevious final message: tests failed",
+            current_approach="The run retried the same failing test.",
+            final_error="tests failed",
+        )
+    )
+
+    assert action.kind == RecoveryActionKind.INJECT_LATERAL_DIRECTIVE
+    assert action.pattern == StagnationPattern.SPINNING
+    assert action.persona == ThinkingPersona.HACKER
+    assert "Lateral Recovery Directive" in action.directive
+    assert "Selected persona: hacker" in action.directive
+
+
+def test_recovery_planner_respects_intervention_budget() -> None:
+    planner = RecoveryPlanner(max_interventions=1)
+
+    action = planner.plan(
+        RecoverySnapshot(
+            problem_context="Goal: fix tests",
+            current_approach="Already tried recovery.",
+            final_error="tests failed",
+            interventions_used=1,
+        )
+    )
+
+    assert action.kind == RecoveryActionKind.STAGNATED
+    assert "budget exhausted" in action.reason
+
+
+def test_recovery_planner_stagnates_when_all_personas_excluded() -> None:
+    planner = RecoveryPlanner()
+
+    action = planner.plan(
+        RecoverySnapshot(
+            problem_context="Goal: fix tests",
+            current_approach="Tried every lateral path.",
+            final_error="tests failed",
+            failed_attempts=tuple(persona.value for persona in ThinkingPersona),
+        )
+    )
+
+    assert action.kind == RecoveryActionKind.STAGNATED
+    assert "No available" in action.reason


### PR DESCRIPTION
## Summary

- Fixes #354 by adding `stagnation_pattern` to `ouroboros_lateral_think`.
- Uses `LateralThinker.suggest_persona_for_pattern()` when `persona` is omitted.
- Treats matching `failed_attempts` values as persona exclusions while silently skipping unknown names.

## Changes

- Adds `stagnation_pattern` to the MCP tool schema with the four supported stagnation patterns.
- Keeps explicit `persona`, `persona='all'`, and `personas=[...]` behavior unchanged.
- Falls back to `contrarian` when no persona can be suggested because all personas were excluded.

## Tests

- `uv run pytest tests/unit/mcp/tools/test_lateral_think_handler.py`
- `uv run pytest tests/unit/mcp/tools/test_definitions.py::TestLateralThinkHandler`