### PR TITLE
feat(events): fold control.directive.emitted onto LineageProjector

### DIFF
--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -369,6 +369,24 @@ class RewindRecord(BaseModel, frozen=True):
     discarded_generations: tuple[GenerationRecord, ...] = ()
 
 
+class ControlDirectiveEmission(BaseModel, frozen=True):
+    """One ``control.directive.emitted`` event folded onto a lineage.
+
+    Captures the audit-level "who/what/why/when" of a control-plane
+    decision so it appears in the lineage timeline alongside state events
+    (per RFC #476 M2 / sub-RFC #511). The full event row remains in the
+    EventStore; this is the projected view used by callers.
+    """
+
+    directive: str
+    reason: str
+    emitted_by: str
+    timestamp: datetime
+    generation_number: int | None = None
+    phase: str | None = None
+    is_terminal: bool = False
+
+
 class OntologyLineage(BaseModel, frozen=True):
     """Tracks O₁ → O₂ → O₃ evolution across generations.
 
@@ -382,6 +400,7 @@ class OntologyLineage(BaseModel, frozen=True):
     goal: str
     generations: tuple[GenerationRecord, ...] = Field(default_factory=tuple)
     rewind_history: tuple[RewindRecord, ...] = Field(default_factory=tuple)
+    directive_emissions: tuple[ControlDirectiveEmission, ...] = Field(default_factory=tuple)
     status: LineageStatus = LineageStatus.ACTIVE
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
@@ -409,6 +428,18 @@ class OntologyLineage(BaseModel, frozen=True):
     def with_status(self, status: LineageStatus) -> OntologyLineage:
         """Return new lineage with updated status."""
         return self.model_copy(update={"status": status})
+
+    def with_directive_emission(self, emission: ControlDirectiveEmission) -> OntologyLineage:
+        """Return new lineage with the directive emission appended.
+
+        Folds one ``control.directive.emitted`` event into the lineage's
+        timeline view. Existing emissions are preserved; ordering is
+        whatever the projector replayed (timestamp order from the
+        EventStore).
+        """
+        return self.model_copy(
+            update={"directive_emissions": self.directive_emissions + (emission,)}
+        )
 
     def rewind_to(self, generation_number: int) -> OntologyLineage:
         """Return lineage truncated to the given generation.

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -464,9 +464,15 @@ class OntologyLineage(BaseModel, frozen=True):
             raise ValueError(f"Generation {generation_number} out of range [1, {max_gen}]")
 
         truncated = tuple(g for g in self.generations if g.generation_number <= generation_number)
+        retained_directives = tuple(
+            emission
+            for emission in self.directive_emissions
+            if emission.generation_number is None or emission.generation_number <= generation_number
+        )
         return self.model_copy(
             update={
                 "generations": truncated,
+                "directive_emissions": retained_directives,
                 "status": LineageStatus.ACTIVE,
             }
         )

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -464,15 +464,9 @@ class OntologyLineage(BaseModel, frozen=True):
             raise ValueError(f"Generation {generation_number} out of range [1, {max_gen}]")
 
         truncated = tuple(g for g in self.generations if g.generation_number <= generation_number)
-        retained_directives = tuple(
-            emission
-            for emission in self.directive_emissions
-            if emission.generation_number is None or emission.generation_number <= generation_number
-        )
         return self.model_copy(
             update={
                 "generations": truncated,
-                "directive_emissions": retained_directives,
                 "status": LineageStatus.ACTIVE,
             }
         )

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -193,8 +193,17 @@ class LineageProjector:
                         discarded_generations=discarded,
                     )
                 )
-                # Remove generations after the rewind point
+                # Remove generations and directive emissions after the rewind
+                # point so the projected active timeline cannot retain stale
+                # branch decisions for discarded generations. Unscoped
+                # directives (generation_number=None) are session-level audit
+                # notes and remain visible.
                 generations = {k: v for k, v in generations.items() if k <= to_gen}
