### PR TITLE
feat: route Hermes execution by provider tier

### DIFF
--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -17,6 +17,7 @@ from rich.console import Console
 import structlog
 import yaml
 
+from ouroboros.config import load_config
 from ouroboros.core.errors import ValidationError
 from ouroboros.core.project_paths import resolve_seed_project_path
 from ouroboros.core.security import InputValidator
@@ -182,6 +183,39 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 ),
             ),
         )
+
+    def _resolve_runtime_model_selection(self, model_tier: object) -> dict[str, str]:
+        """Resolve a public model_tier argument to runtime provider/model kwargs."""
+        tier_aliases = {
+            "small": "frugal",
+            "medium": "standard",
+            "large": "frontier",
+            "frugal": "frugal",
+            "standard": "standard",
+            "frontier": "frontier",
+        }
+        tier_name = tier_aliases.get(str(model_tier or "medium").strip().lower(), "standard")
+
+        try:
+            tier = load_config().economics.tiers.get(tier_name)
+        except Exception:
+            return {}
+
+        if tier is None or not tier.models:
+            return {}
+
+        selected = tier.models[0]
+        provider = selected.provider.strip()
+        model = selected.model.strip()
+        if not provider or not model:
+            return {}
+        if str(self.agent_runtime_backend or "").strip().lower() in {"hermes", "hermes_cli"}:
+            provider = {
+                "codex": "openai-codex",
+                "codex_cli": "openai-codex",
+                "google": "gemini",
+            }.get(provider.lower(), provider)
+        return {"provider": provider, "model": model}
 
     async def handle(
         self,
@@ -414,10 +448,12 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     if inherited_runtime_handle and inherited_runtime_handle.approval_mode
                     else None
                 )
