### PR TITLE
docs(mcp-bridge): mark evolution loop bridge limitation as resolved (closes #475 partial)

### DIFF
--- a/docs/guides/mcp-bridge.md
+++ b/docs/guides/mcp-bridge.md
@@ -93,5 +93,14 @@ Checked in order:
 
 ## Known Limitations
 
-- Evolution loop (`evolve_step`) does not yet pass the bridge manager
-- No dynamic server addition after initial connection
+- **Resolved (#530, #531).** `evolve_step` and `unstuck` (LateralThinkHandler)
+  now inherit `BridgeAwareMixin` so the composition root's loop-injection
+  populates their `mcp_manager` and `mcp_tool_prefix` whenever an MCP bridge
+  is configured. Earlier releases left these two handlers without bridge
+  access; that gap is closed at the plumbing layer.
+- **Open.** No dynamic server addition after initial connection. Adding an
+  MCP server at runtime requires the orchestrator to re-publish a
+  `policy.capabilities.changed` event so subscribers re-read the runtime
+  context (per the invariant in #476 Q4). The plumbing this depends on —
+  `AgentRuntimeContext + ControlBus` (#474, #515) — is in place; the
+  re-publish wiring is the remaining work.


### PR DESCRIPTION
## Summary

Closes the documentation half of the **`evolve_step` / `unstuck` / `ralph` wiring** tracked by #475. After the Sprint 2 plumbing work landed (#526 → #527 → #529 → #530 → #531), the first of the two #280 known limitations the #475 issue body cites is resolved at the plumbing layer:

> ~~Evolution loop (`evolve_step`) does not yet pass the bridge manager~~

`EvolveStepHandler` (#530) and `LateralThinkHandler` (#531) now inherit `BridgeAwareMixin`, so the composition root's `inject_runtime_context` loop (#529) populates their `mcp_manager` and `mcp_tool_prefix` whenever an MCP bridge is configured.

The second limitation ("No dynamic server addition after initial connection") remains open, but it is now *actionable* — `AgentRuntimeContext + ControlBus` (#474, #515) is the re-publish surface called for in the `policy.capabilities.changed` invariant from #476 Q4. The remaining work is wiring the re-publish itself.

> **Stack notice.** Depends on **#531 → #530 → #529 → #527 → #526 → #524**.

## Changes

- `docs/guides/mcp-bridge.md` — Known Limitations section updated to mark the evolution-loop-bridge gap as resolved (with PR back-references) and to note the actionable plumbing path for the dynamic-addition gap.

Docs-only; no runtime impact.

## Sprint 2 status after this PR

| Issue | Plumbing | Internal forwarding |
|---|---|---|
| #474 (AgentRuntimeContext + ControlBus migration) | ✅ #526 + #527 + #529 | n/a (no internal change required) |
| #475 (`evolve_step` / `unstuck` / `ralph` wiring) | ✅ #530 + #531 + this PR (docs) | open — dynamic-addition follow-up |

## Verification

This is a docs-only PR. No tests needed; the PRs it cites already pin the runtime behaviour:

- `tests/unit/mcp/tools/test_bridge_mixin_runtime_context.py` (6 cases) — equivalence between `inject_bridge` and `inject_runtime_context`
- `tests/unit/mcp/tools/test_evolve_step_bridge_aware.py` (3 cases) — EvolveStepHandler inherits the mixin and `inject_runtime_context` populates its bridge fields
- `tests/unit/mcp/tools/test_unstuck_bridge_aware.py` (3 cases) — same for LateralThinkHandler

## Pre-merge checklist

- [x] Known Limitations entry updated with PR back-references (#530, #531)
- [x] Open limitation framed in terms of the new plumbing (`AgentRuntimeContext + ControlBus`) so future contributors see the path forward
- [x] No code change in this PR

## Post-merge checklist

- [ ] Open a follow-up issue for the dynamic-server-addition wiring once a maintainer agrees on the design (likely a small PR that calls `policy.capabilities.changed` on `mcp_bridge.add_server`).
- [ ] Decide whether #475 itself can be closed by this PR or whether the dynamic-addition follow-up is also in scope.

## Rollback

Pure docs PR. Rollback = revert; no runtime impact.

Closes #475 partial.

Stack: depends on #531 → #530 → #529 → #527 → #526 → #524.
