### PR TITLE
fix(router): preserve Windows path backslashes

### DIFF
--- a/src/ouroboros/router/dispatch.py
+++ b/src/ouroboros/router/dispatch.py
@@ -59,6 +59,7 @@ _WINDOWS_UNC_PATH_PAYLOAD_PATTERN = re.compile(r"^\\\\[^\\/\s]+[\\/][^\\/\s]+")
 _REQUIRED_MCP_FRONTMATTER_KEYS = ("mcp_tool", "mcp_args")
 _MCP_FRONTMATTER_VALUE_TYPES = "string, finite number, boolean, null, list, or mapping"
 _PACKAGED_SKILL_CACHE: TemporaryDirectory[str] | None = None
+_QUOTE_CHARS = {"'", '"'}
 
 
 @dataclass(frozen=True, slots=True)
@@ -259,6 +260,26 @@ def normalize_mcp_frontmatter(
     )
 
 
+def _strip_matching_quotes(value: str) -> str:
+    """Remove one pair of matching shell quotes from a token."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in _QUOTE_CHARS:
+        return value[1:-1]
+    return value
+
+
+def _normalize_windows_literal_payload(remainder: str) -> str | None:
+    """Normalize Windows-path payloads without treating backslashes as escapes."""
+    try:
+        lexer = shlex.shlex(remainder, posix=False)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        parts = list(lexer)
+    except ValueError:
+        parts = remainder.split()
+    normalized = [_strip_matching_quotes(part) for part in parts]
+    return " ".join(normalized) if normalized else None
+
+
 def extract_first_argument(remainder: str | None) -> str | None:
     """Extract the full argument payload following a skill command prefix.
 
@@ -279,7 +300,7 @@ def extract_first_argument(remainder: str | None) -> str | None:
     if _WINDOWS_DRIVE_PATH_PAYLOAD_PATTERN.match(
         stripped_remainder
     ) or _WINDOWS_UNC_PATH_PAYLOAD_PATTERN.match(stripped_remainder):
-        return stripped_remainder
+        return _normalize_windows_literal_payload(stripped_remainder)
     try:
         parts = shlex.split(remainder)
     except ValueError:

