### PR TITLE
fix(tests): make OpenCode config tests platform-agnostic

### DIFF
--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -3,18 +3,13 @@
 CI runners (GitHub Actions) set ``XDG_CONFIG_HOME=/home/runner/.config``.
 ``opencode_config_dir()`` honours XDG before ``Path.home()``, so tests that
 only patch ``Path.home`` leak into the runner's real config directory.
-Clearing the env vars here forces the ``Path.home()`` fallback path, which
-the tests then patch to ``tmp_path``.
+Clearing the env vars here forces the ``Path.home()`` fallback path.
 
-Most existing CLI tests assert the Linux OpenCode path
-``~/.config/opencode``.  Force that platform in the test environment so the
-same assertions hold on macOS developer machines, where production code
-correctly uses ``~/Library/Application Support/OpenCode``.
+Tests that need config isolation now patch ``opencode_config_dir`` directly
+(platform-agnostic), so the ``sys.platform`` override is no longer needed.
 """
 
 from __future__ import annotations
-
-import sys
 
 import pytest
 
@@ -24,4 +19,3 @@ def _isolate_opencode_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear env vars that bypass Path.home() in opencode_config_dir()."""
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     monkeypatch.delenv("APPDATA", raising=False)
-    monkeypatch.setattr(sys, "platform", "linux")

--- a/tests/unit/cli/test_bridge_plugin_hardening.py
+++ b/tests/unit/cli/test_bridge_plugin_hardening.py
@@ -20,6 +20,11 @@ from ouroboros.cli.commands.setup import (
     _is_bridge_plugin_entry,
 )
 
+# Patch targets — both namespaces so internal calls through
+# find_opencode_config() also resolve to the test directory.
+_OCD_SETUP = "ouroboros.cli.commands.setup.opencode_config_dir"
+_OCD_CONFIG = "ouroboros.cli.opencode_config.opencode_config_dir"
+
 # ── helpers ──────────────────────────────────────────────────────
 
 
@@ -40,14 +45,8 @@ class TestContentHashSkip:
 
     def test_identical_content_skips_write(self, tmp_path: Path) -> None:
         content = "// v28 bridge\n"
-        dest = (
-            tmp_path
-            / ".config"
-            / "opencode"
-            / "plugins"
-            / "ouroboros-bridge"
-            / "ouroboros-bridge.ts"
-        )
+        oc_dir = tmp_path / "opencode"
+        dest = oc_dir / "plugins" / "ouroboros-bridge" / "ouroboros-bridge.ts"
         dest.parent.mkdir(parents=True)
         dest.write_text(content)
         original_mtime = dest.stat().st_mtime_ns
@@ -57,7 +56,11 @@ class TestContentHashSkip:
         os.utime(dest, ns=(original_mtime - 1_000_000_000, original_mtime - 1_000_000_000))
         baseline_mtime = dest.stat().st_mtime_ns
 
