### PR TITLE
feat(events): add control.directive.emitted event factory

### DIFF
--- a/src/ouroboros/core/__init__.py
+++ b/src/ouroboros/core/__init__.py
@@ -16,6 +16,8 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "EventPayload": ("ouroboros.core.types", "EventPayload"),
     "CostUnits": ("ouroboros.core.types", "CostUnits"),
     "DriftScore": ("ouroboros.core.types", "DriftScore"),
+    # Control-plane directive vocabulary
+    "Directive": ("ouroboros.core.directive", "Directive"),
     # Errors
     "OuroborosError": ("ouroboros.core.errors", "OuroborosError"),
     "ProviderError": ("ouroboros.core.errors", "ProviderError"),

--- a/src/ouroboros/core/directive.py
+++ b/src/ouroboros/core/directive.py
@@ -1,20 +1,46 @@
-"""Directive vocabulary for control-plane decisions.
+"""Directive vocabulary for the Phase 2 control plane.
 
-This module defines the shared type used to describe "what should happen next"
-at any decision site across the Ouroboros workflow. Decision sites currently
-distributed across `evaluation/`, `evolution/`, `resilience/`, `orchestrator/`,
-and `observability/` will be migrated to this vocabulary in follow-up changes;
-this module adds only the type and its metadata, with no caller modifications.
+This module defines the shared value type that every decision site uses to
+describe "what should happen next." In the Agent OS framing introduced by
+the Phase-2 RFC, ``Directive`` members act as runtime-level syscalls: a
+small, stable alphabet through which decision sites (evaluator, evolver,
+resilience handlers, orchestrator, job manager) express control flow
+without each inventing its own signalling.
 
-Design notes:
-- The enum is additive. Each member has a deliberate precondition and effect.
-- Exactly two members are terminal: ``CANCEL`` and ``CONVERGE``. Every other
-  member implies the run continues.
-- The vocabulary is intentionally small. New directives are only added when an
-  existing one cannot cover the semantics without loss of meaning.
+Positioning within the Agent OS layers described by the RFC:
 
-See the control-plane RFC and the Directive introduction issue for rationale
-and the planned migration path.
+- Capability layer   — answers *what can this environment do?*
+- Policy layer       — answers *who may use which capability?*
+- **Directive layer  — answers what should happen next?*   (this module)*
+- Event journal      — answers *why did the system move?*  (paired with the
+                       ``control.directive.emitted`` event factory)
+
+Design invariants:
+
+- The enum is additive. Each member has a deliberate precondition and
+  effect; additions require a PR-level justification.
+- Exactly two members are terminal: ``CANCEL`` and ``CONVERGE``. Every
+  other member implies the run continues.
+- The vocabulary is intentionally small. New directives are introduced
+  only when an existing one cannot carry the semantics without loss.
+- Directives describe **workflow control**. They do not describe *capability
+  policy* (whether a tool is visible/executable). Those concerns stay in
+  the policy layer and in ``policy.*`` events.
+
+Migration posture (mapping, not replacement):
+
+Existing local enums — notably ``StepAction`` in the evolution loop, and
+the terminal branches in ``evaluation/`` and ``resilience/`` — do not
+disappear when this vocabulary lands. The first reference migration maps
+``StepAction`` onto ``Directive`` at the adapter boundary::
+
+    StepAction.STAGNATED  -> Directive.UNSTUCK
+    StepAction.CONVERGED  -> Directive.CONVERGE
+    StepAction.FAILED     -> Directive.RETRY  or Directive.CANCEL   (budget-dependent)
+
+Later migrations follow the same pattern so callers can be converted one
+at a time without flag days. This PR adds only the type and its
+invariants; no caller is modified here.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/core/directive.py
+++ b/src/ouroboros/core/directive.py
@@ -1,0 +1,87 @@
+"""Directive vocabulary for control-plane decisions.
+
+This module defines the shared type used to describe "what should happen next"
+at any decision site across the Ouroboros workflow. Decision sites currently
+distributed across `evaluation/`, `evolution/`, `resilience/`, `orchestrator/`,
+and `observability/` will be migrated to this vocabulary in follow-up changes;
+this module adds only the type and its metadata, with no caller modifications.
+
+Design notes:
+- The enum is additive. Each member has a deliberate precondition and effect.
+- Exactly two members are terminal: ``CANCEL`` and ``CONVERGE``. Every other
+  member implies the run continues.
+- The vocabulary is intentionally small. New directives are only added when an
+  existing one cannot cover the semantics without loss of meaning.
+
+See the control-plane RFC and the Directive introduction issue for rationale
+and the planned migration path.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Directive(StrEnum):
+    """Control-plane decision emitted by a workflow site.
+
+    Each directive is a single value that a decision site (an evaluator, an
+    evolver, a resilience handler, etc.) can emit to the surrounding runtime.
+    The runtime is responsible for acting on the directive; the site itself
+    does not dispatch work.
+
+    Members are named after the *action requested*, not the state that
+    produced them. ``CONTINUE`` means "proceed", not "we are in a continuing
+    state".
+    """
+
+    CONTINUE = "continue"
+    """Proceed with the current plan. No change in phase or plan required."""
+
+    EVALUATE = "evaluate"
+    """Hand off the current artifacts to the evaluation pipeline."""
+
+    EVOLVE = "evolve"
+    """Emit a next-generation proposal. Used when an evaluation yields
+    feedback that should influence the next seed generation rather than
+    retrying the current one."""
+
+    UNSTUCK = "unstuck"
+    """Invoke a lateral-thinking persona. Used when stagnation is detected
+    and a change in approach is required rather than a simple retry."""
+
+    RETRY = "retry"
+    """Re-execute the last unit under the same plan. The retry budget is
+    owned by the resilience layer and must be respected by the consumer."""
+
+    COMPACT = "compact"
+    """Compress context before continuing. The consumer must preserve the
+    event lineage; compaction affects working context, not persisted events."""
+
+    WAIT = "wait"
+    """Block on external input (user, upstream service, queued event). The
+    consumer must not proceed until the awaited input is delivered."""
+
+    CANCEL = "cancel"
+    """Terminate this execution without claiming success. Terminal."""
+
+    CONVERGE = "converge"
+    """Terminal success. Used when the seed's acceptance threshold has been
+    reached (e.g., ontology similarity satisfied, all ACs passed). Terminal."""
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return True if this directive ends the execution.
+
+        Exactly the ``CANCEL`` and ``CONVERGE`` members are terminal.
+        """
+        return self in _TERMINAL_DIRECTIVES
+
+
+_TERMINAL_DIRECTIVES: frozenset[Directive] = frozenset({Directive.CANCEL, Directive.CONVERGE})
+"""The closed set of directives that end a run.
+
+Maintained as a module-level constant so ``is_terminal`` does not allocate on
+every access and so the terminal set can be referenced from tests and from
+future invariants without inspecting individual enum members.
+"""

