### PR TITLE
fix(mcp): prevent start execute seed uuid4 scope crash

### DIFF
--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -864,8 +864,6 @@ class StartExecuteSeedHandler:
             # while the receipt advertises an orch_* id the child never sees.
             plugin_session_id = arguments.get("session_id")
             if not plugin_session_id:
-                from uuid import uuid4
-
                 plugin_session_id = f"orch_{uuid4().hex[:12]}"
 
             payload = build_execute_subagent(

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import AsyncIterator
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -453,6 +454,42 @@ class TestAsyncJobHandlers:
         handler = StartExecuteSeedHandler()
         assert "ouroboros_ac_tree_hud" in handler.definition.description
         assert "ouroboros_job_wait" not in handler.definition.description
+
+    async def test_start_execute_seed_background_generates_ids_without_session(
+        self,
+    ) -> None:
+        """Background path can generate execution/session IDs before dispatch."""
+
+        class FakeEventStore:
+            async def initialize(self) -> None:
+                return None
+
+        class FakeJobManager:
+            async def start_job(self, *, job_type, initial_message, runner, links):
+                runner.close()
+                return SimpleNamespace(
+                    job_id="job_test",
+                    links=links,
+                    status=SimpleNamespace(value="queued"),
+                    cursor=1,
+                )
+
+        execute_handler = MagicMock()
+        execute_handler.agent_runtime_backend = None
+        execute_handler.llm_backend = None
+        handler = StartExecuteSeedHandler(
+            execute_handler=execute_handler,
+            event_store=FakeEventStore(),
+            job_manager=FakeJobManager(),
+            agent_runtime_backend="codex",
+            opencode_mode=None,
+        )
+
+        result = await handler.handle({"seed_content": "goal: test"})
+
+        assert result.is_ok
+        assert result.value.meta["execution_id"].startswith("exec_")
+        assert result.value.meta["session_id"].startswith("orch_")
 
     def test_job_status_definition_name(self) -> None:
         handler = JobStatusHandler()


### PR DESCRIPTION
## Summary

- Fix `ouroboros_start_execute_seed` crashing with `UnboundLocalError` when the background path generates IDs without an existing session.
- Remove the nested `uuid4` import so the handler consistently uses the module-level import.
- Add a regression test for background execution ID/session ID generation.

## Changes

- Removed the function-local `from uuid import uuid4` in `StartExecuteSeedHandler.handle()`.
- Added a focused async test that exercises the no-session background path and verifies generated `exec_*` and `orch_*` IDs.

## Verification

- `uv run pytest tests/unit/mcp/tools/test_definitions.py -q`
- `uv run ruff check src/ouroboros/mcp/tools/execution_handlers.py tests/unit/mcp/tools/test_definitions.py`
- `uv run ruff format --check src/ouroboros/mcp/tools/execution_handlers.py tests/unit/mcp/tools/test_definitions.py`