### PR TITLE
feat(mcp): wire composition root through AgentRuntimeContext (slice 3 of #474)

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -324,6 +324,7 @@ class MCPServerAdapter:
         self._prompt_handlers: dict[str, PromptHandler] = {}
         self._mcp_server: Any = None
         self._owned_resources: list[Any] = []  # objects with async close()
+        self._runtime_context: AgentRuntimeContext | None = None
 
         # Initialize security layer
         self._security = SecurityLayer(
@@ -698,6 +699,15 @@ class MCPServerAdapter:
             await self._mcp_server.run_streamable_http_async()
         else:
             await self._mcp_server.run_stdio_async()
+
+    @property
+    def runtime_context(self) -> AgentRuntimeContext | None:
+        """Return the session-scoped runtime context owned by this server."""
+        return self._runtime_context
+
+    def set_runtime_context(self, context: AgentRuntimeContext) -> None:
+        """Attach the session-scoped runtime context to the server object graph."""
+        self._runtime_context = context
 
     def register_owned_resource(self, resource: Any) -> None:
         """Register a resource whose ``close()`` will be called on shutdown."""
@@ -1474,6 +1484,7 @@ def create_ouroboros_server(
         mcp_bridge=mcp_bridge,
         control=ControlBus(),
     )
+    server.set_runtime_context(agent_runtime_context)
 
     # Inject the bridge from the runtime context into every
     # BridgeAwareMixin handler. ``inject_runtime_context`` is byte-

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -35,6 +35,8 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
+from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
+from ouroboros.orchestrator.control_bus import ControlBus
 
 log = structlog.get_logger(__name__)
 
@@ -1460,11 +1462,33 @@ def create_ouroboros_server(
     if brownfield_store is not None:
         server.register_owned_resource(brownfield_store)
 
-    # Inject bridge into all BridgeAwareMixin handlers (loop-based auto-discovery)
-    if mcp_bridge is not None:
-        from ouroboros.mcp.tools.bridge_mixin import inject_bridge
+    # Build the AgentRuntimeContext that #474 funnels through every
+    # handler. For now the context only exposes the EventStore, the
+    # backend labels, the optional MCP bridge, and a fresh ControlBus
+    # for #515. Subsequent migration slices move handler internals to
+    # consume context.mcp_bridge directly instead of self.mcp_manager.
+    agent_runtime_context = AgentRuntimeContext(
+        event_store=event_store,
+        runtime_backend=resolved_runtime_backend,
+        llm_backend=llm_backend,
+        mcp_bridge=mcp_bridge,
+        control=ControlBus(),
+    )
 
-        injected = [type(h).__name__ for h in tool_handlers if inject_bridge(h, mcp_bridge)]
+    # Inject the bridge from the runtime context into every
+    # BridgeAwareMixin handler. ``inject_runtime_context`` is byte-
+    # equivalent to the legacy ``inject_bridge`` for the same bridge —
+    # the swap is purely about giving every handler a single funnel
+    # (the context) instead of the per-handler ``mcp_manager`` plumbing
+    # this PR series is replacing.
+    if mcp_bridge is not None:
+        from ouroboros.mcp.tools.bridge_mixin import inject_runtime_context
+
+        injected = [
+            type(h).__name__
+            for h in tool_handlers
+            if inject_runtime_context(h, agent_runtime_context)
+        ]
         if injected:
             log.info("mcp.bridge.injected", handlers=injected)
         server.register_owned_resource(mcp_bridge)

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1032,3 +1032,15 @@ class TestCreateOuroborosServerBrownfieldStore:
 
         assert captured_handler_kwargs["_store"] is mock_brownfield_store
         assert server._owned_resources == [mock_event_store, mock_brownfield_store]
+
+
+def test_create_ouroboros_server_retains_runtime_context() -> None:
+    """The composition root must keep AgentRuntimeContext reachable after return."""
+    from ouroboros.mcp.server.adapter import create_ouroboros_server
+
+    server = create_ouroboros_server(runtime_backend="codex", llm_backend="claude_code")
+
+    assert server.runtime_context is not None
+    assert server.runtime_context.runtime_backend == "codex"
+    assert server.runtime_context.llm_backend == "claude_code"
+    assert server.runtime_context.control is not None


### PR DESCRIPTION
## Summary

Third (and likely final) plumbing slice of the **AgentRuntimeContext + ControlBus migration** tracked by #474. The composition root in `mcp/server/adapter.py` now constructs an `AgentRuntimeContext` and uses `inject_runtime_context` instead of `inject_bridge` to wire BridgeAwareMixin handlers.

Because `inject_runtime_context` is byte-equivalent to `inject_bridge` for the same bridge (pinned by the equivalence test in #526), this is a pure plumbing change. Existing handlers see no runtime behaviour difference; they just receive their `mcp_manager` field through the new funnel.

> **Stack notice.** Depends on **#527** (slice 2 — context-aware factories), which depends on **#526** (slice 1 — `inject_runtime_context` helper), which depends on **#524** (`AgentRuntimeContext`).

## Changes

- `src/ouroboros/mcp/server/adapter.py` — adds an `AgentRuntimeContext` construction at the composition root carrying `event_store`, `runtime_backend`, `llm_backend`, `mcp_bridge`, and a fresh `ControlBus`. The existing bridge-injection block is rewritten to call `inject_runtime_context(h, agent_runtime_context)` instead of `inject_bridge(h, mcp_bridge)`. The `if mcp_bridge is not None` guard is unchanged so installs without a bridge keep skipping injection identically to today.

## After this PR — what's left for #474?

The "per-handler `mcp_manager` plumbing" complaint that motivated #474 is resolved at the **plumbing** layer:

| Concern | Status after this PR |
|---|---|
| Every handler receives the bridge through one funnel | ✅ The `AgentRuntimeContext` |
| New handlers do not need bespoke `mcp_manager=` constructor wiring | ✅ Inherit from `BridgeAwareMixin`; the composition root injects via context |
| Composition root has a single source of truth for runtime-shared deps | ✅ `agent_runtime_context` |
| Handler internals still read `self.mcp_manager` (vs `context.mcp_bridge`) | open — internal field rename is a separate, optional cleanup |

Whether the field-rename cleanup closes #474 is a maintainer call. If yes, this PR can be marked `Closes #474` and the rename becomes a follow-up. I have **not** added `Closes #474` to the trailer so the maintainer can choose.

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/mcp/server/adapter.py` | clean |
| `uv run ruff format ...` | no diff |
| `uv run pytest tests/unit/mcp/tools/test_mcp_manager_wiring.py tests/unit/mcp/bridge/test_handler_wiring.py tests/unit/mcp/server/test_adapter.py tests/unit/cli/test_mcp_startup_cleanup.py tests/unit/mcp/tools/test_bridge_mixin_runtime_context.py tests/unit/mcp/tools/test_definitions_runtime_context.py` (regression) | 99 passed |

## Pre-merge checklist

- [x] Composition root constructs `AgentRuntimeContext`
- [x] `inject_bridge` loop replaced with `inject_runtime_context`
- [x] `if mcp_bridge is not None` guard unchanged
- [x] No handler signature change
- [x] CI: ruff + format + targeted pytest all green (99 cases)
- [x] `inject_runtime_context` is byte-equivalent to `inject_bridge` for the same bridge — pinned by `test_runtime_context_and_legacy_paths_are_equivalent` in #526

## Post-merge checklist

- [ ] Decide with maintainer: does this close #474, or is the per-handler field rename a separate slice?
- [ ] If field rename is wanted, follow-up PR migrates handler internals from `self.mcp_manager` to `context.mcp_bridge.manager` one handler at a time.
- [ ] Begin #475 work (`evolve_step` / `unstuck` / `ralph` BridgeAwareMixin adoption) once #474 is closed.

## Rollback

A small composition-root change with no runtime behaviour difference. Rollback steps:

1. Revert this PR. Composition root returns to using `inject_bridge`. The `AgentRuntimeContext` and `ControlBus` modules remain unused for now (they're still imported by other handlers if any have adopted them — currently none).
2. No data, schema, or runtime behaviour change to undo.

Stack: depends on #527, #526, #524.
