### PR TITLE
fix(mcp): clarify job wait execution progress note

### DIFF
--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -667,6 +667,8 @@ class JobWaitHandler:
                 )
             elif view in {"compact", "summary"}:
                 text = f"unchanged cursor={snapshot.cursor}"
+            elif execution_progress_changed:
+                text += "\n\nExecution progress updated during this wait window."
             else:
                 text += "\n\nNo new job-level events during this wait window."
         elif view == "compact":

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -1212,6 +1212,71 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_job_wait_full_view_labels_execution_progress_without_job_change(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        await store.append(
+            BaseEvent(
+                type="workflow.progress.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_wait_full_progress",
+                data={
+                    "execution_id": "exec_wait_full_progress",
+                    "completed_count": 1,
+                    "total_count": 3,
+                    "current_phase": "Implement",
+                    "activity": "Running",
+                },
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_wait_full_progress",
+            job_type="execute_seed",
+            status=JobStatus.RUNNING,
+            message="Implement | 1/3 ACs",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(execution_id="exec_wait_full_progress"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 0
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {
+                    "job_id": "job_wait_full_progress",
+                    "cursor": 0,
+                    "timeout_seconds": 0,
+                }
+            )
+
+            assert result.is_ok
+            assert result.value.meta["changed"] is True
+            assert "**AC Progress**: 1/3" in result.value.text_content
+            assert "Execution progress updated during this wait window." in (
+                result.value.text_content
+            )
+            assert "No new job-level events during this wait window." not in (
+                result.value.text_content
+            )
+        finally:
+            await store.close()
+
     async def test_job_wait_compact_view_surfaces_subtask_progress_before_workflow(
         self, tmp_path
     ) -> None:


### PR DESCRIPTION
## Summary

- Clarifies `ouroboros_job_wait` full-view wording when execution progress changes without a job-level event.
- Avoids the misleading `No new job-level events...` note when the returned snapshot is still fresher due to execution progress.

## Changes

- Adds a distinct `Execution progress updated during this wait window.` note for full-view execution-only progress updates.
- Adds regression coverage for the full-view job wait path with execution progress but no job aggregate change.

## Verification

- `uv run ruff format --check src/ouroboros/mcp/tools/job_handlers.py tests/unit/mcp/test_job_manager.py`
- `uv run ruff check src/ouroboros/mcp/tools/job_handlers.py tests/unit/mcp/test_job_manager.py`
- `uv run pytest tests/unit/mcp/test_job_manager.py`
