### PR TITLE
feat(evaluation): enforce seed contracts across checks

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -12,33 +12,39 @@ Extract structured requirements from the interview conversation and format them 
 A clear, specific statement of the primary objective.
 Example: "Build a CLI task management tool in Python"
 
-### 2. CONSTRAINTS
+### 2. TASK_TYPE
+The execution mode implied by the interview:
+- `code`: building or modifying software
+- `research`: gathering and synthesizing information
+- `analysis`: producing a structured decision, critique, plan, or perspective
+
+### 3. CONSTRAINTS
 Hard limitations or requirements that must be satisfied.
 Format: pipe-separated list
 Example: "Python >= 3.12 | No external database | Must work offline"
 
-### 3. ACCEPTANCE_CRITERIA
+### 4. ACCEPTANCE_CRITERIA
 Specific, measurable criteria for success.
 Format: pipe-separated list
 Example: "Tasks can be created | Tasks can be listed | Tasks persist to file"
 
-### 4. ONTOLOGY
-The data structure/domain model for this work:
-- **ONTOLOGY_NAME**: A name for the domain model
-- **ONTOLOGY_DESCRIPTION**: What the ontology represents
-- **ONTOLOGY_FIELDS**: Key fields in format: name:type:description (pipe-separated)
+### 5. ONTOLOGY
+The conceptual lens for this work: the domain concepts, boundaries, and relationships that must stay coherent while satisfying the goal.
+- **ONTOLOGY_NAME**: A name for the conceptual lens
+- **ONTOLOGY_DESCRIPTION**: What perspective and domain boundary the ontology represents
+- **ONTOLOGY_FIELDS**: Key concepts in format: name:type:description (pipe-separated)
 
 Field types should be one of: string, number, boolean, array, object
 
-### 5. EVALUATION_PRINCIPLES
+### 6. EVALUATION_PRINCIPLES
 Principles for evaluating output quality.
 Format: name:description:weight (pipe-separated, weight 0.0-1.0)
 
-### 6. EXIT_CONDITIONS
+### 7. EXIT_CONDITIONS
 Conditions that indicate the workflow should terminate.
 Format: name:description:criteria (pipe-separated)
 
-### 7. BROWNFIELD CONTEXT (if applicable)
+### 8. BROWNFIELD CONTEXT (if applicable)
 If the interview mentions existing codebases, extract:
 - **PROJECT_TYPE**: 'greenfield' or 'brownfield'
 - **CONTEXT_REFERENCES**: path:role:summary (pipe-separated, role is 'primary' or 'reference')
