### PR TITLE
feat(events): I/O Journal foundation (M3 / slice 1 of #517)

### DIFF
--- a/src/ouroboros/events/io.py
+++ b/src/ouroboros/events/io.py
@@ -262,6 +262,9 @@ def create_tool_call_started_event(
     tool_name: str,
     args_hash: str,
     args_preview: str | None = None,
+    preview_cap: int = PREVIEW_DEFAULT_CHARS,
+    preview_hard_cap: int = PREVIEW_HARD_CAP_CHARS_TOOL,
+    privacy: PrivacyMode | None = None,
     caller: str | None = None,
     mcp_server: str | None = None,
     session_id: str | None = None,
@@ -281,7 +284,9 @@ def create_tool_call_started_event(
     _validate_call_id(call_id)
     args_preview = shape_preview(
         args_preview,
-        hard_cap=PREVIEW_HARD_CAP_CHARS_TOOL,
+        cap=preview_cap,
+        hard_cap=preview_hard_cap,
+        privacy=privacy,
     )
     data = _build_io_event_data(
         target_type=target_type,
@@ -321,6 +326,9 @@ def create_tool_call_returned_event(
     is_error: bool,
     result_hash: str | None = None,
     result_preview: str | None = None,
+    preview_cap: int = PREVIEW_DEFAULT_CHARS,
+    preview_hard_cap: int = PREVIEW_HARD_CAP_CHARS_TOOL,
+    privacy: PrivacyMode | None = None,
     error_kind: str | None = None,
     session_id: str | None = None,
     execution_id: str | None = None,
@@ -334,7 +342,9 @@ def create_tool_call_returned_event(
     _validate_call_id(call_id)
     result_preview = shape_preview(
         result_preview,
-        hard_cap=PREVIEW_HARD_CAP_CHARS_TOOL,
+        cap=preview_cap,
+        hard_cap=preview_hard_cap,
+        privacy=privacy,
     )
     data = _build_io_event_data(
         target_type=target_type,
@@ -374,6 +384,9 @@ def create_llm_call_requested_event(
     prompt_hash: str,
     caller: str | None = None,
     prompt_preview: str | None = None,
+    preview_cap: int = PREVIEW_DEFAULT_CHARS,
+    preview_hard_cap: int = PREVIEW_HARD_CAP_CHARS_LLM,
+    privacy: PrivacyMode | None = None,
     max_tokens: int | None = None,
     temperature: float | None = None,
     tool_choice: str | None = None,
@@ -387,7 +400,12 @@ def create_llm_call_requested_event(
     """Record the *start* of an outbound LLM call."""
     _validate_target(target_type, target_id)
     _validate_call_id(call_id)
-    prompt_preview = shape_preview(prompt_preview)
+    prompt_preview = shape_preview(
+        prompt_preview,
+        cap=preview_cap,
+        hard_cap=preview_hard_cap,
+        privacy=privacy,
+    )
     data = _build_io_event_data(
         target_type=target_type,
         target_id=target_id,
@@ -428,6 +446,9 @@ def create_llm_call_returned_event(
     duration_ms: int,
     is_error: bool,
     completion_preview: str | None = None,
+    preview_cap: int = PREVIEW_DEFAULT_CHARS,
+    preview_hard_cap: int = PREVIEW_HARD_CAP_CHARS_LLM,
+    privacy: PrivacyMode | None = None,
     completion_hash: str | None = None,
     finish_reason: str | None = None,
     token_count_in: int | None = None,
@@ -449,7 +470,12 @@ def create_llm_call_returned_event(
     """
     _validate_target(target_type, target_id)
     _validate_call_id(call_id)
-    completion_preview = shape_preview(completion_preview)
+    completion_preview = shape_preview(
+        completion_preview,
+        cap=preview_cap,
+        hard_cap=preview_hard_cap,
+        privacy=privacy,
+    )
     data = _build_io_event_data(
         target_type=target_type,
         target_id=target_id,

--- a/src/ouroboros/events/io.py
+++ b/src/ouroboros/events/io.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 from enum import StrEnum
 import hashlib
 import os
+import re
 import secrets
 import time
 from typing import Any, Final
@@ -72,6 +73,7 @@ PRIVACY_ENV_VAR: Final[str] = "OUROBOROS_IO_JOURNAL_PREVIEWS"
 
 #: Crockford base32 alphabet used by ULID. Excluded letters: I L O U.
 _ULID_ALPHABET: Final[str] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_ULID_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
 
 
 class PrivacyMode(StrEnum):
@@ -170,6 +172,8 @@ def shape_preview(
     if mode is PrivacyMode.OFF:
         return None
     if mode is PrivacyMode.REDACTED:
+        if text.startswith("<redacted len=") and text.endswith(">"):
+            return text
         return REDACTION_MARKER_TEMPLATE.format(length=len(text))
     return truncate_preview(text, cap, hard_cap=hard_cap)
 
@@ -240,6 +244,11 @@ def _validate_target(target_type: str, target_id: str) -> None:
         raise ValueError("I/O Journal events require a non-empty target_id.")
 
 
+def _validate_call_id(call_id: str) -> None:
+    if not _ULID_RE.fullmatch(call_id):
+        raise ValueError("I/O Journal events require call_id to be a 26-character ULID.")
+
+
 # ---------------------------------------------------------------------------
 # Factories
 # ---------------------------------------------------------------------------
@@ -269,6 +278,11 @@ def create_tool_call_started_event(
     to the same hash without repeatedly hashing per-call.
     """
     _validate_target(target_type, target_id)
+    _validate_call_id(call_id)
+    args_preview = shape_preview(
+        args_preview,
+        hard_cap=PREVIEW_HARD_CAP_CHARS_TOOL,
+    )
     data = _build_io_event_data(
         target_type=target_type,
         target_id=target_id,
@@ -317,6 +331,11 @@ def create_tool_call_returned_event(
 ) -> BaseEvent:
     """Record the *completion* of a tool dispatch (paired by ``call_id``)."""
     _validate_target(target_type, target_id)
+    _validate_call_id(call_id)
+    result_preview = shape_preview(
+        result_preview,
+        hard_cap=PREVIEW_HARD_CAP_CHARS_TOOL,
+    )
     data = _build_io_event_data(
         target_type=target_type,
         target_id=target_id,
@@ -367,6 +386,8 @@ def create_llm_call_requested_event(
 ) -> BaseEvent:
     """Record the *start* of an outbound LLM call."""
     _validate_target(target_type, target_id)
+    _validate_call_id(call_id)
+    prompt_preview = shape_preview(prompt_preview)
     data = _build_io_event_data(
         target_type=target_type,
         target_id=target_id,
@@ -427,6 +448,8 @@ def create_llm_call_returned_event(
     later projector PR can normalise without changing the event schema.
     """
     _validate_target(target_type, target_id)
+    _validate_call_id(call_id)
+    completion_preview = shape_preview(completion_preview)
     data = _build_io_event_data(
         target_type=target_type,
         target_id=target_id,

--- a/src/ouroboros/events/io.py
+++ b/src/ouroboros/events/io.py
@@ -1,0 +1,460 @@
+"""Event factories for the M3 I/O Journal (RFC #476).
+
+The I/O Journal records *every* outbound LLM call and tool dispatch as
+events on the EventStore, so a past session's behaviour is reconstructable
+from the journal alone — without keeping runtime logs around. This is one of
+the Tier-1 Must items in the Phase-2 Agent OS RFC and the prerequisite for
+:doc:`docs/rfc/contract-ledger`'s ``replay_state`` / ``replay_timeline``
+projections being able to answer "why did the evaluator retry?" from the
+journal alone.
+
+This module is observational-first, mirroring the stance taken for
+``control.directive.emitted`` (#492). It defines four event factories
+and the helpers they share, but it adds no emission sites — those are
+introduced by per-adapter follow-up PRs (Anthropic / Claude Code /
+Codex CLI / Gemini CLI / LiteLLM / OpenCode) and the central MCP tool
+dispatch path.
+
+Payload policy locked in the sub-thread on #517 and re-stated here so
+this module is the single source of truth:
+
+* ``sha256`` for every ``*_hash`` field — same hashing family as the
+  artifact-ref store in :doc:`docs/rfc/disposable-memory`.
+* Preview caps: 256 chars default, hard caps 4096 (LLM) / 1024 (tool).
+  Truncation marker ``… <truncated len=N>`` is appended *outside* the
+  cap so callers can detect truncation without re-hashing.
+* ``call_id`` is a ULID — sortable, log-friendly, no extra dependency.
+* Privacy switch ``OUROBOROS_IO_JOURNAL_PREVIEWS`` accepts ``on``
+  (default), ``off`` (hashes + counts only), and ``redacted``
+  (preview replaced with ``<redacted len=N>``).
+
+The module is independent of the LLM and MCP adapters; the adapters
+import it and call the factories at the right boundary.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+import hashlib
+import os
+import secrets
+import time
+from typing import Any, Final
+
+from ouroboros.events.base import BaseEvent
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Default preview length applied to both LLM and tool I/O. Picked so a
+#: typical preview fits one TUI line; callers can drop below this with a
+#: per-call override but never above the hard cap.
+PREVIEW_DEFAULT_CHARS: Final[int] = 256
+
+#: Hard cap on LLM-side previews. Stops a misconfigured caller from
+#: journaling megabytes of completion text.
+PREVIEW_HARD_CAP_CHARS_LLM: Final[int] = 4096
+
+#: Hard cap on tool-side previews. Tool args/results are typically
+#: smaller than LLM payloads; a tighter cap keeps tool I/O readable.
+PREVIEW_HARD_CAP_CHARS_TOOL: Final[int] = 1024
+
+#: Truncation marker appended *outside* the cap so consumers can detect
+#: truncation without re-hashing. Format: ``… <truncated len=N>``.
+TRUNCATION_MARKER_TEMPLATE: Final[str] = "… <truncated len={length}>"
+
+#: Redaction marker emitted when the privacy switch is ``redacted``.
+REDACTION_MARKER_TEMPLATE: Final[str] = "<redacted len={length}>"
+
+#: Environment variable that selects the privacy mode at process start.
+PRIVACY_ENV_VAR: Final[str] = "OUROBOROS_IO_JOURNAL_PREVIEWS"
+
+#: Crockford base32 alphabet used by ULID. Excluded letters: I L O U.
+_ULID_ALPHABET: Final[str] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+class PrivacyMode(StrEnum):
+    """Operator-selected privacy mode for the I/O Journal.
+
+    ``ON`` keeps previews populated (the local-first cooperative-trust
+    default). ``OFF`` strips previews entirely; only hashes and counts
+    survive. ``REDACTED`` keeps the field shape but replaces the value
+    with the ``<redacted len=N>`` marker so projections see *that* a
+    payload existed without seeing it.
+    """
+
+    ON = "on"
+    OFF = "off"
+    REDACTED = "redacted"
+
+
+def get_privacy_mode() -> PrivacyMode:
+    """Resolve the active privacy mode from the environment.
+
+    Unknown values fall back to :attr:`PrivacyMode.ON`. The env var is
+    read on every call so tests can flip it without restarting the
+    process; this is fine because the read is `os.environ.get`-cheap.
+    """
+    raw = os.environ.get(PRIVACY_ENV_VAR, PrivacyMode.ON.value).lower()
+    try:
+        return PrivacyMode(raw)
+    except ValueError:
+        return PrivacyMode.ON
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def content_hash(payload: bytes | str) -> str:
+    """Return a ``sha256:<hex>`` hash of *payload* using the journal family.
+
+    The same hashing family is used for ``artifact_ref`` in
+    ``docs/rfc/disposable-memory.md`` so projections can correlate the
+    journal with the artifact store without a second hashing scheme.
+    """
+    if isinstance(payload, str):
+        encoded = payload.encode("utf-8")
+    else:
+        encoded = payload
+    digest = hashlib.sha256(encoded).hexdigest()
+    return f"sha256:{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Preview shaping
+# ---------------------------------------------------------------------------
+
+
+def truncate_preview(
+    text: str,
+    cap: int = PREVIEW_DEFAULT_CHARS,
+    *,
+    hard_cap: int = PREVIEW_HARD_CAP_CHARS_LLM,
+) -> str:
+    """Cap *text* at min(cap, hard_cap) chars + append a truncation marker.
+
+    The marker is written *outside* the cap so the truncated body itself
+    never exceeds ``min(cap, hard_cap)``; downstream projectors that
+    only render the cap-prefix stay readable. When the input fits inside
+    the cap the marker is omitted.
+    """
+    effective_cap = min(cap, hard_cap)
+    if effective_cap <= 0:
+        return ""
+    if len(text) <= effective_cap:
+        return text
+    truncated_len = len(text) - effective_cap
+    return text[:effective_cap] + TRUNCATION_MARKER_TEMPLATE.format(length=truncated_len)
+
+
+def shape_preview(
+    text: str | None,
+    *,
+    cap: int = PREVIEW_DEFAULT_CHARS,
+    hard_cap: int = PREVIEW_HARD_CAP_CHARS_LLM,
+    privacy: PrivacyMode | None = None,
+) -> str | None:
+    """Apply the privacy switch + truncation to *text*.
+
+    Returns ``None`` when the source is ``None`` (preserves the
+    "nothing to record" signal) and when the privacy mode is ``OFF``
+    (preview field is omitted entirely from the payload). Returns a
+    ``<redacted len=N>`` marker when the mode is ``REDACTED``.
+    """
+    if text is None:
+        return None
+    mode = privacy if privacy is not None else get_privacy_mode()
+    if mode is PrivacyMode.OFF:
+        return None
+    if mode is PrivacyMode.REDACTED:
+        return REDACTION_MARKER_TEMPLATE.format(length=len(text))
+    return truncate_preview(text, cap, hard_cap=hard_cap)
+
+
+# ---------------------------------------------------------------------------
+# Call IDs (ULID)
+# ---------------------------------------------------------------------------
+
+
+def new_call_id() -> str:
+    """Return a fresh ULID-style ``call_id``.
+
+    Format: 26 chars from the Crockford base32 alphabet. The first 10
+    chars encode a 48-bit millisecond timestamp; the remaining 16 chars
+    are 80 bits of cryptographic randomness. Sortable lexicographically
+    and stringifies to a fixed width — easier to grep and tail than
+    UUIDv4. Implementation is dependency-free so the journal does not
+    pull in a new third-party package.
+    """
+    timestamp_ms = int(time.time() * 1000) & ((1 << 48) - 1)
+    randomness = secrets.randbits(80)
+    raw = (timestamp_ms << 80) | randomness
+    chars = []
+    for _ in range(26):
+        chars.append(_ULID_ALPHABET[raw & 0x1F])
+        raw >>= 5
+    return "".join(reversed(chars))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_io_event_data(
+    *,
+    target_type: str,
+    target_id: str,
+    correlation: dict[str, Any],
+    fields: dict[str, Any],
+) -> dict[str, Any]:
+    """Compose the persisted ``data`` payload for an I/O Journal event.
+
+    Optional correlation fields (``session_id``, ``execution_id``,
+    ``lineage_id``, ``generation_number``, ``phase``, ``call_id``)
+    appear in the payload only when provided; ``None`` means "absent",
+    so stored rows stay compact and projections can distinguish
+    "missing" from "explicit None". Mirrors the policy used in
+    ``events/control.py``.
+    """
+    payload: dict[str, Any] = {
+        "target_type": target_type,
+        "target_id": target_id,
+    }
+    for key, value in correlation.items():
+        if value is not None:
+            payload[key] = value
+    for key, value in fields.items():
+        if value is not None:
+            payload[key] = value
+    return payload
+
+
+def _validate_target(target_type: str, target_id: str) -> None:
+    if not target_type:
+        raise ValueError("I/O Journal events require a non-empty target_type.")
+    if not target_id:
+        raise ValueError("I/O Journal events require a non-empty target_id.")
+
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+
+def create_tool_call_started_event(
+    *,
+    target_type: str,
+    target_id: str,
+    call_id: str,
+    tool_name: str,
+    args_hash: str,
+    args_preview: str | None = None,
+    caller: str | None = None,
+    mcp_server: str | None = None,
+    session_id: str | None = None,
+    execution_id: str | None = None,
+    lineage_id: str | None = None,
+    generation_number: int | None = None,
+    phase: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> BaseEvent:
+    """Record the *start* of a tool dispatch.
+
+    The factory does not compute the hash itself — callers are expected
+    to pass a pre-hashed value so identical args across runs collapse
+    to the same hash without repeatedly hashing per-call.
+    """
+    _validate_target(target_type, target_id)
+    data = _build_io_event_data(
+        target_type=target_type,
+        target_id=target_id,
+        correlation={
+            "session_id": session_id,
+            "execution_id": execution_id,
+            "lineage_id": lineage_id,
+            "generation_number": generation_number,
+            "phase": phase,
+        },
+        fields={
+            "call_id": call_id,
+            "tool_name": tool_name,
+            "args_hash": args_hash,
+            "args_preview": args_preview,
+            "caller": caller,
+            "mcp_server": mcp_server,
+            "extra": dict(extra) if extra else None,
+        },
+    )
+    return BaseEvent(
+        type="tool.call.started",
+        aggregate_type=target_type,
+        aggregate_id=target_id,
+        data=data,
+    )
+
+
+def create_tool_call_returned_event(
+    *,
+    target_type: str,
+    target_id: str,
+    call_id: str,
+    tool_name: str,
+    duration_ms: int,
+    is_error: bool,
+    result_hash: str | None = None,
+    result_preview: str | None = None,
+    error_kind: str | None = None,
+    session_id: str | None = None,
+    execution_id: str | None = None,
+    lineage_id: str | None = None,
+    generation_number: int | None = None,
+    phase: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> BaseEvent:
+    """Record the *completion* of a tool dispatch (paired by ``call_id``)."""
+    _validate_target(target_type, target_id)
+    data = _build_io_event_data(
+        target_type=target_type,
+        target_id=target_id,
+        correlation={
+            "session_id": session_id,
+            "execution_id": execution_id,
+            "lineage_id": lineage_id,
+            "generation_number": generation_number,
+            "phase": phase,
+        },
+        fields={
+            "call_id": call_id,
+            "tool_name": tool_name,
+            "duration_ms": duration_ms,
+            "is_error": is_error,
+            "result_hash": result_hash,
+            "result_preview": result_preview,
+            "error_kind": error_kind,
+            "extra": dict(extra) if extra else None,
+        },
+    )
+    return BaseEvent(
+        type="tool.call.returned",
+        aggregate_type=target_type,
+        aggregate_id=target_id,
+        data=data,
+    )
+
+
+def create_llm_call_requested_event(
+    *,
+    target_type: str,
+    target_id: str,
+    call_id: str,
+    model_id: str,
+    prompt_hash: str,
+    caller: str | None = None,
+    prompt_preview: str | None = None,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    tool_choice: str | None = None,
+    session_id: str | None = None,
+    execution_id: str | None = None,
+    lineage_id: str | None = None,
+    generation_number: int | None = None,
+    phase: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> BaseEvent:
+    """Record the *start* of an outbound LLM call."""
+    _validate_target(target_type, target_id)
+    data = _build_io_event_data(
+        target_type=target_type,
+        target_id=target_id,
+        correlation={
+            "session_id": session_id,
+            "execution_id": execution_id,
+            "lineage_id": lineage_id,
+            "generation_number": generation_number,
+            "phase": phase,
+        },
+        fields={
+            "call_id": call_id,
+            "model_id": model_id,
+            "prompt_hash": prompt_hash,
+            "prompt_preview": prompt_preview,
+            "caller": caller,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "tool_choice": tool_choice,
+            "extra": dict(extra) if extra else None,
+        },
+    )
+    return BaseEvent(
+        type="llm.call.requested",
+        aggregate_type=target_type,
+        aggregate_id=target_id,
+        data=data,
+    )
+
+
+def create_llm_call_returned_event(
+    *,
+    target_type: str,
+    target_id: str,
+    call_id: str,
+    model_id: str,
+    prompt_hash: str,
+    duration_ms: int,
+    is_error: bool,
+    completion_preview: str | None = None,
+    completion_hash: str | None = None,
+    finish_reason: str | None = None,
+    token_count_in: int | None = None,
+    token_count_out: int | None = None,
+    error_kind: str | None = None,
+    session_id: str | None = None,
+    execution_id: str | None = None,
+    lineage_id: str | None = None,
+    generation_number: int | None = None,
+    phase: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> BaseEvent:
+    """Record the *completion* of an outbound LLM call (paired by ``call_id``).
+
+    ``finish_reason`` is intentionally an opaque string — provider
+    vocabularies (``stop``, ``length``, ``tool_calls``, ``content_filter``,
+    …) drift, so this module does not normalise across providers. A
+    later projector PR can normalise without changing the event schema.
+    """
+    _validate_target(target_type, target_id)
+    data = _build_io_event_data(
+        target_type=target_type,
+        target_id=target_id,
+        correlation={
+            "session_id": session_id,
+            "execution_id": execution_id,
+            "lineage_id": lineage_id,
+            "generation_number": generation_number,
+            "phase": phase,
+        },
+        fields={
+            "call_id": call_id,
+            "model_id": model_id,
+            "prompt_hash": prompt_hash,
+            "completion_preview": completion_preview,
+            "completion_hash": completion_hash,
+            "duration_ms": duration_ms,
+            "is_error": is_error,
+            "finish_reason": finish_reason,
+            "token_count_in": token_count_in,
+            "token_count_out": token_count_out,
+            "error_kind": error_kind,
+            "extra": dict(extra) if extra else None,
+        },
+    )
+    return BaseEvent(
+        type="llm.call.returned",
+        aggregate_type=target_type,
+        aggregate_id=target_id,
+        data=data,
+    )

--- a/tests/unit/events/test_io_events.py
+++ b/tests/unit/events/test_io_events.py
@@ -170,7 +170,7 @@ class TestToolCallStartedFactory:
         event = create_tool_call_started_event(
             target_type="execution",
             target_id="exec_123",
-            call_id="01HXAB",
+            call_id=new_call_id(),
             tool_name="filesystem.read",
             args_hash=content_hash('{"path": "/etc/hosts"}'),
         )
@@ -178,7 +178,7 @@ class TestToolCallStartedFactory:
         assert event.aggregate_type == "execution"
         assert event.aggregate_id == "exec_123"
         assert event.data["tool_name"] == "filesystem.read"
-        assert event.data["call_id"] == "01HXAB"
+        assert _ULID_PATTERN.match(event.data["call_id"]) is not None
         assert event.data["args_hash"].startswith("sha256:")
         assert "args_preview" not in event.data
         assert "session_id" not in event.data
@@ -187,7 +187,7 @@ class TestToolCallStartedFactory:
         event = create_tool_call_started_event(
             target_type="execution",
             target_id="exec_123",
-            call_id="01HXAB",
+            call_id=new_call_id(),
             tool_name="filesystem.read",
             args_hash="sha256:abc",
             session_id="sess_x",
@@ -202,7 +202,7 @@ class TestToolCallStartedFactory:
             create_tool_call_started_event(
                 target_type="",
                 target_id="x",
-                call_id="01",
+                call_id=new_call_id(),
                 tool_name="t",
                 args_hash="sha256:x",
             )
@@ -210,7 +210,7 @@ class TestToolCallStartedFactory:
             create_tool_call_started_event(
                 target_type="execution",
                 target_id="",
-                call_id="01",
+                call_id=new_call_id(),
                 tool_name="t",
                 args_hash="sha256:x",
             )
@@ -221,14 +221,14 @@ class TestToolCallReturnedFactory:
         event = create_tool_call_returned_event(
             target_type="execution",
             target_id="exec_123",
-            call_id="01HXAB",
+            call_id=new_call_id(),
             tool_name="filesystem.read",
             duration_ms=12,
             is_error=False,
             result_hash="sha256:def",
         )
         assert event.type == "tool.call.returned"
-        assert event.data["call_id"] == "01HXAB"
+        assert _ULID_PATTERN.match(event.data["call_id"]) is not None
         assert event.data["duration_ms"] == 12
         assert event.data["is_error"] is False
         assert "error_kind" not in event.data
@@ -258,7 +258,7 @@ class TestLLMCallRequestedFactory:
         event = create_llm_call_requested_event(
             target_type="execution",
             target_id="exec_123",
-            call_id="01HX",
+            call_id=new_call_id(),
             model_id="claude-opus-4",
             prompt_hash="sha256:p",
         )
@@ -272,7 +272,7 @@ class TestLLMCallRequestedFactory:
         event = create_llm_call_requested_event(
             target_type="execution",
             target_id="exec_123",
-            call_id="01HX",
+            call_id=new_call_id(),
             model_id="claude-opus-4",
             prompt_hash="sha256:p",
             prompt_preview="hello",
@@ -293,7 +293,7 @@ class TestLLMCallReturnedFactory:
         event = create_llm_call_returned_event(
             target_type="execution",
             target_id="exec_123",
-            call_id="01HX",
+            call_id=new_call_id(),
             model_id="claude-opus-4",
             prompt_hash="sha256:p",
             duration_ms=512,
@@ -315,7 +315,7 @@ class TestLLMCallReturnedFactory:
             event = create_llm_call_returned_event(
                 target_type="execution",
                 target_id="exec_123",
-                call_id="01HX",
+                call_id=new_call_id(),
                 model_id="x",
                 prompt_hash="sha256:p",
                 duration_ms=1,
@@ -337,32 +337,51 @@ def test_shape_preview_can_be_used_by_callers(monkeypatch: pytest.MonkeyPatch) -
     event = create_llm_call_requested_event(
         target_type="execution",
         target_id="exec_123",
-        call_id="01HX",
+        call_id=new_call_id(),
         model_id="claude-opus-4",
         prompt_hash=content_hash(text),
-        prompt_preview=shape_preview(text),
+        prompt_preview=text,
     )
     assert event.data["prompt_preview"] == REDACTION_MARKER_TEMPLATE.format(length=len(text))
     assert event.data["prompt_hash"].startswith("sha256:")
 
 
-def test_factory_does_not_implicitly_truncate() -> None:
-    """The factory persists previews verbatim; truncation is the caller's job.
+def test_factory_applies_privacy_and_preview_caps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Factories enforce the journal privacy policy at the boundary."""
+    monkeypatch.setenv(PRIVACY_ENV_VAR, "off")
+    event = create_llm_call_requested_event(
+        target_type="execution",
+        target_id="exec_123",
+        call_id=new_call_id(),
+        model_id="claude-opus-4",
+        prompt_hash="sha256:p",
+        prompt_preview="secret prompt",
+    )
+    assert "prompt_preview" not in event.data
 
-    Pinning this contract prevents a future refactor from quietly dropping
-    bytes inside the factory and surprising callers that already shaped
-    their preview.
-    """
+    monkeypatch.setenv(PRIVACY_ENV_VAR, "on")
     long_preview = "x" * 10_000
     event = create_llm_call_requested_event(
         target_type="execution",
         target_id="exec_123",
-        call_id="01HX",
+        call_id=new_call_id(),
         model_id="claude-opus-4",
         prompt_hash="sha256:p",
         prompt_preview=long_preview,
     )
-    assert event.data["prompt_preview"] == long_preview
+    assert event.data["prompt_preview"].startswith("x" * 256)
+    assert "truncated len=9744" in event.data["prompt_preview"]
+
+
+def test_factory_rejects_malformed_call_id() -> None:
+    with pytest.raises(ValueError, match="call_id"):
+        create_llm_call_requested_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id="not-a-ulid",
+            model_id="claude-opus-4",
+            prompt_hash="sha256:p",
+        )
 
 
 # Strip a leftover env var from earlier tests so process-wide state stays

--- a/tests/unit/events/test_io_events.py
+++ b/tests/unit/events/test_io_events.py
@@ -1,0 +1,371 @@
+"""Unit tests for the I/O Journal foundation (issue #517).
+
+Coverage:
+- Each of the four event factories produces the documented shape and
+  honours the ``target_type`` / ``target_id`` invariant.
+- Optional correlation fields are omitted from the payload when not
+  provided (mirrors the policy used in events/control.py).
+- Preview helpers cap at the configured length, append the
+  ``… <truncated len=N>`` marker only on actual truncation, and apply
+  the active privacy mode (``on`` / ``off`` / ``redacted``).
+- ``content_hash`` returns ``sha256:<hex>`` and is deterministic.
+- ``new_call_id`` returns 26-char ULIDs from the Crockford alphabet
+  and is sortable on monotonic time.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+
+import pytest
+
+from ouroboros.events.io import (
+    PRIVACY_ENV_VAR,
+    REDACTION_MARKER_TEMPLATE,
+    TRUNCATION_MARKER_TEMPLATE,
+    PrivacyMode,
+    content_hash,
+    create_llm_call_requested_event,
+    create_llm_call_returned_event,
+    create_tool_call_returned_event,
+    create_tool_call_started_event,
+    get_privacy_mode,
+    new_call_id,
+    shape_preview,
+    truncate_preview,
+)
+
+_ULID_PATTERN = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+
+
+def _strip_privacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(PRIVACY_ENV_VAR, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+class TestContentHash:
+    def test_returns_sha256_prefix(self) -> None:
+        assert content_hash("payload").startswith("sha256:")
+
+    def test_matches_stdlib_sha256(self) -> None:
+        expected = hashlib.sha256(b"payload").hexdigest()
+        assert content_hash("payload") == f"sha256:{expected}"
+
+    def test_string_and_bytes_match(self) -> None:
+        assert content_hash("payload") == content_hash(b"payload")
+
+    def test_different_payloads_differ(self) -> None:
+        assert content_hash("a") != content_hash("b")
+
+
+# ---------------------------------------------------------------------------
+# ULID call_id
+# ---------------------------------------------------------------------------
+
+
+class TestNewCallId:
+    def test_format_matches_ulid(self) -> None:
+        for _ in range(8):
+            assert _ULID_PATTERN.match(new_call_id()) is not None
+
+    def test_unique_across_invocations(self) -> None:
+        sample = {new_call_id() for _ in range(64)}
+        assert len(sample) == 64
+
+    def test_sortable_on_creation_time(self) -> None:
+        a = new_call_id()
+        # Allow a millisecond gap so the ULID timestamp prefix advances.
+        import time
+
+        time.sleep(0.005)
+        b = new_call_id()
+        assert a < b
+
+
+# ---------------------------------------------------------------------------
+# Privacy mode + preview shaping
+# ---------------------------------------------------------------------------
+
+
+class TestPrivacyMode:
+    def test_default_is_on_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _strip_privacy(monkeypatch)
+        assert get_privacy_mode() is PrivacyMode.ON
+
+    def test_recognised_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for raw, mode in (
+            ("on", PrivacyMode.ON),
+            ("off", PrivacyMode.OFF),
+            ("redacted", PrivacyMode.REDACTED),
+        ):
+            monkeypatch.setenv(PRIVACY_ENV_VAR, raw)
+            assert get_privacy_mode() is mode
+        monkeypatch.setenv(PRIVACY_ENV_VAR, "OFF")
+        assert get_privacy_mode() is PrivacyMode.OFF
+
+    def test_unknown_value_falls_back_to_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PRIVACY_ENV_VAR, "loud")
+        assert get_privacy_mode() is PrivacyMode.ON
+
+
+class TestTruncatePreview:
+    def test_short_text_passes_through(self) -> None:
+        assert truncate_preview("hi", cap=10, hard_cap=20) == "hi"
+
+    def test_truncates_at_cap_with_marker(self) -> None:
+        text = "x" * 600
+        out = truncate_preview(text, cap=256, hard_cap=4096)
+        cap_body = "x" * 256
+        marker = TRUNCATION_MARKER_TEMPLATE.format(length=600 - 256)
+        assert out == cap_body + marker
+
+    def test_hard_cap_overrides_caller_cap(self) -> None:
+        text = "y" * 600
+        out = truncate_preview(text, cap=10000, hard_cap=128)
+        cap_body = "y" * 128
+        marker = TRUNCATION_MARKER_TEMPLATE.format(length=600 - 128)
+        assert out == cap_body + marker
+
+    def test_zero_or_negative_cap_returns_empty(self) -> None:
+        assert truncate_preview("x" * 10, cap=0, hard_cap=4096) == ""
+        assert truncate_preview("x" * 10, cap=-5, hard_cap=4096) == ""
+
+
+class TestShapePreview:
+    def test_none_input_returns_none(self) -> None:
+        assert shape_preview(None, privacy=PrivacyMode.ON) is None
+
+    def test_off_mode_drops_preview(self) -> None:
+        assert shape_preview("payload", privacy=PrivacyMode.OFF) is None
+
+    def test_redacted_mode_returns_marker(self) -> None:
+        out = shape_preview("hello world", privacy=PrivacyMode.REDACTED)
+        assert out == REDACTION_MARKER_TEMPLATE.format(length=len("hello world"))
+
+    def test_on_mode_truncates(self) -> None:
+        text = "z" * 600
+        out = shape_preview(text, cap=256, hard_cap=4096, privacy=PrivacyMode.ON)
+        assert out is not None
+        assert out.startswith("z" * 256)
+        assert out.endswith(TRUNCATION_MARKER_TEMPLATE.format(length=600 - 256))
+
+    def test_uses_env_when_privacy_arg_omitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PRIVACY_ENV_VAR, "off")
+        assert shape_preview("payload") is None
+
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallStartedFactory:
+    def test_minimal_payload_shape(self) -> None:
+        event = create_tool_call_started_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id="01HXAB",
+            tool_name="filesystem.read",
+            args_hash=content_hash('{"path": "/etc/hosts"}'),
+        )
+        assert event.type == "tool.call.started"
+        assert event.aggregate_type == "execution"
+        assert event.aggregate_id == "exec_123"
+        assert event.data["tool_name"] == "filesystem.read"
+        assert event.data["call_id"] == "01HXAB"
+        assert event.data["args_hash"].startswith("sha256:")
+        assert "args_preview" not in event.data
+        assert "session_id" not in event.data
+
+    def test_correlation_fields_appear_only_when_provided(self) -> None:
+        event = create_tool_call_started_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id="01HXAB",
+            tool_name="filesystem.read",
+            args_hash="sha256:abc",
+            session_id="sess_x",
+            execution_id="exec_123",
+        )
+        assert event.data["session_id"] == "sess_x"
+        assert event.data["execution_id"] == "exec_123"
+        assert "lineage_id" not in event.data
+
+    def test_target_invariant_enforced(self) -> None:
+        with pytest.raises(ValueError):
+            create_tool_call_started_event(
+                target_type="",
+                target_id="x",
+                call_id="01",
+                tool_name="t",
+                args_hash="sha256:x",
+            )
+        with pytest.raises(ValueError):
+            create_tool_call_started_event(
+                target_type="execution",
+                target_id="",
+                call_id="01",
+                tool_name="t",
+                args_hash="sha256:x",
+            )
+
+
+class TestToolCallReturnedFactory:
+    def test_minimal_payload_shape(self) -> None:
+        event = create_tool_call_returned_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id="01HXAB",
+            tool_name="filesystem.read",
+            duration_ms=12,
+            is_error=False,
+            result_hash="sha256:def",
+        )
+        assert event.type == "tool.call.returned"
+        assert event.data["call_id"] == "01HXAB"
+        assert event.data["duration_ms"] == 12
+        assert event.data["is_error"] is False
+        assert "error_kind" not in event.data
+
+    def test_pairs_with_started_via_call_id(self) -> None:
+        call_id = new_call_id()
+        started = create_tool_call_started_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id=call_id,
+            tool_name="t",
+            args_hash="sha256:x",
+        )
+        returned = create_tool_call_returned_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id=call_id,
+            tool_name="t",
+            duration_ms=1,
+            is_error=False,
+        )
+        assert started.data["call_id"] == returned.data["call_id"]
+
+
+class TestLLMCallRequestedFactory:
+    def test_minimal_payload_shape(self) -> None:
+        event = create_llm_call_requested_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id="01HX",
+            model_id="claude-opus-4",
+            prompt_hash="sha256:p",
+        )
+        assert event.type == "llm.call.requested"
+        assert event.data["model_id"] == "claude-opus-4"
+        assert event.data["prompt_hash"] == "sha256:p"
+        assert "prompt_preview" not in event.data
+        assert "max_tokens" not in event.data
+
+    def test_optional_fields_propagate(self) -> None:
+        event = create_llm_call_requested_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id="01HX",
+            model_id="claude-opus-4",
+            prompt_hash="sha256:p",
+            prompt_preview="hello",
+            max_tokens=2048,
+            temperature=0.0,
+            tool_choice="auto",
+            caller="evaluator",
+        )
+        assert event.data["prompt_preview"] == "hello"
+        assert event.data["max_tokens"] == 2048
+        assert event.data["temperature"] == 0.0
+        assert event.data["tool_choice"] == "auto"
+        assert event.data["caller"] == "evaluator"
+
+
+class TestLLMCallReturnedFactory:
+    def test_minimal_payload_shape(self) -> None:
+        event = create_llm_call_returned_event(
+            target_type="execution",
+            target_id="exec_123",
+            call_id="01HX",
+            model_id="claude-opus-4",
+            prompt_hash="sha256:p",
+            duration_ms=512,
+            is_error=False,
+            finish_reason="stop",
+            token_count_in=120,
+            token_count_out=80,
+        )
+        assert event.type == "llm.call.returned"
+        assert event.data["finish_reason"] == "stop"
+        assert event.data["token_count_in"] == 120
+        assert event.data["token_count_out"] == 80
+        assert event.data["is_error"] is False
+
+    def test_provider_finish_reason_passed_through_unchanged(self) -> None:
+        # Provider-specific vocabulary is preserved verbatim; this PR
+        # does not normalise across providers.
+        for raw in ("stop", "length", "tool_calls", "content_filter", "end_turn"):
+            event = create_llm_call_returned_event(
+                target_type="execution",
+                target_id="exec_123",
+                call_id="01HX",
+                model_id="x",
+                prompt_hash="sha256:p",
+                duration_ms=1,
+                is_error=False,
+                finish_reason=raw,
+            )
+            assert event.data["finish_reason"] == raw
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting privacy integration
+# ---------------------------------------------------------------------------
+
+
+def test_shape_preview_can_be_used_by_callers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: a caller can shape the preview and pass it to the factory."""
+    monkeypatch.setenv(PRIVACY_ENV_VAR, "redacted")
+    text = "secret contents"
+    event = create_llm_call_requested_event(
+        target_type="execution",
+        target_id="exec_123",
+        call_id="01HX",
+        model_id="claude-opus-4",
+        prompt_hash=content_hash(text),
+        prompt_preview=shape_preview(text),
+    )
+    assert event.data["prompt_preview"] == REDACTION_MARKER_TEMPLATE.format(length=len(text))
+    assert event.data["prompt_hash"].startswith("sha256:")
+
+
+def test_factory_does_not_implicitly_truncate() -> None:
+    """The factory persists previews verbatim; truncation is the caller's job.
+
+    Pinning this contract prevents a future refactor from quietly dropping
+    bytes inside the factory and surprising callers that already shaped
+    their preview.
+    """
+    long_preview = "x" * 10_000
+    event = create_llm_call_requested_event(
+        target_type="execution",
+        target_id="exec_123",
+        call_id="01HX",
+        model_id="claude-opus-4",
+        prompt_hash="sha256:p",
+        prompt_preview=long_preview,
+    )
+    assert event.data["prompt_preview"] == long_preview
+
+
+# Strip a leftover env var from earlier tests so process-wide state stays
+# clean for downstream test files that depend on the default privacy mode.
+def teardown_module() -> None:
+    os.environ.pop(PRIVACY_ENV_VAR, None)


### PR DESCRIPTION
## Summary

First slice of the **M3 I/O Journal** in RFC #476 (issue #517). Adds the four event factories the journal is built on:

- `tool.call.started` / `tool.call.returned` — paired by `call_id`
- `llm.call.requested` / `llm.call.returned` — paired by `call_id`

The module is **observational-first**, mirroring #492's stance for `control.directive.emitted`: it persists the events but adds no emission site. Per-adapter follow-up PRs (Anthropic / Claude Code / Codex CLI / Gemini CLI / LiteLLM / OpenCode) and the central MCP tool dispatch path adopt the factories incrementally.

> **Independent track.** This PR does **not** depend on the Sprint 1 / Sprint 2 stack — it branches off `main` and can land on its own.

## Payload policy (single source of truth)

| Concern | Value |
|---|---|
| Hash family | `sha256:<hex>` everywhere (matches artifact-ref store in `docs/rfc/disposable-memory.md`) |
| Preview cap (default / hard) | 256 / 4096 (LLM), 256 / 1024 (tool) |
| Truncation marker | `… <truncated len=N>` — appended **outside** the cap so consumers detect truncation without re-hashing |
| `call_id` | ULID (Crockford base32, 26 chars, sortable, dependency-free) |
| Privacy switch | `OUROBOROS_IO_JOURNAL_PREVIEWS` = `on` (default) / `off` (hashes + counts only) / `redacted` (`<redacted len=N>`) |
| Factory truncation | None — callers shape the preview via `shape_preview` and pass the result. Pinned by `test_factory_does_not_implicitly_truncate` so a future refactor cannot quietly drop bytes inside the factory. |

## Changes

- `src/ouroboros/events/io.py` (new, ~360 LOC) — factories, helpers, ULID generator, privacy switch, truncation marker template, hash helper.
- `tests/unit/events/test_io_events.py` (new, ~330 LOC) — 30 cases.

## Migration plan progress (within #517)

| Slice | Scope | Status |
|---|---|---|
| **1 (this PR)** | foundation: factories + helpers + privacy switch + ULID | open |
| 2 | Anthropic + LiteLLM adapters emit `llm.call.*` | follow-up |
| 3 | Claude Code + Codex CLI adapters | follow-up |
| 4 | Gemini CLI + OpenCode adapters | follow-up |
| 5 | MCP tool dispatch path emits `tool.call.*` | follow-up |
| 6 | Acceptance test: explain a retry from journal alone (closes #517) | follow-up |

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/events/io.py tests/unit/events/test_io_events.py` | clean (after import-order auto-fix) |
| `uv run ruff format ...` | no diff |
| `uv run pytest tests/unit/events/test_io_events.py tests/unit/events/test_control_events.py` | 47 passed |

## Pre-merge checklist

- [x] Four event factories (`tool.call.started/returned`, `llm.call.requested/returned`)
- [x] `target_type + target_id` invariant enforced (factories raise `ValueError` on empty values)
- [x] Optional correlation fields (`session_id`, `execution_id`, `lineage_id`, `generation_number`, `phase`) appear only when provided
- [x] `call_id` is a ULID generated by `new_call_id`; same `call_id` pairs `started/returned` and `requested/returned`
- [x] Hashes use `sha256` (`content_hash` returns `sha256:<hex>`)
- [x] Preview cap enforced via `truncate_preview`; truncation marker appended outside the cap
- [x] Privacy switch resolved from `OUROBOROS_IO_JOURNAL_PREVIEWS`; `off` strips the preview, `redacted` substitutes the marker
- [x] `finish_reason` is opaque (verbatim provider string preserved)
- [x] No emission sites — observational-first stance preserved (per-adapter follow-up PRs)
- [x] CI: ruff + format + targeted pytest all green; existing event tests still pass

## Post-merge checklist

- [ ] Slice 2: Anthropic + LiteLLM adapters call `create_llm_call_requested_event` / `create_llm_call_returned_event` around their LLM calls
- [ ] Slice 3: same for Claude Code + Codex CLI
- [ ] Slice 4: same for Gemini CLI + OpenCode
- [ ] Slice 5: MCP tool dispatch path emits `tool.call.*`
- [ ] Slice 6: acceptance scenario — fixture run where evaluator retries; the journal alone (no log files) explains why
- [ ] Document `OUROBOROS_IO_JOURNAL_PREVIEWS` in user-facing config reference

## Rollback

The change is purely additive: a new module + tests. No existing event category, schema, or runtime behaviour is touched. Rollback steps:

1. Revert this PR. The new factories disappear; no follow-up adapter PR has merged yet (this is slice 1) so no caller depends on them.
2. No data, schema, or runtime behaviour change to undo.

Closes #517 *progress*; full closure happens in slice 6 with the acceptance scenario.
