### PR TITLE
feat(mcp): add compact monitoring relay views

### DIFF
--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -76,134 +76,163 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
      session_id: <existing session ID>
    ```
 
-5. **Ask user about polling strategy** using `AskUserQuestion` immediately after IDs are returned:
+5. **Default monitoring stance: relay compact progress in the main session.**
 
-   Present the session/job IDs first, then ask:
-
-   ```
-   Question: "Execution started. How would you like to monitor progress?"
-   Header: "Monitoring"
-   Options:
-     - label: "Poll here (Recommended)"
-       description: "Poll in this session. Context window is consumed but you get real-time updates."
-     - label: "Don't poll — I'll monitor separately"
-       description: "End here. Use `ooo status <session_id>` in a new terminal or /clone to monitor."
-   ```
-
-   **If user chooses "Poll here"**, ask follow-up:
-   ```
-   Question: "How often should I check progress?"
-   Header: "Interval"
-   Options:
-     - label: "Per level (Recommended)"
-       description: "Check once when each parallel level completes. Most context-efficient with meaningful updates."
-     - label: "Every 10 minutes"
-       description: "Periodic check regardless of level progress. Balanced context usage."
-     - label: "Every 20 minutes"
-       description: "Minimal context usage. Best for large seeds with many ACs."
-   ```
-
-   Then display:
-   ```
-   💡 Note: Context compression may occur during long executions.
-   MCP tools remain available after compression, but prior poll results are summarized.
-   If this session is needed for follow-up (ooo evaluate, ooo evolve), shorter polling = more context consumed.
-   ```
-
-   **If user chooses "Don't poll"**, display:
+   After IDs are returned, print only this short handoff:
 
    ```
-   Execution running in background.
-   Session ID: <session_id>
+   Execution started in background.
    Job ID: <job_id>
-   
-   To monitor progress:
-     Option A: Open a new terminal → `ooo status <session_id>`
-     Option B: Use /clone to fork this conversation for monitoring
-     Option C: Come back later and run `ooo status <session_id>` here
-   
-   When execution completes, continue with: `ooo evaluate <session_id>`
+   Session ID: <session_id>
+   Execution ID: <execution_id>
+
+   I will wait in low-token relay mode and report only meaningful state changes.
+   For full details later: `ouroboros_ac_tree_hud(session_id=<session_id>, view="tree")`
    ```
-   Then **stop** — do NOT proceed to polling steps.
 
-6. **Poll for progress** using `ouroboros_ac_tree_hud` (only if user chose to poll):
+   Rationale: the main chat session must wait for MCP calls. Frequent full-tree
+   polling burns context without improving execution. The user usually wants
+   "what is it doing now?" rather than the whole tree, so use compact job
+   read-model snapshots and narrate them like a brief live relay.
 
-   The polling behavior differs based on the user's interval choice. In all cases,
-   the tool returns a compact markdown snapshot when state changed, or a one-line
-   delta ("No AC tree change since cursor <cursor>.") when nothing changed.
-   Keep the latest cursor from the tool's meta payload for the next call.
+6. **Low-token relay loop with `ouroboros_job_wait` (recommended default).**
 
-   **Option A: "Per level (Recommended)"**
+   Use `ouroboros_job_wait`, not repeated `ouroboros_ac_tree_hud`, for routine
+   monitoring. Keep the latest cursor and previous progress counters from the
+   tool meta payload.
+
+   This loop is intentionally harness/model friendly:
+   - Treat `response.meta` as the source of truth.
+   - Do not parse `response.text` for counts, status, or cursor.
+   - Use `response.text` only as a human-readable current-message hint.
+   - Keep all local monitor state in simple scalar variables.
+   - Emit at most one short relay message per changed response.
+   - Always continue to final `ouroboros_job_result` after a terminal status.
+
    ```
-   prev_completed = 0
+   cursor = <cursor from start/status response, or 0>
+   prev_status = "running"
+   prev_phase = null
+   prev_ac_completed = 0
+   prev_sub_ac_completed = 0
+   prev_message = null
 
    loop:
-     Tool: ouroboros_ac_tree_hud
+     Tool: ouroboros_job_wait
      Arguments:
-       session_id: <session_id from step 3>
-       cursor: <cursor from previous response, starts at 0>
-       max_nodes: 50
+       job_id: <job_id from step 3>
+       cursor: <cursor>
+       timeout_seconds: 180
+       view: "summary"
 
-     # Parse completed/total from the snapshot or meta
-     current_completed = <completed count>
-     total = <total count>
+     cursor = response.meta.cursor
 
-     if current_completed > prev_completed:
-       # A level completed — show the returned markdown snapshot as-is
-       print snapshot
-       prev_completed = current_completed
-     # else: continue silently (no output)
+     if response.meta.changed is false:
+       # Do not narrate unless the user explicitly asked for heartbeat updates.
+       continue
 
-     # Continue until meta.status is "completed", "failed", or "cancelled"
+     status = response.meta.status
+     phase = response.meta.current_phase
+     ac_completed = response.meta.ac_completed
+     ac_total = response.meta.ac_total
+     sub_ac_completed = response.meta.sub_ac_completed
+     sub_ac_total = response.meta.sub_ac_total
+     message_hint = first non-empty non-metadata line from response.text, or null
+
+     # Build one short relay update from structured fields.
+     if status in ["completed", "failed", "cancelled", "interrupted"]:
+       print terminal_relay(status, phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total)
+       break
+
+     if ac_completed > prev_ac_completed:
+       print ac_progress_relay(phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total, message_hint)
+     elif sub_ac_completed > prev_sub_ac_completed:
+       print sub_ac_progress_relay(phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total, message_hint)
+     elif phase != prev_phase or status != prev_status:
+       print phase_or_status_relay(status, phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total)
+     elif message_hint != prev_message:
+       print current_work_relay(phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total, message_hint)
+
+     prev_status = status
+     prev_phase = phase
+     prev_ac_completed = ac_completed or prev_ac_completed
+     prev_sub_ac_completed = sub_ac_completed or prev_sub_ac_completed
+     prev_message = message_hint or prev_message
    ```
 
-   **Option B: "Every 10 minutes"**
+   Notes:
+   - `timeout_seconds: 180` means the MCP call can block for up to 3 minutes.
+     This keeps the main session available often enough for a live relay while
+     still avoiding noisy polling.
+   - Use `view: "compact"` for very long jobs or when the user only wants a
+     heartbeat. It returns one-line state such as `job_x | running | AC 3/17`.
+   - Use `view: "summary"` for normal monitoring. It includes the job message
+     plus AC/Sub-AC counts.
+   - Use `view: "full"` only when the user asks for detailed job status.
+
+   Relay style examples:
+   - `In progress: Deliver is at AC 1/3 and Sub-AC 12/16. Current work is the Sub-AC 3 regression test.`
+   - `Level update: parallel level 1/1 has finished, and AC progress advanced to 3/3.`
+   - `Completed: execution finished. Fetching the final job result now.`
+
+   Relay output contract for other harnesses/models:
+   - One update should be 1-2 sentences or 1 compact line.
+   - Include `phase`, `AC completed/total`, and `Sub-AC completed/total` when present.
+   - Include the current work hint only if it changes.
+   - Never include the full AC tree in routine relay output.
+   - Never include raw JSON, raw meta dumps, or repeated unchanged cursor lines.
+   - Terminal statuses must be explicit: completed, failed, cancelled, or interrupted.
+
+   Do not paste the full raw tool output unless the user asks for raw status.
+   Do not add speculative ETA unless the tool provides one.
+
+7. **Use `ouroboros_ac_tree_hud` only for manual drill-down or anomaly checks.**
+
+   Do not call full tree HUD in the normal polling loop.
+
+   Use these targeted calls:
+
    ```
-   loop:
-     Tool: ouroboros_ac_tree_hud
-     Arguments:
-       session_id: <session_id from step 3>
-       cursor: <cursor from previous response, starts at 0>
-       max_nodes: 50
+   # Default short HUD, useful for a one-off check
+   Tool: ouroboros_ac_tree_hud
+   Arguments:
+     session_id: <session_id>
+     cursor: <cursor>
+     view: "summary"
 
-     # Report on every return regardless of change
-     - If unchanged: echo the one-line delta only
-     - If changed: show the returned markdown snapshot as-is
-     sleep 600  # 10 min between polls
+   # Lowest-token one-line HUD
+   Tool: ouroboros_ac_tree_hud
+   Arguments:
+     session_id: <session_id>
+     cursor: <cursor>
+     view: "compact"
 
-     # Continue until meta.status is "completed", "failed", or "cancelled"
+   # Full tree only when user asks "show details", progress looks stuck,
+   # or debugging requires seeing AC/Sub-AC structure.
+   Tool: ouroboros_ac_tree_hud
+   Arguments:
+     session_id: <session_id>
+     cursor: <cursor>
+     view: "tree"
+     max_nodes: 30
    ```
 
-   **Option C: "Every 20 minutes"**
-   ```
-   loop:
-     Tool: ouroboros_ac_tree_hud
-     Arguments:
-       session_id: <session_id from step 3>
-       cursor: <cursor from previous response, starts at 0>
-       max_nodes: 50
+   Treat `unchanged cursor=<cursor>` as a no-op. Do not explain it to the user
+   unless they explicitly asked for heartbeat messages.
 
-     # Report on every return regardless of change
-     - If unchanged: echo the one-line delta only
-     - If changed: show the returned markdown snapshot as-is
-     sleep 1200  # 20 min between polls
-
-     # Continue until meta.status is "completed", "failed", or "cancelled"
-   ```
-
-7. **Fetch final result** with `ouroboros_job_result`:
+8. **Fetch final result** with `ouroboros_job_result`:
    ```
    Tool: ouroboros_job_result
    Arguments:
      job_id: <job_id>
    ```
 
-8. Present the execution results to the user:
+9. Present the execution results to the user:
    - Show success/failure status
    - Show session ID (for later status checks)
    - Show execution summary
 
-9. **Post-execution QA** (automatic):
+10. **Post-execution QA** (automatic):
    `ouroboros_start_execute_seed` automatically runs QA after successful execution.
    The QA verdict is included in the final job result text.
    To skip: pass `skip_qa: true` to the tool.
@@ -239,13 +268,13 @@ Job ID: job_a1b2c3d4e5f6
 Session ID: orch_x1y2z3
 Execution ID: exec_m1n2o3
 
-[Polling for progress...]
-🌳 AC Tree
-✅ Parse seed
-⏳ Implement workflow routing [Edit src/ouroboros/mcp/tools/ac_tree_hud_handler.py]
-⬜ Verify output
+[Relay]
+In progress: Deliver is at AC 1/3 and Sub-AC 12/16.
+Current work is finishing the workflow routing Sub-AC.
 
-elapsed 45s | messages 12 | tools 4
+[Relay]
+Level update: parallel level 1/1 has finished, and AC progress advanced to 3/3.
+Execution is complete. Fetching the final job result now.
 
 [Fetching final result...]
 

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -76,7 +76,7 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
      session_id: <existing session ID>
    ```
 
-5. **Default monitoring stance: relay compact progress in the main session.**
+5. **Recommended monitoring stance: relay compact progress in the main session.**
 
    After IDs are returned, print only this short handoff:
 
@@ -87,7 +87,7 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
    Execution ID: <execution_id>
 
    I will wait in low-token relay mode and report only meaningful state changes.
-   For full details later: `ouroboros_ac_tree_hud(session_id=<session_id>, view="tree")`
+   For full details later: `ouroboros_ac_tree_hud(session_id=<session_id>)`
    ```
 
    Rationale: the main chat session must wait for MCP calls. Frequent full-tree
@@ -193,7 +193,7 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
    Use these targeted calls:
 
    ```
-   # Default short HUD, useful for a one-off check
+   # Explicit short HUD, useful for a one-off check
    Tool: ouroboros_ac_tree_hud
    Arguments:
      session_id: <session_id>
@@ -217,8 +217,9 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
      max_nodes: 30
    ```
 
-   Treat `unchanged cursor=<cursor>` as a no-op. Do not explain it to the user
-   unless they explicitly asked for heartbeat messages.
+   Treat `unchanged cursor=<cursor>` from explicit compact/summary views as a
+   no-op. Do not explain it to the user unless they explicitly asked for
+   heartbeat messages.
 
 8. **Fetch final result** with `ouroboros_job_result`:
    ```

--- a/src/ouroboros/mcp/tools/ac_tree_hud_handler.py
+++ b/src/ouroboros/mcp/tools/ac_tree_hud_handler.py
@@ -62,6 +62,18 @@ _FALLBACK_ACTIVITY_LABELS = {
     "unavailable": "working",
 }
 
+_SUBTASK_STATUS_KEYS = ("completed", "executing", "pending", "failed")
+_DEFAULT_HUD_VIEW = "summary"
+_HUD_VIEW_ALIASES = {
+    "compact": "compact",
+    "brief": "compact",
+    "summary": "summary",
+    "default": "summary",
+    "tree": "tree",
+    "full": "tree",
+    "verbose": "tree",
+}
+
 
 def _coerce_int(value: object, default: int) -> int:
     """Return an integer when possible, otherwise a default."""
@@ -83,6 +95,14 @@ def _coerce_non_empty_string(value: object) -> str | None:
         if stripped:
             return stripped
     return None