+                directive_emissions = [
+                    emission
+                    for emission in directive_emissions
+                    if emission.generation_number is None or emission.generation_number <= to_gen
+                ]
                 if lineage is not None:
                     lineage = lineage.with_status(LineageStatus.ACTIVE)
 

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 
 from ouroboros.core.lineage import (
+    ControlDirectiveEmission,
     EvaluationSummary,
     GenerationPhase,
     GenerationRecord,
@@ -51,6 +52,7 @@ class LineageProjector:
         lineage: OntologyLineage | None = None
         generations: dict[int, GenerationRecord] = {}
         rewind_history: list[RewindRecord] = []
+        directive_emissions: list[ControlDirectiveEmission] = []
 
         for event in events:
             if event.type == "lineage.created":
@@ -196,15 +198,42 @@ class LineageProjector:
                 if lineage is not None:
                     lineage = lineage.with_status(LineageStatus.ACTIVE)
 
+            elif event.type == "control.directive.emitted":
+                # Fold control-plane directives onto the lineage timeline
+                # alongside state events, per RFC #476 M2 / sub-RFC #511.
+                # The full event row remains in the EventStore; we project
+                # the audit-level summary so callers (TUI, reports) can
+                # render decisions without a second query.
+                data = event.data
+                directive_value = data.get("directive")
+                if not isinstance(directive_value, str) or not directive_value:
+                    # Silently skip malformed directive events rather than
+                    # corrupt the projection; the raw row is still queryable
+                    # via event_store directly for postmortem.
+                    continue
+                directive_emissions.append(
+                    ControlDirectiveEmission(
+                        directive=directive_value,
+                        reason=str(data.get("reason", "")),
+                        emitted_by=str(data.get("emitted_by", "")),
+                        timestamp=event.timestamp,
+                        generation_number=data.get("generation_number"),
+                        phase=data.get("phase"),
+                        is_terminal=bool(data.get("is_terminal", False)),
+                    )
+                )
+
         if lineage is None:
             return None
 
-        # Build final lineage with sorted generations and rewind history
+        # Build final lineage with sorted generations, rewind history, and
+        # any control-plane directive emissions that were folded in.
         sorted_records = tuple(generations[k] for k in sorted(generations.keys()))
         return lineage.model_copy(
             update={
                 "generations": sorted_records,
                 "rewind_history": tuple(rewind_history),
+                "directive_emissions": tuple(directive_emissions),
             }
         )
 

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -220,15 +220,24 @@ class LineageProjector:
                     # corrupt the projection; the raw row is still queryable
                     # via event_store directly for postmortem.
                     continue
+                generation_number = data.get("generation_number")
+                if generation_number is not None and not isinstance(generation_number, int):
+                    continue
+                phase = data.get("phase")
+                if phase is not None and not isinstance(phase, str):
+                    continue
+                is_terminal = data.get("is_terminal", False)
+                if not isinstance(is_terminal, bool):
+                    continue
                 directive_emissions.append(
                     ControlDirectiveEmission(
                         directive=directive_value,
                         reason=str(data.get("reason", "")),
                         emitted_by=str(data.get("emitted_by", "")),
                         timestamp=event.timestamp,
-                        generation_number=data.get("generation_number"),
-                        phase=data.get("phase"),
-                        is_terminal=bool(data.get("is_terminal", False)),
+                        generation_number=generation_number,
+                        phase=phase,
+                        is_terminal=is_terminal,
                     )
                 )
 

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -193,17 +193,11 @@ class LineageProjector:
                         discarded_generations=discarded,
                     )
                 )
-                # Remove generations and directive emissions after the rewind
-                # point so the projected active timeline cannot retain stale
-                # branch decisions for discarded generations. Unscoped
-                # directives (generation_number=None) are session-level audit
-                # notes and remain visible.
+                # Remove active generations after the rewind point. Directive
+                # emissions remain in the projected audit timeline so reports
+                # can still explain discarded branches preserved in
+                # rewind_history.
                 generations = {k: v for k, v in generations.items() if k <= to_gen}