-        with patch("pathlib.Path.home", return_value=tmp_path), _patch_source(content):
+        with (
+            patch(_OCD_SETUP, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
+            _patch_source(content),
+        ):
             _install_opencode_bridge_plugin()
 
         # mtime untouched → no write happened
@@ -67,18 +70,16 @@ class TestContentHashSkip:
         assert dest.read_text() == content
 
     def test_different_content_triggers_write(self, tmp_path: Path) -> None:
-        dest = (
-            tmp_path
-            / ".config"
-            / "opencode"
-            / "plugins"
-            / "ouroboros-bridge"
-            / "ouroboros-bridge.ts"
-        )
+        oc_dir = tmp_path / "opencode"
+        dest = oc_dir / "plugins" / "ouroboros-bridge" / "ouroboros-bridge.ts"
         dest.parent.mkdir(parents=True)
         dest.write_text("// old v27\n")
 
-        with patch("pathlib.Path.home", return_value=tmp_path), _patch_source("// new v28\n"):
+        with (
+            patch(_OCD_SETUP, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
+            _patch_source("// new v28\n"),
+        ):
             _install_opencode_bridge_plugin()
 
         assert dest.read_text() == "// new v28\n"
@@ -115,10 +116,12 @@ class TestAtomicWrite:
 
     def test_install_uses_atomic_write(self, tmp_path: Path) -> None:
         """Install path never leaves partial .ts when os.replace fails."""
-        dest_parent = tmp_path / ".config" / "opencode" / "plugins" / "ouroboros-bridge"
+        oc_dir = tmp_path / "opencode"
+        dest_parent = oc_dir / "plugins" / "ouroboros-bridge"
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(_OCD_SETUP, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
             _patch_source("// content\n"),
             patch("os.replace", side_effect=OSError("disk full")),
             patch("ouroboros.cli.commands.setup.print_warning") as warn,
@@ -196,27 +199,21 @@ class TestEnsurePluginEntry:
     """Plugin-array management: append, dedupe, idempotent, atomic."""
 
     def _setup_cfg(self, tmp_path: Path, data: dict | None) -> Path:
-        cfg_dir = tmp_path / ".config" / "opencode"
-        cfg_dir.mkdir(parents=True)
+        cfg_dir = tmp_path / "opencode"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
         cfg = cfg_dir / "opencode.json"
         if data is not None:
             cfg.write_text(json.dumps(data))
         return cfg
 
     def _canonical(self, tmp_path: Path) -> str:
-        return str(
-            tmp_path
-            / ".config"
-            / "opencode"
-            / "plugins"
-            / "ouroboros-bridge"
-            / "ouroboros-bridge.ts"
-        )
+        return str(tmp_path / "opencode" / "plugins" / "ouroboros-bridge" / "ouroboros-bridge.ts")
 
     def test_appends_when_missing(self, tmp_path: Path) -> None:
         cfg = self._setup_cfg(tmp_path, {"provider": "x"})
+        oc_dir = tmp_path / "opencode"
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD_SETUP, return_value=oc_dir), patch(_OCD_CONFIG, return_value=oc_dir):
             _ensure_opencode_plugin_entry()
 
         data = json.loads(cfg.read_text())
@@ -224,9 +221,10 @@ class TestEnsurePluginEntry:
         assert data["provider"] == "x"  # preserved
 
     def test_creates_config_when_missing(self, tmp_path: Path) -> None:
-        cfg = tmp_path / ".config" / "opencode" / "opencode.json"
+        oc_dir = tmp_path / "opencode"
+        cfg = oc_dir / "opencode.json"
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD_SETUP, return_value=oc_dir), patch(_OCD_CONFIG, return_value=oc_dir):
             _ensure_opencode_plugin_entry()
 
         data = json.loads(cfg.read_text())
@@ -238,8 +236,9 @@ class TestEnsurePluginEntry:
         mtime_before = cfg.stat().st_mtime_ns
         os.utime(cfg, ns=(mtime_before - 1_000_000_000, mtime_before - 1_000_000_000))
         baseline = cfg.stat().st_mtime_ns
+        oc_dir = tmp_path / "opencode"
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD_SETUP, return_value=oc_dir), patch(_OCD_CONFIG, return_value=oc_dir):
             _ensure_opencode_plugin_entry()
 
         # No rewrite → mtime unchanged
@@ -250,8 +249,9 @@ class TestEnsurePluginEntry:
         stale2 = "/root/.config/opencode/plugins/ouroboros-bridge/ouroboros-bridge.ts"
         other = "/home/alice/.config/opencode/plugins/other/other.ts"
         cfg = self._setup_cfg(tmp_path, {"plugin": [stale1, other, stale2]})
+        oc_dir = tmp_path / "opencode"
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD_SETUP, return_value=oc_dir), patch(_OCD_CONFIG, return_value=oc_dir):
             _ensure_opencode_plugin_entry()
 
         data = json.loads(cfg.read_text())
@@ -261,8 +261,9 @@ class TestEnsurePluginEntry:
     def test_repoints_single_stale_to_canonical(self, tmp_path: Path) -> None:
         stale = "/wrong/path/plugins/ouroboros-bridge/ouroboros-bridge.ts"
         cfg = self._setup_cfg(tmp_path, {"plugin": [stale]})
+        oc_dir = tmp_path / "opencode"
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD_SETUP, return_value=oc_dir), patch(_OCD_CONFIG, return_value=oc_dir):
             _ensure_opencode_plugin_entry()
 
         data = json.loads(cfg.read_text())
@@ -270,12 +271,12 @@ class TestEnsurePluginEntry:
 
     def test_rewrites_non_dict_root(self, tmp_path: Path) -> None:
         """A bare array at root is replaced with a proper dict."""
-        cfg_dir = tmp_path / ".config" / "opencode"
-        cfg_dir.mkdir(parents=True)
-        cfg = cfg_dir / "opencode.json"
+        oc_dir = tmp_path / "opencode"
+        oc_dir.mkdir(parents=True, exist_ok=True)
+        cfg = oc_dir / "opencode.json"
         cfg.write_text(json.dumps(["broken"]))
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD_SETUP, return_value=oc_dir), patch(_OCD_CONFIG, return_value=oc_dir):
             _ensure_opencode_plugin_entry()
 
         data = json.loads(cfg.read_text())