@@ -51,6 +57,7 @@ Provide your analysis in this exact structure:
 
 ```
 GOAL: <clear goal statement>
+TASK_TYPE: code|research|analysis
 CONSTRAINTS: <constraint 1> | <constraint 2> | ...
 ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2> | ...
 ONTOLOGY_NAME: <name>

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -408,6 +408,7 @@ Please try again. Extract requirements from this interview:
 You MUST respond with ONLY the following format, one field per line, no other text:
 
 GOAL: <clear goal statement>
+TASK_TYPE: code|research|analysis
 CONSTRAINTS: <constraint 1> | <constraint 2> | ...
 ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2> | ...
 ONTOLOGY_NAME: <name>
@@ -465,6 +466,7 @@ PROJECT_TYPE: greenfield"""
 Respond ONLY with the structured format below. Do NOT add explanations, questions, commentary, or prose. Do NOT wrap in markdown code blocks.
 
 GOAL: <clear goal statement>
+TASK_TYPE: code|research|analysis
 CONSTRAINTS: <constraint 1> | <constraint 2> | ...
 ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2> | ...
 ONTOLOGY_NAME: <name>
@@ -476,6 +478,7 @@ PROJECT_TYPE: greenfield"""
 
     _KNOWN_PREFIXES = (
         "GOAL:",
+        "TASK_TYPE:",
         "CONSTRAINTS:",
         "ACCEPTANCE_CRITERIA:",
         "ONTOLOGY_NAME:",
@@ -571,6 +574,9 @@ PROJECT_TYPE: greenfield"""
         Returns:
             Constructed Seed instance.
         """
+        # Parse task type
+        task_type = self._normalize_task_type(requirements.get("task_type"))
+
         # Parse constraints
         constraints: tuple[str, ...] = ()
         if "constraints" in requirements and requirements["constraints"]:
@@ -693,6 +699,7 @@ PROJECT_TYPE: greenfield"""
 
         return Seed(
             goal=requirements["goal"],
+            task_type=task_type,
             brownfield_context=brownfield_context,
             constraints=constraints,
             acceptance_criteria=acceptance_criteria,
@@ -701,6 +708,12 @@ PROJECT_TYPE: greenfield"""
             exit_conditions=tuple(exit_conditions),
             metadata=metadata,
         )
+
+    @staticmethod
+    def _normalize_task_type(raw_value: Any) -> str:
+        """Normalize extracted task type, defaulting conservatively to code."""
+        task_type = str(raw_value or "code").strip().lower()
+        return task_type if task_type in {"code", "research", "analysis"} else "code"
 
     async def save_seed(
         self,

--- a/src/ouroboros/core/seed_contract.py
+++ b/src/ouroboros/core/seed_contract.py
@@ -50,6 +50,13 @@ class SeedContract:
     exit_conditions: tuple[ExitCondition, ...]
     brownfield_context: BrownfieldContext
 
+    @property
+    def artifact_type(self) -> str:
+        """Return the evaluator artifact type implied by the task type."""
+        if self.task_type.lower() in {"research", "analysis"}:
+            return "document"
+        return "code"
+
     @classmethod
     def from_seed(cls, seed: Seed) -> SeedContract:
         """Interpret a Seed as an immutable execution contract."""

--- a/src/ouroboros/core/seed_contract_prompt.py
+++ b/src/ouroboros/core/seed_contract_prompt.py
@@ -159,6 +159,43 @@ def render_seed_contract_for_execution(contract: SeedContract) -> str:
     return "\n".join(sections)
 
 
+def render_seed_contract_for_evaluation(contract: SeedContract) -> str:
+    """Render the Seed contract into evaluator-facing judgment instructions."""
+    sections = [
+        "## Seed Contract",
+        "The Seed is the immutable source of truth for this evaluation. Judge the artifact against this full contract, not only the surface wording of an acceptance criterion.",
+        "",
+        "## Goal",
+        contract.goal,
+        "",
+        "## Task Type",
+        contract.task_type,
+        "",
+        render_acceptance_criteria_section(contract),
+        "",
+        render_constraints_section(contract),
+    ]
+
+    brownfield = render_brownfield_section(contract)
+    if brownfield:
+        sections.extend(["", brownfield])
+
+    sections.extend(
+        [
+            "",
+            render_ontology_lens_section(
+                contract.ontology_lens,
+                decision_context="evaluation judgments",
+            ),
+            "",
+            render_evaluation_principles_section(contract),
+            "",
+            render_exit_conditions_section(contract),
+        ]
+    )
+    return "\n".join(sections)
+
+
 __all__ = [
     "render_brownfield_section",
     "render_acceptance_criteria_section",
@@ -167,4 +204,5 @@ __all__ = [
     "render_exit_conditions_section",
     "render_ontology_lens_section",
     "render_seed_contract_for_execution",
+    "render_seed_contract_for_evaluation",
 ]

--- a/src/ouroboros/evaluation/consensus.py
+++ b/src/ouroboros/evaluation/consensus.py
@@ -30,6 +30,7 @@ from ouroboros.config import (
 )
 from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.ontology_aspect import AnalysisResult
+from ouroboros.core.seed_contract_prompt import render_seed_contract_for_evaluation
 from ouroboros.core.types import Result
 from ouroboros.evaluation.json_utils import extract_json_payload
 from ouroboros.evaluation.models import (
@@ -153,22 +154,32 @@ def build_consensus_prompt(context: EvaluationContext) -> str:
     Returns:
         Formatted prompt string
     """
-    constraints_text = (
-        "\n".join(f"- {c}" for c in context.constraints) if context.constraints else "None"
-    )
+    if context.seed_contract is not None:
+        seed_context = render_seed_contract_for_evaluation(context.seed_contract)
+        artifact_type = (
+            context.seed_contract.artifact_type
+            if context.artifact_type == "code"
+            else context.artifact_type
+        )
+    else:
+        constraints_text = (
+            "\n".join(f"- {c}" for c in context.constraints) if context.constraints else "None"
+        )
+        seed_context = f"""## Original Goal
+{context.goal if context.goal else "Not specified"}
+
+## Constraints
+{constraints_text}"""
+        artifact_type = context.artifact_type
 
     return f"""Review the following artifact for consensus approval:
 
 ## Acceptance Criterion
 {context.current_ac}
 
-## Original Goal
-{context.goal if context.goal else "Not specified"}
+{seed_context}
 
-## Constraints
-{constraints_text}
-
-## Artifact ({context.artifact_type})
+## Artifact ({artifact_type})
 ```
 {context.artifact}
 ```

--- a/src/ouroboros/evaluation/contract_audit.py
+++ b/src/ouroboros/evaluation/contract_audit.py
@@ -1,0 +1,47 @@
+"""Seed contract audit gates for semantic evaluation results."""
+
+from __future__ import annotations
+
+from ouroboros.evaluation.models import SemanticResult
+
+MIN_CONTRACT_SCORE = 0.80
+MIN_GOAL_ALIGNMENT = 0.80
+MAX_DRIFT_SCORE = 0.30
+MAX_UNCERTAINTY = 0.30
+MAX_REWARD_HACKING_RISK = 0.30
+
+
+def contract_audit_failure(result: SemanticResult | None) -> str | None:
+    """Return a failure reason when semantic results violate the Seed contract."""
+    if result is None:
+        return "Seed contract audit failed: semantic evaluation did not run"
+
+    failures: list[str] = []
+    if not result.ac_compliance:
+        failures.append("acceptance criteria were not semantically satisfied")
+    if result.score < MIN_CONTRACT_SCORE:
+        failures.append(f"score {result.score:.2f} < {MIN_CONTRACT_SCORE:.2f}")
+    if result.goal_alignment < MIN_GOAL_ALIGNMENT:
+        failures.append(f"goal alignment {result.goal_alignment:.2f} < {MIN_GOAL_ALIGNMENT:.2f}")
+    if result.drift_score > MAX_DRIFT_SCORE:
+        failures.append(f"drift score {result.drift_score:.2f} > {MAX_DRIFT_SCORE:.2f}")
+    if result.uncertainty > MAX_UNCERTAINTY:
+        failures.append(f"uncertainty {result.uncertainty:.2f} > {MAX_UNCERTAINTY:.2f}")
+    if result.reward_hacking_risk > MAX_REWARD_HACKING_RISK:
+        failures.append(
+            f"reward hacking risk {result.reward_hacking_risk:.2f} > {MAX_REWARD_HACKING_RISK:.2f}"
+        )
+
+    if not failures:
+        return None
+    return "Seed contract audit failed: " + "; ".join(failures)
+
+
+__all__ = [
+    "MAX_DRIFT_SCORE",
+    "MAX_REWARD_HACKING_RISK",
+    "MAX_UNCERTAINTY",
+    "MIN_CONTRACT_SCORE",
+    "MIN_GOAL_ALIGNMENT",
+    "contract_audit_failure",
+]

--- a/src/ouroboros/evaluation/models.py
+++ b/src/ouroboros/evaluation/models.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from ouroboros.core.seed_contract import SeedContract
 from ouroboros.events.base import BaseEvent
 
 
@@ -311,6 +312,7 @@ class EvaluationContext:
         artifact_type: Type of artifact (code, document, etc.)
         goal: Original goal from seed
         constraints: Constraints from seed
+        seed_contract: Full interpreted Seed contract, when available
         artifact_bundle: Optional file-based artifacts for richer evaluation
     """
 
@@ -321,6 +323,7 @@ class EvaluationContext:
     artifact_type: str = "code"
     goal: str = ""
     constraints: tuple[str, ...] = ()
+    seed_contract: SeedContract | None = None
     artifact_bundle: ArtifactBundle | None = None
     trigger_consensus: bool = False
 

--- a/src/ouroboros/evaluation/semantic.py
+++ b/src/ouroboros/evaluation/semantic.py
@@ -13,6 +13,7 @@ import json
 
 from ouroboros.config import get_semantic_model
 from ouroboros.core.errors import ProviderError, ValidationError
+from ouroboros.core.seed_contract_prompt import render_seed_contract_for_evaluation
 from ouroboros.core.types import Result
 from ouroboros.evaluation.json_utils import extract_json_payload
 from ouroboros.evaluation.models import EvaluationContext, SemanticResult
@@ -101,11 +102,25 @@ def build_evaluation_prompt(context: EvaluationContext) -> str:
     Returns:
         Formatted prompt string
     """
-    constraints_text = (
-        "\n".join(f"- {c}" for c in context.constraints)
-        if context.constraints
-        else "None specified"
-    )
+    if context.seed_contract is not None:
+        seed_context = render_seed_contract_for_evaluation(context.seed_contract)
+        artifact_type = (
+            context.seed_contract.artifact_type
+            if context.artifact_type == "code"
+            else context.artifact_type
+        )
+    else:
+        constraints_text = (
+            "\n".join(f"- {c}" for c in context.constraints)
+            if context.constraints
+            else "None specified"
+        )
+        seed_context = f"""## Original Goal
+{context.goal if context.goal else "Not specified"}
+
+## Constraints
+{constraints_text}"""
+        artifact_type = context.artifact_type
 
     has_files = context.artifact_bundle and context.artifact_bundle.files
 
@@ -130,14 +145,10 @@ def build_evaluation_prompt(context: EvaluationContext) -> str:
 ## Acceptance Criterion
 {context.current_ac}
 
-## Original Goal
-{context.goal if context.goal else "Not specified"}
-
-## Constraints
-{constraints_text}
+{seed_context}
 
 ## Artifact Type
-{context.artifact_type}
+{artifact_type}
 
 {artifact_section}
 {code_section}

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import structlog
 
+from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import (
     MCPResourceNotFoundError,
@@ -781,6 +782,7 @@ def create_ouroboros_server(
         PipelineConfig,
         SemanticConfig,
     )
+    from ouroboros.evaluation.contract_audit import contract_audit_failure
     from ouroboros.mcp.job_manager import JobManager
     from ouroboros.mcp.tools.brownfield_handler import BrownfieldHandler
     from ouroboros.mcp.tools.definitions import (
@@ -1131,6 +1133,58 @@ def create_ouroboros_server(
             ac_results=tuple(corrected_results),
         )
 
+    async def _evaluate_semantically_against_seed(
+        seed: Any,
+        artifact: str,
+    ) -> EvaluationSummary:
+        """Evaluate artifact against the full Seed contract."""
+        # Fallback: LLM-based evaluation when no structured AC results
+        acs = getattr(seed, "acceptance_criteria", None)
+        if acs:
+            current_ac = "\n".join(f"AC {i + 1}: {ac}" for i, ac in enumerate(acs))
+        else:
+            current_ac = "Verify execution output meets requirements"
+
+        # Collect file-based artifacts for richer evaluation
+        project_dir = _extract_project_dir(artifact, seed=seed)
+        artifact_bundle = ArtifactCollector().collect(artifact, project_dir)
+
+        seed_contract = SeedContract.from_seed(seed)
+        eval_context = EvaluationContext(
+            execution_id=f"eval_{seed.metadata.seed_id}",
+            seed_id=seed.metadata.seed_id,
+            current_ac=current_ac,
+            artifact=artifact,
+            artifact_type=seed_contract.artifact_type,
+            goal=seed.goal,
+            constraints=tuple(seed.constraints),
+            seed_contract=seed_contract,
+            artifact_bundle=artifact_bundle,
+        )
+
+        eval_result = await evolution_eval_pipeline.evaluate(eval_context)
+        if eval_result.is_err:
+            return EvaluationSummary(
+                final_approved=False,
+                highest_stage_passed=1,
+                score=0.0,
+                drift_score=1.0,
+                failure_reason=f"Seed contract evaluation failed: {eval_result.error}",
+            )
+
+        result = eval_result.value
+        stage2 = result.stage2_result
+        audit_failure = contract_audit_failure(stage2)
+        final_approved = result.final_approved and audit_failure is None
+        return EvaluationSummary(
+            final_approved=final_approved,
+            highest_stage_passed=max(1, result.highest_stage_completed),
+            score=stage2.score if stage2 else None,
+            drift_score=stage2.drift_score if stage2 else None,
+            reward_hacking_risk=stage2.reward_hacking_risk if stage2 else None,
+            failure_reason=audit_failure or result.failure_reason,
+        )
+
     async def _evolution_evaluator(seed: Any, execution_output: str | None) -> EvaluationSummary:
         await _ensure_evolution_store_initialized()
 
@@ -1152,50 +1206,26 @@ def create_ouroboros_server(
             verified = await _verify_spec_compliance(seed, artifact, mechanical)
             if verified is not None:
                 return verified
+            # A structured AC PASS is necessary but not sufficient for Ralph
+            # convergence: the artifact must also preserve the Seed's semantic
+            # contract, including ontology boundaries and evaluation principles.
+            if mechanical.final_approved:
+                contract_audit = await _evaluate_semantically_against_seed(seed, artifact)
+                if not contract_audit.final_approved:
+                    return contract_audit
+                return mechanical.model_copy(
+                    update={
+                        "score": min(
+                            mechanical.score if mechanical.score is not None else 1.0,
+                            contract_audit.score if contract_audit.score is not None else 1.0,
+                        ),
+                        "drift_score": contract_audit.drift_score,
+                        "reward_hacking_risk": contract_audit.reward_hacking_risk,
+                    }
+                )
             return mechanical
 
-        # Fallback: LLM-based evaluation when no structured AC results
-        acs = getattr(seed, "acceptance_criteria", None)
-        if acs:
-            current_ac = "\n".join(f"AC {i + 1}: {ac}" for i, ac in enumerate(acs))
-        else:
-            current_ac = "Verify execution output meets requirements"
-
-        # Collect file-based artifacts for richer evaluation
-        project_dir = _extract_project_dir(artifact, seed=seed)
-        artifact_bundle = ArtifactCollector().collect(artifact, project_dir)
-
-        eval_context = EvaluationContext(
-            execution_id=f"eval_{seed.metadata.seed_id}",
-            seed_id=seed.metadata.seed_id,
-            current_ac=current_ac,
-            artifact=artifact,
-            artifact_type="code",
-            goal=seed.goal,
-            constraints=tuple(seed.constraints),
-            artifact_bundle=artifact_bundle,
-        )
-
-        eval_result = await evolution_eval_pipeline.evaluate(eval_context)
-        if eval_result.is_err:
-            return EvaluationSummary(
-                final_approved=False,
-                highest_stage_passed=1,
-                score=0.0,
-                drift_score=1.0,
-                failure_reason=str(eval_result.error),
-            )
-
-        result = eval_result.value
-        stage2 = result.stage2_result
-        return EvaluationSummary(
-            final_approved=result.final_approved,
-            highest_stage_passed=max(1, result.highest_stage_completed),
-            score=stage2.score if stage2 else None,
-            drift_score=stage2.drift_score if stage2 else None,
-            reward_hacking_risk=stage2.reward_hacking_risk if stage2 else None,
-            failure_reason=result.failure_reason,
-        )
+        return await _evaluate_semantically_against_seed(seed, artifact)
 
     async def _evolution_validator(seed: Any, execution_output: str | None) -> str:
         """Validate and reconcile code generated by parallel AC execution.
@@ -1210,6 +1240,10 @@ def create_ouroboros_server(
         from pathlib import Path  # noqa: I001
         import re
         import subprocess  # noqa: S404  # nosec
+
+        task_type = str(getattr(seed, "task_type", "code")).lower()
+        if task_type != "code":
+            return f"Validation skipped: task_type={task_type} does not require code validation"
 
         project_dir = _extract_project_dir(execution_output or "", seed=seed)
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -874,6 +874,7 @@ def create_ouroboros_server(
     )
 
     # Create evolution engines for evolve_step
+    from ouroboros.core.errors import ProviderError
     from ouroboros.core.lineage import ACResult, EvaluationSummary
     from ouroboros.evaluation.artifact_collector import ArtifactCollector
     from ouroboros.evolution.loop import EvolutionaryLoop, EvolutionaryLoopConfig
@@ -1136,6 +1137,8 @@ def create_ouroboros_server(
     async def _evaluate_semantically_against_seed(
         seed: Any,
         artifact: str,
+        *,
+        allow_provider_unavailable: bool = False,
     ) -> EvaluationSummary:
         """Evaluate artifact against the full Seed contract."""
         # Fallback: LLM-based evaluation when no structured AC results
@@ -1164,6 +1167,19 @@ def create_ouroboros_server(
 
         eval_result = await evolution_eval_pipeline.evaluate(eval_context)
         if eval_result.is_err:
+            if allow_provider_unavailable and isinstance(eval_result.error, ProviderError):
+                log.warning(
+                    "evolution.semantic_contract_audit.unavailable",
+                    error=str(eval_result.error),
+                    seed_id=seed.metadata.seed_id,
+                )
+                return EvaluationSummary(
+                    final_approved=True,
+                    highest_stage_passed=1,
+                    score=None,
+                    drift_score=None,
+                    reward_hacking_risk=None,
+                )
             return EvaluationSummary(
                 final_approved=False,
                 highest_stage_passed=1,
@@ -1210,19 +1226,24 @@ def create_ouroboros_server(
             # convergence: the artifact must also preserve the Seed's semantic
             # contract, including ontology boundaries and evaluation principles.
             if mechanical.final_approved:
-                contract_audit = await _evaluate_semantically_against_seed(seed, artifact)
+                contract_audit = await _evaluate_semantically_against_seed(
+                    seed,
+                    artifact,
+                    allow_provider_unavailable=True,
+                )
                 if not contract_audit.final_approved:
                     return contract_audit
-                return mechanical.model_copy(
-                    update={
-                        "score": min(
-                            mechanical.score if mechanical.score is not None else 1.0,
-                            contract_audit.score if contract_audit.score is not None else 1.0,
-                        ),
-                        "drift_score": contract_audit.drift_score,
-                        "reward_hacking_risk": contract_audit.reward_hacking_risk,
-                    }
-                )
+                audit_update: dict[str, Any] = {}
+                if contract_audit.score is not None:
+                    audit_update["score"] = min(
+                        mechanical.score if mechanical.score is not None else 1.0,
+                        contract_audit.score,
+                    )
+                if contract_audit.drift_score is not None:
+                    audit_update["drift_score"] = contract_audit.drift_score
+                if contract_audit.reward_hacking_risk is not None:
+                    audit_update["reward_hacking_risk"] = contract_audit.reward_hacking_risk
+                return mechanical.model_copy(update=audit_update)
             return mechanical
 
         return await _evaluate_semantically_against_seed(seed, artifact)

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -874,7 +874,7 @@ def create_ouroboros_server(
     )
 
     # Create evolution engines for evolve_step
-    from ouroboros.core.errors import ProviderError
+    from ouroboros.core.errors import ProviderError, ValidationError
     from ouroboros.core.lineage import ACResult, EvaluationSummary
     from ouroboros.evaluation.artifact_collector import ArtifactCollector
     from ouroboros.evolution.loop import EvolutionaryLoop, EvolutionaryLoopConfig
@@ -1167,9 +1167,12 @@ def create_ouroboros_server(
 
         eval_result = await evolution_eval_pipeline.evaluate(eval_context)
         if eval_result.is_err:
-            if allow_provider_unavailable and isinstance(eval_result.error, ProviderError):
+            if allow_provider_unavailable and isinstance(
+                eval_result.error, (ProviderError, ValidationError)
+            ):
                 log.warning(
                     "evolution.semantic_contract_audit.unavailable",
+                    error_type=type(eval_result.error).__name__,
                     error=str(eval_result.error),
                     seed_id=seed.metadata.seed_id,
                 )

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -503,6 +503,10 @@ class EvaluateHandler:
                 except Exception:
                     pass  # Best-effort enrichment
 
+            if seed_contract is not None and artifact_type == "code":
+                artifact_type = seed_contract.artifact_type
+            stage1_enabled = artifact_type == "code"
+
             # Derive current_ac from the unified acceptance_criteria tuple.
             # The tuple already incorporates both the plural and singular params,
             # so we only need to index or fall back to a default.
@@ -561,7 +565,7 @@ class EvaluateHandler:
             # best-effort, so a failed detect simply leaves Stage 1 empty and
             # the pipeline falls through to Stage 2 instead of phantom-failing
             # on hardcoded preset guesses.
-            if not has_mechanical_toml(working_dir):
+            if stage1_enabled and not has_mechanical_toml(working_dir):
                 try:
                     await ensure_mechanical_toml(
                         working_dir,
@@ -574,8 +578,9 @@ class EvaluateHandler:
                         working_dir=str(working_dir),
                         error=str(exc),
                     )
-            mechanical_config = build_mechanical_config(working_dir)
+            mechanical_config = build_mechanical_config(working_dir) if stage1_enabled else None
             config = PipelineConfig(
+                stage1_enabled=stage1_enabled,
                 mechanical=mechanical_config,
                 semantic=SemanticConfig(model=get_semantic_model(self.llm_backend)),
             )

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -466,7 +466,7 @@ class EvaluateHandler:
             artifact=artifact,
             artifact_type=artifact_type,
             seed_content=seed_content,
-            acceptance_criterion=acceptance_criterion,
+            acceptance_criteria=acceptance_criteria,
             working_dir=arguments.get("working_dir"),
             trigger_consensus=trigger_consensus,
         )

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -449,6 +449,9 @@ class EvaluateHandler:
         if not acceptance_criteria and acceptance_criterion and str(acceptance_criterion).strip():
             acceptance_criteria = (str(acceptance_criterion).strip(),)
 
+        if not seed_content:
+            seed_content = await self._load_seed_content_from_session(session_id)
+
         log.info(
             "mcp.tool.evaluate",
             session_id=session_id,
@@ -456,9 +459,6 @@ class EvaluateHandler:
             multi_ac_count=len(acceptance_criteria),
             trigger_consensus=trigger_consensus,
         )
-
-        if not seed_content:
-            seed_content = await self._load_seed_content_from_session(session_id)
 
         # --- Subagent dispatch: gate on runtime + opencode_mode ---
         payload = build_evaluate_subagent(

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -438,6 +438,7 @@ class EvaluateHandler:
             working_dir=arguments.get("working_dir"),
             trigger_consensus=trigger_consensus,
         )
+        delegated_artifact_type = str(payload.context.get("artifact_type", artifact_type))
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):
             await emit_subagent_dispatched_event(
                 self.event_store,
@@ -452,7 +453,7 @@ class EvaluateHandler:
                     "session_id": session_id,
                     "status": "delegated_to_subagent",
                     "dispatch_mode": "plugin",
-                    "artifact_type": artifact_type,
+                    "artifact_type": delegated_artifact_type,
                     "trigger_consensus": trigger_consensus,
                 },
             )

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -277,6 +277,35 @@ class EvaluateHandler:
     opencode_mode: str | None = field(default=None, repr=False)
     TIMEOUT_SECONDS: int = 0  # No server-side timeout; client/runtime decides.
 
+    async def _load_seed_content_from_session(self, session_id: str) -> str | None:
+        """Best-effort load of persisted Seed JSON for evaluation context."""
+        store = self.event_store
+        owns_event_store = False
+        if store is None:
+            store = EventStore()
+            owns_event_store = True
+
+        try:
+            await store.initialize()
+            repo = SessionRepository(store)
+            session_result = await repo.reconstruct_session(session_id)
+            if session_result.is_err:
+                return None
+            seed_json = session_result.value.progress.get("seed_json")
+            if isinstance(seed_json, str) and seed_json.strip():
+                return seed_json
+            return None
+        except Exception as exc:  # noqa: BLE001 - evaluation enrichment is best-effort
+            log.debug(
+                "mcp.tool.evaluate.seed_context_lookup_failed",
+                session_id=session_id,
+                error=str(exc),
+            )
+            return None
+        finally:
+            if owns_event_store and store is not None:
+                await store.close()
+
     @property
     def definition(self) -> MCPToolDefinition:
         """Return the tool definition."""
@@ -427,6 +456,9 @@ class EvaluateHandler:
             multi_ac_count=len(acceptance_criteria),
             trigger_consensus=trigger_consensus,
         )
+
+        if not seed_content:
+            seed_content = await self._load_seed_content_from_session(session_id)
 
         # --- Subagent dispatch: gate on runtime + opencode_mode ---
         payload = build_evaluate_subagent(

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -7,6 +7,7 @@ Contains handlers for drift measurement, evaluation, and lateral thinking tools:
 """
 
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,7 @@ import yaml
 from ouroboros.config import get_semantic_model
 from ouroboros.core.errors import ValidationError
 from ouroboros.core.seed import Seed
+from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.tools.subagent import (
@@ -59,6 +61,14 @@ def _evaluation_allowed_tools(runtime_backend: str | None) -> list[str]:
             execution_phase=PolicyExecutionPhase.EVALUATION,
         )
     )
+
+
+def _normalize_artifact_type(value: Any) -> str:
+    """Normalize legacy artifact type spellings for evaluation prompts."""
+    artifact_type = str(value or "code").strip().lower()
+    if artifact_type == "docs":
+        return "document"
+    return artifact_type or "code"
 
 
 @dataclass
@@ -317,10 +327,10 @@ class EvaluateHandler:
                 MCPToolParameter(
                     name="artifact_type",
                     type=ToolInputType.STRING,
-                    description="Type of artifact: code, docs, config. Default: code",
+                    description="Type of artifact: code, document, config. Default: code",
                     required=False,
                     default="code",
-                    enum=("code", "docs", "config"),
+                    enum=("code", "document", "config", "docs"),
                 ),
                 MCPToolParameter(
                     name="trigger_consensus",
@@ -390,7 +400,7 @@ class EvaluateHandler:
         seed_content = arguments.get("seed_content")
         acceptance_criterion = arguments.get("acceptance_criterion")
         acceptance_criteria_raw = arguments.get("acceptance_criteria")
-        artifact_type = arguments.get("artifact_type", "code")
+        artifact_type = _normalize_artifact_type(arguments.get("artifact_type", "code"))
         trigger_consensus = arguments.get("trigger_consensus", False)
 
         # Normalize all AC inputs into a single tuple (#366 fix):
@@ -456,6 +466,7 @@ class EvaluateHandler:
             # Extract goal/constraints from seed if provided
             goal = ""
             constraints: tuple[str, ...] = ()
+            seed_contract: SeedContract | None = None
             seed_id = session_id  # fallback
 
             if seed_content:
@@ -464,6 +475,7 @@ class EvaluateHandler:
                     seed = Seed.from_dict(seed_dict)
                     goal = seed.goal
                     constraints = tuple(seed.constraints)
+                    seed_contract = SeedContract.from_seed(seed)
                     seed_id = seed.metadata.seed_id
                 except (yaml.YAMLError, ValidationError, PydanticValidationError) as e:
                     log.warning("mcp.tool.evaluate.seed_parse_warning", error=str(e))
@@ -481,6 +493,12 @@ class EvaluateHandler:
                     if session_result.is_ok:
                         tracker = session_result.value
                         seed_id = tracker.seed_id
+                        seed_json = tracker.progress.get("seed_json")
+                        if isinstance(seed_json, str) and seed_json.strip():
+                            seed = Seed.from_dict(json.loads(seed_json))
+                            goal = seed.goal
+                            constraints = tuple(seed.constraints)
+                            seed_contract = SeedContract.from_seed(seed)
                 except Exception:
                     pass  # Best-effort enrichment
 
@@ -576,6 +594,7 @@ class EvaluateHandler:
                     artifact_type=artifact_type,
                     goal=goal,
                     constraints=constraints,
+                    seed_contract=seed_contract,
                     trigger_consensus=trigger_consensus,
                     artifact_bundle=artifact_bundle,
                     pipeline=pipeline,
@@ -590,6 +609,7 @@ class EvaluateHandler:
                 artifact_type=artifact_type,
                 goal=goal,
                 constraints=constraints,
+                seed_contract=seed_contract,
                 trigger_consensus=trigger_consensus,
                 artifact_bundle=artifact_bundle,
             )
@@ -684,6 +704,7 @@ class EvaluateHandler:
         artifact_type: str,
         goal: str,
         constraints: tuple[str, ...],
+        seed_contract: SeedContract | None,
         trigger_consensus: bool,
         artifact_bundle: object | None,
         pipeline: object,  # EvaluationPipeline — typed as object to avoid import cycle
@@ -727,6 +748,7 @@ class EvaluateHandler:
             artifact_type=artifact_type,
             goal=goal,
             constraints=constraints,
+            seed_contract=seed_contract,
             trigger_consensus=trigger_consensus,
             artifact_bundle=artifact_bundle,
         )
@@ -754,6 +776,7 @@ class EvaluateHandler:
                 artifact_type=artifact_type,
                 goal=goal,
                 constraints=constraints,
+                seed_contract=seed_contract,
                 trigger_consensus=trigger_consensus,
                 artifact_bundle=artifact_bundle,
             )

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -391,15 +391,21 @@ class EvolveStepHandler:
         qa_meta = None
         skip_qa = arguments.get("skip_qa", False)
         if step.action.value in ("continue", "converged") and execute and not skip_qa:
+            from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
             from ouroboros.mcp.tools.qa import QAHandler
 
             qa_handler = QAHandler()
-            quality_bar = "Generation must improve upon previous generation."
-            if initial_seed:
-                ac_lines = [f"- {ac}" for ac in initial_seed.acceptance_criteria]
-                quality_bar = "The execution must satisfy all acceptance criteria:\n" + "\n".join(
-                    ac_lines
-                )
+            generation_seed = gen.seed or initial_seed
+            quality_bar = (
+                ExecuteSeedHandler._derive_quality_bar(generation_seed)
+                if generation_seed is not None
+                else "Generation must improve upon previous generation."
+            )
+            qa_seed_content = (
+                yaml.safe_dump(generation_seed.to_dict(), sort_keys=False)
+                if generation_seed is not None
+                else seed_content or ""
+            )
 
             execution_artifact = gen.execution_output or "\n".join(text_lines)
             try:
@@ -419,7 +425,7 @@ class EvolveStepHandler:
                     "artifact_type": "test_output",
                     "quality_bar": quality_bar,
                     "reference": reference,
-                    "seed_content": seed_content or "",
+                    "seed_content": qa_seed_content,
                     "pass_threshold": 0.80,
                 }
             )

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -21,6 +21,8 @@ from ouroboros.core.errors import ValidationError
 from ouroboros.core.project_paths import resolve_seed_project_path
 from ouroboros.core.security import InputValidator
 from ouroboros.core.seed import Seed
+from ouroboros.core.seed_contract import SeedContract
+from ouroboros.core.seed_contract_prompt import render_seed_contract_for_evaluation
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import (
     TaskWorkspace,
@@ -686,9 +688,14 @@ class ExecuteSeedHandler(BridgeAwareMixin):
 
     @staticmethod
     def _derive_quality_bar(seed: Seed) -> str:
-        """Derive a quality bar string from seed acceptance criteria."""
+        """Derive a quality bar string from the full Seed contract."""
         ac_lines = [f"- {ac}" for ac in seed.acceptance_criteria]
-        return "The execution must satisfy all acceptance criteria:\n" + "\n".join(ac_lines)
+        contract = render_seed_contract_for_evaluation(SeedContract.from_seed(seed))
+        return (
+            "The execution must satisfy all acceptance criteria while preserving the Seed contract.\n\n"
+            f"{contract}\n\n"
+            "## Acceptance Criteria\n" + "\n".join(ac_lines)
+        )
 
     @staticmethod
     def _resolve_verification_working_dir(

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -31,6 +31,7 @@ Payload structure:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 import json
 import re
@@ -690,6 +691,7 @@ def build_evaluate_subagent(
     artifact_type: str | None = "code",
     seed_content: str | None = None,
     acceptance_criterion: str | None = None,
+    acceptance_criteria: Sequence[str] | None = None,
     working_dir: str | None = None,
     trigger_consensus: bool = False,
 ) -> SubagentPayload:
@@ -709,9 +711,27 @@ def build_evaluate_subagent(
         )
         seed_section = f"{contract_section}\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
 
+    effective_acceptance_criteria = tuple(
+        str(item).strip()
+        for item in (acceptance_criteria or ())
+        if isinstance(item, (str, int, float)) and str(item).strip()
+    )
+    if (
+        not effective_acceptance_criteria
+        and acceptance_criterion
+        and str(acceptance_criterion).strip()
+    ):
+        effective_acceptance_criteria = (str(acceptance_criterion).strip(),)
+
     ac_section = ""
-    if acceptance_criterion:
-        ac_section = f"\n## Acceptance Criterion\n{acceptance_criterion}\n"
+    if len(effective_acceptance_criteria) == 1:
+        ac_section = f"\n## Acceptance Criterion\n{effective_acceptance_criteria[0]}\n"
+    elif effective_acceptance_criteria:
+        rendered_criteria = "\n".join(
+            f"{index}. {criterion}"
+            for index, criterion in enumerate(effective_acceptance_criteria, start=1)
+        )
+        ac_section = f"\n## Acceptance Criteria\n{rendered_criteria}\n"
 
     consensus_note = ""
     if trigger_consensus:
@@ -748,7 +768,10 @@ Provide your evaluation with pass/fail verdict and detailed reasoning."""
         "artifact": artifact,
         "artifact_type": effective_artifact_type,
         "seed_content": seed_content,
-        "acceptance_criterion": acceptance_criterion,
+        "acceptance_criterion": (
+            effective_acceptance_criteria[0] if len(effective_acceptance_criteria) == 1 else None
+        ),
+        "acceptance_criteria": list(effective_acceptance_criteria),
         "working_dir": working_dir,
         "trigger_consensus": trigger_consensus,
     }

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -88,6 +88,12 @@ def _render_seed_contract_from_content(seed_content: str | None, *, purpose: str
     return f"\n{rendered}\n"
 
 
+def _seed_spec_fence_language(seed_content: str) -> str:
+    """Return the most readable Markdown fence language for Seed content."""
+    stripped = seed_content.lstrip()
+    return "json" if stripped.startswith(("{", "[")) else "yaml"
+
+
 # ---------------------------------------------------------------------------
 # SubagentPayload dataclass
 # ---------------------------------------------------------------------------
@@ -471,7 +477,10 @@ def build_qa_subagent(
             seed_content,
             purpose="evaluation",
         )
-        seed_section = f"{contract_section}\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
+        seed_language = _seed_spec_fence_language(seed_content)
+        seed_section = (
+            f"{contract_section}\n## Seed Specification\n```{seed_language}\n{seed_content}\n```\n"
+        )
 
     prompt = f"""{system_prompt}
 
@@ -709,7 +718,10 @@ def build_evaluate_subagent(
         contract_section = (
             f"\n{render_seed_contract_for_evaluation(contract)}\n" if contract is not None else ""
         )
-        seed_section = f"{contract_section}\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
+        seed_language = _seed_spec_fence_language(seed_content)
+        seed_section = (
+            f"{contract_section}\n## Seed Specification\n```{seed_language}\n{seed_content}\n```\n"
+        )
 
     effective_acceptance_criteria = tuple(
         str(item).strip()
@@ -810,6 +822,7 @@ def build_execute_subagent(
         qa_note = "\n## QA\nRun QA evaluation after execution completes.\n"
 
     contract_section = _render_seed_contract_from_content(seed_content, purpose="execution")
+    seed_language = _seed_spec_fence_language(seed_content)
 
     prompt = f"""## Your Task
 
@@ -823,7 +836,7 @@ in the seed, respecting constraints and acceptance criteria.
 {max_iterations}
 {seed_path_note}{cwd_note}{qa_note}{contract_section}
 ## Seed Specification
-```yaml
+```{seed_language}
 {seed_content}
 ```
 
