### PR TITLE
feat(orchestrator): introduce ControlBus on AgentRuntimeContext

### DIFF
--- a/src/ouroboros/orchestrator/agent_runtime_context.py
+++ b/src/ouroboros/orchestrator/agent_runtime_context.py
@@ -1,0 +1,45 @@
+"""``AgentRuntimeContext`` — the runtime-offering side of #476 Q1.
+
+The runtime context describes *what the orchestrator runtime offers* a
+handler — the EventStore it appends into, optional capability sources,
+and the :class:`ControlBus` that lets handlers react to directive events.
+The context is intentionally narrow: per the maintainer commitment in
+#476 Q1, every new field added later must include a one-line PR-body
+justification so the type does not drift into a service locator.
+
+This first step keeps the membership minimal:
+
+* ``event_store`` — the persistence boundary handlers already share.
+* ``runtime_backend`` / ``llm_backend`` — informational labels existing
+  callers (rate-limit, telemetry) already pass alongside the bridge.
+* ``mcp_bridge`` — the existing capability source from #280's bridge
+  work; optional so non-MCP code paths stay valid.
+* ``control`` — the :class:`ControlBus` introduced alongside this
+  context; ``None`` while #474's migration is in progress so existing
+  callers compile unchanged.
+
+Subsequent issues (#474, #475) wire concrete handlers to consume the
+context. This module deliberately does *not* import any handler-side
+type so that adopting the context becomes a one-import change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ouroboros.mcp.bridge.bridge import MCPBridge
+    from ouroboros.orchestrator.control_bus import ControlBus
+    from ouroboros.persistence.event_store import EventStore
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRuntimeContext:
+    """Minimal, narrow-membership runtime context handed to MCP handlers."""
+
+    event_store: EventStore
+    runtime_backend: str | None = None
+    llm_backend: str | None = None
+    mcp_bridge: MCPBridge | None = None
+    control: ControlBus | None = None

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -37,7 +37,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ouroboros.events.base import BaseEvent
@@ -55,9 +55,12 @@ class SubscriptionHandle:
     """Opaque token returned by :meth:`ControlBus.subscribe`.
 
     Callers pass it back to :meth:`ControlBus.unsubscribe` to detach.
+    Handles are scoped to the bus that created them so identical local
+    integer IDs from different buses cannot detach each other.
     """
 
     _id: int
+    _owner: Any
 
 
 @dataclass(slots=True)
@@ -80,6 +83,8 @@ class ControlBus:
 
     _subscriptions: list[_Subscription] = field(default_factory=list)
     _next_id: int = 0
+    _owner: object = field(default_factory=object)
+    _tasks: set[asyncio.Task[None]] = field(default_factory=set)
     _spawn: Callable[[Awaitable[None]], asyncio.Task[None]] | None = None
 
     def subscribe(self, predicate: Predicate, handler: Handler) -> SubscriptionHandle:
@@ -97,7 +102,7 @@ class ControlBus:
             A :class:`SubscriptionHandle` accepted by
             :meth:`unsubscribe`.
         """