@@ -283,13 +284,14 @@ class TestEnsurePluginEntry:
         assert data["plugin"] == [self._canonical(tmp_path)]
 
     def test_skips_on_parse_error(self, tmp_path: Path) -> None:
-        cfg_dir = tmp_path / ".config" / "opencode"
-        cfg_dir.mkdir(parents=True)
-        cfg = cfg_dir / "opencode.json"
+        oc_dir = tmp_path / "opencode"
+        oc_dir.mkdir(parents=True, exist_ok=True)
+        cfg = oc_dir / "opencode.json"
         cfg.write_text("{ this is not json")
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(_OCD_SETUP, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
             patch("ouroboros.cli.commands.setup.print_warning") as warn,
         ):
             _ensure_opencode_plugin_entry()
@@ -301,8 +303,9 @@ class TestEnsurePluginEntry:
     def test_atomic_json_write(self, tmp_path: Path) -> None:
         """JSON config written atomically — no leftover temp files."""
         cfg = self._setup_cfg(tmp_path, {})
+        oc_dir = tmp_path / "opencode"
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD_SETUP, return_value=oc_dir), patch(_OCD_CONFIG, return_value=oc_dir):
             _ensure_opencode_plugin_entry()
 
         leftovers = list(cfg.parent.glob(".opencode.json.*"))
@@ -314,11 +317,12 @@ class TestEnsurePluginEntry:
             tmp_path,
             {"plugin": ["/stale1/plugins/ouroboros-bridge/ouroboros-bridge.ts"]},
         )
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        oc_dir = tmp_path / "opencode"
+        with patch(_OCD_SETUP, return_value=oc_dir), patch(_OCD_CONFIG, return_value=oc_dir):
             _ensure_opencode_plugin_entry()
             _ensure_opencode_plugin_entry()
             _ensure_opencode_plugin_entry()
 
-        cfg = tmp_path / ".config" / "opencode" / "opencode.json"
+        cfg = oc_dir / "opencode.json"
         data = json.loads(cfg.read_text())
         assert data["plugin"] == [self._canonical(tmp_path)]

--- a/tests/unit/cli/test_bridge_plugin_lifecycle.py
+++ b/tests/unit/cli/test_bridge_plugin_lifecycle.py
@@ -12,6 +12,12 @@ from unittest.mock import MagicMock, patch
 from ouroboros.cli.commands.setup import _install_opencode_bridge_plugin
 from ouroboros.cli.commands.uninstall import _remove_opencode_bridge_plugin
 
+# Patch targets — both namespaces so internal calls through
+# find_opencode_config() also resolve to the test directory.
+_OCD_SETUP = "ouroboros.cli.commands.setup.opencode_config_dir"
+_OCD_UNINSTALL = "ouroboros.cli.commands.uninstall.opencode_config_dir"
+_OCD_CONFIG = "ouroboros.cli.opencode_config.opencode_config_dir"
+
 # ── _install_opencode_bridge_plugin ──────────────────────────────
 
 
@@ -21,6 +27,7 @@ class TestInstallBridgePlugin:
     def test_creates_plugin_dir_and_writes_file(self, tmp_path: Path) -> None:
         """Plugin dir created, .ts file written from package resource."""
         fake_content = "// ouroboros bridge plugin v2\nexport default {}\n"
+        oc_dir = tmp_path / "opencode"
 
         mock_source = MagicMock()
         mock_source.read_text.return_value = fake_content
@@ -29,25 +36,20 @@ class TestInstallBridgePlugin:
         mock_package.joinpath.return_value = mock_source
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(_OCD_SETUP, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
             patch("importlib.resources.files", return_value=mock_package),
         ):
             _install_opencode_bridge_plugin()
 
-        dest = (
-            tmp_path
-            / ".config"
-            / "opencode"
-            / "plugins"
-            / "ouroboros-bridge"
-            / "ouroboros-bridge.ts"
-        )
+        dest = oc_dir / "plugins" / "ouroboros-bridge" / "ouroboros-bridge.ts"
         assert dest.exists()
         assert dest.read_text() == fake_content
 
     def test_overwrites_existing_file(self, tmp_path: Path) -> None:
         """Existing plugin file overwritten with new version."""
