### PR TITLE
fix(router): dispatch multiline run payloads

### DIFF
--- a/src/ouroboros/router/command_parser.py
+++ b/src/ouroboros/router/command_parser.py
@@ -10,7 +10,7 @@ _SKILL_COMMAND_PATTERN = re.compile(
     r"^\s*(?:(?P<ooo_prefix>ooo)\s+(?P<ooo_skill>[a-z0-9][a-z0-9_-]*)|"
     r"(?P<slash_prefix>/ouroboros:)(?P<slash_skill>[a-z0-9][a-z0-9_-]*))"
     r"(?:\s+(?P<remainder>.*))?$",
-    re.IGNORECASE,
+    re.IGNORECASE | re.DOTALL,
 )
 
 

--- a/src/ouroboros/router/command_parser.py
+++ b/src/ouroboros/router/command_parser.py
@@ -6,12 +6,33 @@ import re
 
 from ouroboros.router.types import ParsedOooCommand
 
-_SKILL_COMMAND_PATTERN = re.compile(
+_SKILL_COMMAND_PREFIX_PATTERN = re.compile(
     r"^\s*(?:(?P<ooo_prefix>ooo)\s+(?P<ooo_skill>[a-z0-9][a-z0-9_-]*)|"
-    r"(?P<slash_prefix>/ouroboros:)(?P<slash_skill>[a-z0-9][a-z0-9_-]*))"
-    r"(?:\s+(?P<remainder>.*))?$",
-    re.IGNORECASE | re.DOTALL,
+    r"(?P<slash_prefix>/ouroboros:)(?P<slash_skill>[a-z0-9][a-z0-9_-]*))",
+    re.IGNORECASE,
 )
+
+
+def _extract_command_remainder(prompt: str, start: int) -> tuple[bool, str | None]:
+    """Extract command arguments while preserving multiline payload bytes."""
+    if start >= len(prompt):
+        return True, None
+    if not prompt[start].isspace():
+        return False, None
+
+    for index in range(start, len(prompt)):
+        char = prompt[index]
+        if char == "\r":
+            next_index = (
+                index + 2 if index + 1 < len(prompt) and prompt[index + 1] == "\n" else index + 1
+            )
+            return True, prompt[next_index:]
+        if char == "\n":
+            return True, prompt[index + 1 :]
+        if not char.isspace():
+            return True, prompt[index:]
+
+    return True, ""
 
 
 def parse_ooo_command(prompt: str) -> ParsedOooCommand | None:
@@ -23,12 +44,15 @@ def parse_ooo_command(prompt: str) -> ParsedOooCommand | None:
     lowercases the skill name, and preserves the argument text after the
     command separator.
     """
-    match = _SKILL_COMMAND_PATTERN.match(prompt)
+    match = _SKILL_COMMAND_PREFIX_PATTERN.match(prompt)
     if match is None:
         return None
 
     skill_name = (match.group("ooo_skill") or match.group("slash_skill") or "").lower()
     if not skill_name:
+        return None
+    valid_remainder, remainder = _extract_command_remainder(prompt, match.end())
+    if not valid_remainder:
         return None
 
     command_prefix = (
@@ -37,7 +61,7 @@ def parse_ooo_command(prompt: str) -> ParsedOooCommand | None:
     return ParsedOooCommand(
         skill_name=skill_name,
         command_prefix=command_prefix,
-        remainder=match.group("remainder"),
+        remainder=remainder,
     )
 
 

--- a/src/ouroboros/router/dispatch.py
+++ b/src/ouroboros/router/dispatch.py
@@ -261,16 +261,19 @@ def extract_first_argument(remainder: str | None) -> str | None:
     """Extract the full argument payload following a skill command prefix.
 
     The legacy name is preserved for API stability, but the semantics cover the
-    whole remainder: shell-style tokenization is used purely to strip matching
-    quotes and escape sequences, then tokens are rejoined with single spaces so
-    natural-language usage like ``ooo interview add dark mode to settings``
-    yields the full phrase rather than just ``add``. Quoted forms such as
-    ``ooo interview "add dark mode"`` produce the same unquoted result. If
-    shell tokenization fails (unterminated quote), a whitespace split is used
-    as fallback.
+    whole remainder. Multiline payloads are preserved exactly for inline
+    content such as Seed YAML. Single-line payloads still use shell-style
+    tokenization purely to strip matching quotes and escape sequences, then
+    tokens are rejoined with single spaces so natural-language usage like
+    ``ooo interview add dark mode to settings`` yields the full phrase rather
+    than just ``add``. Quoted forms such as ``ooo interview "add dark mode"``
+    produce the same unquoted result. If shell tokenization fails (unterminated
+    quote), a whitespace split is used as fallback.
     """
     if remainder is None or not remainder.strip():
         return None
+    if "\n" in remainder or "\r" in remainder:
+        return remainder
     try:
         parts = shlex.split(remainder)
     except ValueError:

--- a/src/ouroboros/router/dispatch.py
+++ b/src/ouroboros/router/dispatch.py
@@ -272,7 +272,7 @@ def extract_first_argument(remainder: str | None) -> str | None:
     """
     if remainder is None or not remainder.strip():
         return None
-    if "\n" in remainder or "\r" in remainder:
+    if re.search(r"[\r\n].*\S", remainder):
         return remainder
     try:
         parts = shlex.split(remainder)

--- a/src/ouroboros/router/dispatch.py
+++ b/src/ouroboros/router/dispatch.py
@@ -319,7 +319,8 @@ def _reconstruct_prompt_from_parsed_command(parsed: ParsedOooCommand) -> str:
     """Build a canonical prompt when a caller only has parsed command data."""
     if parsed.remainder is None:
         return parsed.command_prefix
-    return f"{parsed.command_prefix} {parsed.remainder}"
+    separator = "\n" if "\n" in parsed.remainder or "\r" in parsed.remainder else " "
+    return f"{parsed.command_prefix}{separator}{parsed.remainder}"
 
 
 def _validate_parsed_command(parsed: ParsedOooCommand) -> str | None:

--- a/tests/unit/router/test_command_parser.py
+++ b/tests/unit/router/test_command_parser.py
@@ -144,6 +144,16 @@ def test_parse_ooo_command_normalizes_slash_prefix_and_skill_case() -> None:
     )
 
 
