### PR TITLE
feat(core): render seed ontology in execution contract

### DIFF
--- a/src/ouroboros/core/__init__.py
+++ b/src/ouroboros/core/__init__.py
@@ -29,6 +29,9 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "OntologyField": ("ouroboros.core.seed", "OntologyField"),
     "EvaluationPrinciple": ("ouroboros.core.seed", "EvaluationPrinciple"),
     "ExitCondition": ("ouroboros.core.seed", "ExitCondition"),
+    "OntologyConcept": ("ouroboros.core.seed_contract", "OntologyConcept"),
+    "OntologyLens": ("ouroboros.core.seed_contract", "OntologyLens"),
+    "SeedContract": ("ouroboros.core.seed_contract", "SeedContract"),
     # Context management
     "WorkflowContext": ("ouroboros.core.context", "WorkflowContext"),
     "ContextMetrics": ("ouroboros.core.context", "ContextMetrics"),

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -54,13 +54,13 @@ class EvaluationPrinciple(BaseModel, frozen=True):
 
 
 class OntologyField(BaseModel, frozen=True):
-    """A field in the ontology schema.
+    """A concept in the ontology lens.
 
     Attributes:
-        name: Field identifier.
-        field_type: Type of the field (string, number, boolean, array, object).
-        description: Purpose of this field.
-        required: Whether this field is required.
+        name: Concept identifier.
+        field_type: Concept kind (string, number, boolean, array, object).
+        description: Purpose of this concept.
+        required: Whether this concept is required.
     """
 
     model_config = {"populate_by_name": True}
@@ -72,15 +72,16 @@ class OntologyField(BaseModel, frozen=True):
 
 
 class OntologySchema(BaseModel, frozen=True):
-    """Schema defining the structure of workflow outputs.
+    """Conceptual lens defining workflow domain coherence.
 
-    The ontology schema defines what data structure the workflow should
-    produce and maintain throughout iterations.
+    The ontology schema names the domain concepts and boundaries the workflow
+    should preserve throughout iterations. It is not, by itself, a mandatory
+    output shape.
 
     Attributes:
         name: Name of the ontology.
-        description: Purpose and scope of this ontology.
-        fields: List of fields in the ontology.
+        description: Purpose, scope, and perspective of this ontology.
+        fields: Concepts in the ontology.
     """
 
     name: str = Field(..., min_length=1)
@@ -167,7 +168,7 @@ class Seed(BaseModel, frozen=True):
         goal: The primary objective of the workflow.
         constraints: Hard constraints that must be satisfied.
         acceptance_criteria: Specific criteria for success.
-        ontology_schema: Schema for workflow output structure.
+        ontology_schema: Conceptual lens for workflow coherence.
         evaluation_principles: Principles for evaluating outputs.
         exit_conditions: Conditions for terminating the workflow.
         metadata: Generation metadata (version, timestamp, etc.).
@@ -227,10 +228,10 @@ class Seed(BaseModel, frozen=True):
         description="Specific criteria for success evaluation",
     )
 
-    # Structure
+    # Conceptual lens
     ontology_schema: OntologySchema = Field(
         ...,
-        description="Schema defining the structure of workflow outputs",
+        description="Ontology defining the workflow's conceptual lens",
     )
 
     # Evaluation

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -54,13 +54,13 @@ class EvaluationPrinciple(BaseModel, frozen=True):
 
 
 class OntologyField(BaseModel, frozen=True):
-    """A concept in the ontology lens.
+    """A field in an ontology schema.
 
     Attributes:
-        name: Concept identifier.
-        field_type: Concept kind (string, number, boolean, array, object).
-        description: Purpose of this concept.
-        required: Whether this concept is required.
+        name: Field identifier.
+        field_type: Field type (string, number, boolean, array, object).
+        description: Purpose of this field.
+        required: Whether this field is required.
     """
 
     model_config = {"populate_by_name": True}
@@ -72,16 +72,16 @@ class OntologyField(BaseModel, frozen=True):
 
 
 class OntologySchema(BaseModel, frozen=True):
-    """Conceptual lens defining workflow domain coherence.
+    """Schema describing workflow domain structure.
 
-    The ontology schema names the domain concepts and boundaries the workflow
+    The ontology schema names the domain fields and boundaries the workflow
     should preserve throughout iterations. It is not, by itself, a mandatory
     output shape.
 
     Attributes:
         name: Name of the ontology.
         description: Purpose, scope, and perspective of this ontology.
-        fields: Concepts in the ontology.
+        fields: Fields in the ontology.
     """
 
     name: str = Field(..., min_length=1)