-        plugin_dir = tmp_path / ".config" / "opencode" / "plugins" / "ouroboros-bridge"
+        oc_dir = tmp_path / "opencode"
+        plugin_dir = oc_dir / "plugins" / "ouroboros-bridge"
         plugin_dir.mkdir(parents=True)
         dest = plugin_dir / "ouroboros-bridge.ts"
         dest.write_text("// old version")
@@ -59,7 +61,8 @@ class TestInstallBridgePlugin:
         mock_package.joinpath.return_value = mock_source
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(_OCD_SETUP, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
             patch("importlib.resources.files", return_value=mock_package),
         ):
             _install_opencode_bridge_plugin()
@@ -68,10 +71,7 @@ class TestInstallBridgePlugin:
 
     def test_fallback_to_dev_source(self, tmp_path: Path) -> None:
         """When importlib.resources fails, fallback to dev tree source."""
-        # Create dev source file relative to setup.py's __file__
-        # setup.py is at src/ouroboros/cli/commands/setup.py
-        # dev_source = parents[3] / "opencode" / "plugin" / "ouroboros-bridge.ts"
-        # parents[3] of setup.py = src/ouroboros/
+        oc_dir = tmp_path / "opencode"
         dev_content = "// dev bridge plugin"
         dev_root = tmp_path / "src" / "ouroboros"
         dev_plugin = dev_root / "opencode" / "plugin" / "ouroboros-bridge.ts"
