### PR TITLE
Fix OpenCode setup config path resolution

### DIFF
--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -12,7 +12,9 @@ Also provides brownfield repository management subcommands:
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 import json
+import os
 from pathlib import Path
 import shutil
 from typing import Annotated
@@ -718,6 +720,21 @@ def _detect_opencode_mcp_command() -> dict[str, list[str]] | None:
 # this file keeps its historic `_BRIDGE_PLUGIN_*` naming.
 
 
+@contextmanager
+def _temporary_opencode_cli_path(opencode_path: str):
+    """Expose the setup-selected OpenCode CLI path to config-dir discovery."""
+    key = "OUROBOROS_OPENCODE_CLI_PATH"
+    previous = os.environ.get(key)
+    os.environ[key] = opencode_path
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = previous
+
+
 def _bridge_plugin_source_text() -> str | None:
     """Return the bridge plugin TypeScript source, or ``None`` when missing.
 
@@ -778,7 +795,7 @@ def _install_opencode_bridge_plugin() -> bool:
     Writes to the platform-appropriate OpenCode plugins directory:
 
     * Linux:   ``~/.config/opencode/plugins/ouroboros-bridge/``
-    * macOS:   ``~/Library/Application Support/OpenCode/plugins/ouroboros-bridge/``
+    * macOS:   ``~/.config/opencode/plugins/ouroboros-bridge/`` (or the directory reported by ``opencode debug paths``)
     * Windows: ``%APPDATA%\\OpenCode\\plugins\\ouroboros-bridge\\``
 
     Robustness:
@@ -1003,7 +1020,8 @@ def _setup_opencode(opencode_path: str, mode: str = "plugin") -> bool:
 
         # Mutual-exclusion cleanup: remove plugin-mode artifacts so both
         # paths are not active simultaneously (duplicate dispatch).
-        _cleanup_plugin_artifacts()
+        with _temporary_opencode_cli_path(opencode_path):
+            _cleanup_plugin_artifacts()
 
         print_success(f"Configured OpenCode subprocess runtime (CLI: {opencode_path})")
         print_info(f"Config saved to: {config_path}")
@@ -1013,9 +1031,10 @@ def _setup_opencode(opencode_path: str, mode: str = "plugin") -> bool:
     # if ALL steps succeed (fail-closed).  Without this, a failed bridge install
     # leaves the user in plugin mode without a working bridge — subsequent runs
     # take the plugin dispatch path and silently break.
-    _install_ok = _install_opencode_bridge_plugin()
-    _mcp_ok = _ensure_opencode_mcp_entry()
-    _plugin_ok = _ensure_opencode_plugin_entry()
+    with _temporary_opencode_cli_path(opencode_path):
+        _install_ok = _install_opencode_bridge_plugin()
+        _mcp_ok = _ensure_opencode_mcp_entry()
+        _plugin_ok = _ensure_opencode_plugin_entry()
 
     if not (_install_ok and _mcp_ok and _plugin_ok):
         failed = []

--- a/src/ouroboros/cli/opencode_config.py
+++ b/src/ouroboros/cli/opencode_config.py
@@ -10,14 +10,44 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-import shutil
 import subprocess
 import sys
+
+import yaml
 
 
 def _expand_config_dir(raw: str) -> Path:
     """Expand an OpenCode config directory string into a :class:`Path`."""
     return Path(raw).expanduser()
+
+
+def _configured_opencode_cli_path() -> Path | None:
+    """Return the setup-selected OpenCode CLI path when one is persisted.
+
+    Path discovery must be stable across setup, cleanup, and uninstall.  Do not
+    fall back to whichever ``opencode`` happens to be on ``PATH`` here: machines
+    can have several OpenCode installs, and uninstall should target the same
+    install tree that setup recorded.
+    """
+    for key in ("OUROBOROS_OPENCODE_CLI_PATH", "OPENCODE_CLI_PATH"):
+        raw = os.environ.get(key, "").strip()
+        if raw:
+            return Path(raw).expanduser()
+
+    config_path = Path.home() / ".ouroboros" / "config.yaml"
+    try:
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(config, dict):
+        return None
+    orchestrator = config.get("orchestrator")
+    if not isinstance(orchestrator, dict):
+        return None
+    raw = orchestrator.get("opencode_cli_path")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return Path(raw.strip()).expanduser()
 
 
 def _debug_paths_config_dir() -> Path | None:
@@ -28,16 +58,12 @@ def _debug_paths_config_dir() -> Path | None:
     platform assumptions into Ouroboros. Any failure falls back to deterministic
     local resolution so setup still works on machines without OpenCode on PATH.
     """
