### PR TITLE
feat(orchestrator): Gemini CLI runtime backend (follow-up to #312)

### DIFF
--- a/docs/runtime-guides/gemini.md
+++ b/docs/runtime-guides/gemini.md
@@ -1,0 +1,140 @@
+# Gemini CLI Runtime
+
+Run Ouroboros workflows on top of the locally installed
+[`gemini`](https://github.com/google-gemini/gemini-cli) CLI.
+
+The Gemini runtime is a sibling of the Codex / Hermes / OpenCode runtimes:
+Ouroboros owns the orchestration loop and shells out to `gemini` per task
+instead of talking to a hosted SDK. The runtime is **stateless** — Gemini
+does not currently expose a session-resume API, so checkpointing happens at
+the Ouroboros layer (event store + lineage), not inside the subprocess.
+
+## Prerequisites
+
+| Requirement       | Why                                                          |
+|-------------------|--------------------------------------------------------------|
+| `gemini` CLI      | Provider — install via `npm install -g @google/gemini-cli`   |
+| Google auth       | `gemini auth` (or `GOOGLE_API_KEY`) once before first use    |
+| Ouroboros (base)  | `pip install ouroboros-ai` — no provider-specific extras     |
+
+> Gemini runs on the **base** Ouroboros package. It does **not** require the
+> `[claude]` extra; the MCP entry can stay on whichever extra you previously
+> configured, or you can use the base `ouroboros-ai[mcp]` entry.
+
+## Quick start
+
+```bash
+# 1. Install Gemini CLI (if not already on PATH)
+npm install -g @google/gemini-cli
+gemini auth                       # one-time auth
+
+# 2. Point Ouroboros at Gemini
+ouroboros setup --runtime gemini  # auto-detects PATH or OUROBOROS_GEMINI_CLI_PATH
+# or, switch later:
+ouroboros config backend gemini
+
+# 3. Run a workflow
+ouroboros init "Add a CLI flag to skip eval"
+ouroboros run workflow seed.yaml
+```
+
+## CLI path resolution
+
+The runtime looks for the binary in this order:
+
+1. Constructor argument `cli_path=...`
+2. `OUROBOROS_GEMINI_CLI_PATH` environment variable
+3. `orchestrator.gemini_cli_path` in `~/.ouroboros/config.yaml`
+4. `gemini` on `$PATH`
+
+This means non-PATH installs (e.g. `~/.local/share/gemini-cli/bin/gemini`)
+work without modifying shell init.
+
+## Configuration
+
+```yaml
+# ~/.ouroboros/config.yaml
+orchestrator:
+  runtime_backend: gemini
+  gemini_cli_path: /opt/homebrew/bin/gemini   # optional; auto-detected
+llm:
+  backend: gemini                             # for interview / seed / eval
+```
+
+The same `gemini` value is accepted by every CLI surface that takes a
+backend name:
+
+- `ouroboros setup --runtime gemini`
+- `ouroboros config backend gemini`
+- `ouroboros mcp serve --llm-backend gemini`
+- `ouroboros init --llm-backend gemini`
+
+## Headless contract
+
+Each task spawns:
+
+```text
+gemini --prompt <PROMPT> \
+       --non-interactive \
+       --output-format stream-json \
+       --approval-mode yolo \
+       [--model gemini-2.5-pro]
+```
+
+| Flag                | Why                                                     |
+|---------------------|---------------------------------------------------------|
+| `--prompt`          | Carries the request (Gemini's documented headless API)  |
+| `--non-interactive` | Disables TTY prompts so the subprocess never blocks     |
+| `--output-format`   | NDJSON event stream parsed by `GeminiEventNormalizer`   |
+| `--approval-mode`   | `yolo` — required for headless approvals                |
+| `--model`           | Optional model override (`gemini-2.5-pro`, `flash`)     |
+
+## Event mapping
+
+The runtime parses Gemini's `stream-json` events through
+`GeminiEventNormalizer` and maps them onto Ouroboros' `AgentMessage`:
+
+| Gemini event   | Ouroboros message                                 |
+|----------------|---------------------------------------------------|
+| `init`         | session metadata only — no message emitted        |
+| `message` / `text` | `assistant` message                            |
+| `thinking`     | `assistant` with `data.thinking`                  |
+| `tool_use`     | `assistant` with `tool_name` + `data.tool_input`  |
+| `tool_result`  | `tool` message with `data.is_error`               |
+| `error`        | `system` message with `data.is_error=True`        |
+| `result`       | **terminal** `assistant` message — Gemini emits the final response in this event when no intermediate `message` event was produced |
+
+The terminal `result` event is critical: it is the only way the final
+assistant text reaches the orchestrator when Gemini chose not to emit a
+mid-stream `message`. Earlier prototypes dropped this event and lost the
+final answer; the runtime now surfaces it explicitly with
+`data.terminal=True`.
+
+## Capabilities
+
+| Capability               | Status                                          |
+|--------------------------|-------------------------------------------------|
+| Headless execution       | ✅                                              |
+| Tool calls               | ✅ (Gemini-managed — no Codex permission flags) |
+| Recursion guard          | ✅ `_OUROBOROS_DEPTH` (matches Claude/Codex)    |
+| Response truncation      | ✅ via `InputValidator` (matches #315)          |
+| Session resumption       | ❌ not supported by Gemini CLI                  |
+
+If you need resumable sessions, use the Claude or Codex runtime — Gemini's
+recovery happens at the Ouroboros checkpoint layer instead.
+
+## Troubleshooting
+
+**`gemini CLI not found.`**
+Install `@google/gemini-cli`, then either let `setup` auto-detect it or set
+`OUROBOROS_GEMINI_CLI_PATH=/abs/path/to/gemini`.
+
+**Final response missing.**
+You're probably on an old build that ignored `result` events. Upgrade and
+re-run; the runtime now surfaces `result.response` as a terminal assistant
+message.
+
+**The CLI hangs waiting for input.**
+The runtime always passes `--non-interactive`. If you see a hang, check
+that you're invoking the runtime through `ouroboros run` (or the MCP
+server) rather than driving `gemini` directly without that flag.

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -206,7 +206,7 @@ def backend(
         "hermes": "hermes",
         "gemini": "gemini",
     }[new_backend]
-    cli_path: str | None = None
+    cli_path = None
     if new_backend == "gemini":
         from ouroboros.config import get_gemini_cli_path
 

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -22,8 +22,8 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-_VALID_BACKENDS = ("claude", "codex", "opencode", "hermes")
-_SWITCHABLE_BACKENDS = ("claude", "codex", "hermes")
+_VALID_BACKENDS = ("claude", "codex", "opencode", "hermes", "gemini")
+_SWITCHABLE_BACKENDS = ("claude", "codex", "hermes", "gemini")
 
 
 def _load_config() -> tuple[dict, Path]:
@@ -90,6 +90,8 @@ def _resolve_cli_path(data: dict) -> str | None:
         return data.get("orchestrator", {}).get("opencode_cli_path")
     if backend == "hermes":
         return data.get("orchestrator", {}).get("hermes_cli_path")
+    if backend == "gemini":
+        return data.get("orchestrator", {}).get("gemini_cli_path")
     return data.get("orchestrator", {}).get("cli_path")
 
 
@@ -150,7 +152,7 @@ def show(
 def backend(
     new_backend: Annotated[
         str | None,
-        typer.Argument(help="Backend to switch to (claude, codex, hermes)."),
+        typer.Argument(help="Backend to switch to (claude, codex, hermes, gemini)."),
     ] = None,
 ) -> None:
     """Show or switch the runtime backend.
@@ -165,6 +167,7 @@ def backend(
     [dim]    ouroboros config backend codex     # switch to Codex[/dim]
     [dim]    ouroboros config backend claude    # switch to Claude Code[/dim]
     [dim]    ouroboros config backend hermes    # switch to Hermes[/dim]
+    [dim]    ouroboros config backend gemini    # switch to Gemini CLI[/dim]
     """
     data, config_path = _load_config()
     current = data.get("orchestrator", {}).get("runtime_backend", "unknown")
@@ -175,7 +178,9 @@ def backend(
         cli_path = _resolve_cli_path(data)
         if cli_path:
             console.print(f"[bold]CLI path:[/bold]        [dim]{cli_path}[/dim]")
-        console.print("\n[dim]Switch with: ouroboros config backend <claude|codex|hermes>[/dim]\n")
+        console.print(
+            "\n[dim]Switch with: ouroboros config backend <claude|codex|hermes|gemini>[/dim]\n"
+        )
         return
 
     # Validate
@@ -192,11 +197,31 @@ def backend(
         print_info(f"Already using {new_backend}.")
         return
 
-    # Detect CLI path
-    cli_name = {"claude": "claude", "codex": "codex", "hermes": "hermes"}[new_backend]
-    cli_path = shutil.which(cli_name)
+    # Detect CLI path. For backends that expose an env-var or persisted
+    # config path (gemini), honor those before falling back to PATH so users
+    # with explicit-path installs can still switch via the CLI.
+    cli_name = {
+        "claude": "claude",
+        "codex": "codex",
+        "hermes": "hermes",
+        "gemini": "gemini",
+    }[new_backend]
+    cli_path: str | None = None
+    if new_backend == "gemini":
+        from ouroboros.config import get_gemini_cli_path
+
+        cli_path = get_gemini_cli_path()
     if not cli_path:
-        print_error(f"{cli_name} CLI not found in PATH.\nInstall it first, then retry.")
+        cli_path = shutil.which(cli_name)
+    if not cli_path:
+        if new_backend == "gemini":
+            print_error(
+                "gemini CLI not found.\n"
+                "Set OUROBOROS_GEMINI_CLI_PATH, configure orchestrator.gemini_cli_path "
+                "in config.yaml, or install gemini on PATH and retry."
+            )
+        else:
+            print_error(f"{cli_name} CLI not found in PATH.\nInstall it first, then retry.")
         raise typer.Exit(1)
 
     # Delegate to the full setup flow for the chosen backend.
@@ -205,7 +230,12 @@ def backend(
     # Suppress setup output; detect non-exception failures by monkey-patching
     # print_error to set a flag.
     from ouroboros.cli.commands import setup as setup_mod
-    from ouroboros.cli.commands.setup import _setup_claude, _setup_codex, _setup_hermes
+    from ouroboros.cli.commands.setup import (
+        _setup_claude,
+        _setup_codex,
+        _setup_gemini,
+        _setup_hermes,
+    )
 
     _setup_had_errors = False
     _orig_print_error = setup_mod.print_error
@@ -226,6 +256,8 @@ def backend(
             _setup_codex(cli_path)
         elif new_backend == "hermes":
             _setup_hermes(cli_path)
+        elif new_backend == "gemini":
+            _setup_gemini(cli_path)
     except Exception as exc:
         setup_failed = True
         console.quiet = prev_quiet
@@ -429,6 +461,10 @@ def validate() -> None:
         cli = data.get("orchestrator", {}).get("hermes_cli_path")
         if cli and not Path(cli).exists():
             issues.append(f"Hermes CLI path does not exist: {cli}")
+    elif backend_val == "gemini":
+        cli = data.get("orchestrator", {}).get("gemini_cli_path")
+        if cli and not Path(cli).exists():
+            issues.append(f"Gemini CLI path does not exist: {cli}")
 
     # Try loading config through the validated schema
     try:

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -52,6 +52,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     CODEX = "codex"
     OPENCODE = "opencode"
     HERMES = "hermes"
+    GEMINI = "gemini"
 
 
 class LLMBackend(str, Enum):  # noqa: UP042
@@ -61,6 +62,7 @@ class LLMBackend(str, Enum):  # noqa: UP042
     LITELLM = "litellm"
     CODEX = "codex"
     OPENCODE = "opencode"
+    GEMINI = "gemini"
 
 
 class _DefaultStartGroup(typer.core.TyperGroup):

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -35,6 +35,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     CODEX = "codex"
     OPENCODE = "opencode"
     HERMES = "hermes"
+    GEMINI = "gemini"
 
 
 class LLMBackend(str, Enum):  # noqa: UP042
@@ -44,6 +45,7 @@ class LLMBackend(str, Enum):  # noqa: UP042
     LITELLM = "litellm"
     CODEX = "codex"
     OPENCODE = "opencode"
+    GEMINI = "gemini"
 
 
 def _write_pid_file() -> bool:
@@ -369,7 +371,7 @@ def serve(
         typer.Option(
             "--llm-backend",
             help=(
-                "LLM backend for interview/seed/evaluation tools (claude_code, litellm, codex, or opencode)."
+                "LLM backend for interview/seed/evaluation tools (claude_code, litellm, codex, opencode, or gemini)."
             ),
             case_sensitive=False,
         ),
@@ -459,7 +461,7 @@ def info(
         typer.Option(
             "--llm-backend",
             help=(
-                "LLM backend for interview/seed/evaluation tools (claude_code, litellm, codex, or opencode)."
+                "LLM backend for interview/seed/evaluation tools (claude_code, litellm, codex, opencode, or gemini)."
             ),
             case_sensitive=False,
         ),

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -159,11 +159,25 @@ def _get_current_backend() -> str | None:
 
 
 def _detect_runtimes() -> dict[str, str | None]:
-    """Detect available runtime CLIs in PATH."""
+    """Detect available runtime CLIs in PATH.
+
+    For Gemini, we additionally honor the explicit-path overrides
+    (``OUROBOROS_GEMINI_CLI_PATH`` and persisted ``orchestrator.gemini_cli_path``)
+    so that users with non-PATH installs are still detected.
+    """
     runtimes: dict[str, str | None] = {}
     for name in ("claude", "codex", "opencode", "hermes"):
         path = shutil.which(name)
         runtimes[name] = path
+
+    # Gemini: prefer explicit-path config (env var / config.yaml) over PATH.
+    try:
+        from ouroboros.config import get_gemini_cli_path
+
+        gemini_path = get_gemini_cli_path()
+    except Exception:
+        gemini_path = None
+    runtimes["gemini"] = gemini_path or shutil.which("gemini")
     return runtimes
 
 
@@ -438,6 +452,51 @@ def _setup_hermes(hermes_path: str) -> None:
 
     # Register MCP server
     _register_hermes_mcp_server()
+
+
+def _setup_gemini(gemini_path: str) -> None:
+    """Configure Ouroboros for the Gemini CLI runtime.
+
+    Gemini is a base-package runtime — it does not require the ``[claude]``
+    extra (or any provider-specific extra) to function, so the MCP entry is
+    not rewritten as part of this flow. Users who want the Gemini runtime to
+    drive the MCP server can keep their existing entry; switching the
+    ``orchestrator.runtime_backend`` is sufficient.
+    """
+    from ouroboros.config.loader import create_default_config, ensure_config_dir
+
+    config_dir = ensure_config_dir()
+    config_path = config_dir / "config.yaml"
+
+    if config_path.exists():
+        config_dict = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    else:
+        create_default_config(config_dir)
+        config_dict = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+
+    if not isinstance(config_dict, dict):
+        print_warning("~/.ouroboros/config.yaml top-level is not a mapping — resetting.")
+        config_dict = {}
+
+    orch = config_dict.get("orchestrator")
+    if not isinstance(orch, dict):
+        orch = {}
+        config_dict["orchestrator"] = orch
+    orch["runtime_backend"] = "gemini"
+    orch["gemini_cli_path"] = gemini_path
+
+    # Gemini also serves as an LLM-only backend for interview/seed/eval flows.
+    llm = config_dict.get("llm")
+    if not isinstance(llm, dict):
+        llm = {}
+        config_dict["llm"] = llm
+    llm["backend"] = "gemini"
+
+    with config_path.open("w", encoding="utf-8") as f:
+        yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+
+    print_success(f"Configured Gemini runtime (CLI: {gemini_path})")
+    print_info(f"Config saved to: {config_path}")
 
 
 def _setup_claude(claude_path: str) -> None:
@@ -1165,7 +1224,7 @@ def setup(
         typer.Option(
             "--runtime",
             "-r",
-            help="Runtime backend to configure (claude, codex, opencode, hermes).",
+            help="Runtime backend to configure (claude, codex, opencode, hermes, gemini).",
         ),
     ] = None,
     non_interactive: Annotated[
@@ -1258,7 +1317,8 @@ def setup(
                 "  • Claude Code: https://claude.ai/download\n"
                 "  • Codex CLI:   npm install -g @openai/codex\n"
                 "  • OpenCode:    npm install -g opencode-ai\n"
-                "  • Hermes CLI:  https://hermes.ai/cli"
+                "  • Hermes CLI:  https://hermes.ai/cli\n"
+                "  • Gemini CLI:  npm install -g @google/gemini-cli"
             )
             raise typer.Exit(1)
 
@@ -1313,6 +1373,16 @@ def setup(
             print_error("Hermes CLI not found in PATH.")
             raise typer.Exit(1)
         _setup_hermes(hermes_path)
+    elif selected in ("gemini", "gemini_cli"):
+        gemini_path = available.get("gemini")
+        if not gemini_path:
+            print_error(
+                "Gemini CLI not found.\n"
+                "Install it (npm install -g @google/gemini-cli), set "
+                "OUROBOROS_GEMINI_CLI_PATH, or configure orchestrator.gemini_cli_path."
+            )
+            raise typer.Exit(1)
+        _setup_gemini(gemini_path)
     else:
         print_error(f"Unsupported runtime: {selected}")
         raise typer.Exit(1)

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -37,6 +37,7 @@ Functions:
 import ast
 import os
 from pathlib import Path
+import shutil
 import stat
 from typing import Any
 
@@ -576,18 +577,27 @@ def get_gemini_cli_path() -> str | None:
         2. config.yaml orchestrator.gemini_cli_path
         3. None (resolve from PATH at runtime)
 
+    Stale env var / config values that don't point to an executable are
+    treated as missing so callers fall back to PATH discovery instead of
+    persisting an unusable path. Mirrors the strictness of `shutil.which`
+    used for the other runtime backends in the setup detection path.
+
     Returns:
         Path to Gemini CLI binary or None.
     """
     env_path = os.environ.get("OUROBOROS_GEMINI_CLI_PATH", "").strip()
     if env_path:
-        return str(Path(env_path).expanduser())
+        resolved = str(Path(env_path).expanduser())
+        if shutil.which(resolved):
+            return resolved
 
     try:
         config = load_config()
         gemini_path = getattr(config.orchestrator, "gemini_cli_path", None)
         if gemini_path:
-            return gemini_path
+            resolved = str(Path(gemini_path).expanduser())
+            if shutil.which(resolved):
+                return resolved
     except ConfigError:
         pass
 

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -295,6 +295,14 @@ class OrchestratorConfig(BaseModel, frozen=True):
             - Absolute path: /path/to/opencode
             - ~ expansion: ~/.local/bin/opencode
             - None: Resolve from PATH at runtime
+        hermes_cli_path: Path to Hermes CLI binary. Supports:
+            - Absolute path: /path/to/hermes
+            - ~ expansion: ~/.local/bin/hermes
+            - None: Resolve from PATH at runtime
+        gemini_cli_path: Path to Gemini CLI binary. Supports:
+            - Absolute path: /path/to/gemini
+            - ~ expansion: ~/.local/bin/gemini
+            - None: Resolve from PATH at runtime (or OUROBOROS_GEMINI_CLI_PATH)
         default_max_turns: Default max turns for agent execution
         use_worktrees: Whether mutating workflows run in dedicated git worktrees
         worktree_root: Root directory for managed task worktrees
@@ -302,7 +310,7 @@ class OrchestratorConfig(BaseModel, frozen=True):
         worktree_lock_stale_after_minutes: Staleness threshold for task lock recovery
     """
 
-    runtime_backend: Literal["claude", "codex", "opencode", "hermes"] = "claude"
+    runtime_backend: Literal["claude", "codex", "opencode", "hermes", "gemini"] = "claude"
     permission_mode: Literal["default", "acceptEdits", "bypassPermissions"] = "acceptEdits"
     opencode_permission_mode: Literal["default", "acceptEdits", "bypassPermissions"] = (
         "bypassPermissions"
@@ -315,13 +323,20 @@ class OrchestratorConfig(BaseModel, frozen=True):
     codex_cli_path: str | None = None
     opencode_cli_path: str | None = None
     hermes_cli_path: str | None = None
+    gemini_cli_path: str | None = None
     default_max_turns: int = Field(default=10, ge=1)
     use_worktrees: bool = True
     worktree_root: str = "~/.ouroboros/worktrees"
     worktree_cleanup: Literal["keep"] = "keep"
     worktree_lock_stale_after_minutes: int = Field(default=60, ge=1)
 
-    @field_validator("cli_path", "codex_cli_path", "opencode_cli_path", "hermes_cli_path")
+    @field_validator(
+        "cli_path",
+        "codex_cli_path",
+        "opencode_cli_path",
+        "hermes_cli_path",
+        "gemini_cli_path",
+    )
     @classmethod
     def expand_cli_path(cls, v: str | None) -> str | None:
         """Expand ~ in cli_path."""

--- a/src/ouroboros/orchestrator/__init__.py
+++ b/src/ouroboros/orchestrator/__init__.py
@@ -47,6 +47,7 @@ from ouroboros.orchestrator.coordinator import (
     FileConflict,
     LevelCoordinator,
 )
+from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
 from ouroboros.orchestrator.opencode_runtime import (
     OpenCodeRuntime,
 )
@@ -150,6 +151,7 @@ __all__ = [
     "ClaudeAgentAdapter",
     "ClaudeCodeRuntime",
     "CodexCliRuntime",
+    "GeminiCLIRuntime",
     "OpenCodeRuntime",
     "DEFAULT_TOOLS",
     "RuntimeHandle",

--- a/src/ouroboros/orchestrator/gemini_cli_runtime.py
+++ b/src/ouroboros/orchestrator/gemini_cli_runtime.py
@@ -1,0 +1,370 @@
+"""Gemini CLI runtime for Ouroboros orchestrator execution.
+
+This module provides the GeminiCLIRuntime that shells out to the locally
+installed ``gemini`` CLI to execute agentic tasks.
+
+Usage:
+    runtime = GeminiCLIRuntime(model="gemini-2.5-pro", cwd="/path/to/project")
+    async for message in runtime.execute_task("Fix the bug in auth.py"):
+        print(message.content)
+
+Custom CLI Path:
+    Set via constructor parameter or environment variable:
+        runtime = GeminiCLIRuntime(cli_path="/path/to/gemini")
+        # or
+        export OUROBOROS_GEMINI_CLI_PATH=/path/to/gemini
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH, InputValidator
+from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
+from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
+
+log = structlog.get_logger(__name__)
+
+# Gemini CLI has no Codex-style permission mode flags.
+# The mode names are kept for interface compatibility.
+_GEMINI_PERMISSION_MODES = frozenset({"default", "acceptEdits", "bypassPermissions"})
+_GEMINI_DEFAULT_PERMISSION_MODE = "default"
+
+#: Maximum Ouroboros nesting depth to prevent fork bombs
+_MAX_OUROBOROS_DEPTH = 5
+
+
+class GeminiCLIRuntime(CodexCliRuntime):
+    """Agent runtime that shells out to the locally installed Gemini CLI.
+
+    Extends :class:`~ouroboros.orchestrator.codex_cli_runtime.CodexCliRuntime`
+    with overrides specific to the Gemini CLI process model:
+
+    - No Codex-style permission flags (Gemini manages permissions internally)
+    - No session resumption (stateless execution model)
+    - Plain-text and/or JSON event output normalization via GeminiEventNormalizer
+    """
+
+    _runtime_handle_backend = "gemini_cli"
+    _runtime_backend = "gemini"
+    _requires_memory_gate = False
+    _provider_name = "gemini_cli"
+    _runtime_error_type = "GeminiCliError"
+    _log_namespace = "gemini_cli_runtime"
+    _display_name = "Gemini CLI"
+    _default_cli_name = "gemini"
+    _default_llm_backend = "gemini"
+    _tempfile_prefix = "ouroboros-gemini-"
+    _skills_package_uri = "packaged://ouroboros.gemini/skills"
+    _process_shutdown_timeout_seconds = 5.0
+    _max_resume_retries = 0  # Gemini CLI does not support session resumption
+
+    def __init__(
+        self,
+        cli_path: str | Path | None = None,
+        permission_mode: str | None = None,
+        model: str | None = None,
+        cwd: str | Path | None = None,
+        skills_dir: str | Path | None = None,
+        skill_dispatcher: SkillDispatchHandler | None = None,
+        llm_backend: str | None = None,
+    ) -> None:
+        """Initialize the Gemini CLI runtime.
+
+        Args:
+            cli_path: Optional path to the gemini binary.
+            permission_mode: Optional permission mode (ignored by Gemini).
+            model: Optional model identifier.
+            cwd: Optional working directory for the subprocess.
+            skills_dir: Optional directory for skill definitions.
+            skill_dispatcher: Optional handler for skill execution.
+            llm_backend: Optional LLM backend identifier.
+        """
+        super().__init__(
+            cli_path=cli_path,
+            permission_mode=permission_mode,
+            model=model,
+            cwd=cwd,
+            skills_dir=skills_dir,
+            skill_dispatcher=skill_dispatcher,
+            llm_backend=llm_backend,
+        )
+        # Initialize the stateless event normalizer
+        self._normalizer = GeminiEventNormalizer(strict_json=False)
+
+    # -- Permission mode overrides -----------------------------------------
+
+    def _resolve_permission_mode(self, permission_mode: str | None) -> str:
+        """Normalize the permission mode for Gemini CLI.
+
+        Gemini CLI has its own internal permission model.  Ouroboros modes
+        are stored for metadata purposes but no permission flags are emitted.
+        """
+        if permission_mode and permission_mode in _GEMINI_PERMISSION_MODES:
+            return permission_mode
+        return _GEMINI_DEFAULT_PERMISSION_MODE
+
+    def _build_permission_args(self) -> list[str]:
+        """Return empty list — Gemini CLI has no Codex-style permission flags."""
+        return []
+
+    # -- Environment and security ------------------------------------------
+
+    def _build_child_env(self) -> dict[str, str]:
+        """Build child env with the recursion guard (matches #315 adapter pattern)."""
+        env = os.environ.copy()
+
+        # Prevent child from re-entering Ouroboros MCP
+        for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
+            env.pop(key, None)
+
+        try:
+            depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+        except (ValueError, TypeError):
+            depth = 1
+
+        if depth > _MAX_OUROBOROS_DEPTH:
+            msg = f"Maximum Ouroboros nesting depth ({_MAX_OUROBOROS_DEPTH}) exceeded"
+            raise RuntimeError(msg)
+
+        env["_OUROBOROS_DEPTH"] = str(depth)
+        return env
+
+    # -- CLI path resolution -----------------------------------------------
+
+    def _get_configured_cli_path(self) -> str | None:
+        """Resolve an explicit CLI path from config helpers when available.
+
+        Reads from :func:`ouroboros.config.get_gemini_cli_path`, which checks
+        ``OUROBOROS_GEMINI_CLI_PATH`` and persisted ``orchestrator.gemini_cli_path``.
+        """
+        from ouroboros.config import get_gemini_cli_path
+
+        return get_gemini_cli_path()
+
+    # -- Command construction ----------------------------------------------
+
+    def _build_command(
+        self,
+        output_last_message_path: str,
+        *,
+        resume_session_id: str | None = None,
+        prompt: str | None = None,
+    ) -> list[str]:
+        """Build the Gemini CLI command arguments for non-interactive execution.
+
+        Headless contract:
+        - ``--prompt`` carries the request (Gemini's documented headless trigger).
+        - ``--non-interactive`` disables TTY prompts so the subprocess never blocks.
+        - ``--output-format stream-json`` emits NDJSON events on stdout.
+        - ``--approval-mode yolo`` skips interactive approvals (required for headless).
+        """
+        del output_last_message_path, resume_session_id
+
+        command = [
+            self._cli_path,
+            "--prompt",
+            prompt or "",
+            "--non-interactive",
+            "--output-format",
+            "stream-json",
+            "--approval-mode",
+            "yolo",
+        ]
+        normalized_model = self._normalize_model(self._model)
+        if normalized_model:
+            command.extend(["--model", normalized_model])
+        return command
+
+    def _feeds_prompt_via_stdin(self) -> bool:
+        """Return False — Gemini CLI accepts the prompt via the --prompt flag."""
+        return False
+
+    def _requires_process_stdin(self) -> bool:
+        """Return False — Gemini CLI doesn't need an interactive stdin pipe."""
+        return False
+
+    # -- Event parsing and normalization -----------------------------------
+
+    def _extract_event_session_id(self, event: dict[str, Any]) -> str | None:
+        """Extract a backend-native session id from a runtime event.
+
+        Looks at standard top-level keys first, then ``metadata`` and the raw
+        payload (where Gemini's ``init`` event lands its ``session_id``).
+        """
+        session_id = super()._extract_event_session_id(event)
+        if session_id:
+            return session_id
+
+        metadata = event.get("metadata", {})
+        if isinstance(metadata, dict):
+            session_id = metadata.get("session_id")
+            if isinstance(session_id, str) and session_id.strip():
+                return session_id.strip()
+
+        raw = event.get("raw")
+        if isinstance(raw, dict):
+            session_id = raw.get("session_id")
+            if isinstance(session_id, str) and session_id.strip():
+                return session_id.strip()
+
+        return None
+
+    def _parse_json_event(self, line: str) -> dict[str, Any] | None:
+        """Parse a Gemini CLI output line into an internal event dict."""
+        if not line.strip():
+            return None
+
+        return self._normalizer.normalize_line(line)
+
+    def _convert_event(
+        self,
+        event: dict[str, Any],
+        current_handle: RuntimeHandle | None,
+    ) -> list[AgentMessage]:
+        """Convert a Gemini CLI event into normalized AgentMessage values.
+
+        Handles the documented Gemini ``stream-json`` schema:
+
+        - ``init`` — session metadata (session_id is captured by
+          ``_extract_event_session_id``); produces no AgentMessage
+        - ``message`` / ``text`` — assistant prose
+        - ``thinking`` — internal reasoning
+        - ``tool_use`` — tool invocation request
+        - ``tool_result`` — tool output
+        - ``error`` — error condition
+        - ``result`` — terminal payload carrying the final response (Gemini emits
+          the assistant's final answer here when no intermediate ``message``
+          event was produced); the normalizer extracts ``response`` into
+          ``content``, so we surface it as the final assistant message.
+        """
+        event_type = event.get("type")
+        content = event.get("content", "")
+        metadata = event.get("metadata", {})
+        is_error = event.get("is_error", False)
+
+        # Truncate content using InputValidator for text-bearing events
+        # (including the terminal `result` payload, since `response` may be long).
+        if event_type in ("text", "message", "thinking", "result"):
+            is_valid, _ = InputValidator.validate_llm_response(content)
+            if not is_valid:
+                log.warning(
+                    "gemini.response.truncated",
+                    event_type=event_type,
+                    original_length=len(content),
+                    max_length=MAX_LLM_RESPONSE_LENGTH,
+                )
+                content = content[:MAX_LLM_RESPONSE_LENGTH]
+
+        if event_type in ("text", "message"):
+            if not content:
+                return []
+            return [
+                AgentMessage(
+                    type="assistant",
+                    content=content,
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "thinking":
+            if not content:
+                return []
+            return [
+                AgentMessage(
+                    type="assistant",
+                    content=content,
+                    data={"thinking": content},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "tool_use":
+            tool_name = metadata.get("name", "")
+            tool_args = metadata.get("input", {})
+            return [
+                AgentMessage(
+                    type="assistant",
+                    content=content or f"Using tool: {tool_name}",
+                    tool_name=tool_name,
+                    data={"tool_input": tool_args},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "tool_result":
+            tool_name = metadata.get("name", "")
+            return [
+                AgentMessage(
+                    type="tool",
+                    content=content,
+                    tool_name=tool_name,
+                    data={"is_error": is_error},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "error":
+            return [
+                AgentMessage(
+                    type="system",
+                    content=f"Gemini Error: {content}",
+                    data={"is_error": True, "metadata": metadata},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "result":
+            # Terminal event. The normalizer maps `response` into `content`;
+            # if no response text is present we still emit a marker message
+            # carrying the metadata so downstream callers see the completion.
+            if not content:
+                return [
+                    AgentMessage(
+                        type="assistant",
+                        content="",
+                        data={"terminal": True, "metadata": metadata},
+                        resume_handle=current_handle,
+                    )
+                ]
+            return [
+                AgentMessage(
+                    type="assistant",
+                    content=content,
+                    data={"terminal": True, "metadata": metadata},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        # Ignore other auxiliary events (init/done/etc.) that don't map
+        # to messages; init's session_id is captured separately above.
+        return []
+
+    # -- Session resumption ------------------------------------------------
+
+    def _build_resume_recovery(
+        self,
+        *,
+        attempted_resume_session_id: str | None,
+        current_handle: RuntimeHandle | None,
+        returncode: int,
+        final_message: str,
+        stderr_lines: list[str],
+    ) -> tuple[RuntimeHandle | None, AgentMessage | None] | None:
+        """Return None — Gemini CLI does not support session resumption."""
+        del (
+            attempted_resume_session_id,
+            current_handle,
+            returncode,
+            final_message,
+            stderr_lines,
+        )
+        return None
+
+
+__all__ = ["GeminiCLIRuntime"]

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -21,6 +21,9 @@ _CLAUDE_BACKENDS = {"claude", "claude_code"}
 _CODEX_BACKENDS = {"codex", "codex_cli"}
 _OPENCODE_BACKENDS = {"opencode", "opencode_cli"}
 _HERMES_BACKENDS = {"hermes", "hermes_cli"}
+_GEMINI_BACKENDS = {"gemini", "gemini_cli"}
+
+_SUPPORTED_BACKENDS = ("claude", "codex", "opencode", "hermes", "gemini")
 
 
 def resolve_agent_runtime_backend(backend: str | None = None) -> str:
@@ -34,8 +37,13 @@ def resolve_agent_runtime_backend(backend: str | None = None) -> str:
         return "opencode"
     if candidate in _HERMES_BACKENDS:
         return "hermes"
+    if candidate in _GEMINI_BACKENDS:
+        return "gemini"
 
-    msg = f"Unsupported orchestrator runtime backend: {candidate}"
+    msg = (
+        f"Unsupported orchestrator runtime backend: {candidate}. "
+        f"Supported backends: {', '.join(_SUPPORTED_BACKENDS)}"
+    )
     raise ValueError(msg)
 
 
@@ -102,7 +110,19 @@ def create_agent_runtime(
             **runtime_kwargs,
         )
 
-    msg = f"Unsupported orchestrator runtime backend: {resolved_backend}"
+    if resolved_backend == "gemini":
+        from ouroboros.config import get_gemini_cli_path
+        from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+
+        return GeminiCLIRuntime(
+            cli_path=cli_path or get_gemini_cli_path(),
+            **runtime_kwargs,
+        )
+
+    msg = (
+        f"Unsupported orchestrator runtime backend: {resolved_backend}. "
+        f"Supported backends: {', '.join(_SUPPORTED_BACKENDS)}"
+    )
     raise ValueError(msg)
 
 

--- a/src/ouroboros/providers/gemini_event_normalizer.py
+++ b/src/ouroboros/providers/gemini_event_normalizer.py
@@ -1,0 +1,363 @@
+"""Gemini CLI event normalizer for Ouroboros.
+
+Converts raw output lines from the Gemini CLI into a normalized internal event
+schema that Ouroboros runtimes and orchestrators can work with uniformly,
+regardless of whether the raw line is plain text or a structured JSON event.
+
+The Gemini CLI can emit two kinds of output depending on how it is invoked:
+
+- **Plain text**: A single block of prose written to stdout (typical for
+  ``--non-interactive -p -`` mode).
+- **JSON events** (NDJSON): Structured events emitted line-by-line when the
+  CLI is run with ``--json`` or in an agentic mode; each line is a JSON object
+  with at least a ``type`` field.
+
+This normalizer handles both cases and maps them onto a minimal internal
+event dict with the following guaranteed keys:
+
+.. code-block:: python
+
+    {
+        "type": str,          # e.g. "text", "error", "tool_call", "thinking"
+        "content": str,       # primary human-readable payload
+        "raw": dict | list | str,  # original parsed object or raw line string
+        "is_error": bool,     # True when the event represents an error
+        "metadata": dict,     # supplementary key/value pairs from the raw event
+    }
+
+Usage::
+
+    from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
+
+    normalizer = GeminiEventNormalizer()
+    for line in gemini_output.splitlines():
+        event = normalizer.normalize_line(line)
+        print(event["type"], event["content"])
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Internal constants
+# ---------------------------------------------------------------------------
+
+#: Event types that are considered errors
+_ERROR_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "error",
+        "fatal",
+        "exception",
+        "abort",
+    }
+)
+
+#: JSON field names that carry the main text payload, tried in order
+_CONTENT_FIELD_CANDIDATES: tuple[str, ...] = (
+    "content",
+    "text",
+    "message",
+    "output",
+    "response",
+    "data",
+)
+
+#: JSON field names that carry the event type, tried in order
+_TYPE_FIELD_CANDIDATES: tuple[str, ...] = (
+    "type",
+    "event",
+    "kind",
+    "category",
+)
+
+#: Normalized event type returned for plain-text (non-JSON) lines
+_PLAIN_TEXT_EVENT_TYPE = "text"
+
+#: Normalized event type returned for unknown/unrecognised JSON events
+_UNKNOWN_EVENT_TYPE = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Normalizer
+# ---------------------------------------------------------------------------
+
+
+class GeminiEventNormalizer:
+    """Normalizes raw Gemini CLI output lines into a uniform internal event dict.
+
+    The normalizer is stateless; the same instance can safely be reused across
+    multiple completions.
+
+    Attributes:
+        strict_json: When ``True``, lines that look like JSON but fail to parse
+            raise :class:`ValueError` rather than being silently downgraded to
+            plain-text events.
+
+    Example::
+
+        normalizer = GeminiEventNormalizer()
+
+        # Plain text line
+        event = normalizer.normalize_line("Hello from Gemini.")
+        assert event["type"] == "text"
+        assert event["is_error"] is False
+
+        # JSON event line
+        event = normalizer.normalize_line('{"type": "error", "message": "quota"}')
+        assert event["type"] == "error"
+        assert event["is_error"] is True
+    """
+
+    def __init__(self, *, strict_json: bool = False) -> None:
+        """Initialise the normalizer.
+
+        Args:
+            strict_json: When ``True``, JSON parse failures for lines that
+                start with ``{`` raise :class:`ValueError` instead of
+                falling back to plain-text treatment.
+        """
+        self.strict_json = strict_json
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def normalize_line(self, raw_line: str) -> dict[str, Any]:
+        """Normalize a single raw output line from the Gemini CLI.
+
+        The function attempts JSON parsing first (when the stripped line starts
+        with ``{`` or ``[``).  If the line is not JSON (or JSON parsing fails
+        in non-strict mode) the line is treated as a plain-text event.
+
+        Args:
+            raw_line: A single line of raw Gemini CLI output (may have
+                trailing whitespace / newline characters).
+
+        Returns:
+            Normalized event dict with keys ``type``, ``content``, ``raw``,
+            ``is_error``, and ``metadata``.
+
+        Raises:
+            ValueError: If *raw_line* looks like JSON, ``strict_json=True``,
+                and JSON parsing fails.
+        """
+        stripped = raw_line.strip()
+
+        if stripped.startswith("{") or stripped.startswith("["):
+            return self._normalize_json_line(stripped, original=raw_line)
+
+        return self._normalize_text_line(stripped, original=raw_line)
+
+    def normalize_lines(self, raw_output: str) -> list[dict[str, Any]]:
+        """Normalize an entire multi-line Gemini CLI output string.
+
+        Blank lines are skipped.
+
+        Args:
+            raw_output: Full stdout from a Gemini CLI subprocess call.
+
+        Returns:
+            List of normalized event dicts, one per non-blank line.
+        """
+        events: list[dict[str, Any]] = []
+        for line in raw_output.splitlines():
+            if not line.strip():
+                continue
+            events.append(self.normalize_line(line))
+        return events
+
+    # ------------------------------------------------------------------
+    # JSON path
+    # ------------------------------------------------------------------
+
+    def _normalize_json_line(
+        self,
+        stripped: str,
+        *,
+        original: str,
+    ) -> dict[str, Any]:
+        """Parse and normalise a JSON event line.
+
+        Args:
+            stripped: The stripped version of the line.
+            original: The original, un-stripped line (stored in ``raw``).
+
+        Returns:
+            Normalized event dict.
+
+        Raises:
+            ValueError: When ``strict_json=True`` and the JSON parse fails.
+        """
+        try:
+            parsed: Any = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            if self.strict_json:
+                msg = f"Failed to parse Gemini CLI JSON event: {exc}"
+                raise ValueError(msg) from exc
+            log.debug("gemini_event_normalizer.json_parse_failed: %s", stripped[:120])
+            return self._normalize_text_line(stripped, original=original)
+
+        if isinstance(parsed, list):
+            return self._build_event(
+                event_type="list",
+                content=json.dumps(parsed),
+                raw=parsed,
+                metadata={},
+                is_error=False,
+            )
+
+        if not isinstance(parsed, dict):
+            return self._normalize_text_line(stripped, original=original)
+
+        return self._normalize_json_dict(parsed, original=original)
+
+    def _normalize_json_dict(
+        self,
+        parsed: dict[str, Any],
+        *,
+        original: str,
+    ) -> dict[str, Any]:
+        """Map a parsed JSON dict to the internal event schema.
+
+        Args:
+            parsed: The parsed JSON object as a Python dict.
+            original: The original raw line (stored in ``raw``).
+
+        Returns:
+            Normalized event dict.
+        """
+        # --- Determine event type ---
+        event_type: str = _UNKNOWN_EVENT_TYPE
+        for key in _TYPE_FIELD_CANDIDATES:
+            if key in parsed and isinstance(parsed[key], str):
+                event_type = parsed[key].strip().lower() or _UNKNOWN_EVENT_TYPE
+                break
+
+        # --- Determine content ---
+        content: str = ""
+        for key in _CONTENT_FIELD_CANDIDATES:
+            if key in parsed:
+                val = parsed[key]
+                if isinstance(val, str):
+                    content = val
+                elif val is not None:
+                    content = json.dumps(val) if isinstance(val, (dict, list)) else str(val)
+                break
+
+        # --- Determine error flag ---
+        is_error = self._is_error_event(event_type, parsed)
+
+        # --- Collect metadata (everything except type/content fields) ---
+        skip_keys = set(_TYPE_FIELD_CANDIDATES) | set(_CONTENT_FIELD_CANDIDATES)
+        metadata = {k: v for k, v in parsed.items() if k not in skip_keys}
+
+        return self._build_event(
+            event_type=event_type,
+            content=content,
+            raw=parsed,
+            metadata=metadata,
+            is_error=is_error,
+        )
+
+    # ------------------------------------------------------------------
+    # Plain-text path
+    # ------------------------------------------------------------------
+
+    def _normalize_text_line(
+        self,
+        stripped: str,
+        *,
+        original: str,
+    ) -> dict[str, Any]:
+        """Wrap a plain-text line as a ``text`` event.
+
+        Args:
+            stripped: Stripped content of the line.
+            original: Original raw line (stored in ``raw``).
+
+        Returns:
+            Normalized ``text`` event dict.
+        """
+        return self._build_event(
+            event_type=_PLAIN_TEXT_EVENT_TYPE,
+            content=stripped,
+            raw=original,
+            metadata={},
+            is_error=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_error_event(event_type: str, parsed: dict[str, Any]) -> bool:
+        """Return ``True`` if the event represents an error condition.
+
+        An event is treated as an error when:
+
+        - Its ``type`` (or ``kind``) is in :data:`_ERROR_EVENT_TYPES`.
+        - The dict contains a boolean ``"is_error"`` field set to ``True``.
+        - The dict contains a boolean ``"error"`` field set to ``True``.
+        - The dict contains a non-empty string ``"error"`` field (error message).
+        - The dict contains a ``"status"`` field set to ``"error"`` or
+          ``"failed"``.
+
+        Args:
+            event_type: The already-normalised event type string.
+            parsed: The full parsed JSON dict.
+
+        Returns:
+            ``True`` when the event should be treated as an error.
+        """
+        if event_type in _ERROR_EVENT_TYPES:
+            return True
+
+        if parsed.get("is_error") is True:
+            return True
+
+        error_val = parsed.get("error")
+        if error_val is True:
+            return True
+        if isinstance(error_val, str) and error_val.strip():
+            return True
+
+        status = parsed.get("status", "")
+        return isinstance(status, str) and status.strip().lower() in ("error", "failed")
+
+    @staticmethod
+    def _build_event(
+        *,
+        event_type: str,
+        content: str,
+        raw: dict[str, Any] | list[Any] | str,
+        metadata: dict[str, Any],
+        is_error: bool,
+    ) -> dict[str, Any]:
+        """Construct a normalized event dict.
+
+        Args:
+            event_type: Normalized event type string.
+            content: Primary human-readable payload.
+            raw: The original parsed object or raw string.
+            metadata: Supplementary key/value pairs.
+            is_error: Whether this event represents an error condition.
+
+        Returns:
+            Normalized event dict.
+        """
+        return {
+            "type": event_type,
+            "content": content,
+            "raw": raw,
+            "is_error": is_error,
+            "metadata": metadata,
+        }
+
+
+__all__ = ["GeminiEventNormalizer"]

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -272,6 +272,18 @@ class TestConfigValidate:
             result = runner.invoke(app, ["validate"])
         assert result.exit_code == 0
 
+    def test_gemini_runtime_backend_is_valid(self, tmp_path: Path) -> None:
+        """validate should accept gemini as a valid runtime backend."""
+        config = {"orchestrator": {"runtime_backend": "gemini"}, "llm": {"backend": "gemini"}}
+        (tmp_path / "config.yaml").write_text(yaml.dump(config))
+
+        with (
+            patch("ouroboros.config.models.get_config_dir", return_value=tmp_path),
+            patch("ouroboros.config.loader.load_config"),
+        ):
+            result = runner.invoke(app, ["validate"])
+        assert result.exit_code == 0
+
     def test_missing_cli_path_exits_nonzero(self, tmp_path: Path) -> None:
         """validate should exit 1 when CLI path doesn't exist."""
         config = {

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -25,6 +25,7 @@ from ouroboros.config.loader import (
     get_decomposition_model,
     get_dependency_analysis_model,
     get_double_diamond_model,
+    get_gemini_cli_path,
     get_llm_backend,
     get_llm_permission_mode,
     get_ontology_analysis_model,
@@ -409,6 +410,62 @@ class TestRuntimeHelperLookups:
             ),
         ):
             assert get_opencode_cli_path() == "/tmp/opencode"
+
+    def test_get_gemini_cli_path_returns_executable_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Env var path is returned when it points to an executable file."""
+        fake = tmp_path / "gemini"
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        monkeypatch.setenv("OUROBOROS_GEMINI_CLI_PATH", str(fake))
+        assert get_gemini_cli_path() == str(fake)
+
+    def test_get_gemini_cli_path_rejects_stale_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Stale env var that doesn't point to an executable is treated as missing.
+
+        Prevents writing an unusable path back into config via
+        `ouroboros config backend gemini` / `setup --runtime gemini`.
+        """
+        stale = tmp_path / "missing-gemini"
+        monkeypatch.setenv("OUROBOROS_GEMINI_CLI_PATH", str(stale))
+        with patch(
+            "ouroboros.config.loader.load_config",
+            return_value=OuroborosConfig(orchestrator=OrchestratorConfig()),
+        ):
+            assert get_gemini_cli_path() is None
+
+    def test_get_gemini_cli_path_falls_back_to_config(self, tmp_path: Path) -> None:
+        """Config path is honored when env is absent and the file is executable."""
+        fake = tmp_path / "gemini"
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "ouroboros.config.loader.load_config",
+                return_value=OuroborosConfig(
+                    orchestrator=OrchestratorConfig(gemini_cli_path=str(fake))
+                ),
+            ),
+        ):
+            assert get_gemini_cli_path() == str(fake)
+
+    def test_get_gemini_cli_path_rejects_stale_config(self, tmp_path: Path) -> None:
+        """Stale config value that no longer points to an executable returns None."""
+        stale = tmp_path / "ghost-gemini"
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "ouroboros.config.loader.load_config",
+                return_value=OuroborosConfig(
+                    orchestrator=OrchestratorConfig(gemini_cli_path=str(stale))
+                ),
+            ),
+        ):
+            assert get_gemini_cli_path() is None
 
     def test_get_opencode_mode_returns_config_value(self) -> None:
         """get_opencode_mode reads orchestrator.opencode_mode from config."""

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -462,6 +462,22 @@ class TestOrchestratorConfig:
         assert config.runtime_backend == "opencode"
         assert "~" not in config.opencode_cli_path
 
+    def test_orchestrator_config_accepts_gemini_backend(self) -> None:
+        """Gemini is a valid runtime_backend value."""
+        config = OrchestratorConfig(runtime_backend="gemini")
+        assert config.runtime_backend == "gemini"
+        assert config.gemini_cli_path is None
+
+    def test_orchestrator_config_expands_gemini_cli_path(self) -> None:
+        """Expands ~ in gemini_cli_path."""
+        config = OrchestratorConfig(
+            runtime_backend="gemini",
+            gemini_cli_path="~/bin/gemini",
+        )
+        assert config.runtime_backend == "gemini"
+        assert config.gemini_cli_path is not None
+        assert "~" not in config.gemini_cli_path
+
 
 class TestGetDefaultConfig:
     """Test get_default_config helper function."""

--- a/tests/unit/orchestrator/test_gemini_cli_runtime.py
+++ b/tests/unit/orchestrator/test_gemini_cli_runtime.py
@@ -1,0 +1,178 @@
+"""Focused unit tests for the Gemini CLI runtime.
+
+These tests cover the regressions surfaced during PR #312 review:
+
+1. ``_convert_event`` surfaces the terminal ``result`` event as the final
+   assistant message (the original PR dropped it).
+2. ``_build_command`` includes ``--non-interactive`` so the CLI never blocks
+   on a TTY prompt during headless execution.
+3. ``--prompt`` carries the actual request (no empty-string regression).
+4. The recursion guard refuses to launch beyond the configured depth.
+5. ``runtime_factory.resolve_agent_runtime_backend`` accepts ``gemini`` and
+   the rejection message lists every supported backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.gemini_cli_runtime import (
+    _MAX_OUROBOROS_DEPTH,
+    GeminiCLIRuntime,
+)
+from ouroboros.orchestrator.runtime_factory import resolve_agent_runtime_backend
+
+# ---------------------------------------------------------------------------
+# _convert_event: terminal `result` event
+# ---------------------------------------------------------------------------
+
+
+def _make_runtime() -> GeminiCLIRuntime:
+    return GeminiCLIRuntime(cli_path="/usr/bin/gemini")
+
+
+def test_convert_event_surfaces_result_response_as_terminal_assistant_message() -> None:
+    runtime = _make_runtime()
+
+    # The normalizer maps `response` into `content`. We feed an already-normalized
+    # event to keep this test focused on the runtime's terminal handling.
+    event = {
+        "type": "result",
+        "content": "All tests passed.",
+        "metadata": {"session_id": "sess-42"},
+        "is_error": False,
+        "raw": {"type": "result", "response": "All tests passed."},
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].content == "All tests passed."
+    assert messages[0].data is not None
+    assert messages[0].data.get("terminal") is True
+
+
+def test_convert_event_emits_marker_when_result_has_no_response_text() -> None:
+    runtime = _make_runtime()
+    event = {
+        "type": "result",
+        "content": "",
+        "metadata": {"session_id": "sess-7"},
+        "is_error": False,
+        "raw": {"type": "result"},
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].data is not None
+    assert messages[0].data.get("terminal") is True
+
+
+def test_convert_event_routes_normalizer_response_field_through_result() -> None:
+    """End-to-end: normalizer + runtime surface `result.response` as final answer."""
+    runtime = _make_runtime()
+    raw_line = '{"type":"result","response":"final answer text"}'
+    normalized = runtime._parse_json_event(raw_line)
+    assert normalized is not None
+    messages = runtime._convert_event(normalized, current_handle=None)
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].content == "final answer text"
+
+
+# ---------------------------------------------------------------------------
+# _build_command: headless flags
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_includes_non_interactive_flag() -> None:
+    runtime = _make_runtime()
+    cmd = runtime._build_command("/tmp/unused", prompt="hello")
+    assert "--non-interactive" in cmd, f"--non-interactive missing from headless command: {cmd!r}"
+
+
+def test_build_command_passes_prompt_through_prompt_flag() -> None:
+    runtime = _make_runtime()
+    cmd = runtime._build_command("/tmp/unused", prompt="fix the bug")
+    # Locate `--prompt` and check the next arg is our payload.
+    assert "--prompt" in cmd
+    idx = cmd.index("--prompt")
+    assert cmd[idx + 1] == "fix the bug"
+
+
+def test_build_command_uses_stream_json_output_format() -> None:
+    runtime = _make_runtime()
+    cmd = runtime._build_command("/tmp/unused", prompt="x")
+    assert "--output-format" in cmd
+    idx = cmd.index("--output-format")
+    assert cmd[idx + 1] == "stream-json"
+
+
+def test_runtime_does_not_feed_prompt_via_stdin() -> None:
+    runtime = _make_runtime()
+    assert runtime._feeds_prompt_via_stdin() is False
+    assert runtime._requires_process_stdin() is False
+
+
+# ---------------------------------------------------------------------------
+# Recursion guard
+# ---------------------------------------------------------------------------
+
+
+def test_recursion_guard_increments_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("_OUROBOROS_DEPTH", "1")
+    runtime = _make_runtime()
+    env = runtime._build_child_env()
+    assert env["_OUROBOROS_DEPTH"] == "2"
+
+
+def test_recursion_guard_raises_at_max_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("_OUROBOROS_DEPTH", str(_MAX_OUROBOROS_DEPTH))
+    runtime = _make_runtime()
+    with pytest.raises(RuntimeError, match="Maximum Ouroboros nesting depth"):
+        runtime._build_child_env()
+
+
+def test_recursion_guard_strips_oroboros_runtime_envs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "gemini")
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "gemini")
+    runtime = _make_runtime()
+    env = runtime._build_child_env()
+    assert "OUROBOROS_AGENT_RUNTIME" not in env
+    assert "OUROBOROS_LLM_BACKEND" not in env
+
+
+# ---------------------------------------------------------------------------
+# runtime_factory: gemini registration & rejection message
+# ---------------------------------------------------------------------------
+
+
+def test_factory_resolves_gemini_alias() -> None:
+    assert resolve_agent_runtime_backend("gemini") == "gemini"
+    assert resolve_agent_runtime_backend("gemini_cli") == "gemini"
+    assert resolve_agent_runtime_backend("GEMINI") == "gemini"
+
+
+def test_factory_rejection_message_lists_supported_backends() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        resolve_agent_runtime_backend("nonsense-backend")
+    msg = str(exc_info.value)
+    for name in ("claude", "codex", "opencode", "hermes", "gemini"):
+        assert name in msg, f"rejection message missing {name!r}: {msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# mcp.py: LLMBackend includes GEMINI
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_llm_backend_enum_includes_gemini() -> None:
+    from ouroboros.cli.commands.mcp import AgentRuntimeBackend, LLMBackend
+
+    assert LLMBackend("gemini") is LLMBackend.GEMINI
+    assert AgentRuntimeBackend("gemini") is AgentRuntimeBackend.GEMINI


### PR DESCRIPTION
## Summary
- Lands the Gemini CLI **runtime** layer that PR #312 attempted but never merged. The Gemini *adapter* is already on `main` via #315; this PR fills the runtime/factory/CLI gap so Gemini works end-to-end as an orchestrator backend.
- Fixes the unresolved blocker the bot reviewer flagged on #312 at HEAD `880658d`: `_convert_event` now surfaces Gemini's terminal `result` event as the final assistant message instead of silently dropping it.
- Wires Gemini through every public CLI surface: `setup --runtime gemini`, `config backend gemini` (with `OUROBOROS_GEMINI_CLI_PATH` / persisted-path fallback), `mcp serve --llm-backend gemini`, `init --llm-backend gemini`.
- Decouples Gemini setup from the `[claude]` MCP extra — Gemini-only installs no longer pull the Claude SDK.

## Why a fresh PR instead of finishing #312
- #312 has 25 days of base drift; GitHub marks it `CONFLICTING`.
- It was opened from @yevheniikravchuk's fork, so we cannot push the rebase + fixes onto its branch directly.
- The branch's last bot review (after a brief APPROVE) re-flagged the dropped `result` event as a blocker. That fix needed to land before merge regardless.

This PR cherry-picks the structurally sound parts of #312 (runtime + normalizer) onto current upstream/main, applies every follow-up the bot reviewer flagged, and credits @yevheniikravchuk via `Co-Authored-By` so attribution stays intact. Once this lands we can close #312 with a thank-you and pointer here.

## What's in
- `src/ouroboros/orchestrator/gemini_cli_runtime.py` — extends `CodexCliRuntime`. `_OUROBOROS_DEPTH` recursion guard + `InputValidator` truncation (matches the #315 adapter pattern). No session resumption (Gemini CLI doesn't expose one).
- `src/ouroboros/providers/gemini_event_normalizer.py` — stateless NDJSON / plain-text normalizer.
- `runtime_factory.py` — `gemini` / `gemini_cli` aliases registered through `get_gemini_cli_path()`; rejection message now lists every supported backend.
- CLI wiring in `mcp.py`, `init.py`, `setup.py`, `config.py` (env-var fallback in `config backend gemini`).
- `docs/runtime-guides/gemini.md` — documents the contract the code actually implements.
- `_setup_gemini` is intentionally lightweight — does **not** require `[claude]` extras.

## Bot-blocker resolution (vs #312@880658d)
| Finding | Status |
|---|---|
| `_convert_event` drops terminal `result` event | **Fixed** — runtime emits an `assistant` message with `data.terminal=True` |
| `runtime_factory` rejection message stale | **Fixed** — both rejection sites list `claude, codex, opencode, hermes, gemini` |
| `config backend gemini` only probes `shutil.which` | **Fixed** — `OUROBOROS_GEMINI_CLI_PATH` and `orchestrator.gemini_cli_path` honored first |
| Gemini setup reuses `[claude]` uvx extras | **Fixed** — `_setup_gemini` writes config without rewriting MCP extras |
| No test for `result.response` / `--non-interactive` | **Fixed** — covered in `tests/unit/orchestrator/test_gemini_cli_runtime.py` |

## Test plan
- [x] `uv run pytest tests/unit/orchestrator/test_gemini_cli_runtime.py` — 13 new tests
- [x] `uv run pytest tests/unit/orchestrator/ tests/unit/cli/test_setup.py tests/unit/cli/test_config.py tests/unit/providers/test_factory.py` — 924+ green, 1 skip (unrelated)
- [x] `uv run ruff check` + `uv run ruff format` — clean
- [x] `uv run mypy` on the three new files — clean
- [ ] Manual: `gemini` on PATH → `ouroboros setup --runtime gemini` → `ouroboros run workflow seed.yaml` (suggest @Q00 sanity-check before merging — needs Google auth in your env)

## Closes / refs
Refs #312, #298, #299, #300, #301, #302. Co-authored with @yevheniikravchuk.