@@ -84,7 +84,8 @@ class TestInstallBridgePlugin:
         fake_setup_file.write_text("")
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(_OCD_SETUP, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
             patch("importlib.resources.files", side_effect=FileNotFoundError),
             patch(
                 "ouroboros.cli.commands.setup.__file__",
@@ -93,26 +94,20 @@ class TestInstallBridgePlugin:
         ):
             _install_opencode_bridge_plugin()
 
-        dest = (
-            tmp_path
-            / ".config"
-            / "opencode"
-            / "plugins"
-            / "ouroboros-bridge"
-            / "ouroboros-bridge.ts"
-        )
+        dest = oc_dir / "plugins" / "ouroboros-bridge" / "ouroboros-bridge.ts"
         assert dest.exists()
         assert dest.read_text() == dev_content
 
     def test_prints_warning_when_no_source(self, tmp_path: Path) -> None:
         """Warning printed when both importlib and dev source fail."""
-        # Point __file__ somewhere with no dev tree so fallback also fails
+        oc_dir = tmp_path / "opencode"
         fake_file = tmp_path / "nowhere" / "cli" / "commands" / "setup.py"
         fake_file.parent.mkdir(parents=True)
         fake_file.write_text("")
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(_OCD_SETUP, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
             patch("importlib.resources.files", side_effect=ModuleNotFoundError),
             patch("ouroboros.cli.commands.setup.__file__", str(fake_file)),
             patch("ouroboros.cli.commands.setup.print_warning") as mock_warn,
@@ -131,11 +126,15 @@ class TestRemoveBridgePlugin:
 
     def test_removes_existing_plugin_dir(self, tmp_path: Path) -> None:
         """Plugin dir removed successfully returns True."""
-        plugin_dir = tmp_path / ".config" / "opencode" / "plugins" / "ouroboros-bridge"
+        oc_dir = tmp_path / "opencode"
+        plugin_dir = oc_dir / "plugins" / "ouroboros-bridge"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "ouroboros-bridge.ts").write_text("// plugin")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with (
+            patch(_OCD_UNINSTALL, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
+        ):
             result = _remove_opencode_bridge_plugin(dry_run=False)
 
         assert result is True
@@ -143,11 +142,15 @@ class TestRemoveBridgePlugin:
 
     def test_dry_run_preserves_dir(self, tmp_path: Path) -> None:
         """Dry run returns True but does not delete."""
-        plugin_dir = tmp_path / ".config" / "opencode" / "plugins" / "ouroboros-bridge"
+        oc_dir = tmp_path / "opencode"
+        plugin_dir = oc_dir / "plugins" / "ouroboros-bridge"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "ouroboros-bridge.ts").write_text("// plugin")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with (
+            patch(_OCD_UNINSTALL, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
+        ):
             result = _remove_opencode_bridge_plugin(dry_run=True)
 
         assert result is True
@@ -155,19 +158,26 @@ class TestRemoveBridgePlugin:
 
     def test_missing_dir_returns_false(self, tmp_path: Path) -> None:
         """No plugin dir returns False (nothing to remove)."""
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        oc_dir = tmp_path / "opencode"
+
+        with (
+            patch(_OCD_UNINSTALL, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
+        ):
             result = _remove_opencode_bridge_plugin(dry_run=False)
 
         assert result is False
 
     def test_os_error_returns_false(self, tmp_path: Path) -> None:
         """OSError during rmtree returns False + prints warning."""
-        plugin_dir = tmp_path / ".config" / "opencode" / "plugins" / "ouroboros-bridge"
+        oc_dir = tmp_path / "opencode"
+        plugin_dir = oc_dir / "plugins" / "ouroboros-bridge"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "ouroboros-bridge.ts").write_text("// plugin")
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(_OCD_UNINSTALL, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
             patch("shutil.rmtree", side_effect=OSError("permission denied")),
             patch("ouroboros.cli.commands.uninstall.print_warning") as mock_warn,
         ):
@@ -189,8 +199,9 @@ class TestUninstallBridgePluginIntegration:
 
         from ouroboros.cli.commands.uninstall import app
 
-        # Create bridge plugin dir
-        plugin_dir = tmp_path / ".config" / "opencode" / "plugins" / "ouroboros-bridge"
+        # Create bridge plugin dir under the patched opencode config dir.
+        oc_dir = tmp_path / "opencode"
+        plugin_dir = oc_dir / "plugins" / "ouroboros-bridge"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "ouroboros-bridge.ts").write_text("// plugin")
 
@@ -198,6 +209,8 @@ class TestUninstallBridgePluginIntegration:
         with (
             patch("pathlib.Path.home", return_value=tmp_path),
             patch("pathlib.Path.cwd", return_value=tmp_path),
+            patch(_OCD_UNINSTALL, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
         ):
             result = runner.invoke(app, ["--dry-run"])
 
@@ -215,8 +228,9 @@ class TestUninstallBridgePluginIntegration:
         project_dir = tmp_path / "project"
         project_dir.mkdir()
 
-        # Create bridge plugin dir
-        plugin_dir = home_dir / ".config" / "opencode" / "plugins" / "ouroboros-bridge"
+        # Create bridge plugin dir under the patched opencode config dir.
+        oc_dir = tmp_path / "opencode"
+        plugin_dir = oc_dir / "plugins" / "ouroboros-bridge"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "ouroboros-bridge.ts").write_text("// plugin")
 
@@ -224,6 +238,8 @@ class TestUninstallBridgePluginIntegration:
         with (
             patch("pathlib.Path.home", return_value=home_dir),
             patch("pathlib.Path.cwd", return_value=project_dir),
+            patch(_OCD_UNINSTALL, return_value=oc_dir),
+            patch(_OCD_CONFIG, return_value=oc_dir),
         ):
             result = runner.invoke(app, ["-y"])
 

--- a/tests/unit/cli/test_opencode_config.py
+++ b/tests/unit/cli/test_opencode_config.py
@@ -1,4 +1,8 @@
-"""Unit tests for the shared opencode_config helper."""
+"""Unit tests for the shared opencode_config helper.
+
+All tests patch ``opencode_config_dir`` directly so they are
+platform-agnostic — no reliance on Linux-specific XDG paths.
+"""
 
 from __future__ import annotations
 
@@ -7,67 +11,75 @@ from unittest.mock import patch
 
 from ouroboros.cli.opencode_config import find_opencode_config
 
+_OCD = "ouroboros.cli.opencode_config.opencode_config_dir"
+
 
 class TestFindOpencodeConfig:
     """Tests for find_opencode_config()."""
 
     def test_prefers_jsonc_over_json(self, tmp_path: Path) -> None:
         """opencode.jsonc takes priority over opencode.json when both exist."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         jsonc = config_dir / "opencode.jsonc"
         json_ = config_dir / "opencode.json"
         jsonc.write_text("{}")
         json_.write_text("{}")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD, return_value=config_dir):
             result = find_opencode_config(allow_default=True)
 
         assert result == jsonc
 
     def test_falls_back_to_json_when_no_jsonc(self, tmp_path: Path) -> None:
         """Returns opencode.json when only that file exists."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         json_ = config_dir / "opencode.json"
         json_.write_text("{}")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD, return_value=config_dir):
             result = find_opencode_config(allow_default=True)
 
         assert result == json_
 
     def test_allow_default_true_returns_default_when_missing(self, tmp_path: Path) -> None:
         """Returns default opencode.json path when no config exists and allow_default=True."""
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
+
+        with patch(_OCD, return_value=config_dir):
             result = find_opencode_config(allow_default=True)
 