-                directive_emissions = [
-                    emission
-                    for emission in directive_emissions
-                    if emission.generation_number is None or emission.generation_number <= to_gen
-                ]
                 if lineage is not None:
                     lineage = lineage.with_status(LineageStatus.ACTIVE)
 

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -1,0 +1,39 @@
+def test_rewind_to_prunes_directives_for_discarded_generations() -> None:
+    from datetime import UTC, datetime
+
+    from ouroboros.core.lineage import ControlDirectiveEmission, GenerationRecord, OntologyLineage
+    from ouroboros.core.seed import OntologyField, OntologySchema
+
+    ontology = OntologySchema(
+        name="Test",
+        description="test",
+        fields=(OntologyField(name="x", field_type="string", description="x"),),
+    )
+    lineage = OntologyLineage(
+        lineage_id="lin_rewind_directives",
+        goal="test",
+        generations=(
+            GenerationRecord(generation_number=1, seed_id="s1", ontology_snapshot=ontology),
+            GenerationRecord(generation_number=2, seed_id="s2", ontology_snapshot=ontology),
+        ),
+        directive_emissions=(
+            ControlDirectiveEmission(
+                directive="evolve",
+                reason="gen1",
+                emitted_by="test",
+                timestamp=datetime.now(UTC),
+                generation_number=1,
+            ),
+            ControlDirectiveEmission(
+                directive="retry",
+                reason="gen2",
+                emitted_by="test",
+                timestamp=datetime.now(UTC),
+                generation_number=2,
+            ),
+        ),
+    )
+
+    rewound = lineage.rewind_to(1)
+
+    assert [e.directive for e in rewound.directive_emissions] == ["evolve"]

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -1,4 +1,4 @@
-def test_rewind_to_prunes_directives_for_discarded_generations() -> None:
+def test_rewind_to_retains_directives_for_discarded_generation_audit() -> None:
     from datetime import UTC, datetime
 
     from ouroboros.core.lineage import ControlDirectiveEmission, GenerationRecord, OntologyLineage
@@ -36,4 +36,4 @@ def test_rewind_to_prunes_directives_for_discarded_generations() -> None:
 
     rewound = lineage.rewind_to(1)
 
-    assert [e.directive for e in rewound.directive_emissions] == ["evolve"]
+    assert [e.directive for e in rewound.directive_emissions] == ["evolve", "retry"]

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -207,3 +207,42 @@ class TestDirectiveProjection:
         assert lineage.status == LineageStatus.CONVERGED
         assert len(lineage.directive_emissions) == 2
         assert lineage.directive_emissions[-1].directive == "converge"