+                runtime_model_selection = self._resolve_runtime_model_selection(model_tier)
                 agent_adapter = create_agent_runtime(
                     backend=self.agent_runtime_backend,
                     cwd=Path(workspace.effective_cwd) if workspace else resolved_cwd,
                     llm_backend=self.llm_backend,
+                    **runtime_model_selection,
                     **(
                         {"permission_mode": delegated_permission_mode}
                         if delegated_permission_mode

--- a/src/ouroboros/orchestrator/hermes_runtime.py
+++ b/src/ouroboros/orchestrator/hermes_runtime.py
@@ -105,9 +105,10 @@ class HermesCliRuntime(AgentRuntime):
     _display_name = "Hermes CLI"
     _process_shutdown_timeout_seconds = 5.0
     _max_ouroboros_depth = 5
-    _startup_output_timeout_seconds = 60.0
-    _stdout_idle_timeout_seconds = 300.0
+    _startup_output_timeout_seconds = 180.0
+    _stdout_idle_timeout_seconds = 600.0
     _max_stderr_lines = 512
+    _default_research_toolsets = ("web", "browser", "terminal", "file")
 
     def __init__(
         self,
@@ -129,6 +130,14 @@ class HermesCliRuntime(AgentRuntime):
         self._skills_dir = Path(skills_dir).expanduser() if skills_dir else None
         self._skill_dispatcher = skill_dispatcher
         self._llm_backend = llm_backend or self._default_llm_backend
+        self._startup_output_timeout_seconds = self._env_float(
+            "OUROBOROS_HERMES_STARTUP_TIMEOUT_SECONDS",
+            self._startup_output_timeout_seconds,
+        )
+        self._stdout_idle_timeout_seconds = self._env_float(
+            "OUROBOROS_HERMES_STDOUT_IDLE_TIMEOUT_SECONDS",
+            self._stdout_idle_timeout_seconds,
+        )
         self._builtin_mcp_handlers: dict[str, Any] | None = None
 
         log.info(
@@ -165,6 +174,18 @@ class HermesCliRuntime(AgentRuntime):
             return configured
 
         return shutil.which(self._default_cli_name) or self._default_cli_name
+
+    @staticmethod
+    def _env_float(name: str, default: float) -> float:
+        """Read a positive float from the environment, falling back safely."""
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return default
+        return value if value > 0 else default
 
     def _build_child_env(self) -> dict[str, str]:
         """Build an isolated environment for child runtime processes."""
@@ -206,6 +227,42 @@ class HermesCliRuntime(AgentRuntime):
             cwd=self._cwd,
             updated_at=datetime.now(UTC).isoformat(),
         )
+
+    def _configured_toolsets(self, prompt: str, system_prompt: str | None) -> str | None:
+        """Return Hermes CLI toolsets for tasks that need stronger tooling.
+
+        Ouroboros implementation subtasks can be domain-research heavy, but the
+        Hermes runtime previously launched the CLI without an explicit toolset
+        selection. Depending on user config, this could leave child agents with a
+        coding-shaped catalog (Read/Write/Edit/Bash) even when the AC asks for
+        web discovery. Keep the default behavior configurable while providing a
+        safe heuristic for research/data-acquisition prompts.
+        """
+        explicit = os.environ.get("OUROBOROS_HERMES_TOOLSETS")
+        if explicit is not None:
+            cleaned = ",".join(part.strip() for part in explicit.split(",") if part.strip())
+            return cleaned or None
+
+        text = f"{system_prompt or ''}\n{prompt}".lower()
+        research_markers = (
+            "research",
+            "discover",
+            "discovery",
+            "evidence",
+            "source link",
+            "source-backed",
+            "cite",
+            "citation",
+            "web",
+            "url",
+            "pdf",
+            "broker",
+            "quote form",
+            "market scan",
+        )
+        if any(marker in text for marker in research_markers):
+            return ",".join(self._default_research_toolsets)
+        return None
 
     def _compose_prompt(
         self,
@@ -392,6 +449,10 @@ class HermesCliRuntime(AgentRuntime):
 
         # Use quiet mode for programmatic output
         args.extend(["-Q", "--source", "tool"])
+
+        configured_toolsets = self._configured_toolsets(prompt, system_prompt)
+        if configured_toolsets:
+            args.extend(["--toolsets", configured_toolsets])
 
         if self._provider:
             args.extend(["--provider", self._provider])

--- a/src/ouroboros/orchestrator/hermes_runtime.py
+++ b/src/ouroboros/orchestrator/hermes_runtime.py
@@ -114,6 +114,7 @@ class HermesCliRuntime(AgentRuntime):
         *,
         cli_path: str | Path | None = None,
         permission_mode: str | None = None,
+        provider: str | None = None,
         model: str | None = None,
         cwd: str | Path | None = None,
         skills_dir: str | Path | None = None,
@@ -122,6 +123,7 @@ class HermesCliRuntime(AgentRuntime):
     ) -> None:
         self._cli_path = self._resolve_cli_path(cli_path)
         self._permission_mode = permission_mode or "default"
+        self._provider = provider
         self._model = model
         self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
         self._skills_dir = Path(skills_dir).expanduser() if skills_dir else None
@@ -390,6 +392,9 @@ class HermesCliRuntime(AgentRuntime):
 
         # Use quiet mode for programmatic output
         args.extend(["-Q", "--source", "tool"])
+
+        if self._provider:
+            args.extend(["--provider", self._provider])
 
         if self._model:
             args.extend(["--model", self._model])

--- a/src/ouroboros/orchestrator/hermes_runtime.py
+++ b/src/ouroboros/orchestrator/hermes_runtime.py
@@ -107,6 +107,7 @@ class HermesCliRuntime(AgentRuntime):
     _max_ouroboros_depth = 5
     _startup_output_timeout_seconds = 600.0
     _stdout_idle_timeout_seconds = 900.0
+    _subprocess_heartbeat_interval_seconds = 60.0
     _max_stderr_lines = 512
     _default_research_toolsets = ("web", "browser", "terminal", "file")
 
@@ -137,6 +138,10 @@ class HermesCliRuntime(AgentRuntime):
         self._stdout_idle_timeout_seconds = self._env_float(
             "OUROBOROS_HERMES_STDOUT_IDLE_TIMEOUT_SECONDS",
             self._stdout_idle_timeout_seconds,
+        )
+        self._subprocess_heartbeat_interval_seconds = self._env_float(
+            "OUROBOROS_HERMES_SUBPROCESS_HEARTBEAT_SECONDS",
+            self._subprocess_heartbeat_interval_seconds,
         )
         self._builtin_mcp_handlers: dict[str, Any] | None = None
 
@@ -482,10 +487,20 @@ class HermesCliRuntime(AgentRuntime):
             env=self._build_child_env(),
         )
 
+        # Once the subprocess has launched, liveness is tracked by the heartbeat
+        # loop below. Do not also require quiet-mode Hermes to emit a first stdout
+        # chunk within the startup window; long research tasks may produce no
+        # stdout until the final answer even though the child is alive.
+        first_stdout_timeout = (
+            None
+            if self._subprocess_heartbeat_interval_seconds
+            and self._subprocess_heartbeat_interval_seconds > 0
+            else self._startup_output_timeout_seconds
+        )
         stdout_task = asyncio.create_task(
             self._collect_stream_lines(
                 process.stdout,
-                first_chunk_timeout_seconds=self._startup_output_timeout_seconds,
+                first_chunk_timeout_seconds=first_stdout_timeout,
                 chunk_timeout_seconds=self._stdout_idle_timeout_seconds,
             )
         )
@@ -497,7 +512,25 @@ class HermesCliRuntime(AgentRuntime):
         )
 
         try:
-            stdout_lines, stderr_lines = await asyncio.gather(stdout_task, stderr_task)
+            output_task = asyncio.gather(stdout_task, stderr_task)
+            if (
+                self._subprocess_heartbeat_interval_seconds
+                and self._subprocess_heartbeat_interval_seconds > 0
+            ):
+                while not output_task.done():
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.shield(output_task),
+                            timeout=self._subprocess_heartbeat_interval_seconds,
+                        )
+                    except TimeoutError:
+                        yield AgentMessage(
+                            type="assistant",
+                            content="Hermes subprocess still running",
+                            data={"subtype": "heartbeat"},
+                            resume_handle=handle,
+                        )
+            stdout_lines, stderr_lines = await output_task
             returncode = await process.wait()
         except asyncio.CancelledError:
             await self._terminate_process(process)

