### PR TITLE
fix(mcp): reconnect stale client transports

### DIFF
--- a/src/ouroboros/mcp/client/manager.py
+++ b/src/ouroboros/mcp/client/manager.py
@@ -431,26 +431,33 @@ class MCPClientManager:
         Returns:
             Result containing tool result or error.
         """
-        conn = self._connections.get(server_name)
-        if not conn:
-            return Result.err(
-                MCPClientError(
-                    f"Server not found: {server_name}",
-                    is_retriable=False,
-                    details={"resource_type": "server", "resource_id": server_name},
-                )
-            )
-
-        if conn.state != ConnectionState.CONNECTED:
-            return Result.err(
-                MCPConnectionError(
-                    f"Server not connected: {server_name}",
-                    server_name=server_name,
-                )
-            )
-
+        conn_result = await self._connected_or_reconnected(server_name)
+        if conn_result.is_err:
+            return Result.err(conn_result.error)
+        conn = conn_result.value
         effective_timeout = timeout or self._default_timeout
 
+        result = await self._call_tool_once(conn, tool_name, arguments, effective_timeout)
+        if result.is_ok or not self._should_reconnect_after_error(result.error):
+            return result
+
+        reconnect_result = await self._mark_unhealthy_and_reconnect(server_name, conn, result.error)
+        if reconnect_result.is_err:
+            return Result.err(reconnect_result.error)
+        return await self._call_tool_once(
+            reconnect_result.value,
+            tool_name,
+            arguments,
+            effective_timeout,
+        )
+
+    async def _call_tool_once(
+        self,
+        conn: ServerConnection,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        effective_timeout: float,
+    ) -> Result[MCPToolResult, MCPClientError]:
         try:
             return await asyncio.wait_for(
                 conn.adapter.call_tool(tool_name, arguments),
@@ -514,26 +521,27 @@ class MCPClientManager:
         Returns:
             Result containing resource content or error.
         """
-        conn = self._connections.get(server_name)
-        if not conn:
-            return Result.err(
-                MCPClientError(
-                    f"Server not found: {server_name}",
-                    is_retriable=False,
-                    details={"resource_type": "server", "resource_id": server_name},
-                )
-            )
-
-        if conn.state != ConnectionState.CONNECTED:
-            return Result.err(
-                MCPConnectionError(
-                    f"Server not connected: {server_name}",
-                    server_name=server_name,
-                )
-            )
-
+        conn_result = await self._connected_or_reconnected(server_name)
+        if conn_result.is_err:
+            return Result.err(conn_result.error)
+        conn = conn_result.value
         effective_timeout = timeout or self._default_timeout
 
+        result = await self._read_resource_once(conn, uri, effective_timeout)
+        if result.is_ok or not self._should_reconnect_after_error(result.error):
+            return result
+
+        reconnect_result = await self._mark_unhealthy_and_reconnect(server_name, conn, result.error)
+        if reconnect_result.is_err:
+            return Result.err(reconnect_result.error)
+        return await self._read_resource_once(reconnect_result.value, uri, effective_timeout)
+
+    async def _read_resource_once(
+        self,
+        conn: ServerConnection,
+        uri: str,
+        effective_timeout: float,
+    ) -> Result[MCPResourceContent, MCPClientError]:
         try:
             return await asyncio.wait_for(
                 conn.adapter.read_resource(uri),
@@ -550,6 +558,88 @@ class MCPClientManager:
                     operation="read_resource",
                 )
             )