--- a/src/ouroboros/core/seed_contract.py
+++ b/src/ouroboros/core/seed_contract.py
@@ -1,0 +1,91 @@
+"""Execution contract derived from an immutable Seed.
+
+The Seed remains the frozen source of truth.  This module provides a small
+interpretation layer that turns the Seed into semantic parts the runtime can
+render consistently across execution, evaluation, and evolution without
+teaching every caller how to read Seed internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.core.seed import BrownfieldContext, EvaluationPrinciple, ExitCondition, Seed
+
+
+@dataclass(frozen=True, slots=True)
+class OntologyConcept:
+    """A concept exposed by the Seed ontology."""
+
+    name: str
+    field_type: str
+    description: str
+    required: bool
+
+
+@dataclass(frozen=True, slots=True)
+class OntologyLens:
+    """The Seed ontology interpreted as a conceptual lens."""
+
+    name: str
+    description: str
+    concepts: tuple[OntologyConcept, ...]
+
+    @property
+    def has_concepts(self) -> bool:
+        """Return True when the lens names concrete concepts."""
+        return bool(self.concepts)
+
+
+@dataclass(frozen=True, slots=True)
+class SeedContract:
+    """Runtime-ready semantic contract derived from a Seed."""
+
+    goal: str
+    task_type: str
+    acceptance_criteria: tuple[str, ...]
+    constraints: tuple[str, ...]
+    ontology_lens: OntologyLens
+    evaluation_principles: tuple[EvaluationPrinciple, ...]
+    exit_conditions: tuple[ExitCondition, ...]
+    brownfield_context: BrownfieldContext
+
+    @property
+    def artifact_type(self) -> str:
+        """Return the evaluator artifact type implied by the task type."""
+        if self.task_type.lower() in {"research", "analysis"}:
+            return "document"
+        return "code"
+
+    @classmethod
+    def from_seed(cls, seed: Seed) -> SeedContract:
+        """Interpret a Seed as an immutable execution contract."""
+        return cls(
+            goal=seed.goal,
+            task_type=seed.task_type,
+            acceptance_criteria=seed.acceptance_criteria,
+            constraints=seed.constraints,
+            ontology_lens=OntologyLens(
+                name=seed.ontology_schema.name,
+                description=seed.ontology_schema.description,
+                concepts=tuple(
+                    OntologyConcept(
+                        name=field.name,
+                        field_type=field.field_type,
+                        description=field.description,
+                        required=field.required,
+                    )
+                    for field in seed.ontology_schema.fields
+                ),
+            ),
+            evaluation_principles=seed.evaluation_principles,
+            exit_conditions=seed.exit_conditions,
+            brownfield_context=seed.brownfield_context,
+        )
+
+
+__all__ = [
+    "OntologyConcept",
+    "OntologyLens",
+    "SeedContract",
+]

--- a/src/ouroboros/core/seed_contract.py
+++ b/src/ouroboros/core/seed_contract.py
@@ -2,8 +2,8 @@
 
 The Seed remains the frozen source of truth.  This module provides a small
 interpretation layer that turns the Seed into semantic parts the runtime can
-render consistently across execution, evaluation, and evolution without
-teaching every caller how to read Seed internals.
+render consistently during execution without teaching every caller how to read
+Seed internals.
 """
 
 from __future__ import annotations
@@ -49,13 +49,6 @@ class SeedContract:
     evaluation_principles: tuple[EvaluationPrinciple, ...]
     exit_conditions: tuple[ExitCondition, ...]
     brownfield_context: BrownfieldContext
-
-    @property
-    def artifact_type(self) -> str:
-        """Return the evaluator artifact type implied by the task type."""
-        if self.task_type.lower() in {"research", "analysis"}:
-            return "document"
-        return "code"
 
     @classmethod
     def from_seed(cls, seed: Seed) -> SeedContract:

