### PR TITLE
fix(router): preserve Windows literal path payloads through skill dispatch

### DIFF
--- a/src/ouroboros/router/dispatch.py
+++ b/src/ouroboros/router/dispatch.py
@@ -54,6 +54,10 @@ from ouroboros.router.types import (
 _MCP_TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _SKILL_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _DISPATCH_TEMPLATE_PATTERN = re.compile(r"\$(?:CWD|1)(?![A-Za-z0-9_])")
+# Windows literal path payloads (drive-letter `C:\…` or UNC `\\server\share\…`)
+# must skip shell tokenization — `shlex.split` treats backslash as an escape and
+# silently drops it, so `C:\temp\seed.yaml` would dispatch as `C:tempseed.yaml`.
+_WINDOWS_LITERAL_PATH_PATTERN = re.compile(r"^(?:[A-Za-z]:\\|\\\\)")
 _REQUIRED_MCP_FRONTMATTER_KEYS = ("mcp_tool", "mcp_args")
 _MCP_FRONTMATTER_VALUE_TYPES = "string, finite number, boolean, null, list, or mapping"
 _PACKAGED_SKILL_CACHE: TemporaryDirectory[str] | None = None
@@ -273,6 +277,8 @@ def extract_first_argument(remainder: str | None) -> str | None:
     if remainder is None or not remainder.strip():
         return None
     if re.search(r"[\r\n].*\S", remainder):
+        return remainder
+    if _WINDOWS_LITERAL_PATH_PATTERN.match(remainder.strip()):
         return remainder
     try:
         parts = shlex.split(remainder)

--- a/tests/unit/router/test_extract_first_argument.py
+++ b/tests/unit/router/test_extract_first_argument.py
@@ -53,6 +53,21 @@ from ouroboros.router import extract_first_argument
             "goal: test\nconstraints:\n  - keep it simple\nacceptance_criteria:\n  - works",
             id="multiline-inline-content-preserved",
         ),