-        assert result == tmp_path / ".config" / "opencode" / "opencode.json"
+        assert result == config_dir / "opencode.json"
         assert result is not None
 
     def test_allow_default_false_returns_none_when_missing(self, tmp_path: Path) -> None:
         """Returns None when no config exists and allow_default=False."""
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
+
+        with patch(_OCD, return_value=config_dir):
             result = find_opencode_config(allow_default=False)
 
         assert result is None
 
     def test_allow_default_false_returns_existing_file(self, tmp_path: Path) -> None:
         """Returns existing file even when allow_default=False."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         jsonc = config_dir / "opencode.jsonc"
         jsonc.write_text("{}")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD, return_value=config_dir):
             result = find_opencode_config(allow_default=False)
 
         assert result == jsonc
 
     def test_oserror_on_candidate_is_skipped(self, tmp_path: Path) -> None:
         """OSError on exists() check is silently skipped — fallback continues."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         json_ = config_dir / "opencode.json"
         json_.write_text("{}")
 
@@ -79,7 +91,7 @@ class TestFindOpencodeConfig:
             return original_exists(self)
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(_OCD, return_value=config_dir),
             patch.object(Path, "exists", patched_exists),
         ):
             result = find_opencode_config(allow_default=True)
@@ -89,11 +101,11 @@ class TestFindOpencodeConfig:
 
     def test_returns_jsonc_path_type(self, tmp_path: Path) -> None:
         """Return value is always a Path instance (not str)."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         (config_dir / "opencode.jsonc").write_text("{}")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(_OCD, return_value=config_dir):
             result = find_opencode_config(allow_default=True)
 
         assert isinstance(result, Path)

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -1176,12 +1176,17 @@ class TestSetDefaultRepoExtended:
 
 
 class TestOpenCodeMCPSetup:
-    """Tests for OpenCode JSONC config handling in _ensure_opencode_mcp_entry."""
+    """Tests for OpenCode JSONC config handling in _ensure_opencode_mcp_entry.
+
+    Patches ``opencode_config_dir`` directly for platform-agnostic tests.
+    """
+
+    _OCD = "ouroboros.cli.opencode_config.opencode_config_dir"
 
     def test_jsonc_comments_preserved(self, tmp_path: Path) -> None:
         """JSONC with line and block comments parses without crashing and preserves non-MCP keys."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             '{\n  // line comment\n  /* block comment */\n  "theme": "dark",\n  "mcp": {}\n}\n',
@@ -1189,7 +1194,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1204,8 +1209,8 @@ class TestOpenCodeMCPSetup:
 
     def test_jsonc_trailing_commas_preserved(self, tmp_path: Path) -> None:
         """JSONC with trailing commas parses correctly and preserves keys."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             '{\n  "editor": "vim",\n  "mcp": {},\n}\n',
@@ -1213,7 +1218,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1227,8 +1232,8 @@ class TestOpenCodeMCPSetup:
 
     def test_existing_keys_survive_setup(self, tmp_path: Path) -> None:
         """Non-MCP keys like $schema and plugin survive _ensure_opencode_mcp_entry."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps(
@@ -1238,7 +1243,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1253,8 +1258,8 @@ class TestOpenCodeMCPSetup:
 
     def test_mcp_as_non_dict_is_replaced(self, tmp_path: Path) -> None:
         """If mcp is a list instead of a dict, setup replaces it with a valid dict."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps({"mcp": ["invalid"]}),
@@ -1262,7 +1267,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1276,8 +1281,8 @@ class TestOpenCodeMCPSetup:
 
     def test_ouroboros_entry_as_non_dict_is_replaced(self, tmp_path: Path) -> None:
         """If mcp.ouroboros is a string, setup replaces it with a proper entry."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps({"mcp": {"ouroboros": "disabled"}}),
@@ -1285,7 +1290,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1299,8 +1304,8 @@ class TestOpenCodeMCPSetup:
 
     def test_quoted_slashes_in_config_values_survive(self, tmp_path: Path) -> None:
         """URLs and patterns containing // or /* */ inside values are preserved."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             '{\n  "$schema": "https://opencode.ai/config.json",\n  "mcp": {}\n}\n',
@@ -1308,7 +1313,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1322,8 +1327,8 @@ class TestOpenCodeMCPSetup:
 
     def test_environment_as_string_is_replaced(self, tmp_path: Path) -> None:
         """If mcp.ouroboros.environment is a string, setup replaces it with a valid dict."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps(
