### PR TITLE
fix: harden interview closure prompt + router multiline dispatch

### DIFF
--- a/src/ouroboros/bigbang/ambiguity.py
+++ b/src/ouroboros/bigbang/ambiguity.py
@@ -283,7 +283,7 @@ class AmbiguityScorer:
     llm_adapter: LLMAdapter
     model: str = field(default_factory=get_clarification_model)
     temperature: float = SCORING_TEMPERATURE
-    initial_max_tokens: int = 512
+    initial_max_tokens: int = 2048
     max_retries: int | None = 10  # Default to 10 retries (None = unlimited)
     max_format_error_retries: int = 5  # Stop after N format errors (non-truncation)
 

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -288,7 +288,7 @@ class InterviewEngine:
     state_dir: Path = field(default_factory=lambda: Path.home() / ".ouroboros" / "data")
     model: str = field(default_factory=get_clarification_model)
     temperature: float = 0.7
-    max_tokens: int = 512
+    max_tokens: int = 2048
     _MAX_TOTAL_PROMPT_CHARS = 4800
     _MAX_SYSTEM_PROMPT_CHARS = 3500
     _MIN_SYSTEM_PROMPT_CHARS = 1200
@@ -729,62 +729,17 @@ class InterviewEngine:
         if state.ambiguity_score is None:
             return ""
 
-        from pydantic import ValidationError as PydanticValidationError
-
-        from ouroboros.bigbang.ambiguity import (
-            AMBIGUITY_THRESHOLD,
-            AUTO_COMPLETE_STREAK_REQUIRED,
-            SEED_CLOSER_ACTIVATION_THRESHOLD,
-            AmbiguityScore,
-            ScoreBreakdown,
-            get_completion_floor_failures,
-            get_milestone,
-            get_next_milestone,
-        )
+        from ouroboros.bigbang.ambiguity import get_milestone
 
         milestone, milestone_desc = get_milestone(state.ambiguity_score)
-        next_ms = get_next_milestone(state.ambiguity_score)
 
         lines = [
             "## Current Ambiguity Snapshot",
             f"- Overall ambiguity: {state.ambiguity_score:.2f}",
             f"- Milestone: **{milestone.value.upper()}** — {milestone_desc}",
         ]
-        if next_ms is not None:
-            lines.append(
-                f"- Next milestone: {next_ms[1].value} (<= {next_ms[0]:.1f}) — {next_ms[2]}"
-            )
-        lines.extend(
-            [
-                f"- Seed-ready threshold: {AMBIGUITY_THRESHOLD:.2f}",
-                f"- Closure-mode threshold: {SEED_CLOSER_ACTIVATION_THRESHOLD:.2f}",
-                (
-                    "- Seed-ready now: yes"
-                    if state.ambiguity_score <= AMBIGUITY_THRESHOLD
-                    else "- Seed-ready now: no"
-                ),
-                (
-                    "- Closure mode active: yes"
-                    if state.ambiguity_score <= SEED_CLOSER_ACTIVATION_THRESHOLD
-                    else "- Closure mode active: no"
-                ),
-                (
-                    "- Completion candidate streak: "
-                    f"{state.completion_candidate_streak}/{AUTO_COMPLETE_STREAK_REQUIRED}"
-                ),
-            ]
-        )
 
-        reconstructed_score: AmbiguityScore | None = None
         if isinstance(state.ambiguity_breakdown, dict):
-            try:
-                reconstructed_score = AmbiguityScore(
-                    overall_score=state.ambiguity_score,
-                    breakdown=ScoreBreakdown.model_validate(state.ambiguity_breakdown),
-                )
-            except PydanticValidationError:
-                reconstructed_score = None
-
             weakest_components: list[tuple[float, str, str]] = []
             for payload in state.ambiguity_breakdown.values():
                 if not isinstance(payload, dict):
@@ -806,22 +761,7 @@ class InterviewEngine:
                 if justification:
                     lines.append(f"  Reason: {justification}")
 
-        if reconstructed_score is not None:
-            floor_failures = get_completion_floor_failures(
-                reconstructed_score,
-                is_brownfield=state.is_brownfield,
-            )
-            if floor_failures:
-                lines.append(f"- Completion floors unmet: {'; '.join(floor_failures)}")
-            else:
-                lines.append("- Completion floors: passed")
-
-        lines.append(
-            "- Use this snapshot to drill into the weakest area until closure mode is active."
-        )
-        lines.append(
-            "- A single seed-ready score is not enough to end the interview; require sustained clarity before asking a closure question."
-        )
+        lines.append("- Drill into the weakest area with a concrete, scenario-grounded question.")
         return "\n".join(lines)
 
     def _select_perspectives(self, state: InterviewState) -> tuple[InterviewPerspective, ...]:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -729,7 +729,14 @@ class InterviewEngine:
         if state.ambiguity_score is None:
             return ""
 
-        from ouroboros.bigbang.ambiguity import get_milestone
+        from pydantic import ValidationError as PydanticValidationError
+
+        from ouroboros.bigbang.ambiguity import (
+            AmbiguityScore,
+            ScoreBreakdown,
+            get_completion_floor_failures,
+            get_milestone,
+        )
 
         milestone, milestone_desc = get_milestone(state.ambiguity_score)
 
