### PR TITLE
feat(mcp): add inject_runtime_context helper to bridge_mixin (slice 1 of #474)

### DIFF
--- a/src/ouroboros/mcp/tools/bridge_mixin.py
+++ b/src/ouroboros/mcp/tools/bridge_mixin.py
@@ -3,12 +3,30 @@
 Handlers that inherit from this mixin will automatically receive
 an MCPClientManager reference when an MCPBridge is configured,
 via loop-based injection in the composition root.
+
+This module exposes two equivalent injection helpers:
+
+* :func:`inject_bridge` — original entry point. Accepts a raw
+  ``MCPBridge`` instance and populates the mixin fields.
+* :func:`inject_runtime_context` — context-aware entry point added by
+  #474. Accepts an :class:`AgentRuntimeContext` and pulls the bridge
+  off it. Subsequent ``mcp_manager`` plumbing migrations (#474 PR-3
+  through PR-5) gradually swap call sites at the composition root from
+  the legacy form to this one, then move handler internals to read
+  ``context.mcp_bridge`` directly instead of ``self.mcp_manager``.
+
+Both helpers are additive: the legacy form continues to work for
+callers that have not yet adopted the runtime context, so the
+migration can land in small reviewable slices without a flag day.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
 
 
 @dataclass
@@ -50,3 +68,37 @@ def inject_bridge(handler: object, bridge: object | None) -> bool:
     handler.mcp_manager = getattr(bridge, "manager", None)
     handler.mcp_tool_prefix = getattr(bridge, "tool_prefix", "")
     return True
+
+
+def inject_runtime_context(
+    handler: object,
+    context: AgentRuntimeContext | None,
+) -> bool:
+    """Inject the ``AgentRuntimeContext``'s bridge into a mixin handler.
+
+    Equivalent to calling :func:`inject_bridge` with
+    ``context.mcp_bridge`` but accepts the runtime context directly.
+    This is the entry point subsequent #474 PRs use at the composition
+    root so handlers can reach the bridge through the same context
+    object that already carries the EventStore and the
+    :class:`ControlBus` (per #476 Q1's narrow-membership commitment).
+
+    Args:
+        handler: A tool handler, possibly :class:`BridgeAwareMixin`.
+        context: The :class:`AgentRuntimeContext` carrying the runtime's
+            optional MCP bridge. Passing ``None`` is treated as
+            "no bridge available" and skips injection — that keeps the
+            non-MCP code paths valid.
+
+    Returns:
+        ``True`` if injection was performed; ``False`` otherwise.
+
+    The function is intentionally a thin adapter so the legacy
+    :func:`inject_bridge` code path remains the single source of truth
+    for the actual attribute write. When the migration is complete and
+    every caller flows through this helper, the legacy entry point can
+    be deprecated without behaviour change.
+    """
+    if context is None:
+        return False
+    return inject_bridge(handler, context.mcp_bridge)

--- a/src/ouroboros/orchestrator/agent_runtime_context.py
+++ b/src/ouroboros/orchestrator/agent_runtime_context.py
@@ -1,0 +1,45 @@
+"""``AgentRuntimeContext`` — the runtime-offering side of #476 Q1.
+
+The runtime context describes *what the orchestrator runtime offers* a
+handler — the EventStore it appends into, optional capability sources,
+and the :class:`ControlBus` that lets handlers react to directive events.
+The context is intentionally narrow: per the maintainer commitment in
+#476 Q1, every new field added later must include a one-line PR-body
+justification so the type does not drift into a service locator.
+
+This first step keeps the membership minimal:
+
+* ``event_store`` — the persistence boundary handlers already share.
+* ``runtime_backend`` / ``llm_backend`` — informational labels existing
+  callers (rate-limit, telemetry) already pass alongside the bridge.
+* ``mcp_bridge`` — the existing capability source from #280's bridge
+  work; optional so non-MCP code paths stay valid.
+* ``control`` — the :class:`ControlBus` introduced alongside this
+  context; ``None`` while #474's migration is in progress so existing
+  callers compile unchanged.
+
+Subsequent issues (#474, #475) wire concrete handlers to consume the
+context. This module deliberately does *not* import any handler-side
+type so that adopting the context becomes a one-import change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ouroboros.mcp.bridge.bridge import MCPBridge
+    from ouroboros.orchestrator.control_bus import ControlBus
+    from ouroboros.persistence.event_store import EventStore
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRuntimeContext:
+    """Minimal, narrow-membership runtime context handed to MCP handlers."""
+
+    event_store: EventStore
+    runtime_backend: str | None = None
+    llm_backend: str | None = None
+    mcp_bridge: MCPBridge | None = None
+    control: ControlBus | None = None

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -37,7 +37,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ouroboros.events.base import BaseEvent
@@ -55,9 +55,12 @@ class SubscriptionHandle:
     """Opaque token returned by :meth:`ControlBus.subscribe`.
 
     Callers pass it back to :meth:`ControlBus.unsubscribe` to detach.
+    Handles are scoped to the bus that created them so identical local
+    integer IDs from different buses cannot detach each other.
     """
 
     _id: int
+    _owner: Any
 
 
 @dataclass(slots=True)
@@ -80,6 +83,8 @@ class ControlBus:
 
     _subscriptions: list[_Subscription] = field(default_factory=list)
     _next_id: int = 0
+    _owner: object = field(default_factory=object)
+    _tasks: set[asyncio.Task[None]] = field(default_factory=set)
     _spawn: Callable[[Awaitable[None]], asyncio.Task[None]] | None = None
 
     def subscribe(self, predicate: Predicate, handler: Handler) -> SubscriptionHandle:
@@ -97,7 +102,7 @@ class ControlBus:
             A :class:`SubscriptionHandle` accepted by
             :meth:`unsubscribe`.
         """
-        handle = SubscriptionHandle(_id=self._next_id)
+        handle = SubscriptionHandle(_id=self._next_id, _owner=self._owner)
         self._next_id += 1
         self._subscriptions.append(
             _Subscription(handle=handle, predicate=predicate, handler=handler)
@@ -110,6 +115,8 @@ class ControlBus:
         Idempotent: detaching an unknown or already-removed handle is a
         no-op.
         """
+        if handle._owner is not self._owner:
+            return
         self._subscriptions = [sub for sub in self._subscriptions if sub.handle != handle]
 
     def publish(self, event: BaseEvent) -> tuple[asyncio.Task[None], ...]:
@@ -140,7 +147,10 @@ class ControlBus:
     def _spawn_handler(self, handler: Handler, event: BaseEvent) -> asyncio.Task[None]:
         """Run *handler* on its own task with structured error isolation."""
         spawn = self._spawn or asyncio.ensure_future
-        return spawn(self._invoke_handler(handler, event))
+        task = spawn(self._invoke_handler(handler, event))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
 
     @staticmethod
     async def _invoke_handler(handler: Handler, event: BaseEvent) -> None:

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -1,0 +1,153 @@
+"""In-process ControlBus for ``control.directive.emitted`` events.
+
+The bus is the *reactive* surface paired with the *observational* event
+factory landed in #492. Subscribers register a predicate and a handler;
+when callsites publish a directive event onto the bus, every matching
+handler fires concurrently on its own task. A slow or failing handler
+never blocks other handlers or the publisher.
+
+Per the maintainer alignment in #476 Q1, the bus is exposed as
+``AgentRuntimeContext.control`` (see :mod:`agent_runtime_context`). The
+context describes *what the runtime offers*; the bus describes *where
+directives flow*. Two different concerns, two different names.
+
+Scope choices baked in here:
+
+* The bus does *not* know about persistence. EventStore stays simple;
+  callsites call :meth:`ControlBus.publish` themselves after
+  :meth:`EventStore.append`. This honours the "no service locator"
+  guardrail from #476 Q1 (narrow membership for the runtime context) and
+  keeps the bus a pure in-process primitive that future callers — for
+  example the #474 ``AgentRuntimeContext`` migration and #475
+  ``evolve_step`` / ``unstuck`` / ``ralph`` wiring — can adopt
+  incrementally.
+
+* Cross-runtime delivery is a *separate* concern; that is the Mesh
+  (sub-RFC :doc:`../../docs/rfc/mesh`). The Mesh, when it lands, can
+  reuse this surface or wrap it.
+
+* Forging resistance is *not* a goal. The cooperative-trust model from
+  #476 explicitly accepts that any in-process actor can publish; the bus
+  does not police identity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ouroboros.events.base import BaseEvent
+
+
+logger = logging.getLogger(__name__)
+
+
+Predicate = Callable[["BaseEvent"], bool]
+Handler = Callable[["BaseEvent"], Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class SubscriptionHandle:
+    """Opaque token returned by :meth:`ControlBus.subscribe`.
+
+    Callers pass it back to :meth:`ControlBus.unsubscribe` to detach.
+    """
+
+    _id: int
+
+
+@dataclass(slots=True)
+class _Subscription:
+    """One predicate/handler pair tracked by the bus."""
+
+    handle: SubscriptionHandle
+    predicate: Predicate
+    handler: Handler
+
+
+@dataclass(slots=True)
+class ControlBus:
+    """Concurrent in-process publish/subscribe surface for control events.
+
+    The bus is intended to live on :class:`AgentRuntimeContext` for the
+    lifetime of an orchestrator session. It is **not** thread-safe in the
+    classic shared-memory sense; it expects a single asyncio event loop.
+    """
+
+    _subscriptions: list[_Subscription] = field(default_factory=list)
+    _next_id: int = 0
+    _spawn: Callable[[Awaitable[None]], asyncio.Task[None]] | None = None
+
+    def subscribe(self, predicate: Predicate, handler: Handler) -> SubscriptionHandle:
+        """Register *handler* to be invoked when *predicate* returns ``True``.
+
+        Args:
+            predicate: Pure synchronous filter on the event. Predicate
+                exceptions are treated like ``False`` and logged so a
+                broken predicate cannot starve other subscribers.
+            handler: Async callable invoked once per matching event. The
+                handler is awaited on its own task so a slow handler does
+                not block fast ones.
+
+        Returns:
+            A :class:`SubscriptionHandle` accepted by
+            :meth:`unsubscribe`.
+        """
+        handle = SubscriptionHandle(_id=self._next_id)
+        self._next_id += 1
+        self._subscriptions.append(
+            _Subscription(handle=handle, predicate=predicate, handler=handler)
+        )
+        return handle
+
+    def unsubscribe(self, handle: SubscriptionHandle) -> None:
+        """Remove the subscription identified by *handle*.
+
+        Idempotent: detaching an unknown or already-removed handle is a
+        no-op.
+        """
+        self._subscriptions = [sub for sub in self._subscriptions if sub.handle != handle]
+
+    def publish(self, event: BaseEvent) -> tuple[asyncio.Task[None], ...]:
+        """Spawn a delivery task for every matching subscription.
+
+        Returns a tuple of the spawned tasks so tests can ``await`` them.
+        Production callers can ignore the return value: handler errors
+        are logged on the task so they cannot poison the publisher.
+
+        A subscription whose predicate raises an exception is treated as
+        non-matching for that event; the predicate is not unsubscribed.
+        """
+        spawned: list[asyncio.Task[None]] = []
+        for sub in tuple(self._subscriptions):
+            try:
+                if not sub.predicate(event):
+                    continue
+            except Exception as exc:  # noqa: BLE001 — predicate isolation
+                logger.warning(
+                    "control_bus.predicate_raised",
+                    extra={"handle_id": sub.handle._id, "error": repr(exc)},
+                )
+                continue
+
+            spawned.append(self._spawn_handler(sub.handler, event))
+        return tuple(spawned)
+
+    def _spawn_handler(self, handler: Handler, event: BaseEvent) -> asyncio.Task[None]:
+        """Run *handler* on its own task with structured error isolation."""
+        spawn = self._spawn or asyncio.ensure_future
+        return spawn(self._invoke_handler(handler, event))
+
+    @staticmethod
+    async def _invoke_handler(handler: Handler, event: BaseEvent) -> None:
+        try:
+            await handler(event)
+        except Exception as exc:  # noqa: BLE001 — handler isolation
+            logger.warning(
+                "control_bus.handler_raised",
+                extra={"event_type": event.type, "error": repr(exc)},
+            )

--- a/tests/unit/mcp/tools/test_bridge_mixin_runtime_context.py
+++ b/tests/unit/mcp/tools/test_bridge_mixin_runtime_context.py
@@ -1,0 +1,111 @@
+"""Unit tests for the AgentRuntimeContext-aware bridge injection helper.
+
+Issue: #474 PR-1 of the AgentRuntimeContext + ControlBus migration.
+The new ``inject_runtime_context`` helper is purely additive — the
+legacy ``inject_bridge`` continues to work, and handler internals are
+unchanged. Subsequent migration PRs swap composition-root call sites
+from the legacy form to this one, then move handler internals to read
+``context.mcp_bridge`` directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ouroboros.mcp.tools.bridge_mixin import (
+    BridgeAwareMixin,
+    inject_bridge,
+    inject_runtime_context,
+)
+from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
+from ouroboros.persistence.event_store import EventStore
+
+
+@dataclass
+class _FakeBridge:
+    """Minimal stand-in for ``MCPBridge`` carrying the two attributes the mixin reads."""
+
+    manager: Any = None
+    tool_prefix: str = ""
+
+
+@dataclass
+class _FakeHandler(BridgeAwareMixin):
+    """Subclass that does nothing extra — exercises the mixin in isolation."""
+
+    extra_field: str = field(default="")
+
+
+def _runtime_context(bridge: _FakeBridge | None = None) -> AgentRuntimeContext:
+    """Build a minimal runtime context for tests."""
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    return AgentRuntimeContext(event_store=store, mcp_bridge=bridge)
+
+
+class TestInjectRuntimeContext:
+    def test_injects_bridge_from_context(self) -> None:
+        """A handler with the mixin receives the bridge from context.mcp_bridge."""
+        manager = object()
+        bridge = _FakeBridge(manager=manager, tool_prefix="ext_")
+        context = _runtime_context(bridge=bridge)
+        handler = _FakeHandler()
+
+        assert inject_runtime_context(handler, context) is True
+        assert handler.mcp_manager is manager
+        assert handler.mcp_tool_prefix == "ext_"
+
+    def test_returns_false_when_context_is_none(self) -> None:
+        """``None`` context is treated as 'no bridge' — non-MCP paths stay valid."""
+        handler = _FakeHandler()
+        assert inject_runtime_context(handler, None) is False
+        assert handler.mcp_manager is None
+        assert handler.mcp_tool_prefix == ""
+
+    def test_returns_false_when_context_has_no_bridge(self) -> None:
+        """A context without an mcp_bridge does not write to the handler."""
+        context = _runtime_context(bridge=None)
+        handler = _FakeHandler()
+
+        assert inject_runtime_context(handler, context) is False
+        assert handler.mcp_manager is None
+
+    def test_returns_false_when_handler_lacks_mixin(self) -> None:
+        """Handlers that do not inherit from BridgeAwareMixin are skipped."""
+
+        class _BareHandler:
+            mcp_manager: Any = None
+            mcp_tool_prefix: str = ""
+
+        bridge = _FakeBridge(manager=object(), tool_prefix="ext_")
+        context = _runtime_context(bridge=bridge)
+        handler = _BareHandler()
+
+        assert inject_runtime_context(handler, context) is False
+        assert handler.mcp_manager is None
+        assert handler.mcp_tool_prefix == ""
+
+    def test_legacy_inject_bridge_still_works(self) -> None:
+        """The original entry point keeps the same contract."""
+        manager = object()
+        bridge = _FakeBridge(manager=manager, tool_prefix="ext_")
+        handler = _FakeHandler()
+
+        assert inject_bridge(handler, bridge) is True
+        assert handler.mcp_manager is manager
+        assert handler.mcp_tool_prefix == "ext_"
+
+    def test_runtime_context_and_legacy_paths_are_equivalent(self) -> None:
+        """Both helpers must produce the same handler state for the same bridge."""
+        manager = object()
+        bridge = _FakeBridge(manager=manager, tool_prefix="ext_")
+        context = _runtime_context(bridge=bridge)
+
+        legacy = _FakeHandler()
+        modern = _FakeHandler()
+
+        inject_bridge(legacy, bridge)
+        inject_runtime_context(modern, context)
+
+        assert legacy.mcp_manager is modern.mcp_manager
+        assert legacy.mcp_tool_prefix == modern.mcp_tool_prefix

--- a/tests/unit/orchestrator/test_agent_runtime_context.py
+++ b/tests/unit/orchestrator/test_agent_runtime_context.py
@@ -1,0 +1,63 @@
+"""Unit tests for :class:`AgentRuntimeContext`.
+
+Issue: #515 / #474 Q1. The context is intentionally narrow: it must
+remain frozen, slot-based, and only carry the minimal fields the
+maintainer alignment in #476 Q1 specified.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
+from ouroboros.orchestrator.control_bus import ControlBus
+from ouroboros.persistence.event_store import EventStore
+
+
+def test_context_is_frozen_and_slotted() -> None:
+    """The dataclass must reject attribute mutation post-construction."""
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    context = AgentRuntimeContext(event_store=store)
+
+    assert dataclasses.is_dataclass(context)
+    assert context.runtime_backend is None
+    assert context.llm_backend is None
+    assert context.mcp_bridge is None
+    assert context.control is None
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        context.runtime_backend = "codex_cli"  # type: ignore[misc]
+
+
+def test_context_carries_optional_control_bus() -> None:
+    """The optional ControlBus slot is the reactive surface for #515."""
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    bus = ControlBus()
+    context = AgentRuntimeContext(event_store=store, control=bus)
+
+    assert context.control is bus
+    # Existing handlers that do not opt into the bus still see the
+    # default ``None`` and remain valid.
+    no_bus = AgentRuntimeContext(event_store=store)
+    assert no_bus.control is None
+
+
+def test_context_membership_is_narrow() -> None:
+    """Adding a field requires a deliberate PR (no service-locator drift).
+
+    This regression test pins the field set so reviewers see explicit
+    diffs when the membership grows. If this assertion fails because a
+    field was added, the PR must include a justification line per the
+    #476 Q1 narrow-membership commitment.
+    """
+    expected = {
+        "event_store",
+        "runtime_backend",
+        "llm_backend",
+        "mcp_bridge",
+        "control",
+    }
+    actual = {f.name for f in dataclasses.fields(AgentRuntimeContext)}
+    assert actual == expected

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -230,3 +230,42 @@ async def test_unsubscribe_stops_delivery() -> None:
     tasks = bus.publish(_directive_event())
     assert tasks == ()
     assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_rejects_foreign_handle_with_same_local_id() -> None:
+    bus_a = ControlBus()
+    bus_b = ControlBus()
+    seen: list[BaseEvent] = []
+
+    async def handler(event: BaseEvent) -> None:
+        seen.append(event)
+
+    handle_a = bus_a.subscribe(_is_directive, handler)
+    handle_b = bus_b.subscribe(_is_directive, handler)
+    assert handle_a._id == handle_b._id
+
+    bus_a.unsubscribe(handle_b)
+    tasks = bus_a.publish(_directive_event())
+    await asyncio.gather(*tasks)
+
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_retains_fire_and_forget_tasks_until_done() -> None:
+    bus = ControlBus()
+    release = asyncio.Event()
+
+    async def slow(event: BaseEvent) -> None:
+        await release.wait()
+
+    bus.subscribe(_is_directive, slow)
+    tasks = bus.publish(_directive_event())
+
+    assert len(tasks) == 1
+    assert len(bus._tasks) == 1
+    release.set()
+    await asyncio.gather(*tasks)
+    await asyncio.sleep(0)
+    assert bus._tasks == set()

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -1,0 +1,232 @@
+"""Unit tests for :class:`ControlBus`.
+
+Issue: #515. The bus is the reactive surface paired with the
+observational event factory in #492 / ``events/control.py``.
+
+Coverage:
+- ``subscribe`` returns a handle and ``unsubscribe(handle)`` detaches it.
+- A predicate filter scopes delivery: subscribers only see matching
+  events.
+- Multiple subscribers receive the same event independently.
+- A failing handler does not affect other handlers' delivery for the
+  same event.
+- A predicate that raises is treated as ``False`` for that event without
+  unsubscribing.
+- Slow and fast handlers do not block one another (per-handler task).
+- Re-entrant ``subscribe`` from inside a publish loop does not produce a
+  ``RuntimeError``.
+- ``unsubscribe`` is idempotent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.control_bus import ControlBus, SubscriptionHandle
+
+
+def _directive_event(directive: str = "retry") -> BaseEvent:
+    """Build a minimal directive event for delivery tests."""
+    return BaseEvent(
+        type="control.directive.emitted",
+        aggregate_type="lineage",
+        aggregate_id="lin_bus_test",
+        data={
+            "directive": directive,
+            "reason": "Bus delivery probe.",
+            "emitted_by": "test",
+        },
+    )
+
+
+def _state_event() -> BaseEvent:
+    """An unrelated state event used for predicate filtering."""
+    return BaseEvent(
+        type="lineage.created",
+        aggregate_type="lineage",
+        aggregate_id="lin_bus_test",
+        data={"goal": "filter probe"},
+    )
+
+
+def _is_directive(event: BaseEvent) -> bool:
+    return event.type == "control.directive.emitted"
+
+
+@pytest.mark.asyncio
+async def test_subscribe_and_publish_delivers_to_handler() -> None:
+    bus = ControlBus()
+    received: list[BaseEvent] = []
+
+    async def handler(event: BaseEvent) -> None:
+        received.append(event)
+
+    handle = bus.subscribe(_is_directive, handler)
+    assert isinstance(handle, SubscriptionHandle)
+
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+
+    assert [e.type for e in received] == ["control.directive.emitted"]
+
+
+@pytest.mark.asyncio
+async def test_predicate_filters_unrelated_events() -> None:
+    bus = ControlBus()
+    seen: list[BaseEvent] = []
+
+    async def handler(event: BaseEvent) -> None:
+        seen.append(event)
+
+    bus.subscribe(_is_directive, handler)
+
+    # A non-directive event is published; predicate rejects it, no task spawned.
+    tasks = bus.publish(_state_event())
+    assert tasks == ()
+    assert seen == []
+
+    # A directive event is delivered.
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_multiple_subscribers_each_receive_event() -> None:
+    bus = ControlBus()
+    a_seen: list[BaseEvent] = []
+    b_seen: list[BaseEvent] = []
+
+    async def handler_a(event: BaseEvent) -> None:
+        a_seen.append(event)
+
+    async def handler_b(event: BaseEvent) -> None:
+        b_seen.append(event)
+
+    bus.subscribe(_is_directive, handler_a)
+    bus.subscribe(_is_directive, handler_b)
+
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+
+    assert len(a_seen) == 1
+    assert len(b_seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_error_isolated_from_siblings() -> None:
+    bus = ControlBus()
+    healthy_seen: list[BaseEvent] = []
+
+    async def broken(event: BaseEvent) -> None:
+        raise RuntimeError("intentional handler failure")
+
+    async def healthy(event: BaseEvent) -> None:
+        healthy_seen.append(event)
+
+    bus.subscribe(_is_directive, broken)
+    bus.subscribe(_is_directive, healthy)
+
+    tasks = bus.publish(_directive_event())
+    # gather() with return_exceptions=False would raise; the handler's
+    # exception is *swallowed inside the per-handler wrapper*, so the
+    # broken task completes successfully (with the warning logged).
+    await asyncio.gather(*tasks)
+
+    assert len(healthy_seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_predicate_exception_is_treated_as_non_match() -> None:
+    bus = ControlBus()
+    seen: list[BaseEvent] = []
+
+    def broken_predicate(event: BaseEvent) -> bool:
+        raise ValueError("intentional predicate failure")
+
+    async def handler(event: BaseEvent) -> None:
+        seen.append(event)
+
+    handle = bus.subscribe(broken_predicate, handler)
+
+    tasks = bus.publish(_directive_event())
+    assert tasks == ()
+    assert seen == []
+
+    # The broken subscription is *not* auto-unsubscribed; idempotent
+    # unsubscribe still removes it cleanly.
+    bus.unsubscribe(handle)
+    bus.unsubscribe(handle)  # second call is a no-op
+
+
+@pytest.mark.asyncio
+async def test_slow_handler_does_not_block_fast_handler() -> None:
+    bus = ControlBus()
+    fast_done = asyncio.Event()
+
+    async def slow(event: BaseEvent) -> None:
+        await asyncio.sleep(0.05)
+
+    async def fast(event: BaseEvent) -> None:
+        fast_done.set()
+
+    bus.subscribe(_is_directive, slow)
+    bus.subscribe(_is_directive, fast)
+
+    tasks = bus.publish(_directive_event())
+    # The fast handler should fire well before the slow one finishes.
+    await asyncio.wait_for(fast_done.wait(), timeout=0.5)
+    assert fast_done.is_set()
+    await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_inside_handler_does_not_raise() -> None:
+    bus = ControlBus()
+    delivery_count = 0
+
+    async def adopter(event: BaseEvent) -> None:
+        nonlocal delivery_count
+        delivery_count += 1
+        # Adding a subscriber while iterating the live publish loop must
+        # not raise; ``publish`` snapshots the subscription list.
+
+        async def latecomer(_event: BaseEvent) -> None:
+            nonlocal delivery_count
+            delivery_count += 1
+
+        bus.subscribe(_is_directive, latecomer)
+
+    bus.subscribe(_is_directive, adopter)
+
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+
+    # The latecomer is not invoked retroactively for the in-flight event;
+    # it will receive the next publish.
+    assert delivery_count == 1
+
+    tasks = bus.publish(_directive_event())
+    await asyncio.gather(*tasks)
+    # Now both subscribers fired: adopter (1) + latecomer (1) for the
+    # second event, plus adopter's first delivery.
+    assert delivery_count == 3
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_stops_delivery() -> None:
+    bus = ControlBus()
+    seen: list[BaseEvent] = []
+
+    async def handler(event: BaseEvent) -> None:
+        seen.append(event)
+
+    handle = bus.subscribe(_is_directive, handler)
+    bus.unsubscribe(handle)
+
+    tasks = bus.publish(_directive_event())
+    assert tasks == ()
+    assert seen == []


### PR DESCRIPTION
## Summary

First slice of the **AgentRuntimeContext + ControlBus migration** tracked by #474. Adds a context-aware injection entry point on `bridge_mixin` (`inject_runtime_context`) alongside the existing `inject_bridge`. The change is intentionally additive: the legacy code path stays in place as the single source of truth for the mixin's field write, and no existing handler or composition-root call site is modified in this PR.

This unblocks subsequent slices that migrate `mcp_manager` plumbing one file at a time without a flag day.

> **Stack notice.** This PR is stacked on **#524** (`feat(orchestrator): introduce ControlBus on AgentRuntimeContext`) because it imports `AgentRuntimeContext`, which #524 introduces. It must merge after #524.

## Migration plan it unlocks

| Slice | File | Status |
|---|---|---|
| 1 (this PR) | `mcp/tools/bridge_mixin.py` (helper added) | open |
| 2 | `mcp/tools/definitions.py` (mixin consumer call sites) | follow-up |
| 3 | `mcp/tools/execution_handlers.py` | follow-up |
| 4 | `mcp/server/adapter.py` (composition root) — closes #474 | follow-up |

Each follow-up swaps `inject_bridge(h, bridge)` for `inject_runtime_context(h, context)` at one call site at a time, then moves the consuming handler internals to read `context.mcp_bridge` directly instead of `self.mcp_manager`. Because the two helpers produce byte-identical handler state for the same bridge (pinned by the equivalence test in this PR), each slice can be reviewed and merged independently.

## Changes

- `src/ouroboros/mcp/tools/bridge_mixin.py` — add `inject_runtime_context(handler, context)` that pulls `context.mcp_bridge` and delegates to `inject_bridge`. Module docstring updated to describe the two equivalent entry points and the migration plan they support. `BridgeAwareMixin` signature is unchanged.
- `tests/unit/mcp/tools/test_bridge_mixin_runtime_context.py` — 6 new cases.

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/mcp/tools/bridge_mixin.py tests/unit/mcp/tools/test_bridge_mixin_runtime_context.py` | clean |
| `uv run ruff format ...` | no diff |
| `uv run pytest tests/unit/mcp/tools/test_bridge_mixin_runtime_context.py` | 6 passed |
| `uv run pytest tests/unit/mcp/bridge/test_bridge.py tests/unit/cli/test_bridge_plugin_hardening.py` (regression — bridge subsystem) | 29 passed |
| `uv run pytest tests/unit/orchestrator/test_agent_runtime_context.py tests/unit/orchestrator/test_control_bus.py` (regression — #524) | 11 passed |

## Pre-merge checklist

- [x] `inject_runtime_context(handler, context)` added with type-only `AgentRuntimeContext` import (no runtime cycle)
- [x] Legacy `inject_bridge(handler, bridge)` is unchanged and still public
- [x] Both entry points produce byte-identical handler state for the same bridge (pinned by `test_runtime_context_and_legacy_paths_are_equivalent`)
- [x] `None` context and `None` bridge are both handled gracefully (returns `False`, no write)
- [x] Handlers that do not inherit from `BridgeAwareMixin` are skipped (returns `False`)
- [x] No existing handler signature, composition root, or test file is modified in this PR
- [x] CI: ruff + format + targeted pytest all green; bridge regression suite untouched

## Post-merge checklist

- [ ] Slice 2 PR can begin: swap `inject_bridge` → `inject_runtime_context` at the first composition-root call site
- [ ] Track migration progress on #474 with a checkbox per slice
- [ ] When all 4 slices land, drop `inject_bridge` if no external callers remain (deprecation TBD)

## Rollback

The change is purely additive: a new function next to an existing one, plus its tests. Rollback steps:

1. Revert this PR. The new helper disappears; subsequent migration PRs that depend on it would need their bases updated, but the legacy `inject_bridge` path continues to work for any caller that has not yet been migrated.
2. No data, schema, or runtime behaviour change to undo.

Stack: depends on #524 (`AgentRuntimeContext`).