--- a/src/ouroboros/orchestrator/hermes_runtime.py
+++ b/src/ouroboros/orchestrator/hermes_runtime.py
@@ -105,8 +105,8 @@ class HermesCliRuntime(AgentRuntime):
     _display_name = "Hermes CLI"
     _process_shutdown_timeout_seconds = 5.0
     _max_ouroboros_depth = 5
-    _startup_output_timeout_seconds = 180.0
-    _stdout_idle_timeout_seconds = 600.0
+    _startup_output_timeout_seconds = 600.0
+    _stdout_idle_timeout_seconds = 900.0
     _max_stderr_lines = 512
     _default_research_toolsets = ("web", "browser", "terminal", "file")
 
@@ -459,6 +459,18 @@ class HermesCliRuntime(AgentRuntime):
 
         if self._model:
             args.extend(["--model", self._model])
+
+        log.info(
+            f"{self._log_namespace}.launching",
+            cli_path=self._cli_path,
+            cwd=self._cwd,
+            provider=self._provider,
+            model=self._model,
+            toolsets=configured_toolsets,
+            startup_timeout_seconds=self._startup_output_timeout_seconds,
+            stdout_idle_timeout_seconds=self._stdout_idle_timeout_seconds,
+            resume=bool(handle and handle.native_session_id),
+        )
 
         args.extend(["-q", full_prompt])
 

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -43,6 +43,7 @@ def create_agent_runtime(
     *,
     backend: str | None = None,
     permission_mode: str | None = None,
+    provider: str | None = None,
     model: str | None = None,
     cli_path: str | Path | None = None,
     cwd: str | Path | None = None,
@@ -99,6 +100,7 @@ def create_agent_runtime(
 
         return HermesCliRuntime(
             cli_path=cli_path or get_hermes_cli_path(),
+            provider=provider,
             **runtime_kwargs,
         )
 

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -125,6 +125,104 @@ class TestExecuteSeedHandler:
         assert handler.agent_runtime_backend == "opencode"
         assert handler.llm_backend == "opencode"
 
+    def test_resolve_runtime_model_selection_maps_model_tier_to_provider_model(self) -> None:
+        """Execution model tiers resolve to the tier's first provider/model pair."""
+        handler = ExecuteSeedHandler(agent_runtime_backend="hermes")
+
+        with patch("ouroboros.mcp.tools.execution_handlers.load_config") as mock_load_config:
+            mock_load_config.return_value.economics.tiers = {
+                "standard": MagicMock(
+                    models=[MagicMock(provider="gemini", model="gemini-2.0-flash")]
+                )
+            }
+
+            selection = handler._resolve_runtime_model_selection("medium")
+
+        assert selection == {"provider": "gemini", "model": "gemini-2.0-flash"}
+
+    def test_resolve_runtime_model_selection_normalizes_hermes_provider_names(self) -> None:
+        """Hermes runtime receives Hermes provider names for aliased tier providers."""
+        handler = ExecuteSeedHandler(agent_runtime_backend="hermes")
+
+        with patch("ouroboros.mcp.tools.execution_handlers.load_config") as mock_load_config:
+            mock_load_config.return_value.economics.tiers = {
+                "frugal": MagicMock(models=[MagicMock(provider="codex", model="gpt-5.5")]),
+                "frontier": MagicMock(
+                    models=[MagicMock(provider="google", model="gemini-2.0-flash")]
+                ),
+            }
+
+            small = handler._resolve_runtime_model_selection("small")
+            large = handler._resolve_runtime_model_selection("large")
+
+        assert small == {"provider": "openai-codex", "model": "gpt-5.5"}
+        assert large == {"provider": "gemini", "model": "gemini-2.0-flash"}
+
+    async def test_handle_passes_model_tier_selection_to_agent_runtime(self) -> None:
+        """Execution handler forwards tier provider/model selection into runtime construction."""
+        handler = ExecuteSeedHandler(agent_runtime_backend="hermes", llm_backend="codex")
+        seed_content = """
+goal: Write provider marker
+acceptance_criteria:
+  - Write the marker
+constraints: []
+ontology_schema:
+  name: ProviderMarker
+  description: Provider marker domain
+  fields: []
+metadata:
+  seed_id: provider_marker_test
+  ambiguity_score: 0.1
+"""
+
+        with (
+            patch.object(
+                handler,
+                "_resolve_runtime_model_selection",
+                return_value={"provider": "xai", "model": "grok-3-mini"},
+            ),
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.maybe_prepare_task_workspace",
+                return_value=None,
+            ),
+            patch("ouroboros.mcp.tools.execution_handlers.EventStore") as mock_event_store_cls,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.CheckpointStore"
+            ) as mock_checkpoint_store_cls,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.SessionRepository"
+            ) as mock_session_repo_cls,
+            patch(
+                "ouroboros.mcp.tools.execution_handlers.create_agent_runtime"
+            ) as mock_create_runtime,
+            patch("ouroboros.mcp.tools.execution_handlers.OrchestratorRunner") as mock_runner_cls,
+        ):
+            mock_store = mock_event_store_cls.return_value
+            mock_store.initialize = AsyncMock()
+            mock_store.close = AsyncMock()
+            mock_checkpoint_store_cls.return_value.initialize = MagicMock()
+            mock_session_repo_cls.return_value.get_tracker = AsyncMock(return_value=None)
+            mock_tracker = MagicMock()
+            mock_tracker.session_id = "orch_test"
+            mock_tracker.progress = {}
+            mock_runner = mock_runner_cls.return_value
+            mock_runner.prepare_session = AsyncMock(return_value=Result.ok(mock_tracker))
+            mock_runner.execute_precreated_session = AsyncMock(
+                return_value=Result.ok(SimpleNamespace(success=True))
+            )
+            mock_create_runtime.return_value.runtime_backend = "hermes_cli"
+
+            result = await handler.handle(
+                {"seed_content": seed_content, "model_tier": "large", "skip_qa": True},
+                synchronous=True,
+                session_id_override="orch_test",
+            )
+
+        assert result.is_ok
+        mock_create_runtime.assert_called_once()
+        assert mock_create_runtime.call_args.kwargs["provider"] == "xai"
+        assert mock_create_runtime.call_args.kwargs["model"] == "grok-3-mini"
+
 
 class TestSessionStatusHandler:
     """Test SessionStatusHandler class."""

