### PR TITLE
feat(mcp): accept AgentRuntimeContext in tool factories (slice 2 of #474)

### DIFF
--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -19,6 +19,8 @@ Handler modules:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ouroboros.mcp.tools.ac_tree_hud_handler import ACTreeHUDHandler
 from ouroboros.mcp.tools.authoring_handlers import (
     GenerateSeedHandler,
@@ -54,6 +56,29 @@ from ouroboros.mcp.tools.query_handlers import (
     SessionStatusHandler,
 )
 
+if TYPE_CHECKING:
+    from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
+
+
+def _resolve_bridge_fields(
+    context: AgentRuntimeContext | None,
+    mcp_manager: object | None,
+    mcp_tool_prefix: str,
+) -> tuple[object | None, str]:
+    """Pick which (mcp_manager, mcp_tool_prefix) pair the factory should use.
+
+    When ``context`` is provided and carries an ``mcp_bridge``, its bridge
+    wins over the legacy explicit kwargs — that is the migration path
+    captured by #474. When ``context`` is ``None`` (or carries no
+    bridge), the legacy kwargs are returned unchanged so existing
+    callers continue to work.
+    """
+    if context is not None and context.mcp_bridge is not None:
+        bridge = context.mcp_bridge
+        return getattr(bridge, "manager", None), getattr(bridge, "tool_prefix", "")
+    return mcp_manager, mcp_tool_prefix
+
+
 # ---------------------------------------------------------------------------
 # Convenience factory functions
 # ---------------------------------------------------------------------------
@@ -66,13 +91,24 @@ def execute_seed_handler(
     mcp_manager: object | None = None,
     mcp_tool_prefix: str = "",
     opencode_mode: str | None = None,
+    context: AgentRuntimeContext | None = None,
 ) -> ExecuteSeedHandler:
-    """Create an ExecuteSeedHandler instance."""
+    """Create an ExecuteSeedHandler instance.
+
+    When ``context`` is provided and carries an ``mcp_bridge``, the
+    bridge supersedes the explicit ``mcp_manager`` / ``mcp_tool_prefix``
+    kwargs. This is the migration path captured by #474; the legacy
+    kwargs continue to work for callers that have not adopted
+    :class:`AgentRuntimeContext`.
+    """
+    resolved_manager, resolved_prefix = _resolve_bridge_fields(
+        context, mcp_manager, mcp_tool_prefix
+    )
     return ExecuteSeedHandler(
         agent_runtime_backend=runtime_backend,
         llm_backend=llm_backend,
-        mcp_manager=mcp_manager,
-        mcp_tool_prefix=mcp_tool_prefix,
+        mcp_manager=resolved_manager,
+        mcp_tool_prefix=resolved_prefix,
         opencode_mode=opencode_mode,
     )
 
@@ -84,13 +120,21 @@ def start_execute_seed_handler(
     mcp_manager: object | None = None,
     mcp_tool_prefix: str = "",
     opencode_mode: str | None = None,
+    context: AgentRuntimeContext | None = None,
 ) -> StartExecuteSeedHandler:
-    """Create a StartExecuteSeedHandler instance."""
+    """Create a StartExecuteSeedHandler instance.
+
+    Accepts the same ``context`` keyword as :func:`execute_seed_handler`;
+    see that function's docstring for the migration semantics.
+    """
+    resolved_manager, resolved_prefix = _resolve_bridge_fields(
+        context, mcp_manager, mcp_tool_prefix
+    )
     execute_handler = ExecuteSeedHandler(
         agent_runtime_backend=runtime_backend,
         llm_backend=llm_backend,
-        mcp_manager=mcp_manager,
-        mcp_tool_prefix=mcp_tool_prefix,
+        mcp_manager=resolved_manager,
+        mcp_tool_prefix=resolved_prefix,
         opencode_mode=opencode_mode,
     )
     return StartExecuteSeedHandler(
@@ -285,6 +329,7 @@ def get_ouroboros_tools(
     mcp_manager: object | None = None,
     mcp_tool_prefix: str = "",
     opencode_mode: str | None = None,
+    context: AgentRuntimeContext | None = None,
 ) -> OuroborosToolHandlers:
     """Create the default set of Ouroboros MCP tool handlers.
 
@@ -294,12 +339,20 @@ def get_ouroboros_tools(
     In every other combination (including ``opencode_mode=None``) the handler
     falls through to its real in-process path. See
     ``ouroboros.mcp.tools.subagent.should_dispatch_via_plugin``.
+
+    When ``context`` is provided and carries an ``mcp_bridge``, the
+    bridge supersedes the explicit ``mcp_manager`` / ``mcp_tool_prefix``
+    kwargs (see :func:`_resolve_bridge_fields`). This is the migration
+    path captured by #474; legacy kwargs continue to work unchanged.
     """
+    resolved_manager, resolved_prefix = _resolve_bridge_fields(
+        context, mcp_manager, mcp_tool_prefix
+    )
     execute_seed = ExecuteSeedHandler(
         agent_runtime_backend=runtime_backend,
         llm_backend=llm_backend,
-        mcp_manager=mcp_manager,
-        mcp_tool_prefix=mcp_tool_prefix,
+        mcp_manager=resolved_manager,
+        mcp_tool_prefix=resolved_prefix,
         opencode_mode=opencode_mode,
     )
     start_execute = StartExecuteSeedHandler(

--- a/tests/unit/mcp/tools/test_definitions_runtime_context.py
+++ b/tests/unit/mcp/tools/test_definitions_runtime_context.py
@@ -1,0 +1,107 @@
+"""Tests for context-aware factory kwargs added in slice 2 of #474.
+
+The three factories (``execute_seed_handler``,
+``start_execute_seed_handler``, ``get_ouroboros_tools``) now accept an
+optional ``context: AgentRuntimeContext`` keyword. When the context
+carries an ``mcp_bridge`` it supersedes the explicit ``mcp_manager`` /
+``mcp_tool_prefix`` kwargs; otherwise the legacy kwargs are used
+unchanged. This module pins both paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ouroboros.mcp.tools.definitions import (
+    execute_seed_handler,
+    get_ouroboros_tools,
+    start_execute_seed_handler,
+)
+from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
+from ouroboros.persistence.event_store import EventStore
+
+
+@dataclass
+class _FakeBridge:
+    manager: Any = None
+    tool_prefix: str = ""
+
+
+def _context(bridge: _FakeBridge | None = None) -> AgentRuntimeContext:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    return AgentRuntimeContext(event_store=store, mcp_bridge=bridge)
+
+
+class TestExecuteSeedHandlerFactory:
+    def test_context_bridge_overrides_explicit_kwargs(self) -> None:
+        manager = object()
+        bridge = _FakeBridge(manager=manager, tool_prefix="ctx_")
+        ignored_manager = object()
+
+        handler = execute_seed_handler(
+            mcp_manager=ignored_manager,  # legacy explicit
+            mcp_tool_prefix="legacy_",
+            context=_context(bridge=bridge),
+        )
+
+        assert handler.mcp_manager is manager
+        assert handler.mcp_tool_prefix == "ctx_"
+
+    def test_legacy_kwargs_used_when_context_is_none(self) -> None:
+        manager = object()
+        handler = execute_seed_handler(mcp_manager=manager, mcp_tool_prefix="legacy_")
+
+        assert handler.mcp_manager is manager
+        assert handler.mcp_tool_prefix == "legacy_"
+
+    def test_context_without_bridge_does_not_override(self) -> None:
+        legacy_manager = object()
+        handler = execute_seed_handler(
+            mcp_manager=legacy_manager,
+            mcp_tool_prefix="legacy_",
+            context=_context(bridge=None),
+        )
+
+        assert handler.mcp_manager is legacy_manager
+        assert handler.mcp_tool_prefix == "legacy_"
+
+
+class TestStartExecuteSeedHandlerFactory:
+    def test_context_bridge_overrides_explicit_kwargs(self) -> None:
+        manager = object()
+        bridge = _FakeBridge(manager=manager, tool_prefix="ctx_")
+
+        handler = start_execute_seed_handler(
+            mcp_manager=object(),
+            mcp_tool_prefix="legacy_",
+            context=_context(bridge=bridge),
+        )
+
+        assert handler.execute_handler.mcp_manager is manager
+        assert handler.execute_handler.mcp_tool_prefix == "ctx_"
+
+
+class TestGetOuroborosTools:
+    def test_context_bridge_propagates_to_execute_seed_handler(self) -> None:
+        manager = object()
+        bridge = _FakeBridge(manager=manager, tool_prefix="ctx_")
+
+        handlers = get_ouroboros_tools(
+            mcp_manager=object(),  # legacy — must lose
+            mcp_tool_prefix="legacy_",
+            context=_context(bridge=bridge),
+        )
+
+        # ExecuteSeedHandler is exposed via the OuroborosToolHandlers tuple;
+        # find it by class identity to avoid coupling to the field order.
+        execute_handler = next(h for h in handlers if type(h).__name__ == "ExecuteSeedHandler")
+        assert execute_handler.mcp_manager is manager
+        assert execute_handler.mcp_tool_prefix == "ctx_"
+
+    def test_no_context_keeps_legacy_kwargs(self) -> None:
+        manager = object()
+        handlers = get_ouroboros_tools(mcp_manager=manager, mcp_tool_prefix="legacy_")
+        execute_handler = next(h for h in handlers if type(h).__name__ == "ExecuteSeedHandler")
+        assert execute_handler.mcp_manager is manager
+        assert execute_handler.mcp_tool_prefix == "legacy_"


### PR DESCRIPTION
## Summary

Second slice of the **AgentRuntimeContext + ControlBus migration** tracked by #474. The three public factories in `mcp/tools/definitions.py` now accept an optional `context: AgentRuntimeContext` keyword. When the context carries an `mcp_bridge`, it supersedes the explicit legacy `mcp_manager` / `mcp_tool_prefix` kwargs. Otherwise the legacy kwargs are used unchanged, so callers that have not yet adopted the runtime context continue to work.

> **Stack notice.** Depends on **#526** (slice 1 — `inject_runtime_context` helper). Both depend on **#524** (`AgentRuntimeContext` introduction).

## Changes

- `src/ouroboros/mcp/tools/definitions.py`
  - Adds a `_resolve_bridge_fields(context, mcp_manager, mcp_tool_prefix)` private helper that centralises the precedence rule.
  - Threads an optional `context: AgentRuntimeContext` kwarg through `execute_seed_handler`, `start_execute_seed_handler`, and `get_ouroboros_tools`.
  - Doc-comment lines describe the new precedence rule and call back to #474.
- `tests/unit/mcp/tools/test_definitions_runtime_context.py` — 6 cases.

No handler internals or signatures change.

## Migration plan progress

| Slice | File | Status |
|---|---|---|
| 1 | `mcp/tools/bridge_mixin.py` (helper) | merged in #526 |
| **2 (this PR)** | `mcp/tools/definitions.py` (factory kwargs) | **open** |
| 3 | `mcp/server/adapter.py` (composition root passes `context=`) | follow-up |
| 4 | `mcp/tools/execution_handlers.py` (consumer reads from context where needed) | follow-up |

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/mcp/tools/definitions.py tests/unit/mcp/tools/test_definitions_runtime_context.py` | clean |
| `uv run ruff format ...` | one auto-format applied (no logic change) |
| `uv run pytest tests/unit/mcp/tools/test_definitions_runtime_context.py tests/unit/mcp/tools/test_bridge_mixin_runtime_context.py` | 12 passed |

## Pre-merge checklist

- [x] Optional `context` kwarg added to each of the three factories
- [x] Context bridge supersedes legacy kwargs when present
- [x] Legacy kwargs continue to work when no context is passed
- [x] Context without an `mcp_bridge` does not override legacy kwargs (graceful)
- [x] No handler signature change (only the factory call sites)
- [x] CI: ruff + format + targeted pytest all green
- [x] Existing bridge regression suite untouched

## Post-merge checklist

- [ ] Slice 3 PR can begin: composition root constructs an `AgentRuntimeContext` and threads it through `get_ouroboros_tools(..., context=context)` instead of explicit `mcp_manager=` / `mcp_tool_prefix=`.
- [ ] Once slices 3–4 merge, drop the legacy explicit kwargs (deprecation TBD).

## Rollback

Purely additive: a new keyword on each factory plus a private helper. Rollback steps:

1. Revert this PR. Composition root continues to use legacy explicit kwargs (unchanged in this PR).
2. No data, schema, or runtime behaviour change to undo.

Stack: depends on #526 (slice 1), which depends on #524 (`AgentRuntimeContext`).