+
+    async def _connected_or_reconnected(
+        self,
+        server_name: str,
+    ) -> Result[ServerConnection, MCPClientError]:
+        """Return a connected server, reconnecting unhealthy servers first."""
+        conn = self._connections.get(server_name)
+        if not conn:
+            return Result.err(
+                MCPClientError(
+                    f"Server not found: {server_name}",
+                    is_retriable=False,
+                    details={"resource_type": "server", "resource_id": server_name},
+                )
+            )
+
+        if conn.state == ConnectionState.CONNECTED:
+            return Result.ok(conn)
+        if conn.state == ConnectionState.UNHEALTHY:
+            reconnect_result = await self.connect(server_name)
+            if reconnect_result.is_err:
+                return Result.err(reconnect_result.error)
+            refreshed = self._connections.get(server_name)
+            if refreshed and refreshed.state == ConnectionState.CONNECTED:
+                return Result.ok(refreshed)
+
+        return Result.err(
+            MCPConnectionError(
+                f"Server not connected: {server_name}",
+                server_name=server_name,
+            )
+        )
+
+    def _should_reconnect_after_error(self, error: MCPClientError) -> bool:
+        """Return True when an MCP failure looks like a lost transport."""
+        if isinstance(error, MCPConnectionError) or error.is_retriable:
+            return True
+        error_text = str(error).lower()
+        return any(
+            token in error_text
+            for token in (
+                "broken pipe",
+                "connection reset",
+                "connection closed",
+                "end of file",
+                "eof",
+                "not connected",
+                "transport closed",
+            )
+        )
+
+    async def _mark_unhealthy_and_reconnect(
+        self,
+        server_name: str,
+        conn: ServerConnection,
+        error: MCPClientError,
+    ) -> Result[ServerConnection, MCPClientError]:
+        """Mark a connection unhealthy, reconnect, and return the refreshed connection."""
+        async with self._lock:
+            current = self._connections.get(server_name, conn)
+            self._connections[server_name] = ServerConnection(
+                config=current.config,
+                adapter=current.adapter,
+                state=ConnectionState.UNHEALTHY,
+                last_error=str(error),
+                tools=current.tools,
+                resources=current.resources,
+            )
+
+        reconnect_result = await self.connect(server_name)
+        if reconnect_result.is_err:
+            return Result.err(reconnect_result.error)
+
+        refreshed = self._connections.get(server_name)
+        if refreshed is None or refreshed.state != ConnectionState.CONNECTED:
+            return Result.err(
+                MCPConnectionError(
+                    f"Server reconnect did not restore connection: {server_name}",
+                    server_name=server_name,
+                )
+            )
+        return Result.ok(refreshed)
 
     def start_health_checks(self) -> None:
         """Start periodic health checks for all connections."""
@@ -591,6 +681,9 @@ class MCPClientManager:
                         server=server_name,
                         error=str(result.error),
                     )
+                    reconnect_result = await self.connect(server_name)
+                    if reconnect_result.is_ok:
+                        log.info("mcp.manager.reconnected", server=server_name)
             elif conn.state == ConnectionState.UNHEALTHY:
                 # Try to reconnect
                 reconnect_result = await self.connect(server_name)

