### PR TITLE
fix(providers): surface codex stdout error events in ProviderError (#560)

### DIFF
--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -484,6 +484,39 @@ class CodexCliLLMAdapter:
 
         return stderr.strip()
 
+    def _extract_stdout_errors(self, stdout_lines: list[str]) -> list[str]:
+        """Pull error event messages from a Codex JSONL stdout stream.
+
+        Codex CLI 0.128+ emits in-flight failures (provider 502s, model
+        registry mismatches, auth issues, retry exhaustion) as JSONL events
+        on stdout with ``type`` of ``"error"`` or ``"turn.failed"``. The
+        process eventually exits with rc != 0 and only the static startup
+        banner ("Reading prompt from stdin...") on stderr — so any error
+        report that forwards just stderr loses every actionable detail.
+
+        This helper reads ``stdout_lines`` in arrival order and returns the
+        textual ``message`` from each terminal/error event, preserving order
+        so callers can use ``[-1]`` for the most recent (final) error.
+        """
+        errors: list[str] = []
+        for line in stdout_lines:
+            event = self._parse_json_event(line)
+            if not event:
+                continue
+            event_type = event.get("type")
+            if event_type not in {"error", "turn.failed"}:
+                continue
+
+            payload = event.get("error") if event_type == "turn.failed" else event
+            if isinstance(payload, dict):
+                msg = payload.get("message")
+                if isinstance(msg, str) and msg.strip():
+                    errors.append(msg.strip())
+                    continue
+            if isinstance(payload, str) and payload.strip():
+                errors.append(payload.strip())
+        return errors
+
     def _format_tool_info(self, tool_name: str, tool_input: dict[str, Any]) -> str:
         """Format tool name and input details for debug callbacks."""
         detail = ""
@@ -728,15 +761,18 @@ class CodexCliLLMAdapter:
                 )
 
             if process.returncode != 0:
+                stdout_errors = self._extract_stdout_errors(stdout_lines)
                 return Result.err(
                     ProviderError(
-                        message=content
+                        message=(stdout_errors[-1] if stdout_errors else None)
+                        or content
                         or f"{self._display_name} exited with code {process.returncode}",
                         provider=self._provider_name,
                         details={
                             "returncode": process.returncode,
                             "session_id": session_id,
                             "stderr": "\n".join(stderr_lines).strip(),
+                            "stdout_errors": stdout_errors,
                         },
                     )
                 )
@@ -889,15 +925,18 @@ class CodexCliLLMAdapter:
             content = last_content or self._fallback_content(stdout_lines, "\n".join(stderr_lines))
 
         if process.returncode != 0:
+            stdout_errors = self._extract_stdout_errors(stdout_lines)
             return Result.err(
                 ProviderError(
-                    message=content
+                    message=(stdout_errors[-1] if stdout_errors else None)
+                    or content
                     or f"{self._display_name} exited with code {process.returncode}",
                     provider=self._provider_name,
                     details={
                         "returncode": process.returncode,
                         "session_id": session_id,
                         "stderr": "\n".join(stderr_lines).strip(),
+                        "stdout_errors": stdout_errors,
                     },
                 )
             )

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -93,6 +93,27 @@ class _FakeProcess:
         self.returncode = self._final_returncode
 
 
+class _LegacyFakeProcess:
+    """Process stub that exercises the communicate() fallback branch."""
+
+    def __init__(
+        self,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+    ) -> None:
+        self.stdin = _FakeStdin()
+        self._stdout = stdout.encode("utf-8")
+        self._stderr = stderr.encode("utf-8")
+        self.returncode = returncode
+        self.communicate_calls = 0
+
+    async def communicate(self, _input: bytes | None = None) -> tuple[bytes, bytes]:
+        self.communicate_calls += 1
+        return self._stdout, self._stderr
+
+
 class TestCodexCliLLMAdapter:
     """Tests for CodexCliLLMAdapter."""
 
@@ -607,7 +628,6 @@ class TestCodexCliLLMAdapter:
         assert result.error.details["overflow_stage"] == "stream_capture"
         assert result.error.details["capture_limit_bytes"] == 8
 