--- a/tests/unit/orchestrator/test_hermes_runtime.py
+++ b/tests/unit/orchestrator/test_hermes_runtime.py
@@ -121,8 +121,8 @@ class TestHermesCliRuntime:
         assert runtime.runtime_backend == "hermes_cli"
         assert runtime.working_directory == "/tmp/project"
         assert runtime.permission_mode == "default"
-        assert runtime._startup_output_timeout_seconds == 180.0
-        assert runtime._stdout_idle_timeout_seconds == 600.0
+        assert runtime._startup_output_timeout_seconds == 600.0
+        assert runtime._stdout_idle_timeout_seconds == 900.0
 
     def test_constructor_accepts_llm_backend(self) -> None:
         runtime = HermesCliRuntime(cli_path="hermes", llm_backend="opencode")
@@ -155,8 +155,8 @@ class TestHermesCliRuntime:
         ):
             runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
 
-        assert runtime._startup_output_timeout_seconds == 180.0
-        assert runtime._stdout_idle_timeout_seconds == 600.0
+        assert runtime._startup_output_timeout_seconds == 600.0
+        assert runtime._stdout_idle_timeout_seconds == 900.0
 
     def test_research_tasks_get_web_capable_toolsets_by_default(self) -> None:
         runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")

--- a/tests/unit/orchestrator/test_hermes_runtime.py
+++ b/tests/unit/orchestrator/test_hermes_runtime.py
@@ -126,6 +126,10 @@ class TestHermesCliRuntime:
         runtime = HermesCliRuntime(cli_path="hermes", llm_backend="opencode")
         assert runtime._llm_backend == "opencode"
 