+
+
+def _normalize_hud_view(value: object) -> str:
+    """Normalize requested HUD verbosity."""
+    raw_view = _coerce_non_empty_string(value)
+    if raw_view is None:
+        return _DEFAULT_HUD_VIEW
+    return _HUD_VIEW_ALIASES.get(raw_view.lower(), _DEFAULT_HUD_VIEW)
 
 
 def _coerce_children_ids(value: object) -> list[str]:
@@ -321,6 +341,99 @@ def _has_status_change_event(events: list[Any]) -> bool:
 def _has_tree_change_event(events: list[Any]) -> bool:
     """Return True when execution events may change the rendered AC tree."""
     return any(getattr(event, "type", None) in _TREE_CHANGE_EVENT_TYPES for event in events)
+
+
+def summarize_subtask_events(execution_events: object) -> dict[str, Any]:
+    """Summarize the latest known state of execution subtask events.
+
+    Top-level AC progress intentionally rolls up only after an AC finishes.
+    Long-running decomposed executions can therefore sit at ``0/N`` while many
+    Sub-ACs are already complete. This summary gives monitoring clients a
+    second, fine-grained progress signal without changing top-level AC counts.
+    """
+    if not isinstance(execution_events, list | tuple):
+        return {}
+
+    latest_by_id: dict[str, Mapping[str, Any]] = {}
+    order_by_id: dict[str, int] = {}
+
+    for order, event in enumerate(execution_events):
+        if getattr(event, "type", None) != "execution.subtask.updated":
+            continue
+
+        data = getattr(event, "data", None)
+        if not isinstance(data, Mapping):
+            continue
+
+        ac_index = _coerce_int(data.get("ac_index"), 0)
+        sub_task_index = _coerce_int(data.get("sub_task_index"), 0)
+        sub_task_id = _coerce_non_empty_string(data.get("sub_task_id"))
+        if sub_task_id is None:
+            if ac_index <= 0 or sub_task_index <= 0:
+                continue
+            sub_task_id = f"ac_{ac_index}_sub_{sub_task_index}"
+
+        latest_by_id[sub_task_id] = data
+        order_by_id[sub_task_id] = order
+
+    if not latest_by_id:
+        return {}
+
+    counts = dict.fromkeys(_SUBTASK_STATUS_KEYS, 0)
+    active: list[dict[str, Any]] = []
+
+    for sub_task_id, data in latest_by_id.items():
+        status = _normalize_status(data.get("status"))
+        counts[status] = counts.get(status, 0) + 1
+
+        if status == "executing":
+            active.append(
+                {
+                    "sub_task_id": sub_task_id,
+                    "ac_index": _coerce_int(data.get("ac_index"), 0),
+                    "sub_task_index": _coerce_int(data.get("sub_task_index"), 0),
+                    "content": _coerce_non_empty_string(data.get("content")) or sub_task_id,
+                    "status": status,
+                    "_order": order_by_id.get(sub_task_id, 0),
+                }
+            )
+
+    active.sort(key=lambda item: item.get("_order", 0), reverse=True)
+    for item in active:
+        item.pop("_order", None)
+
+    return {
+        "completed_count": counts.get("completed", 0),
+        "executing_count": counts.get("executing", 0),
+        "pending_count": counts.get("pending", 0),
+        "failed_count": counts.get("failed", 0),
+        "total_count": len(latest_by_id),
+        "active": active[:5],
+    }
+
+
+def format_subtask_progress_summary(summary: object) -> str | None:
+    """Format a compact Sub-AC progress summary for monitoring output."""
+    if not isinstance(summary, Mapping):
+        return None
+
+    total_count = _coerce_int(summary.get("total_count"), 0)
+    if total_count <= 0:
+        return None
+
+    completed_count = _coerce_int(summary.get("completed_count"), 0)
+    executing_count = _coerce_int(summary.get("executing_count"), 0)
+    pending_count = _coerce_int(summary.get("pending_count"), 0)
+    failed_count = _coerce_int(summary.get("failed_count"), 0)
+
+    parts = [f"{completed_count}/{total_count} complete"]
+    if executing_count > 0:
+        parts.append(f"{executing_count} working")
+    if pending_count > 0:
+        parts.append(f"{pending_count} pending")
+    if failed_count > 0:
+        parts.append(f"{failed_count} failed")
+    return " · ".join(parts)
 
 
 def _valid_tree_payload(value: object) -> bool:
@@ -607,6 +720,9 @@ def _compose_progress_data(
         _extract_tree_snapshot(progress_data),
         execution_events,
     )
+    subtask_summary = summarize_subtask_events(execution_events)
+    if subtask_summary:
+        composed["sub_ac_progress"] = subtask_summary
     return composed
 
 
@@ -619,6 +735,8 @@ def _tree_snapshot_changed(
         return True
     return _extract_tree_snapshot(previous_progress_data) != _extract_tree_snapshot(
         current_progress_data
+    ) or previous_progress_data.get("sub_ac_progress") != current_progress_data.get(
+        "sub_ac_progress"
     )
 
 
@@ -889,6 +1007,112 @@ def _format_footer(progress_data: Mapping[str, Any]) -> str | None:
     return " · ".join(parts)
 
 
+def _format_active_subtasks(progress_data: Mapping[str, Any], *, limit: int = 3) -> str | None:
+    """Format currently active Sub-AC IDs as a short monitoring hint."""
+    summary = progress_data.get("sub_ac_progress")
+    if not isinstance(summary, Mapping):
+        return None
+
+    active = summary.get("active")
+    if not isinstance(active, list | tuple):
+        return None
+
+    labels: list[str] = []
+    for item in active:
+        if not isinstance(item, Mapping):
+            continue
+        label = _coerce_non_empty_string(item.get("sub_task_id"))
+        if label:
+            labels.append(label)
+        if len(labels) >= limit:
+            break
+
+    if not labels:
+        return None
+    return ", ".join(labels)
+
+
+def _format_compact_hud(
+    *,
+    session_id: str,
+    execution_id: str,
+    session_status: str,
+    progress_data: Mapping[str, Any],
+    cursor: int | None,
+) -> str:
+    """Render the lowest-token HUD view for frequent polling."""
+    completed_count = _coerce_int(progress_data.get("completed_count"), 0)
+    total_count = _coerce_int(progress_data.get("total_count"), 0)
+    phase = _coerce_non_empty_string(progress_data.get("current_phase")) or "working"
+    subtask_summary = progress_data.get("sub_ac_progress")
+    subtask_total = (
+        _coerce_int(subtask_summary.get("total_count"), 0)
+        if isinstance(subtask_summary, Mapping)
+        else 0
+    )
+    subtask_completed = (
+        _coerce_int(subtask_summary.get("completed_count"), 0)
+        if isinstance(subtask_summary, Mapping)
+        else 0
+    )
+
+    parts = [
+        session_id,
+        session_status,
+        phase,
+        f"AC {completed_count}/{total_count}",
+    ]
+    if subtask_total > 0:
+        parts.append(f"Sub-AC {subtask_completed}/{subtask_total}")
+    if cursor is not None:
+        parts.append(f"cursor {cursor}")
+    return " | ".join(parts) + f"\n{execution_id}"
+
+
+def _format_summary_hud(
+    *,
+    session_id: str,
+    execution_id: str,
+    session_status: str,
+    progress_data: Mapping[str, Any],
+    cursor: int | None,
+) -> str:
+    """Render a small status card without the full AC tree."""
+    completed_count = _coerce_int(progress_data.get("completed_count"), 0)
+    total_count = _coerce_int(progress_data.get("total_count"), 0)
+    phase = _coerce_non_empty_string(progress_data.get("current_phase"))
+    subtask_progress = format_subtask_progress_summary(progress_data.get("sub_ac_progress"))
+
+    status_parts = [f"Status: {session_status}"]
+    if phase:
+        status_parts.append(f"Phase: {phase}")
+    status_parts.append(f"AC: {completed_count}/{total_count}")
+    if subtask_progress:
+        status_parts.append(f"Sub-AC: {subtask_progress}")
+
+    lines = [
+        f"Session: {session_id}",
+        f"Execution: {execution_id}",
+        " | ".join(status_parts),
+    ]
+
+    activity = _format_activity(
+        progress_data.get("activity"),
+        progress_data.get("activity_detail"),
+    )
+    if activity:
+        lines.append(f"Activity: {activity}")
+
+    active_subtasks = _format_active_subtasks(progress_data)
+    if active_subtasks:
+        lines.append(f"Active: {active_subtasks}")
+
+    if cursor is not None:
+        lines.append(f"Cursor: {cursor}")
+
+    return "\n".join(lines)
+
+
 def render_ac_tree_hud_markdown(
     *,
     session_id: str,
@@ -896,8 +1120,28 @@ def render_ac_tree_hud_markdown(
     session_status: str,
     progress_data: Mapping[str, Any],
     max_nodes: int = _DEFAULT_MAX_NODES,
+    view: str = "tree",
+    cursor: int | None = None,
 ) -> str:
     """Render a compact markdown HUD from workflow progress data."""
+    normalized_view = _normalize_hud_view(view)
+    if normalized_view == "compact":
+        return _format_compact_hud(
+            session_id=session_id,
+            execution_id=execution_id,
+            session_status=session_status,
+            progress_data=progress_data,
+            cursor=cursor,
+        )
+    if normalized_view == "summary":
+        return _format_summary_hud(
+            session_id=session_id,
+            execution_id=execution_id,
+            session_status=session_status,
+            progress_data=progress_data,
+            cursor=cursor,
+        )
+
     completed_count = _coerce_int(progress_data.get("completed_count"), 0)
     total_count = _coerce_int(progress_data.get("total_count"), 0)
     current_ac_index = _coerce_int(progress_data.get("current_ac_index"), 0) or None
@@ -919,6 +1163,9 @@ def render_ac_tree_hud_markdown(
         lines.append(f"Phase: {phase}")
 
     lines.append(f"Progress: {completed_count}/{total_count} AC complete")
+    subtask_progress = format_subtask_progress_summary(progress_data.get("sub_ac_progress"))
+    if subtask_progress:
+        lines.append(f"Sub-AC Progress: {subtask_progress}")
 
     activity = _format_activity(
         progress_data.get("activity"),
@@ -1004,8 +1251,9 @@ class ACTreeHUDHandler:
         return MCPToolDefinition(
             name="ouroboros_ac_tree_hud",
             description=(
-                "Return a compact, render-ready markdown snapshot of the live "
-                "acceptance-criteria tree for an Ouroboros session."
+                "Return a token-efficient live acceptance-criteria progress "
+                "snapshot for an Ouroboros session. Use view='tree' only when "
+                "the full AC tree is needed."
             ),
             parameters=(
                 MCPToolParameter(
@@ -1022,9 +1270,19 @@ class ACTreeHUDHandler:
                     default=0,
                 ),
                 MCPToolParameter(
+                    name="view",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "Verbosity: 'compact' for one-line polling, 'summary' "
+                        "for the default short monitor, or 'tree' for full details."
+                    ),
+                    required=False,
+                    default=_DEFAULT_HUD_VIEW,
+                ),
+                MCPToolParameter(
                     name="max_nodes",
                     type=ToolInputType.INTEGER,
-                    description="Maximum nodes to render before truncation.",
+                    description="Maximum tree nodes to render when view='tree'.",
                     required=False,
                     default=_DEFAULT_MAX_NODES,
                 ),
@@ -1038,6 +1296,7 @@ class ACTreeHUDHandler:
         """Render the current AC tree HUD for a session."""
         session_id = _coerce_non_empty_string(arguments.get("session_id")) or ""
         cursor = max(0, _coerce_int(arguments.get("cursor"), 0))
+        view = _normalize_hud_view(arguments.get("view"))
         max_nodes = max(1, _coerce_int(arguments.get("max_nodes"), _DEFAULT_MAX_NODES))
 
         if not session_id:
@@ -1097,7 +1356,7 @@ class ACTreeHUDHandler:
                         content=(
                             MCPContentItem(
                                 type=ContentType.TEXT,
-                                text=f"No AC tree change since cursor {cursor}.",
+                                text=f"unchanged cursor={new_cursor}",
                             ),
                         ),
                         is_error=False,
@@ -1107,6 +1366,7 @@ class ACTreeHUDHandler:
                             "status": tracker.status.value,
                             "cursor": new_cursor,
                             "changed": False,
+                            "view": view,
                         },
                     )
                 )
@@ -1151,7 +1411,7 @@ class ACTreeHUDHandler:
                             content=(
                                 MCPContentItem(
                                     type=ContentType.TEXT,
-                                    text=f"No AC tree change since cursor {cursor}.",
+                                    text=f"unchanged cursor={new_cursor}",
                                 ),
                             ),
                             is_error=False,
@@ -1161,6 +1421,7 @@ class ACTreeHUDHandler:
                                 "status": tracker.status.value,
                                 "cursor": new_cursor,
                                 "changed": False,
+                                "view": view,
                             },
                         )
                     )
@@ -1171,6 +1432,8 @@ class ACTreeHUDHandler:
                 session_status=tracker.status.value,
                 progress_data=progress_data,
                 max_nodes=max_nodes,