--- a/src/ouroboros/router/dispatch.py
+++ b/src/ouroboros/router/dispatch.py
@@ -54,7 +54,7 @@ from ouroboros.router.types import (
 _MCP_TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _SKILL_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _DISPATCH_TEMPLATE_PATTERN = re.compile(r"\$(?:CWD|1)(?![A-Za-z0-9_])")
-_WINDOWS_DRIVE_PATH_PAYLOAD_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_DRIVE_PATH_PAYLOAD_PATTERN = re.compile(r"^[A-Za-z]:\\")
 _WINDOWS_UNC_PATH_PAYLOAD_PATTERN = re.compile(r"^\\\\[^\\/\s]+[\\/][^\\/\s]+")
 _REQUIRED_MCP_FRONTMATTER_KEYS = ("mcp_tool", "mcp_args")
 _MCP_FRONTMATTER_VALUE_TYPES = "string, finite number, boolean, null, list, or mapping"
@@ -276,10 +276,9 @@ def extract_first_argument(remainder: str | None) -> str | None:
     if remainder is None or not remainder.strip():
         return None
     stripped_remainder = remainder.strip()
-    if (
-        _WINDOWS_DRIVE_PATH_PAYLOAD_PATTERN.match(stripped_remainder)
-        or _WINDOWS_UNC_PATH_PAYLOAD_PATTERN.match(stripped_remainder)
-    ):
+    if _WINDOWS_DRIVE_PATH_PAYLOAD_PATTERN.match(
+        stripped_remainder
+    ) or _WINDOWS_UNC_PATH_PAYLOAD_PATTERN.match(stripped_remainder):
         return stripped_remainder
     try:
         parts = shlex.split(remainder)

--- a/src/ouroboros/router/dispatch.py
+++ b/src/ouroboros/router/dispatch.py
@@ -54,6 +54,8 @@ from ouroboros.router.types import (
 _MCP_TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _SKILL_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _DISPATCH_TEMPLATE_PATTERN = re.compile(r"\$(?:CWD|1)(?![A-Za-z0-9_])")
+_WINDOWS_DRIVE_PATH_PAYLOAD_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_UNC_PATH_PAYLOAD_PATTERN = re.compile(r"^\\\\[^\\/\s]+[\\/][^\\/\s]+")
 _REQUIRED_MCP_FRONTMATTER_KEYS = ("mcp_tool", "mcp_args")
 _MCP_FRONTMATTER_VALUE_TYPES = "string, finite number, boolean, null, list, or mapping"
 _PACKAGED_SKILL_CACHE: TemporaryDirectory[str] | None = None
@@ -261,16 +263,24 @@ def extract_first_argument(remainder: str | None) -> str | None:
     """Extract the full argument payload following a skill command prefix.
 
     The legacy name is preserved for API stability, but the semantics cover the
-    whole remainder: shell-style tokenization is used purely to strip matching
-    quotes and escape sequences, then tokens are rejoined with single spaces so
-    natural-language usage like ``ooo interview add dark mode to settings``
-    yields the full phrase rather than just ``add``. Quoted forms such as
-    ``ooo interview "add dark mode"`` produce the same unquoted result. If
-    shell tokenization fails (unterminated quote), a whitespace split is used
-    as fallback.
+    whole remainder. Windows drive-letter and UNC path payloads are preserved
+    before shell-style tokenization because POSIX ``shlex`` treats backslashes
+    as escapes. Other single-line payloads still use shell-style tokenization
+    purely to strip matching quotes and escape sequences, then tokens are
+    rejoined with single spaces so natural-language usage like
+    ``ooo interview add dark mode to settings`` yields the full phrase rather
+    than just ``add``. Quoted forms such as ``ooo interview "add dark mode"``
+    produce the same unquoted result. If shell tokenization fails (unterminated
+    quote), a whitespace split is used as fallback.
     """
     if remainder is None or not remainder.strip():
         return None
+    stripped_remainder = remainder.strip()
+    if (
+        _WINDOWS_DRIVE_PATH_PAYLOAD_PATTERN.match(stripped_remainder)
+        or _WINDOWS_UNC_PATH_PAYLOAD_PATTERN.match(stripped_remainder)
+    ):
+        return stripped_remainder
     try:
         parts = shlex.split(remainder)
     except ValueError:

--- a/src/ouroboros/router/dispatch.py
+++ b/src/ouroboros/router/dispatch.py
@@ -59,7 +59,6 @@ _WINDOWS_UNC_PATH_PAYLOAD_PATTERN = re.compile(r"^\\\\[^\\/\s]+[\\/][^\\/\s]+")
 _REQUIRED_MCP_FRONTMATTER_KEYS = ("mcp_tool", "mcp_args")
 _MCP_FRONTMATTER_VALUE_TYPES = "string, finite number, boolean, null, list, or mapping"
 _PACKAGED_SKILL_CACHE: TemporaryDirectory[str] | None = None
-_QUOTE_CHARS = {"'", '"'}
 
 
 @dataclass(frozen=True, slots=True)
@@ -260,24 +259,20 @@ def normalize_mcp_frontmatter(
     )
 
 
-def _strip_matching_quotes(value: str) -> str:
-    """Remove one pair of matching shell quotes from a token."""
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in _QUOTE_CHARS:
-        return value[1:-1]
-    return value
-
-
 def _normalize_windows_literal_payload(remainder: str) -> str | None:
-    """Normalize Windows-path payloads without treating backslashes as escapes."""
+    """Preserve the Windows path token while shell-normalizing trailing args."""
+    match = re.match(r"(?P<path>\S+)(?:\s+(?P<tail>.*))?$", remainder, re.DOTALL)
+    if match is None:
+        return None
+    path = match.group("path")
+    tail = match.group("tail")
+    if tail is None or not tail.strip():
+        return path
     try:
-        lexer = shlex.shlex(remainder, posix=False)
-        lexer.whitespace_split = True
-        lexer.commenters = ""
-        parts = list(lexer)
+        tail_parts = shlex.split(tail)
     except ValueError:
-        parts = remainder.split()
-    normalized = [_strip_matching_quotes(part) for part in parts]
-    return " ".join(normalized) if normalized else None
+        tail_parts = tail.split()
+    return " ".join([path, *tail_parts]) if tail_parts else path
 
 
 def extract_first_argument(remainder: str | None) -> str | None:

--- a/tests/unit/router/test_extract_first_argument.py
+++ b/tests/unit/router/test_extract_first_argument.py
@@ -52,6 +52,11 @@ from ouroboros.router import extract_first_argument
             r"\\server\share\seed.yaml --strict",
             id="windows-unc-path-backslashes-preserved",
         ),
+        pytest.param(
+            'C:/temp/seed.yaml "two words"',
+            "C:/temp/seed.yaml two words",
+            id="windows-forward-slash-path-still-normalized",
+        ),
     ],
 )
 def test_extract_first_argument_returns_full_argument_payload(

--- a/tests/unit/router/test_extract_first_argument.py
+++ b/tests/unit/router/test_extract_first_argument.py
@@ -48,9 +48,19 @@ from ouroboros.router import extract_first_argument
             id="windows-drive-path-backslashes-preserved",
         ),
         pytest.param(
+            r'C:\temp\seed.yaml "two words"',
+            r"C:\temp\seed.yaml two words",
+            id="windows-drive-path-backslashes-preserved-and-quotes-normalized",
+        ),
+        pytest.param(
             r"\\server\share\seed.yaml --strict",
             r"\\server\share\seed.yaml --strict",
             id="windows-unc-path-backslashes-preserved",
+        ),
+        pytest.param(
+            r'\\server\share\seed.yaml "two words"',
+            r"\\server\share\seed.yaml two words",
+            id="windows-unc-path-backslashes-preserved-and-quotes-normalized",
         ),
         pytest.param(
             'C:/temp/seed.yaml "two words"',

--- a/tests/unit/router/test_extract_first_argument.py
+++ b/tests/unit/router/test_extract_first_argument.py
@@ -42,6 +42,16 @@ from ouroboros.router import extract_first_argument
             "add dark mode to settings",
             id="fully-quoted-phrase",
         ),