+def test_parse_ooo_command_accepts_multiline_slash_payload() -> None:
+    payload = "goal: test\nconstraints:\n  - keep it simple\nacceptance_criteria:\n  - works"
+
+    assert parse_ooo_command(f"/ouroboros:run\n{payload}") == ParsedOooCommand(
+        skill_name="run",
+        command_prefix="/ouroboros:run",
+        remainder=payload,
+    )
+
+
 def test_parsed_ooo_command_type_is_immutable_normalized_command_data() -> None:
     parsed = TypesParsedOooCommand(
         skill_name="run",

--- a/tests/unit/router/test_command_parser.py
+++ b/tests/unit/router/test_command_parser.py
@@ -154,6 +154,16 @@ def test_parse_ooo_command_accepts_multiline_slash_payload() -> None:
     )
 
 
+def test_parse_ooo_command_preserves_multiline_payload_leading_whitespace() -> None:
+    payload = "  goal: test\n  constraints:\n    - keep it simple"
+
+    assert parse_ooo_command(f"/ouroboros:run\n{payload}") == ParsedOooCommand(
+        skill_name="run",
+        command_prefix="/ouroboros:run",
+        remainder=payload,
+    )
+
+
 def test_parsed_ooo_command_type_is_immutable_normalized_command_data() -> None:
     parsed = TypesParsedOooCommand(
         skill_name="run",

--- a/tests/unit/router/test_extract_first_argument.py
+++ b/tests/unit/router/test_extract_first_argument.py
@@ -42,6 +42,11 @@ from ouroboros.router import extract_first_argument
             "add dark mode to settings",
             id="fully-quoted-phrase",
         ),
+        pytest.param(
+            "goal: test\nconstraints:\n  - keep it simple\nacceptance_criteria:\n  - works",
+            "goal: test\nconstraints:\n  - keep it simple\nacceptance_criteria:\n  - works",
+            id="multiline-inline-content-preserved",
+        ),
     ],
 )
 def test_extract_first_argument_returns_full_argument_payload(

--- a/tests/unit/router/test_extract_first_argument.py
+++ b/tests/unit/router/test_extract_first_argument.py
@@ -27,6 +27,12 @@ from ouroboros.router import extract_first_argument
             "seed file.yaml --strict",
             id="double-quoted-joined",
         ),
