### PR TITLE
fix(mcp): protect startup stdin during shell env loading

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -131,7 +131,13 @@ def _ensure_shell_env(*, timeout: float = 10.0) -> None:
         cmd = [shell, "-l", "-c", dump_cmd]
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=timeout,
+        )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
         _stderr_console.print(f"[yellow]Warning: shell env load failed: {e}[/yellow]")
         return

--- a/tests/unit/cli/test_mcp_shell_env.py
+++ b/tests/unit/cli/test_mcp_shell_env.py
@@ -1,0 +1,38 @@
+"""Tests for MCP shell environment loading."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+
+from ouroboros.cli.commands import mcp
+
+
+def test_shell_env_loader_preserves_mcp_stdin(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+
+    initialize_message = '{"jsonrpc":"2.0","id":1,"method":"initialize"}\n'
+    fake_stdin = io.StringIO(initialize_message)
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    calls: list[dict[str, object]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(kwargs)
+        if kwargs.get("stdin") != subprocess.DEVNULL:
+            sys.stdin.read()
+        stdout = json.dumps({"PATH": os.environ["PATH"], "OUROBOROS_TEST_ENV": "loaded"})
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+    mcp._ensure_shell_env(timeout=1.25)
+
+    assert fake_stdin.read() == initialize_message
+    assert calls[0]["stdin"] == subprocess.DEVNULL
+    assert os.environ["OUROBOROS_TEST_ENV"] == "loaded"


### PR DESCRIPTION
## Summary

- Prevent MCP stdio startup timeouts caused by shell environment probing inheriting the protocol stdin stream.
- Route shell env probe stdin to `subprocess.DEVNULL` so shell startup hooks cannot consume or block the JSON RPC initialize message.
- Add focused regression coverage proving the initialize payload remains unread while env loading still succeeds.

## Problem

`_ensure_shell_env()` runs a login shell before MCP server initialization to import shell environment values. For stdio MCP servers, parent stdin is also the protocol stream carrying the JSON RPC `initialize` message.

If `.zshrc`, `.bashrc`, or a command launched from shell startup reads stdin, it can drain or block the initialize message before the server reads it. The client then waits until startup timeout.

## Changes

- Pass `stdin=subprocess.DEVNULL` to the shell environment subprocess in `src/ouroboros/cli/commands/mcp.py`.
- Add `tests/unit/cli/test_mcp_shell_env.py` to simulate an MCP initialize message on stdin and a shell subprocess that would consume it without the guard.

## Docs

Reviewed the `mcp.py` documentation mapping in `CONTRIBUTING.md`. No docs were updated because this does not change MCP CLI flags, config shape, command output, or documented user behavior. It only isolates the internal shell env probe from the MCP transport stream.

## Verification

- `uv run pytest tests/unit/cli/test_mcp_shell_env.py -q`
- `uv run pytest tests/unit/cli/test_mcp_startup_cleanup.py tests/unit/cli/test_mcp_nested_guard.py tests/unit/cli/test_mcp_validate_transport_stderr.py -q`
- `uv run ruff check src/ouroboros/cli/commands/mcp.py tests/unit/cli/test_mcp_shell_env.py`
- `uv run ruff format --check src/ouroboros/cli/commands/mcp.py tests/unit/cli/test_mcp_shell_env.py`
- `uv run mypy src/ouroboros/cli/commands/mcp.py tests/unit/cli/test_mcp_shell_env.py`
- `uv run pytest -q` -> 5116 passed, 2 skipped
