### PR TITLE
feat(orchestrator): AgentProcess interface + cooperative lifecycle (M6 / slice 1 of #518)

### DIFF
--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -136,6 +136,7 @@ class AgentProcessHandle:
     _cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
     _paused_event: asyncio.Event = field(default_factory=asyncio.Event)
     _completed_event: asyncio.Event = field(default_factory=asyncio.Event)
+    _cancel_reason: str = "cancel requested"
     _emit_directive: Callable[[Directive, str], Awaitable[None]] | None = None
 
     def __post_init__(self) -> None:
@@ -158,7 +159,6 @@ class AgentProcessHandle:
         if self._status in _TERMINAL_STATUSES:
             return
         self._paused_event.clear()
-        await self._set_status(AgentProcessStatus.PAUSED, reason="pause requested")
 
     async def resume(self) -> None:
         """Release a paused work loop.
@@ -166,10 +166,11 @@ class AgentProcessHandle:
         No-op when the process is not currently paused. Returns it to
         :attr:`AgentProcessStatus.RUNNING`.
         """
-        if self._status is not AgentProcessStatus.PAUSED:
+        if self._status in _TERMINAL_STATUSES or not self.should_pause():
             return
         self._paused_event.set()
-        await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
+        if self._status is AgentProcessStatus.PAUSED:
+            await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
 
     async def cancel(self, reason: str = "cancel requested") -> None:
         """Request a cooperative cancel.
@@ -180,11 +181,12 @@ class AgentProcessHandle:
         """
         if self._status in _TERMINAL_STATUSES:
             return
+        self._cancel_reason = reason
         self._cancel_event.set()
         # Clearing the paused-flag releases a paused loop so it can
-        # observe the cancel flag immediately.
+        # observe the cancel flag immediately. The CANCELLED transition
+        # itself is emitted only when the work task actually exits.
         self._paused_event.set()
-        await self._set_status(AgentProcessStatus.CANCELLED, reason=reason)
 
     async def replay(self) -> Any:
         """Replay the process timeline (slice 3 of #518; not yet implemented)."""
@@ -215,7 +217,11 @@ class AgentProcessHandle:
         The workflow loop calls this at every checkpoint; if the process
         is not paused the call returns immediately.
         """
+        if self.should_pause() and self._status is AgentProcessStatus.RUNNING:
+            await self._set_status(AgentProcessStatus.PAUSED, reason="pause acknowledged")
         await self._paused_event.wait()
+        if self._status is AgentProcessStatus.PAUSED and not self.should_cancel():
+            await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
 
     async def wait_until_complete(self, *, timeout: float | None = None) -> AgentProcessStatus:
         """Wait for a terminal status transition.
@@ -253,6 +259,13 @@ class AgentProcessHandle:
             await self._emit_directive(Directive.CANCEL, reason)
         self._completed_event.set()
 
+    async def mark_cancelled(self) -> None:
+        """Mark the process as cancelled after the work task has exited."""
+        if self._status in {AgentProcessStatus.COMPLETED, AgentProcessStatus.FAILED}:
+            return
+        await self._set_status(AgentProcessStatus.CANCELLED, reason=self._cancel_reason)
+        self._completed_event.set()
+
     def mark_work_exited(self) -> None:
         """Mark the underlying work task as exited without changing lifecycle status."""
         self._completed_event.set()
@@ -264,7 +277,7 @@ class AgentProcessHandle:
         directive = _TRANSITION_DIRECTIVE.get(new_status)
         if directive is not None and self._emit_directive is not None:
             await self._emit_directive(directive, reason)
-        if new_status in {AgentProcessStatus.COMPLETED, AgentProcessStatus.FAILED}:
+        if new_status in _TERMINAL_STATUSES:
             self._completed_event.set()
 
 
@@ -282,7 +295,7 @@ class AgentProcess:
 
     The factory:
 
-    * Allocates a new ``process_id`` per spawn (ULID-style hex).
+    * Allocates a new ``process_id`` per spawn (UUID4 hex).
     * Wires the lifecycle directive emitter so transitions land on the
       EventStore.
     * Drives the work function on the event loop and finalises the
@@ -331,7 +344,7 @@ class AgentProcess:
                 await work_fn(handle)
             except asyncio.CancelledError:
                 await handle.cancel(reason="cancelled by event loop")
-                handle.mark_work_exited()
+                await handle.mark_cancelled()
                 raise
             except BaseException as exc:  # noqa: BLE001 — runtime must capture every failure
                 if handle.status() in _TERMINAL_STATUSES:
@@ -341,8 +354,8 @@ class AgentProcess:
                 logger.exception("agent_process.work_failed", extra={"process_id": pid})
                 return
             else:
-                if handle.status() is AgentProcessStatus.CANCELLED:
-                    handle.mark_work_exited()
+                if handle.should_cancel():
+                    await handle.mark_cancelled()
                 else:
                     await handle.mark_completed(reason="work returned")
 

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -1,0 +1,378 @@
+"""``AgentProcess`` — cooperative lifecycle for long-running workflows.
+
+Issue #518 — M6 of the Phase-2 Agent OS RFC. The five verbs ``spawn``,
+``pause``, ``resume``, ``cancel``, and ``replay`` are the unified
+abstraction every long-running workflow consumes (ralph, evolve_step,
+execute_seed). This module is **slice 1 of #518** — the interface
+itself, an in-memory implementation that supports cooperative
+``cancel()``, ``pause()``, ``resume()``, and ``status()``, plus the
+lifecycle directive emission that lands ``control.directive.emitted``
+events with ``target_type="agent_process"``.
+
+The verbs whose durability is the headline of #518 are intentionally
+left for follow-up slices so this PR stays single-responsibility:
+
+* ``replay()`` raises :class:`NotImplementedError`. Slice 3 (#518)
+  reads the EventStore and reconstructs a timeline.
+* ``pause()`` / ``resume()`` are in-memory only here — they signal a
+  cooperative work loop via :meth:`AgentProcessHandle.should_pause`
+  but they do **not** persist a checkpoint. Slice 2 (#518) extends
+  the existing :class:`CheckpointStore` (#338) so pause survives a
+  process restart.
+
+Cooperative semantics, locked here:
+
+* ``cancel()`` sets a flag. The work loop checks it at deterministic
+  points (start of each AC iteration, before each LLM call, before
+  each tool call — see #518 sub-thread). In-flight LLM/tool calls
+  finish naturally; the loop exits at the next checkpoint.
+* ``pause()`` sets a flag. The work loop awaits
+  :meth:`AgentProcessHandle.wait_unpaused` whenever it reaches a
+  checkpoint, releasing only when ``resume()`` is called.
+* Per #476, the trust model is cooperative: a misbehaving work
+  function can ignore the flags, but the runtime does not police
+  identity. Forced kill is Tier-3 C2 territory, gated by evidence.
+
+Lifecycle directive emission, per the body of #518:
+
+* On every status transition the runtime appends a
+  ``control.directive.emitted`` event with
+  ``target_type="agent_process"`` and ``target_id=<process_id>``.
+* Mapping (locked): pause → ``WAIT``, resume → ``CONTINUE``,
+  cancel → ``CANCEL``, complete → ``CONVERGE``.
+* Internal loop directives (``RETRY``, ``EVOLVE`` …) are *not*
+  emitted by this module — those are the workflow's job
+  (e.g. evolution emits ``RETRY``/``CONVERGE`` itself per #525).
+
+The module deliberately does not import any handler-side type so
+adopting :class:`AgentProcess` is a one-import change for the three
+reference migrations in slices 4–6 of #518.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+import logging
+from typing import Any, Final
+from uuid import uuid4
+
+from ouroboros.core.directive import Directive
+from ouroboros.events.control import create_control_directive_emitted_event
+
+logger = logging.getLogger(__name__)
+
+
+_TARGET_TYPE: Final[str] = "agent_process"
+_EMITTED_BY: Final[str] = "agent_process"
+
+
+class AgentProcessStatus(StrEnum):
+    """Lifecycle state of an :class:`AgentProcessHandle`.
+
+    Transitions land a ``control.directive.emitted`` event so the
+    journal answers "what was this process doing at time T?" without
+    requiring runtime logs (the M2 invariant from #476).
+    """
+
+    RUNNING = "running"
+    PAUSED = "paused"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+_TERMINAL_STATUSES: Final[frozenset[AgentProcessStatus]] = frozenset(
+    {
+        AgentProcessStatus.CANCELLED,
+        AgentProcessStatus.COMPLETED,
+        AgentProcessStatus.FAILED,
+    }
+)
+
+
+# Mapping from a status transition to the directive that lands on the
+# journal. Per the body of #518, only externally-observed lifecycle
+# transitions emit directives; *internal* loop semantics (RETRY,
+# EVOLVE) remain the workflow's responsibility.
+_TRANSITION_DIRECTIVE: Final[dict[AgentProcessStatus, Directive]] = {
+    AgentProcessStatus.RUNNING: Directive.CONTINUE,
+    AgentProcessStatus.PAUSED: Directive.WAIT,
+    AgentProcessStatus.CANCELLED: Directive.CANCEL,
+    AgentProcessStatus.COMPLETED: Directive.CONVERGE,
+    # FAILED has no canonical Directive in the current vocabulary.
+    # The workflow that produced the failure is responsible for the
+    # specific reason directive (e.g. RETRY exhaustion → CANCEL via
+    # the evolution mapping in #525).
+}
+
+
+class _AppendableEventStore:
+    """Structural type for the recorder's ``event_store`` argument.
+
+    Defined here instead of imported so the module has no runtime
+    dependency on the persistence layer; tests use a list-backed fake.
+    """
+
+    def append(self, event: Any) -> Awaitable[None]:  # pragma: no cover — Protocol-style
+        ...
+
+
+@dataclass(slots=True)
+class AgentProcessHandle:
+    """Cooperative handle returned from :meth:`AgentProcess.spawn`.
+
+    The handle is the surface workflows interact with. Internal work
+    loops drive the handle's flag state via :meth:`should_cancel` and
+    :meth:`wait_unpaused`; external callers drive lifecycle via the
+    five verbs (``pause`` / ``resume`` / ``cancel`` / ``replay`` /
+    ``status``).
+    """
+
+    process_id: str
+    _status: AgentProcessStatus = AgentProcessStatus.RUNNING
+    _cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
+    _paused_event: asyncio.Event = field(default_factory=asyncio.Event)
+    _completed_event: asyncio.Event = field(default_factory=asyncio.Event)
+    _emit_directive: Callable[[Directive, str], Awaitable[None]] | None = None
+
+    def __post_init__(self) -> None:
+        # The paused-event is "set" when the loop is *not* paused so a
+        # ``wait_unpaused()`` returns immediately by default. ``pause()``
+        # clears the event.
+        self._paused_event.set()
+
+    # ------------------------------------------------------------------
+    # External lifecycle verbs
+    # ------------------------------------------------------------------
+
+    async def pause(self) -> None:
+        """Request a cooperative pause.
+
+        The work loop reaches a checkpoint, awaits :meth:`wait_unpaused`,
+        and resumes only when :meth:`resume` is called. No-op when the
+        process has already terminated.
+        """
+        if self._status in _TERMINAL_STATUSES:
+            return
+        self._paused_event.clear()
+        await self._set_status(AgentProcessStatus.PAUSED, reason="pause requested")
+
+    async def resume(self) -> None:
+        """Release a paused work loop.
+
+        No-op when the process is not currently paused. Returns it to
+        :attr:`AgentProcessStatus.RUNNING`.
+        """
+        if self._status is not AgentProcessStatus.PAUSED:
+            return
+        self._paused_event.set()
+        await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
+
+    async def cancel(self, reason: str = "cancel requested") -> None:
+        """Request a cooperative cancel.
+
+        The work loop sees the cancel flag at the next checkpoint and
+        exits cleanly. In-flight LLM/tool calls finish naturally; the
+        loop exits before starting the next iteration.
+        """
+        if self._status in _TERMINAL_STATUSES:
+            return
+        self._cancel_event.set()
+        # Clearing the paused-flag releases a paused loop so it can
+        # observe the cancel flag immediately.
+        self._paused_event.set()
+        await self._set_status(AgentProcessStatus.CANCELLED, reason=reason)
+
+    async def replay(self) -> Any:
+        """Replay the process timeline (slice 3 of #518; not yet implemented)."""
+        raise NotImplementedError(
+            "AgentProcessHandle.replay() lands in slice 3 of #518; "
+            "this PR ships the interface and the cooperative cancel/pause path only."
+        )
+
+    def status(self) -> AgentProcessStatus:
+        """Return the current lifecycle status."""
+        return self._status
+
+    # ------------------------------------------------------------------
+    # Internal cooperative signals (consumed by the work loop)
+    # ------------------------------------------------------------------
+
+    def should_cancel(self) -> bool:
+        """``True`` once :meth:`cancel` has been called."""
+        return self._cancel_event.is_set()
+
+    def should_pause(self) -> bool:
+        """``True`` while the loop is paused; pairs with :meth:`wait_unpaused`."""
+        return not self._paused_event.is_set()
+
+    async def wait_unpaused(self) -> None:
+        """Block until the loop is unpaused.
+
+        The workflow loop calls this at every checkpoint; if the process
+        is not paused the call returns immediately.
+        """
+        await self._paused_event.wait()
+
+    async def wait_until_complete(self, *, timeout: float | None = None) -> AgentProcessStatus:
+        """Wait for a terminal status transition.
+
+        Useful for tests and synchronous callers that want to block on
+        completion. Returns the terminal status.
+        """
+        await asyncio.wait_for(self._completed_event.wait(), timeout=timeout)
+        return self._status
+
+    # ------------------------------------------------------------------
+    # Status transition machinery
+    # ------------------------------------------------------------------
+
+    async def mark_completed(self, *, reason: str = "work loop returned") -> None:
+        """Mark the process as completed and emit the lifecycle directive."""
+        if self._status in _TERMINAL_STATUSES:
+            return
+        await self._set_status(AgentProcessStatus.COMPLETED, reason=reason)
+
+    async def mark_failed(self, *, reason: str) -> None:
+        """Mark the process as failed and emit a ``CANCEL`` directive.
+
+        ``FAILED`` does not have a canonical Directive in the current
+        vocabulary; the lifecycle directive is ``CANCEL`` so projections
+        treat it as terminal. The actual *reason* string carries the
+        diagnostic detail.
+        """
+        if self._status in _TERMINAL_STATUSES:
+            return
+        # Manually set status before emission so the directive carries
+        # the FAILED label even though the directive itself is CANCEL.
+        self._status = AgentProcessStatus.FAILED
+        if self._emit_directive is not None:
+            await self._emit_directive(Directive.CANCEL, reason)
+        self._completed_event.set()
+
+    async def _set_status(self, new_status: AgentProcessStatus, *, reason: str) -> None:
+        if new_status == self._status:
+            return
+        self._status = new_status
+        directive = _TRANSITION_DIRECTIVE.get(new_status)
+        if directive is not None and self._emit_directive is not None:
+            await self._emit_directive(directive, reason)
+        if new_status in _TERMINAL_STATUSES:
+            self._completed_event.set()
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProcess:
+    """Factory that spawns :class:`AgentProcessHandle` instances.
+
+    Construction:
+        process = AgentProcess(event_store=event_store)
+        handle = await process.spawn(
+            intent="ralph",
+            work_fn=async_work_function,
+        )
+        await handle.wait_until_complete()
+
+    The factory:
+
+    * Allocates a new ``process_id`` per spawn (ULID-style hex).
+    * Wires the lifecycle directive emitter so transitions land on the
+      EventStore.
+    * Drives the work function on the event loop and finalises the
+      handle's status when the work returns or raises.
+    """
+
+    event_store: _AppendableEventStore | None = None
+
+    async def spawn(
+        self,
+        *,
+        intent: str,
+        work_fn: Callable[[AgentProcessHandle], Awaitable[Any]],
+        process_id: str | None = None,
+    ) -> AgentProcessHandle:
+        """Start a new agent process and return its handle.
+
+        Args:
+            intent: Short human-readable label for the workflow
+                (``"ralph"``, ``"evolve_step"`` …). Surfaced in the
+                lifecycle directive's ``reason`` field as
+                ``"<intent>: <reason>"`` so projections can group by
+                workflow without joining back to context events.
+            work_fn: An async function that performs the workflow.
+                The function receives the :class:`AgentProcessHandle`
+                so it can poll :meth:`AgentProcessHandle.should_cancel`
+                and ``await`` :meth:`AgentProcessHandle.wait_unpaused`
+                at cooperative checkpoints.
+            process_id: Optional identifier override. By default a
+                fresh hex token is allocated.
+
+        Returns:
+            The :class:`AgentProcessHandle` wired to the work loop.
+        """
+        pid = process_id or _new_process_id()
+        emit = self._make_emitter(intent=intent, process_id=pid)
+        handle = AgentProcessHandle(process_id=pid, _emit_directive=emit)
+        # Emit the initial RUNNING transition so projections have a
+        # spawn marker even if the loop fails before the first
+        # cooperative checkpoint.
+        if emit is not None:
+            await emit(Directive.CONTINUE, f"{intent}: spawned")
+
+        async def _runner() -> None:
+            try:
+                await work_fn(handle)
+            except asyncio.CancelledError:
+                await handle.cancel(reason=f"{intent}: cancelled by event loop")
+                raise
+            except BaseException as exc:  # noqa: BLE001 — runtime must capture every failure
+                await handle.mark_failed(
+                    reason=f"{intent}: work raised {type(exc).__name__}: {exc!s}"
+                )
+                logger.exception("agent_process.work_failed", extra={"process_id": pid})
+                return
+            else:
+                await handle.mark_completed(reason=f"{intent}: work returned")
+
+        # Spawn but do not await — the caller drives lifecycle through
+        # the handle.
+        asyncio.create_task(_runner(), name=f"agent_process:{pid}")
+        return handle
+
+    def _make_emitter(
+        self, *, intent: str, process_id: str
+    ) -> Callable[[Directive, str], Awaitable[None]] | None:
+        """Build the directive-emit callable used by the handle."""
+        store = self.event_store
+        if store is None:
+            return None
+
+        async def emit(directive: Directive, reason: str) -> None:
+            try:
+                event = create_control_directive_emitted_event(
+                    target_type=_TARGET_TYPE,
+                    target_id=process_id,
+                    emitted_by=_EMITTED_BY,
+                    directive=directive,
+                    reason=f"{intent}: {reason}" if reason else intent,
+                    extra={"intent": intent},
+                )
+                await store.append(event)
+            except Exception:  # noqa: BLE001 — observational-first
+                # Per #476 the journal stays out of the way. Failures
+                # here are logged but never propagate; lifecycle
+                # transitions complete regardless.
+                logger.warning(
+                    "agent_process.directive_emit_failed",
+                    extra={"process_id": process_id, "directive": directive.value},
+                )
+
+        return emit
+
+
+def _new_process_id() -> str:
+    """Return a fresh process_id."""
+    return uuid4().hex

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -120,6 +120,18 @@ class _AppendableEventStore(Protocol):
         ...
 
 
+async def _ensure_event_store_initialized(store: _AppendableEventStore) -> None:
+    """Initialize concrete EventStore-like objects before first append.
+
+    The real persistence EventStore requires ``initialize()`` before
+    ``append()``. Fakes used in tests usually do not expose that method,
+    so this stays duck-typed and no-ops when unavailable.
+    """
+    initialize = getattr(store, "initialize", None)
+    if callable(initialize):
+        await initialize()
+
+
 @dataclass(slots=True)
 class AgentProcessHandle:
     """Cooperative handle returned from :meth:`AgentProcess.spawn`.
@@ -377,6 +389,7 @@ class AgentProcess:
             directive: Directive, reason: str, lifecycle_status: AgentProcessStatus
         ) -> None:
             try:
+                await _ensure_event_store_initialized(store)
                 event = create_control_directive_emitted_event(
                     target_type=_TARGET_TYPE,
                     target_id=process_id,

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -253,6 +253,10 @@ class AgentProcessHandle:
             await self._emit_directive(Directive.CANCEL, reason)
         self._completed_event.set()
 
+    def mark_work_exited(self) -> None:
+        """Mark the underlying work task as exited without changing lifecycle status."""
+        self._completed_event.set()
+
     async def _set_status(self, new_status: AgentProcessStatus, *, reason: str) -> None:
         if new_status == self._status:
             return
@@ -260,7 +264,7 @@ class AgentProcessHandle:
         directive = _TRANSITION_DIRECTIVE.get(new_status)
         if directive is not None and self._emit_directive is not None:
             await self._emit_directive(directive, reason)
-        if new_status in _TERMINAL_STATUSES:
+        if new_status in {AgentProcessStatus.COMPLETED, AgentProcessStatus.FAILED}:
             self._completed_event.set()
 
 
@@ -320,22 +324,27 @@ class AgentProcess:
         # spawn marker even if the loop fails before the first
         # cooperative checkpoint.
         if emit is not None:
-            await emit(Directive.CONTINUE, f"{intent}: spawned")
+            await emit(Directive.CONTINUE, "spawned")
 
         async def _runner() -> None:
             try:
                 await work_fn(handle)
             except asyncio.CancelledError:
-                await handle.cancel(reason=f"{intent}: cancelled by event loop")
+                await handle.cancel(reason="cancelled by event loop")
+                handle.mark_work_exited()
                 raise
             except BaseException as exc:  # noqa: BLE001 — runtime must capture every failure
-                await handle.mark_failed(
-                    reason=f"{intent}: work raised {type(exc).__name__}: {exc!s}"
-                )
+                if handle.status() in _TERMINAL_STATUSES:
+                    handle.mark_work_exited()
+                else:
+                    await handle.mark_failed(reason=f"work raised {type(exc).__name__}: {exc!s}")
                 logger.exception("agent_process.work_failed", extra={"process_id": pid})
                 return
             else:
-                await handle.mark_completed(reason=f"{intent}: work returned")
+                if handle.status() is AgentProcessStatus.CANCELLED:
+                    handle.mark_work_exited()
+                else:
+                    await handle.mark_completed(reason="work returned")
 
         # Spawn but do not await — the caller drives lifecycle through
         # the handle.

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -137,7 +137,7 @@ class AgentProcessHandle:
     _paused_event: asyncio.Event = field(default_factory=asyncio.Event)
     _completed_event: asyncio.Event = field(default_factory=asyncio.Event)
     _cancel_reason: str = "cancel requested"
-    _emit_directive: Callable[[Directive, str], Awaitable[None]] | None = None
+    _emit_directive: Callable[[Directive, str, AgentProcessStatus], Awaitable[None]] | None = None
 
     def __post_init__(self) -> None:
         # The paused-event is "set" when the loop is *not* paused so a
@@ -236,37 +236,36 @@ class AgentProcessHandle:
     # Status transition machinery
     # ------------------------------------------------------------------
 
-    async def mark_completed(self, *, reason: str = "work loop returned") -> None:
+    async def _mark_completed(self, *, reason: str = "work loop returned") -> None:
         """Mark the process as completed and emit the lifecycle directive."""
         if self._status in _TERMINAL_STATUSES:
             return
         await self._set_status(AgentProcessStatus.COMPLETED, reason=reason)
 
-    async def mark_failed(self, *, reason: str) -> None:
-        """Mark the process as failed and emit a ``CANCEL`` directive.
+    async def _mark_failed(self, *, reason: str, force: bool = False) -> None:
+        """Mark the process as failed and persist structured lifecycle status.
 
         ``FAILED`` does not have a canonical Directive in the current
-        vocabulary; the lifecycle directive is ``CANCEL`` so projections
-        treat it as terminal. The actual *reason* string carries the
-        diagnostic detail.
+        vocabulary, so the directive remains ``CANCEL`` while the journal
+        stores ``extra.lifecycle_status=failed`` for replay/projectors.
+        ``force=True`` is used by the runner exception path so a leaked
+        internal terminal transition cannot hide a later work failure.
         """
-        if self._status in _TERMINAL_STATUSES:
+        if self._status in _TERMINAL_STATUSES and not force:
             return
-        # Manually set status before emission so the directive carries
-        # the FAILED label even though the directive itself is CANCEL.
         self._status = AgentProcessStatus.FAILED
         if self._emit_directive is not None:
-            await self._emit_directive(Directive.CANCEL, reason)
+            await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)
         self._completed_event.set()
 
-    async def mark_cancelled(self) -> None:
+    async def _mark_cancelled(self) -> None:
         """Mark the process as cancelled after the work task has exited."""
         if self._status in {AgentProcessStatus.COMPLETED, AgentProcessStatus.FAILED}:
             return
         await self._set_status(AgentProcessStatus.CANCELLED, reason=self._cancel_reason)
         self._completed_event.set()
 
-    def mark_work_exited(self) -> None:
+    def _mark_work_exited(self) -> None:
         """Mark the underlying work task as exited without changing lifecycle status."""
         self._completed_event.set()
 
@@ -276,7 +275,7 @@ class AgentProcessHandle:
         self._status = new_status
         directive = _TRANSITION_DIRECTIVE.get(new_status)
         if directive is not None and self._emit_directive is not None:
-            await self._emit_directive(directive, reason)
+            await self._emit_directive(directive, reason, new_status)
         if new_status in _TERMINAL_STATUSES:
             self._completed_event.set()
 
@@ -337,27 +336,29 @@ class AgentProcess:
         # spawn marker even if the loop fails before the first
         # cooperative checkpoint.
         if emit is not None:
-            await emit(Directive.CONTINUE, "spawned")
+            await emit(Directive.CONTINUE, "spawned", AgentProcessStatus.RUNNING)
 
         async def _runner() -> None:
             try:
                 await work_fn(handle)
             except asyncio.CancelledError:
                 await handle.cancel(reason="cancelled by event loop")
-                await handle.mark_cancelled()
+                await handle._mark_cancelled()
                 raise
             except BaseException as exc:  # noqa: BLE001 — runtime must capture every failure
                 if handle.status() in _TERMINAL_STATUSES:
-                    handle.mark_work_exited()
+                    await handle._mark_failed(
+                        reason=f"work raised {type(exc).__name__}: {exc!s}", force=True
+                    )
                 else:
-                    await handle.mark_failed(reason=f"work raised {type(exc).__name__}: {exc!s}")
+                    await handle._mark_failed(reason=f"work raised {type(exc).__name__}: {exc!s}")
                 logger.exception("agent_process.work_failed", extra={"process_id": pid})
                 return
             else:
                 if handle.should_cancel():
-                    await handle.mark_cancelled()
+                    await handle._mark_cancelled()
                 else:
-                    await handle.mark_completed(reason="work returned")
+                    await handle._mark_completed(reason="work returned")
 
         # Spawn but do not await — the caller drives lifecycle through
         # the handle.
@@ -366,13 +367,15 @@ class AgentProcess:
 
     def _make_emitter(
         self, *, intent: str, process_id: str
-    ) -> Callable[[Directive, str], Awaitable[None]] | None:
+    ) -> Callable[[Directive, str, AgentProcessStatus], Awaitable[None]] | None:
         """Build the directive-emit callable used by the handle."""
         store = self.event_store
         if store is None:
             return None
 
-        async def emit(directive: Directive, reason: str) -> None:
+        async def emit(
+            directive: Directive, reason: str, lifecycle_status: AgentProcessStatus
+        ) -> None:
             try:
                 event = create_control_directive_emitted_event(
                     target_type=_TARGET_TYPE,
@@ -380,7 +383,7 @@ class AgentProcess:
                     emitted_by=_EMITTED_BY,
                     directive=directive,
                     reason=f"{intent}: {reason}" if reason else intent,
-                    extra={"intent": intent},
+                    extra={"intent": intent, "lifecycle_status": lifecycle_status.value},
                 )
                 await store.append(event)
             except Exception:  # noqa: BLE001 — observational-first

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -56,7 +56,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 import logging
-from typing import Any, Final
+from typing import Any, Final, Protocol
 from uuid import uuid4
 
 from ouroboros.core.directive import Directive
@@ -109,7 +109,7 @@ _TRANSITION_DIRECTIVE: Final[dict[AgentProcessStatus, Directive]] = {
 }
 
 
-class _AppendableEventStore:
+class _AppendableEventStore(Protocol):
     """Structural type for the recorder's ``event_store`` argument.
 
     Defined here instead of imported so the module has no runtime

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -156,7 +156,7 @@ class AgentProcessHandle:
         and resumes only when :meth:`resume` is called. No-op when the
         process has already terminated.
         """
-        if self._status in _TERMINAL_STATUSES:
+        if self._status in _TERMINAL_STATUSES or self.should_cancel():
             return
         self._paused_event.clear()
 

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -16,6 +16,7 @@ from ouroboros.orchestrator.agent_process import (
     AgentProcess,
     AgentProcessStatus,
 )
+from ouroboros.persistence.event_store import EventStore
 
 
 class _FakeEventStore:
@@ -40,6 +41,24 @@ async def _wait_for_status(handle, status: AgentProcessStatus) -> None:
             return
         await asyncio.sleep(0.01)
     raise AssertionError(f"status did not become {status}")
+
+
+@pytest.mark.asyncio
+async def test_spawn_initializes_concrete_event_store_before_emitting() -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):
+        return None
+
+    try:
+        handle = await process.spawn(intent="ralph", work_fn=work)
+        await handle.wait_until_complete(timeout=1.0)
+        events = await store.replay("agent_process", handle.process_id)
+    finally:
+        await store.close()
+
+    assert [event.data["directive"] for event in events] == ["continue", "converge"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -268,3 +268,46 @@ async def test_status_is_running_immediately_after_spawn() -> None:
     await asyncio.wait_for(started.wait(), timeout=1.0)
     assert handle.status() is AgentProcessStatus.RUNNING
     await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_until_complete_waits_for_cancelled_work_to_exit() -> None:
+    process = AgentProcess(event_store=None)
+    release = asyncio.Event()
+    exited = asyncio.Event()
+
+    async def work(handle):
+        while not handle.should_cancel():
+            await asyncio.sleep(0)
+        await release.wait()
+        exited.set()
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await handle.cancel(reason="stop requested")
+
+    waiter = asyncio.create_task(handle.wait_until_complete(timeout=1.0))
+    await asyncio.sleep(0.05)
+    assert not waiter.done()
+    assert not exited.is_set()
+
+    release.set()
+    final = await waiter
+    assert final is AgentProcessStatus.CANCELLED
+    assert exited.is_set()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_reasons_are_prefixed_once() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):
+        return None
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await handle.wait_until_complete(timeout=1.0)
+
+    reasons = [event.data["reason"] for event in store.appended]
+    assert "ralph: spawned" in reasons
+    assert "ralph: work returned" in reasons
+    assert all("ralph: ralph:" not in reason for reason in reasons)

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -127,6 +127,7 @@ async def test_cancel_status_and_directive_wait_for_work_exit() -> None:
     final = await handle.wait_until_complete(timeout=1.0)
     assert final is AgentProcessStatus.CANCELLED
     assert _directives(store.appended)[-1] == "cancel"
