### PR TITLE
feat(core): introduce Directive StrEnum for control-plane decisions

### DIFF
--- a/src/ouroboros/core/__init__.py
+++ b/src/ouroboros/core/__init__.py
@@ -16,6 +16,8 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "EventPayload": ("ouroboros.core.types", "EventPayload"),
     "CostUnits": ("ouroboros.core.types", "CostUnits"),
     "DriftScore": ("ouroboros.core.types", "DriftScore"),
+    # Control-plane directive vocabulary
+    "Directive": ("ouroboros.core.directive", "Directive"),
     # Errors
     "OuroborosError": ("ouroboros.core.errors", "OuroborosError"),
     "ProviderError": ("ouroboros.core.errors", "ProviderError"),

--- a/src/ouroboros/core/directive.py
+++ b/src/ouroboros/core/directive.py
@@ -1,20 +1,46 @@
-"""Directive vocabulary for control-plane decisions.
+"""Directive vocabulary for the Phase 2 control plane.
 
-This module defines the shared type used to describe "what should happen next"
-at any decision site across the Ouroboros workflow. Decision sites currently
-distributed across `evaluation/`, `evolution/`, `resilience/`, `orchestrator/`,
-and `observability/` will be migrated to this vocabulary in follow-up changes;
-this module adds only the type and its metadata, with no caller modifications.
+This module defines the shared value type that every decision site uses to
+describe "what should happen next." In the Agent OS framing introduced by
+the Phase-2 RFC, ``Directive`` members act as runtime-level syscalls: a
+small, stable alphabet through which decision sites (evaluator, evolver,
+resilience handlers, orchestrator, job manager) express control flow
+without each inventing its own signalling.
 
-Design notes:
-- The enum is additive. Each member has a deliberate precondition and effect.
-- Exactly two members are terminal: ``CANCEL`` and ``CONVERGE``. Every other
-  member implies the run continues.
-- The vocabulary is intentionally small. New directives are only added when an
-  existing one cannot cover the semantics without loss of meaning.
+Positioning within the Agent OS layers described by the RFC:
 
