### PR TITLE
fix(brownfield): scan repos with any origin remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Inside AI coding agent sessions, use `ooo <cmd>` skills. From the terminal, use 
 | `ooo pm`         | *(via MCP)*                                                       | PM-focused interview + PRD generation                        |
 | `ooo qa`         | *(via skill)*                                                     | General-purpose QA verdict for any artifact                  |
 | `ooo update`     | `ouroboros update`                                                | Check for updates + upgrade to latest                        |
-| `ooo brownfield` | *(via skill)*                                                     | Scan and manage brownfield repo defaults                     |
+| `ooo brownfield` | *(via skill)*                                                     | Scan and manage brownfield repo/worktree defaults            |
 | `ooo publish`    | *(skill/runtime surface; uses `gh` CLI)*                          | Publish a Seed as GitHub Epic/Task issues for team workflows |
 
 > Not all skills have direct CLI equivalents. Some (`evaluate`, `evolve`, `unstuck`, `ralph`, `publish`) are available through agent skills, runtime rules, or MCP tools rather than a direct `ouroboros <subcommand>` shell command.

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -261,6 +261,25 @@ Ouroboros exposes workflow tools as ordinary MCP handlers. The MCP server does
 not parse `ooo` syntax and does not receive channel-specific identifiers for
 skill routing.
 
+### `ouroboros_brownfield` Scan Boundaries
+
+The brownfield MCP tool registers existing codebases for PM/interview context.
+For `{"action": "scan"}`, `scan_root` controls only the filesystem walk for
+seed repositories and worktrees. When `scan_root` is omitted, the walk starts at
+the current user's home directory. Dot-prefixed directories and known noisy
+directories such as `node_modules` are not walked as seed locations.
+
+Linked worktree expansion is asymmetric. When the walk finds a normal repo root
+with a `.git` directory, Ouroboros runs `git worktree list --porcelain` from
+that repo and may register Git-reported linked worktrees even when those paths
+are outside `scan_root`. When the walk finds a linked worktree root with a
+`.git` file, Ouroboros registers that worktree itself but does not use it to
+register the main worktree or sibling worktrees outside `scan_root`. This keeps
+narrow scans scoped when a user intentionally passes one worktree as AI context.
+Local repos, repos without remotes, and repos whose remotes are not named
+`origin` are all eligible. Stale linked worktree paths are skipped when the path
+no longer exists or is no longer a valid Git working tree.
+
 Runtime integrations that support `ooo <skill>` or `/ouroboros:<skill>` use the
 shared stateless router in `ouroboros.router` before invoking MCP. The router
 loads packaged `SKILL.md` frontmatter, validates `mcp_tool` and `mcp_args`,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,6 +103,20 @@ ouroboros setup --non-interactive
 
 > **Codex config split:** put persistent Ouroboros per-role model overrides in `~/.ouroboros/config.yaml` (`clarification.default_model`, `llm.qa_model`, `evaluation.semantic_model`, `consensus.models`, `consensus.advocate_model`, `consensus.devil_model`, `consensus.judge_model`). `~/.codex/config.toml` is only the Codex MCP/env hookup file used by setup.
 
+### Brownfield Subcommands
+
+`ouroboros setup` also includes brownfield repository registration helpers:
+
+```bash
+ouroboros setup scan [SCAN_ROOT]
+ouroboros setup list
+ouroboros setup default
+```
+
+`ouroboros setup scan [SCAN_ROOT]` walks `scan_root` for valid seed git repositories and worktrees. When `SCAN_ROOT` is omitted, `scan_root` defaults to the current user's home directory. The filesystem walk is bounded to `scan_root`: dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations. Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
+
+Linked worktree expansion has a different boundary. For each normal repo root found under `scan_root` with a `.git` directory, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even when their paths are outside `scan_root`, as long as Git reports them and the paths still exist. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. This keeps narrow scans scoped when a user intentionally passes one worktree as AI context. Existing registrations and default selections are preserved by upsert.
+
 ---
 
 ## `ouroboros init`

--- a/skills/brownfield/SKILL.md
+++ b/skills/brownfield/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: brownfield
-description: "Scan and manage brownfield repository defaults for interviews"
+description: "Scan and manage brownfield repository/worktree defaults for interviews"
 ---
 
 # /ouroboros:brownfield
 
-Scan your home directory for existing git repositories and manage default repos used as context in interviews.
+Scan a root directory for existing git repositories and linked worktrees, then manage default repos used as context in interviews.
 
 ## Usage
 
@@ -33,8 +33,9 @@ Show scanning indicator:
   Scanning for Existing Projects...
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Looking for git repositories in your home directory.
-Only GitHub-hosted repos will be registered.
+Looking for git repositories and worktrees under the scan root directory.
+Linked worktrees reported by discovered normal repo roots may also be registered, even outside the scan root directory.
+Local repos and repos with any remote name are eligible.
 This may take a moment...
 ```
 
@@ -46,7 +47,7 @@ This may take a moment...
    Tool: ouroboros_brownfield
    Arguments: { "action": "scan" }
    ```
-   This scans `~/` for GitHub repos and registers them in DB. Existing defaults are preserved.
+   This walks `scan_root` for valid seed repos/worktrees and registers them in DB. For each discovered normal repo root with a `.git` directory, Git-reported linked worktrees are also considered, even when they live outside `scan_root`. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. Existing defaults are preserved.
 
 The scan response `text` already contains a pre-formatted numbered list with `[default]` markers. **Do NOT make any additional MCP calls to list or query repos.**
 
@@ -65,9 +66,18 @@ Include `*` markers for defaults exactly as they appear in the scan response.
 
 **If no repos found**, show:
 ```
-No GitHub repositories found in your home directory.
+No git repositories or worktrees found.
 ```
 Then stop.
+
+### Scan boundaries
+
+- The filesystem walk starts at `scan_root`; when omitted, `scan_root` defaults to the current user's home directory.
+- Repositories are only discovered directly by walking directories inside `scan_root`.
+- Dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations.
+- Git worktrees are different: once a normal repo root with a `.git` directory is discovered, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even if their paths are outside `scan_root`.
+- A linked worktree found inside `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`.
+- Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
 
 **Step 2: Default Selection**
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -369,7 +369,7 @@ Join the community:
 
 ### Step 5.5: Brownfield Repository Scan
 
-Scan the user's home directory for existing git repositories and register them in the Ouroboros DB. This enables interviews to use brownfield context for existing projects.
+Scan a root directory for existing git repositories and linked worktrees, then register them in the Ouroboros DB. This enables interviews to use brownfield context for existing projects.
 
 **Show scanning indicator:**
 ```
@@ -377,8 +377,9 @@ Scan the user's home directory for existing git repositories and register them i
   Scanning for Existing Projects...
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Looking for git repositories in your home directory.
-Only GitHub-hosted repos will be registered.
+Looking for git repositories and worktrees under the scan root directory.
+Linked worktrees reported by discovered normal repo roots may also be registered, even outside the scan root directory.
+Local repos and repos with any remote name are eligible.
 This may take a moment...
 ```
 