+        pytest.param("seed.yaml\n", "seed.yaml", id="trailing-newline-normalized"),
+        pytest.param(
+            '"seed file.yaml"\r\n',
+            "seed file.yaml",
+            id="quoted-trailing-crlf-normalized",
+        ),
         pytest.param(
             "'seed file.yaml' --strict",
             "seed file.yaml --strict",

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -149,6 +149,25 @@ def test_valid_dispatch_inputs_normalize_to_canonical_runtime_metadata(
     assert result.outcome is ResolveOutcome.MATCH
 
 
+def test_valid_dispatch_normalizes_trailing_line_ending_on_single_line_argument(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_dispatchable_skill(skills_dir, "run")
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt='ooo run "seed file.yaml"\r\n',
+            cwd=tmp_path,
+            skills_dir=skills_dir,
+        )
+    )
+
+    assert isinstance(result, Resolved)
+    assert result.first_argument == "seed file.yaml"
+    assert result.mcp_args["seed_path"] == "seed file.yaml"
+
+
 @pytest.mark.parametrize(
     ("prompt", "expected_prefix"),
     [

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -249,6 +249,56 @@ def test_valid_router_dispatch_forms_resolve_expected_parsed_dispatch_fields(
     assert result.outcome is ResolveOutcome.MATCH
 
 
+def test_valid_dispatch_preserves_multiline_inline_seed_payload(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    skill_md_path = _write_dispatchable_skill(skills_dir, "run")
+    runtime_cwd = tmp_path / "workspace"
+    seed_content = (
+        "goal: test\n"
+        "constraints:\n"
+        "  - keep it simple\n"
+        "acceptance_criteria:\n"
+        "  - works"
+    )
+    prompt = f"/ouroboros:run\n{seed_content}"
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt=prompt,
+            cwd=runtime_cwd,
+            skills_dir=skills_dir,
+        )
+    )
+
+    expected_args = {
+        "seed_path": seed_content,
+        "cwd": str(runtime_cwd),
+        "combined": f"cwd={runtime_cwd} seed={seed_content}",
+        "nested": {
+            "values": [
+                seed_content,
+                str(runtime_cwd),
+                True,
+            ],
+        },
+    }
+    _assert_resolved_payload(
+        result,
+        Resolved(
+            skill_name="run",
+            command_prefix="/ouroboros:run",
+            prompt=prompt,
+            skill_path=skill_md_path,
+            mcp_tool="ouroboros_execute_seed",
+            mcp_args=expected_args,
+            first_argument=seed_content,
+        ),
+    )
+    assert result.outcome is ResolveOutcome.MATCH
+
+
 def test_valid_dispatch_without_argument_normalizes_first_argument_template_to_empty_string(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -7,6 +7,7 @@ import pytest
 from ouroboros.router import (
     MCPDispatchTarget,
     NormalizedMCPFrontmatter,
+    ParsedOooCommand,
     Resolved,
     ResolveOutcome,
     ResolveRequest,
@@ -255,13 +256,7 @@ def test_valid_dispatch_preserves_multiline_inline_seed_payload(
     skills_dir = tmp_path / "skills"
     skill_md_path = _write_dispatchable_skill(skills_dir, "run")
     runtime_cwd = tmp_path / "workspace"
-    seed_content = (
-        "goal: test\n"
-        "constraints:\n"
-        "  - keep it simple\n"
-        "acceptance_criteria:\n"
-        "  - works"
-    )
+    seed_content = "goal: test\nconstraints:\n  - keep it simple\nacceptance_criteria:\n  - works"
     prompt = f"/ouroboros:run\n{seed_content}"
 
     result = resolve_skill_dispatch(
@@ -297,6 +292,26 @@ def test_valid_dispatch_preserves_multiline_inline_seed_payload(
         ),
     )
     assert result.outcome is ResolveOutcome.MATCH
+
+
+def test_valid_parsed_dispatch_reconstructs_multiline_prompt_with_newline_separator(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_dispatchable_skill(skills_dir, "run")
+    seed_content = "goal: test\nconstraints:\n  - keep it simple"
+    parsed = ParsedOooCommand(
+        skill_name="run",
+        command_prefix="/ouroboros:run",
+        remainder=seed_content,
+    )
+
+    result = resolve_skill_dispatch(parsed, cwd=tmp_path, skills_dir=skills_dir)
+
+    assert isinstance(result, Resolved)
+    assert result.prompt == f"/ouroboros:run\n{seed_content}"
+    assert result.first_argument == seed_content
+    assert result.mcp_args["seed_path"] == seed_content
 
 
 def test_valid_dispatch_without_argument_normalizes_first_argument_template_to_empty_string(

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -294,6 +294,27 @@ def test_valid_dispatch_preserves_multiline_inline_seed_payload(
     assert result.outcome is ResolveOutcome.MATCH
 
 
+def test_valid_dispatch_preserves_multiline_inline_seed_leading_whitespace(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_dispatchable_skill(skills_dir, "run")
+    seed_content = "  goal: test\n  constraints:\n    - keep it simple"
+    prompt = f"/ouroboros:run\n{seed_content}"
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt=prompt,
+            cwd=tmp_path,
+            skills_dir=skills_dir,
+        )
+    )
+
+    assert isinstance(result, Resolved)
+    assert result.first_argument == seed_content
+    assert result.mcp_args["seed_path"] == seed_content
+
+
 def test_valid_parsed_dispatch_reconstructs_multiline_prompt_with_newline_separator(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Closes #479 by allowing deterministic skill command parsing to keep multiline payloads after `/ouroboros:run`.
- Preserves inline Seed YAML exactly when resolving `$1`, so documented `seed_file_or_content` behavior works for real multiline YAML.

## Changes

- Enables DOTALL parsing for supported `ooo` and `/ouroboros:` command prefixes.
- Keeps multiline argument payloads out of shell-style normalization.
- Adds parser, extraction, and dispatch regression coverage for multiline inline seed content.

## Tests

- `uv run pytest tests/unit/router/test_command_parser.py tests/unit/router/test_extract_first_argument.py tests/unit/router/test_valid_dispatch_normalization.py -q`
- `uv run ruff check src/ouroboros/router/command_parser.py src/ouroboros/router/dispatch.py tests/unit/router/test_command_parser.py tests/unit/router/test_extract_first_argument.py tests/unit/router/test_valid_dispatch_normalization.py`

Closes #479