@@ -1341,7 +1346,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1355,14 +1360,14 @@ class TestOpenCodeMCPSetup:
 
     def test_malformed_json_aborts_without_overwriting(self, tmp_path: Path) -> None:
         """If the config file is unparseable, setup must abort — not overwrite it."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         original_content = '{"theme": "dark", BROKEN JSON HERE}'
         config_path.write_text(original_content, encoding="utf-8")
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1375,8 +1380,8 @@ class TestOpenCodeMCPSetup:
 
     def test_custom_command_not_overwritten(self, tmp_path: Path) -> None:
         """User-managed commands (docker, nix, etc.) must survive setup."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         custom_cmd = ["docker", "run", "--rm", "ouroboros", "mcp", "serve"]
         config_path.write_text(
@@ -1395,7 +1400,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1410,8 +1415,8 @@ class TestOpenCodeMCPSetup:
 
     def test_stale_type_remote_rewritten_to_local(self, tmp_path: Path) -> None:
         """A stale type='remote' must be normalised to 'local' by setup."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps(
@@ -1429,7 +1434,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1442,8 +1447,8 @@ class TestOpenCodeMCPSetup:
 
     def test_command_as_bare_string_replaced_with_array(self, tmp_path: Path) -> None:
         """A hand-edited command: "ouroboros" string must be replaced with array."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps(
@@ -1461,7 +1466,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1475,8 +1480,8 @@ class TestOpenCodeMCPSetup:
 
     def test_empty_list_command_replaced(self, tmp_path: Path) -> None:
         """An empty command array must be replaced with the detected launcher."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps(
@@ -1494,7 +1499,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1507,8 +1512,8 @@ class TestOpenCodeMCPSetup:
 
     def test_non_string_first_element_replaced(self, tmp_path: Path) -> None:
         """A command array with non-string first element must be replaced."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps(
@@ -1526,7 +1531,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1539,8 +1544,8 @@ class TestOpenCodeMCPSetup:
 
     def test_none_first_element_replaced(self, tmp_path: Path) -> None:
         """A command array with null first element must be replaced."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         config_path = config_dir / "opencode.json"
         config_path.write_text(
             json.dumps(
@@ -1558,7 +1563,7 @@ class TestOpenCodeMCPSetup:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1581,10 +1586,10 @@ class TestOpenCodeSetupConfigYaml:
         config_path.write_text("just_a_string\n", encoding="utf-8")
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
             patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry"),
             patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry"),
+            patch("ouroboros.cli.commands.setup._cleanup_plugin_artifacts"),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
@@ -1606,10 +1611,10 @@ class TestOpenCodeSetupConfigYaml:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
             patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry"),
             patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry"),
+            patch("ouroboros.cli.commands.setup._cleanup_plugin_artifacts"),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
@@ -1629,7 +1634,6 @@ class TestOpenCodeSetupConfigYaml:
         claude_dir.mkdir()
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
             patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry"),
             patch("ouroboros.cli.commands.setup._ensure_opencode_plugin_entry"),
@@ -1655,7 +1659,6 @@ class TestOpenCodeSetupConfigYaml:
         config_path.write_text("{}", encoding="utf-8")
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._install_opencode_bridge_plugin", return_value=False
@@ -1677,7 +1680,6 @@ class TestOpenCodeSetupConfigYaml:
 
         runner = CliRunner()
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_runtimes",
@@ -1712,10 +1714,12 @@ class TestOpenCodeModePersisted:
         config_dir.mkdir()
         config_path = config_dir / "config.yaml"
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
             patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry"),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_plugin_entry"),
+            patch("ouroboros.cli.commands.setup._install_opencode_bridge_plugin"),
             patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry"),
+            patch("ouroboros.cli.commands.setup._cleanup_plugin_artifacts"),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
@@ -1739,37 +1743,43 @@ class TestOpenCodeModePersisted:
 
 
 class TestFindOpencodeConfig:
-    """Tests for _find_opencode_config — .jsonc/.json detection logic."""
+    """Tests for _find_opencode_config — .jsonc/.json detection logic.
+
+    Patches ``opencode_config_dir`` directly so tests are platform-agnostic
+    (no reliance on Linux-specific ``~/.config/opencode`` paths).
+    """
+
+    _OCD = "ouroboros.cli.opencode_config.opencode_config_dir"
 
     def test_prefers_jsonc_over_json(self, tmp_path: Path) -> None:
         """When both opencode.jsonc and opencode.json exist, .jsonc wins."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         (config_dir / "opencode.jsonc").write_text("{}", encoding="utf-8")
         (config_dir / "opencode.json").write_text("{}", encoding="utf-8")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(self._OCD, return_value=config_dir):
             result = _find_opencode_config()
 
         assert result.name == "opencode.jsonc"
 
     def test_falls_back_to_json(self, tmp_path: Path) -> None:
         """When only opencode.json exists, it is returned."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         (config_dir / "opencode.json").write_text("{}", encoding="utf-8")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(self._OCD, return_value=config_dir):
             result = _find_opencode_config()
 
         assert result.name == "opencode.json"
 
     def test_returns_json_default_when_neither_exists(self, tmp_path: Path) -> None:
         """When no config exists, returns opencode.json as default for creation."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(self._OCD, return_value=config_dir):
             result = _find_opencode_config()
 
         assert result.name == "opencode.json"
@@ -1777,23 +1787,28 @@ class TestFindOpencodeConfig:
 
     def test_only_jsonc_exists(self, tmp_path: Path) -> None:
         """When only opencode.jsonc exists, it is returned."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         (config_dir / "opencode.jsonc").write_text("{}", encoding="utf-8")
 
-        with patch("pathlib.Path.home", return_value=tmp_path):
+        with patch(self._OCD, return_value=config_dir):
             result = _find_opencode_config()
 
         assert result.name == "opencode.jsonc"
 
 
 class TestSetupJsoncDetection:
-    """Tests for _ensure_opencode_mcp_entry picking up .jsonc files."""
+    """Tests for _ensure_opencode_mcp_entry picking up .jsonc files.
+
+    Patches ``opencode_config_dir`` directly for platform-agnostic tests.
+    """
+
+    _OCD = "ouroboros.cli.opencode_config.opencode_config_dir"
 
     def test_setup_reads_existing_jsonc(self, tmp_path: Path) -> None:
         """Setup should read and update an existing opencode.jsonc file."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         jsonc_path = config_dir / "opencode.jsonc"
         jsonc_path.write_text(
             '{\n  // user comment\n  "theme": "dark",\n  "mcp": {}\n}\n',
@@ -1801,7 +1816,7 @@ class TestSetupJsoncDetection:
         )
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},
@@ -1817,13 +1832,13 @@ class TestSetupJsoncDetection:
 
     def test_setup_does_not_create_json_when_jsonc_exists(self, tmp_path: Path) -> None:
         """No stray opencode.json should be created when .jsonc is present."""