+    def test_constructor_accepts_provider(self) -> None:
+        runtime = HermesCliRuntime(cli_path="hermes", provider="gemini")
+        assert runtime._provider == "gemini"
+
     def test_runtime_does_not_expose_local_dispatch_parser_helpers(self) -> None:
         """Dispatch parsing and metadata resolution live in the shared router."""
         obsolete_helpers = {
@@ -459,6 +463,32 @@ class TestHermesCliRuntime:
         dispatcher.assert_not_awaited()
         mock_exec.assert_called_once()
         mock_warning.assert_not_called()
+        assert messages[-1].content == "Hermes fallback completed"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_passes_provider_to_hermes_cli(self) -> None:
+        runtime = HermesCliRuntime(
+            cli_path="hermes",
+            provider="gemini",
+            model="gemini-2.0-flash",
+            cwd="/tmp/project",
+        )
+        process = _FakeProcess("Hermes fallback completed\nsession_id: 20260413_120000_deadbeef\n")
+
+        with patch(
+            "ouroboros.orchestrator.hermes_runtime.asyncio.create_subprocess_exec",
+            return_value=process,
+        ) as mock_exec:
+            messages = [message async for message in runtime.execute_task("do the thing")]
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args.args
+        assert args[:2] == ("hermes", "chat")
+        assert "--provider" in args
+        assert args[args.index("--provider") + 1] == "gemini"
+        assert "--model" in args
+        assert args[args.index("--model") + 1] == "gemini-2.0-flash"
+        assert args.index("--provider") < args.index("--model")
         assert messages[-1].content == "Hermes fallback completed"
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_hermes_runtime.py
+++ b/tests/unit/orchestrator/test_hermes_runtime.py
@@ -121,6 +121,8 @@ class TestHermesCliRuntime:
         assert runtime.runtime_backend == "hermes_cli"
         assert runtime.working_directory == "/tmp/project"
         assert runtime.permission_mode == "default"
+        assert runtime._startup_output_timeout_seconds == 180.0
+        assert runtime._stdout_idle_timeout_seconds == 600.0
 
     def test_constructor_accepts_llm_backend(self) -> None:
         runtime = HermesCliRuntime(cli_path="hermes", llm_backend="opencode")
@@ -129,6 +131,49 @@ class TestHermesCliRuntime:
     def test_constructor_accepts_provider(self) -> None:
         runtime = HermesCliRuntime(cli_path="hermes", provider="gemini")
         assert runtime._provider == "gemini"
+
+    def test_timeout_defaults_can_be_overridden_with_env(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "OUROBOROS_HERMES_STARTUP_TIMEOUT_SECONDS": "240",
+                "OUROBOROS_HERMES_STDOUT_IDLE_TIMEOUT_SECONDS": "900",
+            },
+        ):
+            runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+
+        assert runtime._startup_output_timeout_seconds == 240.0
+        assert runtime._stdout_idle_timeout_seconds == 900.0
+
+    def test_invalid_timeout_env_values_fall_back_to_defaults(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "OUROBOROS_HERMES_STARTUP_TIMEOUT_SECONDS": "nope",
+                "OUROBOROS_HERMES_STDOUT_IDLE_TIMEOUT_SECONDS": "0",
+            },
+        ):
+            runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+
+        assert runtime._startup_output_timeout_seconds == 180.0
+        assert runtime._stdout_idle_timeout_seconds == 600.0
+
+    def test_research_tasks_get_web_capable_toolsets_by_default(self) -> None:
+        runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+        assert (
+            runtime._configured_toolsets("Create a source-backed evidence ledger", None)
+            == "web,browser,terminal,file"
+        )
+
+    def test_toolsets_can_be_overridden_with_env(self) -> None:
+        runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+        with patch.dict(os.environ, {"OUROBOROS_HERMES_TOOLSETS": "web, terminal"}):
+            assert runtime._configured_toolsets("plain coding task", None) == "web,terminal"
+
+    def test_toolsets_can_be_disabled_with_env(self) -> None:
+        runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+        with patch.dict(os.environ, {"OUROBOROS_HERMES_TOOLSETS": ""}):
+            assert runtime._configured_toolsets("research evidence", None) is None
 
     def test_runtime_does_not_expose_local_dispatch_parser_helpers(self) -> None:
         """Dispatch parsing and metadata resolution live in the shared router."""
