### PR TITLE
Add bounded auto-mode supervisor loop

### DIFF
--- a/src/ouroboros/auto/__init__.py
+++ b/src/ouroboros/auto/__init__.py
@@ -8,21 +8,35 @@ before starting execution.
 
 from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
 from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
+from ouroboros.auto.interview_driver import AutoInterviewDriver, AutoInterviewResult, InterviewTurn
 from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.seed_repairer import RepairResult, SeedRepairer
+from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoPolicy, AutoStore
 
 __all__ = [
     "AutoAnswer",
     "AutoAnswerSource",
     "AutoAnswerer",
+    "AutoInterviewDriver",
+    "AutoInterviewResult",
     "AutoPhase",
+    "AutoPipeline",
+    "AutoPipelineResult",
     "AutoPipelineState",
     "AutoPolicy",
     "AutoStore",
     "GradeGate",
+    "InterviewTurn",
     "GradeResult",
     "LedgerEntry",
     "LedgerSection",
+    "RepairResult",
+    "ReviewFinding",
     "SeedDraftLedger",
+    "SeedReview",
+    "SeedReviewer",
     "SeedGrade",
+    "SeedRepairer",
 ]

--- a/src/ouroboros/auto/__init__.py
+++ b/src/ouroboros/auto/__init__.py
@@ -1,0 +1,28 @@
+"""Auto-mode convergence primitives for ``ooo auto``.
+
+The auto package is intentionally independent from the existing manual
+``interview``/``seed``/``run`` surfaces.  It provides bounded, serializable
+state plus deterministic quality gates that a higher-level supervisor can use
+before starting execution.
+"""
+
+from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
+from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
+from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoPolicy, AutoStore
+
+__all__ = [
+    "AutoAnswer",
+    "AutoAnswerSource",
+    "AutoAnswerer",
+    "AutoPhase",
+    "AutoPipelineState",
+    "AutoPolicy",
+    "AutoStore",
+    "GradeGate",
+    "GradeResult",
+    "LedgerEntry",
+    "LedgerSection",
+    "SeedDraftLedger",
+    "SeedGrade",
+]

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -301,23 +301,16 @@ class AutoAnswerer:
 def _is_feature_acceptance_question(lowered: str) -> bool:
     if not re.search(r"\b(acceptance|criteria)\b", lowered):
         return False
-    feature_terms = (
-        "endpoint",
-        "api",
-        "command",
-        "delete",
-        "remove",
-        "create",
-        "update",
-        "edit",
-        "export",
-        "import",
-        "login",
-        "signup",
-        "upload",
-        "download",
+    if re.search(
+        r"\b(general|overall|test strategy|verification plan|definition of done)\b", lowered
+    ):
+        return False
+    return bool(
+        re.search(
+            r"\b(for|when|where|should|must|feature|flow|integration|endpoint|api|command|report|webhook|billing|search|generator|users?|user)\b",
+            lowered,
+        )
     )
-    return any(re.search(rf"\b{re.escape(term)}\b", lowered) for term in feature_terms)
 
 
 def _acceptance_subject(question: str) -> str:
@@ -431,11 +424,11 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "destructive external operation requires human authority",
         ),
         (
-            r"\bsecret\b.+\b(value|key|token|credential|env|environment|workflow|ci|production|prod)\b",
+            r"\b(provide|enter|paste|supply|use|configure|set)\b.+\bsecret\b.+\b(value|key|token|credential|env|environment|workflow|ci|production|prod)\b",
             "credential or secret value required",
         ),
         (
-            r"\b(value|key|token|credential|env|environment|workflow|ci|production|prod)\b.+\bsecret\b",
+            r"\b(which|what)\s+secret\b.+\b(use|configure|set|env|environment|workflow|ci|production|prod)\b",
             "credential or secret value required",
         ),
     )

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -118,11 +118,7 @@ class AutoAnswerer:
             ledger.add_entry(section, entry)
 
     def _non_goal_answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:  # noqa: ARG002
-        goal_text = (
-            ledger.sections.get("goal").entries[0].value.lower()
-            if ledger.sections.get("goal") and ledger.sections["goal"].entries
-            else ""
-        )
+        goal_text = _latest_resolved_goal(ledger).lower()
         excluded = ["cloud sync", "paid services"]
         if not re.search(r"\b(auth|authentication|login|sign[- ]?in|signup|password)\b", goal_text):
             excluded.append("authentication")
@@ -284,6 +280,17 @@ def _is_actor_or_io_question(lowered: str) -> bool:
         return True
     return bool(re.search(r"\b(who|which)\s+(is|are)\s+the\s+users?\b", lowered))
 
+
+
+def _latest_resolved_goal(ledger: SeedDraftLedger) -> str:
+    section = ledger.sections.get("goal")
+    if section is None:
+        return ""
+    inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    for entry in reversed(section.entries):
+        if entry.status not in inactive and entry.value.strip():
+            return entry.value
+    return ""
 
 def _blocker_for(question: str) -> AutoBlocker | None:
     lowered = question.lower()

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -83,7 +83,14 @@ class AutoAnswerer:
             return self._verification_answer(question)
         if _matches_any(
             lowered,
-            (r"\bruntime\b", r"\bstack\b", r"\brepo\b", r"\bproject\b", r"\bframework\b"),
+            (
+                r"\bruntime\b",
+                r"\bstack\b",
+                r"\brepo\b",
+                r"\bframework\b",
+                r"\bproject structure\b",
+                r"\bproject runtime\b",
+            ),
         ):
             return self._runtime_answer(question)
         if _is_actor_or_io_question(lowered):
@@ -299,11 +306,11 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "medical judgment required",
         ),
         (
-            r"\b(deploy|release|publish)\b.+\b(production|prod|live|external)\b",
+            r"\b(should|can|may|will|do we|should we)\b.+\b(deploy|release|publish)\b.+\b(to|against|on)\s+\b(production|prod|live|external)\b",
             "deployment target requires human authority",
         ),
         (
-            r"\bproduction\b.+\b(deploy|release|publish|credential|secret|api key)\b",
+            r"\b(production|prod|live|external)\b.+\b(credential|secret|api key)\b",
             "production deployment or irreversible external action required",
         ),
         (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -239,6 +239,7 @@ def _blocker_for(question: str) -> AutoBlocker | None:
     blockers = {
         "credential": "credential or secret value required",
         "api key": "credential or API key required",
+        "secret": "credential or secret value required",
         "payment": "paid service or financial decision required",
         "legal": "legal judgment required",
         "medical": "medical judgment required",

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -282,11 +282,15 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "credential or secret value required",
         ),
         (
-            r"\b(which|what|provide|enter|use|choose|select|configure|set)\b.+\b(credential|credentials)\b",
+            r"\b(provide|enter|use|choose|select|configure|set)\b.+\b(credential|credentials)\b",
             "credential or secret value required",
         ),
         (
-            r"\b(which|what|provide|enter|use|choose|select|configure|set)\b.+\b(api keys?|passwords?)\b",
+            r"\b(provide|enter|use|configure|set)\b.+\b(api keys?|passwords?)\b.+\b(value|secret|token|credential|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what)\b.+\b(api keys?|passwords?)\b.+\b(value|secret|token|credential|env|environment|workflow|ci|production|prod)\b",
             "credential or secret value required",
         ),
         (
@@ -294,7 +298,11 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "credential or secret value required",
         ),
         (
-            r"\b(which|what|provide|enter|use|choose|select|configure|set|charge|purchase|subscribe)\b.+\b(payment|billing|paid service|credit card|bank account|invoice)\b.+\b(account|provider|key|secret|production|live)\b",
+            r"\b(charge|purchase|subscribe|provide|enter|use|configure|set)\b.+\b(payment|billing|paid service|credit card|bank account|invoice)\b.+\b(account|provider|key|secret|production|live)\b",
+            "paid service or financial decision required",
+        ),
+        (
+            r"\b(payment|billing|paid service|credit card|bank account|invoice)\b.+\b(account|provider|key|secret|production|live)\b.+\b(charge|purchase|subscribe|pay)\b",
             "paid service or financial decision required",
         ),
         (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -281,7 +281,6 @@ def _is_actor_or_io_question(lowered: str) -> bool:
     return bool(re.search(r"\b(who|which)\s+(is|are)\s+the\s+users?\b", lowered))
 
 
-
 def _latest_resolved_goal(ledger: SeedDraftLedger) -> str:
     section = ledger.sections.get("goal")
     if section is None:
@@ -291,6 +290,7 @@ def _latest_resolved_goal(ledger: SeedDraftLedger) -> str:
         if entry.status not in inactive and entry.value.strip():
             return entry.value
     return ""
+
 
 def _blocker_for(question: str) -> AutoBlocker | None:
     lowered = question.lower()

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -372,7 +372,7 @@ def _slug_key(value: str) -> str:
 def _is_product_behavior_question(lowered: str) -> bool:
     return bool(
         re.search(
-            r"\b(should|must|can|will|do|does|is|are)\b.+\b(mark|marked|show|display|write|return|create|update|edit|delete|remove|store|save|send|generate|filter|sort|search|export|import|notify|report|use)\b",
+            r"\b(should|must|can|will|do|does|is|are)\b.+\b(mark|marked|show|display|write|return|create|update|edit|delete|remove|rotate|store|save|send|generate|filter|sort|search|export|import|notify|report|use)\b",
             lowered,
         )
         or re.search(r"\bwhat\s+(output|input)\b.+\b(should|does|do|format|write|use)\b", lowered)
@@ -424,7 +424,15 @@ def _blocker_for(question: str) -> AutoBlocker | None:
 
     external_action_patterns = (
         (
-            r"\b(access token|auth token|private key|credential value|credential secret)\b",
+            r"\b(credential value|credential secret)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(provide|enter|paste|supply|configure|set)\b.+\b(access token|auth token|private key)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what)\b.+\b(access token|auth token|private key)\b.+\b(use|configure|set|env|environment|workflow|ci|production|prod)\b",
             "credential or secret value required",
         ),
         (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -72,7 +72,13 @@ class AutoAnswerer:
             return self._non_goal_answer(question)
         if _matches_any(
             lowered,
-            (r"\btests?\b", r"\bverify\b", r"\bvalidation\b", r"\bacceptance\b", r"\bdone\b"),
+            (
+                r"\btests?\b",
+                r"\bverify\b",
+                r"\bvalidation\b",
+                r"\bacceptance\b",
+                r"\bdefinition of done\b",
+            ),
         ):
             return self._verification_answer(question)
         if _matches_any(
@@ -247,16 +253,17 @@ def _matches_any(value: str, patterns: tuple[str, ...]) -> bool:
 
 
 def _is_actor_or_io_question(lowered: str) -> bool:
-    if re.search(r"\b(inputs?|outputs?)\b", lowered):
+    if re.search(
+        r"\b(what|which)\s+(are|inputs? are|outputs? are)\s+.+\b(inputs|outputs)\b", lowered
+    ):
         return True
-    if not re.search(r"\b(actors?|users?|personas?|stakeholders?)\b", lowered):
-        return False
-    return bool(
-        re.search(
-            r"\b(who|which|what|primary|role|roles|persona|personas|stakeholder|stakeholders|actor|actors)\b",
-            lowered,
-        )
-    )
+    if re.search(r"\b(what|which)\s+(inputs|outputs)\s+(are|should be)\b", lowered):
+        return True
+    if re.search(
+        r"\b(who|which|what)\s+(is|are)\s+.+\b(actors?|personas?|stakeholders?)\b", lowered
+    ):
+        return True
+    return bool(re.search(r"\b(who|which)\s+(is|are)\s+the\s+users?\b", lowered))
 
 
 def _blocker_for(question: str) -> AutoBlocker | None:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -149,7 +149,7 @@ class AutoAnswerer:
                 "acceptance_criteria",
                 LedgerEntry(
                     key="acceptance.observable_behavior",
-                    value="At least one automated or command-level check proves each acceptance criterion with observable output or artifacts.",
+                    value="A command-level check returns exit code 0 and stdout contains stable output or writes a reproducible artifact for each acceptance criterion.",
                     source=LedgerSource.CONSERVATIVE_DEFAULT,
                     confidence=0.82,
                     status=LedgerStatus.DEFAULTED,

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -70,6 +70,8 @@ class AutoAnswerer:
             lowered, (r"\bnon-goals?\b", r"\bout of scope\b", r"\bexclude\b", r"\bnot do\b")
         ):
             return self._non_goal_answer(question, ledger)
+        if _is_feature_acceptance_question(lowered):
+            return self._feature_acceptance_answer(question)
         if _matches_any(
             lowered,
             (
@@ -167,6 +169,39 @@ class AutoAnswerer:
         ]
         return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.84, updates)
 
+    def _feature_acceptance_answer(self, question: str) -> AutoAnswer:
+        subject = _acceptance_subject(question)
+        value = (
+            f"Acceptance for {subject} must cover the requested behavior directly: "
+            "a successful operation returns an observable status/output, invalid input fails "
+            "with a non-zero/error status, and any persisted artifact or state change can be verified."
+        )
+        updates = [
+            (
+                "acceptance_criteria",
+                LedgerEntry(
+                    key=f"acceptance.{_slug_key(subject)}",
+                    value=value,
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.82,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Preserves feature-specific acceptance semantics from the interview question.",
+                ),
+            ),
+            (
+                "verification_plan",
+                LedgerEntry(
+                    key=f"verification.{_slug_key(subject)}",
+                    value=f"Verify {subject} with command/API checks for success, failure, and persisted state or output.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.8,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Feature-specific acceptance requires observable verification.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.82, updates)
+
     def _runtime_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
         value = "Use the existing repository runtime, package manager, and architectural patterns; avoid new dependencies unless required by acceptance criteria."
         updates = [
@@ -261,6 +296,49 @@ class AutoAnswerer:
             ),
         ]
         return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.82, updates)
+
+
+def _is_feature_acceptance_question(lowered: str) -> bool:
+    if not re.search(r"\b(acceptance|criteria)\b", lowered):
+        return False
+    feature_terms = (
+        "endpoint",
+        "api",
+        "command",
+        "delete",
+        "remove",
+        "create",
+        "update",
+        "edit",
+        "export",
+        "import",
+        "login",
+        "signup",
+        "upload",
+        "download",
+    )
+    return any(re.search(rf"\b{re.escape(term)}\b", lowered) for term in feature_terms)
+
+
+def _acceptance_subject(question: str) -> str:
+    cleaned = re.sub(r"\s+", " ", question.strip().rstrip("?"))
+    patterns = (
+        r"acceptance criteria should (?P<subject>.+?) satisfy$",
+        r"criteria should (?P<subject>.+?) satisfy$",
+        r"should (?P<subject>.+?) do$",
+        r"for (?P<subject>.+)$",
+    )
+    lowered = cleaned.lower()
+    for pattern in patterns:
+        match = re.search(pattern, lowered)
+        if match:
+            return match.group("subject").strip() or "the requested behavior"
+    return cleaned or "the requested behavior"
+
+
+def _slug_key(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    return slug[:64] or "requested_behavior"
 
 
 def _matches_any(value: str, patterns: tuple[str, ...]) -> bool:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -70,19 +70,10 @@ class AutoAnswerer:
             lowered, (r"\bnon-goals?\b", r"\bout of scope\b", r"\bexclude\b", r"\bnot do\b")
         ):
             return self._non_goal_answer(question, ledger)
+        if _is_verification_question(lowered):
+            return self._verification_answer(question)
         if _is_feature_acceptance_question(lowered):
             return self._feature_acceptance_answer(question)
-        if _matches_any(
-            lowered,
-            (
-                r"\btests?\b",
-                r"\bverify\b",
-                r"\bvalidation\b",
-                r"\bacceptance\b",
-                r"\bdefinition of done\b",
-            ),
-        ):
-            return self._verification_answer(question)
         if _is_actor_or_io_question(lowered):
             return self._io_actor_answer(question)
         if _is_product_behavior_question(lowered):
@@ -333,11 +324,30 @@ class AutoAnswerer:
         return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.82, updates)
 
 
+def _is_verification_question(lowered: str) -> bool:
+    return bool(
+        _matches_any(
+            lowered,
+            (
+                r"\btests?\b",
+                r"\bverify\b",
+                r"\bverifies\b",
+                r"\bverification\b",
+                r"\bvalidation\b",
+                r"\bdefinition of done\b",
+            ),
+        )
+        or re.search(r"\b(command output|output)\b.+\b(verifies|verify|proves?)\b", lowered)
+        or re.search(r"\b(verifies|verify|proves?)\b.+\b(acceptance|criteria)\b", lowered)
+    )
+
+
 def _is_feature_acceptance_question(lowered: str) -> bool:
     if not re.search(r"\b(acceptance|criteria)\b", lowered):
         return False
     if re.search(
-        r"\b(general|overall|test strategy|verification plan|definition of done)\b", lowered
+        r"\b(general|overall|test strategy|verification plan|definition of done|verify|verifies|verification|validation)\b",
+        lowered,
     ):
         return False
     return bool(
@@ -399,7 +409,20 @@ def _is_actor_or_io_question(lowered: str) -> bool:
         r"\b(what|which)\s+(are|inputs? are|outputs? are)\s+.+\b(inputs|outputs)\b", lowered
     ):
         return True
-    if re.search(r"\b(what|which)\s+(inputs|outputs)\s+(are|should be)\b", lowered):
+    if re.search(
+        r"\b(what|which)\s+(inputs|outputs)\s+(are|should be|does|do|will|can|must)\b",
+        lowered,
+    ):
+        return True
+    if re.search(
+        r"\b(what|which)\s+(inputs|outputs)\b.+\b(take|produce|return|emit|write|read|accept|receive)\b",
+        lowered,
+    ):
+        return True
+    if re.search(
+        r"\b(what|which)\s+.+\b(inputs|outputs)\b.+\b(take|produce|return|emit|write|read|accept|receive)\b",
+        lowered,
+    ):
         return True
     if re.search(
         r"\b(who|which|what)\s+(is|are)\s+.+\b(actors?|personas?|stakeholders?)\b", lowered

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -66,13 +66,21 @@ class AutoAnswerer:
                 blocker=blocker,
             )
 
-        if any(word in lowered for word in ("non-goal", "out of scope", "exclude", "not do")):
+        if _matches_any(
+            lowered, (r"\bnon-goals?\b", r"\bout of scope\b", r"\bexclude\b", r"\bnot do\b")
+        ):
             return self._non_goal_answer(question)
-        if any(word in lowered for word in ("test", "verify", "validation", "acceptance", "done")):
+        if _matches_any(
+            lowered,
+            (r"\btests?\b", r"\bverify\b", r"\bvalidation\b", r"\bacceptance\b", r"\bdone\b"),
+        ):
             return self._verification_answer(question)
-        if any(word in lowered for word in ("runtime", "stack", "repo", "project", "framework")):
+        if _matches_any(
+            lowered,
+            (r"\bruntime\b", r"\bstack\b", r"\brepo\b", r"\bproject\b", r"\bframework\b"),
+        ):
             return self._runtime_answer(question)
-        if any(word in lowered for word in ("input", "output", "user", "actor")):
+        if _is_actor_or_io_question(lowered):
             return self._io_actor_answer(question)
 
         return self._default_answer(question, ledger)
@@ -232,6 +240,23 @@ class AutoAnswerer:
             ),
         ]
         return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.82, updates)
+
+
+def _matches_any(value: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.search(pattern, value) for pattern in patterns)
+
+
+def _is_actor_or_io_question(lowered: str) -> bool:
+    if re.search(r"\b(inputs?|outputs?)\b", lowered):
+        return True
+    if not re.search(r"\b(actors?|users?|personas?|stakeholders?)\b", lowered):
+        return False
+    return bool(
+        re.search(
+            r"\b(who|which|what|primary|role|roles|persona|personas|stakeholder|stakeholders|actor|actors)\b",
+            lowered,
+        )
+    )
 
 
 def _blocker_for(question: str) -> AutoBlocker | None:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -239,7 +239,6 @@ def _blocker_for(question: str) -> AutoBlocker | None:
     blockers = {
         "credential": "credential or secret value required",
         "api key": "credential or API key required",
-        "secret": "credential or secret value required",
         "payment": "paid service or financial decision required",
         "legal": "legal judgment required",
         "medical": "medical judgment required",
@@ -258,8 +257,16 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "production deployment or irreversible external action required",
         ),
         (
-            r"\b(delete|drop|erase|wipe|remove)\b.+\b(database|db|file|repo|branch|production|prod|secret|api key|credential)\b",
+            r"\b(delete|drop|erase|wipe|remove)\b.+\b(database|db|repo|branch|production|prod|secret|api key|credential)\b",
             "destructive external operation requires human authority",
+        ),
+        (
+            r"\bsecret\b.+\b(value|key|token|credential|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(value|key|token|credential|env|environment|workflow|ci|production|prod)\b.+\bsecret\b",
+            "credential or secret value required",
         ),
     )
     for pattern, reason in external_action_patterns:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -310,6 +310,14 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "deployment target requires human authority",
         ),
         (
+            r"\b(which|what|choose|select|use|configure|set)\b.+\b(production|prod|live|external)\b.+\b(environment|target|account|project|cluster|region)\b",
+            "deployment target requires human authority",
+        ),
+        (
+            r"\b(which|what|choose|select|use|configure|set)\b.+\b(environment|target|account|project|cluster|region)\b.+\b(deploy|release|publish)\b.+\b(production|prod|live|external)\b",
+            "deployment target requires human authority",
+        ),
+        (
             r"\b(production|prod|live|external)\b.+\b(credential|secret|api key)\b",
             "production deployment or irreversible external action required",
         ),

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -97,6 +97,8 @@ class AutoAnswerer:
             return self._runtime_answer(question)
         if _is_actor_or_io_question(lowered):
             return self._io_actor_answer(question)
+        if _is_product_behavior_question(lowered):
+            return self._product_behavior_answer(question)
 
         return self._default_answer(question, ledger)
 
@@ -269,6 +271,39 @@ class AutoAnswerer:
         ]
         return AutoAnswer(value, AutoAnswerSource.ASSUMPTION, 0.76, updates, assumptions=[value])
 