--- a/src/ouroboros/mcp/client/manager.py
+++ b/src/ouroboros/mcp/client/manager.py
@@ -469,7 +469,7 @@ class MCPClientManager:
             return Result.err(
                 MCPTimeoutError(
                     f"Tool call timed out: {tool_name}",
-                    server_name=server_name,
+                    server_name=conn.config.name,
                     timeout_seconds=effective_timeout,
                     operation="call_tool",
                 )
@@ -553,7 +553,7 @@ class MCPClientManager:
             return Result.err(
                 MCPTimeoutError(
                     f"Resource read timed out: {uri}",
-                    server_name=server_name,
+                    server_name=conn.config.name,
                     timeout_seconds=effective_timeout,
                     operation="read_resource",
                 )
@@ -593,7 +593,7 @@ class MCPClientManager:
 
     def _should_reconnect_after_error(self, error: MCPClientError) -> bool:
         """Return True when an MCP failure looks like a lost transport."""
-        if isinstance(error, MCPConnectionError) or error.is_retriable:
+        if isinstance(error, MCPConnectionError):
             return True
         error_text = str(error).lower()
         return any(

--- a/src/ouroboros/mcp/client/manager.py
+++ b/src/ouroboros/mcp/client/manager.py
@@ -441,15 +441,8 @@ class MCPClientManager:
         if result.is_ok or not self._should_reconnect_after_error(result.error):
             return result
 
-        reconnect_result = await self._mark_unhealthy_and_reconnect(server_name, conn, result.error)
-        if reconnect_result.is_err:
-            return Result.err(reconnect_result.error)
-        return await self._call_tool_once(
-            reconnect_result.value,
-            tool_name,
-            arguments,
-            effective_timeout,
-        )
+        await self._mark_unhealthy_and_reconnect(server_name, conn, result.error)
+        return result
 
     async def _call_tool_once(
         self,

--- a/tests/unit/mcp/client/test_manager.py
+++ b/tests/unit/mcp/client/test_manager.py
@@ -1,11 +1,51 @@
 """Tests for MCP client manager."""
 
+from ouroboros.core.types import Result
 from ouroboros.mcp.client.manager import (
     ConnectionState,
     MCPClientManager,
+    ServerConnection,
 )
-from ouroboros.mcp.errors import MCPClientError
-from ouroboros.mcp.types import MCPServerConfig, TransportType
+from ouroboros.mcp.errors import MCPClientError, MCPConnectionError
+from ouroboros.mcp.types import (
+    ContentType,
+    MCPCapabilities,
+    MCPContentItem,
+    MCPResourceContent,
+    MCPServerConfig,
+    MCPServerInfo,
+    MCPToolDefinition,
+    MCPToolResult,
+    TransportType,
+)
+
+
+class _ToolAdapter:
+    def __init__(self, result):
+        self.result = result
+        self.calls = 0
+
+    async def call_tool(self, _tool_name, _arguments=None):
+        self.calls += 1
+        return self.result
+
+
+class _ResourceAdapter:
+    def __init__(self, result):
+        self.result = result
+        self.calls = 0
+
+    async def read_resource(self, _uri):
+        self.calls += 1
+        return self.result
+
+
+class _HealthAdapter:
+    def __init__(self, result):
+        self.result = result
+
+    async def list_tools(self):
+        return self.result
 
 
 class TestConnectionState:
@@ -134,6 +174,54 @@ class TestMCPClientManagerTools:
         tools = await manager.list_all_tools()
         assert len(tools) == 0
 
+    async def test_call_tool_reconnects_once_after_transport_failure(self) -> None:
+        """call_tool reconnects and retries once when the transport is closed."""
+        manager = MCPClientManager()
+        config = MCPServerConfig(
+            name="test-server",
+            transport=TransportType.STDIO,
+            command="test-cmd",
+        )
+        stale_adapter = _ToolAdapter(
+            Result.err(MCPConnectionError("transport closed", server_name="test-server"))
+        )
+        fresh_result = MCPToolResult(
+            content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+            is_error=False,
+        )
+        fresh_adapter = _ToolAdapter(Result.ok(fresh_result))
+        tool = MCPToolDefinition(name="tool", description="")
+        manager._connections["test-server"] = ServerConnection(
+            config=config,
+            adapter=stale_adapter,
+            state=ConnectionState.CONNECTED,
+            tools=(tool,),
+        )
+
+        async def _connect(server_name: str):
+            manager._connections[server_name] = ServerConnection(
+                config=config,
+                adapter=fresh_adapter,
+                state=ConnectionState.CONNECTED,
+                tools=(tool,),
+            )
+            return Result.ok(
+                MCPServerInfo(
+                    name=server_name,
+                    version="1.0.0",
+                    capabilities=MCPCapabilities(tools=True),
+                )
+            )
+
+        manager.connect = _connect  # type: ignore[method-assign]
+
+        result = await manager.call_tool("test-server", "tool", {})
+
+        assert result.is_ok
+        assert result.value.text_content == "ok"
+        assert stale_adapter.calls == 1
+        assert fresh_adapter.calls == 1
+
 
 class TestMCPClientManagerResources:
     """Test MCPClientManager resource operations."""
@@ -152,3 +240,89 @@ class TestMCPClientManagerResources:
         manager = MCPClientManager()
         resources = await manager.list_all_resources()
         assert len(resources) == 0
+
+    async def test_read_resource_reconnects_once_after_transport_failure(self) -> None:
+        """read_resource reconnects and retries once when the transport is closed."""
+        manager = MCPClientManager()
+        config = MCPServerConfig(
+            name="test-server",
+            transport=TransportType.STDIO,
+            command="test-cmd",
+        )
+        stale_adapter = _ResourceAdapter(
+            Result.err(MCPConnectionError("transport closed", server_name="test-server"))
+        )
+        fresh_adapter = _ResourceAdapter(
+            Result.ok(MCPResourceContent(uri="file://doc", text="ok"))
+        )
+        manager._connections["test-server"] = ServerConnection(
+            config=config,
+            adapter=stale_adapter,
+            state=ConnectionState.CONNECTED,
+        )
+
+        async def _connect(server_name: str):
+            manager._connections[server_name] = ServerConnection(
+                config=config,
+                adapter=fresh_adapter,
+                state=ConnectionState.CONNECTED,
+            )
+            return Result.ok(
+                MCPServerInfo(
+                    name=server_name,
+                    version="1.0.0",
+                    capabilities=MCPCapabilities(resources=True),
+                )
+            )
+
+        manager.connect = _connect  # type: ignore[method-assign]
+
+        result = await manager.read_resource("test-server", "file://doc")
+
+        assert result.is_ok
+        assert result.value.text == "ok"
+        assert stale_adapter.calls == 1
+        assert fresh_adapter.calls == 1
+
+
+class TestMCPClientManagerHealthChecks:
+    """Test MCPClientManager health-check recovery."""
+
+    async def test_health_check_reconnects_immediately_after_failure(self) -> None:
+        """A failed heartbeat check attempts reconnect in the same pass."""
+        manager = MCPClientManager()
+        config = MCPServerConfig(
+            name="test-server",
+            transport=TransportType.STDIO,
+            command="test-cmd",
+        )
+        manager._connections["test-server"] = ServerConnection(
+            config=config,
+            adapter=_HealthAdapter(
+                Result.err(MCPConnectionError("transport closed", server_name="test-server"))
+            ),
+            state=ConnectionState.CONNECTED,
+        )
+        reconnects: list[str] = []
+
+        async def _connect(server_name: str):
+            reconnects.append(server_name)
+            manager._connections[server_name] = ServerConnection(
+                config=config,
+                adapter=_HealthAdapter(Result.ok(())),
+                state=ConnectionState.CONNECTED,
+            )
+            return Result.ok(
+                MCPServerInfo(
+                    name=server_name,
+                    version="1.0.0",
+                    capabilities=MCPCapabilities(tools=True),
+                )
+            )
+
+        manager.connect = _connect  # type: ignore[method-assign]
+
+        await manager._perform_health_checks()
+
+        assert reconnects == ["test-server"]
+        assert manager.get_connection_state("test-server") == ConnectionState.CONNECTED

--- a/tests/unit/mcp/client/test_manager.py
+++ b/tests/unit/mcp/client/test_manager.py
@@ -331,9 +331,7 @@ class TestMCPClientManagerResources:
         stale_adapter = _ResourceAdapter(
             Result.err(MCPConnectionError("transport closed", server_name="test-server"))
         )
-        fresh_adapter = _ResourceAdapter(
-            Result.ok(MCPResourceContent(uri="file://doc", text="ok"))
-        )
+        fresh_adapter = _ResourceAdapter(Result.ok(MCPResourceContent(uri="file://doc", text="ok")))
         manager._connections["test-server"] = ServerConnection(
             config=config,
             adapter=stale_adapter,

--- a/tests/unit/mcp/client/test_manager.py
+++ b/tests/unit/mcp/client/test_manager.py
@@ -1,12 +1,14 @@
 """Tests for MCP client manager."""
 
+import asyncio
+
 from ouroboros.core.types import Result
 from ouroboros.mcp.client.manager import (
     ConnectionState,
     MCPClientManager,
     ServerConnection,
 )
-from ouroboros.mcp.errors import MCPClientError, MCPConnectionError
+from ouroboros.mcp.errors import MCPClientError, MCPConnectionError, MCPTimeoutError
 from ouroboros.mcp.types import (
     ContentType,
     MCPCapabilities,
@@ -28,6 +30,15 @@ class _ToolAdapter:
     async def call_tool(self, _tool_name, _arguments=None):
         self.calls += 1
         return self.result
+
+
+class _SlowToolAdapter:
+    def __init__(self):
+        self.calls = 0
+
+    async def call_tool(self, _tool_name, _arguments=None):
+        self.calls += 1
+        await asyncio.sleep(10)
 
 
 class _ResourceAdapter:
@@ -221,6 +232,74 @@ class TestMCPClientManagerTools:
         assert result.value.text_content == "ok"
         assert stale_adapter.calls == 1
         assert fresh_adapter.calls == 1
+
+    async def test_call_tool_does_not_reconnect_after_timeout_result(self) -> None:
+        """Timeout failures are not retried because tools may have side effects."""
+        manager = MCPClientManager()
+        config = MCPServerConfig(
+            name="test-server",
+            transport=TransportType.STDIO,
+            command="test-cmd",
+        )
+        timeout_adapter = _ToolAdapter(
+            Result.err(
+                MCPTimeoutError(
+                    "Tool call timed out: tool",
+                    server_name="test-server",
+                    timeout_seconds=0.01,
+                    operation="call_tool",
+                )
+            )
+        )
+        manager._connections["test-server"] = ServerConnection(
+            config=config,
+            adapter=timeout_adapter,
+            state=ConnectionState.CONNECTED,
+        )
+        reconnects: list[str] = []
+
+        async def _connect(server_name: str):
+            reconnects.append(server_name)
+            return Result.err(MCPConnectionError("should not reconnect", server_name=server_name))
+
+        manager.connect = _connect  # type: ignore[method-assign]
+
+        result = await manager.call_tool("test-server", "tool", {})
+
+        assert result.is_err
+        assert isinstance(result.error, MCPTimeoutError)
+        assert timeout_adapter.calls == 1
+        assert reconnects == []
+
+    async def test_call_tool_timeout_preserves_server_name_without_retry(self) -> None:
+        """wait_for timeouts return MCPTimeoutError without reconnecting."""
+        manager = MCPClientManager()
+        config = MCPServerConfig(
+            name="test-server",
+            transport=TransportType.STDIO,
+            command="test-cmd",
+        )
+        slow_adapter = _SlowToolAdapter()
+        manager._connections["test-server"] = ServerConnection(
+            config=config,
+            adapter=slow_adapter,
+            state=ConnectionState.CONNECTED,
+        )
+        reconnects: list[str] = []
+
+        async def _connect(server_name: str):
+            reconnects.append(server_name)
+            return Result.err(MCPConnectionError("should not reconnect", server_name=server_name))
+
+        manager.connect = _connect  # type: ignore[method-assign]
+
+        result = await manager.call_tool("test-server", "tool", {}, timeout=0.01)
+
+        assert result.is_err
+        assert isinstance(result.error, MCPTimeoutError)
+        assert result.error.server_name == "test-server"
+        assert slow_adapter.calls == 1
+        assert reconnects == []
 
 
 class TestMCPClientManagerResources:

--- a/tests/unit/mcp/client/test_manager.py
+++ b/tests/unit/mcp/client/test_manager.py
@@ -185,8 +185,8 @@ class TestMCPClientManagerTools:
         tools = await manager.list_all_tools()
         assert len(tools) == 0
 
-    async def test_call_tool_reconnects_once_after_transport_failure(self) -> None:
-        """call_tool reconnects and retries once when the transport is closed."""
+    async def test_call_tool_reconnects_without_replaying_transport_failure(self) -> None:
+        """call_tool restores the connection but does not replay side effects."""
         manager = MCPClientManager()
         config = MCPServerConfig(
             name="test-server",
@@ -196,11 +196,14 @@ class TestMCPClientManagerTools:
         stale_adapter = _ToolAdapter(
             Result.err(MCPConnectionError("transport closed", server_name="test-server"))
         )
-        fresh_result = MCPToolResult(
-            content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
-            is_error=False,
+        fresh_adapter = _ToolAdapter(
+            Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                    is_error=False,
+                )
+            )
         )
-        fresh_adapter = _ToolAdapter(Result.ok(fresh_result))
         tool = MCPToolDefinition(name="tool", description="")
         manager._connections["test-server"] = ServerConnection(
             config=config,
@@ -228,10 +231,11 @@ class TestMCPClientManagerTools:
 
         result = await manager.call_tool("test-server", "tool", {})
 
-        assert result.is_ok
-        assert result.value.text_content == "ok"
+        assert result.is_err
+        assert isinstance(result.error, MCPConnectionError)
         assert stale_adapter.calls == 1
-        assert fresh_adapter.calls == 1
+        assert fresh_adapter.calls == 0
+        assert manager.get_connection_state("test-server") == ConnectionState.CONNECTED
 
     async def test_call_tool_does_not_reconnect_after_timeout_result(self) -> None:
         """Timeout failures are not retried because tools may have side effects."""


### PR DESCRIPTION
## Summary

- Fixes #387 by adding one-shot auto-reconnect for stale MCP client transports.
- Retries tool and resource calls once after transport-style connection failures.
- Makes heartbeat health checks attempt reconnect immediately after a failed check.

## Changes

- Adds connected-or-reconnected lookup for unhealthy connections.
- Marks transport failures as unhealthy, reconnects, and retries with the refreshed adapter.
- Detects common stdio disconnect signatures such as broken pipe, EOF, and closed transport.
- Adds unit coverage for tool calls, resource reads, and heartbeat recovery.

## Tests

- `uv run pytest tests/unit/mcp/client/test_manager.py`
- `uv run pytest tests/unit/mcp/client`