-    opencode = (
-        os.environ.get("OUROBOROS_OPENCODE_CLI_PATH")
-        or os.environ.get("OPENCODE_CLI_PATH")
-        or shutil.which("opencode")
-    )
+    opencode = _configured_opencode_cli_path()
     if not opencode:
         return None
     try:
         result = subprocess.run(
-            [opencode, "debug", "paths"],
+            [str(opencode), "debug", "paths"],
             capture_output=True,
             check=False,
             text=True,

--- a/src/ouroboros/cli/opencode_config.py
+++ b/src/ouroboros/cli/opencode_config.py
@@ -10,27 +10,78 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import shutil
+import subprocess
 import sys
 
 
-def opencode_config_dir() -> Path:
-    """Return the platform-specific OpenCode global config directory.
+def _expand_config_dir(raw: str) -> Path:
+    """Expand an OpenCode config directory string into a :class:`Path`."""
+    return Path(raw).expanduser()
 
-    Mirrors the lookup order used by OpenCode itself:
 
-    * **Windows** – ``%APPDATA%\\OpenCode``
-      (falls back to ``~\\AppData\\Roaming\\OpenCode`` when
-      ``APPDATA`` is unset, which should not happen in practice).
-    * **macOS** – ``~/Library/Application Support/OpenCode``
-    * **Linux / other** – ``$XDG_CONFIG_HOME/opencode`` (defaults to
-      ``~/.config/opencode`` when the env-var is not set).
+def _debug_paths_config_dir() -> Path | None:
+    """Return ``opencode debug paths`` config dir when the CLI reports one.
+
+    Current OpenCode releases expose the authoritative runtime directories via
+    ``opencode debug paths``. Querying it first avoids baking version-specific
+    platform assumptions into Ouroboros. Any failure falls back to deterministic
+    local resolution so setup still works on machines without OpenCode on PATH.
     """
+    opencode = (
+        os.environ.get("OUROBOROS_OPENCODE_CLI_PATH")
+        or os.environ.get("OPENCODE_CLI_PATH")
+        or shutil.which("opencode")
+    )
+    if not opencode:
+        return None
+    try:
+        result = subprocess.run(
+            [opencode, "debug", "paths"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) == 2 and parts[0] == "config":
+            return _expand_config_dir(parts[1])
+    return None
+
+
+def opencode_config_dir() -> Path:
+    """Return the active OpenCode global config directory.
+
+    Resolution order:
+
+    1. ``OPENCODE_CONFIG_DIR`` when explicitly set.
+    2. ``opencode debug paths`` ``config`` value when the CLI is available.
+    3. XDG-style default (``$XDG_CONFIG_HOME/opencode`` or
+       ``~/.config/opencode``) on macOS/Linux/other Unix platforms.
+    4. Windows roaming config directory for Windows.
+
+    Older Ouroboros releases wrote macOS config under
+    ``~/Library/Application Support/OpenCode``. Current OpenCode releases use
+    XDG config paths on macOS too, so that legacy directory is intentionally not
+    the default unless OpenCode itself reports it through ``debug paths``.
+    """
+    explicit = os.environ.get("OPENCODE_CONFIG_DIR")
+    if explicit:
+        return _expand_config_dir(explicit)
+
+    reported = _debug_paths_config_dir()
+    if reported is not None:
+        return reported
+
     if sys.platform == "win32":
         appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
         return Path(appdata) / "OpenCode"
-    if sys.platform == "darwin":
-        return Path.home() / "Library" / "Application Support" / "OpenCode"
-    # Linux / BSD / other — honour XDG
+
     xdg = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
     return Path(xdg) / "opencode"
 
@@ -52,6 +103,13 @@ def find_opencode_config(*, allow_default: bool = True) -> Path | None:
         The first existing config path, the default path (when
         *allow_default* is ``True``), or ``None``.
     """
+    explicit_config = os.environ.get("OPENCODE_CONFIG")
+    if explicit_config:
+        config_path = Path(explicit_config).expanduser()
+        if allow_default or config_path.exists():
+            return config_path
+        return None
+
     config_dir = opencode_config_dir()
     for name in ("opencode.jsonc", "opencode.json"):
         candidate = config_dir / name

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
@@ -64,10 +64,18 @@ describe("cfg — platform config dir", () => {
     expect(cfg()).toBe("/home/u/.config/opencode")
   })
 
-  test("darwin uses Library/Application Support", () => {
+  test("darwin uses XDG-style config path", () => {
     process.env.HOME = "/Users/u"
+    delete process.env.XDG_CONFIG_HOME
     Object.defineProperty(process, "platform", { value: "darwin" })
-    expect(cfg()).toBe("/Users/u/Library/Application Support/OpenCode")
+    expect(cfg()).toBe("/Users/u/.config/opencode")
+  })
+
+  test("OPENCODE_CONFIG_DIR overrides platform defaults", () => {
+    process.env.HOME = "/Users/u"
+    process.env.OPENCODE_CONFIG_DIR = "/custom/opencode"
+    Object.defineProperty(process, "platform", { value: "darwin" })
+    expect(cfg()).toBe("/custom/opencode")
   })
 
   test("win32 uses APPDATA when present", () => {

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
@@ -6,10 +6,10 @@ import { randomBytes } from "crypto"
 // Platform-aware opencode config dir
 export function cfg(): string {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? "/tmp"
+  if (process.env.OPENCODE_CONFIG_DIR)
+    return process.env.OPENCODE_CONFIG_DIR
   if (process.platform === "win32")
     return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "OpenCode")
-  if (process.platform === "darwin")
-    return join(home, "Library", "Application Support", "OpenCode")
   return join(process.env.XDG_CONFIG_HOME ?? join(home, ".config"), "opencode")
 }
 
@@ -557,4 +557,3 @@ export default {
 
 // Test-only exports for mocked-client coverage.
 export { resolveMid as _resolveMid, dispatch as _dispatch, patch as _patch, sleep as _sleep, PATCH_RETRIES as _PATCH_RETRIES, RESOLVE_RETRIES as _RESOLVE_RETRIES }
-

--- a/tests/unit/cli/test_opencode_config.py
+++ b/tests/unit/cli/test_opencode_config.py
@@ -156,21 +156,62 @@ class TestOpencodeConfigDir:
         """The OpenCode CLI-reported config dir is authoritative."""
         reported = tmp_path / ".config" / "opencode"
         monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
-        monkeypatch.delenv("OUROBOROS_OPENCODE_CLI_PATH", raising=False)
+        monkeypatch.setenv("OUROBOROS_OPENCODE_CLI_PATH", "/bin/opencode")
         monkeypatch.delenv("OPENCODE_CLI_PATH", raising=False)
 
         completed = SimpleNamespace(
             returncode=0,
             stdout=f"home       {tmp_path}\nconfig     {reported}\nstate      {tmp_path / '.state'}\n",
         )
+        with patch("ouroboros.cli.opencode_config.subprocess.run", return_value=completed) as run:
+            result = opencode_config_dir()
+
+        assert result == reported
+        run.assert_called_once()
+        assert run.call_args.args[0][:3] == ["/bin/opencode", "debug", "paths"]
+
+    def test_uses_persisted_opencode_cli_path_for_debug_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Post-setup cleanup/uninstall use the configured OpenCode binary."""
+        reported = tmp_path / "active" / "opencode"
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text(
+            "orchestrator:\n  opencode_cli_path: /configured/bin/opencode\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.delenv("OUROBOROS_OPENCODE_CLI_PATH", raising=False)
+        monkeypatch.delenv("OPENCODE_CLI_PATH", raising=False)
+
+        completed = SimpleNamespace(returncode=0, stdout=f"config     {reported}\n")
         with (
-            patch("ouroboros.cli.opencode_config.shutil.which", return_value="/bin/opencode"),
+            patch("pathlib.Path.home", return_value=tmp_path),
             patch("ouroboros.cli.opencode_config.subprocess.run", return_value=completed) as run,
         ):
             result = opencode_config_dir()
 
         assert result == reported
-        run.assert_called_once()
+        assert run.call_args.args[0][:3] == ["/configured/bin/opencode", "debug", "paths"]
+
+    def test_does_not_query_path_opencode_without_configured_cli(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Avoid targeting a different OpenCode install from PATH after setup."""
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.delenv("OUROBOROS_OPENCODE_CLI_PATH", raising=False)
+        monkeypatch.delenv("OPENCODE_CLI_PATH", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.cli.opencode_config.subprocess.run") as run,
+        ):
+            result = opencode_config_dir()
+
+        assert result == tmp_path / ".config" / "opencode"
+        run.assert_not_called()
 
     def test_darwin_defaults_to_xdg_config_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -180,7 +221,6 @@ class TestOpencodeConfigDir:
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
 
         with (
-            patch("ouroboros.cli.opencode_config.shutil.which", return_value=None),
             patch("ouroboros.cli.opencode_config.sys.platform", "darwin"),
             patch("pathlib.Path.home", return_value=tmp_path),
         ):
@@ -197,7 +237,6 @@ class TestOpencodeConfigDir:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
 
         with (
-            patch("ouroboros.cli.opencode_config.shutil.which", return_value=None),
             patch("ouroboros.cli.opencode_config.sys.platform", "darwin"),
         ):
             result = opencode_config_dir()

--- a/tests/unit/cli/test_opencode_config.py
+++ b/tests/unit/cli/test_opencode_config.py
@@ -7,9 +7,12 @@ platform-agnostic — no reliance on Linux-specific XDG paths.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from ouroboros.cli.opencode_config import find_opencode_config
+import pytest
+
+from ouroboros.cli.opencode_config import find_opencode_config, opencode_config_dir
 
 _OCD = "ouroboros.cli.opencode_config.opencode_config_dir"
 
@@ -109,3 +112,94 @@ class TestFindOpencodeConfig:
             result = find_opencode_config(allow_default=True)
 
         assert isinstance(result, Path)
+
+    def test_honors_opencode_config_file_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OPENCODE_CONFIG points setup at an explicit config file."""
+        explicit = tmp_path / "custom" / "opencode.json"
+        monkeypatch.setenv("OPENCODE_CONFIG", str(explicit))
+
+        result = find_opencode_config(allow_default=True)
+
+        assert result == explicit
+
+    def test_opencode_config_file_env_requires_existing_when_no_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Uninstall-style lookup ignores a missing OPENCODE_CONFIG file."""
+        explicit = tmp_path / "missing.json"
+        monkeypatch.setenv("OPENCODE_CONFIG", str(explicit))
+
+        result = find_opencode_config(allow_default=False)
+
+        assert result is None
+
+
+class TestOpencodeConfigDir:
+    """Tests for active OpenCode config-directory resolution."""
+
+    def test_honors_opencode_config_dir_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OPENCODE_CONFIG_DIR is the strongest explicit directory override."""
+        custom = tmp_path / "custom-opencode"
+        monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(custom))
+
+        result = opencode_config_dir()
+
+        assert result == custom
+
+    def test_uses_debug_paths_config_when_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The OpenCode CLI-reported config dir is authoritative."""
+        reported = tmp_path / ".config" / "opencode"
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.delenv("OUROBOROS_OPENCODE_CLI_PATH", raising=False)
+        monkeypatch.delenv("OPENCODE_CLI_PATH", raising=False)
+
+        completed = SimpleNamespace(
+            returncode=0,
+            stdout=f"home       {tmp_path}\nconfig     {reported}\nstate      {tmp_path / '.state'}\n",
+        )
+        with (
+            patch("ouroboros.cli.opencode_config.shutil.which", return_value="/bin/opencode"),
+            patch("ouroboros.cli.opencode_config.subprocess.run", return_value=completed) as run,
+        ):
+            result = opencode_config_dir()
+
+        assert result == reported
+        run.assert_called_once()
+
+    def test_darwin_defaults_to_xdg_config_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Modern OpenCode uses XDG config on macOS, not Application Support."""
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        with (
+            patch("ouroboros.cli.opencode_config.shutil.which", return_value=None),
+            patch("ouroboros.cli.opencode_config.sys.platform", "darwin"),
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            result = opencode_config_dir()
+
+        assert result == tmp_path / ".config" / "opencode"
+
+    def test_darwin_honors_xdg_config_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """XDG_CONFIG_HOME applies on macOS as it does on Linux."""
+        xdg = tmp_path / "xdg"
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+
+        with (
+            patch("ouroboros.cli.opencode_config.shutil.which", return_value=None),
+            patch("ouroboros.cli.opencode_config.sys.platform", "darwin"),
+        ):
+            result = opencode_config_dir()
+
+        assert result == xdg / "opencode"

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -1714,6 +1715,44 @@ class TestOpenCodeSetupConfigYaml:
         result = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         mock_claude.assert_not_called()
         assert result["orchestrator"]["opencode_mode"] == "plugin"
+
+    def test_plugin_setup_exposes_selected_cli_path_during_discovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Plugin setup queries paths through the user-selected OpenCode binary."""
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_path.write_text("{}", encoding="utf-8")
+        cli_path = "/custom/bin/opencode"
+        observed: list[str | None] = []
+        monkeypatch.delenv("OUROBOROS_OPENCODE_CLI_PATH", raising=False)
+
+        def record_cli_path() -> bool:
+            observed.append(os.environ.get("OUROBOROS_OPENCODE_CLI_PATH"))
+            return True
+
+        with (
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._install_opencode_bridge_plugin",
+                side_effect=record_cli_path,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._ensure_opencode_mcp_entry",
+                side_effect=record_cli_path,
+            ),
+            patch(
+                "ouroboros.cli.commands.setup._ensure_opencode_plugin_entry",
+                side_effect=record_cli_path,
+            ),
+        ):
+            from ouroboros.cli.commands.setup import _setup_opencode
+
+            assert _setup_opencode(cli_path, mode="plugin") is True
+
+        assert observed == [cli_path, cli_path, cli_path]
+        assert os.environ.get("OUROBOROS_OPENCODE_CLI_PATH") is None
 
     def test_plugin_setup_failure_returns_false_without_persisting_config(
         self,


### PR DESCRIPTION
## Summary

Fixes #539.

This updates OpenCode plugin-mode setup so Ouroboros writes the MCP entry and bridge plugin under the active OpenCode config directory instead of hardcoding the legacy macOS `~/Library/Application Support/OpenCode` path.

## Changes

- Prefer `OPENCODE_CONFIG_DIR` when explicitly set.
- Query `opencode debug paths` and use its reported `config` directory when available.
- Fall back to XDG config paths on macOS/Linux (`$XDG_CONFIG_HOME/opencode` or `~/.config/opencode`).
- Preserve Windows roaming-directory behavior.
- Honor `OPENCODE_CONFIG` for explicit config-file lookup.
- Pass the setup-selected OpenCode CLI path into config-dir discovery during plugin setup/cleanup.
- Keep the bundled TypeScript bridge plugin resolver aligned with the Python setup resolver.
- Add regression tests for macOS XDG behavior, debug-path parsing, env overrides, and setup-selected CLI path propagation.

## Verification

- `uv run pytest tests/unit/cli/test_setup.py tests/unit/cli/test_opencode_config.py tests/unit/cli/test_bridge_plugin_lifecycle.py tests/unit/cli/test_bridge_plugin_hardening.py -q` → 124 passed
- `bun test` in `src/ouroboros/opencode/plugin` → 91 passed
- `uv run ruff check src/ouroboros/cli/opencode_config.py src/ouroboros/cli/commands/setup.py tests/unit/cli/test_opencode_config.py tests/unit/cli/test_setup.py`
- `uv run ruff format --check src/ouroboros/cli/opencode_config.py src/ouroboros/cli/commands/setup.py tests/unit/cli/test_opencode_config.py tests/unit/cli/test_setup.py`
- `uv run mypy src/ouroboros/cli/opencode_config.py src/ouroboros/cli/commands/setup.py`
- `git diff --check`

## Not tested

- Live macOS OpenCode setup with Homebrew OpenCode 1.14.28.