+    def _product_behavior_answer(self, question: str) -> AutoAnswer:
+        subject = _acceptance_subject(question)
+        value = (
+            f"Treat this requested product behavior as in scope for the MVP: {subject}. "
+            "Implement it directly and make the resulting state, output, or API response observable."
+        )
+        key = _slug_key(subject)
+        updates = [
+            (
+                "constraints",
+                LedgerEntry(
+                    key=f"constraints.behavior.{key}",
+                    value=f"Preserve the product behavior requested by the interview question: {subject}",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.8,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Safe product-semantics questions should not be collapsed into a generic MVP policy.",
+                ),
+            ),
+            (
+                "acceptance_criteria",
+                LedgerEntry(
+                    key=f"acceptance.behavior.{key}",
+                    value=f"The requested behavior is observable: {subject} produces a verifiable output, status, or persisted state change.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.78,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Feature semantics from the interview question must remain visible in the Seed contract.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.8, updates)
+
     def _default_answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:  # noqa: ARG002
         value = "Proceed with a conservative MVP: keep scope small, prefer existing project patterns, document assumptions, and make completion verifiable with observable acceptance criteria."
         updates = [
@@ -332,6 +367,27 @@ def _acceptance_subject(question: str) -> str:
 def _slug_key(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
     return slug[:64] or "requested_behavior"
+
+
+def _is_product_behavior_question(lowered: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(should|must|can|will|do|does|is|are)\b.+\b(mark|marked|show|display|write|return|create|update|edit|delete|store|save|send|generate|filter|sort|search|export|import|notify|report|use)\b",
+            lowered,
+        )
+        or re.search(r"\bwhat\s+(output|input)\b.+\b(should|does|do|format|write|use)\b", lowered)
+        or re.search(
+            r"\bwhat\s+should\b.+\b(write|return|display|show|create|store|generate|edit|delete)\b",
+            lowered,
+        )
+        or re.search(
+            r"\bhow\s+should\b.+\b(behave|work|display|return|write|store|mark)\b", lowered
+        )
+        or re.search(
+            r"\b(which|what)\b.+\b(can|should)\b.+\b(edit|delete|update|create|view|access)\b",
+            lowered,
+        )
+    )
 
 
 def _matches_any(value: str, patterns: tuple[str, ...]) -> bool:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -294,7 +294,7 @@ class AutoAnswerer:
                 "acceptance_criteria",
                 LedgerEntry(
                     key=f"acceptance.behavior.{key}",
-                    value=f"The requested behavior is observable: {subject} produces a verifiable output, status, or persisted state change.",
+                    value=f"A command or API check for {subject} returns exit code 0 or HTTP 2xx status, and stdout, response body, or a persisted file contains evidence of the requested behavior.",
                     source=LedgerSource.CONSERVATIVE_DEFAULT,
                     confidence=0.78,
                     status=LedgerStatus.DEFAULTED,

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+import re
 
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 
@@ -238,14 +239,29 @@ def _blocker_for(question: str) -> AutoBlocker | None:
     blockers = {
         "credential": "credential or secret value required",
         "api key": "credential or API key required",
-        "production": "production deployment or irreversible external action required",
-        "deploy": "deployment target requires human authority",
-        "delete": "destructive operation requires human authority",
         "payment": "paid service or financial decision required",
         "legal": "legal judgment required",
         "medical": "medical judgment required",
     }
     for token, reason in blockers.items():
         if token in lowered:
+            return AutoBlocker(reason=reason, question=question)
+
+    external_action_patterns = (
+        (
+            r"\b(deploy|release|publish)\b.+\b(production|prod|live|external)\b",
+            "deployment target requires human authority",
+        ),
+        (
+            r"\bproduction\b.+\b(deploy|release|publish|credential|secret|api key)\b",
+            "production deployment or irreversible external action required",
+        ),
+        (
+            r"\b(delete|drop|erase|wipe|remove)\b.+\b(database|db|file|repo|branch|production|prod|secret|api key|credential)\b",
+            "destructive external operation requires human authority",
+        ),
+    )
+    for pattern, reason in external_action_patterns:
+        if re.search(pattern, lowered):
             return AutoBlocker(reason=reason, question=question)
     return None

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -236,18 +236,32 @@ class AutoAnswerer:
 
 def _blocker_for(question: str) -> AutoBlocker | None:
     lowered = question.lower()
-    blockers = {
-        "credential": "credential or secret value required",
-        "api key": "credential or API key required",
-        "payment": "paid service or financial decision required",
-        "legal": "legal judgment required",
-        "medical": "medical judgment required",
-    }
-    for token, reason in blockers.items():
-        if token in lowered:
-            return AutoBlocker(reason=reason, question=question)
 
     external_action_patterns = (
+        (
+            r"\b(api key|access token|auth token|private key|password|credential value|credential secret)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what|provide|enter|use|choose|select|configure|set)\b.+\b(credential|credentials)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(credential|credentials)\b.+\b(value|secret|token|key|password|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(payment|billing|paid service|credit card|bank account|invoice)\b.+\b(account|provider|key|secret|charge|purchase|subscribe|production|live)\b",
+            "paid service or financial decision required",
+        ),
+        (
+            r"\b(legal|compliance|license|contract)\b.+\b(advice|judgment|review|approval|liability|risk|interpretation)\b",
+            "legal judgment required",
+        ),
+        (
+            r"\b(medical|clinical|diagnosis|treatment|health)\b.+\b(advice|judgment|diagnose|prescribe|triage|recommendation)\b",
+            "medical judgment required",
+        ),
         (
             r"\b(deploy|release|publish)\b.+\b(production|prod|live|external)\b",
             "deployment target requires human authority",

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -1,0 +1,236 @@
+"""Conservative source-tagged auto answers for Socratic interview prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+
+
+class AutoAnswerSource(StrEnum):
+    """Source categories for generated auto answers."""
+
+    USER_GOAL = "user_goal"
+    REPO_FACT = "repo_fact"
+    EXISTING_CONVENTION = "existing_convention"
+    CONSERVATIVE_DEFAULT = "conservative_default"
+    ASSUMPTION = "assumption"
+    NON_GOAL = "non_goal"
+    BLOCKER = "blocker"
+
+
+@dataclass(frozen=True, slots=True)
+class AutoBlocker:
+    """A hard blocker that should stop auto convergence."""
+
+    reason: str
+    question: str
+
+
+@dataclass(frozen=True, slots=True)
+class AutoAnswer:
+    """Answer plus structured ledger updates."""
+
+    text: str
+    source: AutoAnswerSource
+    confidence: float
+    ledger_updates: list[tuple[str, LedgerEntry]] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
+    non_goals: list[str] = field(default_factory=list)
+    blocker: AutoBlocker | None = None
+
+    @property
+    def prefixed_text(self) -> str:
+        """Return the text sent back to the interview handler."""
+        return f"[from-auto][{self.source.value}] {self.text}"
+
+
+class AutoAnswerer:
+    """Policy engine for bounded auto interview answers.
+
+    This class is deterministic and performs no unbounded repository or network
+    exploration.  Later integrations may pass bounded repo facts into it.
+    """
+
+    def answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:
+        """Answer ``question`` using a conservative policy."""
+        lowered = question.lower()
+        blocker = _blocker_for(question)
+        if blocker is not None:
+            return AutoAnswer(
+                text=f"Cannot safely decide automatically: {blocker.reason}",
+                source=AutoAnswerSource.BLOCKER,
+                confidence=1.0,
+                blocker=blocker,
+            )
+
+        if any(word in lowered for word in ("non-goal", "out of scope", "exclude", "not do")):
+            return self._non_goal_answer(question)
+        if any(word in lowered for word in ("test", "verify", "validation", "acceptance", "done")):
+            return self._verification_answer(question)
+        if any(word in lowered for word in ("runtime", "stack", "repo", "project", "framework")):
+            return self._runtime_answer(question)
+        if any(word in lowered for word in ("input", "output", "user", "actor")):
+            return self._io_actor_answer(question)
+
+        return self._default_answer(question, ledger)
+
+    def apply(self, answer: AutoAnswer, ledger: SeedDraftLedger, *, question: str) -> None:
+        """Apply answer updates to ``ledger``."""
+        ledger.record_qa(question, answer.prefixed_text)
+        for section, entry in answer.ledger_updates:
+            ledger.add_entry(section, entry)
+
+    def _non_goal_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
+        value = "For auto MVP scope, cloud sync, authentication, paid services, and production deployment are non-goals unless explicitly requested."
+        entry = LedgerEntry(
+            key="non_goals.mvp_scope",
+            value=value,
+            source=LedgerSource.NON_GOAL,
+            confidence=0.86,
+            status=LedgerStatus.DEFAULTED,
+            rationale="Conservative auto policy bounds MVP scope.",
+        )
+        return AutoAnswer(value, AutoAnswerSource.NON_GOAL, 0.86, [("non_goals", entry)], non_goals=[value])
+
+    def _verification_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
+        value = "Success must be verified with observable behavior: commands or tests should produce stable output, non-zero failures for invalid input, and reproducible artifacts where applicable."
+        updates = [
+            (
+                "verification_plan",
+                LedgerEntry(
+                    key="verification.observable",
+                    value=value,
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.84,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="A-grade Seeds require testable acceptance criteria.",
+                ),
+            ),
+            (
+                "acceptance_criteria",
+                LedgerEntry(
+                    key="acceptance.observable_behavior",
+                    value="At least one automated or command-level check proves each acceptance criterion with observable output or artifacts.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.82,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Converts vague completion into testable behavior.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.84, updates)
+
+    def _runtime_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
+        value = "Use the existing repository runtime, package manager, and architectural patterns; avoid new dependencies unless required by acceptance criteria."
+        updates = [
+            (
+                "runtime_context",
+                LedgerEntry(
+                    key="runtime.existing_project",
+                    value=value,
+                    source=LedgerSource.EXISTING_CONVENTION,
+                    confidence=0.78,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Auto mode should avoid unnecessary stack choices.",
+                ),
+            ),
+            (
+                "constraints",
+                LedgerEntry(
+                    key="constraints.no_unnecessary_dependencies",
+                    value="Do not add new dependencies unless they are necessary to satisfy explicit acceptance criteria.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.86,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Reduces execution risk and review scope.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.EXISTING_CONVENTION, 0.78, updates)
+
+    def _io_actor_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
+        value = "Assume a single local user operating through the requested interface; inputs and outputs should be explicit command/API arguments and stable returned text or artifacts."
+        updates = [
+            (
+                "actors",
+                LedgerEntry(
+                    key="actors.single_local_user",
+                    value="Single local user",
+                    source=LedgerSource.ASSUMPTION,
+                    confidence=0.76,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="No multi-user requirement was provided.",
+                ),
+            ),
+            (
+                "inputs",
+                LedgerEntry(
+                    key="inputs.explicit_arguments",
+                    value="Explicit command/API arguments derived from the task goal",
+                    source=LedgerSource.ASSUMPTION,
+                    confidence=0.74,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Auto mode needs concrete IO to generate testable Seeds.",
+                ),
+            ),
+            (
+                "outputs",
+                LedgerEntry(
+                    key="outputs.stable_text_or_artifacts",
+                    value="Stable text output or generated artifacts suitable for verification",
+                    source=LedgerSource.ASSUMPTION,
+                    confidence=0.74,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Outputs must be observable for A-grade testability.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.ASSUMPTION, 0.76, updates, assumptions=[value])
+
+    def _default_answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:  # noqa: ARG002
+        value = "Proceed with a conservative MVP: keep scope small, prefer existing project patterns, document assumptions, and make completion verifiable with observable acceptance criteria."
+        updates = [
+            (
+                "constraints",
+                LedgerEntry(
+                    key="constraints.conservative_mvp",
+                    value="Keep the implementation to the smallest safe MVP that satisfies the task goal.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.82,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Default auto policy favors safe convergence.",
+                ),
+            ),
+            (
+                "failure_modes",
+                LedgerEntry(
+                    key="failure_modes.unverified_or_scope_creep",
+                    value="Failure includes unverified behavior, non-reproducible output, or scope expansion beyond the MVP.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.8,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="A-grade Seeds need explicit failure boundaries.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.82, updates)
+
+
+def _blocker_for(question: str) -> AutoBlocker | None:
+    lowered = question.lower()
+    blockers = {
+        "credential": "credential or secret value required",
+        "api key": "credential or API key required",
+        "production": "production deployment or irreversible external action required",
+        "deploy": "deployment target requires human authority",
+        "delete": "destructive operation requires human authority",
+        "payment": "paid service or financial decision required",
+        "legal": "legal judgment required",
+        "medical": "medical judgment required",
+    }
+    for token, reason in blockers.items():
+        if token in lowered:
+            return AutoBlocker(reason=reason, question=question)
+    return None

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -264,11 +264,15 @@ def _blocker_for(question: str) -> AutoBlocker | None:
 
     external_action_patterns = (
         (
-            r"\b(api key|access token|auth token|private key|password|credential value|credential secret)\b",
+            r"\b(access token|auth token|private key|credential value|credential secret)\b",
             "credential or secret value required",
         ),
         (
             r"\b(which|what|provide|enter|use|choose|select|configure|set)\b.+\b(credential|credentials)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what|provide|enter|use|choose|select|configure|set)\b.+\b(api keys?|passwords?)\b",
             "credential or secret value required",
         ),
         (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -83,6 +83,10 @@ class AutoAnswerer:
             ),
         ):
             return self._verification_answer(question)
+        if _is_actor_or_io_question(lowered):
+            return self._io_actor_answer(question)
+        if _is_product_behavior_question(lowered):
+            return self._product_behavior_answer(question)
         if _matches_any(
             lowered,
             (
@@ -95,10 +99,6 @@ class AutoAnswerer:
             ),
         ):
             return self._runtime_answer(question)
-        if _is_actor_or_io_question(lowered):
-            return self._io_actor_answer(question)
-        if _is_product_behavior_question(lowered):
-            return self._product_behavior_answer(question)
 
         return self._default_answer(question, ledger)
 
@@ -372,7 +372,7 @@ def _slug_key(value: str) -> str:
 def _is_product_behavior_question(lowered: str) -> bool:
     return bool(
         re.search(
-            r"\b(should|must|can|will|do|does|is|are)\b.+\b(mark|marked|show|display|write|return|create|update|edit|delete|store|save|send|generate|filter|sort|search|export|import|notify|report|use)\b",
+            r"\b(should|must|can|will|do|does|is|are)\b.+\b(mark|marked|show|display|write|return|create|update|edit|delete|remove|store|save|send|generate|filter|sort|search|export|import|notify|report|use)\b",
             lowered,
         )
         or re.search(r"\bwhat\s+(output|input)\b.+\b(should|does|do|format|write|use)\b", lowered)
@@ -384,7 +384,7 @@ def _is_product_behavior_question(lowered: str) -> bool:
             r"\bhow\s+should\b.+\b(behave|work|display|return|write|store|mark)\b", lowered
         )
         or re.search(
-            r"\b(which|what)\b.+\b(can|should)\b.+\b(edit|delete|update|create|view|access)\b",
+            r"\b(which|what)\b.+\b(can|should)\b.+\b(edit|delete|remove|update|create|view|access)\b",
             lowered,
         )
     )
@@ -428,7 +428,11 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "credential or secret value required",
         ),
         (
-            r"\b(provide|enter|use|choose|select|configure|set)\b.+\b(credential|credentials)\b",
+            r"\b(provide|enter|paste|supply|configure|set)\b.+\b(credentials?)\b.+\b(value|secret|token|key|password|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what)\s+credentials?\b.+\b(use|configure|set|env|environment|workflow|ci|production|prod)\b",
             "credential or secret value required",
         ),
         (
@@ -476,7 +480,7 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "production deployment or irreversible external action required",
         ),
         (
-            r"\b(delete|drop|erase|wipe|remove)\b.+\b(database|db|repo|branch|production|prod|secret|api key|credential)\b",
+            r"\b(delete|drop|erase|wipe|remove)\b.+\b(database|db|branch|production|prod)\b",
             "destructive external operation requires human authority",
         ),
         (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -280,15 +280,15 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "credential or secret value required",
         ),
         (
-            r"\b(payment|billing|paid service|credit card|bank account|invoice)\b.+\b(account|provider|key|secret|charge|purchase|subscribe|production|live)\b",
+            r"\b(which|what|provide|enter|use|choose|select|configure|set|charge|purchase|subscribe)\b.+\b(payment|billing|paid service|credit card|bank account|invoice)\b.+\b(account|provider|key|secret|production|live)\b",
             "paid service or financial decision required",
         ),
         (
-            r"\b(legal|compliance|license|contract)\b.+\b(advice|judgment|review|approval|liability|risk|interpretation)\b",
+            r"\b(which|what|provide|obtain|get|use|choose|select)\b.+\b(legal|compliance|license|contract)\b.+\b(advice|judgment|review|approval|liability|risk|interpretation)\b",
             "legal judgment required",
         ),
         (
-            r"\b(medical|clinical|diagnosis|treatment|health)\b.+\b(advice|judgment|diagnose|prescribe|triage|recommendation)\b",
+            r"\b(which|what|provide|use|choose|select)\b.+\b(medical|clinical|diagnosis|treatment|health)\b.+\b(advice|judgment|diagnose|prescribe|triage|recommendation)\b",
             "medical judgment required",
         ),
         (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -79,6 +79,19 @@ class AutoAnswerer:
     def apply(self, answer: AutoAnswer, ledger: SeedDraftLedger, *, question: str) -> None:
         """Apply answer updates to ``ledger``."""
         ledger.record_qa(question, answer.prefixed_text)
+        if answer.blocker is not None:
+            ledger.add_entry(
+                "constraints",
+                LedgerEntry(
+                    key="blocker.auto_answer",
+                    value=answer.blocker.reason,
+                    source=LedgerSource.BLOCKER,
+                    confidence=1.0,
+                    status=LedgerStatus.BLOCKED,
+                    reversible=False,
+                    rationale=f"Auto mode cannot safely answer: {answer.blocker.question}",
+                ),
+            )
         for section, entry in answer.ledger_updates:
             ledger.add_entry(section, entry)
 

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -69,7 +69,7 @@ class AutoAnswerer:
         if _matches_any(
             lowered, (r"\bnon-goals?\b", r"\bout of scope\b", r"\bexclude\b", r"\bnot do\b")
         ):
-            return self._non_goal_answer(question)
+            return self._non_goal_answer(question, ledger)
         if _matches_any(
             lowered,
             (
@@ -117,8 +117,20 @@ class AutoAnswerer:
         for section, entry in answer.ledger_updates:
             ledger.add_entry(section, entry)
 
-    def _non_goal_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
-        value = "For auto MVP scope, cloud sync, authentication, paid services, and production deployment are non-goals unless explicitly requested."
+    def _non_goal_answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:  # noqa: ARG002
+        goal_text = (
+            ledger.sections.get("goal").entries[0].value.lower()
+            if ledger.sections.get("goal") and ledger.sections["goal"].entries
+            else ""
+        )
+        excluded = ["cloud sync", "paid services"]
+        if not re.search(r"\b(auth|authentication|login|sign[- ]?in|signup|password)\b", goal_text):
+            excluded.append("authentication")
+        if not re.search(r"\b(production|prod|deploy|deployment|release|publish)\b", goal_text):
+            excluded.append("production deployment")
+        value = (
+            f"For auto MVP scope, {', '.join(excluded)} are non-goals unless explicitly requested."
+        )
         entry = LedgerEntry(
             key="non_goals.mvp_scope",
             value=value,

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -92,7 +92,9 @@ class AutoAnswerer:
             status=LedgerStatus.DEFAULTED,
             rationale="Conservative auto policy bounds MVP scope.",
         )
-        return AutoAnswer(value, AutoAnswerSource.NON_GOAL, 0.86, [("non_goals", entry)], non_goals=[value])
+        return AutoAnswer(
+            value, AutoAnswerSource.NON_GOAL, 0.86, [("non_goals", entry)], non_goals=[value]
+        )
 
     def _verification_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
         value = "Success must be verified with observable behavior: commands or tests should produce stable output, non-zero failures for invalid input, and reproducible artifacts where applicable."

--- a/src/ouroboros/auto/gap_detector.py
+++ b/src/ouroboros/auto/gap_detector.py
@@ -1,0 +1,72 @@
+"""Gap detection for auto-mode Seed Draft Ledgers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ouroboros.auto.ledger import REQUIRED_SECTIONS, LedgerStatus, SeedDraftLedger
+
+
+class GapType(StrEnum):
+    """Known Seed gap types."""
+
+    GOAL = "goal_gap"
+    ACTOR = "actor_gap"
+    INPUT = "input_gap"
+    OUTPUT = "output_gap"
+    CONSTRAINT = "constraint_gap"
+    NON_GOAL = "non_goal_gap"
+    ACCEPTANCE_CRITERIA = "acceptance_criteria_gap"
+    VERIFICATION = "verification_gap"
+    FAILURE_MODE = "failure_mode_gap"
+    RUNTIME_CONTEXT = "runtime_context_gap"
+    RISK = "risk_gap"
+
+
+SECTION_TO_GAP = {
+    "goal": GapType.GOAL,
+    "actors": GapType.ACTOR,
+    "inputs": GapType.INPUT,
+    "outputs": GapType.OUTPUT,
+    "constraints": GapType.CONSTRAINT,
+    "non_goals": GapType.NON_GOAL,
+    "acceptance_criteria": GapType.ACCEPTANCE_CRITERIA,
+    "verification_plan": GapType.VERIFICATION,
+    "failure_modes": GapType.FAILURE_MODE,
+    "runtime_context": GapType.RUNTIME_CONTEXT,
+    "risks": GapType.RISK,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Gap:
+    """A structured gap detected in a ledger."""
+
+    section: str
+    gap_type: GapType
+    state: LedgerStatus
+    message: str
+    repairable: bool = True
+
+
+class GapDetector:
+    """Detect missing, conflicting, and blocked auto-mode Seed sections."""
+
+    def detect(self, ledger: SeedDraftLedger) -> list[Gap]:
+        """Return structured gaps for ``ledger``."""
+        statuses = ledger.section_statuses()
+        gaps: list[Gap] = []
+        for section in REQUIRED_SECTIONS:
+            status = statuses[section]
+            if status in {LedgerStatus.MISSING, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED, LedgerStatus.WEAK}:
+                gaps.append(
+                    Gap(
+                        section=section,
+                        gap_type=SECTION_TO_GAP[section],
+                        state=status,
+                        message=f"{section} is {status.value}",
+                        repairable=status != LedgerStatus.BLOCKED,
+                    )
+                )
+        return gaps

--- a/src/ouroboros/auto/gap_detector.py
+++ b/src/ouroboros/auto/gap_detector.py
@@ -59,7 +59,12 @@ class GapDetector:
         gaps: list[Gap] = []
         for section in REQUIRED_SECTIONS:
             status = statuses[section]
-            if status in {LedgerStatus.MISSING, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED, LedgerStatus.WEAK}:
+            if status in {
+                LedgerStatus.MISSING,
+                LedgerStatus.CONFLICTING,
+                LedgerStatus.BLOCKED,
+                LedgerStatus.WEAK,
+            }:
                 gaps.append(
                     Gap(
                         section=section,

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -48,6 +48,10 @@ _OBSERVABLE_HINTS = (
     "non-zero",
     "stdout",
     "stderr",
+    "exits",
+    "exit code",
+    "http",
+    "200",
 )
 
 
@@ -278,6 +282,10 @@ def _is_observable(value: str) -> bool:
         r"\b(stdout|stderr|file|artifact|status|response|output|non-zero|exit code)\b.+\b(contains|equals|includes|is|exists|created|written)\b",
         r"\b(test|check)\b.+\b(passes|fails|asserts|verifies)\b",
         r"\b(api|endpoint|request)\b.+\b(returns|responds|status)\b",
+        r"\b(cli|command|process)\b.+\b(exits|returns)\b\s+(with\s+)?(exit\s+code\s+)?0\b",
+        r"\b(exit\s+code|status)\s+0\b",
+        r"\b(get|post|put|patch|delete)\b.+\b(returns|responds|status)\b\s+(with\s+)?(http\s+)?2\d\d\b",
+        r"\b(http\s+)?status\s+2\d\d\b",
     )
     return any(re.search(pattern, lowered) for pattern in observable_patterns)
 

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -142,6 +142,16 @@ class GradeGate:
 
         if not seed.goal.strip():
             blockers.append(GradeFinding("missing_goal", "high", "Seed goal is empty", "goal"))
+        if seed.metadata.ambiguity_score > 0.20:
+            blockers.append(
+                GradeFinding(
+                    "high_ambiguity_score",
+                    "high",
+                    f"Seed ambiguity score is too high for auto execution: {seed.metadata.ambiguity_score:.2f}",
+                    "metadata.ambiguity_score",
+                    "Continue interview or repair until ambiguity_score <= 0.20.",
+                )
+            )
         if not seed.constraints:
             findings.append(
                 GradeFinding(

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -8,7 +8,7 @@ import re
 from typing import Any
 
 from ouroboros.auto.gap_detector import GapDetector
-from ouroboros.auto.ledger import LedgerSource, SeedDraftLedger
+from ouroboros.auto.ledger import LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.core.seed import Seed
 
 
@@ -292,11 +292,13 @@ def _is_observable(value: str) -> bool:
 
 def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:
     risky_terms = ("credential", "api key", "production", "payment", "legal", "medical")
+    inactive_statuses = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
     return sum(
         1
         for section in ledger.sections.values()
         for entry in section.entries
         if entry.source == LedgerSource.ASSUMPTION
+        and entry.status not in inactive_statuses
         and any(term in entry.value.lower() for term in risky_terms)
     )
 

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -182,6 +182,17 @@ class GradeGate:
 
         non_goals = []
         if ledger is not None:
+            open_gaps = ledger.open_gaps()
+            for gap in open_gaps:
+                blockers.append(
+                    GradeFinding(
+                        "ledger_open_gap",
+                        "high",
+                        f"Ledger required section is unresolved: {gap}",
+                        gap,
+                        "Resolve the ledger section before allowing auto execution.",
+                    )
+                )
             non_goal_section = ledger.sections.get("non_goals")
             non_goals = (
                 [entry.value for entry in non_goal_section.entries] if non_goal_section else []
@@ -259,7 +270,16 @@ def _is_vague(value: str) -> bool:
 
 def _is_observable(value: str) -> bool:
     lowered = value.lower()
-    return any(hint in lowered for hint in _OBSERVABLE_HINTS)
+    if not any(hint in lowered for hint in _OBSERVABLE_HINTS):
+        return False
+    observable_patterns = (
+        r"`[^`]+`\s+(prints|returns|creates|writes|exits|displays)",
+        r"\b(prints|returns|creates|writes|exits|displays|contains)\b.+\b(stdout|stderr|file|artifact|status|response|output|non-zero|exit code)\b",
+        r"\b(stdout|stderr|file|artifact|status|response|output|non-zero|exit code)\b.+\b(contains|equals|includes|is|exists|created|written)\b",
+        r"\b(test|check)\b.+\b(passes|fails|asserts|verifies)\b",
+        r"\b(api|endpoint|request)\b.+\b(returns|responds|status)\b",
+    )
+    return any(re.search(pattern, lowered) for pattern in observable_patterns)
 
 
 def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -303,7 +303,7 @@ def _seed_goal_matches_ledger(seed_goal: str, ledger: SeedDraftLedger) -> bool:
         if not ledger_tokens:
             continue
         shared = seed_tokens & ledger_tokens
-        if ledger_tokens <= seed_tokens or seed_tokens <= ledger_tokens:
+        if ledger_tokens <= seed_tokens:
             return True
         if len(shared) / max(len(ledger_tokens), 1) >= 0.6:
             return True

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -183,7 +183,9 @@ class GradeGate:
         non_goals = []
         if ledger is not None:
             non_goal_section = ledger.sections.get("non_goals")
-            non_goals = [entry.value for entry in non_goal_section.entries] if non_goal_section else []
+            non_goals = (
+                [entry.value for entry in non_goal_section.entries] if non_goal_section else []
+            )
         if ledger is not None and not non_goals:
             findings.append(
                 GradeFinding(
@@ -215,7 +217,9 @@ class GradeGate:
             "ambiguity": min(1.0, 0.05 + 0.08 * len(findings) + 0.2 * len(blockers)),
             "testability": max(0.0, 0.95 - 0.25 * untestable_count),
             "execution_feasibility": 0.85 if not blockers else 0.4,
-            "risk": min(1.0, 0.05 * len(findings) + 0.3 * len(blockers) + 0.2 * high_risk_assumptions),
+            "risk": min(
+                1.0, 0.05 * len(findings) + 0.3 * len(blockers) + 0.2 * high_risk_assumptions
+            ),
         }
         return self._result(scores=scores, findings=findings, blockers=blockers)
 

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -291,7 +291,7 @@ def _is_observable(value: str) -> bool:
 
 
 def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:
-    risky_terms = ("credential", "api key", "production", "delete", "payment", "legal", "medical")
+    risky_terms = ("credential", "api key", "production", "payment", "legal", "medical")
     return sum(
         1
         for section in ledger.sections.values()

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -1,0 +1,273 @@
+"""Deterministic A-grade gate for auto-generated Seeds and ledgers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import re
+from typing import Any
+
+from ouroboros.auto.gap_detector import GapDetector
+from ouroboros.auto.ledger import LedgerSource, SeedDraftLedger
+from ouroboros.core.seed import Seed
+
+
+class SeedGrade(StrEnum):
+    """Supported quality grades for auto-mode execution gates."""
+
+    A = "A"
+    B = "B"
+    C = "C"
+
+
+VAGUE_TERMS = (
+    "easy",
+    "intuitive",
+    "robust",
+    "scalable",
+    "better",
+    "improve",
+    "optimized",
+    "user-friendly",
+    "seamless",
+)
+_OBSERVABLE_HINTS = (
+    "command",
+    "exit",
+    "prints",
+    "returns",
+    "creates",
+    "writes",
+    "file",
+    "test",
+    "api",
+    "status",
+    "displays",
+    "contains",
+    "artifact",
+    "non-zero",
+    "stdout",
+    "stderr",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GradeFinding:
+    """A single deterministic grading finding."""
+
+    code: str
+    severity: str
+    message: str
+    target: str = ""
+    repair_instruction: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "target": self.target,
+            "repair_instruction": self.repair_instruction,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GradeResult:
+    """Structured result returned by GradeGate."""
+
+    grade: SeedGrade
+    scores: dict[str, float]
+    findings: list[GradeFinding] = field(default_factory=list)
+    blockers: list[GradeFinding] = field(default_factory=list)
+    can_repair: bool = True
+    may_run: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "grade": self.grade.value,
+            "scores": self.scores,
+            "findings": [finding.to_dict() for finding in self.findings],
+            "blockers": [blocker.to_dict() for blocker in self.blockers],
+            "can_repair": self.can_repair,
+            "may_run": self.may_run,
+        }
+
+
+class GradeGate:
+    """Deterministic gate that prevents B/C Seeds from running."""
+
+    def __init__(self, gap_detector: GapDetector | None = None) -> None:
+        self.gap_detector = gap_detector or GapDetector()
+
+    def grade_ledger(self, ledger: SeedDraftLedger) -> GradeResult:
+        """Grade a Seed Draft Ledger before Seed generation."""
+        findings: list[GradeFinding] = []
+        blockers: list[GradeFinding] = []
+        gaps = self.gap_detector.detect(ledger)
+        for gap in gaps:
+            finding = GradeFinding(
+                code=f"{gap.section}_{gap.state.value}",
+                severity="high" if not gap.repairable else "medium",
+                message=gap.message,
+                target=gap.section,
+                repair_instruction="Resolve via confirmed fact, conservative default, assumption, or non-goal.",
+            )
+            if gap.repairable:
+                findings.append(finding)
+            else:
+                blockers.append(finding)
+
+        summary = ledger.summary()
+        missing_count = len(summary["open_gaps"])
+        coverage = max(0.0, 1.0 - (missing_count / 10))
+        assumption_count = len(summary["assumptions"])
+        risk = min(1.0, 0.05 * assumption_count + 0.15 * len(blockers))
+        scores = {
+            "coverage": round(coverage, 2),
+            "ambiguity": round(1.0 - coverage, 2),
+            "testability": 0.85 if "acceptance_criteria" not in summary["open_gaps"] else 0.4,
+            "execution_feasibility": 0.85 if "runtime_context" not in summary["open_gaps"] else 0.5,
+            "risk": round(risk, 2),
+        }
+        return self._result(scores=scores, findings=findings, blockers=blockers)
+
+    def grade_seed(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> GradeResult:
+        """Grade a generated Seed deterministically."""
+        findings: list[GradeFinding] = []
+        blockers: list[GradeFinding] = []
+
+        if not seed.goal.strip():
+            blockers.append(GradeFinding("missing_goal", "high", "Seed goal is empty", "goal"))
+        if not seed.constraints:
+            findings.append(
+                GradeFinding(
+                    "missing_constraints",
+                    "medium",
+                    "Seed has no constraints",
+                    "constraints",
+                    "Add explicit execution and scope constraints.",
+                )
+            )
+        if not seed.acceptance_criteria:
+            findings.append(
+                GradeFinding(
+                    "missing_acceptance_criteria",
+                    "high",
+                    "Seed has no acceptance criteria",
+                    "acceptance_criteria",
+                    "Add observable acceptance criteria.",
+                )
+            )
+        for index, criterion in enumerate(seed.acceptance_criteria):
+            if _is_vague(criterion):
+                findings.append(
+                    GradeFinding(
+                        "vague_acceptance_criteria",
+                        "high",
+                        f"Acceptance criterion is vague: {criterion}",
+                        f"acceptance_criteria[{index}]",
+                        "Replace with observable behavior or artifact.",
+                    )
+                )
+            if not _is_observable(criterion):
+                findings.append(
+                    GradeFinding(
+                        "untestable_acceptance_criteria",
+                        "high",
+                        f"Acceptance criterion is not clearly observable: {criterion}",
+                        f"acceptance_criteria[{index}]",
+                        "Mention command output, file/artifact, API response, or test result.",
+                    )
+                )
+
+        non_goals = []
+        if ledger is not None:
+            non_goal_section = ledger.sections.get("non_goals")
+            non_goals = [entry.value for entry in non_goal_section.entries] if non_goal_section else []
+        if ledger is not None and not non_goals:
+            findings.append(
+                GradeFinding(
+                    "missing_non_goals",
+                    "medium",
+                    "Auto-generated Seed has no explicit non-goals",
+                    "non_goals",
+                    "Add MVP non-goals to bound scope.",
+                )
+            )
+
+        high_risk_assumptions = 0
+        if ledger is not None:
+            high_risk_assumptions = _high_risk_assumption_count(ledger)
+            if high_risk_assumptions:
+                blockers.append(
+                    GradeFinding(
+                        "high_risk_assumptions",
+                        "high",
+                        "Ledger contains high-risk assumptions",
+                        "assumptions",
+                        "Replace high-risk assumptions with blockers or user confirmation.",
+                    )
+                )
+
+        untestable_count = sum(1 for finding in findings if "acceptance_criteria" in finding.code)
+        scores = {
+            "coverage": _score_threshold(len(findings), len(blockers), base=0.95),
+            "ambiguity": min(1.0, 0.05 + 0.08 * len(findings) + 0.2 * len(blockers)),
+            "testability": max(0.0, 0.95 - 0.25 * untestable_count),
+            "execution_feasibility": 0.85 if not blockers else 0.4,
+            "risk": min(1.0, 0.05 * len(findings) + 0.3 * len(blockers) + 0.2 * high_risk_assumptions),
+        }
+        return self._result(scores=scores, findings=findings, blockers=blockers)
+
+    def _result(
+        self,
+        *,
+        scores: dict[str, float],
+        findings: list[GradeFinding],
+        blockers: list[GradeFinding],
+    ) -> GradeResult:
+        grade = SeedGrade.A
+        if blockers:
+            grade = SeedGrade.C
+        elif (
+            scores["coverage"] < 0.90
+            or scores["ambiguity"] > 0.20
+            or scores["testability"] < 0.85
+            or scores["execution_feasibility"] < 0.80
+            or scores["risk"] > 0.25
+            or findings
+        ):
+            grade = SeedGrade.B
+        return GradeResult(
+            grade=grade,
+            scores={name: round(value, 2) for name, value in scores.items()},
+            findings=findings,
+            blockers=blockers,
+            can_repair=not blockers,
+            may_run=grade == SeedGrade.A and not blockers,
+        )
+
+
+def _is_vague(value: str) -> bool:
+    lowered = value.lower()
+    return any(re.search(rf"\b{re.escape(term)}\b", lowered) for term in VAGUE_TERMS)
+
+
+def _is_observable(value: str) -> bool:
+    lowered = value.lower()
+    return any(hint in lowered for hint in _OBSERVABLE_HINTS)
+
+
+def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:
+    risky_terms = ("credential", "api key", "production", "delete", "payment", "legal", "medical")
+    return sum(
+        1
+        for section in ledger.sections.values()
+        for entry in section.entries
+        if entry.source == LedgerSource.ASSUMPTION
+        and any(term in entry.value.lower() for term in risky_terms)
+    )
+
+
+def _score_threshold(finding_count: int, blocker_count: int, *, base: float) -> float:
+    return max(0.0, min(1.0, base - 0.08 * finding_count - 0.25 * blocker_count))

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -142,6 +142,16 @@ class GradeGate:
 
         if not seed.goal.strip():
             blockers.append(GradeFinding("missing_goal", "high", "Seed goal is empty", "goal"))
+        elif ledger is not None and not _seed_goal_matches_ledger(seed.goal, ledger):
+            blockers.append(
+                GradeFinding(
+                    "seed_goal_mismatch",
+                    "high",
+                    "Seed goal does not match the converged interview goal",
+                    "goal",
+                    "Regenerate or repair the Seed so its goal matches the auto interview ledger goal.",
+                )
+            )
         if seed.metadata.ambiguity_score > 0.20:
             blockers.append(
                 GradeFinding(
@@ -275,6 +285,55 @@ class GradeGate:
             can_repair=not blockers,
             may_run=grade == SeedGrade.A and not blockers,
         )
+
+
+def _seed_goal_matches_ledger(seed_goal: str, ledger: SeedDraftLedger) -> bool:
+    goal_section = ledger.sections.get("goal")
+    if goal_section is None:
+        return True
+    inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    goals = [entry.value for entry in goal_section.entries if entry.status not in inactive]
+    if not goals:
+        return True
+    seed_tokens = _goal_tokens(seed_goal)
+    if not seed_tokens:
+        return False
+    for goal in goals:
+        ledger_tokens = _goal_tokens(goal)
+        if not ledger_tokens:
+            continue
+        shared = seed_tokens & ledger_tokens
+        if ledger_tokens <= seed_tokens or seed_tokens <= ledger_tokens:
+            return True
+        if len(shared) / max(len(ledger_tokens), 1) >= 0.6:
+            return True
+    return False
+
+
+def _goal_tokens(value: str) -> set[str]:
+    stopwords = {
+        "a",
+        "an",
+        "and",
+        "app",
+        "application",
+        "build",
+        "create",
+        "for",
+        "make",
+        "the",
+        "to",
+    }
+    tokens = {
+        token
+        for token in re.findall(r"[a-z0-9]+", value.casefold())
+        if len(token) >= 2 and token not in stopwords
+    }
+    if "cli" in tokens:
+        tokens.update({"command", "line", "interface"})
+    if {"command", "line", "interface"} <= tokens:
+        tokens.add("cli")
+    return tokens
 
 
 def _is_vague(value: str) -> bool:

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -32,6 +32,9 @@ class InterviewBackend(Protocol):
     async def answer(self, session_id: str, answer: str) -> InterviewTurn:
         """Record an answer and return the next question or completion metadata."""
 
+    async def resume(self, session_id: str) -> InterviewTurn:
+        """Return the outstanding question for a persisted interview session."""
+
 
 @dataclass(frozen=True, slots=True)
 class AutoInterviewResult:
@@ -64,10 +67,19 @@ class AutoInterviewDriver:
         self._ensure_interview_phase(state)
         try:
             if state.interview_session_id:
-                turn = InterviewTurn(
-                    question="Continue from persisted auto interview state.",
-                    session_id=state.interview_session_id,
-                )
+                if state.pending_question:
+                    turn = InterviewTurn(
+                        question=state.pending_question,
+                        session_id=state.interview_session_id,
+                    )
+                else:
+                    turn = await self._with_timeout(
+                        self.backend.resume(state.interview_session_id),
+                        state,
+                        tool_name="interview.resume",
+                    )
+                    state.pending_question = turn.question
+                    self._save(state)
             else:
                 turn = await self._with_timeout(
                     self.backend.start(state.goal, cwd=state.cwd),
@@ -75,6 +87,7 @@ class AutoInterviewDriver:
                     tool_name="interview.start",
                 )
                 state.interview_session_id = turn.session_id
+                state.pending_question = turn.question
                 self._save(state)
         except TimeoutError as exc:
             state.mark_blocked(str(exc), tool_name="interview.start")
@@ -117,6 +130,7 @@ class AutoInterviewDriver:
                 return AutoInterviewResult("blocked", state.interview_session_id, ledger, round_number, str(exc))
 
             state.interview_session_id = turn.session_id
+            state.pending_question = turn.question
             self._save(state)
             if (turn.seed_ready or turn.completed) and ledger.is_seed_ready():
                 return AutoInterviewResult("seed_ready", turn.session_id, ledger, round_number)
@@ -156,12 +170,20 @@ class FunctionInterviewBackend:
         self,
         start: Callable[[str, str], Awaitable[InterviewTurn]],
         answer: Callable[[str, str], Awaitable[InterviewTurn]],
+        resume: Callable[[str], Awaitable[InterviewTurn]] | None = None,
     ) -> None:
         self._start = start
         self._answer = answer
+        self._resume = resume
 
     async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
         return await self._start(goal, cwd)
 
     async def answer(self, session_id: str, answer: str) -> InterviewTurn:
         return await self._answer(session_id, answer)
+
+    async def resume(self, session_id: str) -> InterviewTurn:
+        if self._resume is None:
+            msg = "interview resume is unavailable because no pending question is persisted"
+            raise RuntimeError(msg)
+        return await self._resume(session_id)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -152,11 +152,19 @@ class AutoInterviewDriver:
             state.interview_session_id = turn.session_id
             state.pending_question = turn.question
             self._save(state)
-            if (turn.seed_ready or turn.completed) and ledger.is_seed_ready():
-                state.interview_completed = True
-                state.pending_question = None
+            if turn.seed_ready or turn.completed:
+                if ledger.is_seed_ready():
+                    state.interview_completed = True
+                    state.pending_question = None
+                    self._save(state)
+                    return AutoInterviewResult("seed_ready", turn.session_id, ledger, round_number)
+                gaps = ", ".join(ledger.open_gaps())
+                blocker = f"interview backend completed before auto ledger was ready: {gaps}"
+                state.mark_blocked(blocker, tool_name="interview_driver")
                 self._save(state)
-                return AutoInterviewResult("seed_ready", turn.session_id, ledger, round_number)
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, round_number, blocker
+                )
 
         if not ledger.is_seed_ready():
             gaps = ", ".join(ledger.open_gaps())

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -110,6 +110,8 @@ class AutoInterviewDriver:
 
             answer = self.answerer.answer(turn.question, ledger)
             if answer.blocker is not None:
+                self.answerer.apply(answer, ledger, question=turn.question)
+                state.ledger = ledger.to_dict()
                 state.mark_blocked(answer.blocker.reason, tool_name="auto_answerer")
                 self._save(state)
                 return AutoInterviewResult(

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -150,8 +150,6 @@ class AutoInterviewDriver:
                 )
 
             state.interview_session_id = turn.session_id
-            state.pending_question = turn.question
-            self._save(state)
             if turn.seed_ready or turn.completed:
                 if ledger.is_seed_ready():
                     state.interview_completed = True
@@ -160,11 +158,14 @@ class AutoInterviewDriver:
                     return AutoInterviewResult("seed_ready", turn.session_id, ledger, round_number)
                 gaps = ", ".join(ledger.open_gaps())
                 blocker = f"interview backend completed before auto ledger was ready: {gaps}"
+                state.pending_question = None
                 state.mark_blocked(blocker, tool_name="interview_driver")
                 self._save(state)
                 return AutoInterviewResult(
                     "blocked", state.interview_session_id, ledger, round_number, blocker
                 )
+            state.pending_question = turn.question
+            self._save(state)
 
         if not ledger.is_seed_ready():
             gaps = ", ".join(ledger.open_gaps())

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -107,6 +107,9 @@ class AutoInterviewDriver:
                 "blocked", state.interview_session_id, ledger, state.current_round, blocker
             )
 
+        if turn.seed_ready or turn.completed:
+            return self._handle_completed_turn(state, ledger, turn, state.current_round)
+
         for round_number in range(state.current_round + 1, self.max_rounds + 1):
             state.current_round = round_number
             state.mark_progress(f"interview round {round_number}/{self.max_rounds}")
@@ -158,19 +161,7 @@ class AutoInterviewDriver:
 
             state.interview_session_id = turn.session_id
             if turn.seed_ready or turn.completed:
-                if ledger.is_seed_ready():
-                    state.interview_completed = True
-                    state.pending_question = None
-                    self._save(state)
-                    return AutoInterviewResult("seed_ready", turn.session_id, ledger, round_number)
-                gaps = ", ".join(ledger.open_gaps())
-                blocker = f"interview backend completed before auto ledger was ready: {gaps}"
-                state.pending_question = None
-                state.mark_blocked(blocker, tool_name="interview_driver")
-                self._save(state)
-                return AutoInterviewResult(
-                    "blocked", state.interview_session_id, ledger, round_number, blocker
-                )
+                return self._handle_completed_turn(state, ledger, turn, round_number)
             state.pending_question = turn.question
             self._save(state)
 
@@ -212,6 +203,21 @@ class AutoInterviewDriver:
                 blocker=blocker,
             )
         return self.answerer.answer(_gap_prompt(next_gap), ledger)
+
+    def _handle_completed_turn(
+        self, state: AutoPipelineState, ledger: SeedDraftLedger, turn: InterviewTurn, rounds: int
+    ) -> AutoInterviewResult:
+        state.interview_session_id = turn.session_id
+        state.pending_question = None
+        if ledger.is_seed_ready():
+            state.interview_completed = True
+            self._save(state)
+            return AutoInterviewResult("seed_ready", turn.session_id, ledger, rounds)
+        gaps = ", ".join(ledger.open_gaps())
+        blocker = f"interview backend completed before auto ledger was ready: {gaps}"
+        state.mark_blocked(blocker, tool_name="interview_driver")
+        self._save(state)
+        return AutoInterviewResult("blocked", state.interview_session_id, ledger, rounds, blocker)
 
     async def _with_timeout(
         self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -1,0 +1,167 @@
+"""Bounded auto Socratic interview driver."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from ouroboros.auto.answerer import AutoAnswerer
+from ouroboros.auto.gap_detector import GapDetector
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+
+@dataclass(frozen=True, slots=True)
+class InterviewTurn:
+    """Question returned by an interview backend."""
+
+    question: str
+    session_id: str
+    seed_ready: bool = False
+    completed: bool = False
+
+
+class InterviewBackend(Protocol):
+    """Minimal backend interface needed by the auto interview driver."""
+
+    async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
+        """Start an interview and return the first question."""
+
+    async def answer(self, session_id: str, answer: str) -> InterviewTurn:
+        """Record an answer and return the next question or completion metadata."""
+
+
+@dataclass(frozen=True, slots=True)
+class AutoInterviewResult:
+    """Result from running the bounded auto interview loop."""
+
+    status: str
+    session_id: str | None
+    ledger: SeedDraftLedger
+    rounds: int
+    blocker: str | None = None
+
+
+@dataclass(slots=True)
+class AutoInterviewDriver:
+    """Drive an interview backend with conservative auto answers.
+
+    The driver never relies on the backend to terminate by itself.  All backend
+    calls are timeout-bounded and the loop is capped by ``max_rounds``.
+    """
+
+    backend: InterviewBackend
+    answerer: AutoAnswerer = field(default_factory=AutoAnswerer)
+    gap_detector: GapDetector = field(default_factory=GapDetector)
+    store: AutoStore | None = None
+    timeout_seconds: float = 60.0
+    max_rounds: int = 12
+
+    async def run(self, state: AutoPipelineState, ledger: SeedDraftLedger) -> AutoInterviewResult:
+        """Run bounded auto interview until Seed-ready or blocked."""
+        self._ensure_interview_phase(state)
+        try:
+            if state.interview_session_id:
+                turn = InterviewTurn(
+                    question="Continue from persisted auto interview state.",
+                    session_id=state.interview_session_id,
+                )
+            else:
+                turn = await self._with_timeout(
+                    self.backend.start(state.goal, cwd=state.cwd),
+                    state,
+                    tool_name="interview.start",
+                )
+                state.interview_session_id = turn.session_id
+                self._save(state)
+        except TimeoutError as exc:
+            state.mark_blocked(str(exc), tool_name="interview.start")
+            self._save(state)
+            return AutoInterviewResult("blocked", state.interview_session_id, ledger, state.current_round, str(exc))
+
+        for round_number in range(state.current_round + 1, self.max_rounds + 1):
+            state.current_round = round_number
+            state.mark_progress(f"interview round {round_number}/{self.max_rounds}")
+            self._save(state)
+
+            answer = self.answerer.answer(turn.question, ledger)
+            if answer.blocker is not None:
+                state.mark_blocked(answer.blocker.reason, tool_name="auto_answerer")
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked",
+                    state.interview_session_id,
+                    ledger,
+                    round_number,
+                    answer.blocker.reason,
+                )
+            self.answerer.apply(answer, ledger, question=turn.question)
+            state.ledger = ledger.to_dict()
+            state.mark_progress(
+                f"answered round {round_number}/{self.max_rounds} from {answer.source.value}",
+                tool_name="auto_answerer",
+            )
+            self._save(state)
+
+            try:
+                turn = await self._with_timeout(
+                    self.backend.answer(turn.session_id, answer.prefixed_text),
+                    state,
+                    tool_name="interview.answer",
+                )
+            except TimeoutError as exc:
+                state.mark_blocked(str(exc), tool_name="interview.answer")
+                self._save(state)
+                return AutoInterviewResult("blocked", state.interview_session_id, ledger, round_number, str(exc))
+
+            state.interview_session_id = turn.session_id
+            self._save(state)
+            if (turn.seed_ready or turn.completed) and ledger.is_seed_ready():
+                return AutoInterviewResult("seed_ready", turn.session_id, ledger, round_number)
+
+        if not ledger.is_seed_ready():
+            gaps = ", ".join(ledger.open_gaps())
+            blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
+            state.mark_blocked(blocker, tool_name="interview_driver")
+            self._save(state)
+            return AutoInterviewResult("blocked", state.interview_session_id, ledger, self.max_rounds, blocker)
+        return AutoInterviewResult("seed_ready", state.interview_session_id, ledger, self.max_rounds)
+
+    async def _with_timeout(self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str) -> InterviewTurn:
+        try:
+            return await asyncio.wait_for(awaitable, timeout=self.timeout_seconds)
+        except TimeoutError as exc:
+            msg = f"{tool_name} timed out after {self.timeout_seconds:.0f}s for {state.auto_session_id}"
+            raise TimeoutError(msg) from exc
+
+    def _ensure_interview_phase(self, state: AutoPipelineState) -> None:
+        if state.phase == AutoPhase.CREATED:
+            state.transition(AutoPhase.INTERVIEW, "starting auto interview")
+            self._save(state)
+        elif state.phase != AutoPhase.INTERVIEW:
+            msg = f"Auto interview cannot run from phase {state.phase.value}"
+            raise ValueError(msg)
+
+    def _save(self, state: AutoPipelineState) -> None:
+        if self.store is not None:
+            self.store.save(state)
+
+
+class FunctionInterviewBackend:
+    """Adapter for tests or local integrations built from callables."""
+
+    def __init__(
+        self,
+        start: Callable[[str, str], Awaitable[InterviewTurn]],
+        answer: Callable[[str, str], Awaitable[InterviewTurn]],
+    ) -> None:
+        self._start = start
+        self._answer = answer
+
+    async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
+        return await self._start(goal, cwd)
+
+    async def answer(self, session_id: str, answer: str) -> InterviewTurn:
+        return await self._answer(session_id, answer)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -161,8 +161,11 @@ class AutoInterviewDriver:
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
             )
+        blocker = "auto interview reached max rounds before backend marked the Seed ready"
+        state.mark_blocked(blocker, tool_name="interview_driver")
+        self._save(state)
         return AutoInterviewResult(
-            "seed_ready", state.interview_session_id, ledger, self.max_rounds
+            "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
         )
 
     async def _with_timeout(

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -95,6 +95,13 @@ class AutoInterviewDriver:
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, state.current_round, str(exc)
             )
+        except Exception as exc:
+            blocker = f"interview resume/start failed: {exc}"
+            state.mark_blocked(blocker, tool_name="interview.start")
+            self._save(state)
+            return AutoInterviewResult(
+                "blocked", state.interview_session_id, ledger, state.current_round, blocker
+            )
 
         for round_number in range(state.current_round + 1, self.max_rounds + 1):
             state.current_round = round_number
@@ -131,6 +138,13 @@ class AutoInterviewDriver:
                 self._save(state)
                 return AutoInterviewResult(
                     "blocked", state.interview_session_id, ledger, round_number, str(exc)
+                )
+            except Exception as exc:
+                blocker = f"interview answer failed: {exc}"
+                state.mark_blocked(blocker, tool_name="interview.answer")
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, round_number, blocker
                 )
 
             state.interview_session_id = turn.session_id

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -151,6 +151,9 @@ class AutoInterviewDriver:
             state.pending_question = turn.question
             self._save(state)
             if (turn.seed_ready or turn.completed) and ledger.is_seed_ready():
+                state.interview_completed = True
+                state.pending_question = None
+                self._save(state)
                 return AutoInterviewResult("seed_ready", turn.session_id, ledger, round_number)
 
         if not ledger.is_seed_ready():

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -7,9 +7,9 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Protocol
 
-from ouroboros.auto.answerer import AutoAnswerer
-from ouroboros.auto.gap_detector import GapDetector
-from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource, AutoBlocker
+from ouroboros.auto.gap_detector import Gap, GapDetector
+from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 
 
@@ -108,7 +108,7 @@ class AutoInterviewDriver:
             state.mark_progress(f"interview round {round_number}/{self.max_rounds}")
             self._save(state)
 
-            answer = self.answerer.answer(turn.question, ledger)
+            answer = self._answer_with_gap_steering(turn.question, ledger)
             if answer.blocker is not None:
                 self.answerer.apply(answer, ledger, question=turn.question)
                 state.ledger = ledger.to_dict()
@@ -181,6 +181,30 @@ class AutoInterviewDriver:
             "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
         )
 
+    def _answer_with_gap_steering(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:
+        answer = self.answerer.answer(question, ledger)
+        if answer.blocker is not None:
+            return answer
+        gaps = self.gap_detector.detect(ledger)
+        if not gaps:
+            return answer
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        if any(gap.section in updated_sections for gap in gaps):
+            return answer
+        next_gap = gaps[0]
+        if next_gap.section == "goal" or next_gap.state in {
+            LedgerStatus.CONFLICTING,
+            LedgerStatus.BLOCKED,
+        }:
+            blocker = AutoBlocker(reason=next_gap.message, question=question)
+            return AutoAnswer(
+                text=f"Cannot safely decide automatically: {next_gap.message}",
+                source=AutoAnswerSource.BLOCKER,
+                confidence=1.0,
+                blocker=blocker,
+            )
+        return self.answerer.answer(_gap_prompt(next_gap), ledger)
+
     async def _with_timeout(
         self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str
     ) -> InterviewTurn:
@@ -227,3 +251,19 @@ class FunctionInterviewBackend:
             msg = "interview resume is unavailable because no pending question is persisted"
             raise RuntimeError(msg)
         return await self._resume(session_id)
+
+
+def _gap_prompt(gap: Gap) -> str:
+    prompts = {
+        "goal": "Clarify the primary user goal for the Seed.",
+        "actors": "Who are the actors, inputs, and outputs for this task?",
+        "inputs": "Who are the actors, inputs, and outputs for this task?",
+        "outputs": "Who are the actors, inputs, and outputs for this task?",
+        "constraints": "What conservative constraints and failure modes should bound this MVP?",
+        "failure_modes": "What conservative constraints and failure modes should bound this MVP?",
+        "non_goals": "What non-goals should explicitly remain out of scope?",
+        "acceptance_criteria": "Which command output verifies the acceptance criteria?",
+        "verification_plan": "Which command output verifies the acceptance criteria?",
+        "runtime_context": "Which runtime stack, repo, and project patterns should be used?",
+    }
+    return prompts.get(gap.section, gap.message)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -127,6 +127,7 @@ class AutoInterviewDriver:
                 )
             self.answerer.apply(answer, ledger, question=turn.question)
             state.ledger = ledger.to_dict()
+            state.pending_question = None
             state.mark_progress(
                 f"answered round {round_number}/{self.max_rounds} from {answer.source.value}",
                 tool_name="auto_answerer",

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -73,18 +73,22 @@ class AutoInterviewDriver:
                         session_id=state.interview_session_id,
                     )
                 else:
-                    turn = await self._with_timeout(
-                        self.backend.resume(state.interview_session_id),
-                        state,
-                        tool_name="interview.resume",
+                    turn = _validate_turn(
+                        await self._with_timeout(
+                            self.backend.resume(state.interview_session_id),
+                            state,
+                            tool_name="interview.resume",
+                        )
                     )
                     state.pending_question = turn.question
                     self._save(state)
             else:
-                turn = await self._with_timeout(
-                    self.backend.start(state.goal, cwd=state.cwd),
-                    state,
-                    tool_name="interview.start",
+                turn = _validate_turn(
+                    await self._with_timeout(
+                        self.backend.start(state.goal, cwd=state.cwd),
+                        state,
+                        tool_name="interview.start",
+                    )
                 )
                 state.interview_session_id = turn.session_id
                 state.pending_question = turn.question
@@ -130,10 +134,12 @@ class AutoInterviewDriver:
             self._save(state)
 
             try:
-                turn = await self._with_timeout(
-                    self.backend.answer(turn.session_id, answer.prefixed_text),
-                    state,
-                    tool_name="interview.answer",
+                turn = _validate_turn(
+                    await self._with_timeout(
+                        self.backend.answer(turn.session_id, answer.prefixed_text),
+                        state,
+                        tool_name="interview.answer",
+                    )
                 )
             except TimeoutError as exc:
                 state.mark_blocked(str(exc), tool_name="interview.answer")
@@ -268,3 +274,19 @@ def _gap_prompt(gap: Gap) -> str:
         "runtime_context": "Which runtime stack, repo, and project patterns should be used?",
     }
     return prompts.get(gap.section, gap.message)
+
+
+def _validate_turn(value: object) -> InterviewTurn:
+    if not isinstance(value, InterviewTurn):
+        msg = f"interview backend returned {type(value).__name__}, expected InterviewTurn"
+        raise TypeError(msg)
+    if not isinstance(value.question, str):
+        msg = "interview backend returned non-string question"
+        raise TypeError(msg)
+    if not isinstance(value.session_id, str) or not value.session_id:
+        msg = "interview backend returned invalid session_id"
+        raise TypeError(msg)
+    if type(value.seed_ready) is not bool or type(value.completed) is not bool:
+        msg = "interview backend returned non-boolean completion flags"
+        raise TypeError(msg)
+    return value

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -92,7 +92,9 @@ class AutoInterviewDriver:
         except TimeoutError as exc:
             state.mark_blocked(str(exc), tool_name="interview.start")
             self._save(state)
-            return AutoInterviewResult("blocked", state.interview_session_id, ledger, state.current_round, str(exc))
+            return AutoInterviewResult(
+                "blocked", state.interview_session_id, ledger, state.current_round, str(exc)
+            )
 
         for round_number in range(state.current_round + 1, self.max_rounds + 1):
             state.current_round = round_number
@@ -127,7 +129,9 @@ class AutoInterviewDriver:
             except TimeoutError as exc:
                 state.mark_blocked(str(exc), tool_name="interview.answer")
                 self._save(state)
-                return AutoInterviewResult("blocked", state.interview_session_id, ledger, round_number, str(exc))
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, round_number, str(exc)
+                )
 
             state.interview_session_id = turn.session_id
             state.pending_question = turn.question
@@ -140,10 +144,16 @@ class AutoInterviewDriver:
             blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
             state.mark_blocked(blocker, tool_name="interview_driver")
             self._save(state)
-            return AutoInterviewResult("blocked", state.interview_session_id, ledger, self.max_rounds, blocker)
-        return AutoInterviewResult("seed_ready", state.interview_session_id, ledger, self.max_rounds)
+            return AutoInterviewResult(
+                "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
+            )
+        return AutoInterviewResult(
+            "seed_ready", state.interview_session_id, ledger, self.max_rounds
+        )
 
-    async def _with_timeout(self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str) -> InterviewTurn:
+    async def _with_timeout(
+        self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str
+    ) -> InterviewTurn:
         try:
             return await asyncio.wait_for(awaitable, timeout=self.timeout_seconds)
         except TimeoutError as exc:

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+import re
 from typing import Protocol
 
 from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource, AutoBlocker
@@ -191,6 +192,8 @@ class AutoInterviewDriver:
         if any(gap.section in updated_sections for gap in gaps):
             return answer
         next_gap = gaps[0]
+        if not _can_steer_with_gap_prompt(question):
+            return answer
         if next_gap.section == "goal" or next_gap.state in {
             LedgerStatus.CONFLICTING,
             LedgerStatus.BLOCKED,
@@ -265,6 +268,16 @@ class FunctionInterviewBackend:
             msg = "interview resume is unavailable because no pending question is persisted"
             raise RuntimeError(msg)
         return await self._resume(session_id)
+
+
+def _can_steer_with_gap_prompt(question: str) -> bool:
+    lowered = question.lower()
+    return bool(
+        re.search(
+            r"\b(what else|anything else|additional context|more context|what should we know|clarify further)\b",
+            lowered,
+        )
+    )
 
 
 def _gap_prompt(gap: Gap) -> str:

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -17,6 +17,7 @@ class LedgerSource(StrEnum):
     ASSUMPTION = "assumption"
     NON_GOAL = "non_goal"
     INFERENCE = "inference"
+    BLOCKER = "blocker"
 
 
 class LedgerStatus(StrEnum):
@@ -163,7 +164,12 @@ class SeedDraftLedger:
 
     def open_gaps(self) -> list[str]:
         """Return required sections that are not Seed-ready."""
-        blocked = {LedgerStatus.MISSING, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+        blocked = {
+            LedgerStatus.MISSING,
+            LedgerStatus.WEAK,
+            LedgerStatus.CONFLICTING,
+            LedgerStatus.BLOCKED,
+        }
         return [name for name, status in self.section_statuses().items() if status in blocked]
 
     def is_seed_ready(self) -> bool:

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -163,7 +163,13 @@ class SeedDraftLedger:
         ]
         if matching_prior:
             for existing in same_key_entries:
-                if LedgerStatus.BLOCKED in {existing.status, entry.status}:
+                if entry.status == LedgerStatus.BLOCKED:
+                    continue
+                if existing.status == LedgerStatus.BLOCKED:
+                    existing.status = LedgerStatus.WEAK
+                    existing.rationale = (
+                        existing.rationale or "Superseded by a later same-key answer."
+                    )
                     continue
                 if _normalize_conflict_value(existing.value) == entry_value:
                     if existing.status == LedgerStatus.CONFLICTING:
@@ -175,7 +181,13 @@ class SeedDraftLedger:
                 )
         else:
             for existing in same_key_entries:
-                if LedgerStatus.BLOCKED in {existing.status, entry.status}:
+                if entry.status == LedgerStatus.BLOCKED:
+                    continue
+                if existing.status == LedgerStatus.BLOCKED:
+                    existing.status = LedgerStatus.WEAK
+                    existing.rationale = (
+                        existing.rationale or "Superseded by a later same-key answer."
+                    )
                     continue
                 existing.status = LedgerStatus.CONFLICTING
                 entry.status = LedgerStatus.CONFLICTING

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -1,0 +1,233 @@
+"""Seed Draft Ledger for bounded auto-mode convergence."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class LedgerSource(StrEnum):
+    """Source categories for ledger entries."""
+
+    USER_GOAL = "user_goal"
+    REPO_FACT = "repo_fact"
+    EXISTING_CONVENTION = "existing_convention"
+    CONSERVATIVE_DEFAULT = "conservative_default"
+    ASSUMPTION = "assumption"
+    NON_GOAL = "non_goal"
+    INFERENCE = "inference"
+
+
+class LedgerStatus(StrEnum):
+    """Status of a ledger entry or section."""
+
+    MISSING = "missing"
+    WEAK = "weak"
+    DEFAULTED = "defaulted"
+    INFERRED = "inferred"
+    CONFIRMED = "confirmed"
+    CONFLICTING = "conflicting"
+    BLOCKED = "blocked"
+
+
+REQUIRED_SECTIONS = (
+    "goal",
+    "actors",
+    "inputs",
+    "outputs",
+    "constraints",
+    "non_goals",
+    "acceptance_criteria",
+    "verification_plan",
+    "failure_modes",
+    "runtime_context",
+)
+
+
+@dataclass(slots=True)
+class LedgerEntry:
+    """A single machine-readable fact in the Seed Draft Ledger."""
+
+    key: str
+    value: str
+    source: LedgerSource | str
+    confidence: float
+    status: LedgerStatus | str
+    reversible: bool = True
+    rationale: str = ""
+    evidence: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.source = LedgerSource(str(self.source))
+        self.status = LedgerStatus(str(self.status))
+        self.confidence = max(0.0, min(1.0, float(self.confidence)))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-compatible data."""
+        data = asdict(self)
+        data["source"] = self.source.value
+        data["status"] = self.status.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LedgerEntry:
+        """Deserialize from JSON-compatible data."""
+        return cls(**data)
+
+
+@dataclass(slots=True)
+class LedgerSection:
+    """A Seed section containing one or more ledger entries."""
+
+    name: str
+    entries: list[LedgerEntry] = field(default_factory=list)
+
+    def status(self) -> LedgerStatus:
+        """Return the aggregate status for this section."""
+        if not self.entries:
+            return LedgerStatus.MISSING
+        statuses = {entry.status for entry in self.entries}
+        if LedgerStatus.BLOCKED in statuses:
+            return LedgerStatus.BLOCKED
+        if LedgerStatus.CONFLICTING in statuses:
+            return LedgerStatus.CONFLICTING
+        if LedgerStatus.CONFIRMED in statuses:
+            return LedgerStatus.CONFIRMED
+        if LedgerStatus.DEFAULTED in statuses:
+            return LedgerStatus.DEFAULTED
+        if LedgerStatus.INFERRED in statuses:
+            return LedgerStatus.INFERRED
+        return LedgerStatus.WEAK
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize section data."""
+        return {"name": self.name, "entries": [entry.to_dict() for entry in self.entries]}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LedgerSection:
+        """Deserialize section data."""
+        entries = [LedgerEntry.from_dict(item) for item in data.get("entries", [])]
+        return cls(name=str(data["name"]), entries=entries)
+
+
+@dataclass(slots=True)
+class SeedDraftLedger:
+    """Structured auto-mode Seed draft.
+
+    The ledger performs no external IO or model calls.  It is safe to mutate in
+    tight loops without risking hangs.
+    """
+
+    sections: dict[str, LedgerSection] = field(default_factory=dict)
+    question_history: list[dict[str, str]] = field(default_factory=list)
+
+    @classmethod
+    def from_goal(cls, goal: str) -> SeedDraftLedger:
+        """Create a ledger initialized with a user goal."""
+        ledger = cls(sections={name: LedgerSection(name) for name in REQUIRED_SECTIONS})
+        ledger.add_entry(
+            "goal",
+            LedgerEntry(
+                key="goal.primary",
+                value=goal,
+                source=LedgerSource.USER_GOAL,
+                confidence=0.95,
+                status=LedgerStatus.CONFIRMED,
+                reversible=False,
+                rationale="Initial user-provided auto task.",
+            ),
+        )
+        return ledger
+
+    def add_entry(self, section_name: str, entry: LedgerEntry) -> None:
+        """Append ``entry`` to a section, creating the section when needed."""
+        section = self.sections.setdefault(section_name, LedgerSection(section_name))
+        section.entries.append(entry)
+
+    def record_qa(self, question: str, answer: str) -> None:
+        """Record an interview Q/A pair in bounded form."""
+        self.question_history.append(
+            {
+                "question": _truncate(question),
+                "answer": _truncate(answer),
+            }
+        )
+
+    def section_statuses(self) -> dict[str, LedgerStatus]:
+        """Return aggregate statuses for required sections."""
+        return {name: self.sections.get(name, LedgerSection(name)).status() for name in REQUIRED_SECTIONS}
+
+    def open_gaps(self) -> list[str]:
+        """Return required sections that are not Seed-ready."""
+        blocked = {LedgerStatus.MISSING, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+        return [name for name, status in self.section_statuses().items() if status in blocked]
+
+    def is_seed_ready(self) -> bool:
+        """Return True when no required section is missing/conflicting/blocked."""
+        return not self.open_gaps()
+
+    def assumptions(self) -> list[str]:
+        """Return assumption entry values."""
+        return self._values_for_sources({LedgerSource.ASSUMPTION})
+
+    def non_goals(self) -> list[str]:
+        """Return non-goal entry values."""
+        return self._values_for_sources({LedgerSource.NON_GOAL})
+
+    def summary(self) -> dict[str, Any]:
+        """Return a bounded summary suitable for CLI/MCP output."""
+        statuses = self.section_statuses()
+        return {
+            "complete_sections": [
+                name
+                for name, status in statuses.items()
+                if status in {LedgerStatus.CONFIRMED, LedgerStatus.DEFAULTED, LedgerStatus.INFERRED}
+            ],
+            "weak_sections": [name for name, status in statuses.items() if status == LedgerStatus.WEAK],
+            "defaulted_sections": [name for name, status in statuses.items() if status == LedgerStatus.DEFAULTED],
+            "assumptions": [_truncate(value) for value in self.assumptions()],
+            "non_goals": [_truncate(value) for value in self.non_goals()],
+            "open_gaps": self.open_gaps(),
+            "risks": [
+                _truncate(entry.value)
+                for section in self.sections.values()
+                for entry in section.entries
+                if entry.key.startswith("risk.")
+            ],
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the ledger."""
+        return {
+            "sections": {name: section.to_dict() for name, section in self.sections.items()},
+            "question_history": list(self.question_history),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SeedDraftLedger:
+        """Deserialize the ledger."""
+        sections_raw = data.get("sections", {})
+        sections = {
+            name: LedgerSection.from_dict(section)
+            for name, section in sections_raw.items()
+            if isinstance(section, dict)
+        }
+        ledger = cls(sections=sections, question_history=list(data.get("question_history", [])))
+        for required in REQUIRED_SECTIONS:
+            ledger.sections.setdefault(required, LedgerSection(required))
+        return ledger
+
+    def _values_for_sources(self, sources: set[LedgerSource]) -> list[str]:
+        return [
+            entry.value
+            for section in self.sections.values()
+            for entry in section.entries
+            if entry.source in sources
+        ]
+
+
+def _truncate(value: str, *, limit: int = 500) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 15].rstrip() + " ... (truncated)"

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -161,7 +161,17 @@ class SeedDraftLedger:
             for existing in same_key_entries
             if _normalize_conflict_value(existing.value) == entry_value
         ]
-        if matching_prior:
+        if (
+            same_key_entries
+            and entry.source == LedgerSource.USER_GOAL
+            and entry.status == LedgerStatus.CONFIRMED
+        ):
+            for existing in same_key_entries:
+                existing.status = LedgerStatus.WEAK
+                existing.rationale = (
+                    existing.rationale or "Superseded by a later user-confirmed answer."
+                )
+        elif matching_prior:
             for existing in same_key_entries:
                 if entry.status == LedgerStatus.BLOCKED:
                     continue
@@ -283,12 +293,23 @@ class SeedDraftLedger:
         return ledger
 
     def _values_for_sources(self, sources: set[LedgerSource]) -> list[str]:
-        return [
-            entry.value
-            for section in self.sections.values()
-            for entry in section.entries
-            if entry.source in sources
-        ]
+        resolved: dict[tuple[str, str], str] = {}
+        inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+        for section in self.sections.values():
+            for entry in section.entries:
+                if entry.source not in sources or entry.status in inactive:
+                    continue
+                resolved[(section.name, entry.key)] = entry.value
+
+        values: list[str] = []
+        seen: set[str] = set()
+        for value in resolved.values():
+            normalized = _normalize_conflict_value(value)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            values.append(value)
+        return values
 
 
 def _normalize_conflict_value(value: str) -> str:

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -147,19 +147,42 @@ class SeedDraftLedger:
         return ledger
 
     def add_entry(self, section_name: str, entry: LedgerEntry) -> None:
-        """Append ``entry`` to a section, marking same-key contradictions explicit."""
+        """Append ``entry`` to a section, marking same-key contradictions explicit.
+
+        A later same-key answer that returns to a previously seen value is treated
+        as a correction: older contradictory entries become weak historical facts
+        instead of keeping the section permanently conflicting.
+        """
         section = self.sections.setdefault(section_name, LedgerSection(section_name))
-        for existing in section.entries:
-            if existing.key != entry.key:
-                continue
-            if _normalize_conflict_value(existing.value) == _normalize_conflict_value(entry.value):
-                continue
-            if LedgerStatus.BLOCKED in {existing.status, entry.status}:
-                continue
-            existing.status = LedgerStatus.CONFLICTING
-            entry.status = LedgerStatus.CONFLICTING
-            existing.rationale = existing.rationale or "Conflicts with another auto ledger answer."
-            entry.rationale = entry.rationale or "Conflicts with another auto ledger answer."
+        same_key_entries = [existing for existing in section.entries if existing.key == entry.key]
+        entry_value = _normalize_conflict_value(entry.value)
+        matching_prior = [
+            existing
+            for existing in same_key_entries
+            if _normalize_conflict_value(existing.value) == entry_value
+        ]
+        if matching_prior:
+            for existing in same_key_entries:
+                if LedgerStatus.BLOCKED in {existing.status, entry.status}:
+                    continue
+                if _normalize_conflict_value(existing.value) == entry_value:
+                    if existing.status == LedgerStatus.CONFLICTING:
+                        existing.status = entry.status
+                    continue
+                existing.status = LedgerStatus.WEAK
+                existing.rationale = (
+                    existing.rationale or "Superseded by a later same-key correction."
+                )
+        else:
+            for existing in same_key_entries:
+                if LedgerStatus.BLOCKED in {existing.status, entry.status}:
+                    continue
+                existing.status = LedgerStatus.CONFLICTING
+                entry.status = LedgerStatus.CONFLICTING
+                existing.rationale = (
+                    existing.rationale or "Conflicts with another auto ledger answer."
+                )
+                entry.rationale = entry.rationale or "Conflicts with another auto ledger answer."
         section.entries.append(entry)
 
     def record_qa(self, question: str, answer: str) -> None:

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -147,8 +147,19 @@ class SeedDraftLedger:
         return ledger
 
     def add_entry(self, section_name: str, entry: LedgerEntry) -> None:
-        """Append ``entry`` to a section, creating the section when needed."""
+        """Append ``entry`` to a section, marking same-key contradictions explicit."""
         section = self.sections.setdefault(section_name, LedgerSection(section_name))
+        for existing in section.entries:
+            if existing.key != entry.key:
+                continue
+            if _normalize_conflict_value(existing.value) == _normalize_conflict_value(entry.value):
+                continue
+            if LedgerStatus.BLOCKED in {existing.status, entry.status}:
+                continue
+            existing.status = LedgerStatus.CONFLICTING
+            entry.status = LedgerStatus.CONFLICTING
+            existing.rationale = existing.rationale or "Conflicts with another auto ledger answer."
+            entry.rationale = entry.rationale or "Conflicts with another auto ledger answer."
         section.entries.append(entry)
 
     def record_qa(self, question: str, answer: str) -> None:
@@ -243,6 +254,10 @@ class SeedDraftLedger:
             for entry in section.entries
             if entry.source in sources
         ]
+
+
+def _normalize_conflict_value(value: str) -> str:
+    return " ".join(value.strip().casefold().split())
 
 
 def _truncate(value: str, *, limit: int = 500) -> str:

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -127,16 +127,21 @@ class SeedDraftLedger:
     def from_goal(cls, goal: str) -> SeedDraftLedger:
         """Create a ledger initialized with a user goal."""
         ledger = cls(sections={name: LedgerSection(name) for name in REQUIRED_SECTIONS})
+        clean_goal = goal.strip()
         ledger.add_entry(
             "goal",
             LedgerEntry(
                 key="goal.primary",
-                value=goal,
+                value=clean_goal,
                 source=LedgerSource.USER_GOAL,
-                confidence=0.95,
-                status=LedgerStatus.CONFIRMED,
+                confidence=0.95 if clean_goal else 0.0,
+                status=LedgerStatus.CONFIRMED if clean_goal else LedgerStatus.WEAK,
                 reversible=False,
-                rationale="Initial user-provided auto task.",
+                rationale=(
+                    "Initial user-provided auto task."
+                    if clean_goal
+                    else "Auto task goal is blank and must be clarified before Seed generation."
+                ),
             ),
         )
         return ledger

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -156,7 +156,10 @@ class SeedDraftLedger:
 
     def section_statuses(self) -> dict[str, LedgerStatus]:
         """Return aggregate statuses for required sections."""
-        return {name: self.sections.get(name, LedgerSection(name)).status() for name in REQUIRED_SECTIONS}
+        return {
+            name: self.sections.get(name, LedgerSection(name)).status()
+            for name in REQUIRED_SECTIONS
+        }
 
     def open_gaps(self) -> list[str]:
         """Return required sections that are not Seed-ready."""
@@ -184,8 +187,12 @@ class SeedDraftLedger:
                 for name, status in statuses.items()
                 if status in {LedgerStatus.CONFIRMED, LedgerStatus.DEFAULTED, LedgerStatus.INFERRED}
             ],
-            "weak_sections": [name for name, status in statuses.items() if status == LedgerStatus.WEAK],
-            "defaulted_sections": [name for name, status in statuses.items() if status == LedgerStatus.DEFAULTED],
+            "weak_sections": [
+                name for name, status in statuses.items() if status == LedgerStatus.WEAK
+            ],
+            "defaulted_sections": [
+                name for name, status in statuses.items() if status == LedgerStatus.DEFAULTED
+            ],
             "assumptions": [_truncate(value) for value in self.assumptions()],
             "non_goals": [_truncate(value) for value in self.non_goals()],
             "open_gaps": self.open_gaps(),

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -178,6 +178,12 @@ class AutoPipeline:
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=blocker)
 
+            if not review.may_run and not self.skip_run:
+                blocker = "Seed review did not clear the Seed for execution"
+                state.mark_blocked(blocker, tool_name="grade_gate")
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=blocker)
+
             if self.skip_run:
                 state.transition(
                     AutoPhase.COMPLETE,
@@ -205,6 +211,19 @@ class AutoPipeline:
             if not _grade_meets_required(state.last_grade, state.required_grade):
                 state.mark_blocked(
                     f"Cannot start execution without a persisted grade meeting {state.required_grade}",
+                    tool_name="grade_gate",
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
+            if review is None:
+                reviewer = self.reviewer or SeedReviewer(self.grade_gate)
+                review = reviewer.review(seed)
+                state.last_grade = review.grade_result.grade.value
+                state.findings = [asdict(finding) for finding in review.findings]
+                self._save(state)
+            if not review.may_run:
+                state.mark_blocked(
+                    "Seed review did not clear the Seed for execution",
                     tool_name="grade_gate",
                 )
                 self._save(state)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -65,7 +65,7 @@ class AutoPipeline:
                 return self._result(state, ledger, blocker=interview.blocker)
             state.transition(AutoPhase.SEED_GENERATION, "generating Seed from auto interview")
             self._save(state)
-        elif state.phase != AutoPhase.SEED_GENERATION:
+        elif state.phase not in {AutoPhase.SEED_GENERATION, AutoPhase.REVIEW, AutoPhase.RUN}:
             state.mark_blocked(
                 f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",
                 tool_name="auto_pipeline",
@@ -73,44 +73,62 @@ class AutoPipeline:
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
 
-        try:
-            seed = await self.seed_generator(state.interview_session_id or "")
-        except Exception as exc:
-            state.mark_failed(f"seed generation failed: {exc}", tool_name="seed_generator")
+        if state.phase == AutoPhase.SEED_GENERATION:
+            try:
+                seed = await self.seed_generator(state.interview_session_id or "")
+            except Exception as exc:
+                state.mark_failed(f"seed generation failed: {exc}", tool_name="seed_generator")
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
+            state.seed_id = seed.metadata.seed_id
+            state.seed_artifact = seed.to_dict()
+            state.mark_progress("Seed generated", tool_name="seed_generator")
+            self._save(state)
+            state.transition(AutoPhase.REVIEW, "reviewing Seed for A-grade")
+            self._save(state)
+        elif state.seed_artifact:
+            seed = Seed.from_dict(state.seed_artifact)
+        else:
+            state.mark_blocked(
+                f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",
+                tool_name="auto_pipeline",
+            )
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
-        state.seed_id = seed.metadata.seed_id
-        state.mark_progress("Seed generated", tool_name="seed_generator")
-        self._save(state)
 
-        state.transition(AutoPhase.REVIEW, "reviewing Seed for A-grade")
-        self._save(state)
-        reviewer = self.reviewer or SeedReviewer(self.grade_gate)
-        repairer = self.repairer or SeedRepairer(reviewer=reviewer)
-        seed, review, repairs = repairer.converge(seed, ledger=ledger)
-        state.repair_round = len(repairs)
-        state.last_grade = review.grade_result.grade.value
-        state.findings = [asdict(finding) for finding in review.findings]
-        state.ledger = ledger.to_dict()
-        self._save(state)
-
-        if not review.may_run:
-            state.mark_blocked("Seed did not reach A-grade", tool_name="grade_gate")
+        if state.phase == AutoPhase.REVIEW:
+            reviewer = self.reviewer or SeedReviewer(self.grade_gate)
+            repairer = self.repairer or SeedRepairer(reviewer=reviewer)
+            seed, review, repairs = repairer.converge(seed, ledger=ledger)
+            state.seed_artifact = seed.to_dict()
+            state.repair_round = len(repairs)
+            state.last_grade = review.grade_result.grade.value
+            state.findings = [asdict(finding) for finding in review.findings]
+            state.ledger = ledger.to_dict()
             self._save(state)
-            return self._result(state, ledger, review=review, blocker="Seed did not reach A-grade")
 
-        if self.skip_run:
-            state.transition(AutoPhase.COMPLETE, "A-grade Seed ready; skip-run requested")
-            self._save(state)
-            return self._result(state, ledger, review=review)
+            if not review.may_run:
+                state.mark_blocked("Seed did not reach A-grade", tool_name="grade_gate")
+                self._save(state)
+                return self._result(
+                    state, ledger, review=review, blocker="Seed did not reach A-grade"
+                )
+
+            if self.skip_run:
+                state.transition(AutoPhase.COMPLETE, "A-grade Seed ready; skip-run requested")
+                self._save(state)
+                return self._result(state, ledger, review=review)
+        else:
+            review = None
 
         if self.run_starter is None:
             state.mark_blocked("No run starter configured", tool_name="run_starter")
             self._save(state)
             return self._result(state, ledger, review=review, blocker="No run starter configured")
 
-        state.transition(AutoPhase.RUN, "starting execution for A-grade Seed")
-        self._save(state)
+        if state.phase != AutoPhase.RUN:
+            state.transition(AutoPhase.RUN, "starting execution for A-grade Seed")
+            self._save(state)
         try:
             run_meta = await self.run_starter(seed)
         except Exception as exc:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -68,6 +68,14 @@ class AutoPipeline:
                     )
                     self._save(state)
                     return self._result(state, ledger, blocker=state.last_error)
+                if not ledger.is_seed_ready():
+                    gaps = ", ".join(ledger.open_gaps())
+                    state.mark_blocked(
+                        f"Completed interview has unresolved ledger gaps: {gaps}",
+                        tool_name="auto_pipeline",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
                 state.transition(
                     AutoPhase.SEED_GENERATION, "resuming Seed generation after completed interview"
                 )

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -112,8 +112,15 @@ class AutoPipeline:
                 state.transition(AutoPhase.REVIEW, "resuming review from persisted Seed")
                 self._save(state)
             else:
+                if not state.interview_session_id:
+                    state.mark_failed(
+                        "seed generation cannot resume without interview_session_id",
+                        tool_name="seed_generator",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
                 try:
-                    seed = await self.seed_generator(state.interview_session_id or "")
+                    seed = await self.seed_generator(state.interview_session_id)
                     if not isinstance(seed, Seed):
                         msg = f"seed generator returned {type(seed).__name__}, expected Seed"
                         raise TypeError(msg)
@@ -128,7 +135,15 @@ class AutoPipeline:
                 state.transition(AutoPhase.REVIEW, "reviewing Seed for A-grade")
                 self._save(state)
         elif state.seed_artifact:
-            seed = Seed.from_dict(state.seed_artifact)
+            try:
+                seed = Seed.from_dict(state.seed_artifact)
+            except Exception as exc:
+                state.mark_failed(
+                    f"persisted Seed artifact is invalid: {exc}",
+                    tool_name="auto_pipeline",
+                )
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
         else:
             state.mark_blocked(
                 f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -128,7 +128,13 @@ class AutoPipeline:
         else:
             review = None
 
-        if state.phase == AutoPhase.RUN and not any((state.job_id, state.execution_id)):
+        if state.phase == AutoPhase.RUN:
+            if any((state.job_id, state.execution_id)):
+                state.transition(
+                    AutoPhase.COMPLETE, "execution already started; using persisted run handle"
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review)
             state.mark_blocked(
                 "Run start status is unknown; refusing to start a duplicate execution",
                 tool_name="run_starter",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -99,21 +99,34 @@ class AutoPipeline:
             return self._result(state, ledger, blocker=state.last_error)
 
         if state.phase == AutoPhase.SEED_GENERATION:
-            try:
-                seed = await self.seed_generator(state.interview_session_id or "")
-                if not isinstance(seed, Seed):
-                    msg = f"seed generator returned {type(seed).__name__}, expected Seed"
-                    raise TypeError(msg)
-                state.seed_id = seed.metadata.seed_id
-                state.seed_artifact = seed.to_dict()
-            except Exception as exc:
-                state.mark_failed(f"seed generation failed: {exc}", tool_name="seed_generator")
+            if state.seed_artifact:
+                try:
+                    seed = Seed.from_dict(state.seed_artifact)
+                except Exception as exc:
+                    state.mark_failed(
+                        f"persisted Seed artifact is invalid: {exc}",
+                        tool_name="seed_generator",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
+                state.transition(AutoPhase.REVIEW, "resuming review from persisted Seed")
                 self._save(state)
-                return self._result(state, ledger, blocker=state.last_error)
-            state.mark_progress("Seed generated", tool_name="seed_generator")
-            self._save(state)
-            state.transition(AutoPhase.REVIEW, "reviewing Seed for A-grade")
-            self._save(state)
+            else:
+                try:
+                    seed = await self.seed_generator(state.interview_session_id or "")
+                    if not isinstance(seed, Seed):
+                        msg = f"seed generator returned {type(seed).__name__}, expected Seed"
+                        raise TypeError(msg)
+                    state.seed_id = seed.metadata.seed_id
+                    state.seed_artifact = seed.to_dict()
+                except Exception as exc:
+                    state.mark_failed(f"seed generation failed: {exc}", tool_name="seed_generator")
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
+                state.mark_progress("Seed generated", tool_name="seed_generator")
+                self._save(state)
+                state.transition(AutoPhase.REVIEW, "reviewing Seed for A-grade")
+                self._save(state)
         elif state.seed_artifact:
             seed = Seed.from_dict(state.seed_artifact)
         else:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -10,7 +10,7 @@ from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
-from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore, utc_now_iso
 from ouroboros.core.seed import Seed
 
 SeedGenerator = Callable[[str], Awaitable[Seed]]
@@ -58,11 +58,7 @@ class AutoPipeline:
             try:
                 Seed.from_dict(state.seed_artifact)
             except Exception as exc:
-                state.seed_artifact = {}
-                state.mark_failed(
-                    f"persisted Seed artifact is invalid: {exc}",
-                    tool_name="auto_pipeline",
-                )
+                _mark_invalid_seed_artifact(state, f"persisted Seed artifact is invalid: {exc}")
                 self._save(state)
                 return self._result(state, ledger, blocker=state.last_error)
         self._save(state)
@@ -275,6 +271,21 @@ class AutoPipeline:
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:
             self.store.save(state)
+
+
+def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:
+    state.seed_artifact = {}
+    if state.phase in {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}:
+        now = utc_now_iso()
+        state.phase = AutoPhase.FAILED
+        state.phase_started_at = now
+        state.last_progress_at = now
+        state.updated_at = now
+        state.last_tool_name = "auto_pipeline"
+        state.last_progress_message = message
+        state.last_error = message
+        return
+    state.mark_failed(message, tool_name="auto_pipeline")
 
 
 def _grade_meets_required(actual: str | None, required: str) -> bool:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -54,6 +54,17 @@ class AutoPipeline:
             if state.ledger
             else SeedDraftLedger.from_goal(state.goal)
         )
+        if state.seed_artifact:
+            try:
+                Seed.from_dict(state.seed_artifact)
+            except Exception as exc:
+                state.seed_artifact = None
+                state.mark_failed(
+                    f"persisted Seed artifact is invalid: {exc}",
+                    tool_name="auto_pipeline",
+                )
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
         self._save(state)
 
         if state.phase in {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -202,6 +202,13 @@ class AutoPipeline:
                 )
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=state.last_error)
+            if state.last_grade != "A":
+                state.mark_blocked(
+                    "Cannot start execution without a persisted A-grade review",
+                    tool_name="grade_gate",
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
 
         if self.run_starter is None:
             state.mark_blocked("No run starter configured", tool_name="run_starter")

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1,0 +1,125 @@
+"""Full-quality AutoPipeline supervisor skeleton."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from ouroboros.auto.grading import GradeGate
+from ouroboros.auto.interview_driver import AutoInterviewDriver
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.seed_repairer import SeedRepairer
+from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import Seed
+
+SeedGenerator = Callable[[str], Awaitable[Seed]]
+RunStarter = Callable[[Seed], Awaitable[dict[str, str | None]]]
+
+
+@dataclass(frozen=True, slots=True)
+class AutoPipelineResult:
+    """Structured AutoPipeline result for CLI/MCP surfaces."""
+
+    status: str
+    auto_session_id: str
+    phase: str
+    grade: str | None = None
+    seed_path: str | None = None
+    interview_session_id: str | None = None
+    execution_id: str | None = None
+    job_id: str | None = None
+    assumptions: tuple[str, ...] = ()
+    non_goals: tuple[str, ...] = ()
+    blocker: str | None = None
+
+
+@dataclass(slots=True)
+class AutoPipeline:
+    """Coordinate interview, Seed generation, review, repair, and run handoff."""
+
+    interview_driver: AutoInterviewDriver
+    seed_generator: SeedGenerator
+    run_starter: RunStarter | None = None
+    store: AutoStore | None = None
+    reviewer: SeedReviewer | None = None
+    repairer: SeedRepairer | None = None
+    grade_gate: GradeGate | None = None
+    skip_run: bool = False
+
+    async def run(self, state: AutoPipelineState) -> AutoPipelineResult:
+        """Run a bounded auto pipeline using injected side-effecting dependencies."""
+        ledger = SeedDraftLedger.from_dict(state.ledger) if state.ledger else SeedDraftLedger.from_goal(state.goal)
+        self._save(state)
+
+        interview = await self.interview_driver.run(state, ledger)
+        if interview.status == "blocked":
+            return self._result(state, ledger, blocker=interview.blocker)
+
+        state.transition(AutoPhase.SEED_GENERATION, "generating Seed from auto interview")
+        self._save(state)
+        seed = await self.seed_generator(interview.session_id or "")
+        state.seed_id = seed.metadata.seed_id
+        state.mark_progress("Seed generated", tool_name="seed_generator")
+        self._save(state)
+
+        state.transition(AutoPhase.REVIEW, "reviewing Seed for A-grade")
+        self._save(state)
+        reviewer = self.reviewer or SeedReviewer(self.grade_gate)
+        repairer = self.repairer or SeedRepairer(reviewer=reviewer)
+        seed, review, repairs = repairer.converge(seed, ledger=ledger)
+        state.repair_round = len(repairs)
+        state.last_grade = review.grade_result.grade.value
+        state.findings = [finding.__dict__ for finding in review.findings]
+        state.ledger = ledger.to_dict()
+        self._save(state)
+
+        if not review.may_run:
+            state.mark_blocked("Seed did not reach A-grade", tool_name="grade_gate")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker="Seed did not reach A-grade")
+
+        if self.skip_run:
+            state.transition(AutoPhase.COMPLETE, "A-grade Seed ready; skip-run requested")
+            self._save(state)
+            return self._result(state, ledger, review=review)
+
+        if self.run_starter is None:
+            state.mark_blocked("No run starter configured", tool_name="run_starter")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker="No run starter configured")
+
+        state.transition(AutoPhase.RUN, "starting execution for A-grade Seed")
+        self._save(state)
+        run_meta = await self.run_starter(seed)
+        state.job_id = run_meta.get("job_id")
+        state.execution_id = run_meta.get("execution_id")
+        state.transition(AutoPhase.COMPLETE, "execution started for A-grade Seed")
+        self._save(state)
+        return self._result(state, ledger, review=review)
+
+    def _result(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        review: SeedReview | None = None,
+        blocker: str | None = None,
+    ) -> AutoPipelineResult:
+        return AutoPipelineResult(
+            status=state.phase.value,
+            auto_session_id=state.auto_session_id,
+            phase=state.phase.value,
+            grade=review.grade_result.grade.value if review else state.last_grade,
+            seed_path=state.seed_path,
+            interview_session_id=state.interview_session_id,
+            execution_id=state.execution_id,
+            job_id=state.job_id,
+            assumptions=tuple(ledger.assumptions()),
+            non_goals=tuple(ledger.non_goals()),
+            blocker=blocker or state.last_error,
+        )
+
+    def _save(self, state: AutoPipelineState) -> None:
+        if self.store is not None:
+            self.store.save(state)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -60,11 +60,18 @@ class AutoPipeline:
             return self._result(state, ledger, blocker=state.last_error)
 
         if state.phase in {AutoPhase.CREATED, AutoPhase.INTERVIEW}:
-            interview = await self.interview_driver.run(state, ledger)
-            if interview.status == "blocked":
-                return self._result(state, ledger, blocker=interview.blocker)
-            state.transition(AutoPhase.SEED_GENERATION, "generating Seed from auto interview")
-            self._save(state)
+            if state.phase == AutoPhase.INTERVIEW and state.interview_completed:
+                state.transition(
+                    AutoPhase.SEED_GENERATION, "resuming Seed generation after completed interview"
+                )
+                self._save(state)
+            else:
+                interview = await self.interview_driver.run(state, ledger)
+                if interview.status == "blocked":
+                    return self._result(state, ledger, blocker=interview.blocker)
+                state.interview_completed = True
+                state.transition(AutoPhase.SEED_GENERATION, "generating Seed from auto interview")
+                self._save(state)
         elif state.phase not in {AutoPhase.SEED_GENERATION, AutoPhase.REVIEW, AutoPhase.RUN}:
             state.mark_blocked(
                 f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",
@@ -120,6 +127,14 @@ class AutoPipeline:
                 return self._result(state, ledger, review=review)
         else:
             review = None
+
+        if state.phase == AutoPhase.RUN and not any((state.job_id, state.execution_id)):
+            state.mark_blocked(
+                "Run start status is unknown; refusing to start a duplicate execution",
+                tool_name="run_starter",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
 
         if self.run_starter is None:
             state.mark_blocked("No run starter configured", tool_name="run_starter")

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -152,6 +152,10 @@ class AutoPipeline:
             return self._result(state, ledger, review=review, blocker=state.last_error)
         state.job_id = run_meta.get("job_id")
         state.execution_id = run_meta.get("execution_id")
+        if not any((state.job_id, state.execution_id)):
+            state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
         state.transition(AutoPhase.COMPLETE, "execution started for A-grade Seed")
         self._save(state)
         return self._result(state, ledger, review=review)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -73,7 +73,12 @@ class AutoPipeline:
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
 
-        seed = await self.seed_generator(state.interview_session_id or "")
+        try:
+            seed = await self.seed_generator(state.interview_session_id or "")
+        except Exception as exc:
+            state.mark_failed(f"seed generation failed: {exc}", tool_name="seed_generator")
+            self._save(state)
+            return self._result(state, ledger, blocker=state.last_error)
         state.seed_id = seed.metadata.seed_id
         state.mark_progress("Seed generated", tool_name="seed_generator")
         self._save(state)
@@ -106,7 +111,12 @@ class AutoPipeline:
 
         state.transition(AutoPhase.RUN, "starting execution for A-grade Seed")
         self._save(state)
-        run_meta = await self.run_starter(seed)
+        try:
+            run_meta = await self.run_starter(seed)
+        except Exception as exc:
+            state.mark_failed(f"run start failed: {exc}", tool_name="run_starter")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
         state.job_id = run_meta.get("job_id")
         state.execution_id = run_meta.get("execution_id")
         state.transition(AutoPhase.COMPLETE, "execution started for A-grade Seed")

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -217,7 +217,7 @@ class AutoPipeline:
                 return self._result(state, ledger, review=review, blocker=state.last_error)
             if review is None:
                 reviewer = self.reviewer or SeedReviewer(self.grade_gate)
-                review = reviewer.review(seed)
+                review = reviewer.review(seed, ledger=ledger)
                 state.last_grade = review.grade_result.grade.value
                 state.findings = [asdict(finding) for finding in review.findings]
                 self._save(state)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -58,7 +58,7 @@ class AutoPipeline:
             try:
                 Seed.from_dict(state.seed_artifact)
             except Exception as exc:
-                state.seed_artifact = None
+                state.seed_artifact = {}
                 state.mark_failed(
                     f"persisted Seed artifact is invalid: {exc}",
                     tool_name="auto_pipeline",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -49,7 +49,11 @@ class AutoPipeline:
 
     async def run(self, state: AutoPipelineState) -> AutoPipelineResult:
         """Run a bounded auto pipeline using injected side-effecting dependencies."""
-        ledger = SeedDraftLedger.from_dict(state.ledger) if state.ledger else SeedDraftLedger.from_goal(state.goal)
+        ledger = (
+            SeedDraftLedger.from_dict(state.ledger)
+            if state.ledger
+            else SeedDraftLedger.from_goal(state.goal)
+        )
         self._save(state)
 
         if state.phase in {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -52,13 +52,24 @@ class AutoPipeline:
         ledger = SeedDraftLedger.from_dict(state.ledger) if state.ledger else SeedDraftLedger.from_goal(state.goal)
         self._save(state)
 
-        interview = await self.interview_driver.run(state, ledger)
-        if interview.status == "blocked":
-            return self._result(state, ledger, blocker=interview.blocker)
+        if state.phase in {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}:
+            return self._result(state, ledger, blocker=state.last_error)
 
-        state.transition(AutoPhase.SEED_GENERATION, "generating Seed from auto interview")
-        self._save(state)
-        seed = await self.seed_generator(interview.session_id or "")
+        if state.phase in {AutoPhase.CREATED, AutoPhase.INTERVIEW}:
+            interview = await self.interview_driver.run(state, ledger)
+            if interview.status == "blocked":
+                return self._result(state, ledger, blocker=interview.blocker)
+            state.transition(AutoPhase.SEED_GENERATION, "generating Seed from auto interview")
+            self._save(state)
+        elif state.phase != AutoPhase.SEED_GENERATION:
+            state.mark_blocked(
+                f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",
+                tool_name="auto_pipeline",
+            )
+            self._save(state)
+            return self._result(state, ledger, blocker=state.last_error)
+
+        seed = await self.seed_generator(state.interview_session_id or "")
         state.seed_id = seed.metadata.seed_id
         state.mark_progress("Seed generated", tool_name="seed_generator")
         self._save(state)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -101,12 +101,15 @@ class AutoPipeline:
         if state.phase == AutoPhase.SEED_GENERATION:
             try:
                 seed = await self.seed_generator(state.interview_session_id or "")
+                if not isinstance(seed, Seed):
+                    msg = f"seed generator returned {type(seed).__name__}, expected Seed"
+                    raise TypeError(msg)
+                state.seed_id = seed.metadata.seed_id
+                state.seed_artifact = seed.to_dict()
             except Exception as exc:
                 state.mark_failed(f"seed generation failed: {exc}", tool_name="seed_generator")
                 self._save(state)
                 return self._result(state, ledger, blocker=state.last_error)
-            state.seed_id = seed.metadata.seed_id
-            state.seed_artifact = seed.to_dict()
             state.mark_progress("Seed generated", tool_name="seed_generator")
             self._save(state)
             state.transition(AutoPhase.REVIEW, "reviewing Seed for A-grade")
@@ -170,12 +173,15 @@ class AutoPipeline:
             self._save(state)
         try:
             run_meta = await self.run_starter(seed)
+            if not isinstance(run_meta, dict):
+                msg = f"run starter returned {type(run_meta).__name__}, expected dict"
+                raise TypeError(msg)
+            state.job_id = _optional_str(run_meta.get("job_id"))
+            state.execution_id = _optional_str(run_meta.get("execution_id"))
         except Exception as exc:
             state.mark_failed(f"run start failed: {exc}", tool_name="run_starter")
             self._save(state)
             return self._result(state, ledger, review=review, blocker=state.last_error)
-        state.job_id = run_meta.get("job_id")
-        state.execution_id = run_meta.get("execution_id")
         if not any((state.job_id, state.execution_id)):
             state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
             self._save(state)
@@ -209,3 +215,7 @@ class AutoPipeline:
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:
             self.store.save(state)
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -143,7 +143,9 @@ class AutoPipeline:
                     return self._result(state, ledger, blocker=state.last_error)
                 state.mark_progress("Seed generated", tool_name="seed_generator")
                 self._save(state)
-                state.transition(AutoPhase.REVIEW, "reviewing Seed for A-grade")
+                state.transition(
+                    AutoPhase.REVIEW, f"reviewing Seed for required grade {state.required_grade}"
+                )
                 self._save(state)
         elif state.seed_artifact:
             try:
@@ -174,15 +176,17 @@ class AutoPipeline:
             state.ledger = ledger.to_dict()
             self._save(state)
 
-            if not review.may_run:
-                state.mark_blocked("Seed did not reach A-grade", tool_name="grade_gate")
+            if not _grade_meets_required(review.grade_result.grade.value, state.required_grade):
+                blocker = f"Seed did not reach required grade {state.required_grade}"
+                state.mark_blocked(blocker, tool_name="grade_gate")
                 self._save(state)
-                return self._result(
-                    state, ledger, review=review, blocker="Seed did not reach A-grade"
-                )
+                return self._result(state, ledger, review=review, blocker=blocker)
 
             if self.skip_run:
-                state.transition(AutoPhase.COMPLETE, "A-grade Seed ready; skip-run requested")
+                state.transition(
+                    AutoPhase.COMPLETE,
+                    f"Seed reached required grade {state.required_grade}; skip-run requested",
+                )
                 self._save(state)
                 return self._result(state, ledger, review=review)
         else:
@@ -202,9 +206,9 @@ class AutoPipeline:
                 )
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=state.last_error)
-            if state.last_grade != "A":
+            if not _grade_meets_required(state.last_grade, state.required_grade):
                 state.mark_blocked(
-                    "Cannot start execution without a persisted A-grade review",
+                    f"Cannot start execution without a persisted grade meeting {state.required_grade}",
                     tool_name="grade_gate",
                 )
                 self._save(state)
@@ -217,7 +221,10 @@ class AutoPipeline:
 
         if state.phase != AutoPhase.RUN:
             state.run_start_attempted = False
-            state.transition(AutoPhase.RUN, "starting execution for A-grade Seed")
+            state.transition(
+                AutoPhase.RUN,
+                f"starting execution for grade {state.last_grade or state.required_grade} Seed",
+            )
             self._save(state)
         state.run_start_attempted = True
         self._save(state)
@@ -236,7 +243,10 @@ class AutoPipeline:
             state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
             self._save(state)
             return self._result(state, ledger, review=review, blocker=state.last_error)
-        state.transition(AutoPhase.COMPLETE, "execution started for A-grade Seed")
+        state.transition(
+            AutoPhase.COMPLETE,
+            f"execution started for grade {state.last_grade or state.required_grade} Seed",
+        )
         self._save(state)
         return self._result(state, ledger, review=review)
 
@@ -265,6 +275,23 @@ class AutoPipeline:
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:
             self.store.save(state)
+
+
+def _grade_meets_required(actual: str | None, required: str) -> bool:
+    rank = {"A": 0, "B": 1, "C": 2}
+    if actual not in rank or required not in rank:
+        return False
+    return rank[actual] <= rank[required]
+
+
+def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
+    if tool_name in {"interview.start", "interview.resume", "interview.answer"}:
+        return AutoPhase.INTERVIEW
+    if tool_name == "seed_generator":
+        return AutoPhase.SEED_GENERATION
+    if tool_name in {"seed_saver", "grade_gate"}:
+        return AutoPhase.REVIEW
+    return None
 
 
 def _optional_str(value: object) -> str | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -61,6 +61,13 @@ class AutoPipeline:
 
         if state.phase in {AutoPhase.CREATED, AutoPhase.INTERVIEW}:
             if state.phase == AutoPhase.INTERVIEW and state.interview_completed:
+                if not state.interview_session_id:
+                    state.mark_blocked(
+                        "Completed interview is missing interview_session_id",
+                        tool_name="auto_pipeline",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
                 state.transition(
                     AutoPhase.SEED_GENERATION, "resuming Seed generation after completed interview"
                 )
@@ -72,6 +79,9 @@ class AutoPipeline:
                 state.interview_completed = True
                 state.transition(AutoPhase.SEED_GENERATION, "generating Seed from auto interview")
                 self._save(state)
+        elif state.phase == AutoPhase.REPAIR:
+            state.transition(AutoPhase.REVIEW, "resuming review after repair checkpoint")
+            self._save(state)
         elif state.phase not in {AutoPhase.SEED_GENERATION, AutoPhase.REVIEW, AutoPhase.RUN}:
             state.mark_blocked(
                 f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -169,12 +169,13 @@ class AutoPipeline:
                 )
                 self._save(state)
                 return self._result(state, ledger, review=review)
-            state.mark_blocked(
-                "Run start status is unknown; refusing to start a duplicate execution",
-                tool_name="run_starter",
-            )
-            self._save(state)
-            return self._result(state, ledger, review=review, blocker=state.last_error)
+            if state.run_start_attempted:
+                state.mark_blocked(
+                    "Run start status is unknown; refusing to start a duplicate execution",
+                    tool_name="run_starter",
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
 
         if self.run_starter is None:
             state.mark_blocked("No run starter configured", tool_name="run_starter")
@@ -182,8 +183,11 @@ class AutoPipeline:
             return self._result(state, ledger, review=review, blocker="No run starter configured")
 
         if state.phase != AutoPhase.RUN:
+            state.run_start_attempted = False
             state.transition(AutoPhase.RUN, "starting execution for A-grade Seed")
             self._save(state)
+        state.run_start_attempted = True
+        self._save(state)
         try:
             run_meta = await self.run_starter(seed)
             if not isinstance(run_meta, dict):

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 from ouroboros.auto.grading import GradeGate
 from ouroboros.auto.interview_driver import AutoInterviewDriver
@@ -90,7 +90,7 @@ class AutoPipeline:
         seed, review, repairs = repairer.converge(seed, ledger=ledger)
         state.repair_round = len(repairs)
         state.last_grade = review.grade_result.grade.value
-        state.findings = [finding.__dict__ for finding in review.findings]
+        state.findings = [asdict(finding) for finding in review.findings]
         state.ledger = ledger.to_dict()
         self._save(state)
 

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -134,10 +134,10 @@ class SeedRepairer:
             history.append(repair)
             if repair.blocker or not repair.changed:
                 return current, review, history
+            current = repair.seed
             if high and high == previous_high_fingerprints:
                 return current, review, history
             previous_high_fingerprints = high
-            current = repair.seed
             review = self.reviewer.review(current, ledger=ledger)
         return current, review, history
 

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import re
 
-from ouroboros.auto.grading import SeedGrade
+from ouroboros.auto.grading import VAGUE_TERMS, SeedGrade
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.core.seed import Seed
@@ -52,11 +53,14 @@ class SeedRepairer:
         for finding in review.findings:
             if finding.code in {"vague_acceptance_criteria", "untestable_acceptance_criteria"}:
                 index = _target_index(finding.target)
-                replacement = "A command/API check returns stable observable output or artifacts proving this requirement."
                 if index is not None and index < len(acceptance):
-                    acceptance[index] = replacement
+                    acceptance[index] = _observable_preserving_replacement(
+                        acceptance[index], index=index
+                    )
                 else:
-                    acceptance.append(replacement)
+                    acceptance.append(
+                        "A command/API check returns stable observable output or artifacts proving the task goal."
+                    )
                 applied.append(finding.fingerprint)
             elif finding.code == "missing_acceptance_criteria":
                 acceptance.append(
@@ -122,6 +126,21 @@ class SeedRepairer:
             current = repair.seed
             review = self.reviewer.review(current, ledger=ledger)
         return current, review, history
+
+
+def _observable_preserving_replacement(criterion: str, *, index: int) -> str:
+    """Make a criterion observable without erasing the original feature subject."""
+    normalized = criterion.strip().rstrip(".")
+    for term in VAGUE_TERMS:
+        normalized = re.sub(rf"\b{re.escape(term)}\b", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\b(should be|is|are|be)\b", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\s+(and|or)\s*$", "", normalized.strip(), flags=re.IGNORECASE)
+    normalized = re.sub(r"\s{2,}", " ", normalized).strip().strip("-:;,. ").strip()
+    subject = normalized or f"acceptance criterion {index + 1}"
+    return (
+        "A command/API check returns stable observable output or artifacts "
+        f"proving the original requirement for {subject}."
+    )
 
 
 def _target_index(target: str) -> int | None:

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -136,6 +136,7 @@ class SeedRepairer:
                 return current, review, history
             current = repair.seed
             if high and high == previous_high_fingerprints:
+                review = self.reviewer.review(current, ledger=ledger)
                 return current, review, history
             previous_high_fingerprints = high
             review = self.reviewer.review(current, ledger=ledger)

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -1,0 +1,120 @@
+"""Bounded repair loop for auto-generated Seeds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ouroboros.auto.grading import SeedGrade
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
+from ouroboros.core.seed import Seed
+
+
+@dataclass(frozen=True, slots=True)
+class RepairResult:
+    """Result from one repair attempt."""
+
+    changed: bool
+    seed: Seed
+    applied_repairs: tuple[str, ...] = ()
+    unresolved_findings: tuple[ReviewFinding, ...] = ()
+    blocker: str | None = None
+
+
+@dataclass(slots=True)
+class SeedRepairer:
+    """Deterministically repair common A-grade failures."""
+
+    reviewer: SeedReviewer = field(default_factory=SeedReviewer)
+    max_repair_rounds: int = 5
+
+    def repair_once(
+        self,
+        seed: Seed,
+        review: SeedReview,
+        *,
+        ledger: SeedDraftLedger | None = None,
+    ) -> RepairResult:
+        """Apply one deterministic repair pass."""
+        if review.grade_result.blockers:
+            return RepairResult(
+                changed=False,
+                seed=seed,
+                unresolved_findings=review.findings,
+                blocker="hard blocker present in Seed review",
+            )
+
+        constraints = list(seed.constraints)
+        acceptance = list(seed.acceptance_criteria)
+        applied: list[str] = []
+        unresolved: list[ReviewFinding] = []
+
+        for finding in review.findings:
+            if finding.code in {"vague_acceptance_criteria", "untestable_acceptance_criteria"}:
+                index = _target_index(finding.target)
+                replacement = "A command/API check returns stable observable output or artifacts proving this requirement."
+                if index is not None and index < len(acceptance):
+                    acceptance[index] = replacement
+                else:
+                    acceptance.append(replacement)
+                applied.append(finding.fingerprint)
+            elif finding.code == "missing_acceptance_criteria":
+                acceptance.append("A command/API check returns stable observable output or artifacts proving the task goal.")
+                applied.append(finding.fingerprint)
+            elif finding.code == "missing_constraints":
+                constraints.append("Use existing project patterns and avoid new dependencies unless required by acceptance criteria.")
+                applied.append(finding.fingerprint)
+            elif finding.code == "missing_non_goals" and ledger is not None:
+                ledger.add_entry(
+                    "non_goals",
+                    LedgerEntry(
+                        key="non_goals.auto_mvp",
+                        value="No cloud sync, authentication, paid services, or production deployment in auto MVP scope.",
+                        source=LedgerSource.NON_GOAL,
+                        confidence=0.86,
+                        status=LedgerStatus.DEFAULTED,
+                        rationale="Repair loop bounded scope for A-grade auto Seed.",
+                    ),
+                )
+                applied.append(finding.fingerprint)
+            else:
+                unresolved.append(finding)
+
+        changed = bool(applied)
+        updated_seed = seed.model_copy(
+            update={
+                "constraints": tuple(dict.fromkeys(constraints)),
+                "acceptance_criteria": tuple(dict.fromkeys(acceptance)),
+            }
+        )
+        return RepairResult(changed=changed, seed=updated_seed, applied_repairs=tuple(applied), unresolved_findings=tuple(unresolved))
+
+    def converge(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> tuple[Seed, SeedReview, list[RepairResult]]:
+        """Review/repair until A-grade or bounded stop."""
+        history: list[RepairResult] = []
+        previous_high_fingerprints: set[str] = set()
+        current = seed
+        review = self.reviewer.review(current, ledger=ledger)
+        for _ in range(self.max_repair_rounds):
+            if review.grade_result.grade == SeedGrade.A and review.may_run:
+                return current, review, history
+            high = {finding.fingerprint for finding in review.findings if finding.severity == "high"}
+            repair = self.repair_once(current, review, ledger=ledger)
+            history.append(repair)
+            if repair.blocker or not repair.changed:
+                return current, review, history
+            if high and high == previous_high_fingerprints:
+                return current, review, history
+            previous_high_fingerprints = high
+            current = repair.seed
+            review = self.reviewer.review(current, ledger=ledger)
+        return current, review, history
+
+
+def _target_index(target: str) -> int | None:
+    if "[" not in target or "]" not in target:
+        return None
+    try:
+        return int(target.split("[", 1)[1].split("]", 1)[0])
+    except ValueError:
+        return None

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 import re
+from uuid import uuid4
 
 from ouroboros.auto.grading import VAGUE_TERMS, SeedGrade
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
@@ -92,12 +94,21 @@ class SeedRepairer:
                 unresolved.append(finding)
 
         changed = bool(applied)
-        updated_seed = seed.model_copy(
-            update={
-                "constraints": tuple(dict.fromkeys(constraints)),
-                "acceptance_criteria": tuple(dict.fromkeys(acceptance)),
-            }
-        )
+        updated_seed = seed
+        if changed:
+            updated_seed = seed.model_copy(
+                update={
+                    "constraints": tuple(dict.fromkeys(constraints)),
+                    "acceptance_criteria": tuple(dict.fromkeys(acceptance)),
+                    "metadata": seed.metadata.model_copy(
+                        update={
+                            "seed_id": f"seed_{uuid4().hex[:12]}",
+                            "created_at": datetime.now(UTC),
+                            "parent_seed_id": seed.metadata.seed_id,
+                        }
+                    ),
+                }
+            )
         return RepairResult(
             changed=changed,
             seed=updated_seed,

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -82,11 +82,11 @@ class SeedRepairer:
                     "non_goals",
                     LedgerEntry(
                         key="non_goals.auto_mvp",
-                        value="No cloud sync, authentication, paid services, or production deployment in auto MVP scope.",
+                        value=_safe_auto_mvp_non_goal(ledger),
                         source=LedgerSource.NON_GOAL,
                         confidence=0.86,
                         status=LedgerStatus.DEFAULTED,
-                        rationale="Repair loop bounded scope for A-grade auto Seed.",
+                        rationale="Repair loop bounded scope without contradicting the requested goal.",
                     ),
                 )
                 applied.append(finding.fingerprint)
@@ -164,3 +164,26 @@ def _target_index(target: str) -> int | None:
         return int(target.split("[", 1)[1].split("]", 1)[0])
     except ValueError:
         return None
+
+
+def _safe_auto_mvp_non_goal(ledger: SeedDraftLedger) -> str:
+    goal = _latest_resolved_goal(ledger).lower()
+    excluded = ["cloud sync", "paid services"]
+    if not re.search(r"\b(auth|authentication|login|sign[- ]?in|signup|password)\b", goal):
+        excluded.append("authentication")
+    if not re.search(r"\b(production|prod|deploy|deployment|release|publish)\b", goal):
+        excluded.append("production deployment")
+    if not excluded:
+        return "No scope outside the explicitly requested goal is included in auto MVP scope."
+    return f"For auto MVP scope, {', '.join(excluded)} are non-goals unless explicitly requested."
+
+
+def _latest_resolved_goal(ledger: SeedDraftLedger) -> str:
+    section = ledger.sections.get("goal")
+    if section is None:
+        return ""
+    inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    for entry in reversed(section.entries):
+        if entry.status not in inactive and entry.value.strip():
+            return entry.value
+    return ""

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -49,14 +49,17 @@ class SeedRepairer:
         acceptance = list(seed.acceptance_criteria)
         applied: list[str] = []
         unresolved: list[ReviewFinding] = []
+        repaired_acceptance_indices: set[int] = set()
 
         for finding in review.findings:
             if finding.code in {"vague_acceptance_criteria", "untestable_acceptance_criteria"}:
                 index = _target_index(finding.target)
                 if index is not None and index < len(acceptance):
-                    acceptance[index] = _observable_preserving_replacement(
-                        acceptance[index], index=index
-                    )
+                    if index not in repaired_acceptance_indices:
+                        acceptance[index] = _observable_preserving_replacement(
+                            acceptance[index], index=index
+                        )
+                        repaired_acceptance_indices.add(index)
                 else:
                     acceptance.append(
                         "A command/API check returns stable observable output or artifacts proving the task goal."

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -59,10 +59,14 @@ class SeedRepairer:
                     acceptance.append(replacement)
                 applied.append(finding.fingerprint)
             elif finding.code == "missing_acceptance_criteria":
-                acceptance.append("A command/API check returns stable observable output or artifacts proving the task goal.")
+                acceptance.append(
+                    "A command/API check returns stable observable output or artifacts proving the task goal."
+                )
                 applied.append(finding.fingerprint)
             elif finding.code == "missing_constraints":
-                constraints.append("Use existing project patterns and avoid new dependencies unless required by acceptance criteria.")
+                constraints.append(
+                    "Use existing project patterns and avoid new dependencies unless required by acceptance criteria."
+                )
                 applied.append(finding.fingerprint)
             elif finding.code == "missing_non_goals" and ledger is not None:
                 ledger.add_entry(
@@ -87,9 +91,16 @@ class SeedRepairer:
                 "acceptance_criteria": tuple(dict.fromkeys(acceptance)),
             }
         )
-        return RepairResult(changed=changed, seed=updated_seed, applied_repairs=tuple(applied), unresolved_findings=tuple(unresolved))
+        return RepairResult(
+            changed=changed,
+            seed=updated_seed,
+            applied_repairs=tuple(applied),
+            unresolved_findings=tuple(unresolved),
+        )
 
-    def converge(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> tuple[Seed, SeedReview, list[RepairResult]]:
+    def converge(
+        self, seed: Seed, *, ledger: SeedDraftLedger | None = None
+    ) -> tuple[Seed, SeedReview, list[RepairResult]]:
         """Review/repair until A-grade or bounded stop."""
         history: list[RepairResult] = []
         previous_high_fingerprints: set[str] = set()
@@ -98,7 +109,9 @@ class SeedRepairer:
         for _ in range(self.max_repair_rounds):
             if review.grade_result.grade == SeedGrade.A and review.may_run:
                 return current, review, history
-            high = {finding.fingerprint for finding in review.findings if finding.severity == "high"}
+            high = {
+                finding.fingerprint for finding in review.findings if finding.severity == "high"
+            }
             repair = self.repair_once(current, review, ledger=ledger)
             history.append(repair)
             if repair.blocker or not repair.changed:

--- a/src/ouroboros/auto/seed_reviewer.py
+++ b/src/ouroboros/auto/seed_reviewer.py
@@ -1,0 +1,70 @@
+"""Adversarial review primitives for auto-generated Seeds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+
+from ouroboros.auto.grading import GradeGate, GradeResult
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.core.seed import Seed
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewFinding:
+    """Stable review finding used by repair convergence guards."""
+
+    code: str
+    target: str
+    severity: str
+    message: str
+    repair_instruction: str
+    fingerprint: str
+
+    @classmethod
+    def from_parts(
+        cls,
+        *,
+        code: str,
+        target: str,
+        severity: str,
+        message: str,
+        repair_instruction: str,
+    ) -> ReviewFinding:
+        raw = f"{code}|{target}|{message}|{repair_instruction}"
+        fingerprint = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+        return cls(code, target, severity, message, repair_instruction, fingerprint)
+
+
+@dataclass(frozen=True, slots=True)
+class SeedReview:
+    """Review result with grade and stable findings."""
+
+    grade_result: GradeResult
+    findings: tuple[ReviewFinding, ...]
+
+    @property
+    def may_run(self) -> bool:
+        return self.grade_result.may_run
+
+
+class SeedReviewer:
+    """Review Seeds using deterministic GradeGate findings."""
+
+    def __init__(self, grade_gate: GradeGate | None = None) -> None:
+        self.grade_gate = grade_gate or GradeGate()
+
+    def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:
+        """Return structured review findings for ``seed``."""
+        grade = self.grade_gate.grade_seed(seed, ledger=ledger)
+        findings = tuple(
+            ReviewFinding.from_parts(
+                code=finding.code,
+                target=finding.target,
+                severity=finding.severity,
+                message=finding.message,
+                repair_instruction=finding.repair_instruction,
+            )
+            for finding in [*grade.findings, *grade.blockers]
+        )
+        return SeedReview(grade_result=grade, findings=findings)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -204,4 +204,8 @@ class AutoStore:
         if not isinstance(raw, dict):
             msg = f"Auto session state must be an object: {path}"
             raise ValueError(msg)
-        return AutoPipelineState.from_dict(raw)
+        try:
+            return AutoPipelineState.from_dict(raw)
+        except (TypeError, ValueError) as exc:
+            msg = f"Auto session state is invalid: {path}: {exc}"
+            raise ValueError(msg) from exc

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -205,6 +205,21 @@ class AutoPipelineState:
                 msg = "timeout_seconds_by_phase values must be positive integers"
                 raise ValueError(msg)
 
+        for field_name in ("ledger",):
+            if not isinstance(getattr(self, field_name), dict):
+                msg = f"{field_name} must be an object"
+                raise ValueError(msg)
+        for field_name in ("findings",):
+            value = getattr(self, field_name)
+            if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+                msg = f"{field_name} must be a list of objects"
+                raise ValueError(msg)
+        for field_name in ("repair_round", "current_round"):
+            value = getattr(self, field_name)
+            if type(value) is not int or value < 0:
+                msg = f"{field_name} must be a non-negative integer"
+                raise ValueError(msg)
+
 
 class AutoStore:
     """JSON file store for ``AutoPipelineState`` records."""

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import UTC, datetime
 from enum import StrEnum
 import json
@@ -163,9 +163,14 @@ class AutoPipelineState:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AutoPipelineState:
         """Deserialize from a dictionary and reject malformed persisted state."""
+        required_fields = {item.name for item in fields(cls)}
+        missing_fields = sorted(required_fields - data.keys())
+        if missing_fields:
+            msg = f"state is missing required fields: {', '.join(missing_fields)}"
+            raise ValueError(msg)
         payload = dict(data)
-        payload["phase"] = AutoPhase(payload.get("phase", AutoPhase.CREATED.value))
-        payload["policy"] = AutoPolicy(payload.get("policy", AutoPolicy.CONSERVATIVE.value))
+        payload["phase"] = AutoPhase(payload["phase"])
+        payload["policy"] = AutoPolicy(payload["policy"])
         state = cls(**payload)
         state._validate_loaded()
         return state
@@ -308,7 +313,11 @@ class AutoStore:
             msg = f"Auto session state must be an object: {path}"
             raise ValueError(msg)
         try:
-            return AutoPipelineState.from_dict(raw)
+            state = AutoPipelineState.from_dict(raw)
+            if state.auto_session_id != auto_session_id:
+                msg = f"Auto session id mismatch: requested {auto_session_id}, found {state.auto_session_id}"
+                raise ValueError(msg)
+            return state
         except (TypeError, ValueError) as exc:
             msg = f"Auto session state is invalid: {path}: {exc}"
             raise ValueError(msg) from exc

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -83,6 +83,7 @@ class AutoPipelineState:
     seed_artifact: dict[str, Any] = field(default_factory=dict)
     execution_id: str | None = None
     job_id: str | None = None
+    run_start_attempted: bool = False
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
@@ -239,9 +240,10 @@ class AutoPipelineState:
             if not value.strip():
                 msg = f"{field_name} must be a non-empty string or null"
                 raise ValueError(msg)
-        if type(self.interview_completed) is not bool:
-            msg = "interview_completed must be a boolean"
-            raise ValueError(msg)
+        for field_name in ("interview_completed", "run_start_attempted"):
+            if type(getattr(self, field_name)) is not bool:
+                msg = f"{field_name} must be a boolean"
+                raise ValueError(msg)
         for field_name in ("findings",):
             value = getattr(self, field_name)
             if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -41,7 +41,13 @@ _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
         AutoPhase.FAILED,
     },
     AutoPhase.SEED_GENERATION: {AutoPhase.REVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
-    AutoPhase.REVIEW: {AutoPhase.REPAIR, AutoPhase.RUN, AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.REVIEW: {
+        AutoPhase.REPAIR,
+        AutoPhase.RUN,
+        AutoPhase.COMPLETE,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    },
     AutoPhase.REPAIR: {AutoPhase.REVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
     AutoPhase.RUN: {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED},
     AutoPhase.COMPLETE: set(),
@@ -178,7 +184,9 @@ class AutoStore:
         self.root.mkdir(parents=True, exist_ok=True)
         path = self.path_for(state.auto_session_id)
         tmp_path = path.with_suffix(".json.tmp")
-        tmp_path.write_text(json.dumps(state.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp_path.write_text(
+            json.dumps(state.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8"
+        )
         tmp_path.replace(path)
         return path
 

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -231,8 +231,13 @@ class AutoPipelineState:
         )
         for field_name in optional_string_fields:
             value = getattr(self, field_name)
-            if value is not None and not isinstance(value, str):
+            if value is None:
+                continue
+            if not isinstance(value, str):
                 msg = f"{field_name} must be a string or null"
+                raise ValueError(msg)
+            if not value.strip():
+                msg = f"{field_name} must be a non-empty string or null"
                 raise ValueError(msg)
         if type(self.interview_completed) is not bool:
             msg = "interview_completed must be a boolean"

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -223,6 +223,18 @@ class AutoPipelineState:
                 msg = f"{field_name} must be a non-negative integer"
                 raise ValueError(msg)
 
+        if self.seed_artifact:
+            if not isinstance(self.seed_artifact, dict):
+                msg = "seed_artifact must be an object"
+                raise ValueError(msg)
+            try:
+                from ouroboros.core.seed import Seed
+
+                Seed.from_dict(self.seed_artifact)
+            except Exception as exc:
+                msg = "seed_artifact must be a valid Seed artifact"
+                raise ValueError(msg) from exc
+
 
 class AutoStore:
     """JSON file store for ``AutoPipelineState`` records."""

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -77,6 +77,7 @@ class AutoPipelineState:
     policy: AutoPolicy = AutoPolicy.CONSERVATIVE
     required_grade: str = "A"
     interview_session_id: str | None = None
+    interview_completed: bool = False
     seed_id: str | None = None
     seed_path: str | None = None
     seed_artifact: dict[str, Any] = field(default_factory=dict)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -86,6 +86,7 @@ class AutoPipelineState:
     findings: list[dict[str, Any]] = field(default_factory=list)
     repair_round: int = 0
     current_round: int = 0
+    pending_question: str | None = None
     last_tool_name: str | None = None
     last_error: str | None = None
     last_progress_message: str = "created"

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -171,7 +171,13 @@ class AutoPipelineState:
 
     def _validate_loaded(self) -> None:
         """Validate fields whose bad values would otherwise fail later during resume."""
-        for field_name in ("goal", "cwd", "auto_session_id", "required_grade"):
+        for field_name in (
+            "goal",
+            "cwd",
+            "auto_session_id",
+            "required_grade",
+            "last_progress_message",
+        ):
             value = getattr(self, field_name)
             if not isinstance(value, str) or not value.strip():
                 msg = f"{field_name} must be a non-empty string"
@@ -212,6 +218,25 @@ class AutoPipelineState:
             if not isinstance(getattr(self, field_name), dict):
                 msg = f"{field_name} must be an object"
                 raise ValueError(msg)
+        optional_string_fields = (
+            "interview_session_id",
+            "seed_id",
+            "seed_path",
+            "execution_id",
+            "job_id",
+            "last_grade",
+            "pending_question",
+            "last_tool_name",
+            "last_error",
+        )
+        for field_name in optional_string_fields:
+            value = getattr(self, field_name)
+            if value is not None and not isinstance(value, str):
+                msg = f"{field_name} must be a string or null"
+                raise ValueError(msg)
+        if type(self.interview_completed) is not bool:
+            msg = "interview_completed must be a boolean"
+            raise ValueError(msg)
         for field_name in ("findings",):
             value = getattr(self, field_name)
             if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -158,11 +158,49 @@ class AutoPipelineState:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AutoPipelineState:
-        """Deserialize from a dictionary."""
+        """Deserialize from a dictionary and reject malformed persisted state."""
         payload = dict(data)
         payload["phase"] = AutoPhase(payload.get("phase", AutoPhase.CREATED.value))
         payload["policy"] = AutoPolicy(payload.get("policy", AutoPolicy.CONSERVATIVE.value))
-        return cls(**payload)
+        state = cls(**payload)
+        state._validate_loaded()
+        return state
+
+    def _validate_loaded(self) -> None:
+        """Validate fields whose bad values would otherwise fail later during resume."""
+        for field_name in ("goal", "cwd", "auto_session_id", "required_grade"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                msg = f"{field_name} must be a non-empty string"
+                raise ValueError(msg)
+
+        for field_name in (
+            "phase_started_at",
+            "last_progress_at",
+            "created_at",
+            "updated_at",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str):
+                msg = f"{field_name} must be an ISO timestamp string"
+                raise ValueError(msg)
+            try:
+                datetime.fromisoformat(value)
+            except ValueError as exc:
+                msg = f"{field_name} must be an ISO timestamp string"
+                raise ValueError(msg) from exc
+
+        if not isinstance(self.timeout_seconds_by_phase, dict):
+            msg = "timeout_seconds_by_phase must be an object"
+            raise ValueError(msg)
+        valid_phases = {phase.value for phase in AutoPhase}
+        for phase, timeout in self.timeout_seconds_by_phase.items():
+            if not isinstance(phase, str) or phase not in valid_phases:
+                msg = "timeout_seconds_by_phase keys must be known phase strings"
+                raise ValueError(msg)
+            if type(timeout) is not int or timeout <= 0:
+                msg = "timeout_seconds_by_phase values must be positive integers"
+                raise ValueError(msg)
 
 
 class AutoStore:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -93,7 +93,7 @@ class AutoPipelineState:
             AutoPhase.SEED_GENERATION.value: 120,
             AutoPhase.REVIEW.value: 90,
             AutoPhase.REPAIR.value: 90,
-            "run_start": 60,
+            AutoPhase.RUN.value: 60,
         }
     )
 

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -236,10 +236,17 @@ class AutoPipelineState:
                 msg = "timeout_seconds_by_phase values must be positive integers"
                 raise ValueError(msg)
 
-        for field_name in ("ledger",):
-            if not isinstance(getattr(self, field_name), dict):
-                msg = f"{field_name} must be an object"
-                raise ValueError(msg)
+        if not isinstance(self.ledger, dict):
+            msg = "ledger must be an object"
+            raise ValueError(msg)
+        if self.ledger:
+            try:
+                from ouroboros.auto.ledger import SeedDraftLedger
+
+                SeedDraftLedger.from_dict(self.ledger)
+            except Exception as exc:
+                msg = "ledger must be a valid Seed Draft Ledger"
+                raise ValueError(msg) from exc
         optional_string_fields = (
             "interview_session_id",
             "seed_id",

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -302,6 +302,7 @@ class AutoStore:
 
     def save(self, state: AutoPipelineState) -> Path:
         """Persist ``state`` atomically and return the written path."""
+        state._validate_loaded()
         self.root.mkdir(parents=True, exist_ok=True)
         path = self.path_for(state.auto_session_id)
         tmp_path = path.with_suffix(".json.tmp")

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -188,6 +188,9 @@ class AutoPipelineState:
             if not isinstance(value, str) or not value.strip():
                 msg = f"{field_name} must be a non-empty string"
                 raise ValueError(msg)
+        if self.required_grade not in {"A", "B", "C"}:
+            msg = "required_grade must be one of A, B, or C"
+            raise ValueError(msg)
 
         for field_name in (
             "phase_started_at",

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -273,7 +273,7 @@ class AutoPipelineState:
                 msg = f"{field_name} must be a non-negative integer"
                 raise ValueError(msg)
 
-        if self.seed_artifact:
+        if self.seed_artifact != {}:
             if not isinstance(self.seed_artifact, dict):
                 msg = "seed_artifact must be an object"
                 raise ValueError(msg)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -1,0 +1,199 @@
+"""Persistent state for full-quality ``ooo auto`` sessions."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+class AutoPhase(StrEnum):
+    """Closed set of phases for auto-mode resume and stall handling."""
+
+    CREATED = "created"
+    INTERVIEW = "interview"
+    SEED_GENERATION = "seed_generation"
+    REVIEW = "review"
+    REPAIR = "repair"
+    RUN = "run"
+    COMPLETE = "complete"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+class AutoPolicy(StrEnum):
+    """Supported auto-mode resolution policies."""
+
+    CONSERVATIVE = "conservative"
+    BALANCED = "balanced"
+
+
+TERMINAL_PHASES = {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}
+_ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
+    AutoPhase.CREATED: {AutoPhase.INTERVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.INTERVIEW: {
+        AutoPhase.SEED_GENERATION,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    },
+    AutoPhase.SEED_GENERATION: {AutoPhase.REVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.REVIEW: {AutoPhase.REPAIR, AutoPhase.RUN, AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.REPAIR: {AutoPhase.REVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.RUN: {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.COMPLETE: set(),
+    AutoPhase.BLOCKED: set(),
+    AutoPhase.FAILED: set(),
+}
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time in an ISO-8601 format."""
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(slots=True)
+class AutoPipelineState:
+    """Durable state record for an ``ooo auto`` session.
+
+    The state is intentionally JSON-serializable so a foreground command can
+    safely persist progress before each potentially slow phase and resume later
+    without silently duplicating execution.
+    """
+
+    goal: str
+    cwd: str
+    auto_session_id: str = field(default_factory=lambda: f"auto_{uuid4().hex[:12]}")
+    phase: AutoPhase = AutoPhase.CREATED
+    policy: AutoPolicy = AutoPolicy.CONSERVATIVE
+    required_grade: str = "A"
+    interview_session_id: str | None = None
+    seed_id: str | None = None
+    seed_path: str | None = None
+    execution_id: str | None = None
+    job_id: str | None = None
+    ledger: dict[str, Any] = field(default_factory=dict)
+    last_grade: str | None = None
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    repair_round: int = 0
+    current_round: int = 0
+    last_tool_name: str | None = None
+    last_error: str | None = None
+    last_progress_message: str = "created"
+    phase_started_at: str = field(default_factory=utc_now_iso)
+    last_progress_at: str = field(default_factory=utc_now_iso)
+    created_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
+    timeout_seconds_by_phase: dict[str, int] = field(
+        default_factory=lambda: {
+            AutoPhase.INTERVIEW.value: 120,
+            AutoPhase.SEED_GENERATION.value: 120,
+            AutoPhase.REVIEW.value: 90,
+            AutoPhase.REPAIR.value: 90,
+            "run_start": 60,
+        }
+    )
+
+    def transition(self, next_phase: AutoPhase, message: str, *, error: str | None = None) -> None:
+        """Move to ``next_phase`` after validating the phase state machine."""
+        if next_phase not in _ALLOWED_TRANSITIONS[self.phase]:
+            msg = f"Invalid auto phase transition: {self.phase.value} -> {next_phase.value}"
+            raise ValueError(msg)
+        now = utc_now_iso()
+        self.phase = next_phase
+        self.phase_started_at = now
+        self.last_progress_at = now
+        self.updated_at = now
+        self.last_progress_message = message
+        self.last_error = error
+
+    def mark_progress(self, message: str, *, tool_name: str | None = None) -> None:
+        """Record non-terminal progress within the current phase."""
+        now = utc_now_iso()
+        self.last_progress_at = now
+        self.updated_at = now
+        self.last_progress_message = message
+        self.last_tool_name = tool_name
+
+    def mark_blocked(self, message: str, *, tool_name: str | None = None) -> None:
+        """Transition to blocked with actionable diagnostics."""
+        self.last_tool_name = tool_name
+        self.transition(AutoPhase.BLOCKED, message, error=message)
+
+    def mark_failed(self, message: str, *, tool_name: str | None = None) -> None:
+        """Transition to failed with actionable diagnostics."""
+        self.last_tool_name = tool_name
+        self.transition(AutoPhase.FAILED, message, error=message)
+
+    def is_terminal(self) -> bool:
+        """Return True when the state cannot continue automatically."""
+        return self.phase in TERMINAL_PHASES
+
+    def is_stale(self, now: datetime | None = None) -> bool:
+        """Return True when current phase has exceeded its configured timeout."""
+        if self.is_terminal():
+            return False
+        timeout = self.timeout_seconds_by_phase.get(self.phase.value)
+        if timeout is None:
+            return False
+        current = now or datetime.now(UTC)
+        last = datetime.fromisoformat(self.last_progress_at)
+        return (current - last).total_seconds() > timeout
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        data = asdict(self)
+        data["phase"] = self.phase.value
+        data["policy"] = self.policy.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AutoPipelineState:
+        """Deserialize from a dictionary."""
+        payload = dict(data)
+        payload["phase"] = AutoPhase(payload.get("phase", AutoPhase.CREATED.value))
+        payload["policy"] = AutoPolicy(payload.get("policy", AutoPolicy.CONSERVATIVE.value))
+        return cls(**payload)
+
+
+class AutoStore:
+    """JSON file store for ``AutoPipelineState`` records."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or (Path.home() / ".ouroboros" / "data")
+
+    def path_for(self, auto_session_id: str) -> Path:
+        """Return the JSON path for ``auto_session_id``."""
+        safe = auto_session_id.strip()
+        if not safe.startswith("auto_") or "/" in safe or ".." in safe:
+            msg = f"Invalid auto session id: {auto_session_id}"
+            raise ValueError(msg)
+        return self.root / f"{safe}.json"
+
+    def save(self, state: AutoPipelineState) -> Path:
+        """Persist ``state`` atomically and return the written path."""
+        self.root.mkdir(parents=True, exist_ok=True)
+        path = self.path_for(state.auto_session_id)
+        tmp_path = path.with_suffix(".json.tmp")
+        tmp_path.write_text(json.dumps(state.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp_path.replace(path)
+        return path
+
+    def load(self, auto_session_id: str) -> AutoPipelineState:
+        """Load a state record or raise an actionable error."""
+        path = self.path_for(auto_session_id)
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            msg = f"Auto session not found: {auto_session_id}"
+            raise ValueError(msg) from exc
+        except json.JSONDecodeError as exc:
+            msg = f"Auto session state is corrupt: {path}"
+            raise ValueError(msg) from exc
+        if not isinstance(raw, dict):
+            msg = f"Auto session state must be an object: {path}"
+            raise ValueError(msg)
+        return AutoPipelineState.from_dict(raw)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -79,6 +79,7 @@ class AutoPipelineState:
     interview_session_id: str | None = None
     seed_id: str | None = None
     seed_path: str | None = None
+    seed_artifact: dict[str, Any] = field(default_factory=dict)
     execution_id: str | None = None
     job_id: str | None = None
     ledger: dict[str, Any] = field(default_factory=dict)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -212,6 +212,19 @@ class AutoPipelineState:
             msg = "timeout_seconds_by_phase must be an object"
             raise ValueError(msg)
         valid_phases = {phase.value for phase in AutoPhase}
+        required_timeout_phases = {
+            AutoPhase.INTERVIEW.value,
+            AutoPhase.SEED_GENERATION.value,
+            AutoPhase.REVIEW.value,
+            AutoPhase.REPAIR.value,
+            AutoPhase.RUN.value,
+        }
+        missing_timeout_phases = sorted(
+            required_timeout_phases - self.timeout_seconds_by_phase.keys()
+        )
+        if missing_timeout_phases:
+            msg = f"timeout_seconds_by_phase is missing required phases: {', '.join(missing_timeout_phases)}"
+            raise ValueError(msg)
         for phase, timeout in self.timeout_seconds_by_phase.items():
             if not isinstance(phase, str) or phase not in valid_phases:
                 msg = "timeout_seconds_by_phase keys must be known phase strings"

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -185,10 +185,13 @@ class AutoPipelineState:
                 msg = f"{field_name} must be an ISO timestamp string"
                 raise ValueError(msg)
             try:
-                datetime.fromisoformat(value)
+                parsed = datetime.fromisoformat(value)
             except ValueError as exc:
                 msg = f"{field_name} must be an ISO timestamp string"
                 raise ValueError(msg) from exc
+            if parsed.tzinfo is None or parsed.utcoffset() is None:
+                msg = f"{field_name} must include timezone information"
+                raise ValueError(msg)
 
         if not isinstance(self.timeout_seconds_by_phase, dict):
             msg = "timeout_seconds_by_phase must be an object"

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -595,6 +595,9 @@ async def test_pipeline_resumes_run_with_persisted_handle_without_restarting(tmp
         raise AssertionError("persisted run handle should not start another run")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
     state.seed_artifact = _seed().to_dict()
     state.job_id = "job_existing"
     state.transition(AutoPhase.INTERVIEW, "interview")
@@ -970,6 +973,9 @@ async def test_pipeline_resumes_prepared_run_before_first_attempt(tmp_path) -> N
         return {"job_id": "job_after_resume", "execution_id": "exec_after_resume"}
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
     state.seed_artifact = _seed().to_dict()
     state.transition(AutoPhase.INTERVIEW, "interview")
     state.transition(AutoPhase.SEED_GENERATION, "seed")
@@ -985,6 +991,37 @@ async def test_pipeline_resumes_prepared_run_before_first_attempt(tmp_path) -> N
     assert result.status == "complete"
     assert result.job_id == "job_after_resume"
     assert state.run_start_attempted is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_resume_rechecks_persisted_ledger_before_execution(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("unresolved ledger must not start execution")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "clear the Seed for execution" in (result.blocker or "")
+    assert result.grade == "C"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -154,6 +154,13 @@ async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
 
     assert result.status == "complete"
     assert result.grade == "A"
+    repaired_acceptance = state.seed_artifact["acceptance_criteria"][0]
+    assert "The CLI" in repaired_acceptance
+    assert "stable observable output" in repaired_acceptance
+    assert (
+        repaired_acceptance
+        != "A command/API check returns stable observable output or artifacts proving this requirement."
+    )
     assert result.job_id == "job_1"
     assert state.execution_id == "exec_1"
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -370,3 +370,52 @@ async def test_pipeline_serializes_blocking_review_findings(tmp_path) -> None:
     assert result.status == "blocked"
     assert state.findings
     assert "fingerprint" in state.findings[0]
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_when_backend_never_marks_ready(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("Another question", session_id, seed_ready=False, completed=False)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "before backend marked" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_review_from_persisted_seed_artifact(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -12,7 +12,8 @@ from ouroboros.auto.interview_driver import (
 )
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipeline
-from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview
+from ouroboros.auto.seed_repairer import SeedRepairer
+from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.core.seed import (
     EvaluationPrinciple,
@@ -163,6 +164,21 @@ async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
     )
     assert result.job_id == "job_1"
     assert state.execution_id == "exec_1"
+
+
+def test_seed_repairer_rewrites_each_acceptance_criterion_once() -> None:
+    seed = _seed(ac=("The CLI should be easy and user-friendly",))
+    ledger = SeedDraftLedger.from_goal(seed.goal)
+    _fill_ready(ledger)
+    review = SeedReviewer().review(seed, ledger=ledger)
+
+    result = SeedRepairer().repair_once(seed, review, ledger=ledger)
+
+    assert result.changed
+    repaired_acceptance = result.seed.acceptance_criteria[0]
+    assert repaired_acceptance.count("original requirement for") == 1
+    assert "The CLI" in repaired_acceptance
+    assert "original requirement for A command/API check" not in repaired_acceptance
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -419,3 +419,59 @@ async def test_pipeline_resumes_review_from_persisted_seed_artifact(tmp_path) ->
 
     assert result.status == "complete"
     assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_completed_interview_without_reanswering(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not restart")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not answer again")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.interview_completed = True
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_refuses_duplicate_unknown_run_resume(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("unknown run resume should not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "duplicate execution" in (result.blocker or "")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -230,6 +230,44 @@ def test_seed_repairer_non_goals_do_not_contradict_goal_scope() -> None:
     assert "production deployment" not in non_goals[0].lower()
 
 
+def test_seed_repairer_converge_returns_latest_repair_when_high_findings_repeat() -> None:
+    finding = ReviewFinding.from_parts(
+        code="vague_acceptance_criteria",
+        target="acceptance_criteria[0]",
+        severity="high",
+        message="Still vague",
+        repair_instruction="Make it observable.",
+    )
+
+    class RepeatingReviewer:
+        def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002
+            return SeedReview(
+                grade_result=GradeResult(
+                    grade=SeedGrade.B,
+                    scores={
+                        "coverage": 0.8,
+                        "ambiguity": 0.2,
+                        "testability": 0.5,
+                        "execution_feasibility": 0.8,
+                        "risk": 0.1,
+                    },
+                    findings=[],
+                    blockers=[],
+                    may_run=False,
+                ),
+                findings=(finding,),
+            )
+
+    seed = _seed(ac=("The CLI should be easy and user-friendly",))
+    repaired, _review, history = SeedRepairer(
+        reviewer=RepeatingReviewer(), max_repair_rounds=3
+    ).converge(seed)
+
+    assert history
+    assert repaired == history[-1].seed
+    assert repaired != seed
+
+
 @pytest.mark.asyncio
 async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -34,7 +34,9 @@ def _fill_ready(ledger: SeedDraftLedger) -> None:
         "failure_modes": "Invalid input exits non-zero",
         "runtime_context": "Existing repository runtime",
     }.items():
-        source = LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        source = (
+            LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        )
         ledger.add_entry(
             section,
             LedgerEntry(
@@ -47,7 +49,9 @@ def _fill_ready(ledger: SeedDraftLedger) -> None:
         )
 
 
-def _seed(ac: tuple[str, ...] = ("`habit list` prints stable stdout containing created habits",)) -> Seed:
+def _seed(
+    ac: tuple[str, ...] = ("`habit list` prints stable stdout containing created habits",),
+) -> Seed:
     return Seed(
         goal="Build a local CLI",
         constraints=("Use existing project patterns",),
@@ -57,9 +61,15 @@ def _seed(ac: tuple[str, ...] = ("`habit list` prints stable stdout containing c
             description="CLI task ontology",
             fields=(OntologyField(name="command", field_type="string", description="Command"),),
         ),
-        evaluation_principles=(EvaluationPrinciple(name="testability", description="Observable behavior"),),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior"),
+        ),
         exit_conditions=(
-            ExitCondition(name="verified", description="Checks pass", evaluation_criteria="All acceptance criteria pass"),
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
         ),
         metadata=SeedMetadata(ambiguity_score=0.12),
     )
@@ -161,7 +171,9 @@ async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
     ledger = SeedDraftLedger.from_goal(state.goal)
     _fill_ready(ledger)
     state.ledger = ledger.to_dict()
-    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
     pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
 
     result = await pipeline.run(state)
@@ -169,6 +181,7 @@ async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
     assert result.status == "complete"
     assert result.grade == "A"
     assert result.job_id is None
+
 
 @pytest.mark.asyncio
 async def test_interview_resume_uses_persisted_pending_question(tmp_path) -> None:
@@ -187,7 +200,9 @@ async def test_interview_resume_uses_persisted_pending_question(tmp_path) -> Non
     state.pending_question = "What should we verify?"
     ledger = SeedDraftLedger.from_goal(state.goal)
     _fill_ready(ledger)
-    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
 
     result = await driver.run(state, ledger)
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -805,3 +805,59 @@ async def test_interview_driver_blocks_malformed_backend_turn(tmp_path) -> None:
 
     assert result.status == "blocked"
     assert "expected InterviewTurn" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_clears_pending_question_before_backend_answer(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        persisted = store.load(state.auto_session_id)
+        assert persisted.pending_question is None
+        assert persisted.last_tool_name == "auto_answerer"
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=store, max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.pending_question is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generation_resume_uses_persisted_seed_artifact(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("persisted seed artifact should not regenerate")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.seed_id = "seed_existing"
+    state.seed_artifact = _seed().to_dict()
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -475,3 +475,33 @@ async def test_pipeline_refuses_duplicate_unknown_run_resume(tmp_path) -> None:
 
     assert result.status == "blocked"
     assert "duplicate execution" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_run_start_without_tracking_handle(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        return {"job_id": None, "execution_id": None}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "tracking handle" in (result.blocker or "")
+    assert state.phase == AutoPhase.BLOCKED

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -849,6 +849,34 @@ async def test_interview_driver_clears_pending_question_before_backend_answer(tm
 
 
 @pytest.mark.asyncio
+async def test_pipeline_returns_structured_failure_for_terminal_malformed_seed_artifact(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("terminal resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("terminal resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("terminal resume should not generate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = {"goal": "missing required seed fields"}
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.COMPLETE, "complete")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "persisted Seed artifact is invalid" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
 async def test_pipeline_seed_generation_resume_uses_persisted_seed_artifact(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("seed resume should not restart interview")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -567,3 +567,58 @@ async def test_interview_driver_persists_blocker_ledger_entry(tmp_path) -> None:
         entry.status == LedgerStatus.BLOCKED for entry in persisted.sections["constraints"].entries
     )
     assert persisted.question_history
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_completed_interview_without_session_id(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not restart")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("missing interview session should not generate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_completed = True
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "interview_session_id" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_repair_phase_through_review(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("repair resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("repair resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("repair resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.REPAIR, "repair")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -542,3 +542,28 @@ async def test_pipeline_resumes_run_with_persisted_handle_without_restarting(tmp
 
     assert result.status == "complete"
     assert result.job_id == "job_existing"
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_persists_blocker_ledger_entry(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What API key should the workflow use?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("blocker should stop before backend answer")
+
+    state = AutoPipelineState(goal="Deploy a service", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.ledger
+    persisted = SeedDraftLedger.from_dict(state.ledger)
+    assert any(
+        entry.status == LedgerStatus.BLOCKED for entry in persisted.sections["constraints"].entries
+    )
+    assert persisted.question_history

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -881,6 +881,7 @@ async def test_pipeline_resumes_prepared_run_before_first_attempt(tmp_path) -> N
     state.transition(AutoPhase.INTERVIEW, "interview")
     state.transition(AutoPhase.SEED_GENERATION, "seed")
     state.transition(AutoPhase.REVIEW, "review")
+    state.last_grade = "A"
     state.transition(AutoPhase.RUN, "run prepared")
     state.run_start_attempted = False
     driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
@@ -891,6 +892,37 @@ async def test_pipeline_resumes_prepared_run_before_first_attempt(tmp_path) -> N
     assert result.status == "complete"
     assert result.job_id == "job_after_resume"
     assert state.run_start_attempted is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_refuses_run_resume_without_a_grade(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("non-A run resume must not start execution")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "B"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "A-grade" in (result.blocker or "")
+    assert state.job_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -194,6 +194,42 @@ def test_seed_repairer_assigns_new_seed_identity_after_mutation() -> None:
     assert result.seed.metadata.parent_seed_id == seed.metadata.seed_id
 
 
+def test_seed_repairer_non_goals_do_not_contradict_goal_scope() -> None:
+    seed = _seed()
+    ledger = SeedDraftLedger.from_goal("Add authentication and deploy this service to production")
+    finding = ReviewFinding.from_parts(
+        code="missing_non_goals",
+        target="non_goals",
+        severity="medium",
+        message="Auto-generated Seed has no explicit non-goals",
+        repair_instruction="Add MVP non-goals to bound scope.",
+    )
+    review = SeedReview(
+        grade_result=GradeResult(
+            grade=SeedGrade.B,
+            scores={
+                "coverage": 0.8,
+                "ambiguity": 0.1,
+                "testability": 0.9,
+                "execution_feasibility": 0.9,
+                "risk": 0.1,
+            },
+            findings=[],
+            blockers=[],
+            may_run=False,
+        ),
+        findings=(finding,),
+    )
+
+    result = SeedRepairer().repair_once(seed, review, ledger=ledger)
+
+    assert result.changed
+    non_goals = ledger.non_goals()
+    assert non_goals
+    assert "authentication" not in non_goals[0].lower()
+    assert "production deployment" not in non_goals[0].lower()
+
+
 @pytest.mark.asyncio
 async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
@@ -1088,7 +1124,7 @@ async def test_interview_driver_does_not_replace_specific_verification_answer_wi
 
 
 @pytest.mark.asyncio
-async def test_pipeline_run_resume_honors_persisted_required_grade(tmp_path) -> None:
+async def test_pipeline_run_resume_requires_may_run_even_when_required_grade_is_b(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("run resume should not restart interview")
 
@@ -1099,7 +1135,7 @@ async def test_pipeline_run_resume_honors_persisted_required_grade(tmp_path) -> 
         raise AssertionError("run resume should not regenerate seed")
 
     async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
-        return {"job_id": "job_required_b", "execution_id": None}
+        raise AssertionError("B-grade Seed with may_run=false must not start execution")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.required_grade = "B"
@@ -1114,8 +1150,8 @@ async def test_pipeline_run_resume_honors_persisted_required_grade(tmp_path) -> 
 
     result = await pipeline.run(state)
 
-    assert result.status == "complete"
-    assert result.job_id == "job_required_b"
+    assert result.status == "blocked"
+    assert "clear the Seed for execution" in (result.blocker or "")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -643,3 +643,44 @@ async def test_interview_driver_blocks_when_backend_completes_before_ledger_read
     assert result.status == "blocked"
     assert "completed before auto ledger was ready" in (result.blocker or "")
     assert state.phase == AutoPhase.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_steers_generic_questions_to_open_gaps(tmp_path) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        completed = len(answers) >= 5
+        return InterviewTurn("What else should we know?", session_id, completed=completed)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=6
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert ledger.is_seed_ready()
+    assert any("single local user" in item.lower() for item in answers)
+    assert any("non-goals" in item.lower() or "non-goal" in item.lower() for item in answers)
+    assert any("runtime" in item.lower() for item in answers)
+
+
+def test_auto_state_rejects_malformed_resume_optional_fields() -> None:
+    base = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project").to_dict()
+    base["pending_question"] = []
+
+    with pytest.raises(ValueError, match="pending_question"):
+        AutoPipelineState.from_dict(base)
+
+    base = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project").to_dict()
+    base["interview_completed"] = "yes"
+
+    with pytest.raises(ValueError, match="interview_completed"):
+        AutoPipelineState.from_dict(base)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -891,3 +891,55 @@ async def test_pipeline_resumes_prepared_run_before_first_attempt(tmp_path) -> N
     assert result.status == "complete"
     assert result.job_id == "job_after_resume"
     assert state.run_start_attempted is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generation_resume_requires_interview_session_id(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("missing interview session should fail before generator")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "interview_session_id" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_review_resume_marks_malformed_seed_artifact_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("review resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("review resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("review resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.seed_artifact = {"goal": "missing required fields"}
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "persisted Seed artifact is invalid" in (result.blocker or "")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -181,6 +181,19 @@ def test_seed_repairer_rewrites_each_acceptance_criterion_once() -> None:
     assert "original requirement for A command/API check" not in repaired_acceptance
 
 
+def test_seed_repairer_assigns_new_seed_identity_after_mutation() -> None:
+    seed = _seed(ac=("The CLI should be easy and user-friendly",))
+    ledger = SeedDraftLedger.from_goal(seed.goal)
+    _fill_ready(ledger)
+    review = SeedReviewer().review(seed, ledger=ledger)
+
+    result = SeedRepairer().repair_once(seed, review, ledger=ledger)
+
+    assert result.changed
+    assert result.seed.metadata.seed_id != seed.metadata.seed_id
+    assert result.seed.metadata.parent_seed_id == seed.metadata.seed_id
+
+
 @pytest.mark.asyncio
 async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1001,3 +1001,30 @@ async def test_interview_driver_accepts_initial_completed_turn_without_answering
     assert state.interview_completed is True
     assert state.pending_question is None
     assert not answered
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_does_not_replace_specific_verification_answer_with_gap_prompt(
+    tmp_path,
+) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        return InterviewTurn("done", session_id, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert answers
+    assert "observable behavior" in answers[0].lower()
+    assert "single local user" not in answers[0].lower()

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -943,3 +943,29 @@ async def test_pipeline_review_resume_marks_malformed_seed_artifact_failed(tmp_p
 
     assert result.status == "failed"
     assert "persisted Seed artifact is invalid" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_accepts_initial_completed_turn_without_answering(tmp_path) -> None:
+    answered = False
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("already complete", "interview_done", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        nonlocal answered
+        answered = True
+        raise AssertionError("completed initial turn should not be answered")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert result.rounds == 0
+    assert state.interview_completed is True
+    assert state.pending_question is None
+    assert not answered

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -475,6 +475,7 @@ async def test_pipeline_refuses_duplicate_unknown_run_resume(tmp_path) -> None:
     state.transition(AutoPhase.SEED_GENERATION, "seed")
     state.transition(AutoPhase.REVIEW, "review")
     state.transition(AutoPhase.RUN, "run")
+    state.run_start_attempted = True
     driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
     pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
 
@@ -859,3 +860,34 @@ async def test_pipeline_seed_generation_resume_uses_persisted_seed_artifact(tmp_
 
     assert result.status == "complete"
     assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_prepared_run_before_first_attempt(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        return {"job_id": "job_after_resume", "execution_id": "exec_after_resume"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    state.run_start_attempted = False
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.job_id == "job_after_resume"
+    assert state.run_start_attempted is True

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -823,9 +823,7 @@ async def test_interview_driver_clears_pending_question_before_backend_answer(tm
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     _fill_ready(ledger)
-    driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer), store=store, max_rounds=1
-    )
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=store, max_rounds=1)
 
     result = await driver.run(state, ledger)
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -622,3 +622,24 @@ async def test_pipeline_resumes_repair_phase_through_review(tmp_path) -> None:
 
     assert result.status == "complete"
     assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_when_backend_completes_before_ledger_ready(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=3
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "completed before auto ledger was ready" in (result.blocker or "")
+    assert state.phase == AutoPhase.BLOCKED

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 
+from ouroboros.auto.grading import GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
     FunctionInterviewBackend,
@@ -11,6 +12,7 @@ from ouroboros.auto.interview_driver import (
 )
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.core.seed import (
     EvaluationPrinciple,
@@ -309,3 +311,62 @@ async def test_pipeline_run_starter_error_marks_failed(tmp_path) -> None:
 
     assert result.status == "failed"
     assert "run start failed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_serializes_blocking_review_findings(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed(ac=("The command uses clean architecture",))
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    class BlockingRepairer:
+        def converge(
+            self, seed: Seed, *, ledger: SeedDraftLedger
+        ) -> tuple[Seed, SeedReview, list[object]]:  # noqa: ARG002
+            finding = ReviewFinding.from_parts(
+                code="still_vague",
+                target="acceptance_criteria[0]",
+                severity="high",
+                message="Still not observable",
+                repair_instruction="Make it observable.",
+            )
+            review = SeedReview(
+                grade_result=GradeResult(
+                    grade=SeedGrade.B,
+                    scores={
+                        "coverage": 0.8,
+                        "ambiguity": 0.3,
+                        "testability": 0.4,
+                        "execution_feasibility": 0.8,
+                        "risk": 0.2,
+                    },
+                    findings=[],
+                    blockers=[],
+                    may_run=False,
+                ),
+                findings=(finding,),
+            )
+            return seed, review, []
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(
+        driver, generate_seed, store=AutoStore(tmp_path), repairer=BlockingRepairer(), skip_run=True
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.findings
+    assert "fingerprint" in state.findings[0]

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -233,3 +233,79 @@ async def test_pipeline_non_interview_resume_blocks_without_seed_artifact(tmp_pa
 
     assert result.status == "blocked"
     assert "without persisted Seed artifact" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_resume_backend_error_blocks_and_persists(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not start a new interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer without a question")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "resume interview")
+    state.interview_session_id = "interview_1"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert "resume/start failed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generator_error_marks_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise RuntimeError("generator exploded")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "seed generation failed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_starter_error_marks_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise RuntimeError("runner exploded")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "run start failed" in (result.blocker or "")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -921,7 +921,7 @@ async def test_pipeline_refuses_run_resume_without_a_grade(tmp_path) -> None:
     result = await pipeline.run(state)
 
     assert result.status == "blocked"
-    assert "A-grade" in (result.blocker or "")
+    assert "persisted grade" in (result.blocker or "")
     assert state.job_id is None
 
 
@@ -1028,3 +1028,65 @@ async def test_interview_driver_does_not_replace_specific_verification_answer_wi
     assert answers
     assert "observable behavior" in answers[0].lower()
     assert "single local user" not in answers[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_resume_honors_persisted_required_grade(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        return {"job_id": "job_required_b", "execution_id": None}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.required_grade = "B"
+    state.last_grade = "B"
+    state.seed_artifact = _seed(ac=("The CLI should be easy and user-friendly",)).to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.job_id == "job_required_b"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_resume_rejects_grade_b_when_required_grade_a(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("grade B must not run when required grade is A")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.required_grade = "A"
+    state.last_grade = "B"
+    state.seed_artifact = _seed(ac=("The CLI should be easy and user-friendly",)).to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "persisted grade" in (result.blocker or "")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _fill_ready(ledger: SeedDraftLedger) -> None:
+    for section, value in {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }.items():
+        source = LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=source,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+
+def _seed(ac: tuple[str, ...] = ("`habit list` prints stable stdout containing created habits",)) -> Seed:
+    return Seed(
+        goal="Build a local CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=ac,
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(EvaluationPrinciple(name="testability", description="Observable behavior"),),
+        exit_conditions=(
+            ExitCondition(name="verified", description="Checks pass", evaluation_criteria="All acceptance criteria pass"),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert "unresolved gaps" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_on_backend_timeout(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        await asyncio.sleep(0.05)
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        timeout_seconds=0.001,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "timed out" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed(ac=("The CLI should be easy and user-friendly",))
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        return {"job_id": "job_1", "execution_id": "exec_1"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    assert result.job_id == "job_1"
+    assert state.execution_id == "exec_1"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1)
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    assert result.job_id is None

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -706,3 +706,28 @@ async def test_interview_driver_does_not_persist_completion_as_pending_question(
     assert result.status == "seed_ready"
     assert state.interview_completed is True
     assert state.pending_question is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_completed_interview_with_unresolved_ledger(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not restart")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("unresolved completed interview should not generate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.interview_completed = True
+    state.ledger = SeedDraftLedger.from_goal(state.goal).to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "unresolved ledger gaps" in (result.blocker or "")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -684,3 +684,25 @@ def test_auto_state_rejects_malformed_resume_optional_fields() -> None:
 
     with pytest.raises(ValueError, match="interview_completed"):
         AutoPipelineState.from_dict(base)
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_does_not_persist_completion_as_pending_question(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.interview_completed is True
+    assert state.pending_question is None

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -231,6 +231,7 @@ def test_seed_repairer_non_goals_do_not_contradict_goal_scope() -> None:
 
 
 def test_seed_repairer_converge_returns_latest_repair_when_high_findings_repeat() -> None:
+    original_seed_id: str | None = None
     finding = ReviewFinding.from_parts(
         code="vague_acceptance_criteria",
         target="acceptance_criteria[0]",
@@ -241,11 +242,12 @@ def test_seed_repairer_converge_returns_latest_repair_when_high_findings_repeat(
 
     class RepeatingReviewer:
         def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002
+            coverage = 0.1 if seed.metadata.seed_id == original_seed_id else 0.9
             return SeedReview(
                 grade_result=GradeResult(
                     grade=SeedGrade.B,
                     scores={
-                        "coverage": 0.8,
+                        "coverage": coverage,
                         "ambiguity": 0.2,
                         "testability": 0.5,
                         "execution_feasibility": 0.8,
@@ -259,13 +261,15 @@ def test_seed_repairer_converge_returns_latest_repair_when_high_findings_repeat(
             )
 
     seed = _seed(ac=("The CLI should be easy and user-friendly",))
-    repaired, _review, history = SeedRepairer(
+    original_seed_id = seed.metadata.seed_id
+    repaired, final_review, history = SeedRepairer(
         reviewer=RepeatingReviewer(), max_repair_rounds=3
     ).converge(seed)
 
     assert history
     assert repaired == history[-1].seed
     assert repaired != seed
+    assert final_review.grade_result.scores["coverage"] == 0.9
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -512,3 +512,33 @@ async def test_pipeline_blocks_run_start_without_tracking_handle(tmp_path) -> No
     assert result.status == "blocked"
     assert "tracking handle" in (result.blocker or "")
     assert state.phase == AutoPhase.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_run_with_persisted_handle_without_restarting(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("persisted run handle should not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.job_id = "job_existing"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.job_id == "job_existing"

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -169,3 +169,52 @@ async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
     assert result.status == "complete"
     assert result.grade == "A"
     assert result.job_id is None
+
+@pytest.mark.asyncio
+async def test_interview_resume_uses_persisted_pending_question(tmp_path) -> None:
+    calls: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not start a new interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        calls.append(text)
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "resume interview")
+    state.interview_session_id = "interview_1"
+    state.pending_question = "What should we verify?"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1)
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert calls
+    assert "Continue from persisted" not in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_non_interview_resume_blocks_without_seed_artifact(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("pipeline should not re-enter interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("pipeline should not re-enter interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("review resume without seed artifact should block")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "without persisted Seed artifact" in (result.blocker or "")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -731,3 +731,77 @@ async def test_pipeline_blocks_completed_interview_with_unresolved_ledger(tmp_pa
 
     assert result.status == "blocked"
     assert "unresolved ledger gaps" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_marks_malformed_seed_generator_result_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not restart")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not answer")
+
+    async def generate_seed(session_id: str):  # noqa: ANN202, ARG001
+        return {"not": "a seed"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.interview_completed = True
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "expected Seed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_marks_malformed_run_starter_result_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed):  # noqa: ANN202, ARG001
+        return ["not", "metadata"]
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "expected dict" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_malformed_backend_turn(tmp_path) -> None:
+    async def start(goal: str, cwd: str):  # noqa: ANN202, ARG001
+        return {"question": "not a turn"}
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("malformed start should not answer")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "expected InterviewTurn" in (result.blocker or "")

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -363,3 +363,14 @@ def test_auto_answerer_acceptance_default_matches_grade_observability() -> None:
     seed = _seed(ac=(acceptance[0].value,))
 
     assert GradeGate().grade_seed(seed, ledger=ledger).grade == SeedGrade.A
+
+
+def test_auto_answerer_blocks_production_environment_selection_variants() -> None:
+    questions = (
+        "Which production environment should we deploy to?",
+        "Which AWS account should we deploy production to?",
+    )
+    for question in questions:
+        answer = AutoAnswerer().answer(question, SeedDraftLedger.from_goal("Deploy a service"))
+        assert answer.blocker is not None
+        assert answer.source == AutoAnswerSource.BLOCKER

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -39,9 +39,9 @@ def _fill_minimal_ready_ledger(ledger: SeedDraftLedger) -> None:
         )
 
 
-def _seed(*, ac: tuple[str, ...]) -> Seed:
+def _seed(*, ac: tuple[str, ...], goal: str = "Build a habit tracker") -> Seed:
     return Seed(
-        goal="Build a local CLI",
+        goal=goal,
         constraints=("Use existing project patterns",),
         acceptance_criteria=ac,
         ontology_schema=OntologySchema(
@@ -117,6 +117,21 @@ def test_grade_gate_accepts_observable_seed_with_ready_ledger() -> None:
 
     assert result.grade == SeedGrade.A
     assert result.may_run
+
+
+def test_grade_gate_blocks_seed_goal_mismatch_with_ready_ledger() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(
+        goal="Build a weather dashboard",
+        ac=("`weather list` prints stable stdout containing forecasts",),
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.C
+    assert not result.may_run
+    assert {blocker.code for blocker in result.blockers} == {"seed_goal_mismatch"}
 
 
 def test_grade_gate_rejects_unresolved_ledger_even_with_clean_seed() -> None:
@@ -361,7 +376,7 @@ def test_auto_answerer_acceptance_default_matches_grade_observability() -> None:
     assert acceptance
     ledger = SeedDraftLedger.from_goal("Build a CLI")
     _fill_minimal_ready_ledger(ledger)
-    seed = _seed(ac=(acceptance[0].value,))
+    seed = _seed(ac=(acceptance[0].value,), goal="Build a CLI")
 
     assert GradeGate().grade_seed(seed, ledger=ledger).grade == SeedGrade.A
 
@@ -485,7 +500,9 @@ def test_auto_answerer_non_goals_use_latest_resolved_goal() -> None:
 def test_grade_gate_accepts_exit_status_and_http_status_criteria() -> None:
     ledger = SeedDraftLedger.from_goal("Build health checks")
     _fill_minimal_ready_ledger(ledger)
-    seed = _seed(ac=("CLI exits 0 on success", "GET /health returns 200"))
+    seed = _seed(
+        ac=("CLI exits 0 on success", "GET /health returns 200"), goal="Build health checks"
+    )
 
     result = GradeGate().grade_seed(seed, ledger=ledger)
 
@@ -542,7 +559,10 @@ def test_grade_seed_allows_safe_product_delete_assumptions() -> None:
     )
 
     result = GradeGate().grade_seed(
-        _seed(ac=("`task delete` prints stable stdout confirming deletion",)), ledger=ledger
+        _seed(
+            ac=("`task delete` prints stable stdout confirming deletion",), goal="Build a task app"
+        ),
+        ledger=ledger,
     )
 
     assert result.grade == SeedGrade.A
@@ -563,7 +583,10 @@ def test_grade_gate_ignores_inactive_high_risk_assumptions() -> None:
         ),
     )
 
-    result = GradeGate().grade_seed(_seed(ac=("`task list` prints stable stdout",)), ledger=ledger)
+    result = GradeGate().grade_seed(
+        _seed(ac=("`task list` prints stable stdout",), goal="Build a local task app"),
+        ledger=ledger,
+    )
 
     assert result.grade == SeedGrade.A
     assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
@@ -599,7 +622,10 @@ def test_auto_answerer_preserves_safe_product_behavior_questions() -> None:
     ledger = SeedDraftLedger.from_goal("Build a task app")
     _fill_minimal_ready_ledger(ledger)
     assert (
-        GradeGate().grade_seed(_seed(ac=(acceptance[0].value,)), ledger=ledger).grade == SeedGrade.A
+        GradeGate()
+        .grade_seed(_seed(ac=(acceptance[0].value,), goal="Build a task app"), ledger=ledger)
+        .grade
+        == SeedGrade.A
     )
 
 
@@ -619,7 +645,10 @@ def test_auto_answerer_preserves_output_behavior_questions() -> None:
     ledger = SeedDraftLedger.from_goal("Build an export command")
     _fill_minimal_ready_ledger(ledger)
     assert (
-        GradeGate().grade_seed(_seed(ac=(acceptance[0].value,)), ledger=ledger).grade == SeedGrade.A
+        GradeGate()
+        .grade_seed(_seed(ac=(acceptance[0].value,), goal="Build an export command"), ledger=ledger)
+        .grade
+        == SeedGrade.A
     )
 
 

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -234,6 +234,9 @@ def test_auto_answerer_allows_benign_sensitive_domain_vocabulary() -> None:
         "Should users see payment history?",
         "Should users be able to rotate API keys?",
         "Should the app support password reset?",
+        "Should the app support billing provider integrations?",
+        "Should users subscribe to paid service tiers?",
+        "Should legal review workflows be tracked?",
     )
 
     for question in benign_questions:
@@ -274,6 +277,9 @@ def test_auto_answerer_does_not_route_feature_semantics_to_io_actor_defaults() -
         "Should users see payment history?",
         "Should users be able to rotate API keys?",
         "Should the app support password reset?",
+        "Should the app support billing provider integrations?",
+        "Should users subscribe to paid service tiers?",
+        "Should legal review workflows be tracked?",
     )
 
     for question in questions:

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -388,11 +388,28 @@ def test_auto_answerer_acceptance_default_matches_grade_observability() -> None:
     ]
 
     assert acceptance
+    assert (
+        "which command output verifies the acceptance criteria" not in acceptance[0].value.lower()
+    )
+    assert answer.source == AutoAnswerSource.CONSERVATIVE_DEFAULT
     ledger = SeedDraftLedger.from_goal("Build a CLI")
     _fill_minimal_ready_ledger(ledger)
     seed = _seed(ac=(acceptance[0].value,), goal="Build a CLI")
 
     assert GradeGate().grade_seed(seed, ledger=ledger).grade == SeedGrade.A
+
+
+def test_auto_answerer_routes_common_input_output_prompts_to_io_ledger() -> None:
+    answerer = AutoAnswerer()
+    for question in (
+        "What inputs does the command take?",
+        "What outputs does it produce?",
+    ):
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+
+        assert {"actors", "inputs", "outputs"} <= updated_sections
+        assert not {"constraints", "failure_modes"} >= updated_sections
 
 
 def test_auto_answerer_blocks_production_environment_selection_variants() -> None:

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -305,3 +305,17 @@ def test_auto_answerer_avoids_generic_defaults_for_feature_semantics() -> None:
             not {"actors", "inputs", "outputs", "verification_plan", "acceptance_criteria"}
             & updated_sections
         )
+
+
+def test_auto_answerer_allows_safe_production_and_project_feature_questions() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "What should the production deploy output on failure?",
+        "Should deleting a project also delete its tasks?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a project app"))
+        assert answer.blocker is None
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert "runtime_context" not in updated_sections

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -75,6 +75,25 @@ def test_ledger_not_ready_until_required_sections_are_resolved() -> None:
     assert ledger.summary()["open_gaps"] == []
 
 
+def test_weak_required_sections_remain_open_gaps() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    ledger.sections["actors"].entries.clear()
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.weak_guess",
+            value="Maybe a local user",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.2,
+            status=LedgerStatus.WEAK,
+        ),
+    )
+
+    assert "actors" in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+
+
 def test_gap_detector_reports_missing_sections() -> None:
     gaps = GapDetector().detect(SeedDraftLedger.from_goal("Build a habit tracker"))
 
@@ -125,10 +144,16 @@ def test_auto_answerer_source_tags_and_applies_updates() -> None:
 
 
 def test_auto_answerer_returns_blocker_for_credentials() -> None:
-    answer = AutoAnswerer().answer(
-        "Which production API key should the workflow use?",
-        SeedDraftLedger.from_goal("Deploy a service"),
-    )
+    ledger = SeedDraftLedger.from_goal("Deploy a service")
+    answerer = AutoAnswerer()
+
+    answer = answerer.answer("Which production API key should the workflow use?", ledger)
+    answerer.apply(answer, ledger, question="Which production API key should the workflow use?")
 
     assert answer.blocker is not None
     assert answer.source == AutoAnswerSource.BLOCKER
+    assert "constraints" in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+    assert any(
+        entry.status == LedgerStatus.BLOCKED for entry in ledger.sections["constraints"].entries
+    )

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -524,4 +524,3 @@ def test_grade_seed_allows_safe_product_delete_assumptions() -> None:
 
     assert result.grade == SeedGrade.A
     assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
-

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -621,3 +621,27 @@ def test_auto_answerer_preserves_output_behavior_questions() -> None:
     assert (
         GradeGate().grade_seed(_seed(ac=(acceptance[0].value,)), ledger=ledger).grade == SeedGrade.A
     )
+
+
+def test_auto_answerer_allows_credential_auth_product_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should the app use credential-based authentication?",
+        SeedDraftLedger.from_goal("Build an auth app"),
+    )
+
+    assert answer.blocker is None
+    assert "credential-based authentication" in answer.text.lower()
+
+
+def test_auto_answerer_allows_user_managed_secret_and_integration_deletion() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "Should users be able to delete an API key?",
+        "Should users be able to delete a secret?",
+        "Should users be able to remove a repo integration?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build settings UI"))
+        assert answer.blocker is None
+        assert "product behavior" in answer.text.lower()

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -502,3 +502,26 @@ def test_auto_answerer_preserves_feature_specific_acceptance_semantics() -> None
     assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)
     assert "delete endpoint" in answer.text.lower()
     assert "stdout" not in answer.text.lower()
+
+
+def test_grade_seed_allows_safe_product_delete_assumptions() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a task app")
+    _fill_minimal_ready_ledger(ledger)
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="assumption.safe_delete",
+            value="Users can delete their own tasks after confirmation",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.72,
+            status=LedgerStatus.INFERRED,
+        ),
+    )
+
+    result = GradeGate().grade_seed(
+        _seed(ac=("`task delete` prints stable stdout confirming deletion",)), ledger=ledger
+    )
+
+    assert result.grade == SeedGrade.A
+    assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
+

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -645,3 +645,16 @@ def test_auto_answerer_allows_user_managed_secret_and_integration_deletion() -> 
         answer = answerer.answer(question, SeedDraftLedger.from_goal("Build settings UI"))
         assert answer.blocker is None
         assert "product behavior" in answer.text.lower()
+
+
+def test_auto_answerer_allows_user_managed_token_and_key_product_questions() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "Should users be able to rotate private keys?",
+        "Should the app display access tokens?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build identity settings"))
+        assert answer.blocker is None
+        assert "product behavior" in answer.text.lower()

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -319,3 +319,47 @@ def test_auto_answerer_allows_safe_production_and_project_feature_questions() ->
         assert answer.blocker is None
         updated_sections = {section for section, _entry in answer.ledger_updates}
         assert "runtime_context" not in updated_sections
+
+
+def test_ledger_marks_same_key_conflicting_values_as_open_gap() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.primary",
+            value="Write a JSON report",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.primary",
+            value="Display an HTML dashboard",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    assert ledger.sections["outputs"].status() == LedgerStatus.CONFLICTING
+    assert "outputs" in ledger.open_gaps()
+
+
+def test_auto_answerer_acceptance_default_matches_grade_observability() -> None:
+    answer = AutoAnswerer().answer(
+        "Which command output verifies the acceptance criteria?",
+        SeedDraftLedger.from_goal("Build a CLI"),
+    )
+    acceptance = [
+        entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+    ]
+
+    assert acceptance
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=(acceptance[0].value,))
+
+    assert GradeGate().grade_seed(seed, ledger=ledger).grade == SeedGrade.A

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -504,6 +504,28 @@ def test_auto_answerer_preserves_feature_specific_acceptance_semantics() -> None
     assert "stdout" not in answer.text.lower()
 
 
+def test_auto_answerer_allows_secret_token_product_requirement_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should users be able to store secret tokens?",
+        SeedDraftLedger.from_goal("Build a token vault"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_preserves_open_ended_feature_acceptance_semantics() -> None:
+    answer = AutoAnswerer().answer(
+        "What acceptance criteria should the webhook delivery flow satisfy?",
+        SeedDraftLedger.from_goal("Build webhook delivery"),
+    )
+
+    assert answer.blocker is None
+    assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)
+    assert "webhook delivery flow" in answer.text.lower()
+    assert "stdout" not in answer.text.lower()
+
+
 def test_grade_seed_allows_safe_product_delete_assumptions() -> None:
     ledger = SeedDraftLedger.from_goal("Build a task app")
     _fill_minimal_ready_ledger(ledger)

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -253,3 +253,24 @@ def test_auto_answerer_blocks_contextual_human_authority_questions() -> None:
         answer = answerer.answer(question, SeedDraftLedger.from_goal("Deploy a service"))
         assert answer.blocker is not None
         assert answer.source == AutoAnswerSource.BLOCKER
+
+
+def test_blank_goal_remains_open_gap() -> None:
+    ledger = SeedDraftLedger.from_goal("   ")
+    _fill_minimal_ready_ledger(ledger)
+
+    assert "goal" in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+
+
+def test_auto_answerer_does_not_route_feature_semantics_to_io_actor_defaults() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "Should users be able to delete habits?",
+        "Should users see payment history?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a habit tracker"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert not {"actors", "inputs", "outputs"} & updated_sections

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -179,6 +179,16 @@ def test_auto_answerer_allows_product_domain_delete_questions() -> None:
     assert answer.source != AutoAnswerSource.BLOCKER
 
 
+def test_auto_answerer_returns_blocker_for_plain_secret_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Which secret should the workflow use?",
+        SeedDraftLedger.from_goal("Deploy a service"),
+    )
+
+    assert answer.blocker is not None
+    assert answer.source == AutoAnswerSource.BLOCKER
+
+
 def test_auto_answerer_returns_blocker_for_credentials() -> None:
     ledger = SeedDraftLedger.from_goal("Deploy a service")
     answerer = AutoAnswerer()

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -301,10 +301,11 @@ def test_auto_answerer_avoids_generic_defaults_for_feature_semantics() -> None:
     for question in questions:
         answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a task app"))
         updated_sections = {section for section, _entry in answer.ledger_updates}
-        assert (
-            not {"actors", "inputs", "outputs", "verification_plan", "acceptance_criteria"}
-            & updated_sections
-        )
+        assert answer.blocker is None
+        assert "conservative mvp" not in answer.text.lower()
+        assert "product behavior" in answer.text.lower()
+        assert {"constraints", "acceptance_criteria"} <= updated_sections
+        assert not {"actors", "inputs", "outputs", "verification_plan"} & updated_sections
 
 
 def test_auto_answerer_allows_safe_production_and_project_feature_questions() -> None:
@@ -566,3 +567,41 @@ def test_grade_gate_ignores_inactive_high_risk_assumptions() -> None:
 
     assert result.grade == SeedGrade.A
     assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
+
+
+def test_grade_gate_blocks_high_ambiguity_seed() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("`task list` prints stable stdout",)).model_copy(
+        update={"metadata": SeedMetadata(ambiguity_score=0.45)}
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.C
+    assert not result.may_run
+    assert any(blocker.code == "high_ambiguity_score" for blocker in result.blockers)
+
+
+def test_auto_answerer_preserves_safe_product_behavior_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should completed tasks be marked done?",
+        SeedDraftLedger.from_goal("Build a task app"),
+    )
+
+    assert answer.blocker is None
+    assert "marked done" in answer.text.lower()
+    assert "conservative mvp" not in answer.text.lower()
+    assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)
+
+
+def test_auto_answerer_preserves_output_behavior_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "What output should the export command write?",
+        SeedDraftLedger.from_goal("Build an export command"),
+    )
+
+    assert answer.blocker is None
+    assert "export command write" in answer.text.lower()
+    assert "conservative mvp" not in answer.text.lower()
+    assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -119,6 +119,32 @@ def test_grade_gate_accepts_observable_seed_with_ready_ledger() -> None:
     assert result.may_run
 
 
+def test_grade_gate_rejects_unresolved_ledger_even_with_clean_seed() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    seed = _seed(ac=("`habit list` prints stdout containing created habits",))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.C
+    assert not result.may_run
+    assert any(blocker.code == "ledger_open_gap" for blocker in result.blockers)
+
+
+def test_grade_gate_requires_observable_acceptance_behavior_not_keywords() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("The command uses clean architecture", "The API is maintainable"))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.B
+    assert not result.may_run
+    assert (
+        sum(1 for finding in result.findings if finding.code == "untestable_acceptance_criteria")
+        == 2
+    )
+
+
 def test_grade_gate_rejects_vague_acceptance_criteria() -> None:
     ledger = SeedDraftLedger.from_goal("Build a habit tracker")
     _fill_minimal_ready_ledger(ledger)
@@ -141,6 +167,16 @@ def test_auto_answerer_source_tags_and_applies_updates() -> None:
     assert answer.source == AutoAnswerSource.CONSERVATIVE_DEFAULT
     assert answer.prefixed_text.startswith("[from-auto][conservative_default]")
     assert "verification_plan" not in ledger.open_gaps()
+
+
+def test_auto_answerer_allows_product_domain_delete_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should users be able to delete habits?",
+        SeedDraftLedger.from_goal("Build a habit tracker"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
 
 
 def test_auto_answerer_returns_blocker_for_credentials() -> None:

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -404,3 +404,41 @@ def test_auto_answerer_allows_product_security_and_billing_requirement_questions
     for question in questions:
         answer = AutoAnswerer().answer(question, SeedDraftLedger.from_goal("Build a SaaS app"))
         assert answer.blocker is None
+
+
+def test_ledger_later_answer_can_clear_same_key_blocker() -> None:
+    ledger = SeedDraftLedger.from_goal("Deploy a service")
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="blocker.auto_answer",
+            value="production credential required",
+            source=LedgerSource.BLOCKER,
+            confidence=1.0,
+            status=LedgerStatus.BLOCKED,
+        ),
+    )
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="blocker.auto_answer",
+            value="Use staging-only dry run; no production credential is needed",
+            source=LedgerSource.USER_GOAL,
+            confidence=0.95,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    assert ledger.sections["constraints"].status() == LedgerStatus.CONFIRMED
+    assert "constraints" not in ledger.open_gaps()
+
+
+def test_auto_answerer_non_goals_respect_explicit_goal_scope() -> None:
+    cases = (
+        ("Deploy this service to production", "production deployment"),
+        ("Add authentication to the app", "authentication"),
+    )
+
+    for goal, forbidden_non_goal in cases:
+        answer = AutoAnswerer().answer("What are the non-goals?", SeedDraftLedger.from_goal(goal))
+        assert forbidden_non_goal not in answer.text.lower()

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -592,7 +592,15 @@ def test_auto_answerer_preserves_safe_product_behavior_questions() -> None:
     assert answer.blocker is None
     assert "marked done" in answer.text.lower()
     assert "conservative mvp" not in answer.text.lower()
-    assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)
+    acceptance = [
+        entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+    ]
+    assert acceptance
+    ledger = SeedDraftLedger.from_goal("Build a task app")
+    _fill_minimal_ready_ledger(ledger)
+    assert (
+        GradeGate().grade_seed(_seed(ac=(acceptance[0].value,)), ledger=ledger).grade == SeedGrade.A
+    )
 
 
 def test_auto_answerer_preserves_output_behavior_questions() -> None:
@@ -604,4 +612,12 @@ def test_auto_answerer_preserves_output_behavior_questions() -> None:
     assert answer.blocker is None
     assert "export command write" in answer.text.lower()
     assert "conservative mvp" not in answer.text.lower()
-    assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)
+    acceptance = [
+        entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+    ]
+    assert acceptance
+    ledger = SeedDraftLedger.from_goal("Build an export command")
+    _fill_minimal_ready_ledger(ledger)
+    assert (
+        GradeGate().grade_seed(_seed(ac=(acceptance[0].value,)), ledger=ledger).grade == SeedGrade.A
+    )

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -374,3 +374,33 @@ def test_auto_answerer_blocks_production_environment_selection_variants() -> Non
         answer = AutoAnswerer().answer(question, SeedDraftLedger.from_goal("Deploy a service"))
         assert answer.blocker is not None
         assert answer.source == AutoAnswerSource.BLOCKER
+
+
+def test_ledger_later_same_key_correction_resolves_conflict() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    for value in ("Write a JSON report", "Display an HTML dashboard", "Write a JSON report"):
+        ledger.add_entry(
+            "outputs",
+            LedgerEntry(
+                key="outputs.primary",
+                value=value,
+                source=LedgerSource.CONSERVATIVE_DEFAULT,
+                confidence=0.8,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+    assert ledger.sections["outputs"].status() == LedgerStatus.DEFAULTED
+    assert "outputs" not in ledger.open_gaps()
+
+
+def test_auto_answerer_allows_product_security_and_billing_requirement_questions() -> None:
+    questions = (
+        "Which password rules should the signup form enforce?",
+        "Which API keys should users be able to rotate?",
+        "Which billing provider integrations should the app support?",
+    )
+
+    for question in questions:
+        answer = AutoAnswerer().answer(question, SeedDraftLedger.from_goal("Build a SaaS app"))
+        assert answer.blocker is None

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -223,3 +223,33 @@ def test_auto_answerer_returns_blocker_for_credentials() -> None:
     assert any(
         entry.status == LedgerStatus.BLOCKED for entry in ledger.sections["constraints"].entries
     )
+
+
+def test_auto_answerer_allows_benign_sensitive_domain_vocabulary() -> None:
+    answerer = AutoAnswerer()
+    benign_questions = (
+        "Should the app support credential login?",
+        "Should legal documents be editable?",
+        "Should medical records be exportable?",
+        "Should users see payment history?",
+    )
+
+    for question in benign_questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a document app"))
+        assert answer.blocker is None
+        assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_blocks_contextual_human_authority_questions() -> None:
+    answerer = AutoAnswerer()
+    blocking_questions = (
+        "Which credential value should production use?",
+        "Which payment provider account should we charge?",
+        "What legal approval is needed for liability risk?",
+        "What medical advice should the app recommend?",
+    )
+
+    for question in blocking_questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Deploy a service"))
+        assert answer.blocker is not None
+        assert answer.source == AutoAnswerSource.BLOCKER

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -546,3 +546,23 @@ def test_grade_seed_allows_safe_product_delete_assumptions() -> None:
 
     assert result.grade == SeedGrade.A
     assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
+
+
+def test_grade_gate_ignores_inactive_high_risk_assumptions() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a local task app")
+    _fill_minimal_ready_ledger(ledger)
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="assumption.old_production",
+            value="Use production credential",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.2,
+            status=LedgerStatus.WEAK,
+        ),
+    )
+
+    result = GradeGate().grade_seed(_seed(ac=("`task list` prints stable stdout",)), ledger=ledger)
+
+    assert result.grade == SeedGrade.A
+    assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -479,3 +479,26 @@ def test_auto_answerer_non_goals_use_latest_resolved_goal() -> None:
     answer = AutoAnswerer().answer("What are the non-goals?", ledger)
 
     assert "authentication" not in answer.text.lower()
+
+
+def test_grade_gate_accepts_exit_status_and_http_status_criteria() -> None:
+    ledger = SeedDraftLedger.from_goal("Build health checks")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("CLI exits 0 on success", "GET /health returns 200"))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.A
+    assert result.may_run
+
+
+def test_auto_answerer_preserves_feature_specific_acceptance_semantics() -> None:
+    answer = AutoAnswerer().answer(
+        "What acceptance criteria should the delete endpoint satisfy?",
+        SeedDraftLedger.from_goal("Build a delete endpoint"),
+    )
+
+    assert answer.blocker is None
+    assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)
+    assert "delete endpoint" in answer.text.lower()
+    assert "stdout" not in answer.text.lower()

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from ouroboros.auto.answerer import AutoAnswerer, AutoAnswerSource
+from ouroboros.auto.gap_detector import GapDetector
+from ouroboros.auto.grading import GradeGate, SeedGrade
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _fill_minimal_ready_ledger(ledger: SeedDraftLedger) -> None:
+    entries = {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }
+    for section, value in entries.items():
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=LedgerSource.CONSERVATIVE_DEFAULT,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+
+def _seed(*, ac: tuple[str, ...]) -> Seed:
+    return Seed(
+        goal="Build a local CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=ac,
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+def test_ledger_not_ready_until_required_sections_are_resolved() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+
+    assert "actors" in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+
+    _fill_minimal_ready_ledger(ledger)
+
+    assert ledger.is_seed_ready()
+    assert ledger.summary()["open_gaps"] == []
+
+
+def test_gap_detector_reports_missing_sections() -> None:
+    gaps = GapDetector().detect(SeedDraftLedger.from_goal("Build a habit tracker"))
+
+    assert {gap.section for gap in gaps} >= {"actors", "acceptance_criteria"}
+
+
+def test_grade_gate_blocks_b_or_c_from_running() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    result = GradeGate().grade_ledger(ledger)
+
+    assert result.grade != SeedGrade.A
+    assert not result.may_run
+
+
+def test_grade_gate_accepts_observable_seed_with_ready_ledger() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("`habit list` prints stable stdout containing created habits",))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.A
+    assert result.may_run
+
+
+def test_grade_gate_rejects_vague_acceptance_criteria() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("The CLI should be easy and user-friendly",))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.B
+    assert not result.may_run
+    assert any(finding.code == "vague_acceptance_criteria" for finding in result.findings)
+
+
+def test_auto_answerer_source_tags_and_applies_updates() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    answerer = AutoAnswerer()
+
+    answer = answerer.answer("How should we verify this is done?", ledger)
+    answerer.apply(answer, ledger, question="How should we verify this is done?")
+
+    assert answer.source == AutoAnswerSource.CONSERVATIVE_DEFAULT
+    assert answer.prefixed_text.startswith("[from-auto][conservative_default]")
+    assert "verification_plan" not in ledger.open_gaps()
+
+
+def test_auto_answerer_returns_blocker_for_credentials() -> None:
+    answer = AutoAnswerer().answer(
+        "Which production API key should the workflow use?",
+        SeedDraftLedger.from_goal("Deploy a service"),
+    )
+
+    assert answer.blocker is not None
+    assert answer.source == AutoAnswerSource.BLOCKER

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -442,3 +442,40 @@ def test_auto_answerer_non_goals_respect_explicit_goal_scope() -> None:
     for goal, forbidden_non_goal in cases:
         answer = AutoAnswerer().answer("What are the non-goals?", SeedDraftLedger.from_goal(goal))
         assert forbidden_non_goal not in answer.text.lower()
+
+
+def test_ledger_assumptions_use_latest_resolved_facts_for_risk() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    _fill_minimal_ready_ledger(ledger)
+    for value in ("CLI user", "CLI user", "CLI user"):
+        ledger.add_entry(
+            "actors",
+            LedgerEntry(
+                key="actors.primary",
+                value=value,
+                source=LedgerSource.ASSUMPTION,
+                confidence=0.72,
+                status=LedgerStatus.INFERRED,
+            ),
+        )
+
+    assert ledger.assumptions().count("CLI user") == 1
+    assert GradeGate().grade_ledger(ledger).scores["risk"] <= 0.25
+
+
+def test_auto_answerer_non_goals_use_latest_resolved_goal() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    ledger.add_entry(
+        "goal",
+        LedgerEntry(
+            key="goal.primary",
+            value="Add authentication to the app",
+            source=LedgerSource.USER_GOAL,
+            confidence=0.95,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    answer = AutoAnswerer().answer("What are the non-goals?", ledger)
+
+    assert "authentication" not in answer.text.lower()

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -232,6 +232,8 @@ def test_auto_answerer_allows_benign_sensitive_domain_vocabulary() -> None:
         "Should legal documents be editable?",
         "Should medical records be exportable?",
         "Should users see payment history?",
+        "Should users be able to rotate API keys?",
+        "Should the app support password reset?",
     )
 
     for question in benign_questions:
@@ -247,6 +249,8 @@ def test_auto_answerer_blocks_contextual_human_authority_questions() -> None:
         "Which payment provider account should we charge?",
         "What legal approval is needed for liability risk?",
         "What medical advice should the app recommend?",
+        "What API key should the workflow use?",
+        "Which password should CI configure?",
     )
 
     for question in blocking_questions:
@@ -268,6 +272,8 @@ def test_auto_answerer_does_not_route_feature_semantics_to_io_actor_defaults() -
     questions = (
         "Should users be able to delete habits?",
         "Should users see payment history?",
+        "Should users be able to rotate API keys?",
+        "Should the app support password reset?",
     )
 
     for question in questions:

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -179,6 +179,26 @@ def test_auto_answerer_allows_product_domain_delete_questions() -> None:
     assert answer.source != AutoAnswerSource.BLOCKER
 
 
+def test_auto_answerer_allows_product_domain_secret_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should the app support secret notes?",
+        SeedDraftLedger.from_goal("Build a notes app"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_allows_product_domain_file_removal_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should users be able to remove uploaded files?",
+        SeedDraftLedger.from_goal("Build a file manager"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
+
+
 def test_auto_answerer_returns_blocker_for_plain_secret_questions() -> None:
     answer = AutoAnswerer().answer(
         "Which secret should the workflow use?",

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -286,3 +286,22 @@ def test_auto_answerer_does_not_route_feature_semantics_to_io_actor_defaults() -
         answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a habit tracker"))
         updated_sections = {section for section, _entry in answer.ledger_updates}
         assert not {"actors", "inputs", "outputs"} & updated_sections
+
+
+def test_auto_answerer_avoids_generic_defaults_for_feature_semantics() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "What output should the export command write?",
+        "What input format does the config file use?",
+        "Should completed tasks be marked done?",
+        "What should users be able to edit?",
+        "Which users can delete projects?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a task app"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert (
+            not {"actors", "inputs", "outputs", "verification_plan", "acceptance_criteria"}
+            & updated_sections
+        )

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -134,6 +134,20 @@ def test_grade_gate_blocks_seed_goal_mismatch_with_ready_ledger() -> None:
     assert {blocker.code for blocker in result.blockers} == {"seed_goal_mismatch"}
 
 
+def test_grade_gate_blocks_subset_goal_mismatch_with_ready_ledger() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a weather dashboard")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(
+        goal="Build a dashboard",
+        ac=("`dashboard show` prints stable stdout containing dashboard status",),
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.C
+    assert {blocker.code for blocker in result.blockers} == {"seed_goal_mismatch"}
+
+
 def test_grade_gate_rejects_unresolved_ledger_even_with_clean_seed() -> None:
     ledger = SeedDraftLedger.from_goal("Build a habit tracker")
     seed = _seed(ac=("`habit list` prints stdout containing created habits",))

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -123,6 +123,30 @@ def test_store_load_wraps_malformed_container_and_counter_fields(tmp_path) -> No
             store.load(state.auto_session_id)
 
 
+def test_store_load_rejects_empty_optional_resume_identifiers(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    for field_name in (
+        "interview_session_id",
+        "seed_id",
+        "seed_path",
+        "execution_id",
+        "job_id",
+        "last_grade",
+        "pending_question",
+        "last_tool_name",
+        "last_error",
+    ):
+        data = state.to_dict()
+        data[field_name] = ""
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)
+
+
 def test_store_load_wraps_malformed_seed_artifact(tmp_path) -> None:
     store = AutoStore(tmp_path)
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -123,7 +123,6 @@ def test_store_load_wraps_malformed_container_and_counter_fields(tmp_path) -> No
             store.load(state.auto_session_id)
 
 
-
 def test_store_load_rejects_empty_optional_resume_identifiers(tmp_path) -> None:
     store = AutoStore(tmp_path)
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -102,3 +102,22 @@ def test_store_load_wraps_naive_timestamps(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="Auto session state is invalid"):
         store.load(state.auto_session_id)
+
+
+def test_store_load_wraps_malformed_container_and_counter_fields(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    for field_name, value in (
+        ("ledger", []),
+        ("findings", "oops"),
+        ("repair_round", "1"),
+        ("current_round", -1),
+    ):
+        data = state.to_dict()
+        data[field_name] = value
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -90,3 +90,15 @@ def test_store_load_wraps_invalid_timestamps_and_timeouts(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="Auto session state is invalid"):
         store.load(state.auto_session_id)
+
+
+def test_store_load_wraps_naive_timestamps(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["last_progress_at"] = "2026-05-01T12:00:00"
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -61,3 +61,13 @@ def test_run_phase_uses_run_timeout_key_for_staleness() -> None:
     future = datetime.fromisoformat(state.last_progress_at) + timedelta(seconds=61)
     assert state.timeout_seconds_by_phase[AutoPhase.RUN.value] == 60
     assert state.is_stale(future)
+
+
+def test_store_load_wraps_semantically_invalid_state(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    path = store.path_for("auto_badstate")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"goal": "x", "cwd": ".", "phase": "bogus"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load("auto_badstate")

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+
+def test_state_transition_and_stale_detection() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+
+    assert state.phase == AutoPhase.INTERVIEW
+    assert state.last_progress_message == "starting interview"
+
+    future = datetime.fromisoformat(state.last_progress_at) + timedelta(seconds=121)
+    assert state.is_stale(future)
+
+
+def test_invalid_phase_transition_rejected() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+
+    with pytest.raises(ValueError, match="Invalid auto phase transition"):
+        state.transition(AutoPhase.RUN, "skip ahead")
+
+
+def test_store_roundtrip_and_corrupt_state(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+
+    path = store.save(state)
+    loaded = store.load(state.auto_session_id)
+
+    assert path.exists()
+    assert loaded.auto_session_id == state.auto_session_id
+    assert loaded.phase == AutoPhase.INTERVIEW
+
+    path.write_text("not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="corrupt"):
+        store.load(state.auto_session_id)
+
+
+def test_terminal_state_is_not_stale() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting")
+    state.transition(AutoPhase.BLOCKED, "need credential", error="need credential")
+
+    future = datetime.now(UTC) + timedelta(days=1)
+    assert not state.is_stale(future)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -212,3 +212,14 @@ def test_store_load_rejects_malformed_optional_strings(tmp_path) -> None:
 
         with pytest.raises(ValueError, match="Auto session state is invalid"):
             store.load(state.auto_session_id)
+
+
+def test_store_save_rejects_invalid_state_before_writing(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.timeout_seconds_by_phase = {AutoPhase.RUN.value: 60}
+
+    with pytest.raises(ValueError, match="missing required phases"):
+        store.save(state)
+
+    assert not store.path_for(state.auto_session_id).exists()

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -123,6 +123,7 @@ def test_store_load_wraps_malformed_container_and_counter_fields(tmp_path) -> No
             store.load(state.auto_session_id)
 
 
+
 def test_store_load_rejects_empty_optional_resume_identifiers(tmp_path) -> None:
     store = AutoStore(tmp_path)
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
@@ -156,4 +157,30 @@ def test_store_load_wraps_malformed_seed_artifact(tmp_path) -> None:
     path.write_text(__import__("json").dumps(data), encoding="utf-8")
 
     with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_truncated_state_without_default_backfill(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data.pop("phase_started_at")
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required fields"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_session_id_mismatch(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["auto_session_id"] = "auto_other"
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="session id mismatch"):
+        store.load(state.auto_session_id)
+
         store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -181,5 +181,3 @@ def test_store_load_rejects_session_id_mismatch(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="session id mismatch"):
         store.load(state.auto_session_id)
-
-        store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -223,3 +223,17 @@ def test_store_save_rejects_invalid_state_before_writing(tmp_path) -> None:
         store.save(state)
 
     assert not store.path_for(state.auto_session_id).exists()
+
+
+def test_store_load_rejects_falsey_non_object_seed_artifacts(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    for value in (None, [], "", 0):
+        data = state.to_dict()
+        data["seed_artifact"] = value
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -181,3 +181,34 @@ def test_store_load_rejects_session_id_mismatch(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="session id mismatch"):
         store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_partial_timeout_map(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["timeout_seconds_by_phase"] = {AutoPhase.RUN.value: 60}
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required phases"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_malformed_optional_strings(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    for field_name, value in (
+        ("seed_path", {"path": "seed.json"}),
+        ("seed_id", ""),
+        ("execution_id", []),
+        ("last_progress_message", []),
+    ):
+        data = state.to_dict()
+        data[field_name] = value
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -237,3 +237,15 @@ def test_store_load_rejects_falsey_non_object_seed_artifacts(tmp_path) -> None:
 
         with pytest.raises(ValueError, match="Auto session state is invalid"):
             store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_unknown_required_grade(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["required_grade"] = "D"
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="required_grade"):
+        store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -49,3 +49,15 @@ def test_terminal_state_is_not_stale() -> None:
 
     future = datetime.now(UTC) + timedelta(days=1)
     assert not state.is_stale(future)
+
+
+def test_run_phase_uses_run_timeout_key_for_staleness() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+
+    future = datetime.fromisoformat(state.last_progress_at) + timedelta(seconds=61)
+    assert state.timeout_seconds_by_phase[AutoPhase.RUN.value] == 60
+    assert state.is_stale(future)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -121,3 +121,15 @@ def test_store_load_wraps_malformed_container_and_counter_fields(tmp_path) -> No
 
         with pytest.raises(ValueError, match="Auto session state is invalid"):
             store.load(state.auto_session_id)
+
+
+def test_store_load_wraps_malformed_seed_artifact(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["seed_artifact"] = {"goal": "missing required seed fields"}
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -71,3 +71,22 @@ def test_store_load_wraps_semantically_invalid_state(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="Auto session state is invalid"):
         store.load("auto_badstate")
+
+
+def test_store_load_wraps_invalid_timestamps_and_timeouts(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["last_progress_at"] = "not-a-timestamp"
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)
+
+    data = state.to_dict()
+    data["timeout_seconds_by_phase"] = {AutoPhase.RUN.value: "sixty"}
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -123,6 +123,48 @@ def test_store_load_wraps_malformed_container_and_counter_fields(tmp_path) -> No
             store.load(state.auto_session_id)
 
 
+def test_store_load_rejects_malformed_nested_ledger(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["ledger"] = {
+        "sections": {
+            "goal": {
+                "name": "goal",
+                "entries": [
+                    {
+                        "key": "goal.primary",
+                        "value": "Build a CLI",
+                        "source": "not-a-source",
+                        "confidence": 0.9,
+                        "status": "confirmed",
+                    }
+                ],
+            }
+        },
+        "question_history": [],
+    }
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="valid Seed Draft Ledger"):
+        store.load(state.auto_session_id)
+
+
+def test_store_save_rejects_malformed_nested_ledger_before_writing(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.ledger = {
+        "sections": {"goal": {"name": "goal", "entries": [{"key": "missing fields"}]}},
+        "question_history": [],
+    }
+
+    with pytest.raises(ValueError, match="valid Seed Draft Ledger"):
+        store.save(state)
+
+    assert not store.path_for(state.auto_session_id).exists()
+
+
 def test_store_load_rejects_empty_optional_resume_identifiers(tmp_path) -> None:
     store = AutoStore(tmp_path)
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")


### PR DESCRIPTION
## Summary

- Adds a bounded AutoInterviewDriver with max-round and timeout enforcement.
- Adds deterministic SeedReviewer and SeedRepairer with stable finding fingerprints and repeated-finding/no-change guards.
- Adds an AutoPipeline supervisor skeleton that coordinates interview → Seed generation → review/repair → A-grade execution handoff through injected adapters.
- Keeps live MCP/CLI integration out of this PR so the core convergence loop remains fully unit-testable.

## Hang-prevention design

- Interview start/answer calls use `asyncio.wait_for` and return blocked state on timeout.
- The interview loop is capped by `max_rounds`; it never relies on the interview backend to self-terminate.
- Repair loops are capped by `max_repair_rounds` and stop on blockers/no-change/repeated high-severity findings.
- The supervisor persists state before/after each phase and refuses to run unless review returns `may_run=True`.

## Tested

- `uv run pytest tests/unit/auto -q`
- `uv run ruff check src/ouroboros/auto tests/unit/auto`
- `uv run mypy src/ouroboros/auto`

## Not tested

- Live MCP adapters for `ouroboros_interview`, `ouroboros_generate_seed`, and `ouroboros_start_execute_seed` are planned for the CLI/MCP surface PR.

Depends on #552
Closes #547
Closes #548
Closes #549
Refs #542
