### PR TITLE
docs(mcp): add onboarding workflow guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <strong>Stop prompting. Start specifying.</strong>
   <br/>
-  <sub>Specification-first workflow engine for AI coding agents</sub>
+  <sub>Agent OS for replayable, specification-first AI coding workflows</sub>
 </p>
 
 <p align="center">
@@ -36,9 +36,13 @@
   <a href="#from-wonder-to-ontology">Philosophy</a>
 </p>
 
-**Turn a vague idea into a verified, working codebase -- with any AI coding agent.**
+**Turn a vague idea into a verified, working codebase -- across Claude Code, Codex CLI, OpenCode, and Hermes.**
 
-Ouroboros sits between you and your AI runtime (Claude Code, Codex CLI, Hermes, or others). It replaces ad-hoc prompting with a structured specification-first workflow: interview, crystallize, execute, evaluate, evolve.
+Ouroboros is an Agent OS for AI coding: a local-first runtime layer that turns
+non-deterministic agent work into a replayable, observable, policy-bound
+execution contract. It replaces ad-hoc prompting with a structured
+specification-first workflow: interview, crystallize, execute, evaluate,
+evolve.
 
 ---
 
@@ -68,7 +72,7 @@ curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.
 > ooo interview "I want to build a task management CLI"
 ```
 
-> Works with Claude Code, Codex CLI, Hermes, and OpenCode. The installer detects Claude Code, Codex CLI, and Hermes CLI automatically and registers the MCP server. For OpenCode, run `ouroboros setup --runtime opencode` after installation.
+> Works with Claude Code, Codex CLI, OpenCode, and Hermes. The installer detects Claude Code, Codex CLI, and Hermes CLI automatically and registers the MCP server. For OpenCode, run `ouroboros setup --runtime opencode` after installation.
 
 <details>
 <summary><strong>Other install methods</strong></summary>
@@ -255,7 +259,7 @@ src/ouroboros/
 +-- resilience/     4-pattern stagnation detection, 5 lateral personas
 +-- observability/  3-component drift measurement, auto-retrospective
 +-- persistence/    Event sourcing (SQLAlchemy + aiosqlite), checkpoints
-+-- orchestrator/   Runtime abstraction layer (Claude Code, Codex CLI)
++-- orchestrator/   Runtime abstraction layer (Claude Code, Codex CLI, OpenCode, Hermes)
 +-- core/           Types, errors, seed, ontology, security
 +-- providers/      LiteLLM adapter (100+ models)
 +-- mcp/            MCP client/server integration
@@ -270,7 +274,8 @@ src/ouroboros/
 - **Brownfield** -- Auto-detects config files across multiple language ecosystems
 - **Evolution** -- Up to 30 generations, convergence at ontology similarity >= 0.95
 - **Stagnation** -- Detects spinning, oscillation, no-drift, and diminishing returns patterns
-- **Runtime backends** -- Pluggable abstraction layer (`orchestrator.runtime_backend` config) with first-class support for Claude Code, Codex CLI, and Hermes; same workflow spec, different execution engines
+- **Agent OS runtime** -- Replayable execution contract across capability discovery, policy, directives, event journal, and agent processes
+- **Runtime backends** -- Pluggable abstraction layer (`orchestrator.runtime_backend` config) with first-class support for Claude Code, Codex CLI, OpenCode, and Hermes; same workflow spec, different execution engines
 
 See [Architecture](./docs/architecture.md) for the full design document.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ Ouroboros is a specification-first workflow engine for AI coding agents. It tran
 - [Evolutionary Loop & Ralph](./guides/evolution-loop.md) - Wonder/Reflect cycle, convergence detection, persistent evolution
 - [Evaluation Pipeline Guide](./guides/evaluation-pipeline.md) - Three-stage evaluation, failure modes, and configuration
 - [Shared `ooo` Skill Dispatch Router](./guides/ooo-skill-dispatch-router.md) - Runtime setup boundary for Codex CLI, Hermes, and OpenCode skill dispatch
+- [MCP Best Practices](./guides/mcp-best-practices.md) - Upstream MCP server configuration, security, and workflow mapping
+- [QA Backends](./guides/qa-backends.md) - External QA backend patterns, including OpenCron-style synthetic checks
 - [TUI Usage Guide](./guides/tui-usage.md) - Dashboard, screens, keyboard shortcuts
 
 ### Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,10 @@
 
 > The serpent that devours itself to be reborn anew.
 
-Ouroboros is a specification-first workflow engine for AI coding agents. It transforms ambiguous human requirements into clear, executable specifications through Socratic questioning and ontological analysis -- then runs them on your choice of runtime backend.
+Ouroboros is an Agent OS for specification-first AI coding workflows. It
+transforms ambiguous human requirements into clear, executable specifications
+through Socratic questioning and ontological analysis, then runs them through a
+replayable execution contract on your choice of runtime backend.
 
 ## Documentation Index
 
@@ -15,6 +18,8 @@ Ouroboros is a specification-first workflow engine for AI coding agents. It tran
 
 - [Claude Code](./runtime-guides/claude-code.md) - Backend-specific configuration and CLI options (see [Getting Started](./getting-started.md) for install/onboarding)
 - [Codex CLI](./runtime-guides/codex.md) - Backend-specific configuration and CLI options (see [Getting Started](./getting-started.md) for install/onboarding)
+- [OpenCode](./runtime-guides/opencode.md) - Interactive plugin mode and headless subprocess runtime
+- [Hermes](./runtime-guides/hermes.md) - Hermes Agent runtime setup and `ooo` dispatch
 - [Runtime Capability Matrix](./runtime-capability-matrix.md) - Feature comparison across runtime backends
 
 ### Architecture

--- a/docs/examples/workflows/design-code-verify.md
+++ b/docs/examples/workflows/design-code-verify.md
@@ -1,0 +1,77 @@
+# Workflow Example: Design -> Code -> Verify
+
+This workflow is for UI work where implementation should follow a design source
+and then be verified through local and browser-based checks.
+
+## MCP Servers
+
+Recommended upstream servers:
+
+- `figma` for design inspection.
+- `context7` for framework or component-library documentation.
+- `opencron` for synthetic browser or endpoint QA when a deployed/staging URL
+  is available.
+
+Example config shape:
+
+```yaml
+mcp_servers:
+  - name: figma
+    transport: stdio
+    command: "<figma-mcp-command>"
+    args: []
+    env:
+      FIGMA_TOKEN: "${FIGMA_TOKEN}"
+
+  - name: context7
+    transport: stdio
+    command: "<context7-mcp-command>"
+    args: []
+
+  - name: opencron
+    transport: stdio
+    command: "<opencron-mcp-command>"
+    args: []
+    env:
+      OPENCRON_API_KEY: "${OPENCRON_API_KEY}"
+
+connection:
+  timeout_seconds: 45
+  retry_attempts: 2
+```
+
+## Seed Shape
+
+```yaml
+goal: "Implement the settings panel from the referenced Figma frame."
+constraints:
+  - "Use the existing component system."
+  - "Do not add new styling primitives unless required by the design."
+  - "Keep keyboard and responsive behavior intact."
+acceptance_criteria:
+  - "Implemented UI matches the referenced layout, spacing, and states."
+  - "Local component tests or app tests pass."
+  - "Browser QA confirms the panel renders at desktop and mobile sizes."
+```
+
+## Execution Notes
+
+1. Pull only the relevant Figma frame or component data. Avoid asking for the
+   entire file unless the design depends on global tokens.
+2. Use Context7 when framework or library behavior is uncertain.
+3. Implement against existing local components first.
+4. Run local tests before browser/synthetic QA.
+5. Use OpenCron or browser checks for deployed/staging verification when the
+   change cannot be fully validated locally.
+
+## QA
+
+For external QA, request concrete evidence:
+
+```text
+Run the settings-panel smoke check. Return viewport, URL, status, duration,
+and any visual or interaction failure.
+```
+
+If no deployed URL exists, keep QA local and state that external verification
+was not applicable for the branch.

--- a/docs/examples/workflows/design-code-verify.md
+++ b/docs/examples/workflows/design-code-verify.md
@@ -44,6 +44,7 @@ connection:
 
 ```yaml
 goal: "Implement the settings panel from the referenced Figma frame."