@@ -1153,7 +1166,8 @@ def build_evolve_subagent(
     """
     seed_note = ""
     if seed_content:
-        seed_note = f"\n## Seed Specification (Gen 1)\n```yaml\n{seed_content}\n```\n"
+        seed_language = _seed_spec_fence_language(seed_content)
+        seed_note = f"\n## Seed Specification (Gen 1)\n```{seed_language}\n{seed_content}\n```\n"
 
     project_dir_note = ""
     if project_dir:

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -61,16 +61,23 @@ _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_ANSWER_CHARS = 220
 _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS = 300
 
 
-def _render_seed_contract_from_content(seed_content: str | None, *, purpose: str) -> str:
-    """Best-effort SeedContract rendering for delegated subagent prompts."""
+def _seed_contract_from_content(seed_content: str | None) -> SeedContract | None:
+    """Best-effort SeedContract parsing for delegated subagent prompts."""
     if not seed_content:
-        return ""
+        return None
     try:
         parsed = yaml.safe_load(seed_content)
         seed = Seed.from_dict(parsed)
-        contract = SeedContract.from_seed(seed)
+        return SeedContract.from_seed(seed)
     except Exception as exc:
         log.debug("subagent.seed_contract_render_skipped", error=str(exc))
+        return None
+
+
+def _render_seed_contract_from_content(seed_content: str | None, *, purpose: str) -> str:
+    """Best-effort SeedContract rendering for delegated subagent prompts."""
+    contract = _seed_contract_from_content(seed_content)
+    if contract is None:
         return ""
 
     if purpose == "evaluation":
@@ -690,12 +697,15 @@ def build_evaluate_subagent(
     from ouroboros.agents.loader import load_agent_prompt
 
     system_prompt = load_agent_prompt("evaluator")
+    effective_artifact_type = artifact_type or "code"
+    contract = _seed_contract_from_content(seed_content)
+    if contract is not None and effective_artifact_type == "code":
+        effective_artifact_type = contract.artifact_type
 
     seed_section = ""
     if seed_content:
-        contract_section = _render_seed_contract_from_content(
-            seed_content,
-            purpose="evaluation",
+        contract_section = (
+            f"\n{render_seed_contract_for_evaluation(contract)}\n" if contract is not None else ""
         )
         seed_section = f"{contract_section}\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
 
@@ -724,7 +734,7 @@ and goal alignment. Provide a detailed semantic evaluation.
 {session_id}
 {seed_section}{ac_section}{consensus_note}
 ## Artifact Type
-{artifact_type or "code"}
+{effective_artifact_type}
 
 ## Artifact
 ```
@@ -736,7 +746,7 @@ Provide your evaluation with pass/fail verdict and detailed reasoning."""
     context: dict[str, Any] = {
         "session_id": session_id,
         "artifact": artifact,
-        "artifact_type": artifact_type,
+        "artifact_type": effective_artifact_type,
         "seed_content": seed_content,
         "acceptance_criterion": acceptance_criterion,
         "working_dir": working_dir,

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -37,7 +37,14 @@ import re
 from typing import Any
 
 import structlog
+import yaml
 
+from ouroboros.core.seed import Seed
+from ouroboros.core.seed_contract import SeedContract
+from ouroboros.core.seed_contract_prompt import (
+    render_seed_contract_for_evaluation,
+    render_seed_contract_for_execution,
+)
 from ouroboros.core.types import Result
 from ouroboros.mcp.types import (
     ContentType,
@@ -52,6 +59,26 @@ _INTERVIEW_SUBAGENT_MAX_PREVIOUS_TRANSCRIPT_CHARS = 200
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_QUESTION_CHARS = 900
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_ANSWER_CHARS = 220
 _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS = 300
+
+
+def _render_seed_contract_from_content(seed_content: str | None, *, purpose: str) -> str:
+    """Best-effort SeedContract rendering for delegated subagent prompts."""
+    if not seed_content:
+        return ""
+    try:
+        parsed = yaml.safe_load(seed_content)
+        seed = Seed.from_dict(parsed)
+        contract = SeedContract.from_seed(seed)
+    except Exception as exc:
+        log.debug("subagent.seed_contract_render_skipped", error=str(exc))
+        return ""
+
+    if purpose == "evaluation":
+        rendered = render_seed_contract_for_evaluation(contract)
+    else:
+        rendered = render_seed_contract_for_execution(contract)
+    return f"\n{rendered}\n"
+
 
 # ---------------------------------------------------------------------------
 # SubagentPayload dataclass
@@ -432,7 +459,11 @@ def build_qa_subagent(
     # Build seed section
     seed_section = ""
     if seed_content:
-        seed_section = f"\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
+        contract_section = _render_seed_contract_from_content(
+            seed_content,
+            purpose="evaluation",
+        )
+        seed_section = f"{contract_section}\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
 
     prompt = f"""{system_prompt}
 
@@ -662,7 +693,11 @@ def build_evaluate_subagent(
 
     seed_section = ""
     if seed_content:
-        seed_section = f"\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
+        contract_section = _render_seed_contract_from_content(
+            seed_content,
+            purpose="evaluation",
+        )
+        seed_section = f"{contract_section}\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
 
     ac_section = ""
     if acceptance_criterion:
@@ -741,6 +776,8 @@ def build_execute_subagent(
     else:
         qa_note = "\n## QA\nRun QA evaluation after execution completes.\n"
 
+    contract_section = _render_seed_contract_from_content(seed_content, purpose="execution")
+
     prompt = f"""## Your Task
 
 Execute the following seed specification. Implement all requirements defined
@@ -751,7 +788,7 @@ in the seed, respecting constraints and acceptance criteria.
 
 ## Max Iterations
 {max_iterations}
-{seed_path_note}{cwd_note}{qa_note}
+{seed_path_note}{cwd_note}{qa_note}{contract_section}
 ## Seed Specification
 ```yaml
 {seed_content}

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -23,6 +23,7 @@ import asyncio
 from contextlib import aclosing
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
+import json
 from typing import TYPE_CHECKING, Any, NamedTuple
 from uuid import uuid4
 
@@ -1451,6 +1452,7 @@ class OrchestratorRunner:
             seed_id=seed.metadata.seed_id,
             session_id=session_id,
             seed_goal=seed.goal,
+            seed_json=json.dumps(seed.to_dict()),
         )
 
         if session_result.is_err:

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -485,6 +485,7 @@ class SessionRepository:
         seed_id: str,
         session_id: str | None = None,
         seed_goal: str | None = None,
+        seed_json: str | None = None,
     ) -> Result[SessionTracker, PersistenceError]:
         """Create a new session and persist start event.
 
@@ -493,6 +494,7 @@ class SessionRepository:
             seed_id: Seed ID being executed.
             session_id: Optional custom session ID.
             seed_goal: Optional goal text to persist with the start event.
+            seed_json: Optional full Seed JSON to preserve evaluation context.
 
         Returns:
             Result containing new SessionTracker.
@@ -506,6 +508,8 @@ class SessionRepository:
         }
         if seed_goal:
             event_data["seed_goal"] = seed_goal
+        if seed_json:
+            event_data["seed_json"] = seed_json
 
         event = BaseEvent(
             type="orchestrator.session.started",
@@ -814,6 +818,11 @@ class SessionRepository:
                 start_time=datetime.fromisoformat(
                     start_event.data.get("start_time", datetime.now(UTC).isoformat())
                 ),
+                progress={
+                    "seed_json": start_event.data["seed_json"],
+                }
+                if start_event.data.get("seed_json")
+                else {},
             )
 
             execution_id = start_event.data.get("execution_id", "")

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -885,6 +885,8 @@ class SessionRepository:
                     }:
                         explicit_terminal_status = status_update
 
+            last_progress = self._merge_progress_payloads(tracker.progress, last_progress)
+
             # Sanitize stale runtime metadata when session reached a terminal
             # state.  Progress events captured during execution may contain
             # ``runtime_status: running`` which contradicts the authoritative

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -53,6 +53,7 @@ def create_mock_completion_response(
 
 def create_valid_extraction_response(
     goal: str = "Build a CLI task manager with project grouping",
+    task_type: str = "code",
     constraints: str = "Python 3.14+ | No external database | Single-file storage",
     acceptance_criteria: str = "Tasks can be created | Tasks can be listed | Tasks can be deleted",
     ontology_name: str = "TaskManager",
@@ -63,6 +64,7 @@ def create_valid_extraction_response(
 ) -> str:
     """Create a valid LLM extraction response string."""
     return f"""GOAL: {goal}
+TASK_TYPE: {task_type}
 CONSTRAINTS: {constraints}
 ACCEPTANCE_CRITERIA: {acceptance_criteria}
 ONTOLOGY_NAME: {ontology_name}
@@ -328,6 +330,34 @@ class TestSeedGeneratorExtraction:
 
             assert result.is_ok
             assert result.value.goal == "Build a task management CLI tool"
+
+    @pytest.mark.asyncio
+    async def test_generate_extracts_task_type(self) -> None:
+        """SeedGenerator extracts task_type so non-code work keeps its strategy."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds(
+            initial_context="Analyze whether to launch a customer interview program"
+        )
+        low_ambiguity = create_low_ambiguity_score()
+
+        extraction_response = create_valid_extraction_response(
+            goal="Analyze whether to launch a customer interview program",
+            task_type="analysis",
+        )
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert result.value.task_type == "analysis"
 
     @pytest.mark.asyncio
     async def test_generate_extracts_constraints(self) -> None:

--- a/tests/unit/evaluation/test_consensus.py
+++ b/tests/unit/evaluation/test_consensus.py
@@ -6,6 +6,8 @@ import pytest
 
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.ontology_aspect import AnalysisResult
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.types import Result
 from ouroboros.evaluation.consensus import (
     ConsensusConfig,
@@ -55,6 +57,43 @@ class TestBuildConsensusPrompt:
         assert "User can logout" in prompt
         assert "Build auth system" in prompt
         assert "Must be secure" in prompt
+
+    def test_seed_contract_context_includes_ontology_lens(self) -> None:
+        """Consensus reviewers judge against the full Seed contract when available."""
+        seed = Seed(
+            goal="Write a decision brief",
+            task_type="analysis",
+            constraints=("Do not produce source code",),
+            acceptance_criteria=("Brief makes a clear recommendation",),
+            ontology_schema=OntologySchema(
+                name="DecisionBrief",
+                description="Decision brief concepts",
+                fields=(
+                    OntologyField(
+                        name="recommendation",
+                        field_type="string",
+                        description="Chosen path and rationale",
+                    ),
+                ),
+            ),
+            metadata=SeedMetadata(ambiguity_score=0.1),
+        )
+        context = EvaluationContext(
+            execution_id="exec-1",
+            seed_id="seed-1",
+            current_ac="Brief makes a clear recommendation",
+            artifact="Ship option B.",
+            artifact_type="document",
+            seed_contract=SeedContract.from_seed(seed),
+        )
+
+        prompt = build_consensus_prompt(context)
+
+        assert "## Seed Contract" in prompt
+        assert "conceptual lens for evaluation judgments" in prompt
+        assert "- recommendation: Chosen path and rationale (required concept)" in prompt
+        assert "Do not produce source code" in prompt
+        assert "## Artifact (document)" in prompt
 
 
 class TestParseVoteResponse:

--- a/tests/unit/evaluation/test_consensus.py
+++ b/tests/unit/evaluation/test_consensus.py
@@ -91,7 +91,7 @@ class TestBuildConsensusPrompt:
 
         assert "## Seed Contract" in prompt
         assert "conceptual lens for evaluation judgments" in prompt
-        assert "- recommendation: Chosen path and rationale (required concept)" in prompt
+        assert "- recommendation [string]: Chosen path and rationale (required concept)" in prompt
         assert "Do not produce source code" in prompt
         assert "## Artifact (document)" in prompt
 

--- a/tests/unit/evaluation/test_contract_audit.py
+++ b/tests/unit/evaluation/test_contract_audit.py
@@ -1,0 +1,38 @@
+"""Tests for Seed contract audit gates."""
+
+from __future__ import annotations
+
+from ouroboros.evaluation.contract_audit import contract_audit_failure
+from ouroboros.evaluation.models import SemanticResult
+
+
+def _semantic(**overrides) -> SemanticResult:
+    data = {
+        "score": 0.9,
+        "ac_compliance": True,
+        "goal_alignment": 0.9,
+        "drift_score": 0.1,
+        "uncertainty": 0.1,
+        "reasoning": "Strong contract alignment",
+        "reward_hacking_risk": 0.0,
+    }
+    data.update(overrides)
+    return SemanticResult(**data)
+
+
+def test_contract_audit_passes_strong_semantic_result() -> None:
+    assert contract_audit_failure(_semantic()) is None
+
+
+def test_contract_audit_fails_high_drift_even_when_ac_passes() -> None:
+    failure = contract_audit_failure(_semantic(drift_score=0.7))
+
+    assert failure is not None
+    assert "drift score" in failure
+
+
+def test_contract_audit_fails_reward_hacking_risk() -> None:
+    failure = contract_audit_failure(_semantic(reward_hacking_risk=0.8))
+
+    assert failure is not None
+    assert "reward hacking risk" in failure

--- a/tests/unit/evaluation/test_contract_audit.py
+++ b/tests/unit/evaluation/test_contract_audit.py
@@ -24,11 +24,45 @@ def test_contract_audit_passes_strong_semantic_result() -> None:
     assert contract_audit_failure(_semantic()) is None
 
 
+def test_contract_audit_fails_when_semantic_result_missing() -> None:
+    failure = contract_audit_failure(None)
+
+    assert failure == "Seed contract audit failed: semantic evaluation did not run"
+
+
+def test_contract_audit_fails_ac_non_compliance() -> None:
+    failure = contract_audit_failure(_semantic(ac_compliance=False))
+
+    assert failure is not None
+    assert "acceptance criteria were not semantically satisfied" in failure
+
+
+def test_contract_audit_fails_low_score() -> None:
+    failure = contract_audit_failure(_semantic(score=0.7))
+
+    assert failure is not None
+    assert "score 0.70 < 0.80" in failure
+
+
+def test_contract_audit_fails_low_goal_alignment() -> None:
+    failure = contract_audit_failure(_semantic(goal_alignment=0.7))
+
+    assert failure is not None
+    assert "goal alignment 0.70 < 0.80" in failure
+
+
 def test_contract_audit_fails_high_drift_even_when_ac_passes() -> None:
     failure = contract_audit_failure(_semantic(drift_score=0.7))
 
     assert failure is not None
     assert "drift score" in failure
+
+
+def test_contract_audit_fails_high_uncertainty() -> None:
+    failure = contract_audit_failure(_semantic(uncertainty=0.7))
+
+    assert failure is not None
+    assert "uncertainty 0.70 > 0.30" in failure
 
 
 def test_contract_audit_fails_reward_hacking_risk() -> None:

--- a/tests/unit/evaluation/test_semantic.py
+++ b/tests/unit/evaluation/test_semantic.py
@@ -139,7 +139,7 @@ class TestBuildEvaluationPrompt:
         assert "## Seed Contract" in prompt
         assert "immutable source of truth for this evaluation" in prompt
         assert "conceptual lens for evaluation judgments" in prompt
-        assert "- claim: Central answer to evaluate (required concept)" in prompt
+        assert "- claim [string]: Central answer to evaluate (required concept)" in prompt
         assert "No code output required" in prompt
         assert "## Artifact Type\ndocument" in prompt
 

--- a/tests/unit/evaluation/test_semantic.py
+++ b/tests/unit/evaluation/test_semantic.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 from ouroboros.core.errors import ProviderError
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.types import Result
 from ouroboros.evaluation.models import ArtifactBundle, EvaluationContext, FileArtifact
 from ouroboros.evaluation.semantic import (
@@ -102,6 +104,44 @@ class TestBuildEvaluationPrompt:
         assert "artifact summary from file" in prompt
         assert "## Artifact Content" not in prompt
         assert "inline artifact text that should not be duplicated" not in prompt
+
+    def test_seed_contract_context_includes_ontology_lens(self) -> None:
+        """Semantic evaluation judges against the full Seed contract when available."""
+        seed = Seed(
+            goal="Create a concise research memo",
+            task_type="analysis",
+            constraints=("No code output required",),
+            acceptance_criteria=("Memo answers the research question",),
+            ontology_schema=OntologySchema(
+                name="ResearchMemo",
+                description="Research memo concepts",
+                fields=(
+                    OntologyField(
+                        name="claim",
+                        field_type="string",
+                        description="Central answer to evaluate",
+                    ),
+                ),
+            ),
+            metadata=SeedMetadata(ambiguity_score=0.1),
+        )
+        context = EvaluationContext(
+            execution_id="exec-1",
+            seed_id="seed-1",
+            current_ac="Memo answers the research question",
+            artifact="The memo says...",
+            artifact_type="document",
+            seed_contract=SeedContract.from_seed(seed),
+        )
+
+        prompt = build_evaluation_prompt(context)
+
+        assert "## Seed Contract" in prompt
+        assert "immutable source of truth for this evaluation" in prompt
+        assert "conceptual lens for evaluation judgments" in prompt
+        assert "- claim: Central answer to evaluate (required concept)" in prompt
+        assert "No code output required" in prompt
+        assert "## Artifact Type\ndocument" in prompt
 
 
 class TestParseSemanticResponse:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from ouroboros.core.errors import ProviderError
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPResourceNotFoundError, MCPServerError
 from ouroboros.mcp.server.adapter import (
@@ -16,6 +18,7 @@ from ouroboros.mcp.server.adapter import (
     _project_dir_from_artifact,
     _project_dir_from_seed,
     _safe_cwd,
+    create_ouroboros_server,
     validate_transport,
 )
 from ouroboros.mcp.types import (
@@ -28,6 +31,7 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
+from ouroboros.persistence.event_store import EventStore
 
 
 class MockToolHandler:
@@ -170,6 +174,64 @@ Feedback Metadata JSON: {"feedback_metadata": [{"code": "decomposition_depth_war
         assert feedback[0].source == "parallel_executor"
         assert feedback[0].details["max_depth"] == 3
         assert feedback[0].details["affected_ac_paths"] == ["1.1.1"]
+
+    @pytest.mark.asyncio
+    async def test_evolution_evaluator_soft_fallback_when_semantic_provider_unavailable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Structured AC approval should survive semantic ProviderError in offline paths."""
+
+        class FailingAdapter:
+            async def complete(self, *args: Any, **kwargs: Any):  # noqa: ANN002, ANN003
+                return Result.err(ProviderError("semantic backend unavailable", provider="test"))
+
+        import ouroboros.orchestrator as orchestrator
+        import ouroboros.providers as providers
+
+        def _failing_adapter_factory(**_kwargs: Any) -> FailingAdapter:
+            return FailingAdapter()
+
+        monkeypatch.setattr(orchestrator, "create_agent_runtime", _failing_adapter_factory)
+        monkeypatch.setattr(providers, "create_llm_adapter", _failing_adapter_factory)
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        try:
+            server = create_ouroboros_server(
+                event_store=store,
+                runtime_backend="claude",
+                llm_backend="test",
+            )
+            handler = server._tool_handlers["ouroboros_evolve_step"]
+            evaluator = handler.evolutionary_loop.evaluator
+
+            seed = Seed(
+                goal="Write a decision brief",
+                task_type="analysis",
+                constraints=("Do not write source code",),
+                acceptance_criteria=("Brief makes a clear recommendation",),
+                ontology_schema=OntologySchema(
+                    name="DecisionBrief",
+                    description="Decision brief ontology",
+                    fields=(
+                        OntologyField(
+                            name="recommendation",
+                            field_type="string",
+                            description="Chosen path",
+                        ),
+                    ),
+                ),
+                metadata=SeedMetadata(seed_id="seed_123", ambiguity_score=0.1),
+            )
+            artifact = "## AC Results\n### AC 1: [PASS] Brief makes a clear recommendation"
+
+            summary = await evaluator(seed, artifact)
+
+            assert summary.final_approved is True
+            assert summary.score == 1.0
+            assert summary.ac_results[0].passed is True
+        finally:
+            await store.close()
 
 
 class TestMCPServerAdapterTools:

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -32,6 +32,7 @@ from ouroboros.mcp.types import (
     ToolInputType,
 )
 from ouroboros.persistence.event_store import EventStore
+from ouroboros.providers.base import CompletionResponse, UsageInfo
 
 
 class MockToolHandler:
@@ -288,6 +289,84 @@ Feedback Metadata JSON: {"feedback_metadata": [{"code": "decomposition_depth_war
             assert summary.final_approved is True
             assert summary.score == 1.0
             assert summary.ac_results[0].passed is True
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_evolution_evaluator_rejects_real_semantic_contract_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Structured AC approval should still fail on a valid contract audit failure."""
+
+        class DriftAuditAdapter:
+            async def complete(self, *args: Any, **kwargs: Any):  # noqa: ANN002, ANN003
+                return Result.ok(
+                    CompletionResponse(
+                        content="""{
+                            "score": 0.92,
+                            "ac_compliance": true,
+                            "goal_alignment": 0.9,
+                            "drift_score": 0.8,
+                            "uncertainty": 0.1,
+                            "reasoning": "The artifact passes the written AC but drifts from intent.",
+                            "reward_hacking_risk": 0.0
+                        }""",
+                        model="test",
+                        usage=UsageInfo(
+                            prompt_tokens=1,
+                            completion_tokens=1,
+                            total_tokens=2,
+                        ),
+                    )
+                )
+
+        import ouroboros.orchestrator as orchestrator
+        import ouroboros.providers as providers
+
+        def _drift_adapter_factory(**_kwargs: Any) -> DriftAuditAdapter:
+            return DriftAuditAdapter()
+
+        monkeypatch.setattr(orchestrator, "create_agent_runtime", _drift_adapter_factory)
+        monkeypatch.setattr(providers, "create_llm_adapter", _drift_adapter_factory)
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        try:
+            server = create_ouroboros_server(
+                event_store=store,
+                runtime_backend="claude",
+                llm_backend="test",
+            )
+            handler = server._tool_handlers["ouroboros_evolve_step"]
+            evaluator = handler.evolutionary_loop.evaluator
+
+            seed = Seed(
+                goal="Write a decision brief",
+                task_type="analysis",
+                constraints=("Do not write source code",),
+                acceptance_criteria=("Brief makes a clear recommendation",),
+                ontology_schema=OntologySchema(
+                    name="DecisionBrief",
+                    description="Decision brief ontology",
+                    fields=(
+                        OntologyField(
+                            name="recommendation",
+                            field_type="string",
+                            description="Chosen path",
+                        ),
+                    ),
+                ),
+                metadata=SeedMetadata(seed_id="seed_123", ambiguity_score=0.1),
+            )
+            artifact = "## AC Results\n### AC 1: [PASS] Brief makes a clear recommendation"
+
+            summary = await evaluator(seed, artifact)
+
+            assert summary.final_approved is False
+            assert summary.highest_stage_passed == 2
+            assert summary.failure_reason
+            assert "Seed contract audit failed" in summary.failure_reason
+            assert "drift score 0.80 > 0.30" in summary.failure_reason
         finally:
             await store.close()
 

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from ouroboros.core.errors import ProviderError
+from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPResourceNotFoundError, MCPServerError
@@ -194,6 +194,64 @@ Feedback Metadata JSON: {"feedback_metadata": [{"code": "decomposition_depth_war
 
         monkeypatch.setattr(orchestrator, "create_agent_runtime", _failing_adapter_factory)
         monkeypatch.setattr(providers, "create_llm_adapter", _failing_adapter_factory)
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        try:
+            server = create_ouroboros_server(
+                event_store=store,
+                runtime_backend="claude",
+                llm_backend="test",
+            )
+            handler = server._tool_handlers["ouroboros_evolve_step"]
+            evaluator = handler.evolutionary_loop.evaluator
+
+            seed = Seed(
+                goal="Write a decision brief",
+                task_type="analysis",
+                constraints=("Do not write source code",),
+                acceptance_criteria=("Brief makes a clear recommendation",),
+                ontology_schema=OntologySchema(
+                    name="DecisionBrief",
+                    description="Decision brief ontology",
+                    fields=(
+                        OntologyField(
+                            name="recommendation",
+                            field_type="string",
+                            description="Chosen path",
+                        ),
+                    ),
+                ),
+                metadata=SeedMetadata(seed_id="seed_123", ambiguity_score=0.1),
+            )
+            artifact = "## AC Results\n### AC 1: [PASS] Brief makes a clear recommendation"
+
+            summary = await evaluator(seed, artifact)
+
+            assert summary.final_approved is True
+            assert summary.score == 1.0
+            assert summary.ac_results[0].passed is True
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_evolution_evaluator_soft_fallback_when_semantic_audit_malformed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Structured AC approval should survive malformed semantic audit output."""
+
+        class MalformedAuditAdapter:
+            async def complete(self, *args: Any, **kwargs: Any):  # noqa: ANN002, ANN003
+                return Result.err(ValidationError("malformed evaluator output"))
+
+        import ouroboros.orchestrator as orchestrator
+        import ouroboros.providers as providers
+
+        def _malformed_adapter_factory(**_kwargs: Any) -> MalformedAuditAdapter:
+            return MalformedAuditAdapter()
+
+        monkeypatch.setattr(orchestrator, "create_agent_runtime", _malformed_adapter_factory)
+        monkeypatch.setattr(providers, "create_llm_adapter", _malformed_adapter_factory)
 
         store = EventStore("sqlite+aiosqlite:///:memory:")
         try:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -781,6 +782,87 @@ class TestEvaluateHandler:
 
         assert result.is_err
         assert "artifact is required" in str(result.error)
+
+    async def test_document_seed_skips_stage1_mechanical_checks(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Research/analysis Seed evaluation should not fail on code-project Stage 1."""
+        import ouroboros.evaluation as evaluation
+        from ouroboros.evaluation.models import EvaluationResult, SemanticResult
+        import ouroboros.mcp.tools.evaluation_handlers as evaluation_handlers
+
+        captured: dict[str, object] = {}
+
+        class FakePipeline:
+            def __init__(self, llm_adapter: object, config: object) -> None:
+                captured["config"] = config
+
+            async def evaluate(self, context: Any, *_args: object, **_kwargs: object):
+                captured["context"] = context
+                return Result.ok(
+                    EvaluationResult(
+                        execution_id=context.execution_id,
+                        stage1_result=None,
+                        stage2_result=SemanticResult(
+                            score=0.9,
+                            ac_compliance=True,
+                            goal_alignment=0.9,
+                            drift_score=0.0,
+                            uncertainty=0.1,
+                            reasoning="document satisfies the contract",
+                        ),
+                        final_approved=True,
+                    )
+                )
+
+        def _fake_llm_adapter(**_kwargs: object) -> object:
+            return object()
+
+        def _unexpected_stage1_call(*_args: object, **_kwargs: object) -> bool:
+            pytest.fail("document evaluation should not touch Stage 1 mechanical checks")
+
+        monkeypatch.setattr(evaluation, "EvaluationPipeline", FakePipeline)
+        monkeypatch.setattr(evaluation, "has_mechanical_toml", _unexpected_stage1_call)
+        monkeypatch.setattr(evaluation, "ensure_mechanical_toml", _unexpected_stage1_call)
+        monkeypatch.setattr(evaluation, "build_mechanical_config", _unexpected_stage1_call)
+        monkeypatch.setattr(evaluation_handlers, "create_llm_adapter", _fake_llm_adapter)
+
+        seed_content = """
+goal: Write a decision brief
+task_type: analysis
+constraints:
+  - Do not produce source code
+acceptance_criteria:
+  - Brief makes a clear recommendation
+ontology_schema:
+  name: DecisionBrief
+  description: Decision brief concepts
+  fields:
+    - name: recommendation
+      type: string
+      description: Chosen path and rationale
+metadata:
+  ambiguity_score: 0.1
+""".strip()
+
+        handler = EvaluateHandler()
+        result = await handler.handle(
+            {
+                "session_id": "sess-doc",
+                "artifact": "Recommendation: choose option B.",
+                "seed_content": seed_content,
+                "working_dir": str(tmp_path),
+            }
+        )
+
+        assert result.is_ok
+        config: Any = captured["config"]
+        context: Any = captured["context"]
+        assert config.stage1_enabled is False
+        assert config.mechanical is None
+        assert context.artifact_type == "document"
 
 
 class TestEvaluateHandlerCodeChanges:

--- a/tests/unit/mcp/tools/test_execution_quality_bar.py
+++ b/tests/unit/mcp/tools/test_execution_quality_bar.py
@@ -31,6 +31,6 @@ def test_derive_quality_bar_uses_full_seed_contract() -> None:
     assert "preserving the Seed contract" in quality_bar
     assert "## Seed Contract" in quality_bar
     assert "conceptual lens for evaluation judgments" in quality_bar
-    assert "- claim: Central answer to evaluate (required concept)" in quality_bar
+    assert "- claim [string]: Central answer to evaluate (required concept)" in quality_bar
     assert "Do not produce source code" in quality_bar
     assert "- Memo answers the research question" in quality_bar

--- a/tests/unit/mcp/tools/test_execution_quality_bar.py
+++ b/tests/unit/mcp/tools/test_execution_quality_bar.py
@@ -1,0 +1,36 @@
+"""Tests for post-execution QA quality bar derivation."""
+
+from __future__ import annotations
+
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+
+
+def test_derive_quality_bar_uses_full_seed_contract() -> None:
+    """Post-run QA should judge ACs through the same Seed ontology lens."""
+    seed = Seed(
+        goal="Write a concise research memo",
+        constraints=("Do not produce source code",),
+        acceptance_criteria=("Memo answers the research question",),
+        ontology_schema=OntologySchema(
+            name="ResearchMemo",
+            description="Research memo concepts",
+            fields=(
+                OntologyField(
+                    name="claim",
+                    field_type="string",
+                    description="Central answer to evaluate",
+                ),
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.1),
+    )
+
+    quality_bar = ExecuteSeedHandler._derive_quality_bar(seed)
+
+    assert "preserving the Seed contract" in quality_bar
+    assert "## Seed Contract" in quality_bar
+    assert "conceptual lens for evaluation judgments" in quality_bar
+    assert "- claim: Central answer to evaluate (required concept)" in quality_bar
+    assert "Do not produce source code" in quality_bar
+    assert "- Memo answers the research question" in quality_bar

--- a/tests/unit/mcp/tools/test_handler_subagent_wiring.py
+++ b/tests/unit/mcp/tools/test_handler_subagent_wiring.py
@@ -10,13 +10,17 @@ instead of calling LLMs directly. Each handler.handle() should:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
 from ouroboros.core.types import Result
+from ouroboros.orchestrator.session import SessionRepository
+from ouroboros.persistence.event_store import EventStore
 
 # ---------------------------------------------------------------------------
 # Shared mock helper for plugin I/O
@@ -262,6 +266,60 @@ class TestEvaluateHandlerSubagentDispatch:
         assert ctx["session_id"] == "sess-123"
         assert ctx["seed_content"] == "goal: test"
         assert ctx["trigger_consensus"] is True
+
+    async def test_plugin_dispatch_enriches_seed_content_from_session(self) -> None:
+        from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+        try:
+            seed = Seed(
+                goal="Write a decision brief",
+                task_type="analysis",
+                constraints=("Do not produce source code",),
+                acceptance_criteria=("Brief makes a clear recommendation",),
+                ontology_schema=OntologySchema(
+                    name="DecisionBrief",
+                    description="Decision brief concepts",
+                    fields=(
+                        OntologyField(
+                            name="recommendation",
+                            field_type="string",
+                            description="Chosen path and rationale",
+                        ),
+                    ),
+                ),
+                metadata=SeedMetadata(seed_id="seed-doc", ambiguity_score=0.1),
+            )
+            repo = SessionRepository(store)
+            create_result = await repo.create_session(
+                execution_id="exec-doc",
+                seed_id="seed-doc",
+                session_id="sess-doc",
+                seed_json=json.dumps(seed.to_dict()),
+            )
+            assert create_result.is_ok
+
+            handler = EvaluateHandler(
+                event_store=store,
+                agent_runtime_backend="opencode",
+                opencode_mode="plugin",
+            )
+            result = await handler.handle(
+                {
+                    "session_id": "sess-doc",
+                    "artifact": "Recommendation: choose option B.",
+                }
+            )
+
+            assert result.is_ok
+            payload = result.value.meta["_subagent"]
+            ctx = payload["context"]
+            assert ctx["artifact_type"] == "document"
+            assert "Write a decision brief" in ctx["seed_content"]
+            assert "## Seed Contract" in payload["prompt"]
+        finally:
+            await store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_handler_subagent_wiring.py
+++ b/tests/unit/mcp/tools/test_handler_subagent_wiring.py
@@ -267,6 +267,32 @@ class TestEvaluateHandlerSubagentDispatch:
         assert ctx["seed_content"] == "goal: test"
         assert ctx["trigger_consensus"] is True
 
+    async def test_plugin_dispatch_preserves_plural_acceptance_criteria(self, handler) -> None:
+        result = await handler.handle(
+            {
+                "session_id": "sess-123",
+                "artifact": "evaluation target",
+                "acceptance_criterion": "Legacy single AC should be ignored",
+                "acceptance_criteria": [
+                    "First AC is satisfied",
+                    "Second AC is satisfied",
+                ],
+            }
+        )
+
+        assert result.is_ok
+        payload = result.value.meta["_subagent"]
+        ctx = payload["context"]
+        assert ctx["acceptance_criteria"] == [
+            "First AC is satisfied",
+            "Second AC is satisfied",
+        ]
+        assert ctx["acceptance_criterion"] is None
+        assert "## Acceptance Criteria" in payload["prompt"]
+        assert "1. First AC is satisfied" in payload["prompt"]
+        assert "2. Second AC is satisfied" in payload["prompt"]
+        assert "Legacy single AC should be ignored" not in payload["prompt"]
+
     async def test_plugin_dispatch_enriches_seed_content_from_session(self) -> None:
         from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler
 

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -622,6 +622,28 @@ class TestBuildEvaluateSubagent:
         assert "conceptual lens for evaluation judgments" in p.prompt
         assert "## Artifact Type" in p.prompt
 
+    def test_analysis_seed_defaults_to_document_artifact_type(self) -> None:
+        """Plugin-mode evaluation should not review analysis/research Seeds as code."""
+        p = build_evaluate_subagent(
+            session_id="sess-123",
+            artifact="Decision: ship option B",
+            seed_content=VALID_ANALYSIS_SEED_YAML,
+        )
+
+        assert "## Artifact Type\ndocument" in p.prompt
+        assert p.context["artifact_type"] == "document"
+
+    def test_explicit_non_code_artifact_type_is_preserved(self) -> None:
+        p = build_evaluate_subagent(
+            session_id="sess-123",
+            artifact="Decision: ship option B",
+            artifact_type="report",
+            seed_content=VALID_ANALYSIS_SEED_YAML,
+        )
+
+        assert "## Artifact Type\nreport" in p.prompt
+        assert p.context["artifact_type"] == "report"
+
 
 # ---------------------------------------------------------------------------
 # Tool-specific builders: Execute

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -30,6 +30,23 @@ from ouroboros.mcp.tools.subagent import (
 )
 from ouroboros.mcp.types import ContentType, MCPToolResult
 
+VALID_ANALYSIS_SEED_YAML = """goal: Write a decision brief
+task_type: analysis
+constraints:
+  - Do not produce source code
+acceptance_criteria:
+  - Brief makes a clear recommendation
+ontology_schema:
+  name: DecisionBrief
+  description: Decision brief concepts
+  fields:
+    - name: recommendation
+      type: string
+      description: Chosen path and rationale
+metadata:
+  ambiguity_score: 0.1
+"""
+
 # ---------------------------------------------------------------------------
 # build_subagent_payload: core structure tests
 # ---------------------------------------------------------------------------
@@ -594,6 +611,17 @@ class TestBuildEvaluateSubagent:
         assert p.context["session_id"] == "sess-123"
         assert p.context["trigger_consensus"] is True
 
+    def test_prompt_includes_seed_contract_when_seed_is_valid(self) -> None:
+        p = build_evaluate_subagent(
+            session_id="sess-123",
+            artifact="Decision: ship option B",
+            seed_content=VALID_ANALYSIS_SEED_YAML,
+        )
+
+        assert "## Seed Contract" in p.prompt
+        assert "conceptual lens for evaluation judgments" in p.prompt
+        assert "## Artifact Type" in p.prompt
+
 
 # ---------------------------------------------------------------------------
 # Tool-specific builders: Execute
@@ -616,6 +644,15 @@ class TestBuildExecuteSubagent:
             session_id="sess-123",
         )
         assert "build a CLI tool" in p.prompt
+
+    def test_prompt_includes_seed_contract_when_seed_is_valid(self) -> None:
+        p = build_execute_subagent(
+            seed_content=VALID_ANALYSIS_SEED_YAML,
+            session_id="sess-123",
+        )
+
+        assert "## Seed Contract" in p.prompt
+        assert "conceptual lens for execution decisions" in p.prompt
 
     def test_context_preserves_execution_args(self) -> None:
         p = build_execute_subagent(

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -47,6 +47,27 @@ metadata:
   ambiguity_score: 0.1
 """
 
+VALID_ANALYSIS_SEED_JSON = json.dumps(
+    {
+        "goal": "Write a decision brief",
+        "task_type": "analysis",
+        "constraints": ["Do not produce source code"],
+        "acceptance_criteria": ["Brief makes a clear recommendation"],
+        "ontology_schema": {
+            "name": "DecisionBrief",
+            "description": "Decision brief concepts",
+            "fields": [
+                {
+                    "name": "recommendation",
+                    "type": "string",
+                    "description": "Chosen path and rationale",
+                }
+            ],
+        },
+        "metadata": {"ambiguity_score": 0.1},
+    }
+)
+
 # ---------------------------------------------------------------------------
 # build_subagent_payload: core structure tests
 # ---------------------------------------------------------------------------
@@ -653,6 +674,16 @@ class TestBuildEvaluateSubagent:
 
         assert "## Artifact Type\ndocument" in p.prompt
         assert p.context["artifact_type"] == "document"
+
+    def test_json_seed_content_uses_json_fence(self) -> None:
+        p = build_evaluate_subagent(
+            session_id="sess-123",
+            artifact="Decision: ship option B",
+            seed_content=VALID_ANALYSIS_SEED_JSON,
+        )
+
+        assert "## Seed Specification\n```json" in p.prompt
+        assert "## Artifact Type\ndocument" in p.prompt
 
     def test_explicit_non_code_artifact_type_is_preserved(self) -> None:
         p = build_evaluate_subagent(

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -611,6 +611,27 @@ class TestBuildEvaluateSubagent:
         assert p.context["session_id"] == "sess-123"
         assert p.context["trigger_consensus"] is True
 
+    def test_prompt_includes_plural_acceptance_criteria(self) -> None:
+        p = build_evaluate_subagent(
+            session_id="sess-123",
+            artifact="code",
+            acceptance_criterion="Legacy single AC should be ignored",
+            acceptance_criteria=[
+                "First AC is satisfied",
+                "Second AC is satisfied",
+            ],
+        )
+
+        assert "## Acceptance Criteria" in p.prompt
+        assert "1. First AC is satisfied" in p.prompt
+        assert "2. Second AC is satisfied" in p.prompt
+        assert "Legacy single AC should be ignored" not in p.prompt
+        assert p.context["acceptance_criteria"] == [
+            "First AC is satisfied",
+            "Second AC is satisfied",
+        ]
+        assert p.context["acceptance_criterion"] is None
+
     def test_prompt_includes_seed_contract_when_seed_is_valid(self) -> None:
         p = build_evaluate_subagent(
             session_id="sess-123",

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -443,6 +444,7 @@ class TestOrchestratorRunner:
             seed_id=sample_seed.metadata.seed_id,
             session_id="orch_prepared",
             seed_goal=sample_seed.goal,
+            seed_json=json.dumps(sample_seed.to_dict()),
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_seed_prompt.py
+++ b/tests/unit/orchestrator/test_seed_prompt.py
@@ -6,6 +6,7 @@ from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadat
 from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.seed_contract_prompt import (
     render_ontology_lens_section,
+    render_seed_contract_for_evaluation,
     render_seed_contract_for_execution,
 )
 
@@ -36,12 +37,23 @@ def test_seed_contract_from_seed_interprets_ontology_lens() -> None:
 
     assert contract.goal == "Build a task manager"
     assert contract.task_type == "code"
+    assert contract.artifact_type == "code"
     assert contract.acceptance_criteria == ("Tasks can be created",)
     assert contract.ontology_lens.name == "TaskManager"
     assert contract.ontology_lens.description == "Task management ontology"
     assert len(contract.ontology_lens.concepts) == 1
     assert contract.ontology_lens.concepts[0].name == "tasks"
     assert contract.ontology_lens.concepts[0].field_type == "array"
+
+
+def test_seed_contract_maps_non_code_tasks_to_document_artifacts() -> None:
+    """Research and analysis Seeds should not be evaluated as code artifacts."""
+    seed = _seed().model_copy(update={"task_type": "analysis"})
+
+    contract = SeedContract.from_seed(seed)
+
+    assert contract.task_type == "analysis"
+    assert contract.artifact_type == "document"
 
 
 def test_render_ontology_lens_section_frames_ontology_as_lens() -> None:
@@ -74,3 +86,17 @@ def test_render_seed_contract_for_execution_includes_core_sections() -> None:
     assert "- No external database" in rendered
     assert "## Ontology / Conceptual Lens" in rendered
     assert "## Exit Conditions" in rendered
+
+
+def test_render_seed_contract_for_evaluation_frames_contract_as_judgment_lens() -> None:
+    """Evaluation renderer uses the same Seed contract without coding bias."""
+    contract = SeedContract.from_seed(_seed())
+
+    rendered = render_seed_contract_for_evaluation(contract)
+
+    assert "immutable source of truth for this evaluation" in rendered
+    assert "not only the surface wording of an acceptance criterion" in rendered
+    assert "## Task Type" in rendered
+    assert "conceptual lens for evaluation judgments" in rendered
+    assert "When evaluation judgments are ambiguous:" in rendered
+    assert "It is not a mandatory output outline." in rendered

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -202,6 +202,23 @@ class TestSessionRepository:
         assert event.data["seed_goal"] == "Ship the OpenCode runtime"
 
     @pytest.mark.asyncio
+    async def test_create_session_persists_seed_json(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Session start events retain the full Seed for later evaluation."""
+        result = await repository.create_session(
+            execution_id="exec_123",
+            seed_id="seed_456",
+            seed_json='{"goal": "Ship"}',
+        )
+
+        assert result.is_ok
+        event = mock_event_store.append.call_args[0][0]
+        assert event.data["seed_json"] == '{"goal": "Ship"}'
+
+    @pytest.mark.asyncio
     async def test_create_session_with_custom_id(
         self,
         repository: SessionRepository,

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -540,6 +540,35 @@ class TestSessionRepository:
         assert tracker.progress["runtime"]["native_session_id"] == "sess_native"
 
     @pytest.mark.asyncio
+    async def test_reconstruct_session_preserves_seed_json_across_progress_updates(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Start-event Seed JSON must survive later progress payload replacement."""
+        start_event = MagicMock()
+        start_event.type = "orchestrator.session.started"
+        start_event.data = {
+            "execution_id": "exec_123",
+            "seed_id": "seed_456",
+            "start_time": datetime.now(UTC).isoformat(),
+            "seed_json": '{"goal": "Ship"}',
+        }
+
+        progress_event = MagicMock()
+        progress_event.type = "orchestrator.progress.updated"
+        progress_event.data = {"progress": {"step": 1}}
+
+        mock_event_store.replay.return_value = [start_event, progress_event]
+
+        result = await repository.reconstruct_session("sess_123")
+
+        assert result.is_ok
+        tracker = result.value
+        assert tracker.progress["seed_json"] == '{"goal": "Ship"}'
+        assert tracker.progress["step"] == 1
+
+    @pytest.mark.asyncio
     async def test_reconstruct_session_merges_parallel_execution_progress(
         self,
         repository: SessionRepository,


### PR DESCRIPTION
## Summary

- Builds on #495 by carrying SeedContract into semantic, consensus, evaluate, QA, subagent, and Ralph/evolution paths.
- Adds a Seed contract audit gate for goal alignment, drift, uncertainty, and reward-hacking risk so mechanical AC passes are necessary but not sufficient.
- Preserves non-code task intent by extracting `task_type` and evaluating research/analysis outputs as documents instead of code.

## Changes

- Add `contract_audit_failure()` and use it in Ralph/evolution semantic approval.
- Thread `SeedContract` through evaluation contexts, consensus prompts, MCP evaluate, delegated subagents, and post-run QA quality bars.
- Persist `seed_json` in sessions so later evaluation can reconstruct the Seed contract.
- Extract `TASK_TYPE` in seed generation and update seed-architect guidance.
- Skip code validation for non-code evolution tasks.
- Expand tests for semantic/consensus prompts, session restoration, quality bars, task type extraction, and contract audit thresholds.

## Notes

Stacked on #495. This PR still does not implement the later Idea/Origin-contract convergence refactor; it only enforces the SeedContract introduced by #495 across execution/evaluation paths.