### PR TITLE
fix(evolution): rebuild Reflect adapter on llm.backend config drift (#562)

### DIFF
--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -89,17 +89,18 @@ class ReflectEngine:
     llm_adapter: LLMAdapter
     model: str = field(default_factory=get_reflect_model)
     adapter_factory: Callable[[], LLMAdapter | None] | None = field(default=None)
+    adapter_backend: str | None = None
     _captured_backend: str | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         try:
-            self._captured_backend = get_llm_backend()
+            self._captured_backend = self.adapter_backend or get_llm_backend()
         except Exception:  # noqa: BLE001 — never fail engine init on config read
             self._captured_backend = None
 
     def _resolve_adapter(self) -> LLMAdapter:
         """Return the adapter the next ``complete()`` call should use."""
-        current_backend = self._current_backend()
+        current_backend = self._selected_backend()
         backend_drifted = (
             self._captured_backend is not None
             and current_backend
@@ -143,7 +144,9 @@ class ReflectEngine:
 
         return self.llm_adapter
 
-    def _current_backend(self) -> str | None:
+    def _selected_backend(self) -> str | None:
+        if self.adapter_backend is not None:
+            return self.adapter_backend
         try:
             return get_llm_backend()
         except Exception:  # noqa: BLE001

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -12,6 +12,7 @@ Reflect handles all subsequent generations autonomously.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 import json
 import logging
@@ -87,51 +88,48 @@ class ReflectEngine:
 
     llm_adapter: LLMAdapter
     model: str = field(default_factory=get_reflect_model)
-    adapter_factory: object = field(default=None)
+    adapter_factory: Callable[[], LLMAdapter | None] | None = field(default=None)
     _captured_backend: str | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
-        # Snapshot the backend at construction time so we can detect drift.
         try:
             self._captured_backend = get_llm_backend()
         except Exception:  # noqa: BLE001 — never fail engine init on config read
             self._captured_backend = None
 
     def _resolve_adapter(self) -> LLMAdapter:
-        """Return the adapter the next ``complete()`` call should use.
+        """Return the adapter the next ``complete()`` call should use."""
+        current_backend = self._current_backend()
+        backend_drifted = (
+            self._captured_backend is not None
+            and current_backend
+            and current_backend != self._captured_backend
+        )
 
-        Priority:
-            1. ``adapter_factory()`` if supplied (always per-call fresh).
-            2. A freshly constructed adapter when the live ``llm.backend``
-               differs from the one captured at engine init.
-            3. The originally injected ``llm_adapter`` (today's behavior).
-        """
         if self.adapter_factory is not None:
             try:
                 fresh = self.adapter_factory()
                 if fresh is not None:
+                    if backend_drifted:
+                        self._captured_backend = current_backend
+                        self.model = get_reflect_model(current_backend)
                     return fresh
             except Exception:  # noqa: BLE001 — fall through to captured adapter
                 logger.exception("ReflectEngine adapter_factory raised; using captured adapter")
                 return self.llm_adapter
 
-        # Detect post-startup config drift and rebuild the adapter inline.
-        try:
-            current_backend = get_llm_backend()
-        except Exception:  # noqa: BLE001
-            return self.llm_adapter
-
-        if (
-            self._captured_backend is not None
-            and current_backend
-            and current_backend != self._captured_backend
-        ):
+        if backend_drifted:
             try:
                 from ouroboros.providers.factory import create_llm_adapter
 
-                rebuilt = create_llm_adapter(backend=current_backend, max_turns=1)
+                rebuilt = create_llm_adapter(
+                    backend=current_backend,
+                    cwd=_adapter_cwd(self.llm_adapter),
+                    max_turns=_adapter_max_turns(self.llm_adapter),
+                )
                 self.llm_adapter = rebuilt
                 self._captured_backend = current_backend
+                self.model = get_reflect_model(current_backend)
                 logger.info(
                     "reflect.adapter_rebuilt_for_backend_drift",
                     extra={"new_backend": current_backend},
@@ -145,6 +143,12 @@ class ReflectEngine:
                 return self.llm_adapter
 
         return self.llm_adapter
+
+    def _current_backend(self) -> str | None:
+        try:
+            return get_llm_backend()
+        except Exception:  # noqa: BLE001
+            return None
 
     async def reflect(
         self,
@@ -405,3 +409,13 @@ Guidelines:
                 },
             )
             return None
+
+
+def _adapter_cwd(adapter: LLMAdapter) -> str | None:
+    value = getattr(adapter, "_cwd", None)
+    return str(value) if value is not None else None
+
+
+def _adapter_max_turns(adapter: LLMAdapter) -> int:
+    value = getattr(adapter, "_max_turns", 1)
+    return value if isinstance(value, int) and value > 0 else 1

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -115,7 +115,7 @@ class ReflectEngine:
                     # a later transient factory failure does not fall back to a
                     # stale startup adapter after backend/model state has moved.
                     self.llm_adapter = fresh
-                    if backend_drifted:
+                    if current_backend:
                         self._captured_backend = current_backend
                         self.model = get_reflect_model(current_backend)
                     return fresh
@@ -189,13 +189,14 @@ class ReflectEngine:
             Message(role=MessageRole.USER, content=prompt),
         ]
 
+        adapter = self._resolve_adapter()
         config = CompletionConfig(
             model=self.model,
             temperature=0.5,
             max_tokens=3000,
         )
 
-        result = await self._resolve_adapter().complete(messages, config)
+        result = await adapter.complete(messages, config)
 
         if result.is_err:
             logger.error("ReflectEngine LLM call failed: %s", result.error)

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -18,7 +18,7 @@ import logging
 
 from pydantic import BaseModel, Field
 
-from ouroboros.config import get_reflect_model
+from ouroboros.config import get_llm_backend, get_reflect_model
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.lineage import EvaluationSummary, MutationAction, OntologyDelta, OntologyLineage
 from ouroboros.core.seed import Seed
@@ -72,10 +72,79 @@ class ReflectEngine:
 
     When evaluation is fully approved (score >= 0.8, no drift), outputs
     minimal changes to allow convergence.
+
+    Adapter freshness:
+        ``llm_adapter`` is captured at MCP server startup. If the user
+        changes ``llm.backend`` in ``~/.ouroboros/config.yaml`` after the
+        server has started, the captured adapter is stale and every Reflect
+        call still hits the previous backend's adapter (issue #562). The
+        ``adapter_factory`` field lets callers supply a zero-arg factory
+        the engine invokes per call so Reflect always honors the live
+        config; if no factory is supplied the engine falls back to the
+        captured adapter (preserving today's behavior for tests and direct
+        consumers).
     """
 
     llm_adapter: LLMAdapter
     model: str = field(default_factory=get_reflect_model)
+    adapter_factory: object = field(default=None)
+    _captured_backend: str | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Snapshot the backend at construction time so we can detect drift.
+        try:
+            self._captured_backend = get_llm_backend()
+        except Exception:  # noqa: BLE001 — never fail engine init on config read
+            self._captured_backend = None
+
+    def _resolve_adapter(self) -> LLMAdapter:
+        """Return the adapter the next ``complete()`` call should use.
+
+        Priority:
+            1. ``adapter_factory()`` if supplied (always per-call fresh).
+            2. A freshly constructed adapter when the live ``llm.backend``
+               differs from the one captured at engine init.
+            3. The originally injected ``llm_adapter`` (today's behavior).
+        """
+        if self.adapter_factory is not None:
+            try:
+                fresh = self.adapter_factory()
+                if fresh is not None:
+                    return fresh
+            except Exception:  # noqa: BLE001 — fall through to captured adapter
+                logger.exception("ReflectEngine adapter_factory raised; using captured adapter")
+                return self.llm_adapter
+
+        # Detect post-startup config drift and rebuild the adapter inline.
+        try:
+            current_backend = get_llm_backend()
+        except Exception:  # noqa: BLE001
+            return self.llm_adapter
+
+        if (
+            self._captured_backend is not None
+            and current_backend
+            and current_backend != self._captured_backend
+        ):
+            try:
+                from ouroboros.providers.factory import create_llm_adapter
+
+                rebuilt = create_llm_adapter(backend=current_backend, max_turns=1)
+                self.llm_adapter = rebuilt
+                self._captured_backend = current_backend
+                logger.info(
+                    "reflect.adapter_rebuilt_for_backend_drift",
+                    extra={"new_backend": current_backend},
+                )
+                return rebuilt
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "ReflectEngine failed to rebuild adapter for drifted backend; "
+                    "falling back to captured adapter"
+                )
+                return self.llm_adapter
+
+        return self.llm_adapter
 
     async def reflect(
         self,
@@ -116,7 +185,7 @@ class ReflectEngine:
             max_tokens=3000,
         )
 
-        result = await self.llm_adapter.complete(messages, config)
+        result = await self._resolve_adapter().complete(messages, config)
 
         if result.is_err:
             logger.error("ReflectEngine LLM call failed: %s", result.error)

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -110,7 +110,7 @@ class ReflectEngine:
             try:
                 fresh = self.adapter_factory()
                 if fresh is not None:
-                    if backend_drifted:
+                    if current_backend:
                         self._captured_backend = current_backend
                         self.model = get_reflect_model(current_backend)
                     return fresh
@@ -124,8 +124,7 @@ class ReflectEngine:
 
                 rebuilt = create_llm_adapter(
                     backend=current_backend,
-                    cwd=_adapter_cwd(self.llm_adapter),
-                    max_turns=_adapter_max_turns(self.llm_adapter),
+                    **_adapter_rebuild_kwargs(self.llm_adapter),
                 )
                 self.llm_adapter = rebuilt
                 self._captured_backend = current_backend
@@ -409,6 +408,28 @@ Guidelines:
                 },
             )
             return None
+
+
+def _adapter_rebuild_kwargs(adapter: LLMAdapter) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "cwd": _adapter_cwd(adapter),
+        "max_turns": _adapter_max_turns(adapter),
+    }
+    for key, attr in (
+        ("permission_mode", "_permission_mode"),
+        ("allowed_tools", "_allowed_tools"),
+        ("cli_path", "_cli_path"),
+        ("timeout", "_timeout"),
+        ("max_retries", "_max_retries"),
+        ("on_message", "_on_message"),
+        ("api_key", "_api_key"),
+        ("api_base", "_api_base"),
+    ):
+        if hasattr(adapter, attr):
+            value = getattr(adapter, attr)
+            if value is not None:
+                kwargs[key] = value
+    return kwargs
 
 
 def _adapter_cwd(adapter: LLMAdapter) -> str | None:

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -111,6 +111,10 @@ class ReflectEngine:
             try:
                 fresh = self.adapter_factory()
                 if fresh is not None:
+                    # Treat the factory result as the latest known-good adapter so
+                    # a later transient factory failure does not fall back to a
+                    # stale startup adapter after backend/model state has moved.
+                    self.llm_adapter = fresh
                     if backend_drifted:
                         self._captured_backend = current_backend
                         self.model = get_reflect_model(current_backend)

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -110,7 +110,7 @@ class ReflectEngine:
             try:
                 fresh = self.adapter_factory()
                 if fresh is not None:
-                    if current_backend:
+                    if backend_drifted:
                         self._captured_backend = current_backend
                         self.model = get_reflect_model(current_backend)
                     return fresh

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -87,16 +87,30 @@ class ReflectEngine:
     """
 
     llm_adapter: LLMAdapter
-    model: str = field(default_factory=get_reflect_model)
+    model: str | None = None
     adapter_factory: Callable[[], LLMAdapter | None] | None = field(default=None)
     adapter_backend: str | None = None
     _captured_backend: str | None = field(default=None, init=False, repr=False)
+    _model_is_explicit: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        self._model_is_explicit = self.model is not None
         try:
             self._captured_backend = self.adapter_backend or get_llm_backend()
         except Exception:  # noqa: BLE001 — never fail engine init on config read
             self._captured_backend = None
+        if self.model is None:
+            self._refresh_model(self._captured_backend)
+
+    def _refresh_model(self, backend: str | None) -> None:
+        if not self._model_is_explicit:
+            self.model = get_reflect_model(backend)
+
+    def _completion_model(self) -> str:
+        if self.model is None:
+            self._refresh_model(self._selected_backend())
+        assert self.model is not None
+        return self.model
 
     def _resolve_adapter(self) -> LLMAdapter:
         """Return the adapter the next ``complete()`` call should use."""
@@ -117,7 +131,7 @@ class ReflectEngine:
                     self.llm_adapter = fresh
                     if current_backend:
                         self._captured_backend = current_backend
-                        self.model = get_reflect_model(current_backend)
+                        self._refresh_model(current_backend)
                     return fresh
             except Exception:  # noqa: BLE001 — fall through to captured adapter
                 logger.exception("ReflectEngine adapter_factory raised; using captured adapter")
@@ -133,7 +147,7 @@ class ReflectEngine:
                 )
                 self.llm_adapter = rebuilt
                 self._captured_backend = current_backend
-                self.model = get_reflect_model(current_backend)
+                self._refresh_model(current_backend)
                 logger.info(
                     "reflect.adapter_rebuilt_for_backend_drift",
                     extra={"new_backend": current_backend},
@@ -191,7 +205,7 @@ class ReflectEngine:
 
         adapter = self._resolve_adapter()
         config = CompletionConfig(
-            model=self.model,
+            model=self._completion_model(),
             temperature=0.5,
             max_tokens=3000,
         )

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -61,16 +61,17 @@ class WonderEngine:
     llm_adapter: LLMAdapter
     model: str = field(default_factory=get_wonder_model)
     adapter_factory: Callable[[], LLMAdapter | None] | None = field(default=None)
+    adapter_backend: str | None = None
     _captured_backend: str | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         try:
-            self._captured_backend = get_llm_backend()
+            self._captured_backend = self.adapter_backend or get_llm_backend()
         except Exception:  # noqa: BLE001
             self._captured_backend = None
 
     def _resolve_adapter(self) -> LLMAdapter:
-        current_backend = self._current_backend()
+        current_backend = self._selected_backend()
         backend_drifted = (
             self._captured_backend is not None
             and current_backend
@@ -114,7 +115,9 @@ class WonderEngine:
 
         return self.llm_adapter
 
-    def _current_backend(self) -> str | None:
+    def _selected_backend(self) -> str | None:
+        if self.adapter_backend is not None:
+            return self.adapter_backend
         try:
             return get_llm_backend()
         except Exception:  # noqa: BLE001

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -16,7 +16,7 @@ import logging
 
 from pydantic import BaseModel, Field
 
-from ouroboros.config import get_wonder_model
+from ouroboros.config import get_llm_backend, get_wonder_model
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.lineage import EvaluationSummary, OntologyLineage
 from ouroboros.core.seed import OntologySchema, Seed
@@ -58,6 +58,41 @@ class WonderEngine:
     """
 
     llm_adapter: LLMAdapter
+    adapter_factory: object = field(default=None)
+    _captured_backend: str | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        try:
+            self._captured_backend = get_llm_backend()
+        except Exception:  # noqa: BLE001
+            self._captured_backend = None
+
+    def _resolve_adapter(self) -> LLMAdapter:
+        if self.adapter_factory is not None:
+            try:
+                fresh = self.adapter_factory()
+                if fresh is not None:
+                    return fresh
+            except Exception:  # noqa: BLE001
+                return self.llm_adapter
+        try:
+            current_backend = get_llm_backend()
+        except Exception:  # noqa: BLE001
+            return self.llm_adapter
+        if (
+            self._captured_backend is not None
+            and current_backend
+            and current_backend != self._captured_backend
+        ):
+            try:
+                from ouroboros.providers.factory import create_llm_adapter
+                rebuilt = create_llm_adapter(backend=current_backend, max_turns=1)
+                self.llm_adapter = rebuilt
+                self._captured_backend = current_backend
+                return rebuilt
+            except Exception:  # noqa: BLE001
+                return self.llm_adapter
+        return self.llm_adapter
     model: str = field(default_factory=get_wonder_model)
 
     async def wonder(
@@ -95,7 +130,7 @@ class WonderEngine:
             max_tokens=2048,
         )
 
-        result = await self.llm_adapter.complete(messages, config)
+        result = await self._resolve_adapter().complete(messages, config)
 
         if result.is_err:
             logger.warning(

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -81,7 +81,7 @@ class WonderEngine:
             try:
                 fresh = self.adapter_factory()
                 if fresh is not None:
-                    if current_backend:
+                    if backend_drifted:
                         self._captured_backend = current_backend
                         self.model = get_wonder_model(current_backend)
                     return fresh

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -86,7 +86,7 @@ class WonderEngine:
                     # a later transient factory failure does not fall back to a
                     # stale startup adapter after backend/model state has moved.
                     self.llm_adapter = fresh
-                    if backend_drifted:
+                    if current_backend:
                         self._captured_backend = current_backend
                         self.model = get_wonder_model(current_backend)
                     return fresh
@@ -156,13 +156,14 @@ class WonderEngine:
             Message(role=MessageRole.USER, content=prompt),
         ]
 
+        adapter = self._resolve_adapter()
         config = CompletionConfig(
             model=self.model,
             temperature=0.7,
             max_tokens=2048,
         )
 
-        result = await self._resolve_adapter().complete(messages, config)
+        result = await adapter.complete(messages, config)
 
         if result.is_err:
             logger.warning(

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -10,6 +10,7 @@ The WonderEngine asks: "Given what we learned, what do we still not know?"
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 import json
 import logging
@@ -58,7 +59,8 @@ class WonderEngine:
     """
 
     llm_adapter: LLMAdapter
-    adapter_factory: object = field(default=None)
+    model: str = field(default_factory=get_wonder_model)
+    adapter_factory: Callable[[], LLMAdapter | None] | None = field(default=None)
     _captured_backend: str | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -68,32 +70,56 @@ class WonderEngine:
             self._captured_backend = None
 
     def _resolve_adapter(self) -> LLMAdapter:
+        current_backend = self._current_backend()
+        backend_drifted = (
+            self._captured_backend is not None
+            and current_backend
+            and current_backend != self._captured_backend
+        )
+
         if self.adapter_factory is not None:
             try:
                 fresh = self.adapter_factory()
                 if fresh is not None:
+                    if backend_drifted:
+                        self._captured_backend = current_backend
+                        self.model = get_wonder_model(current_backend)
                     return fresh
             except Exception:  # noqa: BLE001
+                logger.exception("WonderEngine adapter_factory raised; using captured adapter")
                 return self.llm_adapter
-        try:
-            current_backend = get_llm_backend()
-        except Exception:  # noqa: BLE001
-            return self.llm_adapter
-        if (
-            self._captured_backend is not None
-            and current_backend
-            and current_backend != self._captured_backend
-        ):
+
+        if backend_drifted:
             try:
                 from ouroboros.providers.factory import create_llm_adapter
-                rebuilt = create_llm_adapter(backend=current_backend, max_turns=1)
+
+                rebuilt = create_llm_adapter(
+                    backend=current_backend,
+                    cwd=_adapter_cwd(self.llm_adapter),
+                    max_turns=_adapter_max_turns(self.llm_adapter),
+                )
                 self.llm_adapter = rebuilt
                 self._captured_backend = current_backend
+                self.model = get_wonder_model(current_backend)
+                logger.info(
+                    "wonder.adapter_rebuilt_for_backend_drift",
+                    extra={"new_backend": current_backend},
+                )
                 return rebuilt
             except Exception:  # noqa: BLE001
+                logger.exception(
+                    "WonderEngine failed to rebuild adapter for drifted backend; "
+                    "falling back to captured adapter"
+                )
                 return self.llm_adapter
+
         return self.llm_adapter
-    model: str = field(default_factory=get_wonder_model)
+
+    def _current_backend(self) -> str | None:
+        try:
+            return get_llm_backend()
+        except Exception:  # noqa: BLE001
+            return None
 
     async def wonder(
         self,
@@ -338,3 +364,13 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
             if should_continue
             else "Degraded mode: evaluation passed, no in-scope gaps remain",
         )
+
+
+def _adapter_cwd(adapter: LLMAdapter) -> str | None:
+    value = getattr(adapter, "_cwd", None)
+    return str(value) if value is not None else None
+
+
+def _adapter_max_turns(adapter: LLMAdapter) -> int:
+    value = getattr(adapter, "_max_turns", 1)
+    return value if isinstance(value, int) and value > 0 else 1

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -81,7 +81,7 @@ class WonderEngine:
             try:
                 fresh = self.adapter_factory()
                 if fresh is not None:
-                    if backend_drifted:
+                    if current_backend:
                         self._captured_backend = current_backend
                         self.model = get_wonder_model(current_backend)
                     return fresh
@@ -95,8 +95,7 @@ class WonderEngine:
 
                 rebuilt = create_llm_adapter(
                     backend=current_backend,
-                    cwd=_adapter_cwd(self.llm_adapter),
-                    max_turns=_adapter_max_turns(self.llm_adapter),
+                    **_adapter_rebuild_kwargs(self.llm_adapter),
                 )
                 self.llm_adapter = rebuilt
                 self._captured_backend = current_backend
@@ -364,6 +363,28 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
             if should_continue
             else "Degraded mode: evaluation passed, no in-scope gaps remain",
         )
+
+
+def _adapter_rebuild_kwargs(adapter: LLMAdapter) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "cwd": _adapter_cwd(adapter),
+        "max_turns": _adapter_max_turns(adapter),
+    }
+    for key, attr in (
+        ("permission_mode", "_permission_mode"),
+        ("allowed_tools", "_allowed_tools"),
+        ("cli_path", "_cli_path"),
+        ("timeout", "_timeout"),
+        ("max_retries", "_max_retries"),
+        ("on_message", "_on_message"),
+        ("api_key", "_api_key"),
+        ("api_base", "_api_base"),
+    ):
+        if hasattr(adapter, attr):
+            value = getattr(adapter, attr)
+            if value is not None:
+                kwargs[key] = value
+    return kwargs
 
 
 def _adapter_cwd(adapter: LLMAdapter) -> str | None:

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -59,16 +59,30 @@ class WonderEngine:
     """
 
     llm_adapter: LLMAdapter
-    model: str = field(default_factory=get_wonder_model)
+    model: str | None = None
     adapter_factory: Callable[[], LLMAdapter | None] | None = field(default=None)
     adapter_backend: str | None = None
     _captured_backend: str | None = field(default=None, init=False, repr=False)
+    _model_is_explicit: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        self._model_is_explicit = self.model is not None
         try:
             self._captured_backend = self.adapter_backend or get_llm_backend()
         except Exception:  # noqa: BLE001
             self._captured_backend = None
+        if self.model is None:
+            self._refresh_model(self._captured_backend)
+
+    def _refresh_model(self, backend: str | None) -> None:
+        if not self._model_is_explicit:
+            self.model = get_wonder_model(backend)
+
+    def _completion_model(self) -> str:
+        if self.model is None:
+            self._refresh_model(self._selected_backend())
+        assert self.model is not None
+        return self.model
 
     def _resolve_adapter(self) -> LLMAdapter:
         current_backend = self._selected_backend()
@@ -88,7 +102,7 @@ class WonderEngine:
                     self.llm_adapter = fresh
                     if current_backend:
                         self._captured_backend = current_backend
-                        self.model = get_wonder_model(current_backend)
+                        self._refresh_model(current_backend)
                     return fresh
             except Exception:  # noqa: BLE001
                 logger.exception("WonderEngine adapter_factory raised; using captured adapter")
@@ -104,7 +118,7 @@ class WonderEngine:
                 )
                 self.llm_adapter = rebuilt
                 self._captured_backend = current_backend
-                self.model = get_wonder_model(current_backend)
+                self._refresh_model(current_backend)
                 logger.info(
                     "wonder.adapter_rebuilt_for_backend_drift",
                     extra={"new_backend": current_backend},
@@ -158,7 +172,7 @@ class WonderEngine:
 
         adapter = self._resolve_adapter()
         config = CompletionConfig(
-            model=self.model,
+            model=self._completion_model(),
             temperature=0.7,
             max_tokens=2048,
         )

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -82,6 +82,10 @@ class WonderEngine:
             try:
                 fresh = self.adapter_factory()
                 if fresh is not None:
+                    # Treat the factory result as the latest known-good adapter so
+                    # a later transient factory failure does not fall back to a
+                    # stale startup adapter after backend/model state has moved.
+                    self.llm_adapter = fresh
                     if backend_drifted:
                         self._captured_backend = current_backend
                         self.model = get_wonder_model(current_backend)

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -889,7 +889,7 @@ def create_ouroboros_server(
 
     def fresh_llm_adapter():
         return create_llm_adapter(
-            backend=llm_backend,
+            backend=None,
             max_turns=1,
             cwd=effective_cwd,
         )

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -887,13 +887,22 @@ def create_ouroboros_server(
     from ouroboros.verification.extractor import AssertionExtractor
     from ouroboros.verification.verifier import SpecVerifier
 
+    def fresh_llm_adapter():
+        return create_llm_adapter(
+            backend=llm_backend,
+            max_turns=1,
+            cwd=effective_cwd,
+        )
+
     wonder_engine = WonderEngine(
         llm_adapter=llm_adapter,
         model=get_wonder_model(llm_backend),
+        adapter_factory=fresh_llm_adapter,
     )
     reflect_engine = ReflectEngine(
         llm_adapter=llm_adapter,
         model=get_reflect_model(llm_backend),
+        adapter_factory=fresh_llm_adapter,
     )
 
     # Wire real execution/evaluation callables for evolve_step so that

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -898,11 +898,13 @@ def create_ouroboros_server(
         llm_adapter=llm_adapter,
         model=get_wonder_model(llm_backend),
         adapter_factory=fresh_llm_adapter,
+        adapter_backend=llm_backend,
     )
     reflect_engine = ReflectEngine(
         llm_adapter=llm_adapter,
         model=get_reflect_model(llm_backend),
         adapter_factory=fresh_llm_adapter,
+        adapter_backend=llm_backend,
     )
 
     # Wire real execution/evaluation callables for evolve_step so that

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -889,7 +889,7 @@ def create_ouroboros_server(
 
     def fresh_llm_adapter():
         return create_llm_adapter(
-            backend=None,
+            backend=llm_backend if llm_backend is not None else None,
             max_turns=1,
             cwd=effective_cwd,
         )

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -778,9 +778,7 @@ def create_ouroboros_server(
     from ouroboros.config import (
         get_assertion_extraction_model,
         get_clarification_model,
-        get_reflect_model,
         get_semantic_model,
-        get_wonder_model,
     )
     from ouroboros.evaluation import (
         EvaluationContext,
@@ -896,13 +894,11 @@ def create_ouroboros_server(
 
     wonder_engine = WonderEngine(
         llm_adapter=llm_adapter,
-        model=get_wonder_model(llm_backend),
         adapter_factory=fresh_llm_adapter,
         adapter_backend=llm_backend,
     )
     reflect_engine = ReflectEngine(
         llm_adapter=llm_adapter,
-        model=get_reflect_model(llm_backend),
         adapter_factory=fresh_llm_adapter,
         adapter_backend=llm_backend,
     )

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -569,6 +569,30 @@ class TestCreateOuroborosServer:
         assert mock_create_llm_adapter.call_args.kwargs["backend"] == "codex"
         assert mock_create_llm_adapter.call_args.kwargs["max_turns"] == 1
 
+    def test_evolution_adapter_factory_resolves_live_backend_with_cwd(self) -> None:
+        """Per-call evolution adapter factory must not freeze startup llm_backend."""
+        with (
+            patch("ouroboros.providers.create_llm_adapter") as mock_create_llm_adapter,
+            patch("ouroboros.orchestrator.create_agent_runtime") as mock_create_runtime,
+            patch("ouroboros.evolution.wonder.WonderEngine") as mock_wonder_engine,
+            patch("ouroboros.evolution.reflect.ReflectEngine") as mock_reflect_engine,
+        ):
+            mock_create_llm_adapter.return_value = MagicMock()
+            mock_create_runtime.return_value = MagicMock()
+
+            create_ouroboros_server(runtime_backend="codex", llm_backend="codex")
+
+            initial_kwargs = mock_create_llm_adapter.call_args.kwargs
+            factory = mock_wonder_engine.call_args.kwargs["adapter_factory"]
+            assert mock_reflect_engine.call_args.kwargs["adapter_factory"] is factory
+
+            factory()
+
+        assert initial_kwargs["backend"] == "codex"
+        assert mock_create_llm_adapter.call_args.kwargs["backend"] is None
+        assert mock_create_llm_adapter.call_args.kwargs["cwd"] == initial_kwargs["cwd"]
+        assert mock_create_llm_adapter.call_args.kwargs["max_turns"] == 1
+
     def test_opencode_backend_is_accepted_at_server_creation(self) -> None:
         """OpenCode backend is forwarded through the shared adapter factory."""
         with (

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -584,7 +584,9 @@ class TestCreateOuroborosServer:
 
             initial_kwargs = mock_create_llm_adapter.call_args.kwargs
             factory = mock_wonder_engine.call_args.kwargs["adapter_factory"]
+            assert mock_wonder_engine.call_args.kwargs["adapter_backend"] == "codex"
             assert mock_reflect_engine.call_args.kwargs["adapter_factory"] is factory
+            assert mock_reflect_engine.call_args.kwargs["adapter_backend"] == "codex"
 
             factory()
 
@@ -607,6 +609,7 @@ class TestCreateOuroborosServer:
             create_ouroboros_server(runtime_backend="codex")
 
             factory = mock_wonder_engine.call_args.kwargs["adapter_factory"]
+            assert mock_wonder_engine.call_args.kwargs["adapter_backend"] is None
             factory()
 
         assert mock_create_llm_adapter.call_args.kwargs["backend"] is None

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -589,9 +589,27 @@ class TestCreateOuroborosServer:
             factory()
 
         assert initial_kwargs["backend"] == "codex"
-        assert mock_create_llm_adapter.call_args.kwargs["backend"] is None
+        assert mock_create_llm_adapter.call_args.kwargs["backend"] == "codex"
         assert mock_create_llm_adapter.call_args.kwargs["cwd"] == initial_kwargs["cwd"]
         assert mock_create_llm_adapter.call_args.kwargs["max_turns"] == 1
+
+    def test_evolution_adapter_factory_uses_live_backend_without_explicit_override(self) -> None:
+        """Per-call evolution adapter factory resolves live config absent override."""
+        with (
+            patch("ouroboros.providers.create_llm_adapter") as mock_create_llm_adapter,
+            patch("ouroboros.orchestrator.create_agent_runtime") as mock_create_runtime,
+            patch("ouroboros.evolution.wonder.WonderEngine") as mock_wonder_engine,
+            patch("ouroboros.evolution.reflect.ReflectEngine"),
+        ):
+            mock_create_llm_adapter.return_value = MagicMock()
+            mock_create_runtime.return_value = MagicMock()
+
+            create_ouroboros_server(runtime_backend="codex")
+
+            factory = mock_wonder_engine.call_args.kwargs["adapter_factory"]
+            factory()
+
+        assert mock_create_llm_adapter.call_args.kwargs["backend"] is None
 
     def test_opencode_backend_is_accepted_at_server_creation(self) -> None:
         """OpenCode backend is forwarded through the shared adapter factory."""

--- a/tests/unit/evolution/test_backend_drift.py
+++ b/tests/unit/evolution/test_backend_drift.py
@@ -130,3 +130,45 @@ class TestEvolutionBackendDrift:
 
         assert engine._resolve_adapter() is fresh
         assert engine.model == "codex-reflect"
+
+    def test_factory_pinned_backend_keeps_model_on_config_drift(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
+        )
+        fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
+        engine = ReflectEngine(
+            llm_adapter=_Adapter("initial"),
+            model="codex-reflect",
+            adapter_factory=lambda: fresh,
+            adapter_backend="codex",
+        )
+        get_model = Mock(return_value="gemini-reflect")
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="gemini")
+        )
+        monkeypatch.setattr("ouroboros.evolution.reflect.get_reflect_model", get_model)
+
+        assert engine._resolve_adapter() is fresh
+        assert engine.model == "codex-reflect"
+        get_model.assert_not_called()
+
+    def test_wonder_factory_pinned_backend_keeps_model_on_config_drift(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="codex")
+        )
+        fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
+        engine = WonderEngine(
+            llm_adapter=_Adapter("initial"),
+            model="codex-wonder",
+            adapter_factory=lambda: fresh,
+            adapter_backend="codex",
+        )
+        get_model = Mock(return_value="gemini-wonder")
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="gemini")
+        )
+        monkeypatch.setattr("ouroboros.evolution.wonder.get_wonder_model", get_model)
+
+        assert engine._resolve_adapter() is fresh
+        assert engine.model == "codex-wonder"
+        get_model.assert_not_called()

--- a/tests/unit/evolution/test_backend_drift.py
+++ b/tests/unit/evolution/test_backend_drift.py
@@ -129,7 +129,80 @@ class TestEvolutionBackendDrift:
         )
 
         assert engine._resolve_adapter() is fresh
+        assert engine.llm_adapter is fresh
         assert engine.model == "codex-reflect"
+
+    def test_factory_failure_falls_back_to_latest_successful_reflect_adapter(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
+        )
+        initial = _Adapter("initial")
+        fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
+        calls = 0
+
+        def flaky_factory():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return fresh
+            raise RuntimeError("temporary factory failure")
+
+        engine = ReflectEngine(
+            llm_adapter=initial,
+            model="claude-old",
+            adapter_factory=flaky_factory,
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="codex-reflect")
+        )
+
+        assert engine._resolve_adapter() is fresh
+        assert engine.llm_adapter is fresh
+        assert engine.model == "codex-reflect"
+        assert engine._resolve_adapter() is fresh
+        assert engine.llm_adapter is fresh
+        assert engine.model == "codex-reflect"
+
+    def test_factory_failure_falls_back_to_latest_successful_wonder_adapter(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="claude")
+        )
+        initial = _Adapter("initial")
+        fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
+        calls = 0
+
+        def flaky_factory():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return fresh
+            raise RuntimeError("temporary factory failure")
+
+        engine = WonderEngine(
+            llm_adapter=initial,
+            model="claude-old",
+            adapter_factory=flaky_factory,
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="codex")
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_wonder_model", Mock(return_value="codex-wonder")
+        )
+
+        assert engine._resolve_adapter() is fresh
+        assert engine.llm_adapter is fresh
+        assert engine.model == "codex-wonder"
+        assert engine._resolve_adapter() is fresh
+        assert engine.llm_adapter is fresh
+        assert engine.model == "codex-wonder"
 
     def test_factory_pinned_backend_keeps_model_on_config_drift(self, monkeypatch) -> None:
         monkeypatch.setattr(

--- a/tests/unit/evolution/test_backend_drift.py
+++ b/tests/unit/evolution/test_backend_drift.py
@@ -76,6 +76,10 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
         )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model",
+            Mock(side_effect=lambda backend=None: f"{backend}-reflect"),
+        )
         engine = ReflectEngine(
             llm_adapter=_Adapter(
                 "initial",
@@ -84,14 +88,11 @@ class TestEvolutionBackendDrift:
                 _timeout=12.5,
                 _max_retries=7,
             ),
-            model="claude-old",
         )
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="gemini")
         )
-        monkeypatch.setattr(
-            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="gemini-reflect")
-        )
+        # model selection is already patched above and should now refresh to gemini.
         monkeypatch.setattr(
             "ouroboros.providers.factory.create_llm_adapter", fake_create_llm_adapter
         )
@@ -122,6 +123,10 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="claude")
         )
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_wonder_model",
+            Mock(side_effect=lambda backend=None: f"{backend}-wonder"),
+        )
         engine = WonderEngine(
             llm_adapter=_Adapter(
                 "initial",
@@ -130,14 +135,11 @@ class TestEvolutionBackendDrift:
                 _timeout=12.5,
                 _max_retries=7,
             ),
-            model="claude-old",
         )
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="gemini")
         )
-        monkeypatch.setattr(
-            "ouroboros.evolution.wonder.get_wonder_model", Mock(return_value="gemini-wonder")
-        )
+        # model selection is already patched above and should now refresh to gemini.
         monkeypatch.setattr(
             "ouroboros.providers.factory.create_llm_adapter", fake_create_llm_adapter
         )
@@ -160,17 +162,17 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
         )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model",
+            Mock(side_effect=lambda backend=None: f"{backend}-reflect"),
+        )
         fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
         engine = ReflectEngine(
             llm_adapter=_Adapter("initial"),
-            model="claude-old",
             adapter_factory=lambda: fresh,
         )
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
-        )
-        monkeypatch.setattr(
-            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="codex-reflect")
         )
 
         assert engine._resolve_adapter() is fresh
@@ -183,6 +185,9 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
         )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="new-reflect")
+        )
         fresh = _CompletingAdapter(
             "fresh",
             content=(
@@ -192,11 +197,7 @@ class TestEvolutionBackendDrift:
         )
         engine = ReflectEngine(
             llm_adapter=_Adapter("initial"),
-            model="old-reflect",
             adapter_factory=lambda: fresh,
-        )
-        monkeypatch.setattr(
-            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="new-reflect")
         )
 
         result = asyncio.run(
@@ -219,14 +220,13 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="codex")
         )
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_wonder_model", Mock(return_value="new-wonder")
+        )
         fresh = _CompletingAdapter("fresh")
         engine = WonderEngine(
             llm_adapter=_Adapter("initial"),
-            model="old-wonder",
             adapter_factory=lambda: fresh,
-        )
-        monkeypatch.setattr(
-            "ouroboros.evolution.wonder.get_wonder_model", Mock(return_value="new-wonder")
         )
 
         result = asyncio.run(
@@ -249,6 +249,10 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
         )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model",
+            Mock(side_effect=lambda backend=None: f"{backend}-reflect"),
+        )
         initial = _Adapter("initial")
         fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
         calls = 0
@@ -262,14 +266,10 @@ class TestEvolutionBackendDrift:
 
         engine = ReflectEngine(
             llm_adapter=initial,
-            model="claude-old",
             adapter_factory=flaky_factory,
         )
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
-        )
-        monkeypatch.setattr(
-            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="codex-reflect")
         )
 
         assert engine._resolve_adapter() is fresh
@@ -285,6 +285,10 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="claude")
         )
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_wonder_model",
+            Mock(side_effect=lambda backend=None: f"{backend}-wonder"),
+        )
         initial = _Adapter("initial")
         fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
         calls = 0
@@ -298,14 +302,10 @@ class TestEvolutionBackendDrift:
 
         engine = WonderEngine(
             llm_adapter=initial,
-            model="claude-old",
             adapter_factory=flaky_factory,
         )
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="codex")
-        )
-        monkeypatch.setattr(
-            "ouroboros.evolution.wonder.get_wonder_model", Mock(return_value="codex-wonder")
         )
 
         assert engine._resolve_adapter() is fresh
@@ -319,40 +319,146 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
         )
+        get_model = Mock(return_value="codex-reflect-updated")
+        monkeypatch.setattr("ouroboros.evolution.reflect.get_reflect_model", get_model)
         fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
         engine = ReflectEngine(
             llm_adapter=_Adapter("initial"),
-            model="codex-reflect",
             adapter_factory=lambda: fresh,
             adapter_backend="codex",
         )
-        get_model = Mock(return_value="codex-reflect-updated")
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="gemini")
         )
-        monkeypatch.setattr("ouroboros.evolution.reflect.get_reflect_model", get_model)
 
         assert engine._resolve_adapter() is fresh
         assert engine.model == "codex-reflect-updated"
-        get_model.assert_called_once_with("codex")
+        assert get_model.call_args_list[-1].args == ("codex",)
 
     def test_wonder_factory_pinned_backend_keeps_model_on_config_drift(self, monkeypatch) -> None:
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="codex")
         )
+        get_model = Mock(return_value="codex-wonder-updated")
+        monkeypatch.setattr("ouroboros.evolution.wonder.get_wonder_model", get_model)
         fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
         engine = WonderEngine(
             llm_adapter=_Adapter("initial"),
-            model="codex-wonder",
             adapter_factory=lambda: fresh,
             adapter_backend="codex",
         )
-        get_model = Mock(return_value="codex-wonder-updated")
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="gemini")
         )
-        monkeypatch.setattr("ouroboros.evolution.wonder.get_wonder_model", get_model)
 
         assert engine._resolve_adapter() is fresh
         assert engine.model == "codex-wonder-updated"
-        get_model.assert_called_once_with("codex")
+        assert get_model.call_args_list[-1].args == ("codex",)
+
+
+class TestEvolutionExplicitModelOverride:
+    def test_reflect_explicit_model_survives_factory_refresh(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
+        )
+        get_model = Mock(return_value="config-reflect")
+        monkeypatch.setattr("ouroboros.evolution.reflect.get_reflect_model", get_model)
+        fresh = _CompletingAdapter(
+            "fresh",
+            content=(
+                '{"refined_goal": "Build a login system", "refined_constraints": [], '
+                '"refined_acs": [], "ontology_mutations": [], "reasoning": "ok"}'
+            ),
+        )
+        engine = ReflectEngine(
+            llm_adapter=_Adapter("initial"),
+            model="explicit-reflect",
+            adapter_factory=lambda: fresh,
+        )
+
+        result = asyncio.run(
+            engine.reflect(
+                _seed(),
+                "execution output",
+                _summary(),
+                WonderOutput(questions=(), ontology_tensions=(), should_continue=False),
+                _lineage(),
+            )
+        )
+
+        assert result.is_ok
+        assert engine.model == "explicit-reflect"
+        assert fresh.seen_configs[-1].model == "explicit-reflect"
+        get_model.assert_not_called()
+
+    def test_wonder_explicit_model_survives_factory_refresh(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="codex")
+        )
+        get_model = Mock(return_value="config-wonder")
+        monkeypatch.setattr("ouroboros.evolution.wonder.get_wonder_model", get_model)
+        fresh = _CompletingAdapter("fresh")
+        engine = WonderEngine(
+            llm_adapter=_Adapter("initial"),
+            model="explicit-wonder",
+            adapter_factory=lambda: fresh,
+        )
+
+        result = asyncio.run(
+            engine.wonder(
+                _seed().ontology_schema,
+                _summary(),
+                "execution output",
+                _lineage(),
+                _seed(),
+            )
+        )
+
+        assert result.is_ok
+        assert engine.model == "explicit-wonder"
+        assert fresh.seen_configs[-1].model == "explicit-wonder"
+        get_model.assert_not_called()
+
+    def test_reflect_explicit_model_survives_backend_rebuild(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
+        )
+        get_model = Mock(return_value="config-reflect")
+        monkeypatch.setattr("ouroboros.evolution.reflect.get_reflect_model", get_model)
+
+        def fake_create_llm_adapter(**_kwargs):
+            return _Adapter("rebuilt")
+
+        monkeypatch.setattr(
+            "ouroboros.providers.factory.create_llm_adapter", fake_create_llm_adapter
+        )
+        engine = ReflectEngine(llm_adapter=_Adapter("initial"), model="explicit-reflect")
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="gemini")
+        )
+
+        assert engine._resolve_adapter().name == "rebuilt"
+        assert engine.model == "explicit-reflect"
+        get_model.assert_not_called()
+
+    def test_wonder_explicit_model_survives_backend_rebuild(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="claude")
+        )
+        get_model = Mock(return_value="config-wonder")
+        monkeypatch.setattr("ouroboros.evolution.wonder.get_wonder_model", get_model)
+
+        def fake_create_llm_adapter(**_kwargs):
+            return _Adapter("rebuilt")
+
+        monkeypatch.setattr(
+            "ouroboros.providers.factory.create_llm_adapter", fake_create_llm_adapter
+        )
+        engine = WonderEngine(llm_adapter=_Adapter("initial"), model="explicit-wonder")
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="gemini")
+        )
+
+        assert engine._resolve_adapter().name == "rebuilt"
+        assert engine.model == "explicit-wonder"
+        get_model.assert_not_called()

--- a/tests/unit/evolution/test_backend_drift.py
+++ b/tests/unit/evolution/test_backend_drift.py
@@ -111,23 +111,6 @@ class TestEvolutionBackendDrift:
         }
         assert engine.model == "gemini-wonder"
 
-    def test_factory_fresh_adapter_refreshes_model_without_backend_drift(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
-        )
-        fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
-        engine = ReflectEngine(
-            llm_adapter=_Adapter("initial"),
-            model="codex-startup-override",
-            adapter_factory=lambda: fresh,
-        )
-        monkeypatch.setattr(
-            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="claude-reflect")
-        )
-
-        assert engine._resolve_adapter() is fresh
-        assert engine.model == "claude-reflect"
-
     def test_factory_fresh_adapter_refreshes_model_on_backend_drift(self, monkeypatch) -> None:
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")

--- a/tests/unit/evolution/test_backend_drift.py
+++ b/tests/unit/evolution/test_backend_drift.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import Mock
+
+from ouroboros.evolution.reflect import ReflectEngine
+from ouroboros.evolution.wonder import WonderEngine
+
+
+@dataclass
+class _Adapter:
+    name: str
+    _cwd: str = "/repo"
+    _max_turns: int = 3
+
+
+class TestEvolutionBackendDrift:
+    def test_reflect_rebuild_preserves_runtime_options_and_refreshes_model(
+        self, monkeypatch
+    ) -> None:
+        created: dict[str, object] = {}
+
+        def fake_create_llm_adapter(**kwargs):
+            created.update(kwargs)
+            return _Adapter("rebuilt", _cwd=str(kwargs.get("cwd")), _max_turns=kwargs["max_turns"])
+
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
+        )
+        engine = ReflectEngine(llm_adapter=_Adapter("initial"), model="claude-old")
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="gemini")
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="gemini-reflect")
+        )
+        monkeypatch.setattr(
+            "ouroboros.providers.factory.create_llm_adapter", fake_create_llm_adapter
+        )
+
+        rebuilt = engine._resolve_adapter()
+
+        assert rebuilt.name == "rebuilt"
+        assert created == {"backend": "gemini", "cwd": "/repo", "max_turns": 3}
+        assert engine.model == "gemini-reflect"
+
+    def test_wonder_rebuild_preserves_runtime_options_and_refreshes_model(
+        self, monkeypatch
+    ) -> None:
+        created: dict[str, object] = {}
+
+        def fake_create_llm_adapter(**kwargs):
+            created.update(kwargs)
+            return _Adapter("rebuilt", _cwd=str(kwargs.get("cwd")), _max_turns=kwargs["max_turns"])
+
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="claude")
+        )
+        engine = WonderEngine(llm_adapter=_Adapter("initial"), model="claude-old")
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="gemini")
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_wonder_model", Mock(return_value="gemini-wonder")
+        )
+        monkeypatch.setattr(
+            "ouroboros.providers.factory.create_llm_adapter", fake_create_llm_adapter
+        )
+
+        rebuilt = engine._resolve_adapter()
+
+        assert rebuilt.name == "rebuilt"
+        assert created == {"backend": "gemini", "cwd": "/repo", "max_turns": 3}
+        assert engine.model == "gemini-wonder"
+
+    def test_factory_fresh_adapter_refreshes_model_on_backend_drift(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
+        )
+        fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
+        engine = ReflectEngine(
+            llm_adapter=_Adapter("initial"),
+            model="claude-old",
+            adapter_factory=lambda: fresh,
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="codex-reflect")
+        )
+
+        assert engine._resolve_adapter() is fresh
+        assert engine.model == "codex-reflect"

--- a/tests/unit/evolution/test_backend_drift.py
+++ b/tests/unit/evolution/test_backend_drift.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+import asyncio
+from dataclasses import dataclass, field
 from unittest.mock import Mock
 
+from ouroboros.core.lineage import EvaluationSummary, OntologyLineage
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.core.types import Result
 from ouroboros.evolution.reflect import ReflectEngine
-from ouroboros.evolution.wonder import WonderEngine
+from ouroboros.evolution.wonder import WonderEngine, WonderOutput
+from ouroboros.providers.base import CompletionConfig, CompletionResponse, Message, UsageInfo
 
 
 @dataclass
@@ -16,6 +21,46 @@ class _Adapter:
     _permission_mode: str | None = None
     _timeout: float | None = None
     _max_retries: int | None = None
+
+
+@dataclass
+class _CompletingAdapter(_Adapter):
+    content: str = (
+        '{"questions": [], "ontology_tensions": [], "should_continue": false, "reasoning": "ok"}'
+    )
+    seen_configs: list[CompletionConfig] = field(default_factory=list)
+
+    async def complete(self, messages: list[Message], config: CompletionConfig):
+        self.seen_configs.append(config)
+        return Result.ok(
+            CompletionResponse(
+                content=self.content,
+                model=config.model,
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+        )
+
+
+def _seed() -> Seed:
+    return Seed(
+        metadata=SeedMetadata(ambiguity_score=0.1),
+        goal="Build a login system",
+        constraints=("Must use OAuth",),
+        acceptance_criteria=("User can log in",),
+        ontology_schema=OntologySchema(
+            name="login",
+            description="Login ontology",
+            fields=(OntologyField(name="user", field_type="entity", description="A user"),),
+        ),
+    )
+
+
+def _summary() -> EvaluationSummary:
+    return EvaluationSummary(final_approved=True, highest_stage_passed=3, score=0.95)
+
+
+def _lineage() -> OntologyLineage:
+    return OntologyLineage(goal="Build a login system")
 
 
 class TestEvolutionBackendDrift:
@@ -132,6 +177,72 @@ class TestEvolutionBackendDrift:
         assert engine.llm_adapter is fresh
         assert engine.model == "codex-reflect"
 
+    def test_reflect_factory_same_backend_model_refresh_reaches_completion_config(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="codex")
+        )
+        fresh = _CompletingAdapter(
+            "fresh",
+            content=(
+                '{"refined_goal": "Build a login system", "refined_constraints": [], '
+                '"refined_acs": [], "ontology_mutations": [], "reasoning": "ok"}'
+            ),
+        )
+        engine = ReflectEngine(
+            llm_adapter=_Adapter("initial"),
+            model="old-reflect",
+            adapter_factory=lambda: fresh,
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="new-reflect")
+        )
+
+        result = asyncio.run(
+            engine.reflect(
+                _seed(),
+                "execution output",
+                _summary(),
+                WonderOutput(questions=(), ontology_tensions=(), should_continue=False),
+                _lineage(),
+            )
+        )
+
+        assert result.is_ok
+        assert engine.model == "new-reflect"
+        assert fresh.seen_configs[-1].model == "new-reflect"
+
+    def test_wonder_factory_same_backend_model_refresh_reaches_completion_config(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="codex")
+        )
+        fresh = _CompletingAdapter("fresh")
+        engine = WonderEngine(
+            llm_adapter=_Adapter("initial"),
+            model="old-wonder",
+            adapter_factory=lambda: fresh,
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.wonder.get_wonder_model", Mock(return_value="new-wonder")
+        )
+
+        result = asyncio.run(
+            engine.wonder(
+                _seed().ontology_schema,
+                _summary(),
+                "execution output",
+                _lineage(),
+                _seed(),
+            )
+        )
+
+        assert result.is_ok
+        assert engine.model == "new-wonder"
+        assert fresh.seen_configs[-1].model == "new-wonder"
+
     def test_factory_failure_falls_back_to_latest_successful_reflect_adapter(
         self, monkeypatch
     ) -> None:
@@ -215,15 +326,15 @@ class TestEvolutionBackendDrift:
             adapter_factory=lambda: fresh,
             adapter_backend="codex",
         )
-        get_model = Mock(return_value="gemini-reflect")
+        get_model = Mock(return_value="codex-reflect-updated")
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="gemini")
         )
         monkeypatch.setattr("ouroboros.evolution.reflect.get_reflect_model", get_model)
 
         assert engine._resolve_adapter() is fresh
-        assert engine.model == "codex-reflect"
-        get_model.assert_not_called()
+        assert engine.model == "codex-reflect-updated"
+        get_model.assert_called_once_with("codex")
 
     def test_wonder_factory_pinned_backend_keeps_model_on_config_drift(self, monkeypatch) -> None:
         monkeypatch.setattr(
@@ -236,12 +347,12 @@ class TestEvolutionBackendDrift:
             adapter_factory=lambda: fresh,
             adapter_backend="codex",
         )
-        get_model = Mock(return_value="gemini-wonder")
+        get_model = Mock(return_value="codex-wonder-updated")
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="gemini")
         )
         monkeypatch.setattr("ouroboros.evolution.wonder.get_wonder_model", get_model)
 
         assert engine._resolve_adapter() is fresh
-        assert engine.model == "codex-wonder"
-        get_model.assert_not_called()
+        assert engine.model == "codex-wonder-updated"
+        get_model.assert_called_once_with("codex")

--- a/tests/unit/evolution/test_backend_drift.py
+++ b/tests/unit/evolution/test_backend_drift.py
@@ -12,6 +12,10 @@ class _Adapter:
     name: str
     _cwd: str = "/repo"
     _max_turns: int = 3
+    _allowed_tools: list[str] | None = None
+    _permission_mode: str | None = None
+    _timeout: float | None = None
+    _max_retries: int | None = None
 
 
 class TestEvolutionBackendDrift:
@@ -27,7 +31,16 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
         )
-        engine = ReflectEngine(llm_adapter=_Adapter("initial"), model="claude-old")
+        engine = ReflectEngine(
+            llm_adapter=_Adapter(
+                "initial",
+                _allowed_tools=["Read"],
+                _permission_mode="default",
+                _timeout=12.5,
+                _max_retries=7,
+            ),
+            model="claude-old",
+        )
         monkeypatch.setattr(
             "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="gemini")
         )
@@ -41,7 +54,15 @@ class TestEvolutionBackendDrift:
         rebuilt = engine._resolve_adapter()
 
         assert rebuilt.name == "rebuilt"
-        assert created == {"backend": "gemini", "cwd": "/repo", "max_turns": 3}
+        assert created == {
+            "backend": "gemini",
+            "cwd": "/repo",
+            "max_turns": 3,
+            "allowed_tools": ["Read"],
+            "permission_mode": "default",
+            "timeout": 12.5,
+            "max_retries": 7,
+        }
         assert engine.model == "gemini-reflect"
 
     def test_wonder_rebuild_preserves_runtime_options_and_refreshes_model(
@@ -56,7 +77,16 @@ class TestEvolutionBackendDrift:
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="claude")
         )
-        engine = WonderEngine(llm_adapter=_Adapter("initial"), model="claude-old")
+        engine = WonderEngine(
+            llm_adapter=_Adapter(
+                "initial",
+                _allowed_tools=["Read"],
+                _permission_mode="default",
+                _timeout=12.5,
+                _max_retries=7,
+            ),
+            model="claude-old",
+        )
         monkeypatch.setattr(
             "ouroboros.evolution.wonder.get_llm_backend", Mock(return_value="gemini")
         )
@@ -70,8 +100,33 @@ class TestEvolutionBackendDrift:
         rebuilt = engine._resolve_adapter()
 
         assert rebuilt.name == "rebuilt"
-        assert created == {"backend": "gemini", "cwd": "/repo", "max_turns": 3}
+        assert created == {
+            "backend": "gemini",
+            "cwd": "/repo",
+            "max_turns": 3,
+            "allowed_tools": ["Read"],
+            "permission_mode": "default",
+            "timeout": 12.5,
+            "max_retries": 7,
+        }
         assert engine.model == "gemini-wonder"
+
+    def test_factory_fresh_adapter_refreshes_model_without_backend_drift(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_llm_backend", Mock(return_value="claude")
+        )
+        fresh = _Adapter("fresh", _cwd="/safe", _max_turns=1)
+        engine = ReflectEngine(
+            llm_adapter=_Adapter("initial"),
+            model="codex-startup-override",
+            adapter_factory=lambda: fresh,
+        )
+        monkeypatch.setattr(
+            "ouroboros.evolution.reflect.get_reflect_model", Mock(return_value="claude-reflect")
+        )
+
+        assert engine._resolve_adapter() is fresh
+        assert engine.model == "claude-reflect"
 
     def test_factory_fresh_adapter_refreshes_model_on_backend_drift(self, monkeypatch) -> None:
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Fixes #562.

`ReflectEngine` captures `llm_adapter` at MCP server startup. When a user changes `~/.ouroboros/config.yaml` (e.g. switching `llm.backend` mid-session) without restarting Claude Code, every subsequent `evolve_step` Reflect call still uses the stale adapter — even though `ouroboros_evaluate` works correctly because `EvaluateHandler` constructs its own adapter per call.

This change makes Reflect honor live config without a server restart.

## What changed

`src/ouroboros/evolution/reflect.py`:

- Added `from ouroboros.config import get_llm_backend` for live backend reads.
- Snapshot the configured backend in `__post_init__` (via `_captured_backend`).
- New optional `adapter_factory` field — zero-arg callable for callers that want full per-call freshness (no behavior change when omitted).
- New `_resolve_adapter()` method:
  1. If `adapter_factory` is supplied, invoke it.
  2. Otherwise compare `get_llm_backend()` to the captured snapshot; if drifted, rebuild via `create_llm_adapter()` once, update both the cache and the snapshot.
  3. Otherwise return the originally injected `llm_adapter`.
- The `complete()` call site uses `self._resolve_adapter()` instead of `self.llm_adapter` directly.

Defensive: failures in factory/config-read paths log and fall back to the captured adapter, so the engine never crashes harder than before.

## Test plan

```bash
python -c \"import ast; ast.parse(open('src/ouroboros/evolution/reflect.py').read())\"
python -c \"from ouroboros.evolution.reflect import ReflectEngine\"
```

Both pass. Behavior is unchanged for callers that don't touch config mid-session (captured == current ⇒ identity returns the injected adapter), so existing engines/tests don't regress.

For full verification of the rebuild path, an integration test would need to mock `get_llm_backend()` returning a different value between calls and assert the adapter type changes — happy to add that if reviewers want it inline (kept the diff minimal here).

## Why this matters

Without this fix, any user who switches `llm.backend` without restarting Claude Code sees `evolve_step` keep failing on the previous backend's adapter, even when other tools (`ouroboros_evaluate`) work correctly with the new backend. The asymmetry is confusing and the workaround (full session restart) is heavyweight.

This also covers the broader \"cached-stale-adapter\" pattern that surfaced as #455 (closed-but-unfixed) and parts of #475.

## Follow-up

`WonderEngine` has the same caching pattern and should get the same treatment — happy to do that in a follow-up PR (omitted here to keep this PR focused on the Reflect path that actively blocks `evolve_step`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)