+task_type: code
 constraints:
   - "Use the existing component system."
   - "Do not add new styling primitives unless required by the design."
@@ -52,6 +53,21 @@ acceptance_criteria:
   - "Implemented UI matches the referenced layout, spacing, and states."
   - "Local component tests or app tests pass."
   - "Browser QA confirms the panel renders at desktop and mobile sizes."
+ontology_schema:
+  name: "settings_panel"
+  description: "UI implementation aligned to a referenced design frame."
+  fields:
+    - name: "component_structure"
+      field_type: "code"
+      description: "Components, props, and state used for the panel."
+    - name: "visual_states"
+      field_type: "list"
+      description: "Desktop, mobile, loading, error, and interaction states."
+    - name: "verification"
+      field_type: "list"
+      description: "Local and browser QA evidence for the implemented UI."
+metadata:
+  ambiguity_score: 0.15
 ```
 
 ## Execution Notes

--- a/docs/examples/workflows/research-to-deliverable.md
+++ b/docs/examples/workflows/research-to-deliverable.md
@@ -1,0 +1,66 @@
+# Workflow Example: Research -> Deliverable
+
+This workflow is for tasks where the agent must gather current external
+information and turn it into a concrete artifact such as a report, plan, spec,
+or comparison matrix.
+
+## MCP Servers
+
+Recommended upstream servers:
+
+- `tavily` for web/source discovery.
+- `context7` for library and framework documentation.
+
+Example config shape:
+
+```yaml
+mcp_servers:
+  - name: tavily
+    transport: stdio
+    command: "<tavily-mcp-command>"
+    args: []
+    env:
+      TAVILY_API_KEY: "${TAVILY_API_KEY}"
+
+  - name: context7
+    transport: stdio
+    command: "<context7-mcp-command>"
+    args: []
+
+connection:
+  timeout_seconds: 30
+  retry_attempts: 3
+```
+
+## Seed Shape
+
+```yaml
+goal: "Create a sourced implementation brief for adding streaming responses."
+constraints:
+  - "Use official documentation for API behavior."
+  - "Separate facts from recommendations."
+  - "Include links or source identifiers for non-obvious claims."
+acceptance_criteria:
+  - "Brief explains the recommended implementation path."
+  - "Brief lists risks, unknowns, and verification steps."
+  - "All current API claims are attributed to fetched sources."
+```
+
+## Execution Notes
+
+1. Start with Tavily only when the topic requires broad discovery.
+2. Use Context7 for exact library/API behavior before writing implementation
+   guidance.
+3. Ask the agent to preserve citations in the deliverable rather than only in
+   intermediate notes.
+4. Keep the final artifact narrow enough to act on: decisions, tradeoffs,
+   implementation steps, and verification.
+
+## QA
+
+Run `ouroboros_qa` on the final deliverable with a quality bar such as:
+
+```text
+The brief must distinguish sourced facts from recommendations, cite external
+claims, and include enough implementation detail for an engineer to start.
+```

--- a/docs/examples/workflows/research-to-deliverable.md
+++ b/docs/examples/workflows/research-to-deliverable.md
@@ -36,6 +36,7 @@ connection:
 
 ```yaml
 goal: "Create a sourced implementation brief for adding streaming responses."