--- a/src/ouroboros/events/control.py
+++ b/src/ouroboros/events/control.py
@@ -1,19 +1,48 @@
-"""Event factories for control-plane directive emissions.
+"""Event factories for the Phase 2 Event Journal — directive emissions.
 
-This module provides the factory for persisting control-plane decisions
-(continue / evaluate / evolve / unstuck / retry / compact / wait / cancel /
-converge) to the EventStore. Existing event categories (decomposition,
-evaluation, interview, lineage, ontology) capture data causality — what was
-produced — but not decision causality — *why* the run moved from one step to
-the next. This module adds the missing category without modifying existing
-emission sites.
+This module corresponds to the **Event Journal** layer in the Phase 2
+Agent OS framing (RFC #476). Existing event categories — ``decomposition``,
+``evaluation``, ``interview``, ``lineage``, ``ontology`` — capture *what*
+was produced. This category captures *why* the run moved from one step
+to the next, so the journal can answer both questions from the same
+replayable source.
 
-Event Types:
-    control.directive.emitted - A workflow site emitted a Directive
+The Event Journal is the causal source of truth. Every control-plane
+decision persists here before any live projection observes it. Consumers
+that later react to directives (TUI lineage timelines, drift monitors,
+future ControlBus subscribers) are projections of these events — they
+do not decide anything the journal does not already record.
 
-Follow-up changes will wire this factory into individual decision sites so
-the store contains a full directive timeline. This module adds only the
-factory and its tests; no production emission is added here.
+Event types:
+    control.directive.emitted — a workflow site emitted a ``Directive``
+
+Emission stance:
+
+This PR is **observational-first**. It persists the event; no emission
+site is wired, and no reactive consumer is added. Reactive consumption
+via a ControlBus subscription surface is a separate, later concern so
+the primitive stays stable while projections evolve. The TUI lineage
+renderer is the intended first projection.
+
+Payload shape:
+
+- ``emitted_by``   — logical source, e.g. ``"evaluator"``, ``"evolver"``,
+                     ``"resilience.lateral"``. Free-form to keep new
+                     emission sites from requiring a schema change.
+- ``directive``    — the ``Directive`` member's string value, so downstream
+                     consumers classify events without importing the enum.
+- ``is_terminal``  — denormalized terminality flag, for the same reason.
+- ``reason``       — short audit rationale; the structured source of
+                     truth for "why" remains the surrounding lineage.
+- ``context_snapshot_id`` — optional link into the context snapshot
+                     captured at emission; omitted when absent so stored
+                     rows stay compact.
+- ``extra``        — optional forward-compatibility slot; omitted when
+                     unused. Prefer promoting fields to named arguments
+                     over expanding ``extra`` in the long run.
+
+This module adds only the factory and its unit tests; follow-up changes
+wire it into individual decision sites one at a time.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/events/control.py
+++ b/src/ouroboros/events/control.py
@@ -1,0 +1,83 @@
+"""Event factories for control-plane directive emissions.
+
+This module provides the factory for persisting control-plane decisions
+(continue / evaluate / evolve / unstuck / retry / compact / wait / cancel /
+converge) to the EventStore. Existing event categories (decomposition,
+evaluation, interview, lineage, ontology) capture data causality — what was
+produced — but not decision causality — *why* the run moved from one step to
+the next. This module adds the missing category without modifying existing
+emission sites.
+
+Event Types:
+    control.directive.emitted - A workflow site emitted a Directive
+
+Follow-up changes will wire this factory into individual decision sites so
+the store contains a full directive timeline. This module adds only the
+factory and its tests; no production emission is added here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ouroboros.core.directive import Directive
+from ouroboros.events.base import BaseEvent
+
+
+def create_control_directive_emitted_event(
+    execution_id: str,
+    emitted_by: str,
+    directive: Directive,
+    reason: str,
+    context_snapshot_id: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> BaseEvent:
+    """Create an event recording a control-plane directive emission.
+
+    Args:
+        execution_id: Identifier of the execution the directive belongs to.
+            Used as the aggregate id so the directive timeline of a single
+            run can be reconstructed by aggregate-id query.
+        emitted_by: Logical source of the directive, e.g., ``"evaluator"``,
+            ``"evolver"``, ``"resilience.lateral"``. Free-form so new
+            emission sites do not require schema changes.
+        directive: The Directive being emitted.
+        reason: Short human-readable rationale. The *structured* source of
+            truth for "why" is the surrounding event lineage; this field is
+            intended for audit and debugging, not for programmatic routing.
+        context_snapshot_id: Optional reference to a context snapshot
+            captured at emission time. ``None`` when the emission site has
+            no relevant snapshot to link.
+        extra: Optional additional key-value pairs to include in the payload.
+            Intended for forward-compatibility during the migration; if a
+            callers needs a new structured field, prefer adding it to this
+            factory's signature rather than through ``extra``.
+
+    Returns:
+        BaseEvent of type ``control.directive.emitted``.
+
+    Example:
+        event = create_control_directive_emitted_event(
+            execution_id="exec_123",
+            emitted_by="evaluator",
+            directive=Directive.RETRY,
+            reason="Stage 1 mechanical checks failed; retry budget remains.",
+        )
+    """
+    data: dict[str, Any] = {
+        "emitted_by": emitted_by,
+        "directive": directive.value,
+        "is_terminal": directive.is_terminal,
+        "reason": reason,
+    }
+    if context_snapshot_id is not None:
+        data["context_snapshot_id"] = context_snapshot_id
+    if extra:
+        data["extra"] = dict(extra)
+
+    return BaseEvent(
+        type="control.directive.emitted",
+        aggregate_type="control",
+        aggregate_id=execution_id,
+        data=data,
+    )

--- a/src/ouroboros/events/control.py
+++ b/src/ouroboros/events/control.py
@@ -7,42 +7,45 @@ was produced. This category captures *why* the run moved from one step
 to the next, so the journal can answer both questions from the same
 replayable source.
 
-The Event Journal is the causal source of truth. Every control-plane
-decision persists here before any live projection observes it. Consumers
-that later react to directives (TUI lineage timelines, drift monitors,
-future ControlBus subscribers) are projections of these events — they
-do not decide anything the journal does not already record.
+Target-oriented aggregation
+---------------------------
+
+Every ``control.directive.emitted`` event is aggregated by the object the
+decision is *about*: ``(target_type, target_id)``. Using the targeted
+aggregate — rather than a neutral ``"control"`` bucket — means existing
+projectors that filter by aggregate (for example, a lineage projector
+reading ``aggregate_type="lineage"``) naturally see the interleaved
+directive stream alongside their state events. That is the difference
+between *storing* a control event and *earning* a replayable decision
+journal (per #476 maintainer feedback on #478).
+
+Canonical target types:
+
+- ``"session"``       — a whole orchestrator session
+- ``"execution"``     — a specific execution/run
+- ``"lineage"``       — a lineage chain (evolution loop)
+- ``"agent_process"`` — Phase 3 agent process (forward-compatible)
+
+The field is intentionally a string, not an enum, so new target types
+(e.g. a future ``"agent_process"``) land without changing the event type
+or the event schema.
+
+Correlation fields (``session_id``, ``execution_id``, ``lineage_id``,
+``generation_number``, ``phase``) are optional and stored in the payload
+only when provided. They let projections filter directive streams by
+additional axes without needing to join back to lineage state events.
+
+Emission stance
+---------------
+
+This module is **observational-first**. It persists the event; no
+emission site is wired, and no reactive consumer is added. Reactive
+consumption via a ControlBus subscription surface is a separate, later
+concern so the primitive stays stable while projections evolve. The TUI
+lineage renderer is the intended first projection.
 
 Event types:
     control.directive.emitted — a workflow site emitted a ``Directive``
-
-Emission stance:
-
-This PR is **observational-first**. It persists the event; no emission
-site is wired, and no reactive consumer is added. Reactive consumption
-via a ControlBus subscription surface is a separate, later concern so
-the primitive stays stable while projections evolve. The TUI lineage
-renderer is the intended first projection.
-
-Payload shape:
-
-- ``emitted_by``   — logical source, e.g. ``"evaluator"``, ``"evolver"``,
-                     ``"resilience.lateral"``. Free-form to keep new
-                     emission sites from requiring a schema change.
-- ``directive``    — the ``Directive`` member's string value, so downstream
-                     consumers classify events without importing the enum.
-- ``is_terminal``  — denormalized terminality flag, for the same reason.
-- ``reason``       — short audit rationale; the structured source of
-                     truth for "why" remains the surrounding lineage.
-- ``context_snapshot_id`` — optional link into the context snapshot
-                     captured at emission; omitted when absent so stored
-                     rows stay compact.
-- ``extra``        — optional forward-compatibility slot; omitted when
-                     unused. Prefer promoting fields to named arguments
-                     over expanding ``extra`` in the long run.
-
-This module adds only the factory and its unit tests; follow-up changes
-wire it into individual decision sites one at a time.
 """
 
 from __future__ import annotations
@@ -54,51 +57,91 @@ from ouroboros.events.base import BaseEvent
 
 
 def create_control_directive_emitted_event(
-    execution_id: str,
+    target_type: str,
+    target_id: str,
     emitted_by: str,
     directive: Directive,
     reason: str,
+    *,
+    session_id: str | None = None,
+    execution_id: str | None = None,
+    lineage_id: str | None = None,
+    generation_number: int | None = None,
+    phase: str | None = None,
     context_snapshot_id: str | None = None,
     extra: dict[str, Any] | None = None,
 ) -> BaseEvent:
     """Create an event recording a control-plane directive emission.
 
+    The event is aggregated by ``(target_type, target_id)`` so that any
+    projector filtering by a specific aggregate — e.g. a LineageProjector
+    querying ``aggregate_type="lineage"`` and ``aggregate_id=<lineage_id>`` —
+    naturally sees the interleaved directive stream alongside its state
+    events, without having to read the control bucket separately.
+
     Args:
-        execution_id: Identifier of the execution the directive belongs to.
-            Used as the aggregate id so the directive timeline of a single
-            run can be reconstructed by aggregate-id query.
-        emitted_by: Logical source of the directive, e.g., ``"evaluator"``,
-            ``"evolver"``, ``"resilience.lateral"``. Free-form so new
-            emission sites do not require schema changes.
-        directive: The Directive being emitted.
-        reason: Short human-readable rationale. The *structured* source of
-            truth for "why" is the surrounding event lineage; this field is
-            intended for audit and debugging, not for programmatic routing.
+        target_type: What kind of object this decision is about.
+            Canonical values: ``"session"``, ``"execution"``, ``"lineage"``,
+            ``"agent_process"``. Kept as a free-form string so new target
+            types land without a schema change.
+        target_id: Identifier of the targeted object. Becomes
+            ``aggregate_id`` on the stored event.
+        emitted_by: Logical source — e.g. ``"evaluator"``, ``"evolver"``,
+            ``"resilience.lateral"``. Free-form so new emission sites do
+            not require a schema change.
+        directive: The ``Directive`` being emitted.
+        reason: Short human-readable rationale. Audit-level field; the
+            structured source of truth for "why" remains the surrounding
+            event lineage.
+        session_id: Optional correlation into the owning session.
+        execution_id: Optional correlation into a specific execution.
+        lineage_id: Optional correlation into a lineage chain. For
+            lineage-targeted events, typically equal to ``target_id``.
+        generation_number: Optional lineage generation index.
+        phase: Optional phase name (e.g. ``"wondering"``, ``"reflecting"``).
         context_snapshot_id: Optional reference to a context snapshot
-            captured at emission time. ``None`` when the emission site has
-            no relevant snapshot to link.
-        extra: Optional additional key-value pairs to include in the payload.
-            Intended for forward-compatibility during the migration; if a
-            callers needs a new structured field, prefer adding it to this
-            factory's signature rather than through ``extra``.
+            captured at emission time. Omitted from the payload when
+            ``None`` to keep stored rows compact.
+        extra: Optional forward-compatibility slot. Prefer promoting
+            fields to named arguments as they stabilize.
 
     Returns:
-        BaseEvent of type ``control.directive.emitted``.
+        BaseEvent of type ``control.directive.emitted`` aggregated by
+        ``(target_type, target_id)``.
 
     Example:
         event = create_control_directive_emitted_event(
-            execution_id="exec_123",
-            emitted_by="evaluator",
+            target_type="lineage",
+            target_id="ralph-zepia-20260420-v3",
+            emitted_by="evolver",
             directive=Directive.RETRY,
-            reason="Stage 1 mechanical checks failed; retry budget remains.",
+            reason="Reflect failed; retry budget remains.",
+            lineage_id="ralph-zepia-20260420-v3",
+            generation_number=2,
+            phase="reflecting",
         )
     """
     data: dict[str, Any] = {
+        "target_type": target_type,
+        "target_id": target_id,
         "emitted_by": emitted_by,
         "directive": directive.value,
         "is_terminal": directive.is_terminal,
         "reason": reason,
     }
+    # Optional correlation + context fields land in the payload only when
+    # provided, so absence is distinguishable from an explicit None and
+    # stored rows stay compact.
+    if session_id is not None:
+        data["session_id"] = session_id
+    if execution_id is not None:
+        data["execution_id"] = execution_id
+    if lineage_id is not None:
+        data["lineage_id"] = lineage_id
+    if generation_number is not None:
+        data["generation_number"] = generation_number
+    if phase is not None:
+        data["phase"] = phase
     if context_snapshot_id is not None:
         data["context_snapshot_id"] = context_snapshot_id
     if extra:
@@ -106,7 +149,7 @@ def create_control_directive_emitted_event(
 
     return BaseEvent(
         type="control.directive.emitted",
-        aggregate_type="control",
-        aggregate_id=execution_id,
+        aggregate_type=target_type,
+        aggregate_id=target_id,
         data=data,
     )

--- a/tests/unit/core/test_directive.py
+++ b/tests/unit/core/test_directive.py
@@ -1,0 +1,86 @@
+"""Unit tests for ouroboros.core.directive module."""
+
+from ouroboros.core.directive import Directive
+
+
+class TestDirectiveValues:
+    """Directive member string values are stable and unique."""
+
+    def test_directive_values_are_lowercase_names(self) -> None:
+        """Every directive's string value matches its lowercased member name."""
+        for member in Directive:
+            assert member.value == member.name.lower()
+
+    def test_directive_values_are_unique(self) -> None:
+        """No two directives share a string value."""
+        values = [member.value for member in Directive]
+
+        assert len(values) == len(set(values))
+
+    def test_directive_is_str_subclass(self) -> None:
+        """Directive members are usable as strings (StrEnum contract)."""
+        assert Directive.CONTINUE == "continue"
+        assert Directive.CONVERGE == "converge"
+
+
+class TestDirectiveTerminality:
+    """Terminality is a closed, documented property of the vocabulary."""
+
+    def test_cancel_is_terminal(self) -> None:
+        """CANCEL ends the execution."""
+        assert Directive.CANCEL.is_terminal is True
+
+    def test_converge_is_terminal(self) -> None:
+        """CONVERGE ends the execution."""
+        assert Directive.CONVERGE.is_terminal is True
+
+    def test_non_terminal_directives_are_not_terminal(self) -> None:
+        """Every directive other than CANCEL and CONVERGE continues the run."""
+        terminals = {Directive.CANCEL, Directive.CONVERGE}
+        for member in Directive:
+            if member in terminals:
+                continue
+            assert member.is_terminal is False, f"{member} should not be terminal"
+
+    def test_exactly_two_terminal_directives(self) -> None:
+        """The terminal set is intentionally small; guard against accidental growth."""
+        terminals = [member for member in Directive if member.is_terminal]
+
+        assert len(terminals) == 2
+
+
+class TestDirectiveMembership:
+    """Vocabulary membership is an API commitment — renaming or removing
+    members is a breaking change, so guard it with explicit assertions."""
+
+    def test_required_members_present(self) -> None:
+        """The initial vocabulary set must be preserved."""
+        required = {
+            "CONTINUE",
+            "EVALUATE",
+            "EVOLVE",
+            "UNSTUCK",
+            "RETRY",
+            "COMPACT",
+            "WAIT",
+            "CANCEL",
+            "CONVERGE",
+        }
+        names = {member.name for member in Directive}
+
+        assert required.issubset(names)
+
+    def test_lookup_by_value_round_trips(self) -> None:
+        """Directive(value) returns the same member it was created from."""
+        for member in Directive:
+            assert Directive(member.value) is member
+
+
+class TestDirectiveCoreReExport:
+    """Directive is exposed at the ouroboros.core package boundary."""
+
+    def test_directive_importable_from_core(self) -> None:
+        """Directive is re-exported via the lazy loader in ouroboros.core."""
+        from ouroboros.core import Directive as CoreDirective
+
+        assert CoreDirective is Directive

--- a/tests/unit/events/test_control_events.py
+++ b/tests/unit/events/test_control_events.py
@@ -1,22 +1,25 @@
 """Unit tests for ouroboros.events.control module.
 
 Tests cover:
-- Event factory function
-- Event type naming convention
-- Payload shape (directive value, terminality, optional fields)
+- Event type + target-oriented aggregation
+- Payload basics (directive value, terminality, emitter, reason)
+- Optional correlation fields (appear iff provided)
+- Forward-compatible target types
+- Coverage across every Directive member
 """
 
 from ouroboros.core.directive import Directive
 from ouroboros.events.control import create_control_directive_emitted_event
 
 
-class TestControlDirectiveEmittedEvent:
-    """Tests for create_control_directive_emitted_event factory."""
+class TestControlDirectiveEmittedCoreShape:
+    """Event type + target aggregation + payload basics."""
 
     def test_event_type(self):
-        """Event should have type 'control.directive.emitted'."""
+        """Event type is the dot.notation.past_tense string."""
         event = create_control_directive_emitted_event(
-            execution_id="exec_123",
+            target_type="execution",
+            target_id="exec_123",
             emitted_by="evaluator",
             directive=Directive.RETRY,
             reason="Stage 1 failed; retry budget remains.",
@@ -24,23 +27,40 @@ class TestControlDirectiveEmittedEvent:
 
         assert event.type == "control.directive.emitted"
 
-    def test_event_aggregate(self):
-        """Event should be aggregated by execution id under the control aggregate."""
+    def test_aggregate_mirrors_target(self):
+        """aggregate_(type, id) = (target_type, target_id) so that
+        projectors filtering by aggregate naturally include directives."""
         event = create_control_directive_emitted_event(
-            execution_id="exec_123",
+            target_type="lineage",
+            target_id="lin_abc",
+            emitted_by="evolver",
+            directive=Directive.EVOLVE,
+            reason="Advance generation.",
+        )
+
+        assert event.aggregate_type == "lineage"
+        assert event.aggregate_id == "lin_abc"
+
+    def test_payload_includes_target(self):
+        """target_type and target_id are duplicated into the payload
+        for query convenience (no JOIN required to inspect)."""
+        event = create_control_directive_emitted_event(
+            target_type="execution",
+            target_id="exec_xyz",
             emitted_by="evaluator",
             directive=Directive.CONTINUE,
             reason="All checks passed.",
         )
 
-        assert event.aggregate_type == "control"
-        assert event.aggregate_id == "exec_123"
+        assert event.data["target_type"] == "execution"
+        assert event.data["target_id"] == "exec_xyz"
 
     def test_payload_serializes_directive_string_value(self):
-        """The payload stores the directive's string value (StrEnum .value),
-        not the Python member, so the event is JSON-safe through BaseEvent."""
+        """Payload stores the StrEnum value so downstream consumers
+        classify events without importing the Directive enum."""
         event = create_control_directive_emitted_event(
-            execution_id="exec_456",
+            target_type="execution",
+            target_id="exec_456",
             emitted_by="evolver",
             directive=Directive.EVOLVE,
             reason="Evaluation fed critique; advancing generation.",
@@ -49,28 +69,31 @@ class TestControlDirectiveEmittedEvent:
         assert event.data["directive"] == "evolve"
 
     def test_payload_records_terminality(self):
-        """Terminality is denormalized into the payload so downstream consumers
-        do not need to import the Directive enum to classify events."""
-        terminal_event = create_control_directive_emitted_event(
-            execution_id="exec_789",
+        """Denormalized is_terminal flag lets consumers classify
+        terminal vs non-terminal events without the enum."""
+        terminal = create_control_directive_emitted_event(
+            target_type="lineage",
+            target_id="lin_1",
             emitted_by="evolver",
             directive=Directive.CONVERGE,
             reason="Ontology similarity threshold reached.",
         )
-        non_terminal_event = create_control_directive_emitted_event(
-            execution_id="exec_789",
+        non_terminal = create_control_directive_emitted_event(
+            target_type="execution",
+            target_id="exec_1",
             emitted_by="evaluator",
             directive=Directive.CONTINUE,
             reason="Stage 2 passed.",
         )
 
-        assert terminal_event.data["is_terminal"] is True
-        assert non_terminal_event.data["is_terminal"] is False
+        assert terminal.data["is_terminal"] is True
+        assert non_terminal.data["is_terminal"] is False
 
-    def test_payload_records_reason_and_source(self):
-        """The emission source and rationale are preserved verbatim."""
+    def test_payload_records_emitter_and_reason(self):
+        """Emitter and reason are preserved verbatim."""
         event = create_control_directive_emitted_event(
-            execution_id="exec_abc",
+            target_type="execution",
+            target_id="exec_abc",
             emitted_by="resilience.lateral",
             directive=Directive.UNSTUCK,
             reason="Stagnation pattern 3 of 4 detected.",
@@ -79,63 +102,156 @@ class TestControlDirectiveEmittedEvent:
         assert event.data["emitted_by"] == "resilience.lateral"
         assert event.data["reason"] == "Stagnation pattern 3 of 4 detected."
 
-    def test_context_snapshot_id_is_optional(self):
-        """When the emission site has no snapshot to link, the key is absent —
-        not None — to keep stored payloads compact."""
+
+class TestOptionalCorrelationFields:
+    """Correlation fields appear in the payload iff provided, so
+    projections can filter by lineage / generation / phase without
+    reading None sentinels."""
+
+    def test_session_id_omitted_when_absent(self):
         event = create_control_directive_emitted_event(
-            execution_id="exec_def",
+            target_type="execution",
+            target_id="exec_def",
             emitted_by="evaluator",
             directive=Directive.CONTINUE,
-            reason="No snapshot needed.",
+            reason="n/a",
+        )
+
+        assert "session_id" not in event.data
+
+    def test_session_id_recorded_when_present(self):
+        event = create_control_directive_emitted_event(
+            target_type="execution",
+            target_id="exec_def",
+            emitted_by="evaluator",
+            directive=Directive.CONTINUE,
+            reason="n/a",
+            session_id="sess_99",
+        )
+
+        assert event.data["session_id"] == "sess_99"
+
+    def test_execution_id_correlation(self):
+        """A lineage-targeted directive can still correlate back to the
+        execution it ran inside."""
+        event = create_control_directive_emitted_event(
+            target_type="lineage",
+            target_id="lin_xyz",
+            emitted_by="evolver",
+            directive=Directive.EVOLVE,
+            reason="next gen",
+            execution_id="exec_from_which_this_ran",
+        )
+
+        assert event.data["execution_id"] == "exec_from_which_this_ran"
+
+    def test_lineage_generation_and_phase_correlation(self):
+        """Lineage-targeted directives carry generation_number + phase
+        so TUI lineage rendering places them exactly in the timeline."""
+        event = create_control_directive_emitted_event(
+            target_type="lineage",
+            target_id="lin_ralph",
+            emitted_by="evolver",
+            directive=Directive.RETRY,
+            reason="Reflect failed; retry budget remains.",
+            lineage_id="lin_ralph",
+            generation_number=2,
+            phase="reflecting",
+        )
+
+        assert event.data["lineage_id"] == "lin_ralph"
+        assert event.data["generation_number"] == 2
+        assert event.data["phase"] == "reflecting"
+
+    def test_context_snapshot_id_is_optional(self):
+        event = create_control_directive_emitted_event(
+            target_type="execution",
+            target_id="e",
+            emitted_by="x",
+            directive=Directive.CONTINUE,
+            reason="n",
         )
 
         assert "context_snapshot_id" not in event.data
 
     def test_context_snapshot_id_is_recorded_when_given(self):
-        """A linked snapshot id lands in the payload."""
         event = create_control_directive_emitted_event(
-            execution_id="exec_def",
-            emitted_by="evaluator",
+            target_type="execution",
+            target_id="e",
+            emitted_by="x",
             directive=Directive.COMPACT,
-            reason="Context nearing window limit.",
+            reason="nearing window limit",
             context_snapshot_id="snap_01",
         )
 
         assert event.data["context_snapshot_id"] == "snap_01"
 
     def test_extra_is_merged_when_given(self):
-        """Forward-compatibility knob: extra fields land under 'extra'."""
+        """Forward-compatibility slot; prefer promoting to named args as
+        fields stabilize, but extra keeps new data flowing in the mean
+        time."""
         event = create_control_directive_emitted_event(
-            execution_id="exec_xyz",
+            target_type="lineage",
+            target_id="lin_1",
             emitted_by="evolver",
             directive=Directive.EVOLVE,
-            reason="Generation advance.",
-            extra={"generation": 3},
+            reason="adv",
+            extra={"branch_hint": "a"},
         )
 
-        assert event.data["extra"] == {"generation": 3}
+        assert event.data["extra"] == {"branch_hint": "a"}
 
     def test_extra_absent_when_empty(self):
-        """Empty or omitted 'extra' keeps the payload compact."""
         event = create_control_directive_emitted_event(
-            execution_id="exec_xyz",
+            target_type="lineage",
+            target_id="lin_1",
             emitted_by="evolver",
             directive=Directive.EVOLVE,
-            reason="Generation advance.",
+            reason="adv",
         )
 
         assert "extra" not in event.data
 
 
+class TestTargetTypeIsForwardCompatible:
+    """target_type is free-form so new target types (e.g. Phase 3's
+    agent_process) land without a schema change."""
+
+    def test_agent_process_target(self):
+        event = create_control_directive_emitted_event(
+            target_type="agent_process",
+            target_id="proc_42",
+            emitted_by="scheduler",
+            directive=Directive.WAIT,
+            reason="awaiting external input",
+        )
+
+        assert event.aggregate_type == "agent_process"
+        assert event.aggregate_id == "proc_42"
+        assert event.data["target_type"] == "agent_process"
+
+    def test_session_target(self):
+        event = create_control_directive_emitted_event(
+            target_type="session",
+            target_id="sess_001",
+            emitted_by="orchestrator",
+            directive=Directive.CANCEL,
+            reason="user interrupt",
+        )
+
+        assert event.aggregate_type == "session"
+
+
 class TestControlDirectiveCoversEveryDirective:
-    """Smoke-level check that every Directive member serializes through the
-    factory without surprises. Guards against new members that add hidden
-    fields incompatible with BaseEvent's JSON-friendly payload contract."""
+    """Smoke check: every Directive member serializes through the
+    factory without surprises. Guards against vocabulary additions
+    introducing payload regressions."""
 
     def test_every_directive_produces_event(self):
         for directive in Directive:
             event = create_control_directive_emitted_event(
-                execution_id="exec_all",
+                target_type="execution",
+                target_id="exec_all",
                 emitted_by="test",
                 directive=directive,
                 reason=f"coverage for {directive.value}",

--- a/tests/unit/events/test_control_events.py
+++ b/tests/unit/events/test_control_events.py
@@ -1,0 +1,145 @@
+"""Unit tests for ouroboros.events.control module.
+
+Tests cover:
+- Event factory function
+- Event type naming convention
+- Payload shape (directive value, terminality, optional fields)
+"""
+
+from ouroboros.core.directive import Directive
+from ouroboros.events.control import create_control_directive_emitted_event
+
+
+class TestControlDirectiveEmittedEvent:
+    """Tests for create_control_directive_emitted_event factory."""
+
+    def test_event_type(self):
+        """Event should have type 'control.directive.emitted'."""
+        event = create_control_directive_emitted_event(
+            execution_id="exec_123",
+            emitted_by="evaluator",
+            directive=Directive.RETRY,
+            reason="Stage 1 failed; retry budget remains.",
+        )
+
+        assert event.type == "control.directive.emitted"
+
+    def test_event_aggregate(self):
+        """Event should be aggregated by execution id under the control aggregate."""
+        event = create_control_directive_emitted_event(
+            execution_id="exec_123",
+            emitted_by="evaluator",
+            directive=Directive.CONTINUE,
+            reason="All checks passed.",
+        )
+
+        assert event.aggregate_type == "control"
+        assert event.aggregate_id == "exec_123"
+
+    def test_payload_serializes_directive_string_value(self):
+        """The payload stores the directive's string value (StrEnum .value),
+        not the Python member, so the event is JSON-safe through BaseEvent."""
+        event = create_control_directive_emitted_event(
+            execution_id="exec_456",
+            emitted_by="evolver",
+            directive=Directive.EVOLVE,
+            reason="Evaluation fed critique; advancing generation.",
+        )
+
+        assert event.data["directive"] == "evolve"
+
+    def test_payload_records_terminality(self):
+        """Terminality is denormalized into the payload so downstream consumers
+        do not need to import the Directive enum to classify events."""
+        terminal_event = create_control_directive_emitted_event(
+            execution_id="exec_789",
+            emitted_by="evolver",
+            directive=Directive.CONVERGE,
+            reason="Ontology similarity threshold reached.",
+        )
+        non_terminal_event = create_control_directive_emitted_event(
+            execution_id="exec_789",
+            emitted_by="evaluator",
+            directive=Directive.CONTINUE,
+            reason="Stage 2 passed.",
+        )
+
+        assert terminal_event.data["is_terminal"] is True
+        assert non_terminal_event.data["is_terminal"] is False
+
+    def test_payload_records_reason_and_source(self):
+        """The emission source and rationale are preserved verbatim."""
+        event = create_control_directive_emitted_event(
+            execution_id="exec_abc",
+            emitted_by="resilience.lateral",
+            directive=Directive.UNSTUCK,
+            reason="Stagnation pattern 3 of 4 detected.",
+        )
+
+        assert event.data["emitted_by"] == "resilience.lateral"
+        assert event.data["reason"] == "Stagnation pattern 3 of 4 detected."
+
+    def test_context_snapshot_id_is_optional(self):
+        """When the emission site has no snapshot to link, the key is absent —
+        not None — to keep stored payloads compact."""
+        event = create_control_directive_emitted_event(
+            execution_id="exec_def",
+            emitted_by="evaluator",
+            directive=Directive.CONTINUE,
+            reason="No snapshot needed.",
+        )
+
+        assert "context_snapshot_id" not in event.data
+
+    def test_context_snapshot_id_is_recorded_when_given(self):
+        """A linked snapshot id lands in the payload."""
+        event = create_control_directive_emitted_event(
+            execution_id="exec_def",
+            emitted_by="evaluator",
+            directive=Directive.COMPACT,
+            reason="Context nearing window limit.",
+            context_snapshot_id="snap_01",
+        )
+
+        assert event.data["context_snapshot_id"] == "snap_01"
+
+    def test_extra_is_merged_when_given(self):
+        """Forward-compatibility knob: extra fields land under 'extra'."""
+        event = create_control_directive_emitted_event(
+            execution_id="exec_xyz",
+            emitted_by="evolver",
+            directive=Directive.EVOLVE,
+            reason="Generation advance.",
+            extra={"generation": 3},
+        )
+
+        assert event.data["extra"] == {"generation": 3}
+
+    def test_extra_absent_when_empty(self):
+        """Empty or omitted 'extra' keeps the payload compact."""
+        event = create_control_directive_emitted_event(
+            execution_id="exec_xyz",
+            emitted_by="evolver",
+            directive=Directive.EVOLVE,
+            reason="Generation advance.",
+        )
+
+        assert "extra" not in event.data
+
+
+class TestControlDirectiveCoversEveryDirective:
+    """Smoke-level check that every Directive member serializes through the
+    factory without surprises. Guards against new members that add hidden
+    fields incompatible with BaseEvent's JSON-friendly payload contract."""
+
+    def test_every_directive_produces_event(self):
+        for directive in Directive:
+            event = create_control_directive_emitted_event(
+                execution_id="exec_all",
+                emitted_by="test",
+                directive=directive,
+                reason=f"coverage for {directive.value}",
+            )
+
+            assert event.data["directive"] == directive.value
+            assert event.data["is_terminal"] == directive.is_terminal


### PR DESCRIPTION
## Summary

- Add `ouroboros.events.control.create_control_directive_emitted_event` — a factory that persists control-plane decisions (continue / evaluate / evolve / unstuck / retry / compact / wait / cancel / converge) to the EventStore via the existing `BaseEvent` contract.
- Pure addition — no emission site is added in this PR. Wiring each source lands as a separate reviewable change.

> **Depends on #477** (the `Directive` type). This PR is currently **stacked** on that branch; once #477 merges, this PR's diff reduces to only the new event factory.

## Motivation

First step of #473 under the control-plane framing in #471. The repo's event-sourcing story is strong — `decomposition`, `evaluation`, `interview`, `lineage`, and `ontology` categories together reconstruct prior state — but there is no category for the decisions *themselves*. Today, *why* a run moved from `evaluate` to `evolve`, or *why* a `retry` was issued, is implied by downstream effects and visible only in logs.

This is the reason the TUI `lineage` screen can show phase progress but not the decisions that produced it, and the reason the `Directive` type introduced in #472 would otherwise be ephemeral.

The factory follows the same surgical-addition pattern as #436 (`feat(events): add event_version to BaseEvent payload`) and #443 (`feat(evaluate): add ouroboros_checklist_verify MCP tool`): a new primitive introduced alongside its tests, with no existing caller modified.

## Changes

- **`src/ouroboros/events/control.py`** — new module.
  - `create_control_directive_emitted_event(execution_id, emitted_by, directive, reason, context_snapshot_id=None, extra=None)`.
  - Emits a `BaseEvent` with `type="control.directive.emitted"`, `aggregate_type="control"`, `aggregate_id=execution_id`.
  - Payload denormalizes `directive.value` **and** `is_terminal` so downstream consumers (TUI, drift detector, future replay) classify events without importing `Directive`.
  - `context_snapshot_id` and `extra` stay out of the payload when unset — matching the "compact payload" convention used by `events/evaluation.py` and `events/decomposition.py`.
- **`tests/unit/events/test_control_events.py`** — 10 tests covering event type, aggregate shape, StrEnum serialization, terminality, optional-field compaction, and coverage of every `Directive` member (guards future vocabulary growth).

## Not changed

- No emission site is wired up in this PR. Wiring is a separate concern and becomes its own small PR (e.g., `feat(evaluation): emit control.directive.emitted from terminal branches`).
- No Alembic migration is required — `BaseEvent.to_db_dict` already stores arbitrary payloads. Schema-level work (a dedicated `control_directive` table, if the maintainers prefer one over the generic `events` table) is deferred to a follow-up.
- No TUI rendering change.

## Verification

```
uv run ruff check src/ouroboros/events/control.py tests/unit/events/test_control_events.py
uv run ruff format --check src/ouroboros/events/control.py tests/unit/events/test_control_events.py
uv run pytest tests/unit/events/ tests/unit/core/ -q
```

Result: `343 passed` (10 new), ruff clean, format clean.

## References

- #471 (RFC — control plane vs capability plane framing)
- #472 / #477 (Directive vocabulary — required by this PR)
- #473 (parent issue — `control_directive` event category)
- #280 (source Known Limitations this work addresses across follow-ups)