-        config_dir = tmp_path / ".config" / "opencode"
-        config_dir.mkdir(parents=True)
+        config_dir = tmp_path / "opencode"
+        config_dir.mkdir()
         jsonc_path = config_dir / "opencode.jsonc"
         jsonc_path.write_text('{"mcp": {}}', encoding="utf-8")
 
         with (
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(self._OCD, return_value=config_dir),
             patch(
                 "ouroboros.cli.commands.setup._detect_opencode_mcp_command",
                 return_value={"command": ["ouroboros", "mcp", "serve"]},


### PR DESCRIPTION
## Summary

Fixes #468 — OpenCode config tests hardcoded Linux XDG path `~/.config/opencode` via `Path.home()` patches, breaking on macOS where `opencode_config_dir()` returns `~/Library/Application Support/OpenCode`.

## Changes

**`tests/unit/cli/test_opencode_config.py`** (7 tests)
- Replace `Path.home` patches with `opencode_config_dir` patches
- Use flat `tmp_path / "opencode"` layout instead of `tmp_path / ".config" / "opencode"`

**`tests/unit/cli/test_setup.py`** (27 tests across 5 classes)
- `TestOpenCodeMCPSetup` (14 tests): `opencode_config_dir` + `find_opencode_config` patches
- `TestFindOpencodeConfig` (4 tests): `opencode_config_dir` patch
- `TestSetupJsoncDetection` (2 tests): `opencode_config_dir` patch
- `TestOpenCodeSetupConfigYaml` (5 tests): Remove `Path.home`, patch helpers directly
- `TestOpenCodeModePersisted` (2 tests): Patch all helper functions (test only cares about config.yaml content)

**`tests/unit/cli/conftest.py`**
- Remove `sys.platform = "linux"` workaround (no longer needed)
- Keep XDG_CONFIG_HOME/APPDATA env clearing for CI runners

## Not changed

`TestCodexSetup`, `TestClaudeSetup`, `TestHermesSetup` — these test `.codex/`, `.claude/`, `.hermes/` paths, not OpenCode. Their `Path.home` patches are correct and unrelated.

## Testing

- 427 CLI tests pass (1 pre-existing `pip-fallback` failure on main)
- `ruff format --check` + `ruff check` clean