@@ -739,7 +746,16 @@ class InterviewEngine:
             f"- Milestone: **{milestone.value.upper()}** — {milestone_desc}",
         ]
 
+        reconstructed_score: AmbiguityScore | None = None
         if isinstance(state.ambiguity_breakdown, dict):
+            try:
+                reconstructed_score = AmbiguityScore(
+                    overall_score=state.ambiguity_score,
+                    breakdown=ScoreBreakdown.model_validate(state.ambiguity_breakdown),
+                )
+            except PydanticValidationError:
+                reconstructed_score = None
+
             weakest_components: list[tuple[float, str, str]] = []
             for payload in state.ambiguity_breakdown.values():
                 if not isinstance(payload, dict):
@@ -760,6 +776,20 @@ class InterviewEngine:
                 lines.append(f"- Weakest area: {name} ({clarity:.2f} clarity)")
                 if justification:
                     lines.append(f"  Reason: {justification}")
+
+        if reconstructed_score is not None:
+            floor_failures = get_completion_floor_failures(
+                reconstructed_score,
+                is_brownfield=state.is_brownfield,
+            )
+            if floor_failures:
+                lines.append(f"- Per-dimension gaps: {'; '.join(floor_failures)}")
+                lines.append(
+                    "- Keep drilling those dimensions before asking a closure-style question, "
+                    "even when overall ambiguity reads low."
+                )
+            else:
+                lines.append("- Per-dimension gaps: none")
 
         lines.append("- Drill into the weakest area with a concrete, scenario-grounded question.")
         return "\n".join(lines)

--- a/tests/unit/bigbang/test_ambiguity.py
+++ b/tests/unit/bigbang/test_ambiguity.py
@@ -317,7 +317,7 @@ class TestAmbiguityScorerInit:
         assert scorer.llm_adapter == mock_adapter
         assert scorer.model == get_clarification_model()
         assert scorer.temperature == SCORING_TEMPERATURE
-        assert scorer.initial_max_tokens == 512
+        assert scorer.initial_max_tokens == 2048
         assert scorer.max_retries == 10  # Default to 10 retries
 
     def test_scorer_custom_values(self) -> None:

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -1068,7 +1068,6 @@ class TestInterviewEngineSystemPrompt:
         prompt = engine._build_system_prompt(state)
 
         assert "### seed-closer" in prompt
-        assert "Closure mode active: yes" in prompt
 
     def test_system_prompt_omits_seed_closer_when_closure_mode_is_inactive(self) -> None:
         """High ambiguity should keep the closure perspective disabled."""
@@ -1091,7 +1090,6 @@ class TestInterviewEngineSystemPrompt:
         prompt = engine._build_system_prompt(state)
 
         assert "### seed-closer" not in prompt
-        assert "Closure mode active: no" in prompt
 
 
 class TestInterviewEngineConversationHistory:


### PR DESCRIPTION
## Summary

Two-pronged hardening of the interview path plus the router multiline dispatch.

**Interview — remove closure pressure from the question prompt** (`25290459`)
The snapshot block fed to the question generator advertised seed-ready threshold, closure-mode threshold, next-milestone distance, streak progress, and floor pass/fail status. Together these signals told the LLM how close it was to finishing, biasing it toward closure-flavored questions and ending interviews before genuine ambiguity was resolved. The pre-0.27 prompt did not expose any of this distance information and produced sharper Socratic questioning.
- Drop distance and closure-state lines from `_build_ambiguity_snapshot_prompt`; keep only the qualitative milestone label, current overall score, and weakest-area drill-down with reasons
- Restore `initial_max_tokens` to 2048 in both the question generator (`InterviewEngine`) and the ambiguity scorer (`AmbiguityScorer`) so reasoning is not truncated mid-output
- Closure gate itself (overall threshold, per-dimension floors, completion streak) is unchanged — only the hint surface visible to the LLM is reduced

**Router — preserve multiline command payloads** (`bebda684`, `bb7a4562`, `e8534e0c`, `40d3cae7`)
- Dispatch multiline run payloads instead of collapsing them
- Preserve parsed multiline prompts through the parser
- Preserve multiline payload whitespace
- Normalize trailing line endings without dropping content

**Skills — rename resume → resume-session** (`0bacf6dd`, `2ce45c8e`)
- Rename skill directory and surface in help command summary

## Checks passed
- [x] ruff lint
- [x] ruff format
- [x] mypy (changed sources)
- [x] pytest (146 passed for bigbang; router tests included)

## Test plan
- [x] Run `ooo interview` against a vague brownfield request and verify questions stay Socratic (no closure-flavored phrasing) past milestone REFINED
- [x] Confirm interview only auto-closes when overall ≤ 0.2, all dimension floors pass, and streak ≥ 2 — gate behavior unchanged
- [ ] Run `ooo run` with a multiline prompt and verify whitespace and line endings are preserved end-to-end
- [x] `ooo resume-session` resolves correctly via help

🤖 Generated with [Claude Code](https://claude.com/claude-code)