### PR TITLE
feat(mcp): LateralThinkHandler inherits BridgeAwareMixin (slice 2 of #475)

### DIFF
--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -19,6 +19,7 @@ from ouroboros.core.errors import ValidationError
 from ouroboros.core.seed import Seed
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.tools.bridge_mixin import BridgeAwareMixin
 from ouroboros.mcp.tools.subagent import (
     build_evaluate_subagent,
     build_subagent_result,
@@ -1183,11 +1184,18 @@ class ChecklistVerifyHandler:
 
 
 @dataclass
-class LateralThinkHandler:
+class LateralThinkHandler(BridgeAwareMixin):
     """Handler for the lateral_think tool.
 
     Generates alternative thinking approaches using lateral thinking personas
     to break through stagnation in problem-solving.
+
+    Inherits :class:`BridgeAwareMixin` (#475) so the composition root's
+    loop-injection populates ``mcp_manager`` and ``mcp_tool_prefix``
+    automatically when an MCP bridge is configured. The bridge fields
+    are not consumed by this PR — a follow-up slice forwards them into
+    the lateral-think dispatch path so dynamic external MCP servers
+    reach the unstuck pipeline.
 
     The multi-persona fan-out path emits a ``_subagents`` envelope that is
     consumed by the OpenCode bridge plugin. It is gated on

--- a/tests/unit/mcp/tools/test_unstuck_bridge_aware.py
+++ b/tests/unit/mcp/tools/test_unstuck_bridge_aware.py
@@ -1,0 +1,53 @@
+"""Confirm LateralThinkHandler inherits BridgeAwareMixin (slice 2 of #475).
+
+Same shape as the EvolveStepHandler slice (#530): the composition
+root's loop-injection (#529) populates BridgeAwareMixin fields
+automatically, so this test verifies inheritance + injection without
+touching dispatch internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ouroboros.mcp.tools.bridge_mixin import BridgeAwareMixin, inject_runtime_context
+from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
+from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
+from ouroboros.persistence.event_store import EventStore
+
+
+@dataclass
+class _FakeBridge:
+    manager: Any = None
+    tool_prefix: str = ""
+
+
+def test_lateral_think_handler_inherits_bridge_aware_mixin() -> None:
+    handler = LateralThinkHandler()
+    assert isinstance(handler, BridgeAwareMixin)
+    assert handler.mcp_manager is None
+    assert handler.mcp_tool_prefix == ""
+
+
+def test_inject_runtime_context_populates_lateral_think_handler() -> None:
+    manager = object()
+    bridge = _FakeBridge(manager=manager, tool_prefix="ctx_")
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    context = AgentRuntimeContext(event_store=store, mcp_bridge=bridge)
+    handler = LateralThinkHandler()
+
+    assert inject_runtime_context(handler, context) is True
+    assert handler.mcp_manager is manager
+    assert handler.mcp_tool_prefix == "ctx_"
+
+
+def test_existing_lateral_think_handler_constructor_unchanged() -> None:
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+    assert handler.agent_runtime_backend == "opencode"
+    assert handler.opencode_mode == "plugin"
+    assert handler.mcp_manager is None
+    assert handler.mcp_tool_prefix == ""


### PR DESCRIPTION
## Summary

Second slice of the **`evolve_step` / `unstuck` / `ralph` wiring** tracked by #475. Adds `BridgeAwareMixin` as a parent class to `LateralThinkHandler` (the `unstuck` path) so the composition root's loop-injection (#529) automatically populates `mcp_manager` and `mcp_tool_prefix` whenever an MCP bridge is configured.

Same shape as the `EvolveStepHandler` slice in #530.

> **Stack notice.** Depends on **#530 → #529 → #527 → #526 → #524**.

## Changes

- `src/ouroboros/mcp/tools/evaluation_handlers.py` — `class LateralThinkHandler(BridgeAwareMixin):`. Mixin field defaults preserve every existing caller.
- `tests/unit/mcp/tools/test_unstuck_bridge_aware.py` — 3 cases.

Dispatch internals are unchanged in this PR — the populated bridge is now *available* on the handler. A follow-up slice forwards `self.mcp_manager` into the lateral-think dispatch path where dynamic external MCP servers reach the unstuck pipeline.

## Migration plan progress (within #475)

| Slice | Handler | Status |
|---|---|---|
| 1 | `EvolveStepHandler` inherits `BridgeAwareMixin` | merged-pending in #530 |
| **2 (this PR)** | `LateralThinkHandler` inherits `BridgeAwareMixin` | open |
| 3 | Forward bridge into `EvolveStepHandler` → `EvolutionaryLoop` | follow-up |
| 4 | Forward bridge into `LateralThinkHandler` dispatch path | follow-up |
| 5 | Ralph loop pattern verification | follow-up |

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/mcp/tools/evaluation_handlers.py tests/unit/mcp/tools/test_unstuck_bridge_aware.py` | clean |
| `uv run ruff format ...` | no diff |
| `uv run pytest tests/unit/mcp/tools/test_unstuck_bridge_aware.py tests/unit/mcp/tools/test_evolve_step_bridge_aware.py` | 6 passed |
| `uv run pytest tests/unit/mcp/tools/` (regression) | 474 passed |

## Pre-merge checklist

- [x] `LateralThinkHandler` inherits `BridgeAwareMixin`
- [x] Mixin field defaults preserve existing keyword-arg callers
- [x] `inject_runtime_context` populates bridge fields (test pins behavior)
- [x] No internal change to lateral-think dispatch in this PR
- [x] CI: ruff + format + pytest (3 new + 474 regression) all green

## Post-merge checklist

- [ ] Slice 3: forward `self.mcp_manager` from `EvolveStepHandler` into the inner `EvolutionaryLoop` runner.
- [ ] Slice 4: forward `self.mcp_manager` from `LateralThinkHandler` into its dispatch path.
- [ ] Confirm `ralph` (the persistent-loop pattern) does not need a code change — it consumes other handlers that are now mixin-injected.

## Rollback

A two-line class-declaration change plus a small test file. Rollback steps:

1. Revert this PR. `LateralThinkHandler` returns to no-mixin parentage; the composition root continues to inject every other BridgeAwareMixin handler unchanged (now including `EvolveStepHandler` from #530).
2. No data, schema, or runtime behaviour change to undo.

Stack: depends on #530 → #529 → #527 → #526 → #524.