+task_type: research
 constraints:
   - "Use official documentation for API behavior."
   - "Separate facts from recommendations."
@@ -44,6 +45,21 @@ acceptance_criteria:
   - "Brief explains the recommended implementation path."
   - "Brief lists risks, unknowns, and verification steps."
   - "All current API claims are attributed to fetched sources."
+ontology_schema:
+  name: "implementation_brief"
+  description: "Structured sourced brief for an engineering decision."
+  fields:
+    - name: "recommendation"
+      field_type: "markdown"
+      description: "Recommended implementation path and rationale."
+    - name: "sources"
+      field_type: "list"
+      description: "Source identifiers or links for current external claims."
+    - name: "risks"
+      field_type: "list"
+      description: "Known risks, unknowns, and verification steps."
+metadata:
+  ambiguity_score: 0.15
 ```
 
 ## Execution Notes

--- a/docs/guides/mcp-best-practices.md
+++ b/docs/guides/mcp-best-practices.md
@@ -1,0 +1,103 @@
+# MCP Best Practices
+
+Use this guide when adding upstream MCP servers to Ouroboros through
+`~/.ouroboros/mcp_servers.yaml` or `{cwd}/.ouroboros/mcp_servers.yaml`.
+
+## Goals
+
+External MCP servers should make the child agent more capable without making
+execution brittle, slow, or unsafe. Prefer a small, named set of tools for one
+workflow over a large always-on catalog.
+
+## Recommended Server Roles
+
+| Server | Use when | Typical scope |
+|--------|----------|---------------|
+| OpenCron | Scheduled browser or synthetic checks are part of verification | QA and monitoring tasks only |
+| Figma | Design artifacts must guide implementation | Read-only design inspection |
+| Context7 | Current library/framework documentation is needed | Documentation lookup during planning or implementation |
+| Tavily | External web research is required | Research and source discovery |
+
+## Configuration Pattern
+
+```yaml
+mcp_servers:
+  - name: context7
+    transport: stdio
+    command: "<context7-mcp-command>"
+    args: []
+    timeout: 30
+
+  - name: tavily
+    transport: stdio
+    command: "<tavily-mcp-command>"
+    args: []
+    env:
+      TAVILY_API_KEY: "${TAVILY_API_KEY}"
+    timeout: 45
+
+  - name: figma
+    transport: stdio
+    command: "<figma-mcp-command>"
+    args: []
+    env:
+      FIGMA_TOKEN: "${FIGMA_TOKEN}"
+    timeout: 30
+
+  - name: opencron
+    transport: stdio
+    command: "<opencron-mcp-command>"
+    args: []
+    timeout: 60
+
+connection:
+  timeout_seconds: 30
+  retry_attempts: 3
+  health_check_interval: 60
+```
+
+Replace the placeholder commands with the server package or wrapper used by
+your environment. Keep credentials in environment variables rather than in the
+YAML file.
+
+## Naming
+
+Use stable, domain-oriented server names: `context7`, `tavily`, `figma`,
+`opencron`. Avoid names such as `tools` or `research` because they make logs and
+tool provenance harder to audit.
+
+If a server exports generic tool names, add `tool_prefix` in the MCP config or
+wrap the server with prefixed tool names. Built-in agent tools take precedence;
+colliding MCP tools may be skipped.
+
+## Security
+
+- Use read-only tokens for Figma and documentation servers when possible.
+- Do not grant browser or filesystem tools to research-only workflows.
+- Store API keys in the environment and reference them as `${VAR_NAME}`.
+- Keep `mcp_servers.yaml` out of shared logs and examples when it contains
+  private URLs, headers, or workspace IDs.
+- Prefer separate server entries per trust boundary. For example, do not put a
+  public web-research tool and an internal data tool behind the same wrapper.
+
+## Reliability
+
+- Set per-server `timeout` based on expected latency. Browser/synthetic QA
+  servers usually need more time than documentation lookup servers.
+- Keep `connection.retry_attempts` at 2 or 3. Higher values can hide broken
+  credentials and slow every execution.
+- Use health checks for long-running sessions, but do not rely on them as a
+  substitute for per-call timeouts.
+- If a workflow only needs one external server, configure only that server for
+  the run. Smaller catalogs reduce startup and tool-selection noise.
+
+## Workflow Mapping
+
+| Workflow | Suggested servers |
+|----------|-------------------|
+| Research -> Deliverable | Tavily, Context7 |
+| Design -> Code -> Verify | Figma, Context7, OpenCron |
+| Library upgrade | Context7, optional Tavily |
+| Launch QA | OpenCron, optional Context7 |
+
+See `docs/examples/workflows/` for concrete workflow examples.

--- a/docs/guides/mcp-best-practices.md
+++ b/docs/guides/mcp-best-practices.md
@@ -18,6 +18,37 @@ workflow over a large always-on catalog.
 | Context7 | Current library/framework documentation is needed | Documentation lookup during planning or implementation |
 | Tavily | External web research is required | Research and source discovery |
 
+## Quick Setup
+
+For a user-wide setup, create the MCP config file under `~/.ouroboros`:
+
+```bash
+mkdir -p ~/.ouroboros
+$EDITOR ~/.ouroboros/mcp_servers.yaml
+chmod 600 ~/.ouroboros/mcp_servers.yaml
+```
+
+Paste the YAML shape from the next section, then replace each placeholder
+command with the MCP server command used in your environment. Keep API keys in
+environment variables and reference them as `${VAR_NAME}` in the YAML.
+
+Ouroboros discovers upstream MCP config in this order:
+
+1. `$OUROBOROS_MCP_CONFIG`
+2. `~/.ouroboros/mcp_servers.yaml`
+3. `{cwd}/.ouroboros/mcp_servers.yaml`
+
+Use the home config for servers you want available across projects. Use the
+project-local config when the server list or credentials are specific to one
+repository. To bypass discovery for one run, pass an explicit path:
+
+```bash
+ouroboros run seed.yaml --mcp-config .ouroboros/mcp_servers.yaml
+```
+
+For the bridge lifecycle quick start, see
+[`docs/guides/mcp-bridge.md`](./mcp-bridge.md).
+
 ## Configuration Pattern
 
 ```yaml