+    assert store.appended[-1].data["extra"]["lifecycle_status"] == "cancelled"
 
 
 @pytest.mark.asyncio
@@ -180,6 +181,7 @@ async def test_failed_work_marks_status_and_emits_cancel() -> None:
     assert _directives(store.appended)[-1] == "cancel"
     failed_event = store.appended[-1]
     assert "_SimulatedFailure" in failed_event.data["reason"]
+    assert failed_event.data["extra"]["lifecycle_status"] == "failed"
 
 
 @pytest.mark.asyncio
@@ -314,6 +316,7 @@ async def test_lifecycle_directive_carries_target_type_agent_process() -> None:
         assert event.data["target_type"] == "agent_process"
         assert event.data["emitted_by"] == "agent_process"
         assert event.data["extra"]["intent"] == "evolve_step"
+        assert "lifecycle_status" in event.data["extra"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -34,6 +34,14 @@ def _directives(events: list[BaseEvent]) -> list[str]:
     return [e.data["directive"] for e in events if e.type == "control.directive.emitted"]
 
 
+async def _wait_for_status(handle, status: AgentProcessStatus) -> None:
+    for _ in range(100):
+        if handle.status() is status:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"status did not become {status}")
+
+
 @pytest.mark.asyncio
 async def test_spawn_emits_initial_running_directive() -> None:
     store = _FakeEventStore()