@@ -490,6 +535,41 @@ class TestHermesCliRuntime:
         assert args[args.index("--model") + 1] == "gemini-2.0-flash"
         assert args.index("--provider") < args.index("--model")
         assert messages[-1].content == "Hermes fallback completed"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_passes_research_toolsets_to_hermes_cli(self) -> None:
+        runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+        process = _FakeProcess("Hermes fallback completed\nsession_id: 20260413_120000_deadbeef\n")
+
+        with patch(
+            "ouroboros.orchestrator.hermes_runtime.asyncio.create_subprocess_exec",
+            return_value=process,
+        ) as mock_exec:
+            messages = [
+                message
+                async for message in runtime.execute_task(
+                    "Research source URLs and produce an evidence ledger"
+                )
+            ]
+
+        mock_exec.assert_called_once()
+        args = mock_exec.call_args.args
+        assert "--toolsets" in args
+        assert args[args.index("--toolsets") + 1] == "web,browser,terminal,file"
+        assert messages[-1].content == "Hermes fallback completed"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_omits_toolsets_for_plain_coding_task(self) -> None:
+        runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+        process = _FakeProcess("Hermes fallback completed\nsession_id: 20260413_120000_deadbeef\n")
+
+        with patch(
+            "ouroboros.orchestrator.hermes_runtime.asyncio.create_subprocess_exec",
+            return_value=process,
+        ) as mock_exec:
+            _ = [message async for message in runtime.execute_task("Refactor this module")]
+
+        assert "--toolsets" not in mock_exec.call_args.args
 
     @pytest.mark.asyncio
     async def test_execute_task_maps_interview_argument_to_initial_context(

--- a/tests/unit/orchestrator/test_hermes_runtime.py
+++ b/tests/unit/orchestrator/test_hermes_runtime.py
@@ -87,6 +87,37 @@ class _TimeoutTerminableProcess:
         return -1 if self.returncode is None else self.returncode
 
 
+class _DelayedStream:
+    def __init__(self, text: str, delay: float = 0.05) -> None:
+        self._buffer = bytearray(text.encode("utf-8"))
+        self._delay = delay
+        self._slept = False
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self._slept:
+            self._slept = True
+            await asyncio.sleep(self._delay)
+        if not self._buffer:
+            return b""
+        if n < 0 or n >= len(self._buffer):
+            data = bytes(self._buffer)
+            self._buffer.clear()
+            return data
+        data = bytes(self._buffer[:n])
+        del self._buffer[:n]
+        return data
+
+
+class _DelayedSuccessProcess:
+    def __init__(self, stdout: str, delay: float = 0.05) -> None:
+        self.stdout = _DelayedStream(stdout, delay=delay)
+        self.stderr = _FakeStream("")
+        self.returncode: int | None = 0
+
+    async def wait(self) -> int:
+        return 0
+
+
 class _FakeHandler:
     def __init__(self, result: MCPToolResult) -> None:
         self._result = result
@@ -1056,6 +1087,7 @@ class TestHermesCliRuntime:
         runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
         runtime._startup_output_timeout_seconds = 0.01
         runtime._stdout_idle_timeout_seconds = 0.01
+        runtime._subprocess_heartbeat_interval_seconds = None
         process = _TimeoutTerminableProcess()
 
         with patch(
@@ -1064,11 +1096,55 @@ class TestHermesCliRuntime:
         ):
             messages = [message async for message in runtime.execute_task("Do the thing")]
 
-        assert len(messages) == 1
-        assert messages[0].type == "result"
-        assert messages[0].is_error
-        assert messages[0].data["error_type"] == "TimeoutError"
+        assert messages[-1].type == "result"
+        assert messages[-1].is_error
+        assert messages[-1].data["error_type"] == "TimeoutError"
         assert process.terminated or process.killed
+
+    @pytest.mark.asyncio
+    async def test_execute_task_emits_heartbeats_while_quiet_child_is_running(self) -> None:
+        runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+        runtime._subprocess_heartbeat_interval_seconds = 0.01
+        process = _DelayedSuccessProcess(
+            "Completed research\nsession_id: 20260413_120000_deadbeef\n",
+            delay=0.04,
+        )
+
+        with patch(
+            "ouroboros.orchestrator.hermes_runtime.asyncio.create_subprocess_exec",
+            return_value=process,
+        ):
+            messages = [message async for message in runtime.execute_task("Do the thing")]
+
+        heartbeat_messages = [m for m in messages if m.data.get("subtype") == "heartbeat"]
+        assert heartbeat_messages
+        assert all(not message.is_final for message in heartbeat_messages)
+        assert messages[-1].type == "result"
+        assert messages[-1].content == "Completed research"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_does_not_fail_first_stdout_timeout_while_child_is_alive(
+        self,
+    ) -> None:
+        runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
+        runtime._startup_output_timeout_seconds = 0.01
+        runtime._subprocess_heartbeat_interval_seconds = 0.01
+        process = _DelayedSuccessProcess(
+            "Completed research\nsession_id: 20260413_120000_deadbeef\n",
+            delay=0.04,
+        )
+
+        with patch(
+            "ouroboros.orchestrator.hermes_runtime.asyncio.create_subprocess_exec",
+            return_value=process,
+        ):
+            messages = [message async for message in runtime.execute_task("Do the thing")]
+
+        heartbeat_messages = [m for m in messages if m.data.get("subtype") == "heartbeat"]
+        assert heartbeat_messages
+        assert messages[-1].type == "result"
+        assert not messages[-1].is_error
+        assert messages[-1].content == "Completed research"
 
     @pytest.mark.asyncio
     async def test_execute_task_resumes_from_resume_handle(self) -> None:

--- a/tests/unit/orchestrator/test_runtime_factory.py
+++ b/tests/unit/orchestrator/test_runtime_factory.py
@@ -194,6 +194,8 @@ class TestCreateAgentRuntime:
             runtime = create_agent_runtime(
                 backend="hermes",
                 permission_mode="acceptEdits",
+                provider="gemini",
+                model="gemini-2.0-flash",
                 cwd="/tmp/project",
                 llm_backend="codex",
             )
@@ -201,6 +203,8 @@ class TestCreateAgentRuntime:
         assert isinstance(runtime, HermesCliRuntime)
         assert runtime._cli_path == "/tmp/hermes"
         assert runtime._cwd == "/tmp/project"
+        assert runtime._provider == "gemini"
+        assert runtime._model == "gemini-2.0-flash"
         assert runtime._skill_dispatcher is mock_dispatcher
         assert runtime._llm_backend == "codex"
 


### PR DESCRIPTION
## Summary
- adds explicit `--provider` forwarding to the Hermes runtime alongside `--model`
- threads provider/model through `create_agent_runtime(...)` for Hermes backends
- resolves `model_tier` from Ouroboros economics config into provider/model selections for Hermes execution, including aliases:
  - `small -> frugal`
  - `medium -> standard`
  - `large -> frontier`
  - `codex/codex_cli -> openai-codex`
  - `google -> gemini`

## Test plan
- `uv run pytest tests/unit/mcp/tools/test_definitions.py tests/unit/orchestrator/test_hermes_runtime.py tests/unit/orchestrator/test_runtime_factory.py -q`
- `uv run ruff check src/ouroboros/orchestrator/hermes_runtime.py src/ouroboros/orchestrator/runtime_factory.py src/ouroboros/mcp/tools/execution_handlers.py tests/unit/mcp/tools/test_definitions.py tests/unit/orchestrator/test_hermes_runtime.py tests/unit/orchestrator/test_runtime_factory.py`
- `uv run ruff format --check src/ouroboros/orchestrator/hermes_runtime.py src/ouroboros/orchestrator/runtime_factory.py src/ouroboros/mcp/tools/execution_handlers.py tests/unit/mcp/tools/test_definitions.py tests/unit/orchestrator/test_hermes_runtime.py tests/unit/orchestrator/test_runtime_factory.py`
- manual direct Hermes provider smoke:
  - `openai-codex / gpt-5.4-mini`
  - `openai-codex / gpt-5.4`
  - `gemini / gemini-2.5-flash`
  - `openrouter / openai/gpt-4o-mini`
- manual Ouroboros E2E provider matrix via `ExecuteSeedHandler(agent_runtime_backend="hermes")`:
  - `small: codex/gpt-5.4-mini -> openai-codex/gpt-5.4-mini -> completed`
  - `medium: google/gemini-2.5-flash -> gemini/gemini-2.5-flash -> completed`
  - `large: openrouter/openai/gpt-4o-mini -> openrouter/openai/gpt-4o-mini -> completed`
- installed editable tool smoke with `/home/ubuntu/.local/share/uv/tools/ouroboros-ai/bin/python`
- background `ouroboros_start_execute_seed` job wrapper smoke completed successfully