--- a/docs/guides/qa-backends.md
+++ b/docs/guides/qa-backends.md
@@ -1,0 +1,84 @@
+# QA Backends
+
+Ouroboros QA has two layers:
+
+- In-process evaluation tools such as `ouroboros_qa`, `ouroboros_evaluate`,
+  and the mechanical verification pipeline.
+- Upstream MCP servers that provide external checks, browsers, scheduled
+  probes, or domain-specific validators.
+
+Use an external QA backend when correctness depends on behavior outside the
+local repository: browser rendering, deployed endpoints, cron behavior, API
+latency, or third-party integrations.
+
+## OpenCron Backend
+
+OpenCron is useful when QA needs synthetic checks or scheduled verification.
+Keep it scoped to verification tasks and avoid exposing broad filesystem or
+credential access through the same server.
+
+Example upstream entry:
+
+```yaml
+mcp_servers:
+  - name: opencron
+    transport: stdio
+    command: "<opencron-mcp-command>"
+    args: []
+    env:
+      OPENCRON_BASE_URL: "${OPENCRON_BASE_URL}"
+      OPENCRON_API_KEY: "${OPENCRON_API_KEY}"
+    timeout: 60
+
+connection:
+  timeout_seconds: 45
+  retry_attempts: 2
+  health_check_interval: 60
+```
+
+Use a dedicated API key for QA. The key should only be able to read or run the
+checks required by the workflow.
+
+## When To Use
+
+Use an external QA backend for:
+
+- Verifying a deployed URL after a code change.
+- Running browser or endpoint checks that cannot be represented by local unit
+  tests.
+- Confirming scheduled jobs or webhook-like behavior.
+- Producing QA evidence for a PR when local tests are not enough.
+
+Avoid it for:
+
+- Pure unit-test coverage.
+- Static code review.
+- Checks that require production write access.
+
+## Prompting Pattern
+
+When a seed relies on an external QA backend, make the verification surface
+explicit:
+
+```yaml
+acceptance_criteria:
+  - "Local tests pass for the changed module."
+  - "OpenCron synthetic check for the target workflow passes."
+  - "QA output includes the checked URL, check name, and timestamp."
+```
+
+For manual tool calls, include the target, environment, and success threshold:
+
+```text
+Use the OpenCron MCP tools to run the checkout smoke check against staging.
+Return the check name, target URL, status, duration, and any failing step.
+```
+
+## Result Handling
+
+External QA output should be copied into the final execution summary or PR body
+only as evidence, not as the sole source of truth. Keep local mechanical tests
+in the pipeline wherever possible.
+
+If the external QA backend is unavailable, mark the result as blocked or
+inconclusive. Do not silently treat a transport failure as a passed QA check.


### PR DESCRIPTION
## Summary

- Fixes #365 by adding MCP onboarding docs for upstream server configuration and external QA backend usage.
- Adds workflow examples for Research -> Deliverable and Design -> Code -> Verify.
- Links the new guides from the docs index.

## Changes

- `docs/guides/mcp-best-practices.md`: server roles, safe config patterns, security, reliability, workflow mapping.
- `docs/guides/qa-backends.md`: external QA backend guidance, including OpenCron-style synthetic checks.
- `docs/examples/workflows/`: two concrete workflow examples with seed shapes and QA notes.

## Tests

- `git diff --cached --check`