+        pytest.param(
+            r"C:\temp\seed.yaml --strict",
+            r"C:\temp\seed.yaml --strict",
+            id="windows-drive-path-backslashes-preserved",
+        ),
+        pytest.param(
+            r"\\server\share\seed.yaml --strict",
+            r"\\server\share\seed.yaml --strict",
+            id="windows-unc-path-backslashes-preserved",
+        ),
     ],
 )
 def test_extract_first_argument_returns_full_argument_payload(

--- a/tests/unit/router/test_extract_first_argument.py
+++ b/tests/unit/router/test_extract_first_argument.py
@@ -53,6 +53,11 @@ from ouroboros.router import extract_first_argument
             id="windows-drive-path-backslashes-preserved-and-quotes-normalized",
         ),
         pytest.param(
+            r'C:\temp\seed.yaml "two \"quoted\" words"',
+            r'C:\temp\seed.yaml two "quoted" words',
+            id="windows-drive-path-backslashes-preserved-and-escaped-quotes-normalized",
+        ),
+        pytest.param(
             r"\\server\share\seed.yaml --strict",
             r"\\server\share\seed.yaml --strict",
             id="windows-unc-path-backslashes-preserved",

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -277,6 +277,26 @@ def test_valid_dispatch_preserves_windows_path_backslashes(
     assert result.mcp_args["seed_path"] == seed_path
 
 
+def test_valid_dispatch_normalizes_windows_forward_slash_paths(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    runtime_cwd = tmp_path / "workspace"
+    _write_dispatchable_skill(skills_dir, "run")
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt='ooo run C:/temp/seed.yaml "two words"',
+            cwd=runtime_cwd,
+            skills_dir=skills_dir,
+        )
+    )
+
+    assert isinstance(result, Resolved)
+    assert result.first_argument == "C:/temp/seed.yaml two words"
+    assert result.mcp_args["seed_path"] == "C:/temp/seed.yaml two words"
+
+
 def test_valid_dispatch_without_argument_normalizes_first_argument_template_to_empty_string(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -249,6 +249,34 @@ def test_valid_router_dispatch_forms_resolve_expected_parsed_dispatch_fields(
     assert result.outcome is ResolveOutcome.MATCH
 
 
+@pytest.mark.parametrize(
+    "seed_path",
+    [
+        pytest.param(r"C:\temp\seed.yaml --strict", id="drive-letter-path"),
+        pytest.param(r"\\server\share\seed.yaml --strict", id="unc-path"),
+    ],
+)
+def test_valid_dispatch_preserves_windows_path_backslashes(
+    tmp_path: Path,
+    seed_path: str,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    runtime_cwd = tmp_path / "workspace"
+    _write_dispatchable_skill(skills_dir, "run")
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt=f"ooo run {seed_path}",
+            cwd=runtime_cwd,
+            skills_dir=skills_dir,
+        )
+    )
+
+    assert isinstance(result, Resolved)
+    assert result.first_argument == seed_path
+    assert result.mcp_args["seed_path"] == seed_path
+
+
 def test_valid_dispatch_without_argument_normalizes_first_argument_template_to_empty_string(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -277,6 +277,48 @@ def test_valid_dispatch_preserves_windows_path_backslashes(
     assert result.mcp_args["seed_path"] == seed_path
 
 
+def test_valid_dispatch_preserves_windows_backslashes_and_normalizes_quotes(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    runtime_cwd = tmp_path / "workspace"
+    _write_dispatchable_skill(skills_dir, "run")
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt=r'ooo run C:\temp\seed.yaml "two words"',
+            cwd=runtime_cwd,
+            skills_dir=skills_dir,
+        )
+    )
+
+    expected_argument = r"C:\temp\seed.yaml two words"
+    assert isinstance(result, Resolved)
+    assert result.first_argument == expected_argument
+    assert result.mcp_args["seed_path"] == expected_argument
+
+
+def test_valid_dispatch_preserves_unc_backslashes_and_normalizes_quotes(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    runtime_cwd = tmp_path / "workspace"
+    _write_dispatchable_skill(skills_dir, "run")
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt=r'ooo run \\server\share\seed.yaml "two words"',
+            cwd=runtime_cwd,
+            skills_dir=skills_dir,
+        )
+    )
+
+    expected_argument = r"\\server\share\seed.yaml two words"
+    assert isinstance(result, Resolved)
+    assert result.first_argument == expected_argument
+    assert result.mcp_args["seed_path"] == expected_argument
+
+
 def test_valid_dispatch_normalizes_windows_forward_slash_paths(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/router/test_valid_dispatch_normalization.py
+++ b/tests/unit/router/test_valid_dispatch_normalization.py
@@ -298,6 +298,27 @@ def test_valid_dispatch_preserves_windows_backslashes_and_normalizes_quotes(
     assert result.mcp_args["seed_path"] == expected_argument
 
 
+def test_valid_dispatch_preserves_windows_backslashes_and_normalizes_escaped_quotes(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    runtime_cwd = tmp_path / "workspace"
+    _write_dispatchable_skill(skills_dir, "run")
+
+    result = resolve_skill_dispatch(
+        ResolveRequest(
+            prompt=r'ooo run C:\temp\seed.yaml "two \"quoted\" words"',
+            cwd=runtime_cwd,
+            skills_dir=skills_dir,
+        )
+    )
+
+    expected_argument = r'C:\temp\seed.yaml two "quoted" words'
+    assert isinstance(result, Resolved)
+    assert result.first_argument == expected_argument
+    assert result.mcp_args["seed_path"] == expected_argument
+
+
 def test_valid_dispatch_preserves_unc_backslashes_and_normalizes_quotes(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Closes #480 by preserving Windows drive-letter and UNC path payloads before router template substitution.
- Avoids POSIX `shlex` escape handling for Windows-style literal paths while keeping existing natural-language normalization intact.

## Changes

- Detects drive-letter and UNC path payloads in `extract_first_argument()` and returns them without destructive tokenization.
- Adds extraction and dispatch regression tests for backslash-preserving Windows path payloads.

## Tests

- `uv run pytest tests/unit/router/test_extract_first_argument.py tests/unit/router/test_valid_dispatch_normalization.py -q`
- `uv run ruff check src/ouroboros/router/dispatch.py tests/unit/router/test_extract_first_argument.py tests/unit/router/test_valid_dispatch_normalization.py`

Closes #480