@@ -96,6 +104,32 @@ async def test_cancel_transitions_to_cancelled_and_emits_cancel() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancel_status_and_directive_wait_for_work_exit() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await asyncio.sleep(0.005)
+        await release.wait()
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await handle.cancel(reason="stop requested")
+
+    assert handle.status() is AgentProcessStatus.RUNNING
+    assert "cancel" not in _directives(store.appended)
+
+    release.set()
+    final = await handle.wait_until_complete(timeout=1.0)
+    assert final is AgentProcessStatus.CANCELLED
+    assert _directives(store.appended)[-1] == "cancel"
+
+
+@pytest.mark.asyncio
 async def test_pause_then_resume_transitions_emit_wait_continue() -> None:
     store = _FakeEventStore()
     process = AgentProcess(event_store=store)
@@ -113,9 +147,9 @@ async def test_pause_then_resume_transitions_emit_wait_continue() -> None:
     await asyncio.wait_for(started.wait(), timeout=1.0)
 
     await handle.pause()
-    assert handle.status() is AgentProcessStatus.PAUSED
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
     await handle.resume()
-    assert handle.status() is AgentProcessStatus.RUNNING
+    await _wait_for_status(handle, AgentProcessStatus.RUNNING)
     await handle.cancel(reason="end test")
 
     final = await handle.wait_until_complete(timeout=1.0)

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -1,0 +1,270 @@
+"""Unit tests for :class:`AgentProcess` and :class:`AgentProcessHandle`.
+
+Issue: #518 — slice 1 of M6. Pins the cooperative lifecycle, the
+directive emission shape (target_type=agent_process), and the
+deferred-implementation surface (replay raises NotImplementedError).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.agent_process import (
+    AgentProcess,
+    AgentProcessStatus,
+)
+
+
+class _FakeEventStore:
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+
+    async def append(self, event: BaseEvent) -> None:
+        self.appended.append(event)
+
+
+def _types(events: list[BaseEvent]) -> list[str]:
+    return [e.type for e in events]
+
+
+def _directives(events: list[BaseEvent]) -> list[str]:
+    return [e.data["directive"] for e in events if e.type == "control.directive.emitted"]
+
+
+@pytest.mark.asyncio
+async def test_spawn_emits_initial_running_directive() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):
+        await asyncio.sleep(0)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await handle.wait_until_complete(timeout=1.0)
+
+    types = _types(store.appended)
+    assert types[0] == "control.directive.emitted"
+    assert store.appended[0].data["directive"] == "continue"
+    assert store.appended[0].aggregate_type == "agent_process"
+    assert store.appended[0].aggregate_id == handle.process_id
+
+
+@pytest.mark.asyncio
+async def test_completed_emits_converge_terminal_directive() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):
+        return None
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    final = await handle.wait_until_complete(timeout=1.0)
+
+    assert final is AgentProcessStatus.COMPLETED
+    assert _directives(store.appended)[-1] == "converge"
+
+
+@pytest.mark.asyncio
+async def test_cancel_transitions_to_cancelled_and_emits_cancel() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+    cancelled_seen = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        # Spin until cancel is requested at a cooperative checkpoint.
+        while not handle.should_cancel():
+            await asyncio.sleep(0.005)
+        cancelled_seen.set()
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await handle.cancel(reason="test cancel")
+    await asyncio.wait_for(cancelled_seen.wait(), timeout=1.0)
+    final = await handle.wait_until_complete(timeout=1.0)
+
+    assert final is AgentProcessStatus.CANCELLED
+    # Last lifecycle directive emitted by the handle is CANCEL.
+    last_directive = next(
+        d for d in reversed(_directives(store.appended)) if d in {"cancel", "converge"}
+    )
+    assert last_directive == "cancel"
+
+
+@pytest.mark.asyncio
+async def test_pause_then_resume_transitions_emit_wait_continue() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        # Loop forever until cancel — gives the test deterministic
+        # control over the pause/resume timing.
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause()
+    assert handle.status() is AgentProcessStatus.PAUSED
+    await handle.resume()
+    assert handle.status() is AgentProcessStatus.RUNNING
+    await handle.cancel(reason="end test")
+
+    final = await handle.wait_until_complete(timeout=1.0)
+    # Test ends with cancel so the terminal directive is CANCEL.
+    assert final is AgentProcessStatus.CANCELLED
+
+    directives = _directives(store.appended)
+    # Sequence: continue (spawn) → wait (pause) → continue (resume)
+    # → cancel (cancel). Pins the external lifecycle the journal sees.
+    assert directives[:4] == ["continue", "wait", "continue", "cancel"]
+
+
+@pytest.mark.asyncio
+async def test_failed_work_marks_status_and_emits_cancel() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    class _SimulatedFailure(RuntimeError):
+        pass
+
+    async def work(handle):
+        raise _SimulatedFailure("work blew up")
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    final = await handle.wait_until_complete(timeout=1.0)
+
+    assert final is AgentProcessStatus.FAILED
+    assert _directives(store.appended)[-1] == "cancel"
+    failed_event = store.appended[-1]
+    assert "_SimulatedFailure" in failed_event.data["reason"]
+
+
+@pytest.mark.asyncio
+async def test_replay_is_not_yet_implemented() -> None:
+    process = AgentProcess(event_store=None)
+
+    async def _trivial_work(handle) -> None:  # noqa: ARG001 — handle unused on trivial work
+        return None
+
+    handle = await process.spawn(intent="ralph", work_fn=_trivial_work)
+    await handle.wait_until_complete(timeout=1.0)
+
+    with pytest.raises(NotImplementedError):
+        await handle.replay()
+
+
+@pytest.mark.asyncio
+async def test_no_event_store_means_no_emission() -> None:
+    """The handle must still operate without a journal store attached."""
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await handle.pause()
+    await handle.resume()
+    await handle.cancel(reason="end test")
+    final = await handle.wait_until_complete(timeout=1.0)
+    assert final is AgentProcessStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_double_cancel_is_idempotent() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):
+        while not handle.should_cancel():
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await handle.cancel(reason="first")
+    await handle.cancel(reason="second-no-op")
+    final = await handle.wait_until_complete(timeout=1.0)
+
+    assert final is AgentProcessStatus.CANCELLED
+    # Cancel emitted exactly once even though we called cancel twice.
+    cancel_count = sum(1 for d in _directives(store.appended) if d == "cancel")
+    assert cancel_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_releases_paused_loop() -> None:
+    """A paused loop must observe the cancel flag at the next checkpoint."""
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+    saw_cancel = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        # Loop until cancel. Each iteration parks on wait_unpaused so
+        # the test can deterministically pause the work mid-run.
+        while True:
+            await handle.wait_unpaused()
+            if handle.should_cancel():
+                saw_cancel.set()
+                return
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await handle.pause()
+    # Brief delay lets the loop reach its next wait_unpaused checkpoint
+    # while paused. cancel() then sets paused_event + cancel_event;
+    # the loop wakes, sees the cancel flag, and exits cleanly.
+    await asyncio.sleep(0.02)
+    await handle.cancel(reason="cancel while paused")
+    await asyncio.wait_for(saw_cancel.wait(), timeout=1.0)
+    final = await handle.wait_until_complete(timeout=1.0)
+    assert final is AgentProcessStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_directive_carries_target_type_agent_process() -> None:
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):
+        await asyncio.sleep(0)
+
+    handle = await process.spawn(intent="evolve_step", work_fn=work)
+    await handle.wait_until_complete(timeout=1.0)
+
+    for event in store.appended:
+        assert event.aggregate_type == "agent_process"
+        assert event.aggregate_id == handle.process_id
+        assert event.data["target_type"] == "agent_process"
+        assert event.data["emitted_by"] == "agent_process"
+        assert event.data["extra"]["intent"] == "evolve_step"
+
+
+@pytest.mark.asyncio
+async def test_status_is_running_immediately_after_spawn() -> None:
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        await asyncio.sleep(0.05)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    # Wait for the work to actually start so we can observe RUNNING.
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    assert handle.status() is AgentProcessStatus.RUNNING
+    await handle.wait_until_complete(timeout=1.0)

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -270,6 +270,34 @@ async def test_cancel_releases_paused_loop() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pause_after_cancel_cannot_reblock_work_loop() -> None:
+    """Once cancel is requested, a later pause must not reintroduce blocking."""
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+    saw_cancel = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while True:
+            await handle.wait_unpaused()
+            if handle.should_cancel():
+                saw_cancel.set()
+                return
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.cancel(reason="cancel before pause")
+    await handle.pause()
+
+    await asyncio.wait_for(saw_cancel.wait(), timeout=1.0)
+    final = await handle.wait_until_complete(timeout=1.0)
+    assert final is AgentProcessStatus.CANCELLED
+
+
+@pytest.mark.asyncio
 async def test_lifecycle_directive_carries_target_type_agent_process() -> None:
     store = _FakeEventStore()
     process = AgentProcess(event_store=store)


### PR DESCRIPTION
## Summary

First slice of #518 (M6 AgentProcess). Adds the unified `AgentProcess` abstraction that long-running workflows (ralph, evolve_step, execute_seed) will consume in subsequent slices. Ships the interface, the cooperative cancel/pause path (in-memory only), and the lifecycle directive emission with `target_type="agent_process"`.

The verbs whose durability is the headline of #518 are intentionally deferred so this PR stays single-responsibility:

- `replay()` raises `NotImplementedError` — slice 3 (#518) reads the EventStore and reconstructs a timeline.
- `pause()` / `resume()` are in-memory only here — slice 2 (#518) extends `CheckpointStore` (#338) for durability.

> **Independent track.** This PR does not depend on Sprint 1/2/3 work. It branches off `main` and can be reviewed and merged on its own.

## Lifecycle directive mapping (locked)

| Transition | Directive |
|---|---|
| spawn | `CONTINUE` (initial RUNNING marker) |
| pause | `WAIT` |
| resume | `CONTINUE` |
| cancel | `CANCEL` |
| complete | `CONVERGE` |
| failed | `CANCEL` (with the exception type captured in `reason`) |

Internal loop semantics (`RETRY`, `EVOLVE`, …) are **not** emitted by this module — those remain the workflow's responsibility (the evolution mapping in #525).

## Changes

- `src/ouroboros/orchestrator/agent_process.py` (new, ~330 LOC) — interface, status enum, cooperative handle, factory.
- `tests/unit/orchestrator/test_agent_process.py` (~280 LOC) — 11 cases.

## Cooperative semantics

- `cancel()` sets a flag the work loop checks at deterministic checkpoints (start of each AC iteration, before each LLM call, before each tool call — per #518 sub-thread).
- `pause()` clears an `asyncio.Event` the work loop awaits via `wait_unpaused()` at every checkpoint.
- Forced kill is Tier-3 C2 territory per #476, gated by evidence.
- Per #476 cooperative-trust model, a misbehaving work function can ignore the flags; the runtime does not police identity.

## Verification

| Check | Result |
|---|---|
| `uv run ruff check` | clean |
| `uv run ruff format` | 2 files reformatted, no logic change |
| `uv run pytest tests/unit/orchestrator/test_agent_process.py` | 11 passed |

## Pre-merge checklist

- [x] Status enum with 5 members + terminal-state set
- [x] `AgentProcessHandle` exposes 5 verbs (`pause/resume/cancel/replay/status`)
- [x] Cooperative `cancel()` (flag-driven) + `pause()/resume()` (event-driven)
- [x] Spawn emits initial `CONTINUE` directive; complete emits `CONVERGE`; cancel emits `CANCEL`; failure emits `CANCEL` (status=FAILED, reason carries exception type)
- [x] Lifecycle events carry `target_type="agent_process"` + `extra={"intent": ...}` for projector grouping
- [x] `replay()` deferred to slice 3 (raises `NotImplementedError`)
- [x] Pause durability deferred to slice 2 (in-memory only)
- [x] Idempotent: double-cancel emits one event; cancel releases a paused loop
- [x] EventStore append failure does not break lifecycle (observational-first per #476)
- [x] CI: ruff + format + 11 unit tests green

## Post-merge checklist

- [ ] Slice 2: extend `CheckpointStore` so `pause()` writes a durable checkpoint
- [ ] Slice 3: implement `replay()` reading from the EventStore
- [ ] Slices 4–6: migrate ralph, evolve_step, execute_seed to use `AgentProcess`
- [ ] Final slice: M6 acceptance test (pause ralph → inspect → resume → no context loss)

## Rollback

Pure additive: a new module + new tests. No existing code path imports it; no schema or runtime behaviour change.