### PR TITLE
feat(events): IOJournalRecorder context manager (M3 / slice 2 of #517)

### DIFF
--- a/src/ouroboros/events/io_recorder.py
+++ b/src/ouroboros/events/io_recorder.py
@@ -1,0 +1,391 @@
+"""Async context-manager helper that records I/O Journal events.
+
+Issue #517 — slice 2 of #517. Adapters and tool dispatchers wrap their
+LLM/tool calls in :class:`IOJournalRecorder` so the journal entry
+emission becomes a 4-line addition instead of duplicating the
+factory + hashing + privacy + timing boilerplate at every call site.
+
+Design choices baked in:
+
+* The recorder is **always opt-in**. ``event_store=None`` produces a
+  no-op recorder that returns the same context-manager shape but
+  emits nothing. Adapters that have not yet adopted the journal pass
+  ``None`` and continue to work unchanged.
+* The recorder **owns** the ``call_id``, the timing, the hashing, and
+  the privacy switch. Callers only provide payload text and metadata.
+* The recorder pairs a ``*.started`` / ``*.requested`` event with a
+  ``*.returned`` / ``*.returned`` event using a shared ``call_id``.
+  On exception inside the context block the recorder still emits the
+  paired ``returned`` event with ``is_error=True`` so projections see
+  the failure rather than a half-open call.
+* The recorder is **async** so it can ``await event_store.append``;
+  inside the context block the caller can use ordinary ``await``.
+
+The recorder does not import from :mod:`ouroboros.persistence` — it
+takes a duck-typed ``event_store`` with an ``append(event)`` coroutine.
+That keeps it cheaply testable with a ``list``-backed fake.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+import logging
+import time
+from typing import Any, Protocol
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.events.io import (
+    PREVIEW_DEFAULT_CHARS,
+    PREVIEW_HARD_CAP_CHARS_LLM,
+    PREVIEW_HARD_CAP_CHARS_TOOL,
+    PrivacyMode,
+    content_hash,
+    create_llm_call_requested_event,
+    create_llm_call_returned_event,
+    create_tool_call_returned_event,
+    create_tool_call_started_event,
+    new_call_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _AppendableEventStore(Protocol):
+    """Structural type for the recorder's ``event_store`` argument."""
+
+    def append(self, event: BaseEvent) -> Awaitable[None]: ...
+
+
+@dataclass(slots=True)
+class LLMCallRecord:
+    """Mutable handle returned to the caller inside a recorded LLM call.
+
+    The caller fills this in *before* the context exits so the recorder
+    can emit a fully-populated ``llm.call.returned`` event. Any field
+    left at its default reflects "not provided"; the recorder omits
+    ``None`` fields from the persisted payload (matching the policy in
+    ``events/control.py`` and ``events/io.py``).
+    """
+
+    completion_text: str | None = None
+    finish_reason: str | None = None
+    token_count_in: int | None = None
+    token_count_out: int | None = None
+    is_error: bool = False
+    error_kind: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def record_completion(
+        self,
+        *,
+        completion_text: str | None = None,
+        finish_reason: str | None = None,
+        token_count_in: int | None = None,
+        token_count_out: int | None = None,
+        is_error: bool = False,
+        error_kind: str | None = None,
+        **extra: Any,
+    ) -> None:
+        """Fluent setter that mirrors the keyword shape of the factory."""
+        if completion_text is not None:
+            self.completion_text = completion_text
+        if finish_reason is not None:
+            self.finish_reason = finish_reason
+        if token_count_in is not None:
+            self.token_count_in = token_count_in
+        if token_count_out is not None:
+            self.token_count_out = token_count_out
+        if is_error:
+            self.is_error = True
+        if error_kind is not None:
+            self.error_kind = error_kind
+            self.is_error = True
+        if extra:
+            self.extra.update(extra)
+
+    def record_error(self, *, error_kind: str, completion_text: str | None = None) -> None:
+        """Mark a handled provider-level failure without raising from the context."""
+        self.is_error = True
+        self.error_kind = error_kind
+        if completion_text is not None:
+            self.completion_text = completion_text
+
+
+@dataclass(slots=True)
+class ToolCallRecord:
+    """Mutable handle returned to the caller inside a recorded tool call."""
+
+    result_text: str | None = None
+    is_error: bool = False
+    error_kind: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def record_result(
+        self,
+        *,
+        result_text: str | None = None,
+        error_kind: str | None = None,
+        **extra: Any,
+    ) -> None:
+        if result_text is not None:
+            self.result_text = result_text
+        if error_kind is not None:
+            self.error_kind = error_kind
+            self.is_error = True
+        if extra:
+            self.extra.update(extra)
+
+    def record_error(self, *, error_kind: str, result_text: str | None = None) -> None:
+        """Mark a handled tool failure without raising from the context."""
+        self.is_error = True
+        self.error_kind = error_kind
+        if result_text is not None:
+            self.result_text = result_text
+
+
+@dataclass(frozen=True, slots=True)
+class IOJournalRecorder:
+    """Adapter-side helper that wraps LLM and tool calls in journal events.
+
+    Construction:
+        recorder = IOJournalRecorder(
+            event_store=event_store,         # or None for no-op
+            target_type="execution",
+            target_id="exec_123",
+            session_id="sess_x",             # optional correlation
+            execution_id="exec_123",
+            lineage_id=None,
+            generation_number=None,
+            phase=None,
+        )
+
+    Usage::
+
+        async with recorder.record_llm_call(
+            model_id="claude-opus-4",
+            prompt_text=prompt_str,
+            caller="anthropic_adapter",
+        ) as call:
+            response = await client.messages.create(**kwargs)
+            call.record_completion(
+                completion_text=text,
+                finish_reason="stop",
+                token_count_in=120,
+                token_count_out=80,
+            )
+    """
+
+    event_store: _AppendableEventStore | None
+    target_type: str
+    target_id: str
+    session_id: str | None = None
+    execution_id: str | None = None
+    lineage_id: str | None = None
+    generation_number: int | None = None
+    phase: str | None = None
+    privacy: PrivacyMode | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """``True`` when the recorder has somewhere to append events."""
+        return self.event_store is not None
+
+    @asynccontextmanager
+    async def record_llm_call(
+        self,
+        *,
+        model_id: str,
+        prompt_text: str,
+        caller: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        tool_choice: str | None = None,
+        preview_cap: int = PREVIEW_DEFAULT_CHARS,
+        preview_hard_cap: int = PREVIEW_HARD_CAP_CHARS_LLM,
+        extra: dict[str, Any] | None = None,
+    ) -> AsyncIterator[LLMCallRecord]:
+        """Wrap an outbound LLM call and emit started/returned events.
+
+        The recorder owns the ``call_id``, the timing, the prompt hash,
+        and the privacy-aware preview shaping. The caller's job is to
+        fill in completion details on the yielded :class:`LLMCallRecord`
+        before the context exits.
+        """
+        record = LLMCallRecord()
+        if not self.is_active:
+            yield record
+            return
+
+        call_id = new_call_id()
+        prompt_hash_value = content_hash(prompt_text)
+        started = create_llm_call_requested_event(
+            target_type=self.target_type,
+            target_id=self.target_id,
+            call_id=call_id,
+            model_id=model_id,
+            prompt_hash=prompt_hash_value,
+            prompt_preview=prompt_text,
+            preview_cap=preview_cap,
+            preview_hard_cap=preview_hard_cap,
+            privacy=self.privacy,
+            caller=caller,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tool_choice=tool_choice,
+            session_id=self.session_id,
+            execution_id=self.execution_id,
+            lineage_id=self.lineage_id,
+            generation_number=self.generation_number,
+            phase=self.phase,
+            extra=extra,
+        )
+        started_persisted = await self._append(started)
+
+        start_perf = time.perf_counter()
+        is_error = False
+        error_kind: str | None = None
+        try:
+            yield record
+        except BaseException as exc:  # noqa: BLE001 — the journal must capture every failure path
+            is_error = True
+            error_kind = type(exc).__name__
+            raise
+        finally:
+            duration_ms = int((time.perf_counter() - start_perf) * 1000)
+            completion_hash_value = (
+                content_hash(record.completion_text) if record.completion_text is not None else None
+            )
+            if started_persisted:
+                returned = create_llm_call_returned_event(
+                    target_type=self.target_type,
+                    target_id=self.target_id,
+                    call_id=call_id,
+                    model_id=model_id,
+                    prompt_hash=prompt_hash_value,
+                    duration_ms=duration_ms,
+                    is_error=is_error or record.is_error,
+                    completion_preview=record.completion_text,
+                    preview_cap=preview_cap,
+                    preview_hard_cap=preview_hard_cap,
+                    privacy=self.privacy,
+                    completion_hash=completion_hash_value,
+                    finish_reason=record.finish_reason,
+                    token_count_in=record.token_count_in,
+                    token_count_out=record.token_count_out,
+                    error_kind=error_kind or record.error_kind,
+                    session_id=self.session_id,
+                    execution_id=self.execution_id,
+                    lineage_id=self.lineage_id,
+                    generation_number=self.generation_number,
+                    phase=self.phase,
+                    extra=record.extra or None,
+                )
+                await self._append(returned)
+
+    @asynccontextmanager
+    async def record_tool_call(
+        self,
+        *,
+        tool_name: str,
+        args_text: str,
+        caller: str | None = None,
+        mcp_server: str | None = None,
+        preview_cap: int = PREVIEW_DEFAULT_CHARS,
+        preview_hard_cap: int = PREVIEW_HARD_CAP_CHARS_TOOL,
+        extra: dict[str, Any] | None = None,
+    ) -> AsyncIterator[ToolCallRecord]:
+        """Wrap a tool dispatch and emit started/returned events."""
+        record = ToolCallRecord()
+        if not self.is_active:
+            yield record
+            return
+
+        call_id = new_call_id()
+        args_hash_value = content_hash(args_text)
+        started = create_tool_call_started_event(
+            target_type=self.target_type,
+            target_id=self.target_id,
+            call_id=call_id,
+            tool_name=tool_name,
+            args_hash=args_hash_value,
+            args_preview=args_text,
+            preview_cap=preview_cap,
+            preview_hard_cap=preview_hard_cap,
+            privacy=self.privacy,
+            caller=caller,
+            mcp_server=mcp_server,
+            session_id=self.session_id,
+            execution_id=self.execution_id,
+            lineage_id=self.lineage_id,
+            generation_number=self.generation_number,
+            phase=self.phase,
+            extra=extra,
+        )
+        started_persisted = await self._append(started)
+
+        start_perf = time.perf_counter()
+        is_error = False
+        error_kind: str | None = None
+        try:
+            yield record
+        except BaseException as exc:  # noqa: BLE001 — capture every failure
+            is_error = True
+            error_kind = type(exc).__name__
+            raise
+        finally:
+            duration_ms = int((time.perf_counter() - start_perf) * 1000)
+            result_hash_value = (
+                content_hash(record.result_text) if record.result_text is not None else None
+            )
+            if started_persisted:
+                returned = create_tool_call_returned_event(
+                    target_type=self.target_type,
+                    target_id=self.target_id,
+                    call_id=call_id,
+                    tool_name=tool_name,
+                    duration_ms=duration_ms,
+                    is_error=is_error or record.is_error,
+                    result_hash=result_hash_value,
+                    result_preview=record.result_text,
+                    preview_cap=preview_cap,
+                    preview_hard_cap=preview_hard_cap,
+                    privacy=self.privacy,
+                    error_kind=error_kind or record.error_kind,
+                    session_id=self.session_id,
+                    execution_id=self.execution_id,
+                    lineage_id=self.lineage_id,
+                    generation_number=self.generation_number,
+                    phase=self.phase,
+                    extra=record.extra or None,
+                )
+                await self._append(returned)
+
+    async def _append(self, event: BaseEvent) -> bool:
+        """Best-effort append, returning whether the event was persisted.
+
+        A failed start/request append suppresses the paired return event
+        so the EventStore never contains orphaned ``*.returned`` rows.
+        Failures remain observational: the underlying LLM/tool call is
+        never failed because the journal could not record it, but the
+        drop is logged here because generic EventStore failures are not
+        guaranteed to log before raising.
+        """
+        store = self.event_store
+        if store is None:
+            return False
+        try:
+            await store.append(event)
+        except Exception:  # noqa: BLE001 — observational-first
+            logger.warning(
+                "io_journal.append_failed",
+                extra={
+                    "event_type": event.type,
+                    "target_type": event.aggregate_type,
+                    "target_id": event.aggregate_id,
+                },
+                exc_info=True,
+            )
+            return False
+        return True

--- a/tests/unit/events/test_io_recorder.py
+++ b/tests/unit/events/test_io_recorder.py
@@ -1,0 +1,337 @@
+"""Unit tests for :class:`IOJournalRecorder` (slice 2 of #517).
+
+Coverage:
+- ``record_llm_call`` emits a paired ``llm.call.requested`` /
+  ``llm.call.returned`` with a shared ``call_id``, the prompt hash,
+  and the privacy-aware preview.
+- The completion fields the caller fills on the yielded record (text,
+  finish_reason, token counts) appear on the returned event.
+- An exception inside the context block is re-raised but the recorder
+  still emits a returned event with ``is_error=True`` and the
+  exception type name in ``error_kind``.
+- ``record_tool_call`` mirrors the above shape for tool dispatch.
+- ``event_store=None`` produces a no-op recorder that never emits.
+- ``duration_ms`` is non-negative and roughly tracks the wall-clock
+  spent inside the context block.
+- An EventStore that raises during ``append`` does not propagate the
+  failure (observational-first stance).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.events.io import (
+    PRIVACY_ENV_VAR,
+    REDACTION_MARKER_TEMPLATE,
+    PrivacyMode,
+    content_hash,
+)
+from ouroboros.events.io_recorder import IOJournalRecorder
+
+
+class _FakeEventStore:
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+
+    async def append(self, event: BaseEvent) -> None:
+        self.appended.append(event)
+
+
+class _BrokenEventStore:
+    async def append(self, event: BaseEvent) -> None:
+        raise RuntimeError("simulated EventStore outage")
+
+
+@pytest.mark.asyncio
+async def test_record_llm_call_emits_started_and_returned() -> None:
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_123",
+        execution_id="exec_123",
+    )
+
+    async with recorder.record_llm_call(
+        model_id="claude-opus-4",
+        prompt_text="hello",
+        caller="anthropic_adapter",
+        max_tokens=2048,
+    ) as call:
+        call.record_completion(
+            completion_text="hi there",
+            finish_reason="stop",
+            token_count_in=10,
+            token_count_out=4,
+        )
+
+    assert [e.type for e in store.appended] == [
+        "llm.call.requested",
+        "llm.call.returned",
+    ]
+
+    started, returned = store.appended
+    assert started.data["call_id"] == returned.data["call_id"]
+    assert started.data["model_id"] == "claude-opus-4"
+    assert started.data["prompt_hash"] == content_hash("hello")
+    assert started.data["caller"] == "anthropic_adapter"
+    assert started.data["max_tokens"] == 2048
+
+    assert returned.data["finish_reason"] == "stop"
+    assert returned.data["token_count_in"] == 10
+    assert returned.data["token_count_out"] == 4
+    assert returned.data["completion_hash"] == content_hash("hi there")
+    assert returned.data["is_error"] is False
+    assert returned.data["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_record_llm_call_records_exception_and_re_raises() -> None:
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_err",
+    )
+
+    class _SimulatedFailure(RuntimeError):
+        pass
+
+    with pytest.raises(_SimulatedFailure):
+        async with recorder.record_llm_call(
+            model_id="m",
+            prompt_text="p",
+        ) as _call:
+            raise _SimulatedFailure("network blew up")
+
+    assert len(store.appended) == 2
+    returned = store.appended[1]
+    assert returned.type == "llm.call.returned"
+    assert returned.data["is_error"] is True
+    assert returned.data["error_kind"] == "_SimulatedFailure"
+
+
+@pytest.mark.asyncio
+async def test_record_tool_call_emits_started_and_returned() -> None:
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_tool",
+    )
+
+    async with recorder.record_tool_call(
+        tool_name="filesystem.read",
+        args_text='{"path": "/etc/hosts"}',
+        caller="evolver",
+        mcp_server="filesystem",
+    ) as call:
+        call.record_result(result_text="ok bytes")
+
+    assert [e.type for e in store.appended] == [
+        "tool.call.started",
+        "tool.call.returned",
+    ]
+    started, returned = store.appended
+    assert started.data["tool_name"] == "filesystem.read"
+    assert started.data["args_hash"] == content_hash('{"path": "/etc/hosts"}')
+    assert started.data["mcp_server"] == "filesystem"
+    assert returned.data["result_hash"] == content_hash("ok bytes")
+    assert returned.data["is_error"] is False
+    assert returned.data["call_id"] == started.data["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_no_op_when_event_store_is_none() -> None:
+    recorder = IOJournalRecorder(
+        event_store=None,
+        target_type="execution",
+        target_id="exec_none",
+    )
+    assert recorder.is_active is False
+
+    async with recorder.record_llm_call(
+        model_id="m",
+        prompt_text="p",
+    ) as call:
+        call.record_completion(completion_text="anything", finish_reason="stop")
+    # No appendable store, nothing to assert beyond "no error".
+
+
+@pytest.mark.asyncio
+async def test_privacy_mode_redacted_replaces_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PRIVACY_ENV_VAR, "redacted")
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_priv",
+    )
+
+    async with recorder.record_llm_call(
+        model_id="m",
+        prompt_text="secret prompt",
+    ) as call:
+        call.record_completion(completion_text="secret reply", finish_reason="stop")
+
+    started, returned = store.appended
+    assert started.data["prompt_preview"] == REDACTION_MARKER_TEMPLATE.format(
+        length=len("secret prompt")
+    )
+    assert returned.data["completion_preview"] == REDACTION_MARKER_TEMPLATE.format(
+        length=len("secret reply")
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_privacy_arg_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PRIVACY_ENV_VAR, "redacted")
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_priv",
+        privacy=PrivacyMode.OFF,
+    )
+
+    async with recorder.record_llm_call(
+        model_id="m",
+        prompt_text="secret prompt",
+    ) as call:
+        call.record_completion(completion_text="secret reply", finish_reason="stop")
+
+    started, returned = store.appended
+    assert "prompt_preview" not in started.data
+    assert "completion_preview" not in returned.data
+
+
+@pytest.mark.asyncio
+async def test_duration_tracks_wall_clock_inside_block() -> None:
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_time",
+    )
+
+    async with recorder.record_llm_call(
+        model_id="m",
+        prompt_text="p",
+    ) as call:
+        await asyncio.sleep(0.02)
+        call.record_completion(completion_text="x", finish_reason="stop")
+
+    returned = store.appended[1]
+    assert returned.data["duration_ms"] >= 15  # generous floor for CI jitter
+
+
+@pytest.mark.asyncio
+async def test_event_store_failure_does_not_propagate() -> None:
+    """Observational-first: a broken EventStore must never break the LLM call."""
+    store = _BrokenEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_broken",
+    )
+
+    # No exception is raised even though every store.append() call fails.
+    async with recorder.record_llm_call(
+        model_id="m",
+        prompt_text="p",
+    ) as call:
+        call.record_completion(completion_text="ok", finish_reason="stop")
+
+
+class _FailFirstEventStore:
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+        self.calls = 0
+
+    async def append(self, event: BaseEvent) -> None:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("start append failed")
+        self.appended.append(event)
+
+
+@pytest.mark.asyncio
+async def test_started_append_failure_suppresses_orphaned_returned_event(caplog) -> None:
+    store = _FailFirstEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_partial",
+    )
+
+    async with recorder.record_llm_call(model_id="m", prompt_text="p") as call:
+        call.record_completion(completion_text="ok", finish_reason="stop")
+
+    assert store.appended == []
+    assert store.calls == 1
+    assert "io_journal.append_failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_recorder_privacy_override_and_preview_cap_are_honored(monkeypatch) -> None:
+    monkeypatch.setenv(PRIVACY_ENV_VAR, "off")
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_override",
+        privacy=PrivacyMode.ON,
+    )
+
+    async with recorder.record_llm_call(
+        model_id="m",
+        prompt_text="abcdef",
+        preview_cap=3,
+    ) as call:
+        call.record_completion(completion_text="ghijkl", finish_reason="stop")
+
+    started, returned = store.appended
+    assert started.data["prompt_preview"].startswith("abc")
+    assert "truncated len=3" in started.data["prompt_preview"]
+    assert returned.data["completion_preview"].startswith("ghi")
+    assert "truncated len=3" in returned.data["completion_preview"]
+
+
+@pytest.mark.asyncio
+async def test_record_llm_call_allows_handled_error_marking() -> None:
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store, target_type="execution", target_id="exec_handled"
+    )
+
+    async with recorder.record_llm_call(model_id="m", prompt_text="p") as call:
+        call.record_error(error_kind="ProviderError", completion_text="error payload")
+
+    returned = store.appended[1]
+    assert returned.data["is_error"] is True
+    assert returned.data["error_kind"] == "ProviderError"
+    assert returned.data["completion_hash"] == content_hash("error payload")
+
+
+@pytest.mark.asyncio
+async def test_record_tool_call_allows_handled_error_marking() -> None:
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store, target_type="execution", target_id="exec_tool_err"
+    )
+
+    async with recorder.record_tool_call(tool_name="tool", args_text="{}") as call:
+        call.record_error(error_kind="ToolError", result_text="bad result")
+
+    returned = store.appended[1]
+    assert returned.data["is_error"] is True
+    assert returned.data["error_kind"] == "ToolError"
+    assert returned.data["result_hash"] == content_hash("bad result")


### PR DESCRIPTION
## Summary

Second slice of #517: introduces the `IOJournalRecorder` async context manager that wraps an outbound LLM or tool call and emits the paired `started/returned` journal events with shared `call_id`, duration, hashing, privacy-aware preview shaping, and exception capture.

The recorder makes per-adapter wiring a **4-line addition** rather than duplicating factory + hashing + privacy + timing boilerplate at every call site. Subsequent slices (Anthropic / LiteLLM / Claude Code / Codex CLI / Gemini CLI / OpenCode / MCP tool dispatch) just need to pass a recorder where appropriate and call `record_completion` / `record_result` inside the context block.

> **Stack notice.** Depends on **#532** (slice 1 — I/O Journal foundation).

## Usage example

```python
async with recorder.record_llm_call(
    model_id="claude-opus-4",
    prompt_text=prompt_str,
    caller="anthropic_adapter",
    max_tokens=2048,
) as call:
    response = await client.messages.create(**kwargs)
    call.record_completion(
        completion_text=response_text,
        finish_reason="stop",
        token_count_in=120,
        token_count_out=80,
    )
```

## Design choices baked in

- **Always opt-in.** `event_store=None` produces a no-op recorder that yields the same shape but emits nothing. Adapters that have not yet adopted the journal pass `None` and continue to work unchanged.
- **The recorder owns the boilerplate.** `call_id`, timing (`duration_ms`), prompt/result hashing (`sha256:`), and privacy-aware preview shaping all happen inside the recorder. Callers only provide payload text and metadata.
- **Exception-aware.** On an exception inside the context block the recorder re-raises but still emits the paired `*.returned` event with `is_error=True` and the exception type name in `error_kind`. Projections see the failure rather than a half-open call.
- **Observational-first.** A broken EventStore (`append()` raises) does NOT propagate the failure. The journal stays out of the way; LLM/tool calls never fail because the recorder could not persist.
- **Duck-typed `event_store`.** Protocol with one `append(event)` coroutine. No import from `ouroboros.persistence`, so the helper is cheap to test with a list-backed fake.

## Changes

- `src/ouroboros/events/io_recorder.py` — new module, ~330 LOC.
- `tests/unit/events/test_io_recorder.py` — 8 cases.

## Verification

| Check | Result |
|---|---|
| `uv run ruff check src/ouroboros/events/io_recorder.py tests/unit/events/test_io_recorder.py` | clean (after import-order auto-fix) |
| `uv run ruff format ...` | no diff |
| `uv run pytest tests/unit/events/test_io_recorder.py tests/unit/events/test_io_events.py` | 38 passed |

## Pre-merge checklist

- [x] `record_llm_call` emits paired requested/returned with shared `call_id`
- [x] Completion fields filled by the caller propagate to the returned event
- [x] Exception inside the block → `is_error=True` + `error_kind` populated, exception re-raised
- [x] `record_tool_call` mirrors the LLM shape for tool dispatch
- [x] `event_store=None` → no events emitted (recorder is idle)
- [x] Privacy switch resolved from env or explicit override
- [x] Broken EventStore does not propagate (observational-first)
- [x] No emission site introduced — adapters adopt in follow-up PRs
- [x] CI: ruff + format + targeted pytest all green

## Post-merge checklist

- [ ] Slice 3: Anthropic + LiteLLM adapters use the recorder around their LLM call
- [ ] Slice 4: Claude Code + Codex CLI
- [ ] Slice 5: Gemini CLI + OpenCode
- [ ] Slice 6: MCP tool dispatch path uses `record_tool_call`
- [ ] Slice 7: M3 acceptance scenario (closes #517)

## Rollback

The change is purely additive: a new module + tests. No existing behaviour or schema is touched. Rollback steps:

1. Revert this PR. The new helper disappears; no follow-up adapter PR has merged yet, so no caller depends on it.
2. No data, schema, or runtime behaviour change to undo.

Stack: depends on #532.