-See the control-plane RFC and the Directive introduction issue for rationale
-and the planned migration path.
+- Capability layer   — answers *what can this environment do?*
+- Policy layer       — answers *who may use which capability?*
+- **Directive layer  — answers what should happen next?*   (this module)*
+- Event journal      — answers *why did the system move?*  (paired with the
+                       ``control.directive.emitted`` event factory)
+
+Design invariants:
+
+- The enum is additive. Each member has a deliberate precondition and
+  effect; additions require a PR-level justification.
+- Exactly two members are terminal: ``CANCEL`` and ``CONVERGE``. Every
+  other member implies the run continues.
+- The vocabulary is intentionally small. New directives are introduced
+  only when an existing one cannot carry the semantics without loss.
+- Directives describe **workflow control**. They do not describe *capability
+  policy* (whether a tool is visible/executable). Those concerns stay in
+  the policy layer and in ``policy.*`` events.
+
+Migration posture (mapping, not replacement):
+
+Existing local enums — notably ``StepAction`` in the evolution loop, and
+the terminal branches in ``evaluation/`` and ``resilience/`` — do not
+disappear when this vocabulary lands. The first reference migration maps
+``StepAction`` onto ``Directive`` at the adapter boundary::
+
+    StepAction.STAGNATED  -> Directive.UNSTUCK
+    StepAction.CONVERGED  -> Directive.CONVERGE
+    StepAction.FAILED     -> Directive.RETRY  or Directive.CANCEL   (budget-dependent)
+
+Later migrations follow the same pattern so callers can be converted one
+at a time without flag days. This PR adds only the type and its
+invariants; no caller is modified here.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/core/directive.py
+++ b/src/ouroboros/core/directive.py
@@ -1,0 +1,87 @@
+"""Directive vocabulary for control-plane decisions.
+
+This module defines the shared type used to describe "what should happen next"
+at any decision site across the Ouroboros workflow. Decision sites currently
+distributed across `evaluation/`, `evolution/`, `resilience/`, `orchestrator/`,
+and `observability/` will be migrated to this vocabulary in follow-up changes;
+this module adds only the type and its metadata, with no caller modifications.
+
+Design notes:
+- The enum is additive. Each member has a deliberate precondition and effect.
+- Exactly two members are terminal: ``CANCEL`` and ``CONVERGE``. Every other
+  member implies the run continues.
+- The vocabulary is intentionally small. New directives are only added when an
+  existing one cannot cover the semantics without loss of meaning.
+
+See the control-plane RFC and the Directive introduction issue for rationale
+and the planned migration path.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Directive(StrEnum):
+    """Control-plane decision emitted by a workflow site.
+
+    Each directive is a single value that a decision site (an evaluator, an
+    evolver, a resilience handler, etc.) can emit to the surrounding runtime.
+    The runtime is responsible for acting on the directive; the site itself
+    does not dispatch work.
+
+    Members are named after the *action requested*, not the state that
+    produced them. ``CONTINUE`` means "proceed", not "we are in a continuing
+    state".
+    """
+
+    CONTINUE = "continue"
+    """Proceed with the current plan. No change in phase or plan required."""
+
+    EVALUATE = "evaluate"
+    """Hand off the current artifacts to the evaluation pipeline."""
+
+    EVOLVE = "evolve"
+    """Emit a next-generation proposal. Used when an evaluation yields
+    feedback that should influence the next seed generation rather than
+    retrying the current one."""
+
+    UNSTUCK = "unstuck"
+    """Invoke a lateral-thinking persona. Used when stagnation is detected
+    and a change in approach is required rather than a simple retry."""
+
+    RETRY = "retry"
+    """Re-execute the last unit under the same plan. The retry budget is
+    owned by the resilience layer and must be respected by the consumer."""
+
+    COMPACT = "compact"
+    """Compress context before continuing. The consumer must preserve the
+    event lineage; compaction affects working context, not persisted events."""
+
+    WAIT = "wait"
+    """Block on external input (user, upstream service, queued event). The
+    consumer must not proceed until the awaited input is delivered."""
+
+    CANCEL = "cancel"
+    """Terminate this execution without claiming success. Terminal."""
+
+    CONVERGE = "converge"
+    """Terminal success. Used when the seed's acceptance threshold has been
+    reached (e.g., ontology similarity satisfied, all ACs passed). Terminal."""
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return True if this directive ends the execution.
+
+        Exactly the ``CANCEL`` and ``CONVERGE`` members are terminal.
+        """
+        return self in _TERMINAL_DIRECTIVES
+
+
+_TERMINAL_DIRECTIVES: frozenset[Directive] = frozenset({Directive.CANCEL, Directive.CONVERGE})
+"""The closed set of directives that end a run.
+
+Maintained as a module-level constant so ``is_terminal`` does not allocate on
+every access and so the terminal set can be referenced from tests and from
+future invariants without inspecting individual enum members.
+"""

--- a/tests/unit/core/test_directive.py
+++ b/tests/unit/core/test_directive.py
@@ -1,0 +1,86 @@
+"""Unit tests for ouroboros.core.directive module."""
+
+from ouroboros.core.directive import Directive
+
+
+class TestDirectiveValues:
+    """Directive member string values are stable and unique."""
+
+    def test_directive_values_are_lowercase_names(self) -> None:
+        """Every directive's string value matches its lowercased member name."""
+        for member in Directive:
+            assert member.value == member.name.lower()
+
+    def test_directive_values_are_unique(self) -> None:
+        """No two directives share a string value."""
+        values = [member.value for member in Directive]
+
+        assert len(values) == len(set(values))
+
+    def test_directive_is_str_subclass(self) -> None:
+        """Directive members are usable as strings (StrEnum contract)."""
+        assert Directive.CONTINUE == "continue"
+        assert Directive.CONVERGE == "converge"
+
+
+class TestDirectiveTerminality:
+    """Terminality is a closed, documented property of the vocabulary."""
+
+    def test_cancel_is_terminal(self) -> None:
+        """CANCEL ends the execution."""
+        assert Directive.CANCEL.is_terminal is True
+
+    def test_converge_is_terminal(self) -> None:
+        """CONVERGE ends the execution."""
+        assert Directive.CONVERGE.is_terminal is True
+
+    def test_non_terminal_directives_are_not_terminal(self) -> None:
+        """Every directive other than CANCEL and CONVERGE continues the run."""
+        terminals = {Directive.CANCEL, Directive.CONVERGE}
+        for member in Directive:
+            if member in terminals:
+                continue
+            assert member.is_terminal is False, f"{member} should not be terminal"
+
+    def test_exactly_two_terminal_directives(self) -> None:
+        """The terminal set is intentionally small; guard against accidental growth."""
+        terminals = [member for member in Directive if member.is_terminal]
+
+        assert len(terminals) == 2
+
+
+class TestDirectiveMembership:
+    """Vocabulary membership is an API commitment — renaming or removing
+    members is a breaking change, so guard it with explicit assertions."""
+
+    def test_required_members_present(self) -> None:
+        """The initial vocabulary set must be preserved."""
+        required = {
+            "CONTINUE",
+            "EVALUATE",
+            "EVOLVE",
+            "UNSTUCK",
+            "RETRY",
+            "COMPACT",
+            "WAIT",
+            "CANCEL",
+            "CONVERGE",
+        }
+        names = {member.name for member in Directive}
+
+        assert required.issubset(names)
+
+    def test_lookup_by_value_round_trips(self) -> None:
+        """Directive(value) returns the same member it was created from."""
+        for member in Directive:
+            assert Directive(member.value) is member
+
+
+class TestDirectiveCoreReExport:
+    """Directive is exposed at the ouroboros.core package boundary."""
+
+    def test_directive_importable_from_core(self) -> None:
+        """Directive is re-exported via the lazy loader in ouroboros.core."""
+        from ouroboros.core import Directive as CoreDirective
+
+        assert CoreDirective is Directive