@@ -390,7 +391,15 @@ This may take a moment...
    Tool: ouroboros_brownfield
    Arguments: { "action": "scan" }
    ```
-   This scans `~/` for GitHub repos and registers them in DB. Existing defaults are preserved.
+   This walks `scan_root` for valid seed repos/worktrees and registers them in DB. For each discovered normal repo root with a `.git` directory, Git-reported linked worktrees are also considered, even when they live outside `scan_root`. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. Existing defaults are preserved.
+
+**Scan boundaries:**
+- The filesystem walk starts at `scan_root`; when omitted, `scan_root` defaults to the current user's home directory.
+- Repositories are only discovered directly by walking directories inside `scan_root`.
+- Dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations.
+- Git worktrees are different: once a normal repo root with a `.git` directory is discovered, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even if their paths are outside `scan_root`.
+- A linked worktree found inside `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`.
+- Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
 
 The scan response `text` already contains a pre-formatted numbered list with `[default]` markers. **Do NOT make any additional MCP calls to list or query repos.**
 

--- a/src/ouroboros/bigbang/brownfield.py
+++ b/src/ouroboros/bigbang/brownfield.py
@@ -386,13 +386,16 @@ async def scan_and_register(
         model: Unused — kept for backward API compatibility.
 
     Returns:
-        List of all registered BrownfieldRepo instances.
+        List of BrownfieldRepo instances discovered and upserted by THIS scan.
+        Repos that were registered manually or by previous scans but not
+        re-discovered by this scan are not included; callers that need the
+        full registry should call :py:meth:`BrownfieldStore.list` directly.
     """
     scanned = scan_home_for_repos(root)
 
     if not scanned:
         log.info("brownfield.scan_and_register.no_repos")
-        return await store.list()
+        return []
 
     # Upsert scanned repos — register() does INSERT OR UPDATE for
     # existing paths, preserving is_default and desc for repos already
@@ -411,7 +414,11 @@ async def scan_and_register(
 
     log.info("brownfield.upsert_registered", count=len(scanned_paths))
 
-    return await store.list()
+    # Return only the repos that were just discovered/upserted. The full
+    # registry can include manually-registered or previously-scanned repos
+    # outside the current scan root, and conflating them with "what this
+    # scan found" leaks state into a boundary-sensitive operation.
+    return [r for r in await store.list() if r.path in scanned_paths]
 
 
 async def get_default_brownfield_context(

--- a/src/ouroboros/bigbang/brownfield.py
+++ b/src/ouroboros/bigbang/brownfield.py
@@ -4,7 +4,8 @@ Manages the global brownfield registry in ``~/.ouroboros/ouroboros.db``
 via :class:`~ouroboros.persistence.brownfield.BrownfieldStore`.
 
 Business-level operations:
-- Home directory scanning for git repos with an ``origin`` remote
+- Scan-root discovery for valid seed git repos/worktrees
+- Linked worktree discovery from normal repo roots via Git metadata
 - README/CLAUDE.md parsing for one-line description generation (Frugal model)
 - Async CRUD delegated to BrownfieldStore
 
@@ -17,6 +18,7 @@ import asyncio
 import os
 from pathlib import Path
 import subprocess
+from urllib.parse import urlparse
 
 import structlog
 
@@ -73,7 +75,7 @@ _DESC_SYSTEM_PROMPT = (
 )
 
 
-# ── Home directory scanning ────────────────────────────────────────
+# ── Scan root discovery ────────────────────────────────────────────
 
 
 def _has_origin_remote(repo_path: Path) -> bool:
@@ -85,6 +87,11 @@ def _has_origin_remote(repo_path: Path) -> bool:
     Returns:
         True if ``git remote get-url origin`` returns a non-empty URL.
     """
+    return _origin_remote_url(repo_path) is not None
+
+
+def _origin_remote_url(repo_path: Path) -> str | None:
+    """Return the configured ``origin`` remote URL for a git repo, if present."""
     try:
         result = subprocess.run(
             ["git", "-C", str(repo_path), "remote", "get-url", "origin"],
@@ -92,47 +99,161 @@ def _has_origin_remote(repo_path: Path) -> bool:
             text=True,
             timeout=5,
         )
-        return result.returncode == 0 and bool(result.stdout.strip())
+        if result.returncode != 0:
+            return None
+        origin = result.stdout.strip()
+        return origin or None
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        return False
+        return None
+
+
+def _origin_host(remote_url: str) -> str:
+    """Extract the host from common Git remote URL forms."""
+    parsed = urlparse(remote_url)
+    if parsed.hostname:
+        return parsed.hostname.lower()
+
+    # SCP-like remotes: git@github.com:owner/repo.git
+    if ":" in remote_url:
+        before_path = remote_url.split(":", 1)[0]
+        if "@" in before_path:
+            return before_path.rsplit("@", 1)[-1].lower()
+
+    return ""
 
 
 def _has_github_origin(repo_path: Path) -> bool:
-    """Backward-compatible wrapper for callers using the old helper name."""
-    return _has_origin_remote(repo_path)
+    """Check whether a git repo has a GitHub ``origin`` remote."""
+    origin = _origin_remote_url(repo_path)
+    return origin is not None and _origin_host(origin) == "github.com"
+
+
+def _is_git_worktree(repo_path: Path) -> bool:
+    """Check whether a path is inside a valid Git working tree."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _list_git_worktrees(repo_path: Path) -> list[Path]:
+    """Return linked worktree paths reported by Git for a normal repo root."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return []
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+
+    worktrees: list[Path] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            worktree_path = line.removeprefix("worktree ").strip()
+            if worktree_path:
+                worktrees.append(Path(worktree_path))
+    return worktrees
+
+
+def _repo_entry(repo_path: Path) -> dict[str, str] | None:
+    """Build a scan result entry for an existing repository directory."""
+    try:
+        resolved = repo_path.resolve()
+    except OSError:
+        return None
+
+    if not resolved.is_dir():
+        return None
+
+    return {"path": str(resolved), "name": resolved.name}
+
+
+def _add_repo_and_worktrees(
+    repo_path: Path,
+    repos_by_path: dict[str, dict[str, str]],
+    *,
+    include_linked_worktrees: bool,
+) -> None:
+    """Add a seed repo and optionally any Git-reported linked worktrees.
+
+    The seed path must be found by the filesystem walk. For normal repository
+    roots, linked worktrees come from ``git worktree list`` and may be outside
+    the walk root.
+    """
+    if not _is_git_worktree(repo_path):
+        return
+
+    candidates = [repo_path]
+    if include_linked_worktrees:
+        candidates.extend(_list_git_worktrees(repo_path))
+
+    for candidate in candidates:
+        if not _is_git_worktree(candidate):
+            continue
+        entry = _repo_entry(candidate)
+        if entry is None:
+            continue
+        repos_by_path.setdefault(entry["path"], entry)
 
 
 def scan_home_for_repos(
     root: Path | None = None,
 ) -> list[dict[str, str]]:
-    """Walk the home directory to find git repositories with an ``origin`` remote.
+    """Walk a root directory to find valid git repos/worktrees.
 
     Scanning rules:
-    - Prune subdirectories once ``.git`` is found (no nested repos)
-    - Skip hardcoded noise directories (node_modules, .venv, etc.)
-    - Only include repos with a configured ``origin`` remote
+    - Repositories are discovered by filesystem walking under ``root`` only.
+    - A seed repo/worktree is any walked directory with a ``.git`` directory or file.
+    - Prune subdirectories once a seed is found (no nested repo walk).
+    - Skip hardcoded noise directories (node_modules, .venv, etc.).
+    - Skip dot-prefixed directories during filesystem walking.
+    - Normal repo roots are expanded via ``git worktree list --porcelain``.
+    - Linked worktrees reported by normal repo roots may be included outside ``root``.
+    - Linked worktree seeds are registered self-only and do not pull main/sibling
+      worktrees outside ``root``.
+    - Local repos and repos with any remote name are included.
 
     Args:
-        root: Directory to start scanning. Defaults to ``~/``.
+        root: Directory to start the seed filesystem walk. Defaults to the
+            current user's home directory.
 
     Returns:
-        Sorted list of ``{path, name}`` dicts for each discovered repository.
+        Sorted list of ``{path, name}`` dicts for each discovered repo/worktree.
     """
     if root is None:
         root = Path.home()
 
-    repos: list[dict[str, str]] = []
+    repos_by_path: dict[str, dict[str, str]] = {}
 
     # os.walk with topdown=True so we can modify dirs in-place to prune
-    for dirpath, dirnames, _filenames in os.walk(root, topdown=True):
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True):
         current = Path(dirpath)
 
-        # Check for .git directory
-        if ".git" in dirnames:
-            if _has_origin_remote(current):
-                resolved = current.resolve()
-                repos.append({"path": str(resolved), "name": resolved.name})
-                log.debug("brownfield.scan.found", path=str(current))
+        has_git_dir = ".git" in dirnames
+        has_git_file = ".git" in filenames
+        if has_git_dir or has_git_file:
+            # A .git directory is a normal repo root, so it can safely expand to
+            # its Git-reported worktree family. A .git file is a linked worktree
+            # seed; register it, but do not use it as a portal to pull in the
+            # main repo or siblings. Users may scan/pass a specific worktree to
+            # keep the rest of the repository out of AI context.
+            _add_repo_and_worktrees(
+                current,
+                repos_by_path,
+                include_linked_worktrees=has_git_dir,
+            )
+            log.debug("brownfield.scan.found", path=str(current))
 
             # Prune: don't descend into this repo's subdirectories
             dirnames.clear()
@@ -141,6 +262,7 @@ def scan_home_for_repos(
         # Prune skip directories
         dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS and not d.startswith(".")]
 
+    repos = list(repos_by_path.values())
     repos.sort(key=lambda r: r["path"])
     log.info("brownfield.scan.complete", root=str(root), found=len(repos))
     return repos
@@ -241,13 +363,16 @@ async def scan_and_register(
     *,
     model: str = _FRUGAL_MODEL,  # noqa: ARG001
 ) -> list[BrownfieldRepo]:
-    """Scan home directory for repos and bulk-register them in the DB.
+    """Scan a root directory for repos/worktrees and bulk-register them in the DB.
 
-    This is the main entry point for ``ooo setup`` brownfield scanning.
+    This is the main entry point for brownfield scanning.
 
-    1. Walk ``~/`` to find git repos with an ``origin`` remote.
-    2. Bulk-insert all found repos with ``is_default=False`` and ``desc=""``.
-    3. Set the first repo as default if no default exists.
+    1. Walk ``root`` (the current user's home directory when omitted) to find
+       valid seed git repos/worktrees.
+    2. For each normal repo root, include Git-reported linked worktrees even
+       when they live outside ``root``. Linked worktree seeds are self-only.
+    3. Upsert all found repos while preserving existing names, descriptions,
+       and default flags. Default selection is handled by setup/MCP flows.
 
     Description generation is deferred to ``set_default_repo`` (Frugal model).
     The ``llm_adapter`` and ``model`` params are accepted for API compatibility
@@ -256,7 +381,8 @@ async def scan_and_register(
     Args:
         store: Initialized BrownfieldStore.
         llm_adapter: Unused — kept for backward API compatibility.
-        root: Directory to scan. Defaults to ``~/``.
+        root: Directory to walk for seed repos/worktrees. Defaults to the
+            current user's home directory.
         model: Unused — kept for backward API compatibility.
 
     Returns:

--- a/src/ouroboros/bigbang/brownfield.py
+++ b/src/ouroboros/bigbang/brownfield.py
@@ -4,7 +4,7 @@ Manages the global brownfield registry in ``~/.ouroboros/ouroboros.db``
 via :class:`~ouroboros.persistence.brownfield.BrownfieldStore`.
 
 Business-level operations:
-- Home directory scanning for git repos with GitHub origin
+- Home directory scanning for git repos with an ``origin`` remote
 - README/CLAUDE.md parsing for one-line description generation (Frugal model)
 - Async CRUD delegated to BrownfieldStore
 
@@ -76,14 +76,14 @@ _DESC_SYSTEM_PROMPT = (
 # ── Home directory scanning ────────────────────────────────────────
 
 
-def _has_github_origin(repo_path: Path) -> bool:
-    """Check whether a git repo has a remote origin containing github.com.
+def _has_origin_remote(repo_path: Path) -> bool:
+    """Check whether a git repo has a configured ``origin`` remote.
 
     Args:
         repo_path: Path to the repository root (parent of ``.git``).
 
     Returns:
-        True if any origin URL contains ``github.com``.
+        True if ``git remote get-url origin`` returns a non-empty URL.
     """
     try:
         result = subprocess.run(
@@ -92,20 +92,25 @@ def _has_github_origin(repo_path: Path) -> bool:
             text=True,
             timeout=5,
         )
-        return "github.com" in result.stdout
+        return result.returncode == 0 and bool(result.stdout.strip())
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return False
+
+
+def _has_github_origin(repo_path: Path) -> bool:
+    """Backward-compatible wrapper for callers using the old helper name."""
+    return _has_origin_remote(repo_path)
 
 
 def scan_home_for_repos(
     root: Path | None = None,
 ) -> list[dict[str, str]]:
-    """Walk the home directory to find git repositories with GitHub origins.
+    """Walk the home directory to find git repositories with an ``origin`` remote.
 
     Scanning rules:
     - Prune subdirectories once ``.git`` is found (no nested repos)
     - Skip hardcoded noise directories (node_modules, .venv, etc.)
-    - Only include repos whose origin remote contains ``github.com``
+    - Only include repos with a configured ``origin`` remote
 
     Args:
         root: Directory to start scanning. Defaults to ``~/``.
@@ -124,7 +129,7 @@ def scan_home_for_repos(
 
         # Check for .git directory
         if ".git" in dirnames:
-            if _has_github_origin(current):
+            if _has_origin_remote(current):
                 resolved = current.resolve()
                 repos.append({"path": str(resolved), "name": resolved.name})
                 log.debug("brownfield.scan.found", path=str(current))
@@ -240,7 +245,7 @@ async def scan_and_register(
 
     This is the main entry point for ``ooo setup`` brownfield scanning.
 
-    1. Walk ``~/`` to find git repos with GitHub origins.
+    1. Walk ``~/`` to find git repos with an ``origin`` remote.
     2. Bulk-insert all found repos with ``is_default=False`` and ``desc=""``.
     3. Set the first repo as default if no default exists.
 
@@ -335,7 +340,7 @@ async def register_repo(
     resolved_name = name or repo_path.name
     # Resolve only if the path exists on disk (avoids macOS /System/Volumes
     # prefix for non-existent paths in tests and cross-machine registrations).
-    canonical_path = str(repo_path.resolve()) if repo_path.exists() else str(repo_path)
+    canonical_path = str(repo_path.resolve()) if repo_path.exists() else path
 
     # Auto-generate description if not provided and LLM adapter is available
     if desc is None and llm_adapter is not None:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -4,7 +4,7 @@ Standalone setup that works in any terminal — not just inside Claude Code.
 Detects available runtimes and configures Ouroboros accordingly.
 
 Also provides brownfield repository management subcommands:
-    ouroboros setup scan         Re-scan home directory for repos
+    ouroboros setup scan [ROOT]  Re-scan a root directory for repos/worktrees
     ouroboros setup list         List registered brownfield repos
     ouroboros setup default      Toggle default brownfield repos
 """
@@ -1075,19 +1075,23 @@ def _prompt_repo_selection(
 # ── Brownfield async core logic ──────────────────────────────────
 
 
-async def _scan_and_register_repos() -> list[dict]:
-    """Scan home directory and register repos in DB.
+async def _scan_and_register_repos(scan_root: Path | None = None) -> list[dict]:
+    """Scan a root directory and register repos/worktrees in DB.
 
     Uses upsert semantics so that manually-registered repos outside the
-    scan root are preserved across re-scans.
+    scan root are preserved across re-scans. Git-reported linked worktrees for
+    discovered normal repo roots may be registered even when they live outside
+    the scan root. A linked worktree inside the scan root is registered itself
+    but does not pull its main/sibling worktrees outside the scan root.
 
     Returns:
         List of repo dicts with path, name, desc, is_default.
     """
+    scan_root = scan_root or Path.home()
     store = BrownfieldStore()
     try:
         await store.initialize()
-        repos = await scan_and_register(store)
+        repos = await scan_and_register(store, root=scan_root)
         return [
             {
                 "path": r.path,
@@ -1327,16 +1331,33 @@ def setup(
 
 
 @app.command()
-def scan() -> None:
-    """Re-scan home directory and register new repos.
+def scan(
+    scan_root: Annotated[
+        Path | None,
+        typer.Argument(
+            help="Root directory for the brownfield scan. Defaults to the current user's home directory.",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ] = None,
+) -> None:
+    """Re-scan a root directory and register new repos.
 
-    Scans ~/ for git repos with configured origin remotes and updates the
-    brownfield registry. Existing repos are preserved (upsert).
+    Scans the requested root for valid seed git repos/worktrees and updates the
+    brownfield registry. Linked worktrees reported by normal repo roots may be
+    registered even when they live outside the scan root. A linked worktree
+    found inside the scan root is registered itself but does not pull its
+    main/sibling worktrees outside the scan root. Local repos and repos with any
+    remote name are eligible. Existing repos are preserved (upsert).
     """
+    effective_scan_root = scan_root or Path.home()
     console.print("\n[bold cyan]Brownfield Scan[/]\n")
 
     try:
-        repos = asyncio.run(_run_scan_only())
+        repos = asyncio.run(_run_scan_only(effective_scan_root))
     except KeyboardInterrupt:
         print_info("\nScan interrupted.")
         raise typer.Exit(code=0)
@@ -1349,10 +1370,10 @@ def scan() -> None:
     _display_repos_table(repos)
 
 
-async def _run_scan_only() -> list[dict]:
+async def _run_scan_only(scan_root: Path) -> list[dict]:
     """Scan and register, returning repo list."""
-    with console.status("[cyan]Scanning home directory...[/]", spinner="dots"):
-        return await _scan_and_register_repos()
+    with console.status("[cyan]Scanning scan root and linked worktrees...[/]", spinner="dots"):
+        return await _scan_and_register_repos(scan_root)
 
 
 @app.command(name="list")

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -1330,7 +1330,7 @@ def setup(
 def scan() -> None:
     """Re-scan home directory and register new repos.
 
-    Scans ~/ for git repos with GitHub origins and updates the
+    Scans ~/ for git repos with configured origin remotes and updates the
     brownfield registry. Existing repos are preserved (upsert).
     """
     console.print("\n[bold cyan]Brownfield Scan[/]\n")

--- a/src/ouroboros/mcp/tools/brownfield_handler.py
+++ b/src/ouroboros/mcp/tools/brownfield_handler.py
@@ -281,7 +281,28 @@ class BrownfieldHandler:
         root. Linked worktree seeds are registered themselves only.
         """
         scan_root_str = arguments.get("scan_root")
-        scan_root = Path(scan_root_str) if scan_root_str else None
+        if scan_root_str:
+            # Resolve before validating so the existence/dir checks apply to
+            # the same path the walk will actually traverse. Without this,
+            # symlinks and TOCTOU swaps could let a caller pass an exists+dir
+            # check while the underlying walk runs against a different target.
+            scan_root = Path(scan_root_str).resolve()
+            if not scan_root.exists():
+                return Result.err(
+                    MCPToolError(
+                        f"scan_root does not exist: {scan_root_str!r}",
+                        tool_name=_TOOL_NAME,
+                    )
+                )
+            if not scan_root.is_dir():
+                return Result.err(
+                    MCPToolError(
+                        f"scan_root is not a directory: {scan_root_str!r}",
+                        tool_name=_TOOL_NAME,
+                    )
+                )
+        else:
+            scan_root = None
 
         store = await self._get_store()
 

--- a/src/ouroboros/mcp/tools/brownfield_handler.py
+++ b/src/ouroboros/mcp/tools/brownfield_handler.py
@@ -3,8 +3,12 @@
 Provides an ``ouroboros_brownfield`` MCP tool for managing brownfield
 repository registrations in the SQLite database. Supports four actions:
 
-- **scan** — Scan an explicit root (or a caller-provided default root) for git
-  repos/worktrees with an ``origin`` remote and register them in the DB.
+- **scan** — Walk ``scan_root`` (or the current user's home directory when omitted) for seed git
+  repos/worktrees and register them in the DB. For each normal repo root, also
+  register Git-reported linked worktrees, even when those linked worktrees live
+  outside the scan root. Linked worktree seeds are registered themselves, but do
+  not pull their main/sibling worktrees outside the scan root. Local repos and
+  repos with any remote name are eligible.
 - **register** — Manually register a single repository by path.
 - **query** — List all registered repos or get the current default.
 - **set_default** — Set a registered repo as the default brownfield context.
@@ -72,7 +76,8 @@ class BrownfieldHandler:
 
     Manages brownfield repository registrations with action-based dispatch:
 
-    - ``scan`` — Walk a caller-supplied root for repos with an ``origin`` remote and register them.
+    - ``scan`` — Walk a caller-supplied root for seed repos/worktrees, then include
+      Git-reported linked worktrees for normal repo roots.
     - ``register`` — Manually register one repo.
     - ``query`` — List repos or fetch the default.
     - ``set_default`` — Set a repo as the default brownfield context.
@@ -90,7 +95,7 @@ class BrownfieldHandler:
             name=_TOOL_NAME,
             description=(
                 "Manage brownfield repository registrations. "
-                "Scan a requested root for repos, register/query repos, "
+                "Scan a requested root for repos/worktrees, register/query repos, "
                 "or set the default brownfield context for PM interviews."
             ),
             parameters=(
@@ -98,7 +103,8 @@ class BrownfieldHandler:
                     name="action",
                     type=ToolInputType.STRING,
                     description=(
-                        "Action to perform: 'scan' to discover repos from a caller-provided root,"
+                        "Action to perform: 'scan' to discover seed repos/worktrees "
+                        "from scan_root plus Git-reported linked worktrees from normal repos,"
                         " 'register' to add a single repo,"
                         " 'query' to list all repos or get default,"
                         " 'set_default' to toggle a repo's default flag"
@@ -157,7 +163,14 @@ class BrownfieldHandler:
                 MCPToolParameter(
                     name="scan_root",
                     type=ToolInputType.STRING,
-                    description=("Root directory for 'scan' action. Caller chooses the scan root."),
+                    description=(
+                        "Root directory for the 'scan' filesystem walk. "
+                        "Defaults to the current user's home directory. "
+                        "Only seed repos/worktrees are discovered by walking this root; "
+                        "linked worktrees reported by Git for normal repo roots may be "
+                        "included even when their paths are outside scan_root. Linked "
+                        "worktree seeds are registered themselves only."
+                    ),
                     required=False,
                 ),
                 MCPToolParameter(
@@ -251,18 +264,21 @@ class BrownfieldHandler:
                 self._store = None
 
     # ──────────────────────────────────────────────────────────────
-    # scan — Discover repos from home directory
+    # scan — Discover repos/worktrees from a caller-provided root
     # ──────────────────────────────────────────────────────────────
 
     async def _handle_scan(
         self,
         arguments: dict[str, Any],
     ) -> Result[MCPToolResult, MCPServerError]:
-        """Scan a caller-provided root for git repos and register them.
+        """Scan a caller-provided root for git repos/worktrees and register them.
 
         Delegates to ``bigbang.brownfield.scan_and_register`` which handles
-        directory walking, origin-remote filtering, LLM description generation,
-        and DB upsert.
+        directory walking, linked worktree discovery, LLM description generation,
+        and DB upsert. The directory walk is bounded to ``scan_root`` (or the
+        current user's home directory when omitted), but linked worktrees
+        reported by Git for discovered normal repo roots may be outside that
+        root. Linked worktree seeds are registered themselves only.
         """
         scan_root_str = arguments.get("scan_root")
         scan_root = Path(scan_root_str) if scan_root_str else None
@@ -270,7 +286,7 @@ class BrownfieldHandler:
         store = await self._get_store()
 
         # scan_and_register handles the full workflow:
-        # walk dirs → filter origin remotes → generate descs → upsert
+        # walk dirs -> discover linked worktrees -> upsert
         repos = await scan_and_register(
             store=store,
             llm_adapter=None,  # No LLM in MCP context for now

--- a/src/ouroboros/mcp/tools/brownfield_handler.py
+++ b/src/ouroboros/mcp/tools/brownfield_handler.py
@@ -3,9 +3,8 @@
 Provides an ``ouroboros_brownfield`` MCP tool for managing brownfield
 repository registrations in the SQLite database. Supports four actions:
 
-- **scan** — Scan home directory for git repos with GitHub origins and
-  register them in the DB. Optionally generates one-line descriptions
-  via a Frugal-tier LLM.
+- **scan** — Scan an explicit root (or a caller-provided default root) for git
+  repos/worktrees with an ``origin`` remote and register them in the DB.
 - **register** — Manually register a single repository by path.
 - **query** — List all registered repos or get the current default.
 - **set_default** — Set a registered repo as the default brownfield context.
@@ -73,7 +72,7 @@ class BrownfieldHandler:
 
     Manages brownfield repository registrations with action-based dispatch:
 
-    - ``scan`` — Walk ``~/`` for GitHub repos and register them.
+    - ``scan`` — Walk a caller-supplied root for repos with an ``origin`` remote and register them.
     - ``register`` — Manually register one repo.
     - ``query`` — List repos or fetch the default.
     - ``set_default`` — Set a repo as the default brownfield context.
@@ -91,7 +90,7 @@ class BrownfieldHandler:
             name=_TOOL_NAME,
             description=(
                 "Manage brownfield repository registrations. "
-                "Scan home directory for repos, register/query repos, "
+                "Scan a requested root for repos, register/query repos, "
                 "or set the default brownfield context for PM interviews."
             ),
             parameters=(
@@ -99,7 +98,7 @@ class BrownfieldHandler:
                     name="action",
                     type=ToolInputType.STRING,
                     description=(
-                        "Action to perform: 'scan' to discover repos from ~/,"
+                        "Action to perform: 'scan' to discover repos from a caller-provided root,"
                         " 'register' to add a single repo,"
                         " 'query' to list all repos or get default,"
                         " 'set_default' to toggle a repo's default flag"
@@ -158,7 +157,7 @@ class BrownfieldHandler:
                 MCPToolParameter(
                     name="scan_root",
                     type=ToolInputType.STRING,
-                    description=("Root directory for 'scan' action. Defaults to ~/."),
+                    description=("Root directory for 'scan' action. Caller chooses the scan root."),
                     required=False,
                 ),
                 MCPToolParameter(
@@ -259,10 +258,10 @@ class BrownfieldHandler:
         self,
         arguments: dict[str, Any],
     ) -> Result[MCPToolResult, MCPServerError]:
-        """Scan home directory for git repos and register them.
+        """Scan a caller-provided root for git repos and register them.
 
         Delegates to ``bigbang.brownfield.scan_and_register`` which handles
-        directory walking, GitHub origin filtering, LLM description generation,
+        directory walking, origin-remote filtering, LLM description generation,
         and DB upsert.
         """
         scan_root_str = arguments.get("scan_root")
@@ -271,7 +270,7 @@ class BrownfieldHandler:
         store = await self._get_store()
 
         # scan_and_register handles the full workflow:
-        # walk dirs → filter GitHub origins → generate descs → upsert
+        # walk dirs → filter origin remotes → generate descs → upsert
         repos = await scan_and_register(
             store=store,
             llm_adapter=None,  # No LLM in MCP context for now

--- a/src/ouroboros/persistence/schema.py
+++ b/src/ouroboros/persistence/schema.py
@@ -7,7 +7,7 @@ Table: events
     Single unified table for all event types following event sourcing pattern.
 
 Table: brownfield_repos
-    Registered brownfield repositories scanned from the user's home directory.
+    Registered brownfield repositories/worktrees discovered by brownfield scan.
 """
 
 from datetime import UTC, datetime
@@ -61,7 +61,10 @@ events_table = Table(
     Index("ix_events_agg_type_id_timestamp", "aggregate_type", "aggregate_id", "timestamp"),
 )
 
-# Brownfield repos table - registered repositories from home directory scan
+# Brownfield repos table - registered repositories/worktrees from brownfield scan.
+# Filesystem discovery is bounded to the scan root. Normal repo roots can add
+# Git-reported linked worktrees outside that root, but linked worktree seeds are
+# registered themselves only.
 brownfield_repos_table = Table(
     "brownfield_repos",
     metadata,

--- a/tests/unit/bigbang/test_brownfield.py
+++ b/tests/unit/bigbang/test_brownfield.py
@@ -11,8 +11,8 @@ import pytest
 from ouroboros.bigbang.brownfield import (
     _SKIP_DIRS,
     BrownfieldEntry,
-    _has_origin_remote,
     _has_github_origin,
+    _has_origin_remote,
     _read_readme_content,
     generate_desc,
     register_repo,
@@ -22,6 +22,44 @@ from ouroboros.bigbang.brownfield import (
 )
 from ouroboros.core.errors import ProviderError
 from ouroboros.persistence.brownfield import BrownfieldRepo, BrownfieldStore
+
+
+def _git(args: list[str], cwd: Path | None = None) -> None:
+    """Run a git command for tests and fail with stderr on errors."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(["init", str(repo)])
+    _git(
+        [
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test User",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+        cwd=repo,
+    )
+
+
+def _init_repo_with_origin(
+    repo: Path,
+    origin: str = "https://github.com/user/repo.git",
+) -> None:
+    _init_repo(repo)
+    _git(["remote", "add", "origin", origin], cwd=repo)
+
 
 # ── BrownfieldEntry (re-exported BrownfieldRepo) ──────────────────
 
@@ -90,7 +128,7 @@ class TestHasOriginRemote:
         assert _has_origin_remote(tmp_path) is True
         assert _has_github_origin(tmp_path) is True
 
-    def test_returns_true_for_non_github_origin(self, tmp_path: Path) -> None:
+    def test_returns_true_only_for_origin_remote_on_non_github_origin(self, tmp_path: Path) -> None:
         subprocess.run(["git", "init", str(tmp_path)], capture_output=True)
         subprocess.run(
             [
@@ -105,7 +143,41 @@ class TestHasOriginRemote:
             capture_output=True,
         )
         assert _has_origin_remote(tmp_path) is True
+        assert _has_github_origin(tmp_path) is False
+
+    def test_github_helper_returns_true_for_ssh_origin(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init", str(tmp_path)], capture_output=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:user/repo.git",
+            ],
+            capture_output=True,
+        )
+        assert _has_origin_remote(tmp_path) is True
         assert _has_github_origin(tmp_path) is True
+
+    def test_github_helper_rejects_lookalike_hosts(self, tmp_path: Path) -> None:
+        subprocess.run(["git", "init", str(tmp_path)], capture_output=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "remote",
+                "add",
+                "origin",
+                "https://github.com.example.com/user/repo.git",
+            ],
+            capture_output=True,
+        )
+        assert _has_origin_remote(tmp_path) is True
+        assert _has_github_origin(tmp_path) is False
 
     def test_returns_false_for_no_origin(self, tmp_path: Path) -> None:
         subprocess.run(["git", "init", str(tmp_path)], capture_output=True)
@@ -123,8 +195,8 @@ class TestHasOriginRemote:
 class TestScanHomeForRepos:
     """Tests for scan_home_for_repos."""
 
-    def test_finds_repos_with_origin(self, tmp_path: Path) -> None:
-        # Create a repo with a non-GitHub origin
+    def test_finds_repos_with_non_origin_remote(self, tmp_path: Path) -> None:
+        # Create a repo with a remote whose name is not "origin".
         repo = tmp_path / "my-project"
         repo.mkdir()
         subprocess.run(["git", "init", str(repo)], capture_output=True)
@@ -135,7 +207,7 @@ class TestScanHomeForRepos:
                 str(repo),
                 "remote",
                 "add",
-                "origin",
+                "upstream",
                 "https://dev.azure.com/org/project/_git/my-project",
             ],
             capture_output=True,
@@ -146,13 +218,50 @@ class TestScanHomeForRepos:
         assert result[0]["path"] == str(repo.resolve())
         assert result[0]["name"] == "my-project"
 
-    def test_skips_repos_without_origin(self, tmp_path: Path) -> None:
+    def test_finds_worktree_seed_with_git_file_without_expanding_family(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        main = tmp_path / "main"
+        linked = tmp_path / "linked-worktrees" / "task"
+        sibling = tmp_path / "other-worktrees" / "sibling"
+        linked.parent.mkdir(parents=True)
+        sibling.parent.mkdir(parents=True)
+        _init_repo(main)
+        _git(["worktree", "add", "-b", "task", str(linked)], cwd=main)
+        _git(["worktree", "add", "-b", "sibling", str(sibling)], cwd=main)
+
+        result = scan_home_for_repos(linked.parent)
+
+        paths = {r["path"] for r in result}
+        assert paths == {str(linked.resolve())}
+
+    def test_includes_git_reported_worktrees_without_crawling_hidden_dirs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        main = tmp_path / "projects" / "main"
+        managed_worktree = tmp_path / ".ouroboros" / "worktrees" / "main" / "task"
+        unlinked_hidden_repo = tmp_path / ".ouroboros" / "worktrees" / "unlinked"
+        managed_worktree.parent.mkdir(parents=True)
+        _init_repo(main)
+        _git(["worktree", "add", "-b", "task", str(managed_worktree)], cwd=main)
+        _init_repo(unlinked_hidden_repo)
+
+        result = scan_home_for_repos(tmp_path)
+
+        paths = {r["path"] for r in result}
+        assert paths == {str(main.resolve()), str(managed_worktree.resolve())}
+
+    def test_finds_local_repos_without_remotes(self, tmp_path: Path) -> None:
         repo = tmp_path / "local-proj"
         repo.mkdir()
         subprocess.run(["git", "init", str(repo)], capture_output=True)
 
         result = scan_home_for_repos(tmp_path)
-        assert len(result) == 0
+        assert len(result) == 1
+        assert result[0]["path"] == str(repo.resolve())
+        assert result[0]["name"] == "local-proj"
 
     def test_prunes_subdirectories_after_git_found(self, tmp_path: Path) -> None:
         # Parent repo

--- a/tests/unit/bigbang/test_brownfield.py
+++ b/tests/unit/bigbang/test_brownfield.py
@@ -11,6 +11,7 @@ import pytest
 from ouroboros.bigbang.brownfield import (
     _SKIP_DIRS,
     BrownfieldEntry,
+    _has_origin_remote,
     _has_github_origin,
     _read_readme_content,
     generate_desc,
@@ -68,8 +69,8 @@ class TestBrownfieldEntry:
 # ── _has_github_origin ─────────────────────────────────────────────
 
 
-class TestHasGithubOrigin:
-    """Tests for _has_github_origin helper."""
+class TestHasOriginRemote:
+    """Tests for origin-remote helpers."""
 
     def test_returns_true_for_github_origin(self, tmp_path: Path) -> None:
         # Create a real git repo with a GitHub origin
@@ -86,9 +87,10 @@ class TestHasGithubOrigin:
             ],
             capture_output=True,
         )
+        assert _has_origin_remote(tmp_path) is True
         assert _has_github_origin(tmp_path) is True
 
-    def test_returns_false_for_non_github_origin(self, tmp_path: Path) -> None:
+    def test_returns_true_for_non_github_origin(self, tmp_path: Path) -> None:
         subprocess.run(["git", "init", str(tmp_path)], capture_output=True)
         subprocess.run(
             [
@@ -102,13 +104,16 @@ class TestHasGithubOrigin:
             ],
             capture_output=True,
         )
-        assert _has_github_origin(tmp_path) is False
+        assert _has_origin_remote(tmp_path) is True
+        assert _has_github_origin(tmp_path) is True
 
     def test_returns_false_for_no_origin(self, tmp_path: Path) -> None:
         subprocess.run(["git", "init", str(tmp_path)], capture_output=True)
+        assert _has_origin_remote(tmp_path) is False
         assert _has_github_origin(tmp_path) is False
 
     def test_returns_false_for_non_git_dir(self, tmp_path: Path) -> None:
+        assert _has_origin_remote(tmp_path) is False
         assert _has_github_origin(tmp_path) is False
 
 
@@ -118,8 +123,8 @@ class TestHasGithubOrigin:
 class TestScanHomeForRepos:
     """Tests for scan_home_for_repos."""
 
-    def test_finds_github_repos(self, tmp_path: Path) -> None:
-        # Create a repo with GitHub origin
+    def test_finds_repos_with_origin(self, tmp_path: Path) -> None:
+        # Create a repo with a non-GitHub origin
         repo = tmp_path / "my-project"
         repo.mkdir()
         subprocess.run(["git", "init", str(repo)], capture_output=True)
@@ -131,7 +136,7 @@ class TestScanHomeForRepos:
                 "remote",
                 "add",
                 "origin",
-                "git@github.com:user/my-project.git",
+                "https://dev.azure.com/org/project/_git/my-project",
             ],
             capture_output=True,
         )
@@ -141,14 +146,10 @@ class TestScanHomeForRepos:
         assert result[0]["path"] == str(repo.resolve())
         assert result[0]["name"] == "my-project"
 
-    def test_skips_non_github_repos(self, tmp_path: Path) -> None:
-        repo = tmp_path / "gitlab-proj"
+    def test_skips_repos_without_origin(self, tmp_path: Path) -> None:
+        repo = tmp_path / "local-proj"
         repo.mkdir()
         subprocess.run(["git", "init", str(repo)], capture_output=True)
-        subprocess.run(
-            ["git", "-C", str(repo), "remote", "add", "origin", "https://gitlab.com/user/repo.git"],
-            capture_output=True,
-        )
 
         result = scan_home_for_repos(tmp_path)
         assert len(result) == 0

--- a/tests/unit/bigbang/test_brownfield.py
+++ b/tests/unit/bigbang/test_brownfield.py
@@ -1103,8 +1103,14 @@ class TestScanAndRegisterMocked:
         store.update_is_default.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_mocked_scan_empty_returns_store_list(self) -> None:
-        """When scan finds no repos, returns store.list() (may have pre-registered)."""
+    async def test_mocked_scan_empty_returns_empty_list(self) -> None:
+        """An empty scan must not leak previously-registered repos into the result.
+
+        scan_and_register is boundary-sensitive: callers (CLI, MCP) display its
+        return value as "what this scan discovered." Returning the full DB on an
+        empty scan would falsely report unrelated repos as if they were just
+        found. Callers that need the full registry must call store.list() directly.
+        """
         store = AsyncMock(spec=BrownfieldStore)
         pre_registered = [BrownfieldRepo(path="/existing", name="existing")]
         store.list.return_value = pre_registered
@@ -1115,9 +1121,30 @@ class TestScanAndRegisterMocked:
         ):
             result = await scan_and_register(store, root=Path("/fake"))
 
-        assert len(result) == 1
-        assert result[0].path == "/existing"
+        assert result == []
+        store.register.assert_not_called()
         store.bulk_register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mocked_scan_returns_only_scanned_repos(self) -> None:
+        """Result must contain only repos discovered by THIS scan, not the whole DB."""
+        fake_repos = [{"path": "/scanned", "name": "scanned"}]
+        store = AsyncMock(spec=BrownfieldStore)
+        store.register.return_value = BrownfieldRepo(path="/scanned", name="scanned")
+        # store.list() includes both the scanned repo AND an unrelated, manually
+        # registered repo outside the scan root.
+        store.list.return_value = [
+            BrownfieldRepo(path="/scanned", name="scanned"),
+            BrownfieldRepo(path="/manual/outside", name="outside"),
+        ]
+
+        with patch(
+            "ouroboros.bigbang.brownfield.scan_home_for_repos",
+            return_value=fake_repos,
+        ):
+            result = await scan_and_register(store, root=Path("/fake"))
+
+        assert {r.path for r in result} == {"/scanned"}
 
     @pytest.mark.asyncio
     async def test_mocked_scan_llm_adapter_not_called(self) -> None:

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -917,7 +917,8 @@ class TestScanRegisterPipeline:
         mock_store.initialize = AsyncMock(side_effect=lambda: call_order.append("initialize"))
         mock_store.close = AsyncMock(side_effect=lambda: call_order.append("close"))
 
-        async def fake_scan(store):
+        async def fake_scan(store, *, root=None):
+            _ = store, root
             call_order.append("scan_and_register")
             return []
 
@@ -945,7 +946,8 @@ class TestScanRegisterPipeline:
 
         captured_store = None
 
-        async def capture_store(store):
+        async def capture_store(store, *, root=None):
+            _ = root
             nonlocal captured_store
             captured_store = store
             return []
@@ -963,6 +965,35 @@ class TestScanRegisterPipeline:
             await _scan_and_register_repos()
 
         assert captured_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_scan_passes_scan_root_to_scan_and_register(self, tmp_path: Path) -> None:
+        """The requested scan root is passed to scan_and_register."""
+        mock_store = AsyncMock()
+        mock_store.initialize = AsyncMock()
+        mock_store.close = AsyncMock()
+
+        captured_root = None
+
+        async def capture_root(store, *, root=None):
+            _ = store
+            nonlocal captured_root
+            captured_root = root
+            return []
+
+        with (
+            patch(
+                "ouroboros.cli.commands.setup.BrownfieldStore",
+                return_value=mock_store,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup.scan_and_register",
+                side_effect=capture_root,
+            ),
+        ):
+            await _scan_and_register_repos(tmp_path)
+
+        assert captured_root == tmp_path
 
     @pytest.mark.asyncio
     async def test_converts_brownfield_repo_to_dict(self) -> None:
@@ -1061,6 +1092,42 @@ class TestScanRegisterPipeline:
         assert len(result) == count
         assert result[0]["is_default"] is True
         assert all(r["is_default"] is False for r in result[1:])
+
+
+class TestScanCommand:
+    """Tests for the brownfield scan CLI command."""
+
+    def test_scan_command_accepts_scan_root_argument(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+
+        with patch(
+            "ouroboros.cli.commands.setup._run_scan_only",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_run:
+            result = runner.invoke(setup_cmd.app, ["scan", str(tmp_path)])
+
+        assert result.exit_code == 0
+        mock_run.assert_awaited_once_with(tmp_path.resolve())
+
+    def test_scan_command_defaults_scan_root_to_current_user_home(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        runner = CliRunner()
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "ouroboros.cli.commands.setup._run_scan_only",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_run,
+        ):
+            result = runner.invoke(setup_cmd.app, ["scan"])
+
+        assert result.exit_code == 0
+        mock_run.assert_awaited_once_with(tmp_path)
 
 
 # ── List repos extended tests ─────────────────────────────────────

--- a/tests/unit/mcp/tools/test_brownfield_handler.py
+++ b/tests/unit/mcp/tools/test_brownfield_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -298,13 +299,29 @@ class TestBrownfieldHandlerDispatch:
             "ouroboros.mcp.tools.brownfield_handler.scan_and_register",
             new_callable=AsyncMock,
             return_value=[_REPO_A],
-        ):
+        ) as mock_scan:
             result = await handler.handle({"action": "scan"})
 
         assert result.is_ok
         meta = result.value.meta
         assert meta["action"] == "scan"
         assert meta["count"] == 1
+        mock_scan.assert_awaited_once_with(store=store, llm_adapter=None, root=None)
+
+    @pytest.mark.asyncio
+    async def test_scan_action_passes_scan_root(self, tmp_path: Path) -> None:
+        store = _make_store_stub(repos=[_REPO_A], default=_REPO_A)
+        handler = BrownfieldHandler(_store=store)
+
+        with patch(
+            "ouroboros.mcp.tools.brownfield_handler.scan_and_register",
+            new_callable=AsyncMock,
+            return_value=[_REPO_A],
+        ) as mock_scan:
+            result = await handler.handle({"action": "scan", "scan_root": str(tmp_path)})
+
+        assert result.is_ok
+        mock_scan.assert_awaited_once_with(store=store, llm_adapter=None, root=tmp_path)
 
     @pytest.mark.asyncio
     async def test_auto_detect_register(self) -> None:
@@ -364,6 +381,7 @@ class TestBrownfieldHandlerDispatch:
 
         assert result.is_ok
         assert "scan" in result.value.text_content.lower()
+
 
 # ── Pagination tests ──────────────────────────────────────────────
 

--- a/tests/unit/mcp/tools/test_brownfield_handler.py
+++ b/tests/unit/mcp/tools/test_brownfield_handler.py
@@ -365,7 +365,6 @@ class TestBrownfieldHandlerDispatch:
         assert result.is_ok
         assert "scan" in result.value.text_content.lower()
 
-
 # ── Pagination tests ──────────────────────────────────────────────
 
 

--- a/tests/unit/mcp/tools/test_brownfield_handler.py
+++ b/tests/unit/mcp/tools/test_brownfield_handler.py
@@ -324,9 +324,7 @@ class TestBrownfieldHandlerDispatch:
         # The handler resolves scan_root before passing it down so the validity
         # check and the walk operate on the same path. Compare against the
         # resolved tmp_path (e.g. macOS prefixes /private/var with /private).
-        mock_scan.assert_awaited_once_with(
-            store=store, llm_adapter=None, root=tmp_path.resolve()
-        )
+        mock_scan.assert_awaited_once_with(store=store, llm_adapter=None, root=tmp_path.resolve())
 
     @pytest.mark.asyncio
     async def test_scan_action_rejects_nonexistent_scan_root(self, tmp_path: Path) -> None:

--- a/tests/unit/mcp/tools/test_brownfield_handler.py
+++ b/tests/unit/mcp/tools/test_brownfield_handler.py
@@ -321,7 +321,53 @@ class TestBrownfieldHandlerDispatch:
             result = await handler.handle({"action": "scan", "scan_root": str(tmp_path)})
 
         assert result.is_ok
-        mock_scan.assert_awaited_once_with(store=store, llm_adapter=None, root=tmp_path)
+        # The handler resolves scan_root before passing it down so the validity
+        # check and the walk operate on the same path. Compare against the
+        # resolved tmp_path (e.g. macOS prefixes /private/var with /private).
+        mock_scan.assert_awaited_once_with(
+            store=store, llm_adapter=None, root=tmp_path.resolve()
+        )
+
+    @pytest.mark.asyncio
+    async def test_scan_action_rejects_nonexistent_scan_root(self, tmp_path: Path) -> None:
+        """A nonexistent scan_root must be rejected before scan runs.
+
+        Without validation, the scan walks zero directories and the empty-scan
+        fallback would falsely report previously registered repos as found.
+        """
+        store = _make_store_stub(repos=[_REPO_A], default=_REPO_A)
+        handler = BrownfieldHandler(_store=store)
+        bogus = tmp_path / "does-not-exist"
+
+        with patch(
+            "ouroboros.mcp.tools.brownfield_handler.scan_and_register",
+            new_callable=AsyncMock,
+            return_value=[_REPO_A],
+        ) as mock_scan:
+            result = await handler.handle({"action": "scan", "scan_root": str(bogus)})
+
+        assert result.is_err
+        assert "scan_root" in str(result.error)
+        mock_scan.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_scan_action_rejects_file_scan_root(self, tmp_path: Path) -> None:
+        """A scan_root that points at a file (not a directory) must be rejected."""
+        store = _make_store_stub(repos=[_REPO_A], default=_REPO_A)
+        handler = BrownfieldHandler(_store=store)
+        not_a_dir = tmp_path / "regular.txt"
+        not_a_dir.write_text("hello")
+
+        with patch(
+            "ouroboros.mcp.tools.brownfield_handler.scan_and_register",
+            new_callable=AsyncMock,
+            return_value=[_REPO_A],
+        ) as mock_scan:
+            result = await handler.handle({"action": "scan", "scan_root": str(not_a_dir)})
+
+        assert result.is_err
+        assert "scan_root" in str(result.error)
+        mock_scan.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_auto_detect_register(self) -> None:


### PR DESCRIPTION
## Summary
- broaden brownfield repository scanning so repos with any configured `origin` remote are considered
- align setup and brownfield MCP handling with the updated scan behavior
- add focused coverage for the scan and handler paths

## Testing
- `uv run pytest tests/unit/bigbang/test_brownfield.py tests/unit/mcp/tools/test_brownfield_handler.py`