--- a/src/ouroboros/core/seed_contract_prompt.py
+++ b/src/ouroboros/core/seed_contract_prompt.py
@@ -1,0 +1,208 @@
+"""Prompt rendering for Seed semantic contracts."""
+
+from __future__ import annotations
+
+from ouroboros.core.seed_contract import OntologyLens, SeedContract
+
+
+def render_constraints_section(contract: SeedContract) -> str:
+    """Render hard boundaries from the Seed contract."""
+    constraints_text = (
+        "\n".join(f"- {constraint}" for constraint in contract.constraints)
+        if contract.constraints
+        else "None"
+    )
+    return f"""## Constraints
+{constraints_text}"""
+
+
+def render_brownfield_section(contract: SeedContract) -> str:
+    """Render existing-codebase boundaries from the Seed contract."""
+    context = contract.brownfield_context
+    if context.project_type != "brownfield":
+        return ""
+
+    refs = "\n".join(
+        f"- [{reference.role.upper()}] {reference.path}: {reference.summary}"
+        for reference in context.context_references
+    )
+    patterns = "\n".join(f"- {pattern}" for pattern in context.existing_patterns)
+    deps = ", ".join(context.existing_dependencies)
+
+    return f"""## Existing Codebase Context (BROWNFIELD)
+IMPORTANT: You are extending existing code, NOT creating a new project.
+
+### Referenced Codebases
+{refs or "None specified"}
+
+### Existing Patterns to Follow
+{patterns or "None specified"}
+
+### Existing Dependencies to Reuse
+{deps or "None specified"}"""
+
+
+def render_ontology_lens_section(
+    lens: OntologyLens,
+    *,
+    decision_context: str = "execution decisions",
+) -> str:
+    """Render the Seed ontology as a phase-specific conceptual lens."""
+    lines = [
+        "## Ontology / Conceptual Lens",
+        (
+            f"Use this ontology as the conceptual lens for {decision_context}. "
+            "It defines the Seed's domain concepts and the coherence that must be "
+            "preserved while satisfying the goal and acceptance criteria. "
+            "It is not a mandatory output outline."
+        ),
+        "",
+        f"Name: {lens.name}",
+        f"Description: {lens.description}",
+    ]
+
+    if lens.has_concepts:
+        lines.append("")
+        lines.append("Concepts:")
+        for concept in lens.concepts:
+            required = "required concept" if concept.required else "optional concept"
+            lines.append(f"- {concept.name}: {concept.description} ({required})")
+
+    lines.extend(
+        [
+            "",
+            f"When {decision_context} are ambiguous:",
+            "- Preserve this ontology's concepts and boundaries.",
+            "- Do not introduce concepts that contradict the ontology.",
+            "- Prefer choices that make the result closer to the Seed's intended outcome.",
+            "- Do not force the final artifact to mirror these fields unless the task asks for that structure.",
+            "- Treat missing optional concepts as acceptable unless the Seed goal, constraints, or ACs require them.",
+            "- Required concepts must remain represented in the reasoning, artifact, or validation evidence.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_evaluation_principles_section(contract: SeedContract) -> str:
+    """Render evaluation principles from the Seed contract."""
+    principles_text = (
+        "\n".join(
+            f"- {principle.name} (weight {principle.weight:.2f}): {principle.description}"
+            for principle in contract.evaluation_principles
+        )
+        if contract.evaluation_principles
+        else "None"
+    )
+    return f"""## Evaluation Principles
+{principles_text}"""
+
+
+def render_acceptance_criteria_section(contract: SeedContract) -> str:
+    """Render acceptance criteria from the Seed contract."""
+    criteria_text = (
+        "\n".join(
+            f"{index + 1}. {criterion}"
+            for index, criterion in enumerate(contract.acceptance_criteria)
+        )
+        if contract.acceptance_criteria
+        else "None"
+    )
+    return f"""## Acceptance Criteria
+{criteria_text}"""
+
+
+def render_exit_conditions_section(contract: SeedContract) -> str:
+    """Render exit conditions from the Seed contract."""
+    conditions_text = (
+        "\n".join(
+            f"- {condition.name}: {condition.description} ({condition.evaluation_criteria})"
+            for condition in contract.exit_conditions
+        )
+        if contract.exit_conditions
+        else "None"
+    )
+    return f"""## Exit Conditions
+{conditions_text}"""
+
+
+def render_seed_contract_for_execution(contract: SeedContract) -> str:
+    """Render the Seed contract into runtime-facing execution instructions."""
+    sections = [
+        "## Seed Contract",
+        "The Seed is the immutable source of truth for this execution. Interpret every execution decision through this contract.",
+        "",
+        "## Goal",
+        contract.goal,
+        "",
+        "## Task Type",
+        contract.task_type,
+        "",
+        render_acceptance_criteria_section(contract),
+        "",
+        render_constraints_section(contract),
+    ]
+
+    brownfield = render_brownfield_section(contract)
+    if brownfield:
+        sections.extend(["", brownfield])
+
+    sections.extend(
+        [
+            "",
+            render_ontology_lens_section(contract.ontology_lens),
+            "",
+            render_evaluation_principles_section(contract),
+            "",
+            render_exit_conditions_section(contract),
+        ]
+    )
+    return "\n".join(sections)
+
+
+def render_seed_contract_for_evaluation(contract: SeedContract) -> str:
+    """Render the Seed contract into evaluator-facing judgment instructions."""
+    sections = [
+        "## Seed Contract",
+        "The Seed is the immutable source of truth for this evaluation. Judge the artifact against this full contract, not only the surface wording of an acceptance criterion.",
+        "",
+        "## Goal",
+        contract.goal,
+        "",
+        "## Task Type",
+        contract.task_type,
+        "",
+        render_acceptance_criteria_section(contract),
+        "",
+        render_constraints_section(contract),
+    ]
+
+    brownfield = render_brownfield_section(contract)
+    if brownfield:
+        sections.extend(["", brownfield])
+
+    sections.extend(
+        [
+            "",
+            render_ontology_lens_section(
+                contract.ontology_lens,
+                decision_context="evaluation judgments",
+            ),
+            "",
+            render_evaluation_principles_section(contract),
+            "",
+            render_exit_conditions_section(contract),
+        ]
+    )
+    return "\n".join(sections)
+
+
+__all__ = [
+    "render_brownfield_section",
+    "render_acceptance_criteria_section",
+    "render_constraints_section",
+    "render_evaluation_principles_section",
+    "render_exit_conditions_section",
+    "render_ontology_lens_section",
+    "render_seed_contract_for_execution",
+    "render_seed_contract_for_evaluation",
+]

--- a/src/ouroboros/core/seed_contract_prompt.py
+++ b/src/ouroboros/core/seed_contract_prompt.py
@@ -89,7 +89,7 @@ def render_evaluation_principles_section(contract: SeedContract) -> str:
     """Render evaluation principles from the Seed contract."""
     principles_text = (
         "\n".join(
-            f"- {principle.name} (weight {principle.weight:.2f}): {principle.description}"
+            f"- {principle.name}: {principle.description}"
             for principle in contract.evaluation_principles
         )
         if contract.evaluation_principles
@@ -138,8 +138,6 @@ def render_seed_contract_for_execution(contract: SeedContract) -> str:
         "",
         "## Task Type",
         contract.task_type,
-        "",
-        render_acceptance_criteria_section(contract),
         "",
         render_constraints_section(contract),
     ]

--- a/src/ouroboros/core/seed_contract_prompt.py
+++ b/src/ouroboros/core/seed_contract_prompt.py
@@ -161,43 +161,6 @@ def render_seed_contract_for_execution(contract: SeedContract) -> str:
     return "\n".join(sections)
 
 
-def render_seed_contract_for_evaluation(contract: SeedContract) -> str:
-    """Render the Seed contract into evaluator-facing judgment instructions."""
-    sections = [
-        "## Seed Contract",
-        "The Seed is the immutable source of truth for this evaluation. Judge the artifact against this full contract, not only the surface wording of an acceptance criterion.",
-        "",
-        "## Goal",
-        contract.goal,
-        "",
-        "## Task Type",
-        contract.task_type,
-        "",
-        render_acceptance_criteria_section(contract),
-        "",
-        render_constraints_section(contract),
-    ]
-
-    brownfield = render_brownfield_section(contract)
-    if brownfield:
-        sections.extend(["", brownfield])
-
-    sections.extend(
-        [
-            "",
-            render_ontology_lens_section(
-                contract.ontology_lens,
-                decision_context="evaluation judgments",
-            ),
-            "",
-            render_evaluation_principles_section(contract),
-            "",
-            render_exit_conditions_section(contract),
-        ]
-    )
-    return "\n".join(sections)
-
-
 __all__ = [
     "render_brownfield_section",
     "render_acceptance_criteria_section",
@@ -206,5 +169,4 @@ __all__ = [
     "render_exit_conditions_section",
     "render_ontology_lens_section",
     "render_seed_contract_for_execution",
-    "render_seed_contract_for_evaluation",
 ]

--- a/src/ouroboros/core/seed_contract_prompt.py
+++ b/src/ouroboros/core/seed_contract_prompt.py
@@ -66,7 +66,9 @@ def render_ontology_lens_section(
         lines.append("Concepts:")
         for concept in lens.concepts:
             required = "required concept" if concept.required else "optional concept"
-            lines.append(f"- {concept.name}: {concept.description} ({required})")
+            lines.append(
+                f"- {concept.name} [{concept.field_type}]: {concept.description} ({required})"
+            )
 
     lines.extend(
         [

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -31,6 +31,8 @@ from rich.panel import Panel
 from rich.text import Text
 
 from ouroboros.core.errors import OuroborosError
+from ouroboros.core.seed_contract import SeedContract
+from ouroboros.core.seed_contract_prompt import render_seed_contract_for_execution
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import TaskWorkspace, heartbeat_lock, release_lock
 from ouroboros.observability.drift import DriftMeasurement
@@ -252,51 +254,14 @@ def build_system_prompt(
     if strategy is None:
         strategy = get_strategy(seed.task_type)
 
-    constraints_text = "\n".join(f"- {c}" for c in seed.constraints) if seed.constraints else "None"
-
-    principles_text = (
-        "\n".join(f"- {p.name}: {p.description}" for p in seed.evaluation_principles)
-        if seed.evaluation_principles
-        else "None"
-    )
-
-    # Build brownfield context section
-    brownfield_section = ""
-    if seed.brownfield_context.project_type == "brownfield":
-        refs = "\n".join(
-            f"- [{r.role.upper()}] {r.path}: {r.summary}"
-            for r in seed.brownfield_context.context_references
-        )
-        patterns = "\n".join(f"- {p}" for p in seed.brownfield_context.existing_patterns)
-        deps = ", ".join(seed.brownfield_context.existing_dependencies)
-        brownfield_section = f"""
-## Existing Codebase Context (BROWNFIELD)
-IMPORTANT: You are extending existing code, NOT creating a new project.
-
-### Referenced Codebases
-{refs or "None specified"}
-
-### Existing Patterns to Follow
-{patterns or "None specified"}
-
-### Existing Dependencies to Reuse
-{deps or "None specified"}
-"""
-
     ac_tracking = get_ac_tracking_prompt()
     strategy_fragment = strategy.get_system_prompt_fragment()
     recovery_protocol = get_run_recovery_protocol_prompt()
+    seed_contract = render_seed_contract_for_execution(SeedContract.from_seed(seed))
 
     return f"""{strategy_fragment}
 
-## Goal
-{seed.goal}
-
-## Constraints
-{constraints_text}
-{brownfield_section}
-## Evaluation Principles
-{principles_text}
+{seed_contract}
 
 {ac_tracking}
 

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -1770,6 +1770,9 @@ class OrchestratorRunner:
                     status=status,
                 )
 
+                # Same-session recovery is limited to the sequential runner.
+                # Parallel execution owns per-AC retry semantics, and resume_session
+                # is already a recovery workflow.
                 if cancelled_result is None and not success and runtime_handle is not None:
                     planner = RecoveryPlanner()
                     recovery_action = planner.plan(_build_recovery_snapshot())

--- a/tests/e2e/test_full_workflow.py
+++ b/tests/e2e/test_full_workflow.py
@@ -80,6 +80,18 @@ class TestPromptBuilding:
         for principle in sample_seed.evaluation_principles:
             assert principle.name in prompt
 
+    def test_system_prompt_includes_seed_ontology_lens(self, sample_seed: Seed) -> None:
+        """Test that execution receives the Seed ontology as a conceptual lens."""
+        prompt = build_system_prompt(sample_seed)
+
+        assert "## Seed Contract" in prompt
+        assert "## Ontology / Conceptual Lens" in prompt
+        assert sample_seed.ontology_schema.name in prompt
+        assert sample_seed.ontology_schema.description in prompt
+        for field in sample_seed.ontology_schema.fields:
+            assert field.name in prompt
+            assert field.description in prompt
+
     def test_task_prompt_includes_acceptance_criteria(self, sample_seed: Seed) -> None:
         """Test that task prompt includes all acceptance criteria."""
         prompt = build_task_prompt(sample_seed)

--- a/tests/e2e/test_full_workflow.py
+++ b/tests/e2e/test_full_workflow.py
@@ -90,6 +90,7 @@ class TestPromptBuilding:
         assert sample_seed.ontology_schema.description in prompt
         for field in sample_seed.ontology_schema.fields:
             assert field.name in prompt
+            assert field.field_type in prompt
             assert field.description in prompt
 
     def test_task_prompt_includes_acceptance_criteria(self, sample_seed: Seed) -> None:

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -108,6 +108,20 @@ class TestBuildSystemPrompt:
         assert "completeness" in prompt
         assert "All requirements are met" in prompt
 
+    def test_includes_seed_contract_ontology_lens(self, sample_seed: Seed) -> None:
+        """System prompt renders Seed ontology as an execution contract lens."""
+        prompt = build_system_prompt(sample_seed)
+
+        assert "## Seed Contract" in prompt
+        assert "## Ontology / Conceptual Lens" in prompt
+        assert "conceptual lens for execution decisions" in prompt
+        assert "It is not a mandatory output outline." in prompt
+        assert "Name: TaskManager" in prompt
+        assert "Description: Task management ontology" in prompt
+        assert "- tasks: List of tasks (required concept)" in prompt
+        assert "closer to the Seed's intended outcome" in prompt
+        assert "Do not force the final artifact to mirror these fields" in prompt
+
     def test_includes_self_recovery_protocol(self, sample_seed: Seed) -> None:
         """Run prompts should tell agents how to change strategy when stuck."""
         prompt = build_system_prompt(sample_seed)
@@ -129,6 +143,27 @@ class TestBuildSystemPrompt:
         )
         prompt = build_system_prompt(seed)
         assert "None" in prompt or "Constraints" in prompt
+
+    def test_handles_empty_ontology_fields(self) -> None:
+        """Ontology lens renders cleanly even when no concepts are listed."""
+        seed = Seed(
+            goal="Test goal",
+            constraints=(),
+            acceptance_criteria=("AC1",),
+            ontology_schema=OntologySchema(
+                name="TestOntology",
+                description="A minimal ontology",
+            ),
+            metadata=SeedMetadata(ambiguity_score=0.1),
+        )
+
+        prompt = build_system_prompt(seed)
+
+        assert "## Ontology / Conceptual Lens" in prompt
+        assert "Name: TestOntology" in prompt
+        assert "Description: A minimal ontology" in prompt
+        assert "Concepts:" not in prompt
+        assert "When execution decisions are ambiguous:" in prompt
 
 
 class TestBuildTaskPrompt:
@@ -152,6 +187,13 @@ class TestBuildTaskPrompt:
         assert "1." in prompt
         assert "2." in prompt
         assert "3." in prompt
+
+    def test_does_not_duplicate_system_ontology_lens(self, sample_seed: Seed) -> None:
+        """Task prompt remains focused on concrete acceptance criteria."""
+        prompt = build_task_prompt(sample_seed)
+
+        assert "## Ontology / Conceptual Lens" not in prompt
+        assert "conceptual lens for execution decisions" not in prompt
 
 
 class TestOrchestratorResult:

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ouroboros.core.seed import (
+    BrownfieldContext,
+    ContextReference,
     EvaluationPrinciple,
     ExitCondition,
     OntologyField,
@@ -107,6 +109,19 @@ class TestBuildSystemPrompt:
         prompt = build_system_prompt(sample_seed)
         assert "completeness" in prompt
         assert "All requirements are met" in prompt
+        assert "(weight" not in prompt
+
+    def test_system_prompt_leaves_acceptance_criteria_to_task_prompt(
+        self, sample_seed: Seed
+    ) -> None:
+        """System prompt should not duplicate task-level acceptance criteria."""
+        system_prompt = build_system_prompt(sample_seed)
+        task_prompt = build_task_prompt(sample_seed)
+
+        assert "## Acceptance Criteria" not in system_prompt
+        for criterion in sample_seed.acceptance_criteria:
+            assert criterion not in system_prompt
+            assert criterion in task_prompt
 
     def test_includes_seed_contract_ontology_lens(self, sample_seed: Seed) -> None:
         """System prompt renders Seed ontology as an execution contract lens."""
@@ -164,6 +179,32 @@ class TestBuildSystemPrompt:
         assert "Description: A minimal ontology" in prompt
         assert "Concepts:" not in prompt
         assert "When execution decisions are ambiguous:" in prompt
+
+    def test_includes_brownfield_context(self, sample_seed: Seed) -> None:
+        """System prompt preserves brownfield project references and constraints."""
+        seed = sample_seed.model_copy(
+            update={
+                "brownfield_context": BrownfieldContext(
+                    project_type="brownfield",
+                    context_references=(
+                        ContextReference(
+                            path="/repo/app",
+                            role="primary",
+                            summary="Main application repository",
+                        ),
+                    ),
+                    existing_patterns=("Use repository service classes",),
+                    existing_dependencies=("sqlalchemy",),
+                )
+            }
+        )
+
+        prompt = build_system_prompt(seed)
+
+        assert "## Existing Codebase Context (BROWNFIELD)" in prompt
+        assert "[PRIMARY] /repo/app: Main application repository" in prompt
+        assert "Use repository service classes" in prompt
+        assert "sqlalchemy" in prompt
 
 
 class TestBuildTaskPrompt:

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -118,7 +118,7 @@ class TestBuildSystemPrompt:
         assert "It is not a mandatory output outline." in prompt
         assert "Name: TaskManager" in prompt
         assert "Description: Task management ontology" in prompt
-        assert "- tasks: List of tasks (required concept)" in prompt
+        assert "- tasks [array]: List of tasks (required concept)" in prompt
         assert "closer to the Seed's intended outcome" in prompt
         assert "Do not force the final artifact to mirror these fields" in prompt
 

--- a/tests/unit/orchestrator/test_seed_prompt.py
+++ b/tests/unit/orchestrator/test_seed_prompt.py
@@ -1,0 +1,101 @@
+"""Tests for Seed contract prompt rendering."""
+
+from __future__ import annotations
+
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.core.seed_contract import SeedContract
+from ouroboros.core.seed_contract_prompt import (
+    render_ontology_lens_section,
+    render_seed_contract_for_evaluation,
+    render_seed_contract_for_execution,
+)
+
+
+def _seed() -> Seed:
+    return Seed(
+        goal="Build a task manager",
+        constraints=("No external database",),
+        acceptance_criteria=("Tasks can be created",),
+        ontology_schema=OntologySchema(
+            name="TaskManager",
+            description="Task management ontology",
+            fields=(
+                OntologyField(
+                    name="tasks",
+                    field_type="array",
+                    description="List of task objects",
+                ),
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.1),
+    )
+
+
+def test_seed_contract_from_seed_interprets_ontology_lens() -> None:
+    """SeedContract preserves ontology concepts without mutating Seed."""
+    contract = SeedContract.from_seed(_seed())
+
+    assert contract.goal == "Build a task manager"
+    assert contract.task_type == "code"
+    assert contract.artifact_type == "code"
+    assert contract.acceptance_criteria == ("Tasks can be created",)
+    assert contract.ontology_lens.name == "TaskManager"
+    assert contract.ontology_lens.description == "Task management ontology"
+    assert len(contract.ontology_lens.concepts) == 1
+    assert contract.ontology_lens.concepts[0].name == "tasks"
+
+
+def test_seed_contract_maps_non_code_tasks_to_document_artifacts() -> None:
+    """Research and analysis Seeds should not be evaluated as code artifacts."""
+    seed = _seed().model_copy(update={"task_type": "analysis"})
+
+    contract = SeedContract.from_seed(seed)
+
+    assert contract.task_type == "analysis"
+    assert contract.artifact_type == "document"
+
+
+def test_render_ontology_lens_section_frames_ontology_as_lens() -> None:
+    """Ontology rendering states how execution agents should use concepts."""
+    contract = SeedContract.from_seed(_seed())
+
+    section = render_ontology_lens_section(contract.ontology_lens)
+
+    assert "## Ontology / Conceptual Lens" in section
+    assert "conceptual lens for execution decisions" in section
+    assert "It is not a mandatory output outline." in section
+    assert "- tasks: List of task objects (required concept)" in section
+    assert "Do not introduce concepts that contradict the ontology." in section
+    assert "Do not force the final artifact to mirror these fields" in section
+    assert "Required concepts must remain represented" in section
+
+
+def test_render_seed_contract_for_execution_includes_core_sections() -> None:
+    """Full contract renderer includes goal, constraints, ontology, and evaluation."""
+    contract = SeedContract.from_seed(_seed())
+
+    rendered = render_seed_contract_for_execution(contract)
+
+    assert "## Seed Contract" in rendered
+    assert "## Goal" in rendered
+    assert "Build a task manager" in rendered
+    assert "## Task Type" in rendered
+    assert "## Acceptance Criteria" in rendered
+    assert "## Constraints" in rendered
+    assert "- No external database" in rendered
+    assert "## Ontology / Conceptual Lens" in rendered
+    assert "## Exit Conditions" in rendered
+
+
+def test_render_seed_contract_for_evaluation_frames_contract_as_judgment_lens() -> None:
+    """Evaluation renderer uses the same Seed contract without coding bias."""
+    contract = SeedContract.from_seed(_seed())
+
+    rendered = render_seed_contract_for_evaluation(contract)
+
+    assert "immutable source of truth for this evaluation" in rendered
+    assert "not only the surface wording of an acceptance criterion" in rendered
+    assert "## Task Type" in rendered
+    assert "conceptual lens for evaluation judgments" in rendered
+    assert "When evaluation judgments are ambiguous:" in rendered
+    assert "It is not a mandatory output outline." in rendered

--- a/tests/unit/orchestrator/test_seed_prompt.py
+++ b/tests/unit/orchestrator/test_seed_prompt.py
@@ -69,7 +69,7 @@ def test_render_seed_contract_for_execution_includes_core_sections() -> None:
     assert "## Goal" in rendered
     assert "Build a task manager" in rendered
     assert "## Task Type" in rendered
-    assert "## Acceptance Criteria" in rendered
+    assert "## Acceptance Criteria" not in rendered
     assert "## Constraints" in rendered
     assert "- No external database" in rendered
     assert "## Ontology / Conceptual Lens" in rendered

--- a/tests/unit/orchestrator/test_seed_prompt.py
+++ b/tests/unit/orchestrator/test_seed_prompt.py
@@ -6,7 +6,6 @@ from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadat
 from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.seed_contract_prompt import (
     render_ontology_lens_section,
-    render_seed_contract_for_evaluation,
     render_seed_contract_for_execution,
 )
 
@@ -37,23 +36,12 @@ def test_seed_contract_from_seed_interprets_ontology_lens() -> None:
 
     assert contract.goal == "Build a task manager"
     assert contract.task_type == "code"
-    assert contract.artifact_type == "code"
     assert contract.acceptance_criteria == ("Tasks can be created",)
     assert contract.ontology_lens.name == "TaskManager"
     assert contract.ontology_lens.description == "Task management ontology"
     assert len(contract.ontology_lens.concepts) == 1
     assert contract.ontology_lens.concepts[0].name == "tasks"
     assert contract.ontology_lens.concepts[0].field_type == "array"
-
-
-def test_seed_contract_maps_non_code_tasks_to_document_artifacts() -> None:
-    """Research and analysis Seeds should not be evaluated as code artifacts."""
-    seed = _seed().model_copy(update={"task_type": "analysis"})
-
-    contract = SeedContract.from_seed(seed)
-
-    assert contract.task_type == "analysis"
-    assert contract.artifact_type == "document"
 
 
 def test_render_ontology_lens_section_frames_ontology_as_lens() -> None:
@@ -86,17 +74,3 @@ def test_render_seed_contract_for_execution_includes_core_sections() -> None:
     assert "- No external database" in rendered
     assert "## Ontology / Conceptual Lens" in rendered
     assert "## Exit Conditions" in rendered
-
-
-def test_render_seed_contract_for_evaluation_frames_contract_as_judgment_lens() -> None:
-    """Evaluation renderer uses the same Seed contract without coding bias."""
-    contract = SeedContract.from_seed(_seed())
-
-    rendered = render_seed_contract_for_evaluation(contract)
-
-    assert "immutable source of truth for this evaluation" in rendered
-    assert "not only the surface wording of an acceptance criterion" in rendered
-    assert "## Task Type" in rendered
-    assert "conceptual lens for evaluation judgments" in rendered
-    assert "When evaluation judgments are ambiguous:" in rendered
-    assert "It is not a mandatory output outline." in rendered

--- a/tests/unit/orchestrator/test_seed_prompt.py
+++ b/tests/unit/orchestrator/test_seed_prompt.py
@@ -43,6 +43,7 @@ def test_seed_contract_from_seed_interprets_ontology_lens() -> None:
     assert contract.ontology_lens.description == "Task management ontology"
     assert len(contract.ontology_lens.concepts) == 1
     assert contract.ontology_lens.concepts[0].name == "tasks"
+    assert contract.ontology_lens.concepts[0].field_type == "array"
 
 
 def test_seed_contract_maps_non_code_tasks_to_document_artifacts() -> None:
@@ -64,7 +65,7 @@ def test_render_ontology_lens_section_frames_ontology_as_lens() -> None:
     assert "## Ontology / Conceptual Lens" in section
     assert "conceptual lens for execution decisions" in section
     assert "It is not a mandatory output outline." in section
-    assert "- tasks: List of task objects (required concept)" in section
+    assert "- tasks [array]: List of task objects (required concept)" in section
     assert "Do not introduce concepts that contradict the ontology." in section
     assert "Do not force the final artifact to mirror these fields" in section
     assert "Required concepts must remain represented" in section


### PR DESCRIPTION
## Summary

- Closes #493 by deriving a SeedContract from immutable Seeds and rendering ontology as a runtime conceptual lens.
- Moves goal, ACs, constraints, ontology, evaluation principles, exit conditions, and brownfield context into one prompt contract.
- Keeps task prompts focused on concrete AC execution while system prompts carry the Seed-level conceptual contract.

## Changes

- Add `SeedContract`, `OntologyLens`, and prompt renderers for Seed contract sections.
- Reframe ontology docs from output schema to conceptual lens.
- Update `build_system_prompt()` to delegate Seed contract rendering instead of composing goal/constraints inline.
- Add prompt renderer, runner, and e2e coverage for ontology lens rendering and empty ontology fields.

## Notes

This PR intentionally keeps Wonder/Reflect behavior, drift calculation, and evaluation gating out of scope. Those are follow-up contract-enforcement changes.

Closes #493