-        handle = SubscriptionHandle(_id=self._next_id)
+        handle = SubscriptionHandle(_id=self._next_id, _owner=self._owner)
         self._next_id += 1
         self._subscriptions.append(
             _Subscription(handle=handle, predicate=predicate, handler=handler)
@@ -110,6 +115,8 @@ class ControlBus:
         Idempotent: detaching an unknown or already-removed handle is a
         no-op.
         """
+        if handle._owner is not self._owner:
+            return
         self._subscriptions = [sub for sub in self._subscriptions if sub.handle != handle]
 
     def publish(self, event: BaseEvent) -> tuple[asyncio.Task[None], ...]:
@@ -140,7 +147,10 @@ class ControlBus:
     def _spawn_handler(self, handler: Handler, event: BaseEvent) -> asyncio.Task[None]:
         """Run *handler* on its own task with structured error isolation."""
         spawn = self._spawn or asyncio.ensure_future
-        return spawn(self._invoke_handler(handler, event))
+        task = spawn(self._invoke_handler(handler, event))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
 
     @staticmethod
     async def _invoke_handler(handler: Handler, event: BaseEvent) -> None:

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -1,0 +1,153 @@
+"""In-process ControlBus for ``control.directive.emitted`` events.
+
+The bus is the *reactive* surface paired with the *observational* event
+factory landed in #492. Subscribers register a predicate and a handler;
+when callsites publish a directive event onto the bus, every matching
+handler fires concurrently on its own task. A slow or failing handler
+never blocks other handlers or the publisher.
+
+Per the maintainer alignment in #476 Q1, the bus is exposed as
+``AgentRuntimeContext.control`` (see :mod:`agent_runtime_context`). The
+context describes *what the runtime offers*; the bus describes *where
+directives flow*. Two different concerns, two different names.
+
+Scope choices baked in here:
+
+* The bus does *not* know about persistence. EventStore stays simple;
+  callsites call :meth:`ControlBus.publish` themselves after
+  :meth:`EventStore.append`. This honours the "no service locator"
+  guardrail from #476 Q1 (narrow membership for the runtime context) and
+  keeps the bus a pure in-process primitive that future callers — for
+  example the #474 ``AgentRuntimeContext`` migration and #475
+  ``evolve_step`` / ``unstuck`` / ``ralph`` wiring — can adopt
+  incrementally.
+
+* Cross-runtime delivery is a *separate* concern; that is the Mesh
+  (sub-RFC :doc:`../../docs/rfc/mesh`). The Mesh, when it lands, can
+  reuse this surface or wrap it.
+
+* Forging resistance is *not* a goal. The cooperative-trust model from
+  #476 explicitly accepts that any in-process actor can publish; the bus
+  does not police identity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ouroboros.events.base import BaseEvent
+
+
+logger = logging.getLogger(__name__)
+
+
+Predicate = Callable[["BaseEvent"], bool]
+Handler = Callable[["BaseEvent"], Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class SubscriptionHandle:
+    """Opaque token returned by :meth:`ControlBus.subscribe`.
+
+    Callers pass it back to :meth:`ControlBus.unsubscribe` to detach.
+    """
+
+    _id: int
+
+
+@dataclass(slots=True)
+class _Subscription:
+    """One predicate/handler pair tracked by the bus."""
+
+    handle: SubscriptionHandle
+    predicate: Predicate
+    handler: Handler
+
+
+@dataclass(slots=True)
+class ControlBus:
+    """Concurrent in-process publish/subscribe surface for control events.
+
+    The bus is intended to live on :class:`AgentRuntimeContext` for the
+    lifetime of an orchestrator session. It is **not** thread-safe in the
+    classic shared-memory sense; it expects a single asyncio event loop.
+    """
+
+    _subscriptions: list[_Subscription] = field(default_factory=list)
+    _next_id: int = 0
+    _spawn: Callable[[Awaitable[None]], asyncio.Task[None]] | None = None
+
+    def subscribe(self, predicate: Predicate, handler: Handler) -> SubscriptionHandle:
+        """Register *handler* to be invoked when *predicate* returns ``True``.
+
+        Args:
+            predicate: Pure synchronous filter on the event. Predicate
+                exceptions are treated like ``False`` and logged so a
+                broken predicate cannot starve other subscribers.
+            handler: Async callable invoked once per matching event. The
+                handler is awaited on its own task so a slow handler does
+                not block fast ones.
+
+        Returns:
+            A :class:`SubscriptionHandle` accepted by
+            :meth:`unsubscribe`.
+        """
+        handle = SubscriptionHandle(_id=self._next_id)
+        self._next_id += 1
+        self._subscriptions.append(
+            _Subscription(handle=handle, predicate=predicate, handler=handler)
+        )
+        return handle
+
+    def unsubscribe(self, handle: SubscriptionHandle) -> None:
+        """Remove the subscription identified by *handle*.
+
+        Idempotent: detaching an unknown or already-removed handle is a
+        no-op.
+        """
+        self._subscriptions = [sub for sub in self._subscriptions if sub.handle != handle]
+
+    def publish(self, event: BaseEvent) -> tuple[asyncio.Task[None], ...]:
+        """Spawn a delivery task for every matching subscription.
+
+        Returns a tuple of the spawned tasks so tests can ``await`` them.
+        Production callers can ignore the return value: handler errors
+        are logged on the task so they cannot poison the publisher.
+
+        A subscription whose predicate raises an exception is treated as
+        non-matching for that event; the predicate is not unsubscribed.
+        """
+        spawned: list[asyncio.Task[None]] = []
+        for sub in tuple(self._subscriptions):
+            try:
+                if not sub.predicate(event):
+                    continue
+            except Exception as exc:  # noqa: BLE001 — predicate isolation
+                logger.warning(
+                    "control_bus.predicate_raised",
+                    extra={"handle_id": sub.handle._id, "error": repr(exc)},
+                )
+                continue
+
+            spawned.append(self._spawn_handler(sub.handler, event))
+        return tuple(spawned)
+
+    def _spawn_handler(self, handler: Handler, event: BaseEvent) -> asyncio.Task[None]:
+        """Run *handler* on its own task with structured error isolation."""
+        spawn = self._spawn or asyncio.ensure_future
+        return spawn(self._invoke_handler(handler, event))
+
+    @staticmethod
+    async def _invoke_handler(handler: Handler, event: BaseEvent) -> None:
+        try:
+            await handler(event)
+        except Exception as exc:  # noqa: BLE001 — handler isolation
+            logger.warning(
+                "control_bus.handler_raised",
+                extra={"event_type": event.type, "error": repr(exc)},
+            )

--- a/tests/unit/orchestrator/test_agent_runtime_context.py
+++ b/tests/unit/orchestrator/test_agent_runtime_context.py
@@ -1,0 +1,63 @@
+"""Unit tests for :class:`AgentRuntimeContext`.
+
+Issue: #515 / #474 Q1. The context is intentionally narrow: it must
+remain frozen, slot-based, and only carry the minimal fields the
+maintainer alignment in #476 Q1 specified.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
+from ouroboros.orchestrator.control_bus import ControlBus
+from ouroboros.persistence.event_store import EventStore
+
+
+def test_context_is_frozen_and_slotted() -> None:
+    """The dataclass must reject attribute mutation post-construction."""
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    context = AgentRuntimeContext(event_store=store)
+
+    assert dataclasses.is_dataclass(context)
+    assert context.runtime_backend is None
+    assert context.llm_backend is None
+    assert context.mcp_bridge is None
+    assert context.control is None
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        context.runtime_backend = "codex_cli"  # type: ignore[misc]
+
+
+def test_context_carries_optional_control_bus() -> None:
+    """The optional ControlBus slot is the reactive surface for #515."""
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    bus = ControlBus()
+    context = AgentRuntimeContext(event_store=store, control=bus)
+
+    assert context.control is bus
+    # Existing handlers that do not opt into the bus still see the
+    # default ``None`` and remain valid.
+    no_bus = AgentRuntimeContext(event_store=store)
+    assert no_bus.control is None
+
+
+def test_context_membership_is_narrow() -> None:
+    """Adding a field requires a deliberate PR (no service-locator drift).
+
+    This regression test pins the field set so reviewers see explicit
+    diffs when the membership grows. If this assertion fails because a
+    field was added, the PR must include a justification line per the
+    #476 Q1 narrow-membership commitment.
+    """
+    expected = {
+        "event_store",
+        "runtime_backend",
+        "llm_backend",
+        "mcp_bridge",
+        "control",
+    }
+    actual = {f.name for f in dataclasses.fields(AgentRuntimeContext)}
+    assert actual == expected

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -230,3 +230,42 @@ async def test_unsubscribe_stops_delivery() -> None:
     tasks = bus.publish(_directive_event())
     assert tasks == ()
     assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_rejects_foreign_handle_with_same_local_id() -> None:
+    bus_a = ControlBus()
+    bus_b = ControlBus()
+    seen: list[BaseEvent] = []
+
+    async def handler(event: BaseEvent) -> None:
+        seen.append(event)
+
+    handle_a = bus_a.subscribe(_is_directive, handler)
+    handle_b = bus_b.subscribe(_is_directive, handler)
+    assert handle_a._id == handle_b._id
+
+    bus_a.unsubscribe(handle_b)
+    tasks = bus_a.publish(_directive_event())
+    await asyncio.gather(*tasks)
+
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_retains_fire_and_forget_tasks_until_done() -> None:
+    bus = ControlBus()
+    release = asyncio.Event()
+
+    async def slow(event: BaseEvent) -> None:
+        await release.wait()
+
+    bus.subscribe(_is_directive, slow)
+    tasks = bus.publish(_directive_event())
+
+    assert len(tasks) == 1
+    assert len(bus._tasks) == 1
+    release.set()
+    await asyncio.gather(*tasks)
+    await asyncio.sleep(0)
+    assert bus._tasks == set()

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -1,0 +1,232 @@
+"""Unit tests for :class:`ControlBus`.
+
+Issue: #515. The bus is the reactive surface paired with the
+observational event factory in #492 / ``events/control.py``.
+
+Coverage:
+- ``subscribe`` returns a handle and ``unsubscribe(handle)`` detaches it.
+- A predicate filter scopes delivery: subscribers only see matching
+  events.
+- Multiple subscribers receive the same event independently.
+- A failing handler does not affect other handlers' delivery for the
+  same event.
+- A predicate that raises is treated as ``False`` for that event without
+  unsubscribing.
+- Slow and fast handlers do not block one another (per-handler task).
+- Re-entrant ``subscribe`` from inside a publish loop does not produce a
+  ``RuntimeError``.
+- ``unsubscribe`` is idempotent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.control_bus import ControlBus, SubscriptionHandle
+
+
+def _directive_event(directive: str = "retry") -> BaseEvent:
+    """Build a minimal directive event for delivery tests."""
+    return BaseEvent(
+        type="control.directive.emitted",
+        aggregate_type="lineage",
+        aggregate_id="lin_bus_test",
+        data={
+            "directive": directive,
+            "reason": "Bus delivery probe.",
+            "emitted_by": "test",
+        },
+    )
+
+
+def _state_event() -> BaseEvent:
+    """An unrelated state event used for predicate filtering."""
+    return BaseEvent(
+        type="lineage.created",
+        aggregate_type="lineage",
+        aggregate_id="lin_bus_test",
+        data={"goal": "filter probe"},
+    )
+
+
+def _is_directive(event: BaseEvent) -> bool:
+    return event.type == "control.directive.emitted"
+
+
+@pytest.mark.asyncio
+async def test_subscribe_and_publish_delivers_to_handler() -> None:
+    bus = ControlBus()
+    received: list[BaseEvent] = []
+
+    async def handler(event: BaseEvent) -> None:
+        received.append(event)
+
+    handle = bus.subscribe(_is_directive, handler)
+    assert isinstance(handle, SubscriptionHandle)
+
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+
+    assert [e.type for e in received] == ["control.directive.emitted"]
+
+
+@pytest.mark.asyncio
+async def test_predicate_filters_unrelated_events() -> None:
+    bus = ControlBus()
+    seen: list[BaseEvent] = []
+
+    async def handler(event: BaseEvent) -> None:
+        seen.append(event)
+
+    bus.subscribe(_is_directive, handler)
+
+    # A non-directive event is published; predicate rejects it, no task spawned.
+    tasks = bus.publish(_state_event())
+    assert tasks == ()
+    assert seen == []
+
+    # A directive event is delivered.
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_multiple_subscribers_each_receive_event() -> None:
+    bus = ControlBus()
+    a_seen: list[BaseEvent] = []
+    b_seen: list[BaseEvent] = []
+
+    async def handler_a(event: BaseEvent) -> None:
+        a_seen.append(event)
+
+    async def handler_b(event: BaseEvent) -> None:
+        b_seen.append(event)
+
+    bus.subscribe(_is_directive, handler_a)
+    bus.subscribe(_is_directive, handler_b)
+
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+
+    assert len(a_seen) == 1
+    assert len(b_seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_error_isolated_from_siblings() -> None:
+    bus = ControlBus()
+    healthy_seen: list[BaseEvent] = []
+
+    async def broken(event: BaseEvent) -> None:
+        raise RuntimeError("intentional handler failure")
+
+    async def healthy(event: BaseEvent) -> None:
+        healthy_seen.append(event)
+
+    bus.subscribe(_is_directive, broken)
+    bus.subscribe(_is_directive, healthy)
+
+    tasks = bus.publish(_directive_event())
+    # gather() with return_exceptions=False would raise; the handler's
+    # exception is *swallowed inside the per-handler wrapper*, so the
+    # broken task completes successfully (with the warning logged).
+    await asyncio.gather(*tasks)
+
+    assert len(healthy_seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_predicate_exception_is_treated_as_non_match() -> None:
+    bus = ControlBus()
+    seen: list[BaseEvent] = []
+
+    def broken_predicate(event: BaseEvent) -> bool:
+        raise ValueError("intentional predicate failure")
+
+    async def handler(event: BaseEvent) -> None:
+        seen.append(event)
+
+    handle = bus.subscribe(broken_predicate, handler)
+
+    tasks = bus.publish(_directive_event())
+    assert tasks == ()
+    assert seen == []
+
+    # The broken subscription is *not* auto-unsubscribed; idempotent
+    # unsubscribe still removes it cleanly.
+    bus.unsubscribe(handle)
+    bus.unsubscribe(handle)  # second call is a no-op
+
+
+@pytest.mark.asyncio
+async def test_slow_handler_does_not_block_fast_handler() -> None:
+    bus = ControlBus()
+    fast_done = asyncio.Event()
+
+    async def slow(event: BaseEvent) -> None:
+        await asyncio.sleep(0.05)
+
+    async def fast(event: BaseEvent) -> None:
+        fast_done.set()
+
+    bus.subscribe(_is_directive, slow)
+    bus.subscribe(_is_directive, fast)
+
+    tasks = bus.publish(_directive_event())
+    # The fast handler should fire well before the slow one finishes.
+    await asyncio.wait_for(fast_done.wait(), timeout=0.5)
+    assert fast_done.is_set()
+    await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_inside_handler_does_not_raise() -> None:
+    bus = ControlBus()
+    delivery_count = 0
+
+    async def adopter(event: BaseEvent) -> None:
+        nonlocal delivery_count
+        delivery_count += 1
+        # Adding a subscriber while iterating the live publish loop must
+        # not raise; ``publish`` snapshots the subscription list.
+
+        async def latecomer(_event: BaseEvent) -> None:
+            nonlocal delivery_count
+            delivery_count += 1
+
+        bus.subscribe(_is_directive, latecomer)
+
+    bus.subscribe(_is_directive, adopter)
+
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+
+    # The latecomer is not invoked retroactively for the in-flight event;
+    # it will receive the next publish.
+    assert delivery_count == 1
+
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+    # Now both subscribers fired: adopter (1) + latecomer (1) for the
+    # second event, plus adopter's first delivery.
+    assert delivery_count == 3
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_stops_delivery() -> None:
+    bus = ControlBus()
+    seen: list[BaseEvent] = []
+
+    async def handler(event: BaseEvent) -> None:
+        seen.append(event)
+
+    handle = bus.subscribe(_is_directive, handler)
+    bus.unsubscribe(handle)
+
+    tasks = bus.publish(_directive_event())
+    assert tasks == ()
+    assert seen == []


### PR DESCRIPTION
## Summary

Adds the reactive surface paired with the observational event factory from #492. `ControlBus` is an in-process publish/subscribe primitive; `AgentRuntimeContext` is the narrow, frozen dataclass agreed in #476 Q1 that carries the bus alongside the existing per-handler dependencies (EventStore, MCP bridge, runtime/llm backend labels). The `control` slot on the context defaults to `None` so the upcoming #474 migration can adopt it incrementally without breaking existing callers.

Closes #515.

## Changes

- `src/ouroboros/orchestrator/control_bus.py` — new `ControlBus` class with `subscribe(predicate, handler) → SubscriptionHandle`, `unsubscribe(handle)`, and `publish(event) → tuple[Task, ...]`. Per-handler asyncio task spawn isolates a slow or failing handler from siblings. Predicate exceptions are treated as non-matches and logged; the predicate is *not* auto-unsubscribed.
- `src/ouroboros/orchestrator/agent_runtime_context.py` — new frozen, slotted dataclass with the minimal field set from #476 Q1: `event_store`, `runtime_backend`, `llm_backend`, `mcp_bridge`, `control`. A regression test pins the field set so reviewers see explicit diffs when the membership grows.
- `tests/unit/orchestrator/test_control_bus.py` (8 cases) and `tests/unit/orchestrator/test_agent_runtime_context.py` (3 cases).

## Scope choices baked in

- **No coupling to persistence.** EventStore stays untouched; callsites publish to the bus themselves after `EventStore.append`. This honours the "no service locator" guardrail from #476 Q1 (narrow membership for the runtime context) and keeps the bus a pure in-process primitive that future callers (#474, #475) can adopt without modifying EventStore.
- **No cross-runtime delivery.** That is the Mesh's responsibility (sub-RFC #511). The bus is single-runtime by design.
- **No forging resistance.** Cooperative trust per #476: any in-process actor can publish; the bus does not police identity.

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/orchestrator/control_bus.py src/ouroboros/orchestrator/agent_runtime_context.py tests/unit/orchestrator/test_control_bus.py tests/unit/orchestrator/test_agent_runtime_context.py` | clean (after one auto-fix for import order) |
| `uv run ruff format ...` | no diff |
| `uv run pytest tests/unit/orchestrator/test_control_bus.py tests/unit/orchestrator/test_agent_runtime_context.py` | 11 passed |

## Pre-merge checklist (from #515 verification protocol)

- [x] `ControlBus` class with `subscribe` / `unsubscribe` / `publish`
- [x] Slot added to `AgentRuntimeContext` (`control`) with narrow-membership rationale in this PR body and pinned by `test_context_membership_is_narrow`
- [x] Predicate matching: subscribers only see events for which their predicate returns `True`
- [x] Multi-subscriber: all matching subscribers receive the event for one publish call
- [x] Handler failure isolation: a subscriber raising an exception does not affect other subscribers' delivery for the same event
- [x] Slow subscriber test: a handler that sleeps does not delay another handler that completes immediately
- [x] No deadlock when a handler subscribes a new handler from inside `publish`
- [x] `unsubscribe` is idempotent and stops further delivery
- [x] Existing `AgentRuntimeContext` consumers that do not pass `control=` continue to work; `context.control is None` is a valid state — verified by the test where the dataclass is constructed without the slot
- [ ] **Deferred to follow-up:** EventStore append → bus auto-publish wiring. This PR keeps the bus standalone so it stays single-responsibility; the wiring lands either alongside the #474 migration (where the runtime context is actually threaded through handlers) or in a tiny dedicated PR. The current callsite contract is "publish to the bus immediately after `event_store.append` in the same code path" — the bus does not depend on EventStore for its API, and the verification scenario from #515 (subscriber fires on a real directive event) is achievable today by any callsite that holds both objects.

## Post-merge checklist

- [ ] On a real install, register a no-op subscriber via a small dev script; emit one directive; confirm the subscriber fires
- [ ] Confirm `control_bus.handler_raised` log entry appears when a deliberately broken subscriber is registered
- [ ] Open the EventStore-wiring follow-up issue (or fold the wiring into the first slice of #474)

## Rollback

The bus is dormant until callers register subscribers, and #474/#475 callsite migration is in a separate PR. Rollback steps:

1. Revert this PR.
2. No data to clean up — the bus does not persist anything.
3. The new `AgentRuntimeContext` slot disappears; any pre-emptive callers (none in this PR) would fail to construct, surfaced quickly through CI.

Closes #515.
