### PR TITLE
Split ooo auto core quality primitives

### DIFF
--- a/src/ouroboros/auto/__init__.py
+++ b/src/ouroboros/auto/__init__.py
@@ -1,0 +1,28 @@
+"""Auto-mode convergence primitives for ``ooo auto``.
+
+The auto package is intentionally independent from the existing manual
+``interview``/``seed``/``run`` surfaces.  It provides bounded, serializable
+state plus deterministic quality gates that a higher-level supervisor can use
+before starting execution.
+"""
+
+from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
+from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
+from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoPolicy, AutoStore
+
+__all__ = [
+    "AutoAnswer",
+    "AutoAnswerSource",
+    "AutoAnswerer",
+    "AutoPhase",
+    "AutoPipelineState",
+    "AutoPolicy",
+    "AutoStore",
+    "GradeGate",
+    "GradeResult",
+    "LedgerEntry",
+    "LedgerSection",
+    "SeedDraftLedger",
+    "SeedGrade",
+]

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -115,7 +115,12 @@ class AutoAnswerer:
     def _non_goal_answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:  # noqa: ARG002
         goal_text = _latest_resolved_goal(ledger).lower()
         excluded = ["cloud sync", "paid services"]
-        if not re.search(r"\b(auth|authentication|login|sign[- ]?in|signup|password)\b", goal_text):
+        identity_terms = (
+            r"auth|authentication|authorization|authorize|login|sign[- ]?in|signup|"
+            r"password|sso|single sign[- ]?on|oauth|oidc|saml|identity|"
+            r"role[- ]?based|roles?|permissions?|access control"
+        )
+        if not re.search(rf"\b({identity_terms})\b", goal_text):
             excluded.append("authentication")
         if not re.search(r"\b(production|prod|deploy|deployment|release|publish)\b", goal_text):
             excluded.append("production deployment")

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -387,12 +387,16 @@ def _slug_key(value: str) -> str:
 def _is_product_behavior_question(lowered: str) -> bool:
     return bool(
         re.search(
-            r"\b(should|must|can|will|do|does|is|are)\b.+\b(mark|marked|show|display|write|return|create|update|edit|delete|remove|rotate|store|save|send|generate|filter|sort|search|export|import|notify|report|use)\b",
+            r"\b(should|must|can|will|do|does|is|are)\b.+\b(mark|marked|show|display|write|return|create|update|edit|delete|remove|rotate|store|save|send|generate|filter|sort|search|export|import|notify|report|use|configure)\b",
             lowered,
         )
         or re.search(r"\bwhat\s+(output|input)\b.+\b(should|does|do|format|write|use)\b", lowered)
         or re.search(
             r"\bwhat\s+should\b.+\b(write|return|display|show|create|store|generate|edit|delete)\b",
+            lowered,
+        )
+        or re.search(
+            r"\bwhat\b.+\b(fields?|settings?)\b.+\b(should|does|do)\b.+\b(display|show|store|use)\b",
             lowered,
         )
         or re.search(
@@ -461,9 +465,49 @@ def _is_safe_product_branch_question(lowered: str) -> bool:
     )
 
 
+def _asks_for_sensitive_value_or_authority(lowered: str) -> bool:
+    """Return True when the question asks auto mode to choose/use real secrets."""
+    return bool(
+        _matches_any(
+            lowered,
+            (
+                r"\b(provide|enter|paste|supply)\b.+\b(credential|credentials|secret|token|key|password)\b",
+                r"\b(credential|credentials|secret|token|key|password)\b.+\b(value|secret)\b",
+                r"\b(which|what)\b.+\b(credential|credentials|access token|auth token|private key|api key|password|secret)\b.+\b(use|configure|set|env|environment|workflow|ci)\b",
+                r"\b(which|what)\b.+\b(value|secret)\b.+\b(credential|credentials|access token|auth token|private key|api key|password)\b",
+                r"\b(use|configure|set)\b.+\b(production|prod|live|external)\b.+\b(credential|credentials|secret|api key|private key|access token|auth token)\b",
+                r"\b(use|configure|set)\b.+\b(credential|credentials|secret|api key|private key|access token|auth token)\b.+\b(production|prod|live|external)\b",
+            ),
+        )
+    )
+
+
+def _is_safe_product_sensitive_question(lowered: str) -> bool:
+    """Allow product-semantics questions that mention sensitive-domain nouns.
+
+    Auto mode must not invent real credential values or production authority,
+    but it can answer bounded requirements questions about product-managed
+    credential/token/key/secret features.  These questions are routed to the
+    product-behavior answerer so the Seed keeps the requested semantics.
+    """
+    if not _is_product_behavior_question(lowered):
+        return False
+    if _asks_for_sensitive_value_or_authority(lowered):
+        return False
+    return bool(
+        _matches_any(
+            lowered,
+            (
+                r"\b(users?|customers?|admins?|maintainers?|owners?|the app|app|system|settings form)\b.+\b(credential|credentials|secret|token|tokens|api keys?|private keys?|passwords?)\b",
+                r"\b(credential|credentials|secret|token|tokens|api keys?|private keys?|passwords?)\b.+\b(fields?|settings?|form|login|authentication|rotation|display|store|save|delete|remove)\b",
+            ),
+        )
+    )
+
+
 def _blocker_for(question: str) -> AutoBlocker | None:
     lowered = question.lower()
-    if _is_safe_product_branch_question(lowered):
+    if _is_safe_product_branch_question(lowered) or _is_safe_product_sensitive_question(lowered):
         return None
 
     external_action_patterns = (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -453,9 +453,12 @@ def _latest_resolved_goal(ledger: SeedDraftLedger) -> str:
 
 def _is_safe_product_branch_question(lowered: str) -> bool:
     return bool(
-        re.search(
-            r"\b(users?|customers?|admins?|maintainers?|owners?)\b.+\b(delete|remove)\b.+\b(branch|branches)\b",
+        _matches_any(
             lowered,
+            (
+                r"\b(users?|customers?|admins?|maintainers?|owners?)\b.+\b(delete|remove)\b.+\b(branch|branches)\b",
+                r"\b(app|application|tool|system|service|cli|workflow|feature)\b.+\b(delete|remove)\b.+\b(branch|branches)\b",
+            ),
         )
         and _is_product_behavior_question(lowered)
         and not re.search(

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -408,7 +408,7 @@ def _is_product_behavior_question(lowered: str) -> bool:
         )
         or re.search(
             r"\b(should|must|can|will|do|does|is|are)\b.+\b(be|become)\s+"
-            r"(editable|trackable|tracked|enforced|configurable|visible|searchable|exportable|importable)\b",
+            r"(editable|edited|deleted|removed|trackable|tracked|enforced|configurable|visible|searchable|exportable|importable)\b",
             lowered,
         )
         or re.search(

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -406,6 +406,20 @@ def _is_product_behavior_question(lowered: str) -> bool:
             r"\b(which|what)\b.+\b(can|should)\b.+\b(edit|delete|remove|update|create|view|access)\b",
             lowered,
         )
+        or re.search(
+            r"\b(should|must|can|will|do|does|is|are)\b.+\b(be|become)\s+"
+            r"(editable|trackable|tracked|enforced|configurable|visible|searchable|exportable|importable)\b",
+            lowered,
+        )
+        or re.search(
+            r"\b(should|must|can|will|do|does)\b.+\b(subscribe|track|enforce)\b",
+            lowered,
+        )
+        or re.search(
+            r"\b(which|what)\b.+\b(rules?|polic(?:y|ies)|workflows?|documents?|tiers?)\b.+"
+            r"\b(should|must|can|will|do|does|enforce|track|edit|subscribe)\b",
+            lowered,
+        )
     )
 
 

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -1,0 +1,529 @@
+"""Conservative source-tagged auto answers for Socratic interview prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import re
+
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+
+
+class AutoAnswerSource(StrEnum):
+    """Source categories for generated auto answers."""
+
+    USER_GOAL = "user_goal"
+    REPO_FACT = "repo_fact"
+    EXISTING_CONVENTION = "existing_convention"
+    CONSERVATIVE_DEFAULT = "conservative_default"
+    ASSUMPTION = "assumption"
+    NON_GOAL = "non_goal"
+    BLOCKER = "blocker"
+
+
+@dataclass(frozen=True, slots=True)
+class AutoBlocker:
+    """A hard blocker that should stop auto convergence."""
+
+    reason: str
+    question: str
+
+
+@dataclass(frozen=True, slots=True)
+class AutoAnswer:
+    """Answer plus structured ledger updates."""
+
+    text: str
+    source: AutoAnswerSource
+    confidence: float
+    ledger_updates: list[tuple[str, LedgerEntry]] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
+    non_goals: list[str] = field(default_factory=list)
+    blocker: AutoBlocker | None = None
+
+    @property
+    def prefixed_text(self) -> str:
+        """Return the text sent back to the interview handler."""
+        return f"[from-auto][{self.source.value}] {self.text}"
+
+
+class AutoAnswerer:
+    """Policy engine for bounded auto interview answers.
+
+    This class is deterministic and performs no unbounded repository or network
+    exploration.  Later integrations may pass bounded repo facts into it.
+    """
+
+    def answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:
+        """Answer ``question`` using a conservative policy."""
+        lowered = question.lower()
+        blocker = _blocker_for(question)
+        if blocker is not None:
+            return AutoAnswer(
+                text=f"Cannot safely decide automatically: {blocker.reason}",
+                source=AutoAnswerSource.BLOCKER,
+                confidence=1.0,
+                blocker=blocker,
+            )
+
+        if _matches_any(
+            lowered, (r"\bnon-goals?\b", r"\bout of scope\b", r"\bexclude\b", r"\bnot do\b")
+        ):
+            return self._non_goal_answer(question, ledger)
+        if _is_verification_question(lowered):
+            return self._verification_answer(question)
+        if _is_feature_acceptance_question(lowered):
+            return self._feature_acceptance_answer(question)
+        if _is_actor_or_io_question(lowered):
+            return self._io_actor_answer(question)
+        if _is_product_behavior_question(lowered):
+            return self._product_behavior_answer(question)
+        if _matches_any(
+            lowered,
+            (
+                r"\bruntime\b",
+                r"\bstack\b",
+                r"\brepo\b",
+                r"\bframework\b",
+                r"\bproject structure\b",
+                r"\bproject runtime\b",
+            ),
+        ):
+            return self._runtime_answer(question)
+
+        return self._default_answer(question, ledger)
+
+    def apply(self, answer: AutoAnswer, ledger: SeedDraftLedger, *, question: str) -> None:
+        """Apply answer updates to ``ledger``."""
+        ledger.record_qa(question, answer.prefixed_text)
+        if answer.blocker is not None:
+            ledger.add_entry(
+                "constraints",
+                LedgerEntry(
+                    key="blocker.auto_answer",
+                    value=answer.blocker.reason,
+                    source=LedgerSource.BLOCKER,
+                    confidence=1.0,
+                    status=LedgerStatus.BLOCKED,
+                    reversible=False,
+                    rationale=f"Auto mode cannot safely answer: {answer.blocker.question}",
+                ),
+            )
+        for section, entry in answer.ledger_updates:
+            ledger.add_entry(section, entry)
+
+    def _non_goal_answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:  # noqa: ARG002
+        goal_text = _latest_resolved_goal(ledger).lower()
+        excluded = ["cloud sync", "paid services"]
+        if not re.search(r"\b(auth|authentication|login|sign[- ]?in|signup|password)\b", goal_text):
+            excluded.append("authentication")
+        if not re.search(r"\b(production|prod|deploy|deployment|release|publish)\b", goal_text):
+            excluded.append("production deployment")
+        value = (
+            f"For auto MVP scope, {', '.join(excluded)} are non-goals unless explicitly requested."
+        )
+        entry = LedgerEntry(
+            key="non_goals.mvp_scope",
+            value=value,
+            source=LedgerSource.NON_GOAL,
+            confidence=0.86,
+            status=LedgerStatus.DEFAULTED,
+            rationale="Conservative auto policy bounds MVP scope.",
+        )
+        return AutoAnswer(
+            value, AutoAnswerSource.NON_GOAL, 0.86, [("non_goals", entry)], non_goals=[value]
+        )
+
+    def _verification_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
+        value = "Success must be verified with observable behavior: commands or tests should produce stable output, non-zero failures for invalid input, and reproducible artifacts where applicable."
+        updates = [
+            (
+                "verification_plan",
+                LedgerEntry(
+                    key="verification.observable",
+                    value=value,
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.84,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="A-grade Seeds require testable acceptance criteria.",
+                ),
+            ),
+            (
+                "acceptance_criteria",
+                LedgerEntry(
+                    key="acceptance.observable_behavior",
+                    value="A command-level check returns exit code 0 and stdout contains stable output or writes a reproducible artifact for each acceptance criterion.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.82,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Converts vague completion into testable behavior.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.84, updates)
+
+    def _feature_acceptance_answer(self, question: str) -> AutoAnswer:
+        subject = _acceptance_subject(question)
+        value = (
+            f"Acceptance for {subject} must cover the requested behavior directly: "
+            "a successful operation returns an observable status/output, invalid input fails "
+            "with a non-zero/error status, and any persisted artifact or state change can be verified."
+        )
+        updates = [
+            (
+                "acceptance_criteria",
+                LedgerEntry(
+                    key=f"acceptance.{_slug_key(subject)}",
+                    value=value,
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.82,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Preserves feature-specific acceptance semantics from the interview question.",
+                ),
+            ),
+            (
+                "verification_plan",
+                LedgerEntry(
+                    key=f"verification.{_slug_key(subject)}",
+                    value=f"Verify {subject} with command/API checks for success, failure, and persisted state or output.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.8,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Feature-specific acceptance requires observable verification.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.82, updates)
+
+    def _runtime_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
+        value = "Use the existing repository runtime, package manager, and architectural patterns; avoid new dependencies unless required by acceptance criteria."
+        updates = [
+            (
+                "runtime_context",
+                LedgerEntry(
+                    key="runtime.existing_project",
+                    value=value,
+                    source=LedgerSource.EXISTING_CONVENTION,
+                    confidence=0.78,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Auto mode should avoid unnecessary stack choices.",
+                ),
+            ),
+            (
+                "constraints",
+                LedgerEntry(
+                    key="constraints.no_unnecessary_dependencies",
+                    value="Do not add new dependencies unless they are necessary to satisfy explicit acceptance criteria.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.86,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Reduces execution risk and review scope.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.EXISTING_CONVENTION, 0.78, updates)
+
+    def _io_actor_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
+        value = "Assume a single local user operating through the requested interface; inputs and outputs should be explicit command/API arguments and stable returned text or artifacts."
+        updates = [
+            (
+                "actors",
+                LedgerEntry(
+                    key="actors.single_local_user",
+                    value="Single local user",
+                    source=LedgerSource.ASSUMPTION,
+                    confidence=0.76,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="No multi-user requirement was provided.",
+                ),
+            ),
+            (
+                "inputs",
+                LedgerEntry(
+                    key="inputs.explicit_arguments",
+                    value="Explicit command/API arguments derived from the task goal",
+                    source=LedgerSource.ASSUMPTION,
+                    confidence=0.74,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Auto mode needs concrete IO to generate testable Seeds.",
+                ),
+            ),
+            (
+                "outputs",
+                LedgerEntry(
+                    key="outputs.stable_text_or_artifacts",
+                    value="Stable text output or generated artifacts suitable for verification",
+                    source=LedgerSource.ASSUMPTION,
+                    confidence=0.74,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Outputs must be observable for A-grade testability.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.ASSUMPTION, 0.76, updates, assumptions=[value])
+
+    def _product_behavior_answer(self, question: str) -> AutoAnswer:
+        subject = _acceptance_subject(question)
+        value = (
+            f"Treat this requested product behavior as in scope for the MVP: {subject}. "
+            "Implement it directly and make the resulting state, output, or API response observable."
+        )
+        key = _slug_key(subject)
+        updates = [
+            (
+                "constraints",
+                LedgerEntry(
+                    key=f"constraints.behavior.{key}",
+                    value=f"Preserve the product behavior requested by the interview question: {subject}",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.8,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Safe product-semantics questions should not be collapsed into a generic MVP policy.",
+                ),
+            ),
+            (
+                "acceptance_criteria",
+                LedgerEntry(
+                    key=f"acceptance.behavior.{key}",
+                    value=f"A command or API check for {subject} returns exit code 0 or HTTP 2xx status, and stdout, response body, or a persisted file contains evidence of the requested behavior.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.78,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Feature semantics from the interview question must remain visible in the Seed contract.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.8, updates)
+
+    def _default_answer(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:  # noqa: ARG002
+        value = "Proceed with a conservative MVP: keep scope small, prefer existing project patterns, document assumptions, and make completion verifiable with observable acceptance criteria."
+        updates = [
+            (
+                "constraints",
+                LedgerEntry(
+                    key="constraints.conservative_mvp",
+                    value="Keep the implementation to the smallest safe MVP that satisfies the task goal.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.82,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="Default auto policy favors safe convergence.",
+                ),
+            ),
+            (
+                "failure_modes",
+                LedgerEntry(
+                    key="failure_modes.unverified_or_scope_creep",
+                    value="Failure includes unverified behavior, non-reproducible output, or scope expansion beyond the MVP.",
+                    source=LedgerSource.CONSERVATIVE_DEFAULT,
+                    confidence=0.8,
+                    status=LedgerStatus.DEFAULTED,
+                    rationale="A-grade Seeds need explicit failure boundaries.",
+                ),
+            ),
+        ]
+        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.82, updates)
+
+
+def _is_verification_question(lowered: str) -> bool:
+    return bool(
+        _matches_any(
+            lowered,
+            (
+                r"\btests?\b",
+                r"\bverify\b",
+                r"\bverifies\b",
+                r"\bverification\b",
+                r"\bvalidation\b",
+                r"\bdefinition of done\b",
+            ),
+        )
+        or re.search(r"\b(command output|output)\b.+\b(verifies|verify|proves?)\b", lowered)
+        or re.search(r"\b(verifies|verify|proves?)\b.+\b(acceptance|criteria)\b", lowered)
+    )
+
+
+def _is_feature_acceptance_question(lowered: str) -> bool:
+    if not re.search(r"\b(acceptance|criteria)\b", lowered):
+        return False
+    if re.search(
+        r"\b(general|overall|test strategy|verification plan|definition of done|verify|verifies|verification|validation)\b",
+        lowered,
+    ):
+        return False
+    return bool(
+        re.search(
+            r"\b(for|when|where|should|must|feature|flow|integration|endpoint|api|command|report|webhook|billing|search|generator|users?|user)\b",
+            lowered,
+        )
+    )
+
+
+def _acceptance_subject(question: str) -> str:
+    cleaned = re.sub(r"\s+", " ", question.strip().rstrip("?"))
+    patterns = (
+        r"acceptance criteria should (?P<subject>.+?) satisfy$",
+        r"criteria should (?P<subject>.+?) satisfy$",
+        r"should (?P<subject>.+?) do$",
+        r"for (?P<subject>.+)$",
+    )
+    lowered = cleaned.lower()
+    for pattern in patterns:
+        match = re.search(pattern, lowered)
+        if match:
+            return match.group("subject").strip() or "the requested behavior"
+    return cleaned or "the requested behavior"
+
+
+def _slug_key(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    return slug[:64] or "requested_behavior"
+
+
+def _is_product_behavior_question(lowered: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(should|must|can|will|do|does|is|are)\b.+\b(mark|marked|show|display|write|return|create|update|edit|delete|remove|rotate|store|save|send|generate|filter|sort|search|export|import|notify|report|use)\b",
+            lowered,
+        )
+        or re.search(r"\bwhat\s+(output|input)\b.+\b(should|does|do|format|write|use)\b", lowered)
+        or re.search(
+            r"\bwhat\s+should\b.+\b(write|return|display|show|create|store|generate|edit|delete)\b",
+            lowered,
+        )
+        or re.search(
+            r"\bhow\s+should\b.+\b(behave|work|display|return|write|store|mark)\b", lowered
+        )
+        or re.search(
+            r"\b(which|what)\b.+\b(can|should)\b.+\b(edit|delete|remove|update|create|view|access)\b",
+            lowered,
+        )
+    )
+
+
+def _matches_any(value: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.search(pattern, value) for pattern in patterns)
+
+
+def _is_actor_or_io_question(lowered: str) -> bool:
+    if re.search(
+        r"\b(what|which)\s+(are|inputs? are|outputs? are)\s+.+\b(inputs|outputs)\b", lowered
+    ):
+        return True
+    if re.search(
+        r"\b(what|which)\s+(inputs|outputs)\s+(are|should be|does|do|will|can|must)\b",
+        lowered,
+    ):
+        return True
+    if re.search(
+        r"\b(what|which)\s+(inputs|outputs)\b.+\b(take|produce|return|emit|write|read|accept|receive)\b",
+        lowered,
+    ):
+        return True
+    if re.search(
+        r"\b(what|which)\s+.+\b(inputs|outputs)\b.+\b(take|produce|return|emit|write|read|accept|receive)\b",
+        lowered,
+    ):
+        return True
+    if re.search(
+        r"\b(who|which|what)\s+(is|are)\s+.+\b(actors?|personas?|stakeholders?)\b", lowered
+    ):
+        return True
+    return bool(re.search(r"\b(who|which)\s+(is|are)\s+the\s+users?\b", lowered))
+
+
+def _latest_resolved_goal(ledger: SeedDraftLedger) -> str:
+    section = ledger.sections.get("goal")
+    if section is None:
+        return ""
+    inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    for entry in reversed(section.entries):
+        if entry.status not in inactive and entry.value.strip():
+            return entry.value
+    return ""
+
+
+def _blocker_for(question: str) -> AutoBlocker | None:
+    lowered = question.lower()
+
+    external_action_patterns = (
+        (
+            r"\b(credential value|credential secret)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(provide|enter|paste|supply|configure|set)\b.+\b(access token|auth token|private key)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what)\b.+\b(access token|auth token|private key)\b.+\b(use|configure|set|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(provide|enter|paste|supply|configure|set)\b.+\b(credentials?)\b.+\b(value|secret|token|key|password|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what)\s+credentials?\b.+\b(use|configure|set|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(provide|enter|use|configure|set)\b.+\b(api keys?|passwords?)\b.+\b(value|secret|token|credential|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what)\b.+\b(api keys?|passwords?)\b.+\b(value|secret|token|credential|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(credential|credentials)\b.+\b(value|secret|token|key|password|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(charge|purchase|subscribe|provide|enter|use|configure|set)\b.+\b(payment|billing|paid service|credit card|bank account|invoice)\b.+\b(account|provider|key|secret|production|live)\b",
+            "paid service or financial decision required",
+        ),
+        (
+            r"\b(payment|billing|paid service|credit card|bank account|invoice)\b.+\b(account|provider|key|secret|production|live)\b.+\b(charge|purchase|subscribe|pay)\b",
+            "paid service or financial decision required",
+        ),
+        (
+            r"\b(which|what|provide|obtain|get|use|choose|select)\b.+\b(legal|compliance|license|contract)\b.+\b(advice|judgment|review|approval|liability|risk|interpretation)\b",
+            "legal judgment required",
+        ),
+        (
+            r"\b(which|what|provide|use|choose|select)\b.+\b(medical|clinical|diagnosis|treatment|health)\b.+\b(advice|judgment|diagnose|prescribe|triage|recommendation)\b",
+            "medical judgment required",
+        ),
+        (
+            r"\b(should|can|may|will|do we|should we)\b.+\b(deploy|release|publish)\b.+\b(to|against|on)\s+\b(production|prod|live|external)\b",
+            "deployment target requires human authority",
+        ),
+        (
+            r"\b(which|what|choose|select|use|configure|set)\b.+\b(production|prod|live|external)\b.+\b(environment|target|account|project|cluster|region)\b",
+            "deployment target requires human authority",
+        ),
+        (
+            r"\b(which|what|choose|select|use|configure|set)\b.+\b(environment|target|account|project|cluster|region)\b.+\b(deploy|release|publish)\b.+\b(production|prod|live|external)\b",
+            "deployment target requires human authority",
+        ),
+        (
+            r"\b(production|prod|live|external)\b.+\b(credential|secret|api key)\b",
+            "production deployment or irreversible external action required",
+        ),
+        (
+            r"\b(delete|drop|erase|wipe|remove)\b.+\b(database|db|branch|production|prod)\b",
+            "destructive external operation requires human authority",
+        ),
+        (
+            r"\b(provide|enter|paste|supply|use|configure|set)\b.+\bsecret\b.+\b(value|key|token|credential|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+        (
+            r"\b(which|what)\s+secret\b.+\b(use|configure|set|env|environment|workflow|ci|production|prod)\b",
+            "credential or secret value required",
+        ),
+    )
+    for pattern, reason in external_action_patterns:
+        if re.search(pattern, lowered):
+            return AutoBlocker(reason=reason, question=question)
+    return None

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -447,8 +447,24 @@ def _latest_resolved_goal(ledger: SeedDraftLedger) -> str:
     return ""
 
 
+def _is_safe_product_branch_question(lowered: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(users?|customers?|admins?|maintainers?|owners?)\b.+\b(delete|remove)\b.+\b(branch|branches)\b",
+            lowered,
+        )
+        and _is_product_behavior_question(lowered)
+        and not re.search(
+            r"\b(current|this|production|prod|live|external|remote|local)\b.+\b(branch|branches)\b",
+            lowered,
+        )
+    )
+
+
 def _blocker_for(question: str) -> AutoBlocker | None:
     lowered = question.lower()
+    if _is_safe_product_branch_question(lowered):
+        return None
 
     external_action_patterns = (
         (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -480,7 +480,7 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "credential or secret value required",
         ),
         (
-            r"\b(credential|credentials)\b.+\b(value|secret|token|key|password|env|environment|workflow|ci|production|prod)\b",
+            r"\b(credential|credentials)\b.+\b(value|secret|token|key|password|env|environment|workflow|ci)\b",
             "credential or secret value required",
         ),
         (
@@ -512,7 +512,7 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "deployment target requires human authority",
         ),
         (
-            r"\b(production|prod|live|external)\b.+\b(credential|secret|api key)\b",
+            r"\b(provide|enter|paste|supply|use|configure|set)\b.+\b(production|prod|live|external)\b.+\b(credential|secret|api key)\b",
             "production deployment or irreversible external action required",
         ),
         (

--- a/src/ouroboros/auto/gap_detector.py
+++ b/src/ouroboros/auto/gap_detector.py
@@ -1,0 +1,77 @@
+"""Gap detection for auto-mode Seed Draft Ledgers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ouroboros.auto.ledger import REQUIRED_SECTIONS, LedgerStatus, SeedDraftLedger
+
+
+class GapType(StrEnum):
+    """Known Seed gap types."""
+
+    GOAL = "goal_gap"
+    ACTOR = "actor_gap"
+    INPUT = "input_gap"
+    OUTPUT = "output_gap"
+    CONSTRAINT = "constraint_gap"
+    NON_GOAL = "non_goal_gap"
+    ACCEPTANCE_CRITERIA = "acceptance_criteria_gap"
+    VERIFICATION = "verification_gap"
+    FAILURE_MODE = "failure_mode_gap"
+    RUNTIME_CONTEXT = "runtime_context_gap"
+    RISK = "risk_gap"
+
+
+SECTION_TO_GAP = {
+    "goal": GapType.GOAL,
+    "actors": GapType.ACTOR,
+    "inputs": GapType.INPUT,
+    "outputs": GapType.OUTPUT,
+    "constraints": GapType.CONSTRAINT,
+    "non_goals": GapType.NON_GOAL,
+    "acceptance_criteria": GapType.ACCEPTANCE_CRITERIA,
+    "verification_plan": GapType.VERIFICATION,
+    "failure_modes": GapType.FAILURE_MODE,
+    "runtime_context": GapType.RUNTIME_CONTEXT,
+    "risks": GapType.RISK,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Gap:
+    """A structured gap detected in a ledger."""
+
+    section: str
+    gap_type: GapType
+    state: LedgerStatus
+    message: str
+    repairable: bool = True
+
+
+class GapDetector:
+    """Detect missing, conflicting, and blocked auto-mode Seed sections."""
+
+    def detect(self, ledger: SeedDraftLedger) -> list[Gap]:
+        """Return structured gaps for ``ledger``."""
+        statuses = ledger.section_statuses()
+        gaps: list[Gap] = []
+        for section in REQUIRED_SECTIONS:
+            status = statuses[section]
+            if status in {
+                LedgerStatus.MISSING,
+                LedgerStatus.CONFLICTING,
+                LedgerStatus.BLOCKED,
+                LedgerStatus.WEAK,
+            }:
+                gaps.append(
+                    Gap(
+                        section=section,
+                        gap_type=SECTION_TO_GAP[section],
+                        state=status,
+                        message=f"{section} is {status.value}",
+                        repairable=status != LedgerStatus.BLOCKED,
+                    )
+                )
+        return gaps

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -1,0 +1,376 @@
+"""Deterministic A-grade gate for auto-generated Seeds and ledgers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import re
+from typing import Any
+
+from ouroboros.auto.gap_detector import GapDetector
+from ouroboros.auto.ledger import LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.core.seed import Seed
+
+
+class SeedGrade(StrEnum):
+    """Supported quality grades for auto-mode execution gates."""
+
+    A = "A"
+    B = "B"
+    C = "C"
+
+
+VAGUE_TERMS = (
+    "easy",
+    "intuitive",
+    "robust",
+    "scalable",
+    "better",
+    "improve",
+    "optimized",
+    "user-friendly",
+    "seamless",
+)
+_OBSERVABLE_HINTS = (
+    "command",
+    "exit",
+    "prints",
+    "returns",
+    "creates",
+    "writes",
+    "file",
+    "test",
+    "api",
+    "status",
+    "displays",
+    "contains",
+    "artifact",
+    "non-zero",
+    "stdout",
+    "stderr",
+    "exits",
+    "exit code",
+    "http",
+    "200",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GradeFinding:
+    """A single deterministic grading finding."""
+
+    code: str
+    severity: str
+    message: str
+    target: str = ""
+    repair_instruction: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "target": self.target,
+            "repair_instruction": self.repair_instruction,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GradeResult:
+    """Structured result returned by GradeGate."""
+
+    grade: SeedGrade
+    scores: dict[str, float]
+    findings: list[GradeFinding] = field(default_factory=list)
+    blockers: list[GradeFinding] = field(default_factory=list)
+    can_repair: bool = True
+    may_run: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "grade": self.grade.value,
+            "scores": self.scores,
+            "findings": [finding.to_dict() for finding in self.findings],
+            "blockers": [blocker.to_dict() for blocker in self.blockers],
+            "can_repair": self.can_repair,
+            "may_run": self.may_run,
+        }
+
+
+class GradeGate:
+    """Deterministic gate that prevents B/C Seeds from running."""
+
+    def __init__(self, gap_detector: GapDetector | None = None) -> None:
+        self.gap_detector = gap_detector or GapDetector()
+
+    def grade_ledger(self, ledger: SeedDraftLedger) -> GradeResult:
+        """Grade a Seed Draft Ledger before Seed generation."""
+        findings: list[GradeFinding] = []
+        blockers: list[GradeFinding] = []
+        gaps = self.gap_detector.detect(ledger)
+        for gap in gaps:
+            finding = GradeFinding(
+                code=f"{gap.section}_{gap.state.value}",
+                severity="high" if not gap.repairable else "medium",
+                message=gap.message,
+                target=gap.section,
+                repair_instruction="Resolve via confirmed fact, conservative default, assumption, or non-goal.",
+            )
+            if gap.repairable:
+                findings.append(finding)
+            else:
+                blockers.append(finding)
+
+        summary = ledger.summary()
+        missing_count = len(summary["open_gaps"])
+        coverage = max(0.0, 1.0 - (missing_count / 10))
+        assumption_count = len(summary["assumptions"])
+        risk = min(1.0, 0.05 * assumption_count + 0.15 * len(blockers))
+        scores = {
+            "coverage": round(coverage, 2),
+            "ambiguity": round(1.0 - coverage, 2),
+            "testability": 0.85 if "acceptance_criteria" not in summary["open_gaps"] else 0.4,
+            "execution_feasibility": 0.85 if "runtime_context" not in summary["open_gaps"] else 0.5,
+            "risk": round(risk, 2),
+        }
+        return self._result(scores=scores, findings=findings, blockers=blockers)
+
+    def grade_seed(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> GradeResult:
+        """Grade a generated Seed deterministically."""
+        findings: list[GradeFinding] = []
+        blockers: list[GradeFinding] = []
+
+        if not seed.goal.strip():
+            blockers.append(GradeFinding("missing_goal", "high", "Seed goal is empty", "goal"))
+        elif ledger is not None and not _seed_goal_matches_ledger(seed.goal, ledger):
+            blockers.append(
+                GradeFinding(
+                    "seed_goal_mismatch",
+                    "high",
+                    "Seed goal does not match the converged interview goal",
+                    "goal",
+                    "Regenerate or repair the Seed so its goal matches the auto interview ledger goal.",
+                )
+            )
+        if seed.metadata.ambiguity_score > 0.20:
+            blockers.append(
+                GradeFinding(
+                    "high_ambiguity_score",
+                    "high",
+                    f"Seed ambiguity score is too high for auto execution: {seed.metadata.ambiguity_score:.2f}",
+                    "metadata.ambiguity_score",
+                    "Continue interview or repair until ambiguity_score <= 0.20.",
+                )
+            )
+        if not seed.constraints:
+            findings.append(
+                GradeFinding(
+                    "missing_constraints",
+                    "medium",
+                    "Seed has no constraints",
+                    "constraints",
+                    "Add explicit execution and scope constraints.",
+                )
+            )
+        if not seed.acceptance_criteria:
+            findings.append(
+                GradeFinding(
+                    "missing_acceptance_criteria",
+                    "high",
+                    "Seed has no acceptance criteria",
+                    "acceptance_criteria",
+                    "Add observable acceptance criteria.",
+                )
+            )
+        for index, criterion in enumerate(seed.acceptance_criteria):
+            if _is_vague(criterion):
+                findings.append(
+                    GradeFinding(
+                        "vague_acceptance_criteria",
+                        "high",
+                        f"Acceptance criterion is vague: {criterion}",
+                        f"acceptance_criteria[{index}]",
+                        "Replace with observable behavior or artifact.",
+                    )
+                )
+            if not _is_observable(criterion):
+                findings.append(
+                    GradeFinding(
+                        "untestable_acceptance_criteria",
+                        "high",
+                        f"Acceptance criterion is not clearly observable: {criterion}",
+                        f"acceptance_criteria[{index}]",
+                        "Mention command output, file/artifact, API response, or test result.",
+                    )
+                )
+
+        non_goals = []
+        if ledger is not None:
+            open_gaps = ledger.open_gaps()
+            for gap in open_gaps:
+                blockers.append(
+                    GradeFinding(
+                        "ledger_open_gap",
+                        "high",
+                        f"Ledger required section is unresolved: {gap}",
+                        gap,
+                        "Resolve the ledger section before allowing auto execution.",
+                    )
+                )
+            non_goal_section = ledger.sections.get("non_goals")
+            non_goals = (
+                [entry.value for entry in non_goal_section.entries] if non_goal_section else []
+            )
+        if ledger is not None and not non_goals:
+            findings.append(
+                GradeFinding(
+                    "missing_non_goals",
+                    "medium",
+                    "Auto-generated Seed has no explicit non-goals",
+                    "non_goals",
+                    "Add MVP non-goals to bound scope.",
+                )
+            )
+
+        high_risk_assumptions = 0
+        if ledger is not None:
+            high_risk_assumptions = _high_risk_assumption_count(ledger)
+            if high_risk_assumptions:
+                blockers.append(
+                    GradeFinding(
+                        "high_risk_assumptions",
+                        "high",
+                        "Ledger contains high-risk assumptions",
+                        "assumptions",
+                        "Replace high-risk assumptions with blockers or user confirmation.",
+                    )
+                )
+
+        untestable_count = sum(1 for finding in findings if "acceptance_criteria" in finding.code)
+        scores = {
+            "coverage": _score_threshold(len(findings), len(blockers), base=0.95),
+            "ambiguity": min(1.0, 0.05 + 0.08 * len(findings) + 0.2 * len(blockers)),
+            "testability": max(0.0, 0.95 - 0.25 * untestable_count),
+            "execution_feasibility": 0.85 if not blockers else 0.4,
+            "risk": min(
+                1.0, 0.05 * len(findings) + 0.3 * len(blockers) + 0.2 * high_risk_assumptions
+            ),
+        }
+        return self._result(scores=scores, findings=findings, blockers=blockers)
+
+    def _result(
+        self,
+        *,
+        scores: dict[str, float],
+        findings: list[GradeFinding],
+        blockers: list[GradeFinding],
+    ) -> GradeResult:
+        grade = SeedGrade.A
+        if blockers:
+            grade = SeedGrade.C
+        elif (
+            scores["coverage"] < 0.90
+            or scores["ambiguity"] > 0.20
+            or scores["testability"] < 0.85
+            or scores["execution_feasibility"] < 0.80
+            or scores["risk"] > 0.25
+            or findings
+        ):
+            grade = SeedGrade.B
+        return GradeResult(
+            grade=grade,
+            scores={name: round(value, 2) for name, value in scores.items()},
+            findings=findings,
+            blockers=blockers,
+            can_repair=not blockers,
+            may_run=grade == SeedGrade.A and not blockers,
+        )
+
+
+def _seed_goal_matches_ledger(seed_goal: str, ledger: SeedDraftLedger) -> bool:
+    goal_section = ledger.sections.get("goal")
+    if goal_section is None:
+        return True
+    inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    goals = [entry.value for entry in goal_section.entries if entry.status not in inactive]
+    if not goals:
+        return True
+    seed_tokens = _goal_tokens(seed_goal)
+    if not seed_tokens:
+        return False
+    for goal in goals:
+        ledger_tokens = _goal_tokens(goal)
+        if not ledger_tokens:
+            continue
+        shared = seed_tokens & ledger_tokens
+        if ledger_tokens <= seed_tokens:
+            return True
+        if len(shared) / max(len(ledger_tokens), 1) >= 0.6:
+            return True
+    return False
+
+
+def _goal_tokens(value: str) -> set[str]:
+    stopwords = {
+        "a",
+        "an",
+        "and",
+        "app",
+        "application",
+        "build",
+        "create",
+        "for",
+        "make",
+        "the",
+        "to",
+    }
+    tokens = {
+        token
+        for token in re.findall(r"[a-z0-9]+", value.casefold())
+        if len(token) >= 2 and token not in stopwords
+    }
+    if "cli" in tokens:
+        tokens.update({"command", "line", "interface"})
+    if {"command", "line", "interface"} <= tokens:
+        tokens.add("cli")
+    return tokens
+
+
+def _is_vague(value: str) -> bool:
+    lowered = value.lower()
+    return any(re.search(rf"\b{re.escape(term)}\b", lowered) for term in VAGUE_TERMS)
+
+
+def _is_observable(value: str) -> bool:
+    lowered = value.lower()
+    if not any(hint in lowered for hint in _OBSERVABLE_HINTS):
+        return False
+    observable_patterns = (
+        r"`[^`]+`\s+(prints|returns|creates|writes|exits|displays)",
+        r"\b(prints|returns|creates|writes|exits|displays|contains)\b.+\b(stdout|stderr|file|artifact|status|response|output|non-zero|exit code)\b",
+        r"\b(stdout|stderr|file|artifact|status|response|output|non-zero|exit code)\b.+\b(contains|equals|includes|is|exists|created|written)\b",
+        r"\b(test|check)\b.+\b(passes|fails|asserts|verifies)\b",
+        r"\b(api|endpoint|request)\b.+\b(returns|responds|status)\b",
+        r"\b(cli|command|process)\b.+\b(exits|returns)\b\s+(with\s+)?(exit\s+code\s+)?0\b",
+        r"\b(exit\s+code|status)\s+0\b",
+        r"\b(get|post|put|patch|delete)\b.+\b(returns|responds|status)\b\s+(with\s+)?(http\s+)?2\d\d\b",
+        r"\b(http\s+)?status\s+2\d\d\b",
+    )
+    return any(re.search(pattern, lowered) for pattern in observable_patterns)
+
+
+def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:
+    risky_terms = ("credential", "api key", "production", "payment", "legal", "medical")
+    inactive_statuses = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    return sum(
+        1
+        for section in ledger.sections.values()
+        for entry in section.entries
+        if entry.source == LedgerSource.ASSUMPTION
+        and entry.status not in inactive_statuses
+        and any(term in entry.value.lower() for term in risky_terms)
+    )
+
+
+def _score_threshold(finding_count: int, blocker_count: int, *, base: float) -> float:
+    return max(0.0, min(1.0, base - 0.08 * finding_count - 0.25 * blocker_count))

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -74,6 +74,38 @@ class LedgerEntry:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> LedgerEntry:
         """Deserialize from JSON-compatible data."""
+        if not isinstance(data, dict):
+            msg = "ledger entry must be an object"
+            raise ValueError(msg)
+        required = {"key", "value", "source", "confidence", "status"}
+        missing = sorted(required - data.keys())
+        if missing:
+            msg = f"ledger entry is missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+        if not isinstance(data["key"], str) or not data["key"].strip():
+            msg = "ledger entry key must be a non-empty string"
+            raise ValueError(msg)
+        if not isinstance(data["value"], str):
+            msg = "ledger entry value must be a string"
+            raise ValueError(msg)
+        if not isinstance(data.get("rationale", ""), str):
+            msg = "ledger entry rationale must be a string"
+            raise ValueError(msg)
+        evidence = data.get("evidence", [])
+        if not isinstance(evidence, list) or not all(isinstance(item, str) for item in evidence):
+            msg = "ledger entry evidence must be a list of strings"
+            raise ValueError(msg)
+        if "reversible" in data and not isinstance(data["reversible"], bool):
+            msg = "ledger entry reversible must be a boolean"
+            raise ValueError(msg)
+        try:
+            confidence = float(data["confidence"])
+        except (TypeError, ValueError) as exc:
+            msg = "ledger entry confidence must be numeric"
+            raise ValueError(msg) from exc
+        if confidence < 0.0 or confidence > 1.0:
+            msg = "ledger entry confidence must be between 0 and 1"
+            raise ValueError(msg)
         return cls(**data)
 
 
@@ -108,8 +140,18 @@ class LedgerSection:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> LedgerSection:
         """Deserialize section data."""
-        entries = [LedgerEntry.from_dict(item) for item in data.get("entries", [])]
-        return cls(name=str(data["name"]), entries=entries)
+        if not isinstance(data, dict):
+            msg = "ledger section must be an object"
+            raise ValueError(msg)
+        if not isinstance(data.get("name"), str) or not data["name"].strip():
+            msg = "ledger section name must be a non-empty string"
+            raise ValueError(msg)
+        entries_raw = data.get("entries")
+        if not isinstance(entries_raw, list):
+            msg = "ledger section entries must be a list"
+            raise ValueError(msg)
+        entries = [LedgerEntry.from_dict(item) for item in entries_raw]
+        return cls(name=data["name"], entries=entries)
 
 
 @dataclass(slots=True)
@@ -281,13 +323,40 @@ class SeedDraftLedger:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SeedDraftLedger:
         """Deserialize the ledger."""
-        sections_raw = data.get("sections", {})
-        sections = {
-            name: LedgerSection.from_dict(section)
-            for name, section in sections_raw.items()
-            if isinstance(section, dict)
-        }
-        ledger = cls(sections=sections, question_history=list(data.get("question_history", [])))
+        if not isinstance(data, dict):
+            msg = "ledger must be an object"
+            raise ValueError(msg)
+        sections_raw = data.get("sections")
+        if not isinstance(sections_raw, dict):
+            msg = "ledger sections must be an object"
+            raise ValueError(msg)
+        sections: dict[str, LedgerSection] = {}
+        for name, section_raw in sections_raw.items():
+            if not isinstance(name, str) or not name.strip():
+                msg = "ledger section keys must be non-empty strings"
+                raise ValueError(msg)
+            section = LedgerSection.from_dict(section_raw)
+            if section.name != name:
+                msg = f"ledger section key/name mismatch: {name} != {section.name}"
+                raise ValueError(msg)
+            sections[name] = section
+
+        question_history = data.get("question_history")
+        if not isinstance(question_history, list):
+            msg = "ledger question_history must be a list"
+            raise ValueError(msg)
+        for item in question_history:
+            if not isinstance(item, dict):
+                msg = "ledger question_history entries must be objects"
+                raise ValueError(msg)
+            if set(item) != {"question", "answer"}:
+                msg = "ledger question_history entries must contain question and answer"
+                raise ValueError(msg)
+            if not isinstance(item["question"], str) or not isinstance(item["answer"], str):
+                msg = "ledger question_history question and answer must be strings"
+                raise ValueError(msg)
+
+        ledger = cls(sections=sections, question_history=[dict(item) for item in question_history])
         for required in REQUIRED_SECTIONS:
             ledger.sections.setdefault(required, LedgerSection(required))
         return ledger

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -1,0 +1,322 @@
+"""Seed Draft Ledger for bounded auto-mode convergence."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class LedgerSource(StrEnum):
+    """Source categories for ledger entries."""
+
+    USER_GOAL = "user_goal"
+    REPO_FACT = "repo_fact"
+    EXISTING_CONVENTION = "existing_convention"
+    CONSERVATIVE_DEFAULT = "conservative_default"
+    ASSUMPTION = "assumption"
+    NON_GOAL = "non_goal"
+    INFERENCE = "inference"
+    BLOCKER = "blocker"
+
+
+class LedgerStatus(StrEnum):
+    """Status of a ledger entry or section."""
+
+    MISSING = "missing"
+    WEAK = "weak"
+    DEFAULTED = "defaulted"
+    INFERRED = "inferred"
+    CONFIRMED = "confirmed"
+    CONFLICTING = "conflicting"
+    BLOCKED = "blocked"
+
+
+REQUIRED_SECTIONS = (
+    "goal",
+    "actors",
+    "inputs",
+    "outputs",
+    "constraints",
+    "non_goals",
+    "acceptance_criteria",
+    "verification_plan",
+    "failure_modes",
+    "runtime_context",
+)
+
+
+@dataclass(slots=True)
+class LedgerEntry:
+    """A single machine-readable fact in the Seed Draft Ledger."""
+
+    key: str
+    value: str
+    source: LedgerSource | str
+    confidence: float
+    status: LedgerStatus | str
+    reversible: bool = True
+    rationale: str = ""
+    evidence: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.source = LedgerSource(str(self.source))
+        self.status = LedgerStatus(str(self.status))
+        self.confidence = max(0.0, min(1.0, float(self.confidence)))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-compatible data."""
+        data = asdict(self)
+        data["source"] = self.source.value
+        data["status"] = self.status.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LedgerEntry:
+        """Deserialize from JSON-compatible data."""
+        return cls(**data)
+
+
+@dataclass(slots=True)
+class LedgerSection:
+    """A Seed section containing one or more ledger entries."""
+
+    name: str
+    entries: list[LedgerEntry] = field(default_factory=list)
+
+    def status(self) -> LedgerStatus:
+        """Return the aggregate status for this section."""
+        if not self.entries:
+            return LedgerStatus.MISSING
+        statuses = {entry.status for entry in self.entries}
+        if LedgerStatus.BLOCKED in statuses:
+            return LedgerStatus.BLOCKED
+        if LedgerStatus.CONFLICTING in statuses:
+            return LedgerStatus.CONFLICTING
+        if LedgerStatus.CONFIRMED in statuses:
+            return LedgerStatus.CONFIRMED
+        if LedgerStatus.DEFAULTED in statuses:
+            return LedgerStatus.DEFAULTED
+        if LedgerStatus.INFERRED in statuses:
+            return LedgerStatus.INFERRED
+        return LedgerStatus.WEAK
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize section data."""
+        return {"name": self.name, "entries": [entry.to_dict() for entry in self.entries]}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LedgerSection:
+        """Deserialize section data."""
+        entries = [LedgerEntry.from_dict(item) for item in data.get("entries", [])]
+        return cls(name=str(data["name"]), entries=entries)
+
+
+@dataclass(slots=True)
+class SeedDraftLedger:
+    """Structured auto-mode Seed draft.
+
+    The ledger performs no external IO or model calls.  It is safe to mutate in
+    tight loops without risking hangs.
+    """
+
+    sections: dict[str, LedgerSection] = field(default_factory=dict)
+    question_history: list[dict[str, str]] = field(default_factory=list)
+
+    @classmethod
+    def from_goal(cls, goal: str) -> SeedDraftLedger:
+        """Create a ledger initialized with a user goal."""
+        ledger = cls(sections={name: LedgerSection(name) for name in REQUIRED_SECTIONS})
+        clean_goal = goal.strip()
+        ledger.add_entry(
+            "goal",
+            LedgerEntry(
+                key="goal.primary",
+                value=clean_goal,
+                source=LedgerSource.USER_GOAL,
+                confidence=0.95 if clean_goal else 0.0,
+                status=LedgerStatus.CONFIRMED if clean_goal else LedgerStatus.WEAK,
+                reversible=False,
+                rationale=(
+                    "Initial user-provided auto task."
+                    if clean_goal
+                    else "Auto task goal is blank and must be clarified before Seed generation."
+                ),
+            ),
+        )
+        return ledger
+
+    def add_entry(self, section_name: str, entry: LedgerEntry) -> None:
+        """Append ``entry`` to a section, marking same-key contradictions explicit.
+
+        A later same-key answer that returns to a previously seen value is treated
+        as a correction: older contradictory entries become weak historical facts
+        instead of keeping the section permanently conflicting.
+        """
+        section = self.sections.setdefault(section_name, LedgerSection(section_name))
+        same_key_entries = [existing for existing in section.entries if existing.key == entry.key]
+        entry_value = _normalize_conflict_value(entry.value)
+        matching_prior = [
+            existing
+            for existing in same_key_entries
+            if _normalize_conflict_value(existing.value) == entry_value
+        ]
+        if (
+            same_key_entries
+            and entry.source == LedgerSource.USER_GOAL
+            and entry.status == LedgerStatus.CONFIRMED
+        ):
+            for existing in same_key_entries:
+                existing.status = LedgerStatus.WEAK
+                existing.rationale = (
+                    existing.rationale or "Superseded by a later user-confirmed answer."
+                )
+        elif matching_prior:
+            for existing in same_key_entries:
+                if entry.status == LedgerStatus.BLOCKED:
+                    continue
+                if existing.status == LedgerStatus.BLOCKED:
+                    existing.status = LedgerStatus.WEAK
+                    existing.rationale = (
+                        existing.rationale or "Superseded by a later same-key answer."
+                    )
+                    continue
+                if _normalize_conflict_value(existing.value) == entry_value:
+                    if existing.status == LedgerStatus.CONFLICTING:
+                        existing.status = entry.status
+                    continue
+                existing.status = LedgerStatus.WEAK
+                existing.rationale = (
+                    existing.rationale or "Superseded by a later same-key correction."
+                )
+        else:
+            for existing in same_key_entries:
+                if entry.status == LedgerStatus.BLOCKED:
+                    continue
+                if existing.status == LedgerStatus.BLOCKED:
+                    existing.status = LedgerStatus.WEAK
+                    existing.rationale = (
+                        existing.rationale or "Superseded by a later same-key answer."
+                    )
+                    continue
+                existing.status = LedgerStatus.CONFLICTING
+                entry.status = LedgerStatus.CONFLICTING
+                existing.rationale = (
+                    existing.rationale or "Conflicts with another auto ledger answer."
+                )
+                entry.rationale = entry.rationale or "Conflicts with another auto ledger answer."
+        section.entries.append(entry)
+
+    def record_qa(self, question: str, answer: str) -> None:
+        """Record an interview Q/A pair in bounded form."""
+        self.question_history.append(
+            {
+                "question": _truncate(question),
+                "answer": _truncate(answer),
+            }
+        )
+
+    def section_statuses(self) -> dict[str, LedgerStatus]:
+        """Return aggregate statuses for required sections."""
+        return {
+            name: self.sections.get(name, LedgerSection(name)).status()
+            for name in REQUIRED_SECTIONS
+        }
+
+    def open_gaps(self) -> list[str]:
+        """Return required sections that are not Seed-ready."""
+        blocked = {
+            LedgerStatus.MISSING,
+            LedgerStatus.WEAK,
+            LedgerStatus.CONFLICTING,
+            LedgerStatus.BLOCKED,
+        }
+        return [name for name, status in self.section_statuses().items() if status in blocked]
+
+    def is_seed_ready(self) -> bool:
+        """Return True when no required section is missing/conflicting/blocked."""
+        return not self.open_gaps()
+
+    def assumptions(self) -> list[str]:
+        """Return assumption entry values."""
+        return self._values_for_sources({LedgerSource.ASSUMPTION})
+
+    def non_goals(self) -> list[str]:
+        """Return non-goal entry values."""
+        return self._values_for_sources({LedgerSource.NON_GOAL})
+
+    def summary(self) -> dict[str, Any]:
+        """Return a bounded summary suitable for CLI/MCP output."""
+        statuses = self.section_statuses()
+        return {
+            "complete_sections": [
+                name
+                for name, status in statuses.items()
+                if status in {LedgerStatus.CONFIRMED, LedgerStatus.DEFAULTED, LedgerStatus.INFERRED}
+            ],
+            "weak_sections": [
+                name for name, status in statuses.items() if status == LedgerStatus.WEAK
+            ],
+            "defaulted_sections": [
+                name for name, status in statuses.items() if status == LedgerStatus.DEFAULTED
+            ],
+            "assumptions": [_truncate(value) for value in self.assumptions()],
+            "non_goals": [_truncate(value) for value in self.non_goals()],
+            "open_gaps": self.open_gaps(),
+            "risks": [
+                _truncate(entry.value)
+                for section in self.sections.values()
+                for entry in section.entries
+                if entry.key.startswith("risk.")
+            ],
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the ledger."""
+        return {
+            "sections": {name: section.to_dict() for name, section in self.sections.items()},
+            "question_history": list(self.question_history),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SeedDraftLedger:
+        """Deserialize the ledger."""
+        sections_raw = data.get("sections", {})
+        sections = {
+            name: LedgerSection.from_dict(section)
+            for name, section in sections_raw.items()
+            if isinstance(section, dict)
+        }
+        ledger = cls(sections=sections, question_history=list(data.get("question_history", [])))
+        for required in REQUIRED_SECTIONS:
+            ledger.sections.setdefault(required, LedgerSection(required))
+        return ledger
+
+    def _values_for_sources(self, sources: set[LedgerSource]) -> list[str]:
+        resolved: dict[tuple[str, str], str] = {}
+        inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+        for section in self.sections.values():
+            for entry in section.entries:
+                if entry.source not in sources or entry.status in inactive:
+                    continue
+                resolved[(section.name, entry.key)] = entry.value
+
+        values: list[str] = []
+        seen: set[str] = set()
+        for value in resolved.values():
+            normalized = _normalize_conflict_value(value)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            values.append(value)
+        return values
+
+
+def _normalize_conflict_value(value: str) -> str:
+    return " ".join(value.strip().casefold().split())
+
+
+def _truncate(value: str, *, limit: int = 500) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 15].rstrip() + " ... (truncated)"

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -144,17 +144,8 @@ class AutoPipelineState:
         self.last_tool_name = tool_name
 
     def recover(self, next_phase: AutoPhase, message: str) -> None:
-        """Move a blocked/failed session back to a recoverable phase."""
-        if self.phase not in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
-            self.transition(next_phase, message)
-            return
-        now = utc_now_iso()
-        self.phase = next_phase
-        self.phase_started_at = now
-        self.last_progress_at = now
-        self.updated_at = now
-        self.last_progress_message = message
-        self.last_error = None
+        """Move a session back to a valid recoverable phase."""
+        self.transition(next_phase, message)
 
     def mark_blocked(self, message: str, *, tool_name: str | None = None) -> None:
         """Transition to blocked with actionable diagnostics."""

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -1,0 +1,381 @@
+"""Persistent state for full-quality ``ooo auto`` sessions."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, fields
+from datetime import UTC, datetime
+from enum import StrEnum
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+class AutoPhase(StrEnum):
+    """Closed set of phases for auto-mode resume and stall handling."""
+
+    CREATED = "created"
+    INTERVIEW = "interview"
+    SEED_GENERATION = "seed_generation"
+    REVIEW = "review"
+    REPAIR = "repair"
+    RUN = "run"
+    COMPLETE = "complete"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+class AutoPolicy(StrEnum):
+    """Supported auto-mode resolution policies."""
+
+    CONSERVATIVE = "conservative"
+    BALANCED = "balanced"
+
+
+TERMINAL_PHASES = {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}
+_ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
+    AutoPhase.CREATED: {AutoPhase.INTERVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.INTERVIEW: {
+        AutoPhase.SEED_GENERATION,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    },
+    AutoPhase.SEED_GENERATION: {AutoPhase.REVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.REVIEW: {
+        AutoPhase.REPAIR,
+        AutoPhase.RUN,
+        AutoPhase.COMPLETE,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    },
+    AutoPhase.REPAIR: {AutoPhase.REVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.RUN: {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.COMPLETE: set(),
+    AutoPhase.BLOCKED: {
+        AutoPhase.INTERVIEW,
+        AutoPhase.SEED_GENERATION,
+        AutoPhase.REVIEW,
+        AutoPhase.RUN,
+    },
+    AutoPhase.FAILED: {
+        AutoPhase.INTERVIEW,
+        AutoPhase.SEED_GENERATION,
+        AutoPhase.REVIEW,
+        AutoPhase.RUN,
+    },
+}
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time in an ISO-8601 format."""
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(slots=True)
+class AutoPipelineState:
+    """Durable state record for an ``ooo auto`` session.
+
+    The state is intentionally JSON-serializable so a foreground command can
+    safely persist progress before each potentially slow phase and resume later
+    without silently duplicating execution.
+    """
+
+    goal: str
+    cwd: str
+    auto_session_id: str = field(default_factory=lambda: f"auto_{uuid4().hex[:12]}")
+    phase: AutoPhase = AutoPhase.CREATED
+    policy: AutoPolicy = AutoPolicy.CONSERVATIVE
+    required_grade: str = "A"
+    runtime_backend: str | None = None
+    opencode_mode: str | None = None
+    skip_run: bool = False
+    interview_session_id: str | None = None
+    interview_completed: bool = False
+    seed_id: str | None = None
+    seed_path: str | None = None
+    seed_artifact: dict[str, Any] = field(default_factory=dict)
+    execution_id: str | None = None
+    job_id: str | None = None
+    run_session_id: str | None = None
+    run_subagent: dict[str, Any] = field(default_factory=dict)
+    run_start_attempted: bool = False
+    ledger: dict[str, Any] = field(default_factory=dict)
+    last_grade: str | None = None
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    repair_round: int = 0
+    current_round: int = 0
+    pending_question: str | None = None
+    last_tool_name: str | None = None
+    last_error: str | None = None
+    last_progress_message: str = "created"
+    phase_started_at: str = field(default_factory=utc_now_iso)
+    last_progress_at: str = field(default_factory=utc_now_iso)
+    created_at: str = field(default_factory=utc_now_iso)
+    updated_at: str = field(default_factory=utc_now_iso)
+    timeout_seconds_by_phase: dict[str, int] = field(
+        default_factory=lambda: {
+            AutoPhase.INTERVIEW.value: 120,
+            AutoPhase.SEED_GENERATION.value: 120,
+            AutoPhase.REVIEW.value: 90,
+            AutoPhase.REPAIR.value: 90,
+            AutoPhase.RUN.value: 60,
+        }
+    )
+
+    def transition(self, next_phase: AutoPhase, message: str, *, error: str | None = None) -> None:
+        """Move to ``next_phase`` after validating the phase state machine."""
+        if next_phase not in _ALLOWED_TRANSITIONS[self.phase]:
+            msg = f"Invalid auto phase transition: {self.phase.value} -> {next_phase.value}"
+            raise ValueError(msg)
+        now = utc_now_iso()
+        self.phase = next_phase
+        self.phase_started_at = now
+        self.last_progress_at = now
+        self.updated_at = now
+        self.last_progress_message = message
+        self.last_error = error
+
+    def mark_progress(self, message: str, *, tool_name: str | None = None) -> None:
+        """Record non-terminal progress within the current phase."""
+        now = utc_now_iso()
+        self.last_progress_at = now
+        self.updated_at = now
+        self.last_progress_message = message
+        self.last_tool_name = tool_name
+
+    def recover(self, next_phase: AutoPhase, message: str) -> None:
+        """Move a blocked/failed session back to a recoverable phase."""
+        if self.phase not in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
+            self.transition(next_phase, message)
+            return
+        now = utc_now_iso()
+        self.phase = next_phase
+        self.phase_started_at = now
+        self.last_progress_at = now
+        self.updated_at = now
+        self.last_progress_message = message
+        self.last_error = None
+
+    def mark_blocked(self, message: str, *, tool_name: str | None = None) -> None:
+        """Transition to blocked with actionable diagnostics."""
+        self.last_tool_name = tool_name
+        self.transition(AutoPhase.BLOCKED, message, error=message)
+
+    def mark_failed(self, message: str, *, tool_name: str | None = None) -> None:
+        """Transition to failed with actionable diagnostics."""
+        self.last_tool_name = tool_name
+        self.transition(AutoPhase.FAILED, message, error=message)
+
+    def is_terminal(self) -> bool:
+        """Return True when the state cannot continue automatically."""
+        return self.phase in TERMINAL_PHASES
+
+    def is_stale(self, now: datetime | None = None) -> bool:
+        """Return True when current phase has exceeded its configured timeout."""
+        if self.is_terminal():
+            return False
+        timeout = self.timeout_seconds_by_phase.get(self.phase.value)
+        if timeout is None:
+            return False
+        current = now or datetime.now(UTC)
+        last = datetime.fromisoformat(self.last_progress_at)
+        return (current - last).total_seconds() > timeout
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        data = asdict(self)
+        data["phase"] = self.phase.value
+        data["policy"] = self.policy.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AutoPipelineState:
+        """Deserialize from a dictionary and reject malformed persisted state."""
+        required_fields = {item.name for item in fields(cls)}
+        missing_fields = sorted(required_fields - data.keys())
+        if missing_fields:
+            msg = f"state is missing required fields: {', '.join(missing_fields)}"
+            raise ValueError(msg)
+        payload = dict(data)
+        payload["phase"] = AutoPhase(payload["phase"])
+        payload["policy"] = AutoPolicy(payload["policy"])
+        state = cls(**payload)
+        state._validate_loaded()
+        return state
+
+    def _validate_loaded(self) -> None:
+        """Validate fields whose bad values would otherwise fail later during resume."""
+        for field_name in (
+            "goal",
+            "cwd",
+            "auto_session_id",
+            "required_grade",
+            "last_progress_message",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                msg = f"{field_name} must be a non-empty string"
+                raise ValueError(msg)
+        if self.required_grade not in {"A", "B", "C"}:
+            msg = "required_grade must be one of A, B, or C"
+            raise ValueError(msg)
+
+        for field_name in (
+            "phase_started_at",
+            "last_progress_at",
+            "created_at",
+            "updated_at",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str):
+                msg = f"{field_name} must be an ISO timestamp string"
+                raise ValueError(msg)
+            try:
+                parsed = datetime.fromisoformat(value)
+            except ValueError as exc:
+                msg = f"{field_name} must be an ISO timestamp string"
+                raise ValueError(msg) from exc
+            if parsed.tzinfo is None or parsed.utcoffset() is None:
+                msg = f"{field_name} must include timezone information"
+                raise ValueError(msg)
+
+        if not isinstance(self.timeout_seconds_by_phase, dict):
+            msg = "timeout_seconds_by_phase must be an object"
+            raise ValueError(msg)
+        valid_phases = {phase.value for phase in AutoPhase}
+        required_timeout_phases = {
+            AutoPhase.INTERVIEW.value,
+            AutoPhase.SEED_GENERATION.value,
+            AutoPhase.REVIEW.value,
+            AutoPhase.REPAIR.value,
+            AutoPhase.RUN.value,
+        }
+        missing_timeout_phases = sorted(
+            required_timeout_phases - self.timeout_seconds_by_phase.keys()
+        )
+        if missing_timeout_phases:
+            msg = f"timeout_seconds_by_phase is missing required phases: {', '.join(missing_timeout_phases)}"
+            raise ValueError(msg)
+        for phase, timeout in self.timeout_seconds_by_phase.items():
+            if not isinstance(phase, str) or phase not in valid_phases:
+                msg = "timeout_seconds_by_phase keys must be known phase strings"
+                raise ValueError(msg)
+            if type(timeout) is not int or timeout <= 0:
+                msg = "timeout_seconds_by_phase values must be positive integers"
+                raise ValueError(msg)
+
+        if not isinstance(self.ledger, dict):
+            msg = "ledger must be an object"
+            raise ValueError(msg)
+        if not isinstance(self.run_subagent, dict):
+            msg = "run_subagent must be an object"
+            raise ValueError(msg)
+        if self.ledger:
+            try:
+                from ouroboros.auto.ledger import SeedDraftLedger
+
+                SeedDraftLedger.from_dict(self.ledger)
+            except Exception as exc:
+                msg = "ledger must be a valid Seed Draft Ledger"
+                raise ValueError(msg) from exc
+        optional_string_fields = (
+            "runtime_backend",
+            "opencode_mode",
+            "interview_session_id",
+            "seed_id",
+            "seed_path",
+            "execution_id",
+            "job_id",
+            "run_session_id",
+            "last_grade",
+            "pending_question",
+            "last_tool_name",
+            "last_error",
+        )
+        for field_name in optional_string_fields:
+            value = getattr(self, field_name)
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                msg = f"{field_name} must be a string or null"
+                raise ValueError(msg)
+            if not value.strip():
+                msg = f"{field_name} must be a non-empty string or null"
+                raise ValueError(msg)
+        for field_name in ("interview_completed", "skip_run", "run_start_attempted"):
+            if type(getattr(self, field_name)) is not bool:
+                msg = f"{field_name} must be a boolean"
+                raise ValueError(msg)
+        for field_name in ("findings",):
+            value = getattr(self, field_name)
+            if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+                msg = f"{field_name} must be a list of objects"
+                raise ValueError(msg)
+        for field_name in ("repair_round", "current_round"):
+            value = getattr(self, field_name)
+            if type(value) is not int or value < 0:
+                msg = f"{field_name} must be a non-negative integer"
+                raise ValueError(msg)
+
+        if self.seed_artifact != {}:
+            if not isinstance(self.seed_artifact, dict):
+                msg = "seed_artifact must be an object"
+                raise ValueError(msg)
+            try:
+                from ouroboros.core.seed import Seed
+
+                Seed.from_dict(self.seed_artifact)
+            except Exception as exc:
+                msg = "seed_artifact must be a valid Seed artifact"
+                raise ValueError(msg) from exc
+
+
+class AutoStore:
+    """JSON file store for ``AutoPipelineState`` records."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or (Path.home() / ".ouroboros" / "data")
+
+    def path_for(self, auto_session_id: str) -> Path:
+        """Return the JSON path for ``auto_session_id``."""
+        safe = auto_session_id.strip()
+        if not safe.startswith("auto_") or "/" in safe or ".." in safe:
+            msg = f"Invalid auto session id: {auto_session_id}"
+            raise ValueError(msg)
+        return self.root / f"{safe}.json"
+
+    def save(self, state: AutoPipelineState) -> Path:
+        """Persist ``state`` atomically and return the written path."""
+        state._validate_loaded()
+        self.root.mkdir(parents=True, exist_ok=True)
+        path = self.path_for(state.auto_session_id)
+        tmp_path = path.with_suffix(".json.tmp")
+        tmp_path.write_text(
+            json.dumps(state.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        tmp_path.replace(path)
+        return path
+
+    def load(self, auto_session_id: str) -> AutoPipelineState:
+        """Load a state record or raise an actionable error."""
+        path = self.path_for(auto_session_id)
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            msg = f"Auto session not found: {auto_session_id}"
+            raise ValueError(msg) from exc
+        except json.JSONDecodeError as exc:
+            msg = f"Auto session state is corrupt: {path}"
+            raise ValueError(msg) from exc
+        if not isinstance(raw, dict):
+            msg = f"Auto session state must be an object: {path}"
+            raise ValueError(msg)
+        try:
+            state = AutoPipelineState.from_dict(raw)
+            if state.auto_session_id != auto_session_id:
+                msg = f"Auto session id mismatch: requested {auto_session_id}, found {state.auto_session_id}"
+                raise ValueError(msg)
+            return state
+        except (TypeError, ValueError) as exc:
+            msg = f"Auto session state is invalid: {path}: {exc}"
+            raise ValueError(msg) from exc

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -229,14 +229,20 @@ def test_auto_answerer_allows_product_domain_file_removal_questions() -> None:
 
 
 def test_auto_answerer_allows_git_product_branch_deletion_questions() -> None:
-    answer = AutoAnswerer().answer(
+    answerer = AutoAnswerer()
+    ledger = SeedDraftLedger.from_goal("Build a Git branch manager")
+
+    examples = (
         "Should users be able to delete the branch?",
-        SeedDraftLedger.from_goal("Build a Git branch manager"),
+        "Should the app delete the branch automatically?",
+        "Should the tool remove the branch after merge?",
     )
 
-    assert answer.blocker is None
-    assert answer.source != AutoAnswerSource.BLOCKER
-    assert "product behavior" in answer.text.lower()
+    answers = [answerer.answer(question, ledger) for question in examples]
+
+    assert all(answer.blocker is None for answer in answers)
+    assert all(answer.source != AutoAnswerSource.BLOCKER for answer in answers)
+    assert all("product behavior" in answer.text.lower() for answer in answers)
 
 
 def test_auto_answerer_still_blocks_current_branch_deletion_authority() -> None:

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -747,3 +747,35 @@ def test_auto_answerer_allows_user_managed_token_and_key_product_questions() -> 
         answer = answerer.answer(question, SeedDraftLedger.from_goal("Build identity settings"))
         assert answer.blocker is None
         assert "product behavior" in answer.text.lower()
+
+
+def test_auto_answerer_allows_production_credential_product_semantics() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "Should users be able to configure production credentials?",
+        "Should the app store production credentials?",
+        "What credential fields should the production settings form display?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(
+            question,
+            SeedDraftLedger.from_goal("Build credential management settings"),
+        )
+        assert answer.blocker is None
+        assert answer.source != AutoAnswerSource.BLOCKER
+        assert "product behavior" in answer.text.lower()
+
+
+def test_auto_answerer_still_blocks_real_production_credential_authority() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "Which credential value should production use?",
+        "Which credentials should CI configure for production?",
+        "Use the production credential secret for deployment?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Deploy a service"))
+        assert answer.blocker is not None
+        assert answer.source == AutoAnswerSource.BLOCKER

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -263,6 +263,23 @@ def test_auto_answerer_preserves_product_behavior_phrasing_variants() -> None:
     assert all("product behavior" in answer.text.lower() for answer in answers)
 
 
+def test_auto_answerer_preserves_passive_product_behavior_variants() -> None:
+    answerer = AutoAnswerer()
+    ledger = SeedDraftLedger.from_goal("Build a source-control compliance tool")
+
+    examples = (
+        "Should branches be deleted after merge?",
+        "Should API keys be removed after rotation?",
+        "Should legal documents be edited?",
+    )
+
+    answers = [answerer.answer(question, ledger) for question in examples]
+
+    assert all(answer.blocker is None for answer in answers)
+    assert all(answer.source != AutoAnswerSource.BLOCKER for answer in answers)
+    assert all("product behavior" in answer.text.lower() for answer in answers)
+
+
 def test_auto_answerer_still_blocks_current_branch_deletion_authority() -> None:
     answer = AutoAnswerer().answer(
         "Should we delete the current branch?",

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -484,6 +484,9 @@ def test_auto_answerer_non_goals_respect_explicit_goal_scope() -> None:
     cases = (
         ("Deploy this service to production", "production deployment"),
         ("Add authentication to the app", "authentication"),
+        ("Enable SSO for enterprise users", "authentication"),
+        ("Add OAuth support to the CLI", "authentication"),
+        ("Implement authorization roles", "authentication"),
     )
 
     for goal, forbidden_non_goal in cases:

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -1,0 +1,720 @@
+from __future__ import annotations
+
+from ouroboros.auto.answerer import AutoAnswerer, AutoAnswerSource
+from ouroboros.auto.gap_detector import GapDetector
+from ouroboros.auto.grading import GradeGate, SeedGrade
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _fill_minimal_ready_ledger(ledger: SeedDraftLedger) -> None:
+    entries = {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }
+    for section, value in entries.items():
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=LedgerSource.CONSERVATIVE_DEFAULT,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+
+def _seed(*, ac: tuple[str, ...], goal: str = "Build a habit tracker") -> Seed:
+    return Seed(
+        goal=goal,
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=ac,
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+def test_ledger_not_ready_until_required_sections_are_resolved() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+
+    assert "actors" in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+
+    _fill_minimal_ready_ledger(ledger)
+
+    assert ledger.is_seed_ready()
+    assert ledger.summary()["open_gaps"] == []
+
+
+def test_weak_required_sections_remain_open_gaps() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    ledger.sections["actors"].entries.clear()
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.weak_guess",
+            value="Maybe a local user",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.2,
+            status=LedgerStatus.WEAK,
+        ),
+    )
+
+    assert "actors" in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+
+
+def test_gap_detector_reports_missing_sections() -> None:
+    gaps = GapDetector().detect(SeedDraftLedger.from_goal("Build a habit tracker"))
+
+    assert {gap.section for gap in gaps} >= {"actors", "acceptance_criteria"}
+
+
+def test_grade_gate_blocks_b_or_c_from_running() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    result = GradeGate().grade_ledger(ledger)
+
+    assert result.grade != SeedGrade.A
+    assert not result.may_run
+
+
+def test_grade_gate_accepts_observable_seed_with_ready_ledger() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("`habit list` prints stable stdout containing created habits",))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.A
+    assert result.may_run
+
+
+def test_grade_gate_blocks_seed_goal_mismatch_with_ready_ledger() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(
+        goal="Build a weather dashboard",
+        ac=("`weather list` prints stable stdout containing forecasts",),
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.C
+    assert not result.may_run
+    assert {blocker.code for blocker in result.blockers} == {"seed_goal_mismatch"}
+
+
+def test_grade_gate_blocks_subset_goal_mismatch_with_ready_ledger() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a weather dashboard")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(
+        goal="Build a dashboard",
+        ac=("`dashboard show` prints stable stdout containing dashboard status",),
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.C
+    assert {blocker.code for blocker in result.blockers} == {"seed_goal_mismatch"}
+
+
+def test_grade_gate_rejects_unresolved_ledger_even_with_clean_seed() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    seed = _seed(ac=("`habit list` prints stdout containing created habits",))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.C
+    assert not result.may_run
+    assert any(blocker.code == "ledger_open_gap" for blocker in result.blockers)
+
+
+def test_grade_gate_requires_observable_acceptance_behavior_not_keywords() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("The command uses clean architecture", "The API is maintainable"))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.B
+    assert not result.may_run
+    assert (
+        sum(1 for finding in result.findings if finding.code == "untestable_acceptance_criteria")
+        == 2
+    )
+
+
+def test_grade_gate_rejects_vague_acceptance_criteria() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("The CLI should be easy and user-friendly",))
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.B
+    assert not result.may_run
+    assert any(finding.code == "vague_acceptance_criteria" for finding in result.findings)
+
+
+def test_auto_answerer_source_tags_and_applies_updates() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    answerer = AutoAnswerer()
+
+    answer = answerer.answer("How should we verify this is done?", ledger)
+    answerer.apply(answer, ledger, question="How should we verify this is done?")
+
+    assert answer.source == AutoAnswerSource.CONSERVATIVE_DEFAULT
+    assert answer.prefixed_text.startswith("[from-auto][conservative_default]")
+    assert "verification_plan" not in ledger.open_gaps()
+
+
+def test_auto_answerer_allows_product_domain_delete_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should users be able to delete habits?",
+        SeedDraftLedger.from_goal("Build a habit tracker"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_allows_product_domain_secret_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should the app support secret notes?",
+        SeedDraftLedger.from_goal("Build a notes app"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_allows_product_domain_file_removal_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should users be able to remove uploaded files?",
+        SeedDraftLedger.from_goal("Build a file manager"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_returns_blocker_for_plain_secret_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Which secret should the workflow use?",
+        SeedDraftLedger.from_goal("Deploy a service"),
+    )
+
+    assert answer.blocker is not None
+    assert answer.source == AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_returns_blocker_for_credentials() -> None:
+    ledger = SeedDraftLedger.from_goal("Deploy a service")
+    answerer = AutoAnswerer()
+
+    answer = answerer.answer("Which production API key should the workflow use?", ledger)
+    answerer.apply(answer, ledger, question="Which production API key should the workflow use?")
+
+    assert answer.blocker is not None
+    assert answer.source == AutoAnswerSource.BLOCKER
+    assert "constraints" in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+    assert any(
+        entry.status == LedgerStatus.BLOCKED for entry in ledger.sections["constraints"].entries
+    )
+
+
+def test_auto_answerer_allows_benign_sensitive_domain_vocabulary() -> None:
+    answerer = AutoAnswerer()
+    benign_questions = (
+        "Should the app support credential login?",
+        "Should legal documents be editable?",
+        "Should medical records be exportable?",
+        "Should users see payment history?",
+        "Should users be able to rotate API keys?",
+        "Should the app support password reset?",
+        "Should the app support billing provider integrations?",
+        "Should users subscribe to paid service tiers?",
+        "Should legal review workflows be tracked?",
+    )
+
+    for question in benign_questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a document app"))
+        assert answer.blocker is None
+        assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_blocks_contextual_human_authority_questions() -> None:
+    answerer = AutoAnswerer()
+    blocking_questions = (
+        "Which credential value should production use?",
+        "Which payment provider account should we charge?",
+        "What legal approval is needed for liability risk?",
+        "What medical advice should the app recommend?",
+        "What API key should the workflow use?",
+        "Which password should CI configure?",
+    )
+
+    for question in blocking_questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Deploy a service"))
+        assert answer.blocker is not None
+        assert answer.source == AutoAnswerSource.BLOCKER
+
+
+def test_blank_goal_remains_open_gap() -> None:
+    ledger = SeedDraftLedger.from_goal("   ")
+    _fill_minimal_ready_ledger(ledger)
+
+    assert "goal" in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+
+
+def test_auto_answerer_does_not_route_feature_semantics_to_io_actor_defaults() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "Should users be able to delete habits?",
+        "Should users see payment history?",
+        "Should users be able to rotate API keys?",
+        "Should the app support password reset?",
+        "Should the app support billing provider integrations?",
+        "Should users subscribe to paid service tiers?",
+        "Should legal review workflows be tracked?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a habit tracker"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert not {"actors", "inputs", "outputs"} & updated_sections
+
+
+def test_auto_answerer_avoids_generic_defaults_for_feature_semantics() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "What output should the export command write?",
+        "What input format does the config file use?",
+        "Should completed tasks be marked done?",
+        "What should users be able to edit?",
+        "Which users can delete projects?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a task app"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None
+        assert "conservative mvp" not in answer.text.lower()
+        assert "product behavior" in answer.text.lower()
+        assert {"constraints", "acceptance_criteria"} <= updated_sections
+        assert not {"actors", "inputs", "outputs", "verification_plan"} & updated_sections
+
+
+def test_auto_answerer_allows_safe_production_and_project_feature_questions() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "What should the production deploy output on failure?",
+        "Should deleting a project also delete its tasks?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a project app"))
+        assert answer.blocker is None
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert "runtime_context" not in updated_sections
+
+
+def test_ledger_marks_same_key_conflicting_values_as_open_gap() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.primary",
+            value="Write a JSON report",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.primary",
+            value="Display an HTML dashboard",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    assert ledger.sections["outputs"].status() == LedgerStatus.CONFLICTING
+    assert "outputs" in ledger.open_gaps()
+
+
+def test_auto_answerer_acceptance_default_matches_grade_observability() -> None:
+    answer = AutoAnswerer().answer(
+        "Which command output verifies the acceptance criteria?",
+        SeedDraftLedger.from_goal("Build a CLI"),
+    )
+    acceptance = [
+        entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+    ]
+
+    assert acceptance
+    assert (
+        "which command output verifies the acceptance criteria" not in acceptance[0].value.lower()
+    )
+    assert answer.source == AutoAnswerSource.CONSERVATIVE_DEFAULT
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=(acceptance[0].value,), goal="Build a CLI")
+
+    assert GradeGate().grade_seed(seed, ledger=ledger).grade == SeedGrade.A
+
+
+def test_auto_answerer_routes_common_input_output_prompts_to_io_ledger() -> None:
+    answerer = AutoAnswerer()
+    for question in (
+        "What inputs does the command take?",
+        "What outputs does it produce?",
+    ):
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+
+        assert {"actors", "inputs", "outputs"} <= updated_sections
+        assert not {"constraints", "failure_modes"} >= updated_sections
+
+
+def test_auto_answerer_blocks_production_environment_selection_variants() -> None:
+    questions = (
+        "Which production environment should we deploy to?",
+        "Which AWS account should we deploy production to?",
+    )
+    for question in questions:
+        answer = AutoAnswerer().answer(question, SeedDraftLedger.from_goal("Deploy a service"))
+        assert answer.blocker is not None
+        assert answer.source == AutoAnswerSource.BLOCKER
+
+
+def test_ledger_later_same_key_correction_resolves_conflict() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    for value in ("Write a JSON report", "Display an HTML dashboard", "Write a JSON report"):
+        ledger.add_entry(
+            "outputs",
+            LedgerEntry(
+                key="outputs.primary",
+                value=value,
+                source=LedgerSource.CONSERVATIVE_DEFAULT,
+                confidence=0.8,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+    assert ledger.sections["outputs"].status() == LedgerStatus.DEFAULTED
+    assert "outputs" not in ledger.open_gaps()
+
+
+def test_auto_answerer_allows_product_security_and_billing_requirement_questions() -> None:
+    questions = (
+        "Which password rules should the signup form enforce?",
+        "Which API keys should users be able to rotate?",
+        "Which billing provider integrations should the app support?",
+    )
+
+    for question in questions:
+        answer = AutoAnswerer().answer(question, SeedDraftLedger.from_goal("Build a SaaS app"))
+        assert answer.blocker is None
+
+
+def test_ledger_later_answer_can_clear_same_key_blocker() -> None:
+    ledger = SeedDraftLedger.from_goal("Deploy a service")
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="blocker.auto_answer",
+            value="production credential required",
+            source=LedgerSource.BLOCKER,
+            confidence=1.0,
+            status=LedgerStatus.BLOCKED,
+        ),
+    )
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="blocker.auto_answer",
+            value="Use staging-only dry run; no production credential is needed",
+            source=LedgerSource.USER_GOAL,
+            confidence=0.95,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    assert ledger.sections["constraints"].status() == LedgerStatus.CONFIRMED
+    assert "constraints" not in ledger.open_gaps()
+
+
+def test_auto_answerer_non_goals_respect_explicit_goal_scope() -> None:
+    cases = (
+        ("Deploy this service to production", "production deployment"),
+        ("Add authentication to the app", "authentication"),
+    )
+
+    for goal, forbidden_non_goal in cases:
+        answer = AutoAnswerer().answer("What are the non-goals?", SeedDraftLedger.from_goal(goal))
+        assert forbidden_non_goal not in answer.text.lower()
+
+
+def test_ledger_assumptions_use_latest_resolved_facts_for_risk() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    _fill_minimal_ready_ledger(ledger)
+    for value in ("CLI user", "CLI user", "CLI user"):
+        ledger.add_entry(
+            "actors",
+            LedgerEntry(
+                key="actors.primary",
+                value=value,
+                source=LedgerSource.ASSUMPTION,
+                confidence=0.72,
+                status=LedgerStatus.INFERRED,
+            ),
+        )
+
+    assert ledger.assumptions().count("CLI user") == 1
+    assert GradeGate().grade_ledger(ledger).scores["risk"] <= 0.25
+
+
+def test_auto_answerer_non_goals_use_latest_resolved_goal() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    ledger.add_entry(
+        "goal",
+        LedgerEntry(
+            key="goal.primary",
+            value="Add authentication to the app",
+            source=LedgerSource.USER_GOAL,
+            confidence=0.95,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    answer = AutoAnswerer().answer("What are the non-goals?", ledger)
+
+    assert "authentication" not in answer.text.lower()
+
+
+def test_grade_seed_allows_safe_product_delete_assumptions() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a task app")
+    _fill_minimal_ready_ledger(ledger)
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="assumption.safe_delete",
+            value="Users can delete their own tasks after confirmation",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.72,
+            status=LedgerStatus.INFERRED,
+        ),
+    )
+
+    result = GradeGate().grade_seed(
+        _seed(
+            ac=("`task delete` prints stable stdout confirming deletion",), goal="Build a task app"
+        ),
+        ledger=ledger,
+    )
+
+    assert result.grade == SeedGrade.A
+    assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
+
+
+def test_grade_gate_accepts_exit_status_and_http_status_criteria() -> None:
+    ledger = SeedDraftLedger.from_goal("Build health checks")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(
+        ac=("CLI exits 0 on success", "GET /health returns 200"), goal="Build health checks"
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.A
+    assert result.may_run
+
+
+def test_auto_answerer_preserves_feature_specific_acceptance_semantics() -> None:
+    answer = AutoAnswerer().answer(
+        "What acceptance criteria should the delete endpoint satisfy?",
+        SeedDraftLedger.from_goal("Build a delete endpoint"),
+    )
+
+    assert answer.blocker is None
+    assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)
+    assert "delete endpoint" in answer.text.lower()
+    assert "stdout" not in answer.text.lower()
+
+
+def test_auto_answerer_allows_secret_token_product_requirement_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should users be able to store secret tokens?",
+        SeedDraftLedger.from_goal("Build a token vault"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_auto_answerer_preserves_open_ended_feature_acceptance_semantics() -> None:
+    answer = AutoAnswerer().answer(
+        "What acceptance criteria should the webhook delivery flow satisfy?",
+        SeedDraftLedger.from_goal("Build webhook delivery"),
+    )
+
+    assert answer.blocker is None
+    assert any(section == "acceptance_criteria" for section, _entry in answer.ledger_updates)
+    assert "webhook delivery flow" in answer.text.lower()
+    assert "stdout" not in answer.text.lower()
+
+
+def test_grade_gate_ignores_inactive_high_risk_assumptions() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a local task app")
+    _fill_minimal_ready_ledger(ledger)
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="assumption.old_production",
+            value="Use production credential",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.2,
+            status=LedgerStatus.WEAK,
+        ),
+    )
+
+    result = GradeGate().grade_seed(
+        _seed(ac=("`task list` prints stable stdout",), goal="Build a local task app"),
+        ledger=ledger,
+    )
+
+    assert result.grade == SeedGrade.A
+    assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
+
+
+def test_grade_gate_blocks_high_ambiguity_seed() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(ac=("`task list` prints stable stdout",)).model_copy(
+        update={"metadata": SeedMetadata(ambiguity_score=0.45)}
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.C
+    assert not result.may_run
+    assert any(blocker.code == "high_ambiguity_score" for blocker in result.blockers)
+
+
+def test_auto_answerer_preserves_safe_product_behavior_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should completed tasks be marked done?",
+        SeedDraftLedger.from_goal("Build a task app"),
+    )
+
+    assert answer.blocker is None
+    assert "marked done" in answer.text.lower()
+    assert "conservative mvp" not in answer.text.lower()
+    acceptance = [
+        entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+    ]
+    assert acceptance
+    ledger = SeedDraftLedger.from_goal("Build a task app")
+    _fill_minimal_ready_ledger(ledger)
+    assert (
+        GradeGate()
+        .grade_seed(_seed(ac=(acceptance[0].value,), goal="Build a task app"), ledger=ledger)
+        .grade
+        == SeedGrade.A
+    )
+
+
+def test_auto_answerer_preserves_output_behavior_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "What output should the export command write?",
+        SeedDraftLedger.from_goal("Build an export command"),
+    )
+
+    assert answer.blocker is None
+    assert "export command write" in answer.text.lower()
+    assert "conservative mvp" not in answer.text.lower()
+    acceptance = [
+        entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+    ]
+    assert acceptance
+    ledger = SeedDraftLedger.from_goal("Build an export command")
+    _fill_minimal_ready_ledger(ledger)
+    assert (
+        GradeGate()
+        .grade_seed(_seed(ac=(acceptance[0].value,), goal="Build an export command"), ledger=ledger)
+        .grade
+        == SeedGrade.A
+    )
+
+
+def test_auto_answerer_allows_credential_auth_product_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should the app use credential-based authentication?",
+        SeedDraftLedger.from_goal("Build an auth app"),
+    )
+
+    assert answer.blocker is None
+    assert "credential-based authentication" in answer.text.lower()
+
+
+def test_auto_answerer_allows_user_managed_secret_and_integration_deletion() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "Should users be able to delete an API key?",
+        "Should users be able to delete a secret?",
+        "Should users be able to remove a repo integration?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build settings UI"))
+        assert answer.blocker is None
+        assert "product behavior" in answer.text.lower()
+
+
+def test_auto_answerer_allows_user_managed_token_and_key_product_questions() -> None:
+    answerer = AutoAnswerer()
+    questions = (
+        "Should users be able to rotate private keys?",
+        "Should the app display access tokens?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build identity settings"))
+        assert answer.blocker is None
+        assert "product behavior" in answer.text.lower()

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -228,6 +228,27 @@ def test_auto_answerer_allows_product_domain_file_removal_questions() -> None:
     assert answer.source != AutoAnswerSource.BLOCKER
 
 
