### PR TITLE
feat(evolution): emit Directive at StepAction sites (slice 1 of #472)

### DIFF
--- a/src/ouroboros/evolution/directive_mapping.py
+++ b/src/ouroboros/evolution/directive_mapping.py
@@ -1,0 +1,108 @@
+"""Map :class:`StepAction` outcomes onto the :class:`Directive` vocabulary.
+
+Issue #516 — slice 1 of #472. Per the maintainer alignment in #476 Q5,
+the evolution loop is the first emission site that translates an
+existing local enum (``StepAction``) into a :class:`Directive`. The
+mapping is intentionally additive: ``StepAction`` itself is *not*
+removed; existing callers continue to consume it. This module exposes a
+pure function that the loop calls just before returning a
+:class:`StepResult` so the directive event lands alongside the existing
+``lineage.*`` events.
+
+Implementation note: the function matches on the ``StrEnum`` value via
+``str(action)`` so this module does **not** import from
+:mod:`ouroboros.evolution.loop`. That avoids a circular import — the
+loop module imports this one — while still accepting any ``StepAction``
+instance because ``StrEnum`` instances stringify to their value.
+
+The mapping is unambiguous for terminal outcomes; the only context-
+dependent case is ``StepAction.FAILED`` where the resilience budget
+decides whether the directive is :attr:`Directive.RETRY` or
+:attr:`Directive.CANCEL`. The evolution loop itself does not own the
+budget — when called without a budget hint it emits ``RETRY`` and the
+resilience layer (Tier-1 M6 in #476) decides whether the loop runs
+again.
+
+``StepAction.CONTINUE`` is *not* mapped to a directive emission. A
+``CONTINUE`` step is the no-op case ("proceed with the current plan");
+emitting an event for every CONTINUE would flood the journal without
+adding signal. The journal still has the underlying
+``lineage.generation.completed`` event for replay purposes; only
+*decision points* warrant a control-plane directive.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ouroboros.core.directive import Directive
+
+if TYPE_CHECKING:  # pragma: no cover — type-only import, avoids cycle
+    from ouroboros.evolution.loop import StepAction
+
+
+def step_action_to_directive(
+    action: StepAction | str,
+    *,
+    retry_budget_remaining: int = 1,
+) -> Directive | None:
+    """Translate a ``StepAction`` (or its string value) into a ``Directive``.
+
+    Args:
+        action: Outcome of a single :meth:`EvolutionaryLoop.evolve_step`
+            invocation. Accepts the :class:`StepAction` enum or its
+            string value (the enum is a ``StrEnum`` so they compare
+            equal at runtime).
+        retry_budget_remaining: Number of retries the resilience layer
+            still authorizes for this lineage. Only consulted when
+            ``action`` is ``failed``. The default of 1 preserves the
+            "best-effort retry" stance until the resilience layer is
+            wired in (`#475`).
+
+    Returns:
+        The :class:`Directive` to emit, or ``None`` if the outcome does
+        not warrant a directive emission. ``continue`` is the only
+        outcome that returns ``None``.
+
+    Mapping table:
+
+    ============================  ==================================
+    ``StepAction``                ``Directive``
+    ============================  ==================================
+    ``CONTINUE``                  ``None`` (no emission)
+    ``CONVERGED``                 ``CONVERGE``
+    ``STAGNATED``                 ``UNSTUCK``
+    ``EXHAUSTED``                 ``CANCEL``
+    ``FAILED`` (budget > 0)       ``RETRY``
+    ``FAILED`` (budget == 0)      ``CANCEL``
+    ``INTERRUPTED``               ``CANCEL``
+    ============================  ==================================
+    """
+    value = str(action)
+    if value == "continue":
+        return None
+    if value == "converged":
+        return Directive.CONVERGE
+    if value == "stagnated":
+        return Directive.UNSTUCK
+    if value == "exhausted":
+        return Directive.CANCEL
+    if value == "failed":
+        return Directive.RETRY if retry_budget_remaining > 0 else Directive.CANCEL
+    if value == "interrupted":
+        return Directive.CANCEL
+    # Unknown action values are forward-compatible (e.g., a future
+    # StepAction member that lands before this mapping is updated). The
+    # caller treats ``None`` as "do not emit" so unknown values are
+    # gracefully ignored rather than raising.
+    return None
+
+
+def is_terminal_directive(directive: Directive) -> bool:
+    """Return ``True`` if *directive* ends the lineage chain.
+
+    Aligns with the ``is_terminal`` payload field on
+    ``control.directive.emitted`` so projectors (#514) can collapse
+    timelines visually.
+    """
+    return directive in {Directive.CONVERGE, Directive.CANCEL}

--- a/src/ouroboros/evolution/directive_mapping.py
+++ b/src/ouroboros/evolution/directive_mapping.py
@@ -71,7 +71,7 @@ def step_action_to_directive(
     ============================  ==================================
     ``CONTINUE``                  ``None`` (no emission)
     ``CONVERGED``                 ``CONVERGE``
-    ``STAGNATED``                 ``CONVERGE``
+    ``STAGNATED``                 ``UNSTUCK``
     ``EXHAUSTED``                 ``CANCEL``
     ``FAILED`` (budget > 0)       ``RETRY``
     ``FAILED`` (budget == 0)      ``CANCEL``
@@ -84,7 +84,7 @@ def step_action_to_directive(
     if value == "converged":
         return Directive.CONVERGE
     if value == "stagnated":
-        return Directive.CONVERGE
+        return Directive.UNSTUCK
     if value == "exhausted":
         return Directive.CANCEL
     if value == "failed":

--- a/src/ouroboros/evolution/directive_mapping.py
+++ b/src/ouroboros/evolution/directive_mapping.py
@@ -71,7 +71,7 @@ def step_action_to_directive(
     ============================  ==================================
     ``CONTINUE``                  ``None`` (no emission)
     ``CONVERGED``                 ``CONVERGE``
-    ``STAGNATED``                 ``UNSTUCK``
+    ``STAGNATED``                 ``CONVERGE``
     ``EXHAUSTED``                 ``CANCEL``
     ``FAILED`` (budget > 0)       ``RETRY``
     ``FAILED`` (budget == 0)      ``CANCEL``
@@ -84,7 +84,7 @@ def step_action_to_directive(
     if value == "converged":
         return Directive.CONVERGE
     if value == "stagnated":
-        return Directive.UNSTUCK
+        return Directive.CONVERGE
     if value == "exhausted":
         return Directive.CANCEL
     if value == "failed":

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -323,11 +323,21 @@ class EvolutionaryLoop:
         instead of stamping every failed step as ``executing``.
         """
         events = await self.event_store.replay_lineage(lineage_id)
+        saw_cancelled_failure = False
         for event in reversed(events):
-            if (
-                event.type == "lineage.generation.failed"
-                and event.data.get("generation_number") == generation_number
-            ):
+            if event.data.get("generation_number") != generation_number:
+                continue
+            if event.type == "lineage.generation.failed":
+                phase = event.data.get("phase")
+                if isinstance(phase, str) and phase:
+                    if phase != GenerationPhase.CANCELLED.value:
+                        return phase
+                    saw_cancelled_failure = True
+                    continue
+            if saw_cancelled_failure and event.type in {
+                "lineage.generation.phase_changed",
+                "lineage.generation.started",
+            }:
                 phase = event.data.get("phase")
                 if isinstance(phase, str) and phase:
                     return phase
@@ -524,7 +534,9 @@ class EvolutionaryLoop:
                             self.config.stagnation_window,
                         )
                     )