-
     @pytest.mark.asyncio
     async def test_complete_surfaces_stdout_error_events_on_nonzero_exit(self) -> None:
         """Codex emits in-flight failures as JSONL on stdout — those messages must
@@ -661,6 +681,61 @@ class TestCodexCliLLMAdapter:
         assert "Reconnecting... 1/5" in stdout_errors[0]
         assert "502 Bad Gateway final" in stdout_errors[1]
         assert result.error.details["stderr"] == "Reading prompt from stdin..."
+
+    @pytest.mark.asyncio
+    async def test_legacy_complete_surfaces_stdout_error_events_on_nonzero_exit(
+        self,
+    ) -> None:
+        """The communicate() fallback reports stdout JSONL errors like the streaming path."""
+        adapter = CodexCliLLMAdapter(cli_path="codex")
+        process_holder: dict[str, _LegacyFakeProcess] = {}
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _LegacyFakeProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("", encoding="utf-8")
+            process = _LegacyFakeProcess(
+                stdout="\n".join(
+                    [
+                        json.dumps({"type": "thread.started", "thread_id": "legacy-thread"}),
+                        json.dumps(
+                            {
+                                "type": "error",
+                                "message": "legacy transient failure",
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "type": "turn.failed",
+                                "error": {"message": "legacy final failure"},
+                            }
+                        ),
+                    ]
+                ),
+                stderr="Reading prompt from stdin...",
+                returncode=1,
+            )
+            process_holder["process"] = process
+            return process
+
+        with patch(
+            "ouroboros.providers.codex_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Reflect on the legacy run.")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert result.error.provider == "codex_cli"
+        assert result.error.message == "legacy final failure"
+        assert result.error.details["session_id"] == "legacy-thread"
+        assert result.error.details["stdout_errors"] == [
+            "legacy transient failure",
+            "legacy final failure",
+        ]
+        assert result.error.details["stderr"] == "Reading prompt from stdin..."
+        assert process_holder["process"].communicate_calls == 1
 
     def test_extract_stdout_errors_returns_messages_in_arrival_order(self) -> None:
         """Helper extracts only error/turn.failed events and preserves order."""

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -608,6 +608,85 @@ class TestCodexCliLLMAdapter:
         assert result.error.details["capture_limit_bytes"] == 8
 
 
+    @pytest.mark.asyncio
+    async def test_complete_surfaces_stdout_error_events_on_nonzero_exit(self) -> None:
+        """Codex emits in-flight failures as JSONL on stdout — those messages must
+        reach ProviderError.message and details, not just the static stderr banner.
+
+        Regression for #560: previously the adapter forwarded only stderr so all
+        codex failures looked identical regardless of root cause.
+        """
+        adapter = CodexCliLLMAdapter(cli_path="codex")
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("", encoding="utf-8")
+            return _FakeProcess(
+                stdout="\n".join(
+                    [
+                        json.dumps({"type": "thread.started", "thread_id": "t1"}),
+                        json.dumps({"type": "turn.started"}),
+                        json.dumps(
+                            {
+                                "type": "error",
+                                "message": "Reconnecting... 1/5 (502 Bad Gateway)",
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "type": "turn.failed",
+                                "error": {"message": "502 Bad Gateway final"},
+                            }
+                        ),
+                    ]
+                ),
+                stderr="Reading prompt from stdin...",
+                returncode=1,
+            )
+
+        with patch(
+            "ouroboros.providers.codex_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Reflect on the run.")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert result.error.provider == "codex_cli"
+        assert "502 Bad Gateway final" in result.error.message
+        stdout_errors = result.error.details["stdout_errors"]
+        assert len(stdout_errors) == 2
+        assert "Reconnecting... 1/5" in stdout_errors[0]
+        assert "502 Bad Gateway final" in stdout_errors[1]
+        assert result.error.details["stderr"] == "Reading prompt from stdin..."
+
+    def test_extract_stdout_errors_returns_messages_in_arrival_order(self) -> None:
+        """Helper extracts only error/turn.failed events and preserves order."""
+        adapter = CodexCliLLMAdapter(cli_path="codex")
+        stdout_lines = [
+            json.dumps({"type": "thread.started", "thread_id": "t1"}),
+            json.dumps({"type": "turn.started"}),
+            json.dumps({"type": "error", "message": "first transient"}),
+            json.dumps({"type": "item.completed", "item": {"text": "ignored"}}),
+            json.dumps({"type": "error", "message": "second transient"}),
+            json.dumps({"type": "turn.failed", "error": {"message": "final fatal"}}),
+            "not-a-json-line",
+        ]
+        errors = adapter._extract_stdout_errors(stdout_lines)
+        assert errors == ["first transient", "second transient", "final fatal"]
+
+    def test_extract_stdout_errors_handles_empty_and_malformed(self) -> None:
+        """Empty input and malformed events do not crash."""
+        adapter = CodexCliLLMAdapter(cli_path="codex")
+        assert adapter._extract_stdout_errors([]) == []
+        assert adapter._extract_stdout_errors([json.dumps({"type": "error"})]) == []
+        assert adapter._extract_stdout_errors(
+            [json.dumps({"type": "turn.failed", "error": "string fatal"})]
+        ) == ["string fatal"]
+
+
 class TestLazyImport:
     """Test lazy import of CodexCliLLMAdapter from providers package."""
 


### PR DESCRIPTION
## Summary

Fixes #560.

`codex_cli_adapter.py` previously forwarded only `stderr` in `ProviderError.details` when the codex subprocess exited non-zero. But codex CLI 0.128+ emits all in-flight failures (provider 502s, unknown-model errors, auth errors, retry exhaustion) as JSONL events on **stdout** with `type` of `\"error\"` or `\"turn.failed\"`. The eventual non-zero exit only leaves codex's static startup banner (`\"Reading prompt from stdin...\"`) on stderr — so every codex failure looked identical to callers regardless of root cause.

## What changed

- Added `_extract_stdout_errors()` helper that pulls message strings from `error` / `turn.failed` JSONL events, preserving arrival order so the most recent terminal error is at `[-1]`.
- Updated **both** error-reporting branches in `_complete_once` (legacy + streaming codepaths) to:
  - Promote the final stdout error to `ProviderError.message` when present (falling back to existing content / exit-code message — so callers that already have a content fallback don't regress).
  - Expose the full ordered list as `details[\"stdout_errors\"]`.
  - Keep `details[\"stderr\"]` unchanged so existing diagnostics still apply.
- Added three unit tests in `tests/unit/providers/test_codex_cli_adapter.py`:
  - End-to-end surfacing through `complete()` — confirms the user-visible message becomes the final stdout error and `stdout_errors` carries the full list.
  - Helper ordering with mixed event types.
  - Empty / malformed input handling.

## Test plan

```bash
python -m pytest tests/unit/providers/test_codex_cli_adapter.py -x -q
# 24 passed in 1.86s
```

The happy path is unchanged — only the `rc != 0` branch is touched, and only to add information rather than remove it. Pre-existing tests (`test_complete_returns_provider_error_on_nonzero_exit`, etc.) continue to pass without modification.

## Why this matters

Without this fix, every codex backend Reflect / QA / Evaluate / interview failure emits the same useless message:

```
turn.failed (details:
{'returncode': 1, 'session_id': '...', 'stderr': 'Reading prompt from stdin...'})
```

After this fix, the same scenario produces:

```
turn.failed (details:
{'returncode': 1,
 'session_id': '...',
 'stderr': 'Reading prompt from stdin...',
 'stdout_errors': [
     'Reconnecting... 1/5 (502 Bad Gateway: unknown provider for model X)',
     '...',
     'unexpected status 502 Bad Gateway: unknown provider for model X'],
 message: 'unexpected status 502 Bad Gateway: unknown provider for model X'})
```

— which immediately tells the user (or downstream automation) the actionable root cause: model name not registered with the configured codex provider, auth failure, etc.

## Related

- Closes #560
- Same external symptom as #455 (closed-but-unfixed, `needs-human` label) — this fix likely also makes that case diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)