+                view=view,
+                cursor=new_cursor,
             )
             return Result.ok(
                 MCPToolResult(
@@ -1184,6 +1447,7 @@ class ACTreeHUDHandler:
                         "changed": (
                             has_tree_change_event or has_status_change_event or cursor == 0
                         ),
+                        "view": view,
                     },
                 )
             )

--- a/src/ouroboros/mcp/tools/ac_tree_hud_handler.py
+++ b/src/ouroboros/mcp/tools/ac_tree_hud_handler.py
@@ -63,12 +63,12 @@ _FALLBACK_ACTIVITY_LABELS = {
 }
 
 _SUBTASK_STATUS_KEYS = ("completed", "executing", "pending", "failed")
-_DEFAULT_HUD_VIEW = "summary"
+_DEFAULT_HUD_VIEW = "tree"
 _HUD_VIEW_ALIASES = {
     "compact": "compact",
     "brief": "compact",
     "summary": "summary",
-    "default": "summary",
+    "default": "tree",
     "tree": "tree",
     "full": "tree",
     "verbose": "tree",
@@ -103,6 +103,13 @@ def _normalize_hud_view(value: object) -> str:
     if raw_view is None:
         return _DEFAULT_HUD_VIEW
     return _HUD_VIEW_ALIASES.get(raw_view.lower(), _DEFAULT_HUD_VIEW)
+
+
+def _format_unchanged_hud_text(*, cursor: int, new_cursor: int, view: str) -> str:
+    """Return the unchanged text for the requested HUD verbosity."""
+    if view in {"compact", "summary"}:
+        return f"unchanged cursor={new_cursor}"
+    return f"No AC tree change since cursor {cursor}."
 
 
 def _coerce_children_ids(value: object) -> list[str]:
@@ -1251,9 +1258,8 @@ class ACTreeHUDHandler:
         return MCPToolDefinition(
             name="ouroboros_ac_tree_hud",
             description=(
-                "Return a token-efficient live acceptance-criteria progress "
-                "snapshot for an Ouroboros session. Use view='tree' only when "
-                "the full AC tree is needed."
+                "Return a render-ready markdown snapshot of the live "
+                "acceptance-criteria tree for an Ouroboros session."
             ),
             parameters=(
                 MCPToolParameter(
@@ -1273,8 +1279,8 @@ class ACTreeHUDHandler:
                     name="view",
                     type=ToolInputType.STRING,
                     description=(
-                        "Verbosity: 'compact' for one-line polling, 'summary' "
-                        "for the default short monitor, or 'tree' for full details."
+                        "Verbosity: 'tree' (default) for the full AC tree, "
+                        "'summary' for a short monitor, or 'compact' for one-line polling."
                     ),
                     required=False,
                     default=_DEFAULT_HUD_VIEW,
@@ -1356,7 +1362,11 @@ class ACTreeHUDHandler:
                         content=(
                             MCPContentItem(
                                 type=ContentType.TEXT,
-                                text=f"unchanged cursor={new_cursor}",
+                                text=_format_unchanged_hud_text(
+                                    cursor=cursor,
+                                    new_cursor=new_cursor,
+                                    view=view,
+                                ),
                             ),
                         ),
                         is_error=False,
@@ -1411,7 +1421,11 @@ class ACTreeHUDHandler:
                             content=(
                                 MCPContentItem(
                                     type=ContentType.TEXT,
-                                    text=f"unchanged cursor={new_cursor}",
+                                    text=_format_unchanged_hud_text(
+                                        cursor=cursor,
+                                        new_cursor=new_cursor,
+                                        view=view,
+                                    ),
                                 ),
                             ),
                             is_error=False,

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -8,7 +8,7 @@ Contains handlers for background job operations and execution cancellation:
 - CancelJobHandler: Cancel a background job
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import structlog
@@ -36,6 +36,10 @@ log = structlog.get_logger(__name__)
 _DEFAULT_JOB_VIEW = "full"
 _JOB_EXECUTION_EVENT_LIMIT = 250
 _JOB_SUBTASK_EVENT_PAGE_SIZE = 500
+_JOB_PROGRESS_EVENT_TYPES = {
+    "workflow.progress.updated",
+    "execution.subtask.updated",
+}
 _JOB_VIEW_ALIASES = {
     "compact": "compact",
     "brief": "compact",
@@ -623,6 +627,21 @@ class JobWaitHandler:
         except ValueError as exc:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_job_wait"))
 
+        execution_progress_changed = False
+        response_cursor = max(snapshot.cursor, cursor)
+        if snapshot.links.execution_id:
+            execution_events, execution_cursor = await self._event_store.get_events_after(
+                "execution",
+                snapshot.links.execution_id,
+                cursor,
+            )
+            execution_progress_changed = any(
+                event.type in _JOB_PROGRESS_EVENT_TYPES for event in execution_events
+            )
+            response_cursor = max(response_cursor, execution_cursor)
+            if response_cursor != snapshot.cursor:
+                snapshot = replace(snapshot, cursor=response_cursor)
+
         text, progress = await _render_job_snapshot(snapshot, self._event_store)
         has_live_execution_progress = snapshot.links.execution_id is not None and any(
             progress.get(key) is not None
@@ -634,9 +653,13 @@ class JobWaitHandler:
                 "sub_ac_total",
             )
         )
-        response_changed = changed or has_live_execution_progress
+        response_changed = changed or execution_progress_changed
         if not changed:
-            if view in {"compact", "summary"} and has_live_execution_progress:
+            if (
+                view in {"compact", "summary"}
+                and has_live_execution_progress
+                and execution_progress_changed
+            ):
                 text = _render_compact_job_snapshot(
                     snapshot,
                     progress,

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -35,6 +35,7 @@ log = structlog.get_logger(__name__)
 
 _DEFAULT_JOB_VIEW = "full"
 _JOB_EXECUTION_EVENT_LIMIT = 250
+_JOB_SUBTASK_EVENT_PAGE_SIZE = 500
 _JOB_VIEW_ALIASES = {
     "compact": "compact",
     "brief": "compact",
@@ -53,6 +54,28 @@ def _normalize_job_view(value: object) -> str:
         if stripped:
             return _JOB_VIEW_ALIASES.get(stripped, _DEFAULT_JOB_VIEW)
     return _DEFAULT_JOB_VIEW
+
+
+async def _query_all_execution_subtask_events(
+    event_store: EventStore, execution_id: str
+) -> list[Any]:
+    """Fetch all subtask updates for an execution for accurate rollups."""
+    events: list[Any] = []
+    offset = 0
+    while True:
+        page = await event_store.query_events(
+            aggregate_id=execution_id,
+            event_type="execution.subtask.updated",
+            limit=_JOB_SUBTASK_EVENT_PAGE_SIZE,
+            offset=offset,
+        )
+        if not page:
+            break
+        events.extend(page)
+        if len(page) < _JOB_SUBTASK_EVENT_PAGE_SIZE:
+            break
+        offset += _JOB_SUBTASK_EVENT_PAGE_SIZE
+    return events
 
 
 @dataclass
@@ -329,13 +352,15 @@ async def _render_job_snapshot_inner(
             aggregate_id=snapshot.links.execution_id,
             limit=_JOB_EXECUTION_EVENT_LIMIT,
         )
-        events_chronological = list(reversed(recent_events))
         workflow_event = next(
             (event for event in recent_events if event.type == "workflow.progress.updated"),
             None,
         )
 
-        subtask_summary = summarize_subtask_events(events_chronological)
+        subtask_events = await _query_all_execution_subtask_events(
+            event_store, snapshot.links.execution_id
+        )
+        subtask_summary = summarize_subtask_events(list(reversed(subtask_events)))
         subtask_progress = format_subtask_progress_summary(subtask_summary)
         if workflow_event is not None:
             data = workflow_event.data

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -78,9 +78,7 @@ async def _query_all_execution_subtask_events(
     return events
 
 
-async def _query_latest_workflow_event(
-    event_store: EventStore, execution_id: str
-) -> Any | None:
+async def _query_latest_workflow_event(event_store: EventStore, execution_id: str) -> Any | None:
     """Fetch the latest workflow progress event without relying on a mixed window."""
     events = await event_store.query_events(
         aggregate_id=execution_id,

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -16,6 +16,10 @@ import structlog
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobManager, JobSnapshot, JobStatus
+from ouroboros.mcp.tools.ac_tree_hud_handler import (
+    format_subtask_progress_summary,
+    summarize_subtask_events,
+)
 from ouroboros.mcp.types import (
     ContentType,
     MCPContentItem,
@@ -28,6 +32,26 @@ from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
+
+_DEFAULT_JOB_VIEW = "summary"
+_JOB_VIEW_ALIASES = {
+    "compact": "compact",
+    "brief": "compact",
+    "summary": "summary",
+    "default": "summary",
+    "full": "full",
+    "tree": "full",
+    "verbose": "full",
+}
+
+
+def _normalize_job_view(value: object) -> str:
+    """Normalize requested job-status verbosity."""
+    if isinstance(value, str):
+        stripped = value.strip().lower()
+        if stripped:
+            return _JOB_VIEW_ALIASES.get(stripped, _DEFAULT_JOB_VIEW)
+    return _DEFAULT_JOB_VIEW
 
 
 @dataclass
@@ -253,6 +277,36 @@ async def _render_job_snapshot(
     return text, progress
 
 
+def _render_compact_job_snapshot(
+    snapshot: JobSnapshot,
+    progress: dict[str, Any],
+    *,
+    include_message: bool,
+) -> str:
+    """Render a low-token job monitor summary."""
+    parts = [snapshot.job_id, snapshot.status.value]
+
+    phase = progress.get("current_phase")
+    if phase:
+        parts.append(str(phase))
+
+    ac_completed = progress.get("ac_completed")
+    ac_total = progress.get("ac_total")
+    if ac_completed is not None or ac_total is not None:
+        parts.append(f"AC {ac_completed if ac_completed is not None else '?'}/{ac_total or '?'}")
+
+    sub_ac_completed = progress.get("sub_ac_completed")
+    sub_ac_total = progress.get("sub_ac_total")
+    if sub_ac_completed is not None and sub_ac_total:
+        parts.append(f"Sub-AC {sub_ac_completed}/{sub_ac_total}")
+
+    parts.append(f"cursor {snapshot.cursor}")
+    lines = [" | ".join(parts)]
+    if include_message and snapshot.message:
+        lines.append(snapshot.message)
+    return "\n".join(lines)
+
+
 async def _render_job_snapshot_inner(
     snapshot: JobSnapshot, event_store: EventStore
 ) -> tuple[str, dict[str, Any]]:
@@ -270,11 +324,14 @@ async def _render_job_snapshot_inner(
     ]
 
     if snapshot.links.execution_id:
-        events = await event_store.query_events(
-            aggregate_id=snapshot.links.execution_id,
-            limit=25,
-        )
-        workflow_event = next((e for e in events if e.type == "workflow.progress.updated"), None)
+        events = await event_store.replay("execution", snapshot.links.execution_id)
+        workflow_event = None
+        for event in events:
+            if event.type == "workflow.progress.updated":
+                workflow_event = event
+
+        subtask_summary = summarize_subtask_events(events)
+        subtask_progress = format_subtask_progress_summary(subtask_summary)
         if workflow_event is not None:
             data = workflow_event.data
             progress = {
@@ -283,6 +340,16 @@ async def _render_job_snapshot_inner(
                 "current_phase": data.get("current_phase") or "Working",
                 "activity": data.get("activity_detail") or data.get("activity") or "running",
             }
+            if subtask_summary:
+                progress.update(
+                    {
+                        "sub_ac_completed": subtask_summary.get("completed_count"),
+                        "sub_ac_total": subtask_summary.get("total_count"),
+                        "sub_ac_executing": subtask_summary.get("executing_count"),
+                        "sub_ac_pending": subtask_summary.get("pending_count"),
+                        "sub_ac_failed": subtask_summary.get("failed_count"),
+                    }
+                )
             lines.extend(
                 [
                     "",
@@ -293,9 +360,11 @@ async def _render_job_snapshot_inner(
                     f"**AC Progress**: {progress['ac_completed']}/{progress['ac_total'] or '?'}",
                 ]
             )
+            if subtask_progress:
+                lines.append(f"**Sub-AC Progress**: {subtask_progress}")
 
         subtasks: dict[str, tuple[str, str]] = {}
-        for event in events:
+        for event in reversed(events):
             if event.type != "execution.subtask.updated":
                 continue
             sub_task_id = event.data.get("sub_task_id")
@@ -304,6 +373,8 @@ async def _render_job_snapshot_inner(
                     event.data.get("content", ""),
                     event.data.get("status", "unknown"),
                 )
+            if len(subtasks) >= 5:
+                break
 
         if subtasks:
             lines.append("")
@@ -395,6 +466,13 @@ class JobStatusHandler:
                     description="Job ID returned by a start tool",
                     required=True,
                 ),
+                MCPToolParameter(
+                    name="view",
+                    type=ToolInputType.STRING,
+                    description="'compact', 'summary' (default), or 'full'.",
+                    required=False,
+                    default=_DEFAULT_JOB_VIEW,
+                ),
             ),
         )
 
@@ -410,6 +488,7 @@ class JobStatusHandler:
                     tool_name="ouroboros_job_status",
                 )
             )
+        view = _normalize_job_view(arguments.get("view"))
 
         try:
             snapshot = await self._job_manager.get_snapshot(job_id)
@@ -417,6 +496,11 @@ class JobStatusHandler:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_job_status"))
 
         text, progress = await _render_job_snapshot(snapshot, self._event_store)
+        if view == "compact":
+            text = _render_compact_job_snapshot(snapshot, progress, include_message=False)
+        elif view == "summary":
+            text = _render_compact_job_snapshot(snapshot, progress, include_message=True)
+
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
@@ -428,6 +512,7 @@ class JobStatusHandler:
                     "session_id": snapshot.links.session_id,
                     "execution_id": snapshot.links.execution_id,
                     "lineage_id": snapshot.links.lineage_id,
+                    "view": view,
                     **progress,
                 },
             )
@@ -474,6 +559,13 @@ class JobWaitHandler:
                     required=False,
                     default=30,
                 ),
+                MCPToolParameter(
+                    name="view",
+                    type=ToolInputType.STRING,
+                    description="'compact', 'summary' (default), or 'full'.",
+                    required=False,
+                    default=_DEFAULT_JOB_VIEW,
+                ),
             ),
         )
 
@@ -492,6 +584,7 @@ class JobWaitHandler:
 
         cursor = int(arguments.get("cursor", 0))
         timeout_seconds = int(arguments.get("timeout_seconds", 30))
+        view = _normalize_job_view(arguments.get("view"))
 
         try:
             snapshot, changed = await self._job_manager.wait_for_change(
@@ -504,7 +597,11 @@ class JobWaitHandler:
 
         text, progress = await _render_job_snapshot(snapshot, self._event_store)
         if not changed:
-            text += "\n\nNo new job-level events during this wait window."
+            text = f"unchanged cursor={snapshot.cursor}"
+        elif view == "compact":
+            text = _render_compact_job_snapshot(snapshot, progress, include_message=False)
+        elif view == "summary":
+            text = _render_compact_job_snapshot(snapshot, progress, include_message=True)
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
@@ -514,6 +611,7 @@ class JobWaitHandler:
                     "status": snapshot.status.value,
                     "cursor": snapshot.cursor,
                     "changed": changed,
+                    "view": view,
                     **progress,
                 },
             )

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -291,17 +291,18 @@ async def _render_job_snapshot(
     AC progress (ac_completed, ac_total, current_phase, activity) extracted
     from the same query used for rendering — no duplicate event-store hit.
 
-    Results are cached by (job_id, cursor) to avoid redundant EventStore queries
-    when the same snapshot is rendered repeatedly (e.g. poll loops).
-    Terminal snapshots are never cached since they won't change.
+    Results are cached by (job_id, cursor) only when the render does not read
+    directly from execution events. Execution-linked snapshots can change even
+    when the job aggregate cursor does not, so those renders must stay live.
     """
     cache_key = (snapshot.job_id, snapshot.cursor)
-    if not snapshot.is_terminal and cache_key in _render_cache:
+    cacheable = not snapshot.is_terminal and snapshot.links.execution_id is None
+    if cacheable and cache_key in _render_cache:
         return _render_cache[cache_key]
 
     text, progress = await _render_job_snapshot_inner(snapshot, event_store)
 
-    if not snapshot.is_terminal:
+    if cacheable:
         if len(_render_cache) >= _RENDER_CACHE_MAX:
             to_remove = list(_render_cache.keys())[: _RENDER_CACHE_MAX // 2]
             for key in to_remove:

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -59,23 +59,9 @@ def _normalize_job_view(value: object) -> str:
 async def _query_all_execution_subtask_events(
     event_store: EventStore, execution_id: str
 ) -> list[Any]:
-    """Fetch all subtask updates for an execution for accurate rollups."""
-    events: list[Any] = []
-    offset = 0
-    while True:
-        page = await event_store.query_events(
-            aggregate_id=execution_id,
-            event_type="execution.subtask.updated",
-            limit=_JOB_SUBTASK_EVENT_PAGE_SIZE,
-            offset=offset,
-        )
-        if not page:
-            break
-        events.extend(page)
-        if len(page) < _JOB_SUBTASK_EVENT_PAGE_SIZE:
-            break
-        offset += _JOB_SUBTASK_EVENT_PAGE_SIZE
-    return events
+    """Fetch subtask updates from one stable execution replay snapshot."""
+    events, _cursor = await event_store.get_events_after("execution", execution_id, 0)
+    return [event for event in events if event.type == "execution.subtask.updated"]
 
 
 async def _query_latest_workflow_event(event_store: EventStore, execution_id: str) -> Any | None:
@@ -366,7 +352,7 @@ async def _render_job_snapshot_inner(
         subtask_events = await _query_all_execution_subtask_events(
             event_store, snapshot.links.execution_id
         )
-        subtask_summary = summarize_subtask_events(list(reversed(subtask_events)))
+        subtask_summary = summarize_subtask_events(subtask_events)
         subtask_progress = format_subtask_progress_summary(subtask_summary)
         if workflow_event is not None:
             data = workflow_event.data
@@ -400,7 +386,7 @@ async def _render_job_snapshot_inner(
                 lines.append(f"**Sub-AC Progress**: {subtask_progress}")
 
         subtasks: dict[str, tuple[str, str]] = {}
-        for event in subtask_events[:_JOB_EXECUTION_EVENT_LIMIT]:
+        for event in reversed(subtask_events[-_JOB_EXECUTION_EVENT_LIMIT:]):
             sub_task_id = event.data.get("sub_task_id")
             if sub_task_id and sub_task_id not in subtasks:
                 subtasks[sub_task_id] = (
@@ -640,6 +626,7 @@ class JobWaitHandler:
                 "sub_ac_total",
             )
         )
+        response_changed = changed or has_live_execution_progress
         if not changed:
             if view in {"compact", "summary"} and has_live_execution_progress:
                 text = _render_compact_job_snapshot(
@@ -663,7 +650,7 @@ class JobWaitHandler:
                     "job_id": snapshot.job_id,
                     "status": snapshot.status.value,
                     "cursor": snapshot.cursor,
-                    "changed": changed,
+                    "changed": response_changed,
                     "view": view,
                     **progress,
                 },

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -354,24 +354,29 @@ async def _render_job_snapshot_inner(
         )
         subtask_summary = summarize_subtask_events(subtask_events)
         subtask_progress = format_subtask_progress_summary(subtask_summary)
+        if subtask_summary:
+            progress.update(
+                {
+                    "current_phase": "Sub-AC work",
+                    "activity": subtask_progress or "running",
+                    "sub_ac_completed": subtask_summary.get("completed_count"),
+                    "sub_ac_total": subtask_summary.get("total_count"),
+                    "sub_ac_executing": subtask_summary.get("executing_count"),
+                    "sub_ac_pending": subtask_summary.get("pending_count"),
+                    "sub_ac_failed": subtask_summary.get("failed_count"),
+                }
+            )
         if workflow_event is not None:
             data = workflow_event.data
-            progress = {
-                "ac_completed": data.get("completed_count"),
-                "ac_total": data.get("total_count"),
-                "current_phase": data.get("current_phase") or "Working",
-                "activity": data.get("activity_detail") or data.get("activity") or "running",
-            }
-            if subtask_summary:
-                progress.update(
-                    {
-                        "sub_ac_completed": subtask_summary.get("completed_count"),
-                        "sub_ac_total": subtask_summary.get("total_count"),
-                        "sub_ac_executing": subtask_summary.get("executing_count"),
-                        "sub_ac_pending": subtask_summary.get("pending_count"),
-                        "sub_ac_failed": subtask_summary.get("failed_count"),
-                    }
-                )
+            progress.update(
+                {
+                    "ac_completed": data.get("completed_count"),
+                    "ac_total": data.get("total_count"),
+                    "current_phase": data.get("current_phase") or "Working",
+                    "activity": data.get("activity_detail") or data.get("activity") or "running",
+                }
+            )
+        if workflow_event is not None or subtask_summary:
             lines.extend(
                 [
                     "",
@@ -379,9 +384,12 @@ async def _render_job_snapshot_inner(
                     f"**Execution ID**: {snapshot.links.execution_id}",
                     f"**Phase**: {progress['current_phase']}",
                     f"**Activity**: {progress['activity']}",
-                    f"**AC Progress**: {progress['ac_completed']}/{progress['ac_total'] or '?'}",
                 ]
             )
+            if workflow_event is not None:
+                lines.append(
+                    f"**AC Progress**: {progress['ac_completed']}/{progress['ac_total'] or '?'}"
+                )
             if subtask_progress:
                 lines.append(f"**Sub-AC Progress**: {subtask_progress}")
 

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -33,12 +33,13 @@ from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
 
-_DEFAULT_JOB_VIEW = "summary"
+_DEFAULT_JOB_VIEW = "full"
+_JOB_EXECUTION_EVENT_LIMIT = 250
 _JOB_VIEW_ALIASES = {
     "compact": "compact",
     "brief": "compact",
     "summary": "summary",
-    "default": "summary",
+    "default": "full",
     "full": "full",
     "tree": "full",
     "verbose": "full",
@@ -324,13 +325,17 @@ async def _render_job_snapshot_inner(
     ]
 
     if snapshot.links.execution_id:
-        events = await event_store.replay("execution", snapshot.links.execution_id)
-        workflow_event = None
-        for event in events:
-            if event.type == "workflow.progress.updated":
-                workflow_event = event
+        recent_events = await event_store.query_events(
+            aggregate_id=snapshot.links.execution_id,
+            limit=_JOB_EXECUTION_EVENT_LIMIT,
+        )
+        events_chronological = list(reversed(recent_events))
+        workflow_event = next(
+            (event for event in recent_events if event.type == "workflow.progress.updated"),
+            None,
+        )
 
-        subtask_summary = summarize_subtask_events(events)
+        subtask_summary = summarize_subtask_events(events_chronological)
         subtask_progress = format_subtask_progress_summary(subtask_summary)
         if workflow_event is not None:
             data = workflow_event.data
@@ -364,7 +369,7 @@ async def _render_job_snapshot_inner(
                 lines.append(f"**Sub-AC Progress**: {subtask_progress}")
 
         subtasks: dict[str, tuple[str, str]] = {}
-        for event in reversed(events):
+        for event in recent_events:
             if event.type != "execution.subtask.updated":
                 continue
             sub_task_id = event.data.get("sub_task_id")
@@ -469,7 +474,7 @@ class JobStatusHandler:
                 MCPToolParameter(
                     name="view",
                     type=ToolInputType.STRING,
-                    description="'compact', 'summary' (default), or 'full'.",
+                    description="'full' (default), 'summary', or 'compact'.",
                     required=False,
                     default=_DEFAULT_JOB_VIEW,
                 ),
@@ -562,7 +567,7 @@ class JobWaitHandler:
                 MCPToolParameter(
                     name="view",
                     type=ToolInputType.STRING,
-                    description="'compact', 'summary' (default), or 'full'.",
+                    description="'full' (default), 'summary', or 'compact'.",
                     required=False,
                     default=_DEFAULT_JOB_VIEW,
                 ),
@@ -597,7 +602,10 @@ class JobWaitHandler:
 
         text, progress = await _render_job_snapshot(snapshot, self._event_store)
         if not changed:
-            text = f"unchanged cursor={snapshot.cursor}"
+            if view in {"compact", "summary"}:
+                text = f"unchanged cursor={snapshot.cursor}"
+            else:
+                text += "\n\nNo new job-level events during this wait window."
         elif view == "compact":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=False)
         elif view == "summary":

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -78,6 +78,18 @@ async def _query_all_execution_subtask_events(
     return events
 
 
+async def _query_latest_workflow_event(
+    event_store: EventStore, execution_id: str
+) -> Any | None:
+    """Fetch the latest workflow progress event without relying on a mixed window."""
+    events = await event_store.query_events(
+        aggregate_id=execution_id,
+        event_type="workflow.progress.updated",
+        limit=1,
+    )
+    return events[0] if events else None
+
+
 @dataclass
 class CancelExecutionHandler:
     """Handler for the cancel_execution tool.
@@ -348,13 +360,8 @@ async def _render_job_snapshot_inner(
     ]
 
     if snapshot.links.execution_id:
-        recent_events = await event_store.query_events(
-            aggregate_id=snapshot.links.execution_id,
-            limit=_JOB_EXECUTION_EVENT_LIMIT,
-        )
-        workflow_event = next(
-            (event for event in recent_events if event.type == "workflow.progress.updated"),
-            None,
+        workflow_event = await _query_latest_workflow_event(
+            event_store, snapshot.links.execution_id
         )
 
         subtask_events = await _query_all_execution_subtask_events(
@@ -394,9 +401,7 @@ async def _render_job_snapshot_inner(
                 lines.append(f"**Sub-AC Progress**: {subtask_progress}")
 
         subtasks: dict[str, tuple[str, str]] = {}
-        for event in recent_events:
-            if event.type != "execution.subtask.updated":
-                continue
+        for event in subtask_events[:_JOB_EXECUTION_EVENT_LIMIT]:
             sub_task_id = event.data.get("sub_task_id")
             if sub_task_id and sub_task_id not in subtasks:
                 subtasks[sub_task_id] = (

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -630,8 +630,24 @@ class JobWaitHandler:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_job_wait"))
 
         text, progress = await _render_job_snapshot(snapshot, self._event_store)
+        has_live_execution_progress = snapshot.links.execution_id is not None and any(
+            progress.get(key) is not None
+            for key in (
+                "ac_completed",
+                "ac_total",
+                "current_phase",
+                "sub_ac_completed",
+                "sub_ac_total",
+            )
+        )
         if not changed:
-            if view in {"compact", "summary"}:
+            if view in {"compact", "summary"} and has_live_execution_progress:
+                text = _render_compact_job_snapshot(
+                    snapshot,
+                    progress,
+                    include_message=view == "summary",
+                )
+            elif view in {"compact", "summary"}:
                 text = f"unchanged cursor={snapshot.cursor}"
             else:
                 text += "\n\nNo new job-level events during this wait window."

--- a/src/ouroboros/mcp/tools/query_handlers.py
+++ b/src/ouroboros/mcp/tools/query_handlers.py
@@ -13,6 +13,10 @@ import structlog
 
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.tools.ac_tree_hud_handler import (
+    format_subtask_progress_summary,
+    summarize_subtask_events,
+)
 from ouroboros.mcp.types import (
     ContentType,
     MCPContentItem,
@@ -114,6 +118,34 @@ class SessionStatusHandler:
                 )
 
             tracker = result.value
+            progress = dict(tracker.progress or {})
+            if tracker.execution_id:
+                try:
+                    execution_events = await self._event_store.replay(
+                        "execution",
+                        tracker.execution_id,
+                    )
+                except Exception:
+                    execution_events = []
+                    log.debug(
+                        "mcp.tool.session_status.subtask_summary_unavailable",
+                        session_id=session_id,
+                        execution_id=tracker.execution_id,
+                    )
+                if isinstance(execution_events, list):
+                    subtask_summary = summarize_subtask_events(execution_events)
+                    subtask_progress = format_subtask_progress_summary(subtask_summary)
+                    if subtask_progress:
+                        progress["sub_ac_progress"] = subtask_progress
+                        progress["sub_ac_completed_count"] = subtask_summary.get(
+                            "completed_count",
+                        )
+                        progress["sub_ac_total_count"] = subtask_summary.get("total_count")
+                        progress["sub_ac_executing_count"] = subtask_summary.get(
+                            "executing_count",
+                        )
+                        progress["sub_ac_pending_count"] = subtask_summary.get("pending_count")
+                        progress["sub_ac_failed_count"] = subtask_summary.get("failed_count")
 
             # Build status response from SessionTracker.
             # The "Terminal:" line is a machine-parseable summary so callers
@@ -138,9 +170,9 @@ class SessionStatusHandler:
             if tracker.last_message_time:
                 status_text += f"Last Message: {tracker.last_message_time.isoformat()}\n"
 
-            if tracker.progress:
+            if progress:
                 status_text += "\nProgress:\n"
-                for key, value in tracker.progress.items():
+                for key, value in progress.items():
                     status_text += f"  {key}: {value}\n"
 
             return Result.ok(
@@ -156,7 +188,7 @@ class SessionStatusHandler:
                         "is_completed": tracker.is_completed,
                         "is_failed": tracker.is_failed,
                         "messages_processed": tracker.messages_processed,
-                        "progress": tracker.progress,
+                        "progress": progress,
                     },
                 )
             )

--- a/tests/unit/mcp/bridge/test_config.py
+++ b/tests/unit/mcp/bridge/test_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import ouroboros.mcp.bridge.config as bridge_config
 from ouroboros.mcp.bridge.config import MCPBridgeConfig, discover_config, load_bridge_config
 
 
@@ -38,6 +39,11 @@ class TestDiscoverConfig:
 
     def test_cwd_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("OUROBOROS_MCP_CONFIG", raising=False)
+        monkeypatch.setattr(
+            bridge_config,
+            "_HOME_CONFIG",
+            tmp_path / "home" / ".ouroboros" / "mcp_servers.yaml",
+        )
         cwd_config = tmp_path / ".ouroboros" / "mcp_servers.yaml"
         cwd_config.parent.mkdir(parents=True)
         cwd_config.write_text("mcp_servers: []")

--- a/tests/unit/mcp/bridge/test_factory.py
+++ b/tests/unit/mcp/bridge/test_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ouroboros.mcp.bridge.config as bridge_config
 from ouroboros.mcp.bridge.factory import (
     create_bridge_from_env,
 )
@@ -10,11 +11,21 @@ from ouroboros.mcp.bridge.factory import (
 class TestCreateBridgeFromEnv:
     def test_returns_none_when_no_config(self, tmp_path, monkeypatch):
         monkeypatch.delenv("OUROBOROS_MCP_CONFIG", raising=False)
+        monkeypatch.setattr(
+            bridge_config,
+            "_HOME_CONFIG",
+            tmp_path / "home" / ".ouroboros" / "mcp_servers.yaml",
+        )
         result = create_bridge_from_env(cwd=tmp_path)
-        assert result is None or hasattr(result, "manager")
+        assert result is None
 
     def test_returns_bridge_when_config_exists(self, tmp_path, monkeypatch):
         monkeypatch.delenv("OUROBOROS_MCP_CONFIG", raising=False)
+        monkeypatch.setattr(
+            bridge_config,
+            "_HOME_CONFIG",
+            tmp_path / "home" / ".ouroboros" / "mcp_servers.yaml",
+        )
         d = tmp_path / ".ouroboros"
         d.mkdir()
         (d / "mcp_servers.yaml").write_text(

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -1140,7 +1140,7 @@ class TestJobManager:
             message="Implement | 1/3 ACs",
             created_at=datetime(2026, 4, 22, tzinfo=UTC),
             updated_at=datetime(2026, 4, 22, tzinfo=UTC),
-            cursor=21,
+            cursor=0,
             links=JobLinks(execution_id="exec_wait_live_progress"),
         )
 
@@ -1153,7 +1153,7 @@ class TestJobManager:
                 timeout_seconds: int,
             ) -> tuple[JobSnapshot, bool]:
                 assert job_id == snapshot.job_id
-                assert cursor == 21
+                assert cursor == 0
                 assert timeout_seconds == 0
                 return snapshot, False
 
@@ -1162,7 +1162,7 @@ class TestJobManager:
             result = await handler.handle(
                 {
                     "job_id": "job_wait_live_progress",
-                    "cursor": 21,
+                    "cursor": 0,
                     "timeout_seconds": 0,
                     "view": "compact",
                 }
@@ -1172,9 +1172,43 @@ class TestJobManager:
             assert result.value.meta["changed"] is True
             assert result.value.meta["view"] == "compact"
             assert result.value.meta["ac_completed"] == 1
+            assert result.value.meta["cursor"] > 0
             assert result.value.text_content == (
-                "job_wait_live_progress | running | Implement | AC 1/3 | cursor 21"
+                "job_wait_live_progress | running | Implement | AC 1/3 | "
+                f"cursor {result.value.meta['cursor']}"
             )
+
+            second_cursor = result.value.meta["cursor"]
+
+            class UnchangedJobManager:
+                async def wait_for_change(
+                    self,
+                    job_id: str,
+                    *,
+                    cursor: int,
+                    timeout_seconds: int,
+                ) -> tuple[JobSnapshot, bool]:
+                    assert job_id == snapshot.job_id
+                    assert cursor == second_cursor
+                    assert timeout_seconds == 0
+                    return snapshot, False
+
+            unchanged_handler = JobWaitHandler(
+                event_store=store,
+                job_manager=UnchangedJobManager(),
+            )
+            unchanged = await unchanged_handler.handle(
+                {
+                    "job_id": "job_wait_live_progress",
+                    "cursor": second_cursor,
+                    "timeout_seconds": 0,
+                    "view": "compact",
+                }
+            )
+
+            assert unchanged.is_ok
+            assert unchanged.value.meta["changed"] is False
+            assert unchanged.value.text_content == f"unchanged cursor={second_cursor}"
         finally:
             await store.close()
 
@@ -1204,7 +1238,7 @@ class TestJobManager:
             message="Running execute_seed",
             created_at=datetime(2026, 4, 22, tzinfo=UTC),
             updated_at=datetime(2026, 4, 22, tzinfo=UTC),
-            cursor=22,
+            cursor=0,
             links=JobLinks(execution_id="exec_wait_subtask_only"),
         )
 
@@ -1217,7 +1251,7 @@ class TestJobManager:
                 timeout_seconds: int,
             ) -> tuple[JobSnapshot, bool]:
                 assert job_id == snapshot.job_id
-                assert cursor == 22
+                assert cursor == 0
                 assert timeout_seconds == 0
                 return snapshot, False
 
@@ -1226,7 +1260,7 @@ class TestJobManager:
             result = await handler.handle(
                 {
                     "job_id": "job_wait_subtask_only",
-                    "cursor": 22,
+                    "cursor": 0,
                     "timeout_seconds": 0,
                     "view": "compact",
                 }
@@ -1236,8 +1270,10 @@ class TestJobManager:
             assert result.value.meta["changed"] is True
             assert result.value.meta["view"] == "compact"
             assert result.value.meta["sub_ac_executing"] == 1
+            assert result.value.meta["cursor"] > 0
             assert result.value.text_content == (
-                "job_wait_subtask_only | running | Sub-AC work | Sub-AC 0/1 | cursor 22"
+                "job_wait_subtask_only | running | Sub-AC work | Sub-AC 0/1 | "
+                f"cursor {result.value.meta['cursor']}"
             )
         finally:
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -1177,3 +1177,67 @@ class TestJobManager:
             )
         finally:
             await store.close()
+
+    async def test_job_wait_compact_view_surfaces_subtask_progress_before_workflow(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        await store.append(
+            BaseEvent(
+                type="execution.subtask.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_wait_subtask_only",
+                data={
+                    "ac_index": 1,
+                    "sub_task_index": 1,
+                    "sub_task_id": "ac_1_sub_1",
+                    "content": "Child one",
+                    "status": "executing",
+                },
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_wait_subtask_only",
+            job_type="execute_seed",
+            status=JobStatus.RUNNING,
+            message="Running execute_seed",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=22,
+            links=JobLinks(execution_id="exec_wait_subtask_only"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 22
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {
+                    "job_id": "job_wait_subtask_only",
+                    "cursor": 22,
+                    "timeout_seconds": 0,
+                    "view": "compact",
+                }
+            )
+
+            assert result.is_ok
+            assert result.value.meta["changed"] is True
+            assert result.value.meta["view"] == "compact"
+            assert result.value.meta["sub_ac_executing"] == 1
+            assert result.value.text_content == (
+                "job_wait_subtask_only | running | Sub-AC work | Sub-AC 0/1 | cursor 22"
+            )
+        finally:
+            await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3,10 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from ouroboros.core.types import Result
-from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobSnapshot, JobStatus
+from ouroboros.mcp.tools.job_handlers import (
+    JobStatusHandler,
+    JobWaitHandler,
+    _render_compact_job_snapshot,
+    _render_job_snapshot,
+    _render_job_snapshot_inner,
+)
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
 from ouroboros.orchestrator.heartbeat import lock_path
@@ -735,4 +744,436 @@ class TestJobManager:
             lock_path(session_id).unlink(missing_ok=True)
             await clear_cancellation(session_id)
             await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_render_job_snapshot_includes_sub_ac_progress(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+
+        try:
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_job_sub_ac_progress",
+                    data={
+                        "execution_id": "exec_job_sub_ac_progress",
+                        "completed_count": 0,
+                        "total_count": 2,
+                        "current_phase": "Deliver",
+                        "activity": "Monitoring",
+                        "activity_detail": "Level 1/1",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.subtask.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_job_sub_ac_progress",
+                    data={
+                        "ac_index": 1,
+                        "sub_task_index": 1,
+                        "sub_task_id": "ac_1_sub_1",
+                        "content": "Child one",
+                        "status": "completed",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.subtask.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_job_sub_ac_progress",
+                    data={
+                        "ac_index": 1,
+                        "sub_task_index": 2,
+                        "sub_task_id": "ac_1_sub_2",
+                        "content": "Child two",
+                        "status": "executing",
+                    },
+                )
+            )
+
+            snapshot = JobSnapshot(
+                job_id="job_sub_ac_progress",
+                job_type="execute_seed",
+                status=JobStatus.RUNNING,
+                message="Deliver | 0/2 ACs",
+                created_at=datetime(2026, 4, 22, tzinfo=UTC),
+                updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+                cursor=2,
+                links=JobLinks(execution_id="exec_job_sub_ac_progress"),
+            )
+
+            text, progress = await _render_job_snapshot_inner(snapshot, store)
+
+            assert "**AC Progress**: 0/2" in text
+            assert "**Sub-AC Progress**: 1/2 complete · 1 working" in text
+            assert progress["sub_ac_completed"] == 1
+            assert progress["sub_ac_total"] == 2
+            assert "- `ac_1_sub_2`: executing -- Child two" in text
+        finally:
+            await store.close()
+
+    async def test_render_job_snapshot_counts_sub_ac_beyond_recent_event_window(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+
+        try:
+            for index in range(1, 301):
+                await store.append(
+                    BaseEvent(
+                        type="execution.subtask.updated",
+                        aggregate_type="execution",
+                        aggregate_id="exec_job_many_sub_ac",
+                        data={
+                            "ac_index": 1,
+                            "sub_task_index": index,
+                            "sub_task_id": f"ac_1_sub_{index}",
+                            "content": f"Child {index}",
+                            "status": "completed",
+                        },
+                    )
+                )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_job_many_sub_ac",
+                    data={
+                        "execution_id": "exec_job_many_sub_ac",
+                        "completed_count": 0,
+                        "total_count": 1,
+                        "current_phase": "Deliver",
+                        "activity": "Monitoring",
+                    },
+                )
+            )
+
+            snapshot = JobSnapshot(
+                job_id="job_many_sub_ac",
+                job_type="execute_seed",
+                status=JobStatus.RUNNING,
+                message="Deliver | 0/1 ACs",
+                created_at=datetime(2026, 4, 22, tzinfo=UTC),
+                updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+                cursor=301,
+                links=JobLinks(execution_id="exec_job_many_sub_ac"),
+            )
+
+            text, progress = await _render_job_snapshot_inner(snapshot, store)
+
+            assert "**Sub-AC Progress**: 300/300 complete" in text
+            assert progress["sub_ac_completed"] == 300
+            assert progress["sub_ac_total"] == 300
+        finally:
+            await store.close()
+
+    async def test_render_job_snapshot_keeps_workflow_after_subtask_burst(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+
+        try:
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_job_old_workflow",
+                    data={
+                        "execution_id": "exec_job_old_workflow",
+                        "completed_count": 1,
+                        "total_count": 4,
+                        "current_phase": "Implement",
+                        "activity": "Monitoring",
+                    },
+                )
+            )
+            for index in range(1, 301):
+                await store.append(
+                    BaseEvent(
+                        type="execution.subtask.updated",
+                        aggregate_type="execution",
+                        aggregate_id="exec_job_old_workflow",
+                        data={
+                            "ac_index": 1,
+                            "sub_task_index": index,
+                            "sub_task_id": f"ac_1_sub_{index}",
+                            "content": f"Child {index}",
+                            "status": "completed",
+                        },
+                    )
+                )
+
+            snapshot = JobSnapshot(
+                job_id="job_old_workflow",
+                job_type="execute_seed",
+                status=JobStatus.RUNNING,
+                message="Implement | 1/4 ACs",
+                created_at=datetime(2026, 4, 22, tzinfo=UTC),
+                updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+                cursor=301,
+                links=JobLinks(execution_id="exec_job_old_workflow"),
+            )
+
+            text, progress = await _render_job_snapshot_inner(snapshot, store)
+
+            assert "**Phase**: Implement" in text
+            assert "**AC Progress**: 1/4" in text
+            assert "**Sub-AC Progress**: 300/300 complete" in text
+            assert progress["current_phase"] == "Implement"
+            assert progress["ac_completed"] == 1
+            assert progress["ac_total"] == 4
+            assert progress["sub_ac_completed"] == 300
+            assert progress["sub_ac_total"] == 300
+        finally:
+            await store.close()
+
+    async def test_render_job_snapshot_does_not_cache_execution_progress(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+
+        try:
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_job_live_progress",
+                    data={
+                        "execution_id": "exec_job_live_progress",
+                        "completed_count": 0,
+                        "total_count": 2,
+                        "current_phase": "Plan",
+                        "activity": "Starting",
+                    },
+                )
+            )
+            snapshot = JobSnapshot(
+                job_id="job_live_progress",
+                job_type="execute_seed",
+                status=JobStatus.RUNNING,
+                message="Plan | 0/2 ACs",
+                created_at=datetime(2026, 4, 22, tzinfo=UTC),
+                updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+                cursor=77,
+                links=JobLinks(execution_id="exec_job_live_progress"),
+            )
+
+            first_text, first_progress = await _render_job_snapshot(snapshot, store)
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_job_live_progress",
+                    data={
+                        "execution_id": "exec_job_live_progress",
+                        "completed_count": 1,
+                        "total_count": 2,
+                        "current_phase": "Implement",
+                        "activity": "Running",
+                    },
+                )
+            )
+
+            second_text, second_progress = await _render_job_snapshot(snapshot, store)
+
+            assert "**Phase**: Plan" in first_text
+            assert first_progress["ac_completed"] == 0
+            assert "**Phase**: Implement" in second_text
+            assert second_progress["ac_completed"] == 1
+        finally:
+            await store.close()
+
+    def test_render_compact_job_snapshot_omits_full_sections(self) -> None:
+        snapshot = JobSnapshot(
+            job_id="job_compact",
+            job_type="execute_seed",
+            status=JobStatus.RUNNING,
+            message="Deliver | Sub-AC work | 0/2 ACs",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=77,
+            links=JobLinks(execution_id="exec_compact"),
+        )
+
+        text = _render_compact_job_snapshot(
+            snapshot,
+            {
+                "ac_completed": 0,
+                "ac_total": 2,
+                "current_phase": "Deliver",
+                "sub_ac_completed": 1,
+                "sub_ac_total": 3,
+            },
+            include_message=False,
+        )
+
+        assert text == "job_compact | running | Deliver | AC 0/2 | Sub-AC 1/3 | cursor 77"
+
+    async def test_job_status_omitted_view_preserves_full_snapshot(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        snapshot = JobSnapshot(
+            job_id="job_default_full",
+            job_type="execute_seed",
+            status=JobStatus.RUNNING,
+            message="Running execute_seed",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=9,
+            links=JobLinks(),
+        )
+
+        class StaticJobManager:
+            async def get_snapshot(self, job_id: str) -> JobSnapshot:
+                assert job_id == snapshot.job_id
+                return snapshot
+
+        handler = JobStatusHandler(event_store=store, job_manager=StaticJobManager())
+        result = await handler.handle({"job_id": "job_default_full"})
+
+        assert result.is_ok
+        assert result.value.meta["view"] == "full"
+        assert result.value.text_content.startswith("## Job: job_default_full")
+        assert "**Status**: running" in result.value.text_content
+        assert "job_default_full | running" not in result.value.text_content
+
+    async def test_job_wait_omitted_view_preserves_full_unchanged_snapshot(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        snapshot = JobSnapshot(
+            job_id="job_wait_full",
+            job_type="execute_seed",
+            status=JobStatus.RUNNING,
+            message="Running execute_seed",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=12,
+            links=JobLinks(),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 12
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+        result = await handler.handle(
+            {"job_id": "job_wait_full", "cursor": 12, "timeout_seconds": 0}
+        )
+
+        assert result.is_ok
+        assert result.value.meta["view"] == "full"
+        assert result.value.text_content.startswith("## Job: job_wait_full")
+        assert "No new job-level events during this wait window." in result.value.text_content
+        assert result.value.text_content != "unchanged cursor=12"
+
+    async def test_job_wait_summary_view_returns_compact_unchanged_line(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        snapshot = JobSnapshot(
+            job_id="job_wait_summary",
+            job_type="execute_seed",
+            status=JobStatus.RUNNING,
+            message="Running execute_seed",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=15,
+            links=JobLinks(),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                return snapshot, False
+
+        handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+        result = await handler.handle(
+            {
+                "job_id": "job_wait_summary",
+                "cursor": 15,
+                "timeout_seconds": 0,
+                "view": "summary",
+            }
+        )
+
+        assert result.is_ok
+        assert result.value.meta["view"] == "summary"
+        assert result.value.text_content == "unchanged cursor=15"
+
+    async def test_job_wait_compact_view_surfaces_execution_progress_without_job_change(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        await store.append(
+            BaseEvent(
+                type="workflow.progress.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_wait_live_progress",
+                data={
+                    "execution_id": "exec_wait_live_progress",
+                    "completed_count": 1,
+                    "total_count": 3,
+                    "current_phase": "Implement",
+                    "activity": "Running",
+                },
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_wait_live_progress",
+            job_type="execute_seed",
+            status=JobStatus.RUNNING,
+            message="Implement | 1/3 ACs",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=21,
+            links=JobLinks(execution_id="exec_wait_live_progress"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 21
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {
+                    "job_id": "job_wait_live_progress",
+                    "cursor": 21,
+                    "timeout_seconds": 0,
+                    "view": "compact",
+                }
+            )
+
+            assert result.is_ok
+            assert result.value.meta["changed"] is False
+            assert result.value.meta["view"] == "compact"
+            assert result.value.meta["ac_completed"] == 1
+            assert result.value.text_content == (
+                "job_wait_live_progress | running | Implement | AC 1/3 | cursor 21"
+            )
+        finally:
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -1169,7 +1169,7 @@ class TestJobManager:
             )
 
             assert result.is_ok
-            assert result.value.meta["changed"] is False
+            assert result.value.meta["changed"] is True
             assert result.value.meta["view"] == "compact"
             assert result.value.meta["ac_completed"] == 1
             assert result.value.text_content == (

--- a/tests/unit/mcp/tools/test_ac_tree_hud_footer.py
+++ b/tests/unit/mcp/tools/test_ac_tree_hud_footer.py
@@ -86,7 +86,7 @@ async def test_handle_renders_footer_metrics_from_progress_event_payload(
     )
 
     handler = ACTreeHUDHandler(event_store=memory_event_store)
-    result = await handler.handle({"session_id": "sess_footer_event", "cursor": 0})
+    result = await handler.handle({"session_id": "sess_footer_event", "cursor": 0, "view": "tree"})
 
     assert result.is_ok
     assert "Metrics: elapsed 1m 05s · 8 msgs · 3 tools · $0.04" in result.value.text_content

--- a/tests/unit/mcp/tools/test_ac_tree_hud_handler.py
+++ b/tests/unit/mcp/tools/test_ac_tree_hud_handler.py
@@ -10,7 +10,9 @@ from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.tools.ac_tree_hud_handler import (
     ACTreeHUDHandler,
     _extract_tree_snapshot,
+    format_subtask_progress_summary,
     render_ac_tree_hud_markdown,
+    summarize_subtask_events,
 )
 from ouroboros.persistence.event_store import EventStore
 
@@ -73,6 +75,95 @@ class TestRenderACTreeHUDMarkdown:
             "├─ ◐ AC 2: Second criterion  [Read src/ouroboros/mcp/tools/ac_tree_hud_handler.py]"
         ) in markdown
         assert "└─ ○ AC 3: Third criterion" in markdown
+
+    def test_renders_sub_ac_progress_without_changing_top_level_progress(self) -> None:
+        """HUD should expose Sub-AC progress when top-level ACs have not rolled up."""
+        markdown = render_ac_tree_hud_markdown(
+            session_id="sess_sub_ac_progress",
+            execution_id="exec_sub_ac_progress",
+            session_status="running",
+            progress_data={
+                "completed_count": 0,
+                "total_count": 17,
+                "acceptance_criteria": [
+                    {"index": 1, "content": "Parent criterion", "status": "executing"},
+                ],
+                "sub_ac_progress": {
+                    "completed_count": 258,
+                    "executing_count": 7,
+                    "pending_count": 1,
+                    "failed_count": 0,
+                    "total_count": 266,
+                },
+            },
+        )
+
+        assert "Progress: 0/17 AC complete" in markdown
+        assert "Sub-AC Progress: 258/266 complete · 7 working · 1 pending" in markdown
+
+    def test_renders_summary_view_without_tree(self) -> None:
+        """Summary view should keep frequent polling output short."""
+        markdown = render_ac_tree_hud_markdown(
+            session_id="sess_summary",
+            execution_id="exec_summary",
+            session_status="running",
+            progress_data={
+                "current_phase": "Deliver",
+                "completed_count": 0,
+                "total_count": 17,
+                "activity": "Monitoring",
+                "activity_detail": "Level 1/1",
+                "sub_ac_progress": {
+                    "completed_count": 258,
+                    "executing_count": 7,
+                    "pending_count": 1,
+                    "failed_count": 0,
+                    "total_count": 266,
+                    "active": [
+                        {"sub_task_id": "ac_1604_sub_3"},
+                        {"sub_task_id": "ac_1604_sub_2"},
+                    ],
+                },
+                "acceptance_criteria": [
+                    {"index": 1, "content": "Parent criterion", "status": "executing"},
+                ],
+            },
+            view="summary",
+            cursor=443527,
+        )
+
+        assert "Status: running | Phase: Deliver | AC: 0/17" in markdown
+        assert "Sub-AC: 258/266 complete · 7 working · 1 pending" in markdown
+        assert "Active: ac_1604_sub_3, ac_1604_sub_2" in markdown
+        assert "Cursor: 443527" in markdown
+        assert "◇ Acceptance Criteria" not in markdown
+
+    def test_renders_compact_view_for_polling(self) -> None:
+        """Compact view should fit the key monitor state into two short lines."""
+        markdown = render_ac_tree_hud_markdown(
+            session_id="sess_compact",
+            execution_id="exec_compact",
+            session_status="running",
+            progress_data={
+                "current_phase": "Deliver",
+                "completed_count": 3,
+                "total_count": 17,
+                "sub_ac_progress": {
+                    "completed_count": 42,
+                    "executing_count": 2,
+                    "pending_count": 1,
+                    "failed_count": 0,
+                    "total_count": 45,
+                },
+            },
+            view="compact",
+            cursor=123,
+        )
+
+        assert (
+            markdown
+            == "sess_compact | running | Deliver | AC 3/17 | Sub-AC 42/45 | cursor 123\nexec_compact"
+        )
 
     def test_renders_all_top_level_acs_when_tree_has_12_or_fewer_nodes(self) -> None:
         """Small trees should render every top-level AC without ellipsis."""
@@ -456,6 +547,55 @@ class TestRenderACTreeHUDMarkdown:
         assert "└─ ◐ Parent criterion  [working]" in markdown
         assert "   └─ ◐ Nested child waiting on tool payload  [working]" in markdown
 
+    def test_summarize_subtask_events_uses_latest_status_per_subtask(self) -> None:
+        """Subtask summary should count the latest event for each Sub-AC."""
+        events = [
+            BaseEvent(
+                type="execution.subtask.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_summary",
+                data={
+                    "ac_index": 1,
+                    "sub_task_index": 1,
+                    "sub_task_id": "ac_1_sub_1",
+                    "content": "First child",
+                    "status": "pending",
+                },
+            ),
+            BaseEvent(
+                type="execution.subtask.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_summary",
+                data={
+                    "ac_index": 1,
+                    "sub_task_index": 1,
+                    "sub_task_id": "ac_1_sub_1",
+                    "content": "First child",
+                    "status": "completed",
+                },
+            ),
+            BaseEvent(
+                type="execution.subtask.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_summary",
+                data={
+                    "ac_index": 1,
+                    "sub_task_index": 2,
+                    "sub_task_id": "ac_1_sub_2",
+                    "content": "Second child",
+                    "status": "executing",
+                },
+            ),
+        ]
+
+        summary = summarize_subtask_events(events)
+
+        assert summary["completed_count"] == 1
+        assert summary["executing_count"] == 1
+        assert summary["pending_count"] == 0
+        assert summary["total_count"] == 2
+        assert format_subtask_progress_summary(summary) == "1/2 complete · 1 working"
+
 
 class TestACTreeHUDHandler:
     """Integration tests for ACTreeHUDHandler against EventStore data."""
@@ -510,7 +650,7 @@ class TestACTreeHUDHandler:
         )
 
         handler = ACTreeHUDHandler(event_store=memory_event_store)
-        result = await handler.handle({"session_id": "sess_depth1", "cursor": 0})
+        result = await handler.handle({"session_id": "sess_depth1", "cursor": 0, "view": "tree"})
 
         assert result.is_ok
         tool_result = result.value
@@ -521,6 +661,50 @@ class TestACTreeHUDHandler:
         assert "◇ Acceptance Criteria" in tool_result.text_content
         assert "├─ ● AC 1: First criterion" in tool_result.text_content
         assert "└─ ○ AC 3: Third criterion" in tool_result.text_content
+
+    async def test_handle_defaults_to_summary_view(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Default handler output should avoid rendering the full tree."""
+        await memory_event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="sess_default_summary",
+                data={
+                    "execution_id": "exec_default_summary",
+                    "seed_id": "seed_default_summary",
+                    "start_time": "2026-04-05T12:00:00+00:00",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                type="workflow.progress.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_default_summary",
+                data={
+                    "execution_id": "exec_default_summary",
+                    "current_phase": "deliver",
+                    "completed_count": 1,
+                    "total_count": 3,
+                    "acceptance_criteria": [
+                        {"index": 1, "content": "First criterion", "status": "completed"},
+                        {"index": 2, "content": "Second criterion", "status": "pending"},
+                    ],
+                },
+            )
+        )
+
+        handler = ACTreeHUDHandler(event_store=memory_event_store)
+        result = await handler.handle({"session_id": "sess_default_summary", "cursor": 0})
+
+        assert result.is_ok
+        assert result.value.meta["view"] == "summary"
+        assert "Status: running | Phase: deliver | AC: 1/3" in result.value.text_content
+        assert "Cursor: " in result.value.text_content
+        assert "◇ Acceptance Criteria" not in result.value.text_content
 
     async def test_handle_renders_explicit_tree_with_fallback_activity_state(
         self,
@@ -573,7 +757,9 @@ class TestACTreeHUDHandler:
         )
 
         handler = ACTreeHUDHandler(event_store=memory_event_store)
-        result = await handler.handle({"session_id": "sess_explicit_fallback", "cursor": 0})
+        result = await handler.handle(
+            {"session_id": "sess_explicit_fallback", "cursor": 0, "view": "tree"}
+        )
 
         assert result.is_ok
         tool_result = result.value
@@ -584,6 +770,68 @@ class TestACTreeHUDHandler:
         assert "◇ Acceptance Criteria" in tool_result.text_content
         assert "Progress: 0/1 AC complete" in tool_result.text_content
         assert "└─ ◐ AC 1: Fallback-only criterion  [working]" in tool_result.text_content
+
+    async def test_handle_renders_sub_ac_progress_when_top_level_count_is_zero(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Sub-AC completion should be visible before top-level AC roll-up."""
+        await memory_event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="sess_sub_ac_progress",
+                data={
+                    "execution_id": "exec_sub_ac_progress",
+                    "seed_id": "seed_sub_ac_progress",
+                    "start_time": "2026-04-05T12:00:00+00:00",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                type="workflow.progress.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_sub_ac_progress",
+                data={
+                    "execution_id": "exec_sub_ac_progress",
+                    "current_phase": "deliver",
+                    "completed_count": 0,
+                    "total_count": 2,
+                    "acceptance_criteria": [
+                        {"index": 1, "content": "First parent", "status": "executing"},
+                        {"index": 2, "content": "Second parent", "status": "executing"},
+                    ],
+                },
+            )
+        )
+        for sub_task_index, status in ((1, "completed"), (2, "executing"), (3, "pending")):
+            await memory_event_store.append(
+                BaseEvent(
+                    type="execution.subtask.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_sub_ac_progress",
+                    data={
+                        "ac_index": 1,
+                        "sub_task_index": sub_task_index,
+                        "sub_task_id": f"ac_1_sub_{sub_task_index}",
+                        "content": f"Child {sub_task_index}",
+                        "status": status,
+                    },
+                )
+            )
+
+        handler = ACTreeHUDHandler(event_store=memory_event_store)
+        result = await handler.handle(
+            {"session_id": "sess_sub_ac_progress", "cursor": 0, "view": "tree"}
+        )
+
+        assert result.is_ok
+        text = result.value.text_content
+        assert "Progress: 0/2 AC complete" in text
+        assert "Sub-AC Progress: 1/3 complete · 1 working · 1 pending" in text
+        assert "│  ├─ ● Child 1" in text
+        assert "│  ├─ ◐ Child 2  [working]" in text
 
     async def test_handle_returns_delta_one_liner_when_only_non_progress_events_are_new(
         self,
@@ -639,7 +887,7 @@ class TestACTreeHUDHandler:
 
         assert delta_result.is_ok
         tool_result = delta_result.value
-        assert tool_result.text_content == f"No AC tree change since cursor {initial_cursor}."
+        assert tool_result.text_content == f"unchanged cursor={tool_result.meta['cursor']}"
         assert tool_result.meta["session_id"] == "sess_delta"
         assert tool_result.meta["execution_id"] == "exec_delta"
         assert tool_result.meta["changed"] is False
@@ -690,7 +938,7 @@ class TestACTreeHUDHandler:
 
         assert delta_result.is_ok
         tool_result = delta_result.value
-        assert tool_result.text_content == f"No AC tree change since cursor {initial_cursor}."
+        assert tool_result.text_content == f"unchanged cursor={initial_cursor}"
         assert tool_result.meta["session_id"] == "sess_idle"
         assert tool_result.meta["execution_id"] == "exec_idle"
         assert tool_result.meta["changed"] is False
@@ -769,7 +1017,7 @@ class TestACTreeHUDHandler:
 
         assert delta_result.is_ok
         tool_result = delta_result.value
-        assert tool_result.text_content == f"No AC tree change since cursor {initial_cursor}."
+        assert tool_result.text_content == f"unchanged cursor={tool_result.meta['cursor']}"
         assert tool_result.meta["session_id"] == "sess_fallback_delta"
         assert tool_result.meta["execution_id"] == "exec_fallback_delta"
         assert tool_result.meta["changed"] is False
@@ -849,7 +1097,7 @@ class TestACTreeHUDHandler:
 
         assert delta_result.is_ok
         tool_result = delta_result.value
-        assert tool_result.text_content == f"No AC tree change since cursor {initial_cursor}."
+        assert tool_result.text_content == f"unchanged cursor={tool_result.meta['cursor']}"
         assert tool_result.meta["session_id"] == "sess_explicit_fallback_delta"
         assert tool_result.meta["execution_id"] == "exec_explicit_fallback_delta"
         assert tool_result.meta["changed"] is False

--- a/tests/unit/mcp/tools/test_ac_tree_hud_handler.py
+++ b/tests/unit/mcp/tools/test_ac_tree_hud_handler.py
@@ -662,11 +662,11 @@ class TestACTreeHUDHandler:
         assert "├─ ● AC 1: First criterion" in tool_result.text_content
         assert "└─ ○ AC 3: Third criterion" in tool_result.text_content
 
-    async def test_handle_defaults_to_summary_view(
+    async def test_handle_defaults_to_tree_view(
         self,
         memory_event_store: EventStore,
     ) -> None:
-        """Default handler output should avoid rendering the full tree."""
+        """Omitting view should preserve the legacy full-tree handler output."""
         await memory_event_store.append(
             BaseEvent(
                 type="orchestrator.session.started",
@@ -701,10 +701,22 @@ class TestACTreeHUDHandler:
         result = await handler.handle({"session_id": "sess_default_summary", "cursor": 0})
 
         assert result.is_ok
-        assert result.value.meta["view"] == "summary"
-        assert "Status: running | Phase: deliver | AC: 1/3" in result.value.text_content
-        assert "Cursor: " in result.value.text_content
-        assert "◇ Acceptance Criteria" not in result.value.text_content
+        assert result.value.meta["view"] == "tree"
+        assert "Status: running" in result.value.text_content
+        assert "Phase: deliver" in result.value.text_content
+        assert "Progress: 1/3 AC complete" in result.value.text_content
+        assert "◇ Acceptance Criteria" in result.value.text_content
+        assert "├─ ● AC 1: First criterion" in result.value.text_content
+        assert "└─ ○ AC 2: Second criterion" in result.value.text_content
+
+        summary_result = await handler.handle(
+            {"session_id": "sess_default_summary", "cursor": 0, "view": "summary"}
+        )
+
+        assert summary_result.is_ok
+        assert summary_result.value.meta["view"] == "summary"
+        assert "Status: running | Phase: deliver | AC: 1/3" in summary_result.value.text_content
+        assert "◇ Acceptance Criteria" not in summary_result.value.text_content
 
     async def test_handle_renders_explicit_tree_with_fallback_activity_state(
         self,
@@ -833,11 +845,11 @@ class TestACTreeHUDHandler:
         assert "│  ├─ ● Child 1" in text
         assert "│  ├─ ◐ Child 2  [working]" in text
 
-    async def test_handle_returns_delta_one_liner_when_only_non_progress_events_are_new(
+    async def test_handle_preserves_tree_delta_text_when_only_non_progress_events_are_new(
         self,
         memory_event_store: EventStore,
     ) -> None:
-        """A newer cursor with no new progress event returns the compact unchanged line."""
+        """Default tree view should preserve the legacy unchanged response text."""
         await memory_event_store.append(
             BaseEvent(
                 type="orchestrator.session.started",
@@ -887,17 +899,17 @@ class TestACTreeHUDHandler:
 
         assert delta_result.is_ok
         tool_result = delta_result.value
-        assert tool_result.text_content == f"unchanged cursor={tool_result.meta['cursor']}"
+        assert tool_result.text_content == f"No AC tree change since cursor {initial_cursor}."
         assert tool_result.meta["session_id"] == "sess_delta"
         assert tool_result.meta["execution_id"] == "exec_delta"
         assert tool_result.meta["changed"] is False
         assert tool_result.meta["cursor"] > initial_cursor
 
-    async def test_handle_returns_delta_one_liner_when_no_events_arrive_after_cursor(
+    async def test_handle_returns_summary_delta_one_liner_when_no_events_arrive_after_cursor(
         self,
         memory_event_store: EventStore,
     ) -> None:
-        """An unchanged cursor returns the same compact delta line without a full rerender."""
+        """Explicit summary view may use the compact unchanged cursor line."""
         await memory_event_store.append(
             BaseEvent(
                 type="orchestrator.session.started",
@@ -929,12 +941,16 @@ class TestACTreeHUDHandler:
         )
 
         handler = ACTreeHUDHandler(event_store=memory_event_store)
-        initial_result = await handler.handle({"session_id": "sess_idle", "cursor": 0})
+        initial_result = await handler.handle(
+            {"session_id": "sess_idle", "cursor": 0, "view": "summary"}
+        )
 
         assert initial_result.is_ok
         initial_cursor = initial_result.value.meta["cursor"]
 
-        delta_result = await handler.handle({"session_id": "sess_idle", "cursor": initial_cursor})
+        delta_result = await handler.handle(
+            {"session_id": "sess_idle", "cursor": initial_cursor, "view": "summary"}
+        )
 
         assert delta_result.is_ok
         tool_result = delta_result.value
@@ -944,11 +960,11 @@ class TestACTreeHUDHandler:
         assert tool_result.meta["changed"] is False
         assert tool_result.meta["cursor"] == initial_cursor
 
-    async def test_handle_returns_delta_one_liner_when_new_progress_repeats_fallback_snapshot(
+    async def test_handle_preserves_tree_delta_text_when_new_progress_repeats_fallback_snapshot(
         self,
         memory_event_store: EventStore,
     ) -> None:
-        """Repeated fallback-only progress snapshots should collapse to the unchanged delta line."""
+        """Repeated fallback snapshots should not change default tree response contracts."""
         await memory_event_store.append(
             BaseEvent(
                 type="orchestrator.session.started",
@@ -1017,17 +1033,17 @@ class TestACTreeHUDHandler:
 
         assert delta_result.is_ok
         tool_result = delta_result.value
-        assert tool_result.text_content == f"unchanged cursor={tool_result.meta['cursor']}"
+        assert tool_result.text_content == f"No AC tree change since cursor {initial_cursor}."
         assert tool_result.meta["session_id"] == "sess_fallback_delta"
         assert tool_result.meta["execution_id"] == "exec_fallback_delta"
         assert tool_result.meta["changed"] is False
         assert tool_result.meta["cursor"] > initial_cursor
 
-    async def test_handle_returns_delta_one_liner_when_explicit_fallback_tree_repeats(
+    async def test_handle_preserves_tree_delta_text_when_explicit_fallback_tree_repeats(
         self,
         memory_event_store: EventStore,
     ) -> None:
-        """Repeated explicit-tree fallback states should not force a full rerender."""
+        """Repeated explicit-tree fallback states should keep tree unchanged text."""
         await memory_event_store.append(
             BaseEvent(
                 type="orchestrator.session.started",
@@ -1097,7 +1113,7 @@ class TestACTreeHUDHandler:
 
         assert delta_result.is_ok
         tool_result = delta_result.value
-        assert tool_result.text_content == f"unchanged cursor={tool_result.meta['cursor']}"
+        assert tool_result.text_content == f"No AC tree change since cursor {initial_cursor}."
         assert tool_result.meta["session_id"] == "sess_explicit_fallback_delta"
         assert tool_result.meta["execution_id"] == "exec_explicit_fallback_delta"
         assert tool_result.meta["changed"] is False

--- a/tests/unit/mcp/tools/test_ac_tree_hud_handler_completed.py
+++ b/tests/unit/mcp/tools/test_ac_tree_hud_handler_completed.py
@@ -62,7 +62,9 @@ async def test_handle_renders_final_completed_snapshot_after_session_completion(
     )
 
     handler = ACTreeHUDHandler(event_store=memory_event_store)
-    initial_result = await handler.handle({"session_id": "sess_completed_hud", "cursor": 0})
+    initial_result = await handler.handle(
+        {"session_id": "sess_completed_hud", "cursor": 0, "view": "tree"}
+    )
 
     assert initial_result.is_ok
     initial_cursor = initial_result.value.meta["cursor"]
@@ -77,7 +79,7 @@ async def test_handle_renders_final_completed_snapshot_after_session_completion(
     )
 
     completed_result = await handler.handle(
-        {"session_id": "sess_completed_hud", "cursor": initial_cursor}
+        {"session_id": "sess_completed_hud", "cursor": initial_cursor, "view": "tree"}
     )
 
     assert completed_result.is_ok
@@ -87,7 +89,7 @@ async def test_handle_renders_final_completed_snapshot_after_session_completion(
     assert tool_result.meta["status"] == "completed"
     assert tool_result.meta["changed"] is True
     assert tool_result.meta["cursor"] > initial_cursor
-    assert tool_result.text_content != f"No AC tree change since cursor {initial_cursor}."
+    assert not tool_result.text_content.startswith("unchanged cursor=")
     assert "Status: completed" in tool_result.text_content
     assert "Progress: 2/2 AC complete" in tool_result.text_content
     assert "Metrics: elapsed 2m 10s · 11 msgs · 4 tools · $0.05" in tool_result.text_content

--- a/tests/unit/mcp/tools/test_ac_tree_hud_handler_cursor_changed.py
+++ b/tests/unit/mcp/tools/test_ac_tree_hud_handler_cursor_changed.py
@@ -58,7 +58,9 @@ async def test_handle_returns_full_render_when_progress_event_arrives_after_curs
     )
 
     handler = ACTreeHUDHandler(event_store=memory_event_store)
-    initial_result = await handler.handle({"session_id": "sess_changed", "cursor": 0})
+    initial_result = await handler.handle(
+        {"session_id": "sess_changed", "cursor": 0, "view": "tree"}
+    )
 
     assert initial_result.is_ok
     initial_cursor = initial_result.value.meta["cursor"]
@@ -96,7 +98,9 @@ async def test_handle_returns_full_render_when_progress_event_arrives_after_curs
         )
     )
 
-    changed_result = await handler.handle({"session_id": "sess_changed", "cursor": initial_cursor})
+    changed_result = await handler.handle(
+        {"session_id": "sess_changed", "cursor": initial_cursor, "view": "tree"}
+    )
 
     assert changed_result.is_ok
     tool_result = changed_result.value
@@ -104,7 +108,7 @@ async def test_handle_returns_full_render_when_progress_event_arrives_after_curs
     assert tool_result.meta["execution_id"] == "exec_changed"
     assert tool_result.meta["changed"] is True
     assert tool_result.meta["cursor"] > initial_cursor
-    assert tool_result.text_content != f"No AC tree change since cursor {initial_cursor}."
+    assert not tool_result.text_content.startswith("unchanged cursor=")
     assert "Progress: 1/2 AC complete" in tool_result.text_content
     assert "Activity: executing | Update second criterion" in tool_result.text_content
     assert "├─ ● AC 1: First criterion" in tool_result.text_content

--- a/tests/unit/mcp/tools/test_ac_tree_hud_max_nodes.py
+++ b/tests/unit/mcp/tools/test_ac_tree_hud_max_nodes.py
@@ -118,7 +118,9 @@ async def test_handle_respects_max_nodes_override_for_large_top_level_tree(
     )
 
     handler = ACTreeHUDHandler(event_store=memory_event_store)
-    result = await handler.handle({"session_id": "sess_max_nodes", "cursor": 0, "max_nodes": 3})
+    result = await handler.handle(
+        {"session_id": "sess_max_nodes", "cursor": 0, "max_nodes": 3, "view": "tree"}
+    )
 
     assert result.is_ok
     markdown = result.value.text_content

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -235,6 +235,79 @@ class TestSessionStatusHandler:
         assert result.value.meta["is_completed"] == (status_value == "completed")
         assert result.value.meta["is_failed"] == (status_value == "failed")
 
+    async def test_handle_includes_sub_ac_progress(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Session status should expose Sub-AC progress alongside AC progress."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="sess-status-sub-ac",
+                data={
+                    "execution_id": "exec-status-sub-ac",
+                    "seed_id": "seed-status-sub-ac",
+                    "start_time": "2026-04-05T12:00:00+00:00",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                type="workflow.progress.updated",
+                aggregate_type="execution",
+                aggregate_id="exec-status-sub-ac",
+                data={
+                    "session_id": "sess-status-sub-ac",
+                    "completed_count": 0,
+                    "total_count": 2,
+                    "current_phase": "Deliver",
+                    "acceptance_criteria": [
+                        {"index": 1, "content": "First parent", "status": "executing"},
+                        {"index": 2, "content": "Second parent", "status": "executing"},
+                    ],
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                type="execution.subtask.updated",
+                aggregate_type="execution",
+                aggregate_id="exec-status-sub-ac",
+                data={
+                    "ac_index": 1,
+                    "sub_task_index": 1,
+                    "sub_task_id": "ac_1_sub_1",
+                    "content": "Child one",
+                    "status": "completed",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                type="execution.subtask.updated",
+                aggregate_type="execution",
+                aggregate_id="exec-status-sub-ac",
+                data={
+                    "ac_index": 1,
+                    "sub_task_index": 2,
+                    "sub_task_id": "ac_1_sub_2",
+                    "content": "Child two",
+                    "status": "executing",
+                },
+            )
+        )
+
+        handler = SessionStatusHandler(event_store=memory_event_store)
+        result = await handler.handle({"session_id": "sess-status-sub-ac"})
+
+        assert result.is_ok
+        assert "completed_count: 0" in result.value.text_content
+        assert "sub_ac_progress: 1/2 complete · 1 working" in result.value.text_content
+        assert result.value.meta["progress"]["sub_ac_total_count"] == 2
+
 
 class TestQueryEventsHandler:
     """Test QueryEventsHandler class."""
@@ -494,11 +567,13 @@ class TestAsyncJobHandlers:
     def test_job_status_definition_name(self) -> None:
         handler = JobStatusHandler()
         assert handler.definition.name == "ouroboros_job_status"
+        param_names = {p.name for p in handler.definition.parameters}
+        assert param_names == {"job_id", "view"}
 
     def test_job_wait_definition_has_expected_params(self) -> None:
         handler = JobWaitHandler()
         param_names = {p.name for p in handler.definition.parameters}
-        assert param_names == {"job_id", "cursor", "timeout_seconds"}
+        assert param_names == {"job_id", "cursor", "timeout_seconds", "view"}
 
     def test_job_result_definition_name(self) -> None:
         handler = JobResultHandler()
@@ -507,7 +582,7 @@ class TestAsyncJobHandlers:
     def test_ac_tree_hud_definition_has_expected_params(self) -> None:
         handler = ACTreeHUDHandler()
         param_names = {p.name for p in handler.definition.parameters}
-        assert param_names == {"session_id", "cursor", "max_nodes"}
+        assert param_names == {"session_id", "cursor", "view", "max_nodes"}
 
     def test_cancel_job_definition_name(self) -> None:
         handler = CancelJobHandler()

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -567,13 +567,17 @@ class TestAsyncJobHandlers:
     def test_job_status_definition_name(self) -> None:
         handler = JobStatusHandler()
         assert handler.definition.name == "ouroboros_job_status"
-        param_names = {p.name for p in handler.definition.parameters}
+        params = {p.name: p for p in handler.definition.parameters}
+        param_names = set(params)
         assert param_names == {"job_id", "view"}
+        assert params["view"].default == "full"
 
     def test_job_wait_definition_has_expected_params(self) -> None:
         handler = JobWaitHandler()
-        param_names = {p.name for p in handler.definition.parameters}
+        params = {p.name: p for p in handler.definition.parameters}
+        param_names = set(params)
         assert param_names == {"job_id", "cursor", "timeout_seconds", "view"}
+        assert params["view"].default == "full"
 
     def test_job_result_definition_name(self) -> None:
         handler = JobResultHandler()
@@ -581,8 +585,10 @@ class TestAsyncJobHandlers:
 
     def test_ac_tree_hud_definition_has_expected_params(self) -> None:
         handler = ACTreeHUDHandler()
-        param_names = {p.name for p in handler.definition.parameters}
+        params = {p.name: p for p in handler.definition.parameters}
+        param_names = set(params)
         assert param_names == {"session_id", "cursor", "view", "max_nodes"}
+        assert params["view"].default == "tree"
 
     def test_cancel_job_definition_name(self) -> None:
         handler = CancelJobHandler()


### PR DESCRIPTION
## Summary

- Add compact and summary monitoring views for AC HUD and job status/wait tools to reduce token usage during long executions.
- Surface Sub-AC progress separately from top-level AC roll-up so users can see useful progress even when AC completion is still 0/N.
- Update the run skill to use low-token relay monitoring based on structured `response.meta` instead of repeated full-tree polling.

## Changes

- Added `view` modes for `ouroboros_ac_tree_hud`: `compact`, `summary`, and `tree`.
- Added `view` modes for `ouroboros_job_status` and `ouroboros_job_wait`: `compact`, `summary`, and `full`.
- Added Sub-AC event summarization and compact relay formatting helpers.
- Updated session status progress metadata with Sub-AC summary counts.
- Reworked `skills/run/SKILL.md` to define a harness-friendly relay loop using `ouroboros_job_wait(view="summary")`.
- Added regression coverage for compact rendering, Sub-AC progress summaries, cursor behavior, and tool definitions.

## Verification

- `uv run ruff check src/ouroboros/mcp/tools/ac_tree_hud_handler.py src/ouroboros/mcp/tools/job_handlers.py src/ouroboros/mcp/tools/query_handlers.py tests/unit/mcp/tools/test_ac_tree_hud_handler.py tests/unit/mcp/tools/test_ac_tree_hud_handler_cursor_changed.py tests/unit/mcp/tools/test_ac_tree_hud_handler_completed.py tests/unit/mcp/tools/test_ac_tree_hud_max_nodes.py tests/unit/mcp/tools/test_definitions.py tests/unit/mcp/test_job_manager.py`
- `uv run pytest tests/unit/mcp/tools/test_ac_tree_hud_handler.py tests/unit/mcp/tools/test_ac_tree_hud_handler_cursor_changed.py tests/unit/mcp/tools/test_ac_tree_hud_handler_completed.py tests/unit/mcp/tools/test_ac_tree_hud_max_nodes.py tests/unit/mcp/tools/test_definitions.py tests/unit/mcp/test_job_manager.py`