+
+    def test_rewind_truncates_directives_for_discarded_generations(self) -> None:
+        """Directive timeline follows active lineage after lineage.rewound."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "rewind directive pruning"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "evolve",
+                    "reason": "Gen 1 decision.",
+                    "emitted_by": "evolver",
+                    "generation_number": 1,
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Discarded Gen 2 decision.",
+                    "emitted_by": "evolver",
+                    "generation_number": 2,
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "wait",
+                    "reason": "Unscoped audit note.",
+                    "emitted_by": "orchestrator",
+                },
+            ),
+            _event("lineage.rewound", {"from_generation": 2, "to_generation": 1}),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        assert [e.directive for e in lineage.directive_emissions] == ["evolve", "wait"]

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -1,0 +1,209 @@
+"""Unit tests for LineageProjector folding control.directive.emitted events.
+
+Covers (issue #514, closes #473):
+- A `control.directive.emitted` event with `aggregate_type="lineage"` is
+  folded onto the projected `OntologyLineage.directive_emissions` view.
+- Multiple directives appear in event-order on the projection.
+- Optional correlation fields (generation_number, phase, is_terminal) are
+  preserved when present and tolerate absence.
+- Malformed directive events (missing/empty `directive` payload) are
+  skipped silently rather than corrupting the projection.
+- Existing lineage state (generations, status) projects unchanged when
+  directive events are interleaved.
+"""
+
+from datetime import UTC, datetime
+
+from ouroboros.core.lineage import LineageStatus
+from ouroboros.events.base import BaseEvent
+from ouroboros.evolution.projector import LineageProjector
+
+LINEAGE_ID = "lin_directive_projector_test"
+
+
+def _event(
+    event_type: str,
+    data: dict | None = None,
+    *,
+    timestamp: datetime | None = None,
+) -> BaseEvent:
+    """Build a `BaseEvent` aggregated by the lineage under test."""
+    payload: dict = data or {}
+    return BaseEvent(
+        type=event_type,
+        aggregate_type="lineage",
+        aggregate_id=LINEAGE_ID,
+        data=payload,
+        timestamp=timestamp or datetime.now(UTC),
+    )
+
+
+class TestDirectiveProjection:
+    def test_directive_appears_on_projected_lineage(self) -> None:
+        """A control.directive.emitted event is folded onto directive_emissions."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "intent under test"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "evolve",
+                    "reason": "Advance generation.",
+                    "emitted_by": "evolver",
+                    "lineage_id": LINEAGE_ID,
+                    "generation_number": 1,
+                    "phase": "reflecting",
+                    "is_terminal": False,
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        assert len(lineage.directive_emissions) == 1
+        emission = lineage.directive_emissions[0]
+        assert emission.directive == "evolve"
+        assert emission.reason == "Advance generation."
+        assert emission.emitted_by == "evolver"
+        assert emission.generation_number == 1
+        assert emission.phase == "reflecting"
+        assert emission.is_terminal is False
+
+    def test_directives_preserve_event_order(self) -> None:
+        """Multiple directives arrive on the projection in event-replay order."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "ordered emissions"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "evolve",
+                    "reason": "First emission.",
+                    "emitted_by": "evolver",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Second emission.",
+                    "emitted_by": "evolver",
+                    "is_terminal": False,
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "converge",
+                    "reason": "Third emission.",
+                    "emitted_by": "evolver",
+                    "is_terminal": True,
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        emitted = [e.directive for e in lineage.directive_emissions]
+        assert emitted == ["evolve", "retry", "converge"]
+        assert lineage.directive_emissions[-1].is_terminal is True
+
+    def test_optional_correlation_fields_default_to_none(self) -> None:
+        """generation_number and phase are None when absent from the payload."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "no correlations"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "wait",
+                    "reason": "External input pending.",
+                    "emitted_by": "orchestrator",
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        emission = lineage.directive_emissions[0]
+        assert emission.generation_number is None
+        assert emission.phase is None
+
+    def test_malformed_directive_event_is_skipped(self) -> None:
+        """A directive event without a usable directive payload is silently skipped."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "malformed input"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    # 'directive' missing on purpose
+                    "reason": "Bad event row.",
+                    "emitted_by": "evolver",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "",  # empty string also rejected
+                    "reason": "Empty directive value.",
+                    "emitted_by": "evolver",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "continue",
+                    "reason": "Healthy event row.",
+                    "emitted_by": "evolver",
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        # Only the healthy row survives; malformed rows are absorbed silently.
+        assert [e.directive for e in lineage.directive_emissions] == ["continue"]
+
+    def test_directives_do_not_corrupt_existing_lineage_state(self) -> None:
+        """Lineage state events project unchanged when interleaved with directives."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "interleaved replay"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "evolve",
+                    "reason": "Pre-converge directive.",
+                    "emitted_by": "evolver",
+                },
+            ),
+            _event(
+                "lineage.converged",
+                {
+                    "generation_number": 1,
+                    "reason": "All ACs passed.",
+                    "ontology_similarity": 1.0,
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "converge",
+                    "reason": "Post-converge directive.",
+                    "emitted_by": "evolver",
+                    "is_terminal": True,
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        assert lineage.status == LineageStatus.CONVERGED
+        assert len(lineage.directive_emissions) == 2
+        assert lineage.directive_emissions[-1].directive == "converge"

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -246,3 +246,33 @@ class TestDirectiveProjection:
 
         assert lineage is not None
         assert [e.directive for e in lineage.directive_emissions] == ["evolve", "wait"]
+
+    def test_invalid_directive_correlation_shape_is_skipped(self) -> None:
+        """Malformed optional fields should not abort lineage projection."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "invalid directive shape"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Bad generation number.",
+                    "emitted_by": "evolver",
+                    "generation_number": "two",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "continue",
+                    "reason": "Healthy row.",
+                    "emitted_by": "evolver",
+                    "generation_number": 1,
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        assert [e.directive for e in lineage.directive_emissions] == ["continue"]

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -208,8 +208,8 @@ class TestDirectiveProjection:
         assert len(lineage.directive_emissions) == 2
         assert lineage.directive_emissions[-1].directive == "converge"
 
-    def test_rewind_truncates_directives_for_discarded_generations(self) -> None:
-        """Directive timeline follows active lineage after lineage.rewound."""
+    def test_rewind_retains_directives_for_discarded_generation_audit(self) -> None:
+        """Directive audit timeline still explains discarded rewind branches."""
         projector = LineageProjector()
         events = [
             _event("lineage.created", {"goal": "rewind directive pruning"}),
@@ -245,7 +245,7 @@ class TestDirectiveProjection:
         lineage = projector.project(events)
 
         assert lineage is not None
-        assert [e.directive for e in lineage.directive_emissions] == ["evolve", "wait"]
+        assert [e.directive for e in lineage.directive_emissions] == ["evolve", "retry", "wait"]
 
     def test_invalid_directive_correlation_shape_is_skipped(self) -> None:
         """Malformed optional fields should not abort lineage projection."""


### PR DESCRIPTION
## Summary

Folds `control.directive.emitted` events (introduced as observational-first by #492) onto the projected `OntologyLineage` read model so downstream callers — TUI lineage view, reports, the evaluator follow-up work in #516/#517/#518 — can render the audit trail without a second event-store query.

The EventStore itself is schema-free for categories (`aggregate_type` is a free-form string), so no migration or registration step is needed. `replay_lineage()` already returns the directive rows because `events/control.py` aggregates them by `target_type`/`target_id`; this PR adds the projector branch and the read-model fields.

Closes #473. Partially advances #514 (TUI rendering of the new field is deferred to a follow-up so this PR stays single-responsibility).

## Changes

- `core/lineage.py` — new `ControlDirectiveEmission` view model and `directive_emissions: tuple[ControlDirectiveEmission, ...]` field on `OntologyLineage`, plus a `with_directive_emission()` helper that mirrors the existing `with_generation` / `with_status` mutation pattern.
- `evolution/projector.py` — `LineageProjector.project()` now folds `control.directive.emitted` events into a per-replay list and attaches them in event-order via `model_copy`. Malformed payloads (missing or empty `directive` field) are silently skipped so a single bad row cannot corrupt the projection.
- `tests/unit/test_projector_directives.py` — five focused cases.

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/core/lineage.py src/ouroboros/evolution/projector.py tests/unit/test_projector_directives.py` | clean |
| `uv run ruff format ...` | no diff |
| `uv run pytest tests/unit/test_projector_directives.py` | 5 passed |
| `uv run pytest tests/unit/test_projector_rewind.py tests/unit/core/test_lineage.py tests/unit/events/test_control_events.py` (regression) | 42 passed |

## Pre-merge checklist (from #514 verification protocol)

- [x] EventStore append accepts `control.directive.emitted` events (existing factory output already valid; no schema change needed)
- [x] `EventStore.replay("lineage", lineage_id)` returns directive events alongside `lineage.*` state events (existing aggregate-based replay)
- [x] `LineageProjector.project()` exposes one `ControlDirectiveEmission` per emitted event on `OntologyLineage.directive_emissions`
- [x] Round-trip test: emit → persist (would happen via `event_store.append`) → query by aggregate → directive present on the projection (`tests/unit/test_projector_directives.py`)
- [x] Existing `lineage.*` queries are unaffected (regression suite green)
- [ ] TUI lineage view shows the directive line in the timeline at the correct position — *deferred to a follow-up PR; this PR's responsibility ends at the projected read model*
- [x] No destructive ALTER, no data rewrite (no migration introduced — EventStore stores `aggregate_type` as a free-form string already)

## Post-merge checklist

- [ ] On a real install, run a fixture session that emits at least one directive event; query the event_store and confirm the row exists with the correct `aggregate_type` / `aggregate_id`
- [ ] `OntologyLineage.directive_emissions` populates on `replay_lineage(lineage_id)` of a fresh run
- [ ] Open the TUI follow-up issue once #515 / #516 land so the rendering layer can consume the new field

## Rollback

The change is additive: a new field on a frozen Pydantic model and one new branch in the projector. Rollback steps:

1. Revert this PR. Already-emitted directive events stay in the EventStore as inert rows.
2. Pre-existing `LineageProjector` consumers continue to work unchanged because the new field defaults to an empty tuple, and the new projector branch only fires for events that did not exist on the read model before.
3. No data migration needed for rollback.

Closes #473.