### PR DESCRIPTION
## Summary

- Introduce a shared `Directive` `StrEnum` for control-plane decisions (`continue`, `evaluate`, `evolve`, `unstuck`, `retry`, `compact`, `wait`, `cancel`, `converge`).
- Pure addition — no decision site is modified in this PR. Subsequent migrations will land as separate, independently reviewable PRs.

## Motivation

First step of #472. Post-#280, `docs/guides/mcp-bridge.md` records two Known Limitations: `evolve_step` not receiving the bridge manager, and no dynamic upstream-server addition. #471 frames these as **control-plane** symptoms — decision sites across `evaluation/`, `evolution/`, `resilience/`, `orchestrator/`, and `observability/` each emit ad-hoc signals (enums, booleans, literal strings) with no shared vocabulary, which is why new plumbing is required on every handler added post-#280.

#472 proposes introducing that shared vocabulary. This PR lands only the type and its invariants, with no caller modifications, matching the surgical-PR pattern established by recent merges (e.g., #470, #438, #444). Downstream migrations of individual decision sites become their own review units.

## Changes

- **`src/ouroboros/core/directive.py`** — new `Directive` `StrEnum`. Each member has a short docstring stating precondition and effect. Terminality is exposed through `is_terminal`, backed by a module-level `_TERMINAL_DIRECTIVES` `frozenset`. Exactly two terminal members: `CANCEL`, `CONVERGE`.
- **`src/ouroboros/core/__init__.py`** — lazy re-export of `Directive` alongside `Result` and the core type aliases, preserving the existing lazy-loader pattern used for every other core symbol.
- **`tests/unit/core/test_directive.py`** — 10 unit tests covering:
  - string-value stability (lowercased names, uniqueness, `StrEnum` substitutability)
  - terminal-set closure (exactly `CANCEL` and `CONVERGE`; everything else is non-terminal)
  - required vocabulary membership (guards accidental rename/removal)
  - `Directive(value)` round-trip
  - lazy re-export through `ouroboros.core`

## Not changed

No existing decision site is migrated in this PR. Migration is deferred so each call site becomes its own small, reviewable change:

- `evaluation/` terminal branches — follow-up PR
- `evolution/` convergence / `resilience/` stagnation handlers — follow-up PRs
- `orchestrator/` routing — follow-up PR

## Verification

```
uv run ruff check src/ouroboros/core/directive.py src/ouroboros/core/__init__.py tests/unit/core/test_directive.py
uv run ruff format --check src/ouroboros/core/directive.py src/ouroboros/core/__init__.py tests/unit/core/test_directive.py
uv run pytest tests/unit/core/ -q
```

Result: `296 passed` (10 new), ruff clean, format clean.

## References

- #471 (RFC — control plane vs capability plane framing)
- #472 (parent issue — unified Directive vocabulary)
- #280 (source of the Known Limitations this vocabulary is designed to address over follow-up PRs)