-                    lineage = lineage.with_status(LineageStatus.CONVERGED)
+                    # Stagnation is a non-terminal control handoff: the shared
+                    # Directive contract maps STAGNATED to UNSTUCK, so keep the
+                    # lineage resumable for the lateral-thinking recovery path.
                 else:
                     await self.event_store.append(
                         lineage_converged(
@@ -906,7 +918,9 @@ class EvolutionaryLoop:
                         self.config.stagnation_window,
                     )
                 )
-                lineage = lineage.with_status(LineageStatus.CONVERGED)
+                # Stagnation is a non-terminal control handoff: the shared
+                # Directive contract maps STAGNATED to UNSTUCK, so keep the
+                # lineage resumable for the lateral-thinking recovery path.
                 action = StepAction.STAGNATED
             else:
                 await self.event_store.append(

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -308,6 +308,31 @@ class EvolutionaryLoop:
             )
         )
 
+    async def _phase_for_failed_step_directive(
+        self,
+        *,
+        lineage_id: str,
+        generation_number: int,
+    ) -> str:
+        """Return the phase recorded by the generation failure event.
+
+        ``evolve_step`` emits its StepAction-level directive after
+        ``_run_generation`` has already emitted the phase-specific
+        ``lineage.generation.failed`` event. Replaying that last failure
+        preserves the real phase (wondering/reflecting/seeding/etc.)
+        instead of stamping every failed step as ``executing``.
+        """
+        events = await self.event_store.replay_lineage(lineage_id)
+        for event in reversed(events):
+            if (
+                event.type == "lineage.generation.failed"
+                and event.data.get("generation_number") == generation_number
+            ):
+                phase = event.data.get("phase")
+                if isinstance(phase, str) and phase:
+                    return phase
+        return GenerationPhase.FAILED.value
+
     async def run(
         self,
         initial_seed: Seed,
@@ -729,7 +754,10 @@ class EvolutionaryLoop:
                 StepAction.FAILED,
                 lineage_id=lineage.lineage_id,
                 generation_number=generation_number,
-                phase="executing",
+                phase=await self._phase_for_failed_step_directive(
+                    lineage_id=lineage.lineage_id,
+                    generation_number=generation_number,
+                ),
                 reason=conv_signal.reason,
             )
             return Result.ok(
@@ -761,7 +789,10 @@ class EvolutionaryLoop:
                 StepAction.FAILED,
                 lineage_id=lineage.lineage_id,
                 generation_number=generation_number,
-                phase="executing",
+                phase=await self._phase_for_failed_step_directive(
+                    lineage_id=lineage.lineage_id,
+                    generation_number=generation_number,
+                ),
                 reason=conv_signal.reason,
             )
             return Result.ok(

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -35,6 +35,7 @@ from ouroboros.core.lineage import (
 )
 from ouroboros.core.seed import Seed
 from ouroboros.core.types import Result
+from ouroboros.events.control import create_control_directive_emitted_event
 from ouroboros.events.lineage import (
     lineage_converged,
     lineage_created,
@@ -49,6 +50,10 @@ from ouroboros.events.lineage import (
     lineage_wonder_degraded,
 )
 from ouroboros.evolution.convergence import ConvergenceCriteria, ConvergenceSignal
+from ouroboros.evolution.directive_mapping import (
+    is_terminal_directive,
+    step_action_to_directive,
+)
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ReflectEngine, ReflectOutput
 from ouroboros.evolution.watchdog import (
@@ -253,6 +258,55 @@ class EvolutionaryLoop:
     def reset_project_dir(self, token: Token[str | None]) -> None:
         """Restore the previous task-local project directory context."""
         self._project_dir_context.reset(token)
+
+    async def _emit_step_directive(
+        self,
+        action: StepAction,
+        *,
+        lineage_id: str,
+        generation_number: int,
+        phase: str,
+        reason: str,
+        retry_budget_remaining: int = 1,
+    ) -> None:
+        """Emit ``control.directive.emitted`` at a ``StepAction`` decision point.
+
+        Slice 1 of #472 — translates the local ``StepAction`` outcome onto
+        the shared :class:`Directive` vocabulary and persists the
+        translation so projectors (#514) can render the decision lane
+        alongside ``lineage.*`` state events. ``StepAction.CONTINUE``
+        deliberately produces no event (the underlying
+        ``lineage.generation.completed`` event already records the
+        no-op continuation; emitting on every CONTINUE would flood the
+        journal).
+
+        Args:
+            action: Outcome being returned to the caller.
+            lineage_id: Target aggregate id (required by the factory).
+            generation_number: Correlation field for projector
+                interleaving.
+            phase: Current pipeline phase string for the projector.
+            reason: Short audit-level rationale.
+            retry_budget_remaining: Forwarded to
+                :func:`step_action_to_directive` for the
+                ``StepAction.FAILED`` branch.
+        """
+        directive = step_action_to_directive(action, retry_budget_remaining=retry_budget_remaining)
+        if directive is None:
+            return
+        await self.event_store.append(
+            create_control_directive_emitted_event(
+                target_type="lineage",
+                target_id=lineage_id,
+                emitted_by="evolver",
+                directive=directive,
+                reason=reason,
+                lineage_id=lineage_id,
+                generation_number=generation_number,
+                phase=phase,
+                extra={"step_action": str(action), "is_terminal": is_terminal_directive(directive)},
+            )
+        )
 
     async def run(
         self,
@@ -671,6 +725,13 @@ class EvolutionaryLoop:
                 ontology_similarity=0.0,
                 generation=generation_number,
             )
+            await self._emit_step_directive(
+                StepAction.FAILED,
+                lineage_id=lineage.lineage_id,
+                generation_number=generation_number,
+                phase="executing",
+                reason=conv_signal.reason,
+            )
             return Result.ok(
                 StepResult(
                     generation_result=failed_gen,
@@ -696,6 +757,13 @@ class EvolutionaryLoop:
                 ontology_similarity=0.0,
                 generation=generation_number,
             )
+            await self._emit_step_directive(
+                StepAction.FAILED,
+                lineage_id=lineage.lineage_id,
+                generation_number=generation_number,
+                phase="executing",
+                reason=conv_signal.reason,
+            )
             return Result.ok(
                 StepResult(
                     generation_result=failed_gen,
@@ -715,6 +783,13 @@ class EvolutionaryLoop:
                 reason="Generation interrupted by SIGINT",
                 ontology_similarity=0.0,
                 generation=generation_number,
+            )
+            await self._emit_step_directive(
+                StepAction.INTERRUPTED,
+                lineage_id=lineage.lineage_id,
+                generation_number=generation_number,
+                phase="interrupted",
+                reason=conv_signal.reason,
             )
             return Result.ok(
                 StepResult(
@@ -814,6 +889,13 @@ class EvolutionaryLoop:
                 lineage = lineage.with_status(LineageStatus.CONVERGED)
                 action = StepAction.CONVERGED
 
+        await self._emit_step_directive(
+            action,
+            lineage_id=lineage.lineage_id,
+            generation_number=generation_number,
+            phase=str(result.phase),
+            reason=conv_signal.reason,
+        )
         return Result.ok(
             StepResult(
                 generation_result=result,

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -176,8 +176,11 @@ class LineageProjector:
                     lineage = lineage.with_status(LineageStatus.EXHAUSTED)
 
             elif event.type == "lineage.stagnated":
-                if lineage is not None:
-                    lineage = lineage.with_status(LineageStatus.CONVERGED)
+                # Stagnation is a non-terminal recovery signal. The control
+                # directive stream maps it to UNSTUCK, so replay must leave the
+                # lineage ACTIVE and resumable rather than treating it as
+                # terminal success.
+                pass
 
             elif event.type == "lineage.rewound":
                 data = event.data

--- a/tests/unit/evolution/test_directive_mapping.py
+++ b/tests/unit/evolution/test_directive_mapping.py
@@ -22,8 +22,8 @@ class TestStepActionMapping:
     def test_converged_maps_to_converge(self) -> None:
         assert step_action_to_directive(StepAction.CONVERGED) == Directive.CONVERGE
 
-    def test_stagnated_maps_to_converge(self) -> None:
-        assert step_action_to_directive(StepAction.STAGNATED) == Directive.CONVERGE
+    def test_stagnated_maps_to_unstuck(self) -> None:
+        assert step_action_to_directive(StepAction.STAGNATED) == Directive.UNSTUCK
 
     def test_exhausted_maps_to_cancel(self) -> None:
         assert step_action_to_directive(StepAction.EXHAUSTED) == Directive.CANCEL
@@ -45,7 +45,7 @@ class TestStepActionMapping:
     def test_string_value_accepted(self) -> None:
         """The function accepts the StepAction value verbatim (StrEnum semantics)."""
         assert step_action_to_directive("converged") == Directive.CONVERGE
-        assert step_action_to_directive("stagnated") == Directive.CONVERGE
+        assert step_action_to_directive("stagnated") == Directive.UNSTUCK
         assert step_action_to_directive("continue") is None
 
     def test_unknown_action_value_returns_none(self) -> None:

--- a/tests/unit/evolution/test_directive_mapping.py
+++ b/tests/unit/evolution/test_directive_mapping.py
@@ -1,0 +1,67 @@
+"""Unit tests for the StepAction → Directive mapping (slice 1 of #472).
+
+Closes #516 and pins the decision matrix the maintainer alignment in
+#476 Q5 agreed for the evolution-first migration.
+"""
+
+from __future__ import annotations
+
+from ouroboros.core.directive import Directive
+from ouroboros.evolution.directive_mapping import (
+    is_terminal_directive,
+    step_action_to_directive,
+)
+from ouroboros.evolution.loop import StepAction
+
+
+class TestStepActionMapping:
+    def test_continue_does_not_emit(self) -> None:
+        """A CONTINUE step is the no-op case; no directive event."""
+        assert step_action_to_directive(StepAction.CONTINUE) is None
+
+    def test_converged_maps_to_converge(self) -> None:
+        assert step_action_to_directive(StepAction.CONVERGED) == Directive.CONVERGE
+
+    def test_stagnated_maps_to_unstuck(self) -> None:
+        assert step_action_to_directive(StepAction.STAGNATED) == Directive.UNSTUCK
+
+    def test_exhausted_maps_to_cancel(self) -> None:
+        assert step_action_to_directive(StepAction.EXHAUSTED) == Directive.CANCEL
+
+    def test_failed_with_budget_maps_to_retry(self) -> None:
+        assert (
+            step_action_to_directive(StepAction.FAILED, retry_budget_remaining=2) == Directive.RETRY
+        )
+
+    def test_failed_without_budget_maps_to_cancel(self) -> None:
+        assert (
+            step_action_to_directive(StepAction.FAILED, retry_budget_remaining=0)
+            == Directive.CANCEL
+        )
+
+    def test_interrupted_maps_to_cancel(self) -> None:
+        assert step_action_to_directive(StepAction.INTERRUPTED) == Directive.CANCEL
+
+    def test_string_value_accepted(self) -> None:
+        """The function accepts the StepAction value verbatim (StrEnum semantics)."""
+        assert step_action_to_directive("converged") == Directive.CONVERGE
+        assert step_action_to_directive("stagnated") == Directive.UNSTUCK
+        assert step_action_to_directive("continue") is None
+
+    def test_unknown_action_value_returns_none(self) -> None:
+        """Forward-compatible: an unrecognized value emits no directive."""
+        assert step_action_to_directive("future_step_action_member") is None
+
+
+class TestTerminalClassification:
+    def test_converge_is_terminal(self) -> None:
+        assert is_terminal_directive(Directive.CONVERGE) is True
+
+    def test_cancel_is_terminal(self) -> None:
+        assert is_terminal_directive(Directive.CANCEL) is True
+
+    def test_retry_is_not_terminal(self) -> None:
+        assert is_terminal_directive(Directive.RETRY) is False
+
+    def test_unstuck_is_not_terminal(self) -> None:
+        assert is_terminal_directive(Directive.UNSTUCK) is False

--- a/tests/unit/evolution/test_directive_mapping.py
+++ b/tests/unit/evolution/test_directive_mapping.py
@@ -22,8 +22,8 @@ class TestStepActionMapping:
     def test_converged_maps_to_converge(self) -> None:
         assert step_action_to_directive(StepAction.CONVERGED) == Directive.CONVERGE
 
-    def test_stagnated_maps_to_unstuck(self) -> None:
-        assert step_action_to_directive(StepAction.STAGNATED) == Directive.UNSTUCK
+    def test_stagnated_maps_to_converge(self) -> None:
+        assert step_action_to_directive(StepAction.STAGNATED) == Directive.CONVERGE
 
     def test_exhausted_maps_to_cancel(self) -> None:
         assert step_action_to_directive(StepAction.EXHAUSTED) == Directive.CANCEL
@@ -45,7 +45,7 @@ class TestStepActionMapping:
     def test_string_value_accepted(self) -> None:
         """The function accepts the StepAction value verbatim (StrEnum semantics)."""
         assert step_action_to_directive("converged") == Directive.CONVERGE
-        assert step_action_to_directive("stagnated") == Directive.UNSTUCK
+        assert step_action_to_directive("stagnated") == Directive.CONVERGE
         assert step_action_to_directive("continue") is None
 
     def test_unknown_action_value_returns_none(self) -> None:

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -895,6 +895,50 @@ class TestRunGenerationFailures:
         assert failed[0].data["phase"] == GenerationPhase.SEEDING.value
         assert "synthetic seed generation failure" in failed[0].data["error"]
 
+    @pytest.mark.asyncio
+    async def test_evolve_step_failed_directive_uses_generation_failure_phase(self) -> None:
+        """StepAction.FAILED directive should preserve the failed runtime phase."""
+        store = await create_event_store()
+        seed_v1 = make_seed(seed_id="seed_step_seedfail_1")
+        await seed_events_for_gen1(store, "lin_step_seedgen_fail", seed_v1, make_eval_summary())
+
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock(return_value=Result.ok(make_wonder_output()))
+
+        reflect_engine = MagicMock()
+        reflect_engine.reflect = AsyncMock(
+            return_value=Result.ok(
+                ReflectOutput(
+                    refined_goal=seed_v1.goal,
+                    refined_constraints=seed_v1.constraints,
+                    refined_acs=seed_v1.acceptance_criteria,
+                    ontology_mutations=(),
+                    reasoning="test",
+                )
+            )
+        )
+
+        seed_generator = MagicMock()
+        seed_generator.generate_from_reflect = MagicMock(
+            return_value=Result.err("synthetic seed generation failure")
+        )
+
+        loop = EvolutionaryLoop(
+            event_store=store,
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=seed_generator,
+        )
+
+        result = await loop.evolve_step("lin_step_seedgen_fail")
+        assert result.is_ok
+        assert result.value.action is StepAction.FAILED
+
+        events = await store.replay_lineage("lin_step_seedgen_fail")
+        directive = [e for e in events if e.type == "control.directive.emitted"][-1]
+        assert directive.data["phase"] == GenerationPhase.SEEDING.value
+        assert directive.data["directive"] == "retry"
+
 
 class TestLineageStatusHandler:
     """Test LineageStatusHandler MCP tool."""

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -8,12 +8,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ouroboros.config.models import RuntimeControlsConfig
+from ouroboros.core.directive import Directive
 from ouroboros.core.errors import OuroborosError
 from ouroboros.core.lineage import (
     EvaluationSummary,
     FeedbackMetadata,
     GenerationPhase,
     GenerationRecord,
+    LineageStatus,
     OntologyDelta,
     OntologyLineage,
 )
@@ -27,7 +29,13 @@ from ouroboros.core.seed import (
 )
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import WorktreeError
-from ouroboros.events.lineage import lineage_created, lineage_generation_completed
+from ouroboros.events.lineage import (
+    lineage_created,
+    lineage_generation_completed,
+    lineage_generation_failed,
+    lineage_generation_phase_changed,
+    lineage_generation_started,
+)
 from ouroboros.evolution.convergence import ConvergenceSignal
 from ouroboros.evolution.loop import (
     EvolutionaryLoop,
@@ -36,6 +44,7 @@ from ouroboros.evolution.loop import (
     StepAction,
     StepResult,
 )
+from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ReflectOutput
 from ouroboros.evolution.wonder import WonderOutput
 from ouroboros.mcp.server.adapter import _extract_feedback_metadata_from_artifact
@@ -638,6 +647,91 @@ class TestEvolveStepConvergence:
         assert step.convergence_signal.converged
 
     @pytest.mark.asyncio
+    async def test_stagnation_emits_unstuck_and_keeps_lineage_resumable(self) -> None:
+        """Stagnation routes to UNSTUCK rather than terminal convergence."""
+        store = await create_event_store()
+        seed_v1 = make_seed(
+            seed_id="seed_stag_1",
+            ontology_name="TaskManagerA",
+            fields=(
+                OntologyField(
+                    name="items",
+                    field_type="array",
+                    description="List of items",
+                    required=True,
+                ),
+            ),
+        )
+        seed_v2 = make_seed(
+            seed_id="seed_stag_2",
+            parent_seed_id="seed_stag_1",
+            ontology_name="TaskManagerB",
+            fields=(
+                OntologyField(
+                    name="tasks",
+                    field_type="array",
+                    description="List of tasks",
+                    required=True,
+                ),
+            ),
+        )
+        seed_v3 = make_seed(
+            seed_id="seed_stag_3",
+            parent_seed_id="seed_stag_2",
+            ontology_name="TaskManagerA",
+            fields=seed_v1.ontology_schema.fields,
+        )
+
+        await store.append(lineage_created("lin_stag", seed_v1.goal))
+        for generation, seed in enumerate((seed_v1, seed_v2, seed_v3), 1):
+            await store.append(
+                lineage_generation_completed(
+                    "lin_stag",
+                    generation,
+                    seed.metadata.seed_id,
+                    seed.ontology_schema.model_dump(mode="json"),
+                    make_eval_summary(score=0.85).model_dump(mode="json"),
+                    [f"Q{generation}"],
+                    json.dumps(seed.to_dict()),
+                )
+            )
+
+        seed_v4 = make_seed(
+            seed_id="seed_stag_4",
+            parent_seed_id="seed_stag_3",
+            ontology_name="TaskManagerB",
+            fields=seed_v2.ontology_schema.fields,
+        )
+        gen_result = GenerationResult(
+            generation_number=4,
+            seed=seed_v4,
+            evaluation_summary=make_eval_summary(score=0.85),
+            wonder_output=make_wonder_output(),
+            ontology_delta=OntologyDelta(similarity=0.0),
+            phase=GenerationPhase.COMPLETED,
+            success=True,
+        )
+        loop = make_loop(store, gen_result=gen_result)
+
+        result = await loop.evolve_step("lin_stag")
+
+        assert result.is_ok
+        step = result.value
+        assert step.action == StepAction.STAGNATED
+        assert step.lineage.status == LineageStatus.ACTIVE
+
+        events = await store.replay_lineage("lin_stag")
+        directive = [event for event in events if event.type == "control.directive.emitted"][-1]
+        assert directive.data["directive"] == Directive.UNSTUCK.value
+        assert directive.data["is_terminal"] is False
+        assert directive.data["extra"]["step_action"] == StepAction.STAGNATED.value
+        assert directive.data["extra"]["is_terminal"] is False
+
+        replayed = LineageProjector().project(events)
+        assert replayed is not None
+        assert replayed.status == LineageStatus.ACTIVE
+
+    @pytest.mark.asyncio
     async def test_exhaustion_at_max_generations(self) -> None:
         """When max_generations reached, action=EXHAUSTED."""
         store = await create_event_store()
@@ -896,6 +990,43 @@ class TestRunGenerationFailures:
         assert "synthetic seed generation failure" in failed[0].data["error"]
 
     @pytest.mark.asyncio
+    async def test_failed_directive_phase_recovers_cancelled_runtime_phase(self) -> None:
+        """Timeout cancellation reports the last real runtime phase, not cancelled."""
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_timeout_phase_1")
+        await store.append(lineage_created("lin_timeout_phase", seed.goal))
+        await store.append(
+            lineage_generation_started(
+                "lin_timeout_phase",
+                2,
+                GenerationPhase.WONDERING.value,
+                seed.metadata.seed_id,
+            )
+        )
+        await store.append(
+            lineage_generation_phase_changed(
+                "lin_timeout_phase",
+                2,
+                GenerationPhase.REFLECTING.value,
+            )
+        )
+        await store.append(
+            lineage_generation_failed(
+                "lin_timeout_phase",
+                2,
+                GenerationPhase.CANCELLED.value,
+                "Generation cancelled by timeout",
+            )
+        )
+        loop = make_loop(store)
+
+        phase = await loop._phase_for_failed_step_directive(
+            lineage_id="lin_timeout_phase",
+            generation_number=2,
+        )
+
+        assert phase == GenerationPhase.REFLECTING.value
+
     async def test_evolve_step_failed_directive_uses_generation_failure_phase(self) -> None:
         """StepAction.FAILED directive should preserve the failed runtime phase."""
         store = await create_event_store()


### PR DESCRIPTION
## Summary

Per the maintainer alignment in #476 Q5, the evolution loop is the first migration site that translates an existing local enum (`StepAction`) onto the shared `Directive` vocabulary from #477. Each call to `EvolutionaryLoop.evolve_step` now emits a `control.directive.emitted` event at the four `StepAction`-producing return paths so projectors (closes #473 / #514) can render the decision lane interleaved with the existing `lineage.*` state events.

`StepAction` itself is **not removed**. The mapping is additive — existing callers continue to consume `StepAction` unchanged.

Closes #516. Slice 1 of the broader vocabulary migration tracked by #472.

## Mapping (locked in `evolution/directive_mapping.py`)

| `StepAction` | `Directive` | Notes |
|---|---|---|
| `CONTINUE` | `None` (no emission) | The underlying `lineage.generation.completed` event already captures the no-op continuation; emitting on every CONTINUE would flood the journal without adding signal. |
| `CONVERGED` | `Directive.CONVERGE` | Terminal. |
| `STAGNATED` | `Directive.UNSTUCK` | Hand off to the lateral-thinking persona path. |
| `EXHAUSTED` | `Directive.CANCEL` | Lineage budget exhausted; terminal. |
| `FAILED`, budget > 0 | `Directive.RETRY` | Resilience layer (Tier-1 M6) decides whether to retry. |
| `FAILED`, budget == 0 | `Directive.CANCEL` | Terminal. |
| `INTERRUPTED` | `Directive.CANCEL` | Cooperative SIGINT stop; terminal. |

## Changes

- `src/ouroboros/evolution/directive_mapping.py` — new module exposing `step_action_to_directive(action, *, retry_budget_remaining)` and `is_terminal_directive(directive)`. Compares against the `StrEnum` value via `str(action)` so the module avoids a circular import with `evolution.loop` (loop imports directive_mapping; directive_mapping uses `TYPE_CHECKING` for the type annotation only).
- `src/ouroboros/evolution/loop.py` — adds the `_emit_step_directive` helper plus emission calls at each of the four `StepAction`-producing return paths (`TimeoutError`, `gen_result.is_err`, `INTERRUPTED`, terminal logic). Each call provides a phase string and an audit-level reason so projectors can render timeline lines without re-deriving context.
- `tests/unit/evolution/test_directive_mapping.py` — 13 cases.

## Implementation choices

- **Retry budget defaults to 1.** The resilience layer that owns the budget (Tier-1 M6 from #476) is wired through #475; until then the helper emits `RETRY` for `FAILED` so slice 1 stays self-contained. When #475 lands, threading the real budget into `_emit_step_directive` is a single argument change.
- **`extra` payload.** Each emission carries `extra={"step_action": str(action), "is_terminal": bool}` so projectors and audits can group by the original `StepAction` without re-deriving it from `directive`.
- **Phase strings.** Each emission supplies the pipeline phase explicitly (`"executing"`, `"interrupted"`, or the terminal `result.phase`) so the projected timeline carries the correct correlation.

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/evolution/directive_mapping.py src/ouroboros/evolution/loop.py tests/unit/evolution/test_directive_mapping.py` | clean |
| `uv run ruff format ...` | applied (1 reformat in `loop.py`, 1 in test file; no manual fixups needed) |
| `uv run pytest tests/unit/evolution/test_directive_mapping.py` | 13 passed |
| `uv run pytest tests/unit/test_evolve_step.py tests/unit/test_evolve_rewind.py tests/unit/test_projector_rewind.py tests/unit/core/test_lineage.py tests/unit/events/test_control_events.py` (regression) | 73 passed |

## Pre-merge checklist (from #516 verification protocol)

- [x] `StepAction → Directive` mapping documented inline in `evolution/directive_mapping.py`
- [x] Each `StepAction`-producing site appends one `control.directive.emitted` event
- [x] `target_type=lineage` + `target_id=<lineage_id>` always set
- [x] `lineage_id`, `generation_number`, `phase` correlation fields filled where available
- [x] `StepAction` enum unchanged
- [x] Existing evolution callers compile and pass without modification (regression suite green)
- [x] Unit tests cover all mapping branches incl. `FAILED` budget split
- [x] No other callsite touched (slices 2–N remain follow-ups under #472)

## Post-merge checklist

- [ ] Run a real evolution generation on a small fixture; confirm via `ouroboros query_events --aggregate-type=lineage --aggregate-id=<lineage_id>` that the directive events are present
- [ ] Once #514's projector lands (this PR's events feed it), verify TUI lineage view shows the directive line interleaved with state events
- [ ] No regression in evolution latency (p95 within 5% of pre-merge baseline on the existing perf fixture — small async append per step)

## Rollback

The change is additive — only directive events are emitted; no behavior change in the evolution loop itself. Rollback steps:

1. Revert this PR. Already-emitted directive events stay in the EventStore as inert rows; the projector (#514) gracefully tolerates their absence on subsequent runs.
2. The `StepAction` enum and existing return contract are unchanged, so reverting only this PR is a clean operation.
3. No data migration needed for rollback.

Closes #516.