+def test_auto_answerer_allows_git_product_branch_deletion_questions() -> None:
+    answer = AutoAnswerer().answer(
+        "Should users be able to delete the branch?",
+        SeedDraftLedger.from_goal("Build a Git branch manager"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source != AutoAnswerSource.BLOCKER
+    assert "product behavior" in answer.text.lower()
+
+
+def test_auto_answerer_still_blocks_current_branch_deletion_authority() -> None:
+    answer = AutoAnswerer().answer(
+        "Should we delete the current branch?",
+        SeedDraftLedger.from_goal("Clean up repository branches"),
+    )
+
+    assert answer.blocker is not None
+    assert answer.source == AutoAnswerSource.BLOCKER
+
+
 def test_auto_answerer_returns_blocker_for_plain_secret_questions() -> None:
     answer = AutoAnswerer().answer(
         "Which secret should the workflow use?",

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -263,6 +263,8 @@ def test_auto_answerer_allows_benign_sensitive_domain_vocabulary() -> None:
         "Should users see payment history?",
         "Should users be able to rotate API keys?",
         "Should the app support password reset?",
+        "Should admins be able to rotate production credentials?",
+        "Should production credential status be shown in settings?",
         "Should the app support billing provider integrations?",
         "Should users subscribe to paid service tiers?",
         "Should legal review workflows be tracked?",
@@ -278,6 +280,7 @@ def test_auto_answerer_blocks_contextual_human_authority_questions() -> None:
     answerer = AutoAnswerer()
     blocking_questions = (
         "Which credential value should production use?",
+        "Which production credential should the workflow use?",
         "Which payment provider account should we charge?",
         "What legal approval is needed for liability risk?",
         "What medical advice should the app recommend?",
@@ -306,6 +309,8 @@ def test_auto_answerer_does_not_route_feature_semantics_to_io_actor_defaults() -
         "Should users see payment history?",
         "Should users be able to rotate API keys?",
         "Should the app support password reset?",
+        "Should admins be able to rotate production credentials?",
+        "Should production credential status be shown in settings?",
         "Should the app support billing provider integrations?",
         "Should users subscribe to paid service tiers?",
         "Should legal review workflows be tracked?",

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -245,6 +245,24 @@ def test_auto_answerer_allows_git_product_branch_deletion_questions() -> None:
     assert all("product behavior" in answer.text.lower() for answer in answers)
 
 
+def test_auto_answerer_preserves_product_behavior_phrasing_variants() -> None:
+    answerer = AutoAnswerer()
+    ledger = SeedDraftLedger.from_goal("Build a compliance SaaS")
+
+    examples = (
+        "Should legal documents be editable?",
+        "Should users subscribe to paid service tiers?",
+        "Should legal review workflows be tracked?",
+        "Which password rules should the signup form enforce?",
+    )
+
+    answers = [answerer.answer(question, ledger) for question in examples]
+
+    assert all(answer.blocker is None for answer in answers)
+    assert all(answer.source != AutoAnswerSource.BLOCKER for answer in answers)
+    assert all("product behavior" in answer.text.lower() for answer in answers)
+
+
 def test_auto_answerer_still_blocks_current_branch_deletion_authority() -> None:
     answer = AutoAnswerer().answer(
         "Should we delete the current branch?",

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -151,6 +151,33 @@ def test_store_load_rejects_malformed_nested_ledger(tmp_path) -> None:
         store.load(state.auto_session_id)
 
 
+def test_store_load_rejects_dropped_ledger_sections_and_history(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["ledger"] = {"sections": {"goal": []}, "question_history": {}}
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="valid Seed Draft Ledger"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_ledger_question_history_with_non_qa_entries(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["ledger"] = {
+        "sections": {"goal": {"name": "goal", "entries": []}},
+        "question_history": [{"question": "What?"}],
+    }
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="valid Seed Draft Ledger"):
+        store.load(state.auto_session_id)
+
+
 def test_store_save_rejects_malformed_nested_ledger_before_writing(tmp_path) -> None:
     store = AutoStore(tmp_path)
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -304,3 +304,26 @@ def test_store_load_rejects_unknown_required_grade(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="required_grade"):
         store.load(state.auto_session_id)
+
+
+def test_recover_rejects_terminal_phase_from_blocked_state() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("needs user input")
+
+    with pytest.raises(ValueError, match="blocked -> complete"):
+        state.recover(AutoPhase.COMPLETE, "do not skip work")
+
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_error == "needs user input"
+
+
+def test_recover_uses_transition_table_from_failed_state() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_failed("tool failed")
+
+    state.recover(AutoPhase.REVIEW, "retry review")
+
+    assert state.phase is AutoPhase.REVIEW
+    assert state.last_error is None

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+
+def test_state_transition_and_stale_detection() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+
+    assert state.phase == AutoPhase.INTERVIEW
+    assert state.last_progress_message == "starting interview"
+
+    future = datetime.fromisoformat(state.last_progress_at) + timedelta(seconds=121)
+    assert state.is_stale(future)
+
+
+def test_invalid_phase_transition_rejected() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+
+    with pytest.raises(ValueError, match="Invalid auto phase transition"):
+        state.transition(AutoPhase.RUN, "skip ahead")
+
+
+def test_store_roundtrip_and_corrupt_state(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+
+    path = store.save(state)
+    loaded = store.load(state.auto_session_id)
+
+    assert path.exists()
+    assert loaded.auto_session_id == state.auto_session_id
+    assert loaded.phase == AutoPhase.INTERVIEW
+
+    path.write_text("not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="corrupt"):
+        store.load(state.auto_session_id)
+
+
+def test_terminal_state_is_not_stale() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting")
+    state.transition(AutoPhase.BLOCKED, "need credential", error="need credential")
+
+    future = datetime.now(UTC) + timedelta(days=1)
+    assert not state.is_stale(future)
+
+
+def test_run_phase_uses_run_timeout_key_for_staleness() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+
+    future = datetime.fromisoformat(state.last_progress_at) + timedelta(seconds=61)
+    assert state.timeout_seconds_by_phase[AutoPhase.RUN.value] == 60
+    assert state.is_stale(future)
+
+
+def test_store_load_wraps_semantically_invalid_state(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    path = store.path_for("auto_badstate")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"goal": "x", "cwd": ".", "phase": "bogus"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load("auto_badstate")
+
+
+def test_store_load_wraps_invalid_timestamps_and_timeouts(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["last_progress_at"] = "not-a-timestamp"
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)
+
+    data = state.to_dict()
+    data["timeout_seconds_by_phase"] = {AutoPhase.RUN.value: "sixty"}
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_wraps_naive_timestamps(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["last_progress_at"] = "2026-05-01T12:00:00"
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_wraps_malformed_container_and_counter_fields(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    for field_name, value in (
+        ("ledger", []),
+        ("findings", "oops"),
+        ("repair_round", "1"),
+        ("current_round", -1),
+    ):
+        data = state.to_dict()
+        data[field_name] = value
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_malformed_nested_ledger(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["ledger"] = {
+        "sections": {
+            "goal": {
+                "name": "goal",
+                "entries": [
+                    {
+                        "key": "goal.primary",
+                        "value": "Build a CLI",
+                        "source": "not-a-source",
+                        "confidence": 0.9,
+                        "status": "confirmed",
+                    }
+                ],
+            }
+        },
+        "question_history": [],
+    }
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="valid Seed Draft Ledger"):
+        store.load(state.auto_session_id)
+
+
+def test_store_save_rejects_malformed_nested_ledger_before_writing(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.ledger = {
+        "sections": {"goal": {"name": "goal", "entries": [{"key": "missing fields"}]}},
+        "question_history": [],
+    }
+
+    with pytest.raises(ValueError, match="valid Seed Draft Ledger"):
+        store.save(state)
+
+    assert not store.path_for(state.auto_session_id).exists()
+
+
+def test_store_load_rejects_empty_optional_resume_identifiers(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    for field_name in (
+        "interview_session_id",
+        "seed_id",
+        "seed_path",
+        "execution_id",
+        "job_id",
+        "run_session_id",
+        "last_grade",
+        "pending_question",
+        "last_tool_name",
+        "last_error",
+    ):
+        data = state.to_dict()
+        data[field_name] = ""
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)
+
+
+def test_store_load_wraps_malformed_seed_artifact(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["seed_artifact"] = {"goal": "missing required seed fields"}
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_truncated_state_without_default_backfill(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data.pop("phase_started_at")
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required fields"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_session_id_mismatch(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["auto_session_id"] = "auto_other"
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="session id mismatch"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_partial_timeout_map(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["timeout_seconds_by_phase"] = {AutoPhase.RUN.value: 60}
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required phases"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_malformed_optional_strings(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    for field_name, value in (
+        ("seed_path", {"path": "seed.json"}),
+        ("seed_id", ""),
+        ("execution_id", []),
+        ("last_progress_message", []),
+    ):
+        data = state.to_dict()
+        data[field_name] = value
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)
+
+
+def test_store_save_rejects_invalid_state_before_writing(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.timeout_seconds_by_phase = {AutoPhase.RUN.value: 60}
+
+    with pytest.raises(ValueError, match="missing required phases"):
+        store.save(state)
+
+    assert not store.path_for(state.auto_session_id).exists()
+
+
+def test_store_load_rejects_malformed_run_subagent(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["run_subagent"] = []
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Auto session state is invalid"):
+        store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_falsey_non_object_seed_artifacts(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    for value in (None, [], "", 0):
+        data = state.to_dict()
+        data["seed_artifact"] = value
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)
+
+
+def test_store_load_rejects_unknown_required_grade(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    data = state.to_dict()
+    data["required_grade"] = "D"
+    path = store.path_for(state.auto_session_id)
+    path.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="required_grade"):
+        store.load(state.auto_session_id)


### PR DESCRIPTION
## Summary
- Split out the base `ooo auto` quality primitives from the oversized #553/#555 branches.
- Adds serializable auto state/store, seed draft ledger, grade gate, gap detector, and deterministic interview answerer.
- Keeps supervisor execution and public CLI/MCP surfaces out of this PR so bot review can focus on the core quality model.

## Stack
1. #565 — core quality primitives
2. #566 — bounded supervisor loop
3. #567 — CLI/MCP/skill surface
4. #568 — user documentation

## Validation
- `uv run ruff format --check src/ouroboros/auto tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_state.py`
- `uv run ruff check src/ouroboros/auto tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_state.py`
- `uv run pytest tests/unit/auto/test_state.py tests/unit/auto/test_ledger_grading_answerer.py -q`
- `uv run mypy src/ouroboros/auto/answerer.py src/ouroboros/auto/gap_detector.py src/ouroboros/auto/grading.py src/ouroboros/auto/ledger.py src/ouroboros/auto/state.py`

Supersedes part of #553/#555, which were closed because the review scope was too broad.