+        pytest.param(
+            r"C:\temp\seed.yaml --strict",
+            r"C:\temp\seed.yaml --strict",
+            id="windows-drive-path-preserved",
+        ),
+        pytest.param(
+            r"\\server\share\seed.yaml --strict",
+            r"\\server\share\seed.yaml --strict",
+            id="windows-unc-path-preserved",
+        ),
+        pytest.param(
+            "  C:\\temp\\seed.yaml --strict",
+            "  C:\\temp\\seed.yaml --strict",
+            id="windows-drive-path-with-incidental-leading-whitespace-preserved",
+        ),
     ],
 )
 def test_extract_first_argument_returns_full_argument_payload(

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -354,6 +354,98 @@ def test_valid_parsed_dispatch_reconstructs_multiline_prompt_with_newline_separa
     assert result.mcp_args["seed_path"] == seed_content
 
 
+def test_valid_dispatch_preserves_windows_drive_letter_path_payload(tmp_path: Path) -> None:
+    """Windows drive-letter literal paths must reach ``$1`` with backslashes intact.
+
+    Without a Windows-literal carve-out the single-line path falls through to
+    ``shlex.split``, which treats ``\\`` as an escape character and silently
+    drops it. ``C:\\temp\\seed.yaml --strict`` would dispatch as
+    ``C:tempseed.yaml --strict``. This regression goes end-to-end through
+    ``resolve_skill_dispatch`` so the actual ``mcp_args`` payload is asserted
+    against the verbatim path, not just the prompt echo.
+    """
+    skills_dir = tmp_path / "skills"
+    skill_md_path = _write_dispatchable_skill(skills_dir, "run")
+    runtime_cwd = tmp_path / "workspace"
+    prompt = r"ooo run C:\temp\seed.yaml --strict"
+    expected_argument = r"C:\temp\seed.yaml --strict"
+    expected_args = {
+        "seed_path": expected_argument,
+        "cwd": str(runtime_cwd),
+        "combined": f"cwd={runtime_cwd} seed={expected_argument}",
+        "nested": {
+            "values": [
+                expected_argument,
+                str(runtime_cwd),
+                True,
+            ],
+        },
+    }
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt=prompt,
+            cwd=runtime_cwd,
+            skills_dir=skills_dir,
+        )
+    )
+
+    _assert_resolved_payload(
+        result,
+        Resolved(
+            skill_name="run",
+            command_prefix="ooo run",
+            prompt=prompt,
+            skill_path=skill_md_path,
+            mcp_tool="ouroboros_execute_seed",
+            mcp_args=expected_args,
+            first_argument=expected_argument,
+        ),
+    )
+
+
+def test_valid_dispatch_preserves_windows_unc_path_payload(tmp_path: Path) -> None:
+    """Windows UNC literal paths (``\\\\server\\share\\…``) must keep their backslashes."""
+    skills_dir = tmp_path / "skills"
+    skill_md_path = _write_dispatchable_skill(skills_dir, "run")
+    runtime_cwd = tmp_path / "workspace"
+    prompt = r"ooo run \\server\share\seed.yaml --strict"
+    expected_argument = r"\\server\share\seed.yaml --strict"
+    expected_args = {
+        "seed_path": expected_argument,
+        "cwd": str(runtime_cwd),
+        "combined": f"cwd={runtime_cwd} seed={expected_argument}",
+        "nested": {
+            "values": [
+                expected_argument,
+                str(runtime_cwd),
+                True,
+            ],
+        },
+    }
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt=prompt,
+            cwd=runtime_cwd,
+            skills_dir=skills_dir,
+        )
+    )
+
+    _assert_resolved_payload(
+        result,
+        Resolved(
+            skill_name="run",
+            command_prefix="ooo run",
+            prompt=prompt,
+            skill_path=skill_md_path,
+            mcp_tool="ouroboros_execute_seed",
+            mcp_args=expected_args,
+            first_argument=expected_argument,
+        ),
+    )
+
+
 def test_valid_dispatch_without_argument_normalizes_first_argument_template_to_empty_string(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- preserve Windows drive-letter (`C:\…`) and UNC (`\\server\share\…`) literal path payloads through `extract_first_argument` so backslashes survive skill dispatch
- add focused regression coverage at the `extract_first_argument` and end-to-end `resolve_skill_dispatch` levels

Refs #480.

## Problem

`extract_first_argument` returns single-line remainders through `shlex.split`, which on POSIX treats backslash as an escape character and silently drops it. So Windows literal path payloads reach the dispatched MCP tool stripped of every backslash:

| Input remainder | `shlex.split` (POSIX) result rejoined |
|---|---|
| `C:\temp\seed.yaml --strict` | `C:tempseed.yaml --strict` |
| `\\server\share\seed.yaml --strict` | `servershareseed.yaml --strict` |

That contradicts the documented `seed_file_or_content` contract for `/ouroboros:run` and breaks any other skill argument that legitimately contains backslashes on Windows callers.

## What changed

### `src/ouroboros/router/dispatch.py`

- new module-level pattern `_WINDOWS_LITERAL_PATH_PATTERN` recognizing the two literal-path shapes (`[A-Za-z]:\` and `\\`)
- `extract_first_argument` carves out a narrow fast path after the existing multiline branch: if the trimmed remainder starts with one of those prefixes, return the verbatim `remainder` and skip shell tokenization entirely
- the Windows-literal classification runs against `remainder.strip()` while the return value is the unstripped `remainder`, so any incidental leading whitespace in the original payload is preserved

The router parser layer is unchanged; this is strictly a `extract_first_argument` carve-out.

### Tests

- `tests/unit/router/test_extract_first_argument.py`
  - drive-letter path preserved
  - UNC path preserved
  - drive-letter path with incidental leading whitespace preserved
- `tests/unit/router/test_valid_dispatch_normalization.py`
  - end-to-end: drive-letter payload reaches `mcp_args["seed_path"]` and `Resolved.first_argument` with backslashes intact
  - end-to-end: UNC payload reaches `mcp_args["seed_path"]` and `Resolved.first_argument` with backslashes intact

## Why this PR is intentionally narrow

The original PR also covered multiline inline seed content, but that scope has since been resolved on `main` by a separate set of router fixes (`bebda68`, `bb7a456`, `e8534e0`, `40d3cae`) using a different implementation strategy. To avoid reintroducing churn or competing designs, this PR has been narrowed to the single concern that `main` does not yet cover: Windows literal path preservation. The branch was reset on top of `main` and only the Windows-path fast path remains.

## Verification

- `PYTHONPATH=src python3 -m pytest tests/unit/router -q` → **247 passed**
- `PYTHONPATH=src python3 -m pytest tests/unit/orchestrator -q` → **804 passed, 1 skipped**
- `PYTHONPATH=src python3 -m pytest tests/integration/test_codex_skill_smoke.py tests/integration/test_codex_skill_fallback.py -q` → **3 passed**
- `python3 -m ruff check src/ouroboros/router tests/unit/router` → **All checks passed**

## Non-goals

- changes to multiline inline payload handling (already on `main`)
- full native-Windows support beyond the dispatch-payload boundary
- changes to the documented standalone `ouroboros run <seed.yaml>` CLI contract
- changes to natural-language normalization for ordinary single-line skill prompts