### PR TITLE
Split ooo auto bounded supervisor loop

### DIFF
--- a/src/ouroboros/auto/__init__.py
+++ b/src/ouroboros/auto/__init__.py
@@ -8,21 +8,35 @@ before starting execution.
 
 from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
 from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
+from ouroboros.auto.interview_driver import AutoInterviewDriver, AutoInterviewResult, InterviewTurn
 from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.seed_repairer import RepairResult, SeedRepairer
+from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoPolicy, AutoStore
 
 __all__ = [
     "AutoAnswer",
     "AutoAnswerSource",
     "AutoAnswerer",
+    "AutoInterviewDriver",
+    "AutoInterviewResult",
     "AutoPhase",
+    "AutoPipeline",
+    "AutoPipelineResult",
     "AutoPipelineState",
     "AutoPolicy",
     "AutoStore",
     "GradeGate",
+    "InterviewTurn",
     "GradeResult",
     "LedgerEntry",
     "LedgerSection",
+    "RepairResult",
+    "ReviewFinding",
     "SeedDraftLedger",
+    "SeedReview",
+    "SeedReviewer",
     "SeedGrade",
+    "SeedRepairer",
 ]

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -66,6 +66,7 @@ class AutoInterviewDriver:
     async def run(self, state: AutoPipelineState, ledger: SeedDraftLedger) -> AutoInterviewResult:
         """Run bounded auto interview until Seed-ready or blocked."""
         self._ensure_interview_phase(state)
+        interview_tool_name = "interview.start"
         try:
             if state.interview_session_id:
                 if state.pending_question:
@@ -74,11 +75,12 @@ class AutoInterviewDriver:
                         session_id=state.interview_session_id,
                     )
                 else:
+                    interview_tool_name = "interview.resume"
                     turn = _validate_turn(
                         await self._with_timeout(
                             self.backend.resume(state.interview_session_id),
                             state,
-                            tool_name="interview.resume",
+                            tool_name=interview_tool_name,
                         )
                     )
                     state.pending_question = turn.question
@@ -88,21 +90,22 @@ class AutoInterviewDriver:
                     await self._with_timeout(
                         self.backend.start(state.goal, cwd=state.cwd),
                         state,
-                        tool_name="interview.start",
+                        tool_name=interview_tool_name,
                     )
                 )
                 state.interview_session_id = turn.session_id
                 state.pending_question = turn.question
                 self._save(state)
         except TimeoutError as exc:
-            state.mark_blocked(str(exc), tool_name="interview.start")
+            state.mark_blocked(str(exc), tool_name=interview_tool_name)
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, state.current_round, str(exc)
             )
         except Exception as exc:
-            blocker = f"interview resume/start failed: {exc}"
-            state.mark_blocked(blocker, tool_name="interview.start")
+            action = "resume" if interview_tool_name == "interview.resume" else "start"
+            blocker = f"interview {action} failed: {exc}"
+            state.mark_blocked(blocker, tool_name=interview_tool_name)
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, state.current_round, blocker
@@ -112,7 +115,6 @@ class AutoInterviewDriver:
             return self._handle_completed_turn(state, ledger, turn, state.current_round)
 
         for round_number in range(state.current_round + 1, self.max_rounds + 1):
-            state.current_round = round_number
             state.mark_progress(f"interview round {round_number}/{self.max_rounds}")
             self._save(state)
 
@@ -126,9 +128,10 @@ class AutoInterviewDriver:
                     "blocked",
                     state.interview_session_id,
                     ledger,
-                    round_number,
+                    state.current_round,
                     answer.blocker.reason,
                 )
+            state.current_round = round_number
             self.answerer.apply(answer, ledger, question=turn.question)
             state.ledger = ledger.to_dict()
             state.pending_question = None

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -1,0 +1,312 @@
+"""Bounded auto Socratic interview driver."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+import re
+from typing import Protocol
+
+from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource, AutoBlocker
+from ouroboros.auto.gap_detector import Gap, GapDetector
+from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+
+@dataclass(frozen=True, slots=True)
+class InterviewTurn:
+    """Question returned by an interview backend."""
+
+    question: str
+    session_id: str
+    seed_ready: bool = False
+    completed: bool = False
+
+
+class InterviewBackend(Protocol):
+    """Minimal backend interface needed by the auto interview driver."""
+
+    async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
+        """Start an interview and return the first question."""
+
+    async def answer(self, session_id: str, answer: str) -> InterviewTurn:
+        """Record an answer and return the next question or completion metadata."""
+
+    async def resume(self, session_id: str) -> InterviewTurn:
+        """Return the outstanding question for a persisted interview session."""
+
+
+@dataclass(frozen=True, slots=True)
+class AutoInterviewResult:
+    """Result from running the bounded auto interview loop."""
+
+    status: str
+    session_id: str | None
+    ledger: SeedDraftLedger
+    rounds: int
+    blocker: str | None = None
+
+
+@dataclass(slots=True)
+class AutoInterviewDriver:
+    """Drive an interview backend with conservative auto answers.
+
+    The driver never relies on the backend to terminate by itself.  All backend
+    calls are timeout-bounded and the loop is capped by ``max_rounds``.
+    """
+
+    backend: InterviewBackend
+    answerer: AutoAnswerer = field(default_factory=AutoAnswerer)
+    gap_detector: GapDetector = field(default_factory=GapDetector)
+    store: AutoStore | None = None
+    timeout_seconds: float = 60.0
+    max_rounds: int = 12
+
+    async def run(self, state: AutoPipelineState, ledger: SeedDraftLedger) -> AutoInterviewResult:
+        """Run bounded auto interview until Seed-ready or blocked."""
+        self._ensure_interview_phase(state)
+        try:
+            if state.interview_session_id:
+                if state.pending_question:
+                    turn = InterviewTurn(
+                        question=state.pending_question,
+                        session_id=state.interview_session_id,
+                    )
+                else:
+                    turn = _validate_turn(
+                        await self._with_timeout(
+                            self.backend.resume(state.interview_session_id),
+                            state,
+                            tool_name="interview.resume",
+                        )
+                    )
+                    state.pending_question = turn.question
+                    self._save(state)
+            else:
+                turn = _validate_turn(
+                    await self._with_timeout(
+                        self.backend.start(state.goal, cwd=state.cwd),
+                        state,
+                        tool_name="interview.start",
+                    )
+                )
+                state.interview_session_id = turn.session_id
+                state.pending_question = turn.question
+                self._save(state)
+        except TimeoutError as exc:
+            state.mark_blocked(str(exc), tool_name="interview.start")
+            self._save(state)
+            return AutoInterviewResult(
+                "blocked", state.interview_session_id, ledger, state.current_round, str(exc)
+            )
+        except Exception as exc:
+            blocker = f"interview resume/start failed: {exc}"
+            state.mark_blocked(blocker, tool_name="interview.start")
+            self._save(state)
+            return AutoInterviewResult(
+                "blocked", state.interview_session_id, ledger, state.current_round, blocker
+            )
+
+        if turn.seed_ready or turn.completed:
+            return self._handle_completed_turn(state, ledger, turn, state.current_round)
+
+        for round_number in range(state.current_round + 1, self.max_rounds + 1):
+            state.current_round = round_number
+            state.mark_progress(f"interview round {round_number}/{self.max_rounds}")
+            self._save(state)
+
+            answer = self._answer_with_gap_steering(turn.question, ledger)
+            if answer.blocker is not None:
+                self.answerer.apply(answer, ledger, question=turn.question)
+                state.ledger = ledger.to_dict()
+                state.mark_blocked(answer.blocker.reason, tool_name="auto_answerer")
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked",
+                    state.interview_session_id,
+                    ledger,
+                    round_number,
+                    answer.blocker.reason,
+                )
+            self.answerer.apply(answer, ledger, question=turn.question)
+            state.ledger = ledger.to_dict()
+            state.pending_question = None
+            state.mark_progress(
+                f"answered round {round_number}/{self.max_rounds} from {answer.source.value}",
+                tool_name="auto_answerer",
+            )
+            self._save(state)
+
+            try:
+                turn = _validate_turn(
+                    await self._with_timeout(
+                        self.backend.answer(turn.session_id, answer.prefixed_text),
+                        state,
+                        tool_name="interview.answer",
+                    )
+                )
+            except TimeoutError as exc:
+                state.mark_blocked(str(exc), tool_name="interview.answer")
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, round_number, str(exc)
+                )
+            except Exception as exc:
+                blocker = f"interview answer failed: {exc}"
+                state.mark_blocked(blocker, tool_name="interview.answer")
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, round_number, blocker
+                )
+
+            state.interview_session_id = turn.session_id
+            if turn.seed_ready or turn.completed:
+                return self._handle_completed_turn(state, ledger, turn, round_number)
+            state.pending_question = turn.question
+            self._save(state)
+
+        if not ledger.is_seed_ready():
+            gaps = ", ".join(ledger.open_gaps())
+            blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
+            state.mark_blocked(blocker, tool_name="interview_driver")
+            self._save(state)
+            return AutoInterviewResult(
+                "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
+            )
+        blocker = "auto interview reached max rounds before backend marked the Seed ready"
+        state.mark_blocked(blocker, tool_name="interview_driver")
+        self._save(state)
+        return AutoInterviewResult(
+            "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
+        )
+
+    def _answer_with_gap_steering(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:
+        answer = self.answerer.answer(question, ledger)
+        if answer.blocker is not None:
+            return answer
+        gaps = self.gap_detector.detect(ledger)
+        if not gaps:
+            return answer
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        if any(gap.section in updated_sections for gap in gaps):
+            return answer
+        next_gap = gaps[0]
+        if not _can_steer_with_gap_prompt(question):
+            return answer
+        if next_gap.section == "goal" or next_gap.state in {
+            LedgerStatus.CONFLICTING,
+            LedgerStatus.BLOCKED,
+        }:
+            blocker = AutoBlocker(reason=next_gap.message, question=question)
+            return AutoAnswer(
+                text=f"Cannot safely decide automatically: {next_gap.message}",
+                source=AutoAnswerSource.BLOCKER,
+                confidence=1.0,
+                blocker=blocker,
+            )
+        return self.answerer.answer(_gap_prompt(next_gap), ledger)
+
+    def _handle_completed_turn(
+        self, state: AutoPipelineState, ledger: SeedDraftLedger, turn: InterviewTurn, rounds: int
+    ) -> AutoInterviewResult:
+        state.interview_session_id = turn.session_id
+        state.pending_question = None
+        if ledger.is_seed_ready():
+            state.interview_completed = True
+            self._save(state)
+            return AutoInterviewResult("seed_ready", turn.session_id, ledger, rounds)
+        gaps = ", ".join(ledger.open_gaps())
+        blocker = f"interview backend completed before auto ledger was ready: {gaps}"
+        state.mark_blocked(blocker, tool_name="interview_driver")
+        self._save(state)
+        return AutoInterviewResult("blocked", state.interview_session_id, ledger, rounds, blocker)
+
+    async def _with_timeout(
+        self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str
+    ) -> InterviewTurn:
+        try:
+            return await asyncio.wait_for(awaitable, timeout=self.timeout_seconds)
+        except TimeoutError as exc:
+            msg = f"{tool_name} timed out after {self.timeout_seconds:.0f}s for {state.auto_session_id}"
+            raise TimeoutError(msg) from exc
+
+    def _ensure_interview_phase(self, state: AutoPipelineState) -> None:
+        if state.phase == AutoPhase.CREATED:
+            state.transition(AutoPhase.INTERVIEW, "starting auto interview")
+            self._save(state)
+        elif state.phase != AutoPhase.INTERVIEW:
+            msg = f"Auto interview cannot run from phase {state.phase.value}"
+            raise ValueError(msg)
+
+    def _save(self, state: AutoPipelineState) -> None:
+        if self.store is not None:
+            self.store.save(state)
+
+
+class FunctionInterviewBackend:
+    """Adapter for tests or local integrations built from callables."""
+
+    def __init__(
+        self,
+        start: Callable[[str, str], Awaitable[InterviewTurn]],
+        answer: Callable[[str, str], Awaitable[InterviewTurn]],
+        resume: Callable[[str], Awaitable[InterviewTurn]] | None = None,
+    ) -> None:
+        self._start = start
+        self._answer = answer
+        self._resume = resume
+
+    async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
+        return await self._start(goal, cwd)
+
+    async def answer(self, session_id: str, answer: str) -> InterviewTurn:
+        return await self._answer(session_id, answer)
+
+    async def resume(self, session_id: str) -> InterviewTurn:
+        if self._resume is None:
+            msg = "interview resume is unavailable because no pending question is persisted"
+            raise RuntimeError(msg)
+        return await self._resume(session_id)
+
+
+def _can_steer_with_gap_prompt(question: str) -> bool:
+    lowered = question.lower()
+    return bool(
+        re.search(
+            r"\b(what else|anything else|additional context|more context|what should we know|clarify further)\b",
+            lowered,
+        )
+    )
+
+
+def _gap_prompt(gap: Gap) -> str:
+    prompts = {
+        "goal": "Clarify the primary user goal for the Seed.",
+        "actors": "Who are the actors, inputs, and outputs for this task?",
+        "inputs": "Who are the actors, inputs, and outputs for this task?",
+        "outputs": "Who are the actors, inputs, and outputs for this task?",
+        "constraints": "What conservative constraints and failure modes should bound this MVP?",
+        "failure_modes": "What conservative constraints and failure modes should bound this MVP?",
+        "non_goals": "What non-goals should explicitly remain out of scope?",
+        "acceptance_criteria": "Which command output verifies the acceptance criteria?",
+        "verification_plan": "Which command output verifies the acceptance criteria?",
+        "runtime_context": "Which runtime stack, repo, and project patterns should be used?",
+    }
+    return prompts.get(gap.section, gap.message)
+
+
+def _validate_turn(value: object) -> InterviewTurn:
+    if not isinstance(value, InterviewTurn):
+        msg = f"interview backend returned {type(value).__name__}, expected InterviewTurn"
+        raise TypeError(msg)
+    if not isinstance(value.question, str):
+        msg = "interview backend returned non-string question"
+        raise TypeError(msg)
+    if not isinstance(value.session_id, str) or not value.session_id:
+        msg = "interview backend returned invalid session_id"
+        raise TypeError(msg)
+    if type(value.seed_ready) is not bool or type(value.completed) is not bool:
+        msg = "interview backend returned non-boolean completion flags"
+        raise TypeError(msg)
+    return value

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1,0 +1,410 @@
+"""Full-quality AutoPipeline supervisor skeleton."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from ouroboros.auto.grading import GradeGate
+from ouroboros.auto.interview_driver import AutoInterviewDriver
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.seed_repairer import SeedRepairer
+from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore, utc_now_iso
+from ouroboros.core.seed import Seed
+
+SeedGenerator = Callable[[str], Awaitable[Seed]]
+RunStarter = Callable[[Seed], Awaitable[dict[str, Any]]]
+SeedSaver = Callable[[Seed], str]
+SeedLoader = Callable[[str], Seed]
+
+
+@dataclass(frozen=True, slots=True)
+class AutoPipelineResult:
+    """Structured AutoPipeline result for CLI/MCP surfaces."""
+
+    status: str
+    auto_session_id: str
+    phase: str
+    grade: str | None = None
+    seed_path: str | None = None
+    interview_session_id: str | None = None
+    execution_id: str | None = None
+    job_id: str | None = None
+    run_session_id: str | None = None
+    run_subagent: dict[str, Any] | None = None
+    assumptions: tuple[str, ...] = ()
+    non_goals: tuple[str, ...] = ()
+    blocker: str | None = None
+
+
+@dataclass(slots=True)
+class AutoPipeline:
+    """Coordinate interview, Seed generation, review, repair, and run handoff."""
+
+    interview_driver: AutoInterviewDriver
+    seed_generator: SeedGenerator
+    run_starter: RunStarter | None = None
+    store: AutoStore | None = None
+    reviewer: SeedReviewer | None = None
+    repairer: SeedRepairer | None = None
+    grade_gate: GradeGate | None = None
+    seed_saver: SeedSaver | None = None
+    seed_loader: SeedLoader | None = None
+    skip_run: bool = False
+    seed_timeout_seconds: float = 120.0
+    run_start_timeout_seconds: float = 60.0
+
+    async def run(self, state: AutoPipelineState) -> AutoPipelineResult:
+        """Run a bounded auto pipeline using injected side-effecting dependencies."""
+        ledger = (
+            SeedDraftLedger.from_dict(state.ledger)
+            if state.ledger
+            else SeedDraftLedger.from_goal(state.goal)
+        )
+        if self.skip_run and not state.skip_run:
+            state.skip_run = True
+        resume_tool_name = state.last_tool_name
+        if state.seed_artifact:
+            try:
+                Seed.from_dict(state.seed_artifact)
+            except Exception as exc:
+                _mark_invalid_seed_artifact(state, f"persisted Seed artifact is invalid: {exc}")
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
+        self._save(state)
+
+        if state.phase == AutoPhase.COMPLETE:
+            return self._result(state, ledger, blocker=state.last_error)
+        if state.phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
+            resume_phase = _recoverable_phase_for_tool(state.last_tool_name)
+            if resume_phase is None:
+                return self._result(state, ledger, blocker=state.last_error)
+            previous_phase = state.phase
+            state.recover(
+                resume_phase,
+                f"resuming {resume_phase.value} after {previous_phase.value}: {state.last_error or 'no error recorded'}",
+            )
+            self._save(state)
+
+        review: SeedReview | None = None
+        if state.phase in {AutoPhase.CREATED, AutoPhase.INTERVIEW}:
+            if state.phase == AutoPhase.INTERVIEW and state.interview_completed:
+                if not state.interview_session_id:
+                    state.mark_blocked(
+                        "Completed interview is missing interview_session_id",
+                        tool_name="auto_pipeline",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
+                if not ledger.is_seed_ready():
+                    gaps = ", ".join(ledger.open_gaps())
+                    state.mark_blocked(
+                        f"Completed interview has unresolved ledger gaps: {gaps}",
+                        tool_name="auto_pipeline",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
+                state.transition(
+                    AutoPhase.SEED_GENERATION, "resuming Seed generation after completed interview"
+                )
+                self._save(state)
+            else:
+                interview = await self.interview_driver.run(state, ledger)
+                if interview.status == "blocked":
+                    return self._result(state, ledger, blocker=interview.blocker)
+                state.interview_completed = True
+                state.transition(AutoPhase.SEED_GENERATION, "generating Seed from auto interview")
+                self._save(state)
+        elif state.phase == AutoPhase.REPAIR:
+            state.transition(AutoPhase.REVIEW, "resuming review after repair checkpoint")
+            self._save(state)
+        elif state.phase not in {AutoPhase.SEED_GENERATION, AutoPhase.REVIEW, AutoPhase.RUN}:
+            state.mark_blocked(
+                f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",
+                tool_name="auto_pipeline",
+            )
+            self._save(state)
+            return self._result(state, ledger, blocker=state.last_error)
+
+        if state.phase == AutoPhase.SEED_GENERATION:
+            if state.seed_artifact:
+                try:
+                    seed = Seed.from_dict(state.seed_artifact)
+                except Exception as exc:
+                    state.mark_failed(
+                        f"persisted Seed artifact is invalid: {exc}",
+                        tool_name="seed_generator",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
+                state.transition(AutoPhase.REVIEW, "resuming review from persisted Seed")
+                self._save(state)
+            else:
+                if not state.interview_session_id:
+                    state.mark_failed(
+                        "seed generation cannot resume without interview_session_id",
+                        tool_name="seed_generator",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
+                try:
+                    seed = await asyncio.wait_for(
+                        self.seed_generator(state.interview_session_id),
+                        timeout=self.seed_timeout_seconds,
+                    )
+                    if not isinstance(seed, Seed):
+                        msg = f"seed generator returned {type(seed).__name__}, expected Seed"
+                        raise TypeError(msg)
+                    state.seed_id = seed.metadata.seed_id
+                    state.seed_artifact = seed.to_dict()
+                except TimeoutError as exc:
+                    state.mark_blocked(
+                        f"seed generation timed out after {self.seed_timeout_seconds:.0f}s",
+                        tool_name="seed_generator",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, blocker=str(exc) or state.last_error)
+                except Exception as exc:
+                    state.mark_failed(f"seed generation failed: {exc}", tool_name="seed_generator")
+                    self._save(state)
+                    return self._result(state, ledger, blocker=state.last_error)
+                state.mark_progress("Seed generated", tool_name="seed_generator")
+                self._save(state)
+                state.transition(
+                    AutoPhase.REVIEW, f"reviewing Seed for required grade {state.required_grade}"
+                )
+                self._save(state)
+        elif (
+            state.phase == AutoPhase.REVIEW
+            and resume_tool_name in {"grade_gate", "seed_loader"}
+            and self.seed_loader is not None
+            and state.seed_path
+        ):
+            try:
+                seed = self.seed_loader(state.seed_path)
+            except Exception as exc:
+                state.mark_failed(f"seed load failed: {exc}", tool_name="seed_loader")
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
+        elif state.seed_artifact:
+            try:
+                seed = Seed.from_dict(state.seed_artifact)
+            except Exception as exc:
+                state.mark_failed(
+                    f"persisted Seed artifact is invalid: {exc}",
+                    tool_name="auto_pipeline",
+                )
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
+        elif self.seed_loader is not None and state.seed_path:
+            try:
+                seed = self.seed_loader(state.seed_path)
+            except Exception as exc:
+                state.mark_failed(f"seed load failed: {exc}", tool_name="seed_loader")
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
+        else:
+            state.mark_blocked(
+                f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",
+                tool_name="auto_pipeline",
+            )
+            self._save(state)
+            return self._result(state, ledger, blocker=state.last_error)
+
+        if state.phase == AutoPhase.REVIEW:
+            reviewer = self.reviewer or SeedReviewer(self.grade_gate)
+            repairer = self.repairer or SeedRepairer(reviewer=reviewer)
+            seed, review, repairs = repairer.converge(seed, ledger=ledger)
+            state.seed_artifact = seed.to_dict()
+            state.repair_round = len(repairs)
+            state.last_grade = review.grade_result.grade.value
+            state.findings = [asdict(finding) for finding in review.findings]
+            state.ledger = ledger.to_dict()
+            if self.seed_saver is not None:
+                try:
+                    state.seed_path = self.seed_saver(seed)
+                except Exception as exc:
+                    state.mark_failed(f"seed save failed: {exc}", tool_name="seed_saver")
+                    self._save(state)
+                    return self._result(state, ledger, review=review, blocker=state.last_error)
+            self._save(state)
+
+            if not _grade_meets_required(review.grade_result.grade.value, state.required_grade):
+                blocker = (
+                    f"Seed grade {review.grade_result.grade.value} did not meet "
+                    f"required grade {state.required_grade}"
+                )
+                state.mark_blocked(blocker, tool_name="grade_gate")
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=blocker)
+
+            if not review.may_run and not (self.skip_run or state.skip_run):
+                blocker = "Seed review did not clear the Seed for execution"
+                state.mark_blocked(blocker, tool_name="grade_gate")
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=blocker)
+
+            if self.skip_run or state.skip_run:
+                state.transition(
+                    AutoPhase.COMPLETE,
+                    f"Seed grade {review.grade_result.grade.value} ready; skip-run requested",
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review)
+
+        if state.phase == AutoPhase.RUN:
+            if any((state.job_id, state.execution_id, state.run_session_id)):
+                state.transition(
+                    AutoPhase.COMPLETE, "execution already started; using persisted run handle"
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review)
+            if state.run_start_attempted:
+                state.mark_blocked(
+                    "Run start status is unknown; refusing to start a duplicate execution",
+                    tool_name="run_starter",
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
+            if not _grade_meets_required(state.last_grade, state.required_grade):
+                state.mark_blocked(
+                    f"Cannot start execution without a persisted grade meeting {state.required_grade}",
+                    tool_name="grade_gate",
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
+            if review is None:
+                reviewer = self.reviewer or SeedReviewer(self.grade_gate)
+                review = reviewer.review(seed, ledger=ledger)
+                state.last_grade = review.grade_result.grade.value
+                state.findings = [asdict(finding) for finding in review.findings]
+                self._save(state)
+            if not review.may_run:
+                state.mark_blocked(
+                    "Seed review did not clear the Seed for execution",
+                    tool_name="grade_gate",
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
+
+        if self.run_starter is None:
+            state.mark_blocked("No run starter configured", tool_name="run_starter")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker="No run starter configured")
+
+        if state.phase != AutoPhase.RUN:
+            state.run_start_attempted = False
+            state.transition(
+                AutoPhase.RUN,
+                f"starting execution for grade {state.last_grade or state.required_grade} Seed",
+            )
+            self._save(state)
+        state.run_start_attempted = True
+        self._save(state)
+        try:
+            run_meta = await asyncio.wait_for(
+                self.run_starter(seed), timeout=self.run_start_timeout_seconds
+            )
+            if not isinstance(run_meta, dict):
+                msg = f"run starter returned {type(run_meta).__name__}, expected dict"
+                raise TypeError(msg)
+            state.job_id = _optional_str(run_meta.get("job_id"))
+            state.execution_id = _optional_str(run_meta.get("execution_id"))
+        except TimeoutError as exc:
+            state.mark_blocked(
+                f"run start timed out after {self.run_start_timeout_seconds:.0f}s",
+                tool_name="run_starter",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=str(exc) or state.last_error)
+        except Exception as exc:
+            state.run_start_attempted = False
+            state.mark_failed(f"run start failed: {exc}", tool_name="run_starter")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
+        state.run_session_id = _optional_str(run_meta.get("session_id"))
+        run_subagent = (
+            run_meta.get("_subagent") if isinstance(run_meta.get("_subagent"), dict) else None
+        )
+        state.run_subagent = run_subagent or {}
+        if not any((state.job_id, state.execution_id, state.run_session_id)):
+            state.run_start_attempted = False
+            state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
+        state.transition(
+            AutoPhase.COMPLETE,
+            f"execution started for grade {state.last_grade or state.required_grade} Seed",
+        )
+        self._save(state)
+        return self._result(state, ledger, review=review, run_subagent=run_subagent)
+
+    def _result(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        review: SeedReview | None = None,
+        blocker: str | None = None,
+        run_subagent: dict[str, Any] | None = None,
+    ) -> AutoPipelineResult:
+        return AutoPipelineResult(
+            status=state.phase.value,
+            auto_session_id=state.auto_session_id,
+            phase=state.phase.value,
+            grade=review.grade_result.grade.value if review else state.last_grade,
+            seed_path=state.seed_path,
+            interview_session_id=state.interview_session_id,
+            execution_id=state.execution_id,
+            job_id=state.job_id,
+            run_session_id=state.run_session_id,
+            run_subagent=run_subagent or state.run_subagent or None,
+            assumptions=tuple(ledger.assumptions()),
+            non_goals=tuple(ledger.non_goals()),
+            blocker=blocker or state.last_error,
+        )
+
+    def _save(self, state: AutoPipelineState) -> None:
+        if self.store is not None:
+            self.store.save(state)
+
+
+def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:
+    state.seed_artifact = {}
+    if state.phase in {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}:
+        now = utc_now_iso()
+        state.phase = AutoPhase.FAILED
+        state.phase_started_at = now
+        state.last_progress_at = now
+        state.updated_at = now
+        state.last_tool_name = "auto_pipeline"
+        state.last_progress_message = message
+        state.last_error = message
+        return
+    state.mark_failed(message, tool_name="auto_pipeline")
+
+
+def _grade_meets_required(actual: str | None, required: str) -> bool:
+    rank = {"A": 0, "B": 1, "C": 2}
+    if actual not in rank or required not in rank:
+        return False
+    return rank[actual] <= rank[required]
+
+
+def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
+    if tool_name in {"interview.start", "interview.resume", "interview.answer", "auto_answerer"}:
+        return AutoPhase.INTERVIEW
+    if tool_name == "seed_generator":
+        return AutoPhase.SEED_GENERATION
+    if tool_name in {"seed_saver", "grade_gate", "seed_loader"}:
+        return AutoPhase.REVIEW
+    if tool_name == "run_starter":
+        return AutoPhase.RUN
+    return None
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -183,11 +183,8 @@ class AutoPipeline:
             and self.seed_loader is not None
             and state.seed_path
         ):
-            try:
-                seed = self.seed_loader(state.seed_path)
-            except Exception as exc:
-                state.mark_failed(f"seed load failed: {exc}", tool_name="seed_loader")
-                self._save(state)
+            seed = self._load_seed(state, state.seed_path)
+            if seed is None:
                 return self._result(state, ledger, blocker=state.last_error)
         elif state.seed_artifact:
             try:
@@ -200,11 +197,8 @@ class AutoPipeline:
                 self._save(state)
                 return self._result(state, ledger, blocker=state.last_error)
         elif self.seed_loader is not None and state.seed_path:
-            try:
-                seed = self.seed_loader(state.seed_path)
-            except Exception as exc:
-                state.mark_failed(f"seed load failed: {exc}", tool_name="seed_loader")
-                self._save(state)
+            seed = self._load_seed(state, state.seed_path)
+            if seed is None:
                 return self._result(state, ledger, blocker=state.last_error)
         else:
             state.mark_blocked(
@@ -341,6 +335,26 @@ class AutoPipeline:
         )
         self._save(state)
         return self._result(state, ledger, review=review, run_subagent=run_subagent)
+
+    def _load_seed(self, state: AutoPipelineState, seed_path: str) -> Seed | None:
+        if self.seed_loader is None:
+            state.mark_failed("seed loader is not configured", tool_name="seed_loader")
+            self._save(state)
+            return None
+        try:
+            seed = self.seed_loader(seed_path)
+        except Exception as exc:
+            state.mark_failed(f"seed load failed: {exc}", tool_name="seed_loader")
+            self._save(state)
+            return None
+        if not isinstance(seed, Seed):
+            state.mark_failed(
+                f"seed loader returned {type(seed).__name__}, expected Seed",
+                tool_name="seed_loader",
+            )
+            self._save(state)
+            return None
+        return seed
 
     def _result(
         self,

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -1,0 +1,190 @@
+"""Bounded repair loop for auto-generated Seeds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+import re
+from uuid import uuid4
+
+from ouroboros.auto.grading import VAGUE_TERMS, SeedGrade
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
+from ouroboros.core.seed import Seed
+
+
+@dataclass(frozen=True, slots=True)
+class RepairResult:
+    """Result from one repair attempt."""
+
+    changed: bool
+    seed: Seed
+    applied_repairs: tuple[str, ...] = ()
+    unresolved_findings: tuple[ReviewFinding, ...] = ()
+    blocker: str | None = None
+
+
+@dataclass(slots=True)
+class SeedRepairer:
+    """Deterministically repair common A-grade failures."""
+
+    reviewer: SeedReviewer = field(default_factory=SeedReviewer)
+    max_repair_rounds: int = 5
+
+    def repair_once(
+        self,
+        seed: Seed,
+        review: SeedReview,
+        *,
+        ledger: SeedDraftLedger | None = None,
+    ) -> RepairResult:
+        """Apply one deterministic repair pass."""
+        if review.grade_result.blockers:
+            return RepairResult(
+                changed=False,
+                seed=seed,
+                unresolved_findings=review.findings,
+                blocker="hard blocker present in Seed review",
+            )
+
+        constraints = list(seed.constraints)
+        acceptance = list(seed.acceptance_criteria)
+        applied: list[str] = []
+        unresolved: list[ReviewFinding] = []
+        repaired_acceptance_indices: set[int] = set()
+
+        for finding in review.findings:
+            if finding.code in {"vague_acceptance_criteria", "untestable_acceptance_criteria"}:
+                index = _target_index(finding.target)
+                if index is not None and index < len(acceptance):
+                    if index not in repaired_acceptance_indices:
+                        acceptance[index] = _observable_preserving_replacement(
+                            acceptance[index], index=index
+                        )
+                        repaired_acceptance_indices.add(index)
+                else:
+                    acceptance.append(
+                        "A command/API check returns stable observable output or artifacts proving the task goal."
+                    )
+                applied.append(finding.fingerprint)
+            elif finding.code == "missing_acceptance_criteria":
+                acceptance.append(
+                    "A command/API check returns stable observable output or artifacts proving the task goal."
+                )
+                applied.append(finding.fingerprint)
+            elif finding.code == "missing_constraints":
+                constraints.append(
+                    "Use existing project patterns and avoid new dependencies unless required by acceptance criteria."
+                )
+                applied.append(finding.fingerprint)
+            elif finding.code == "missing_non_goals" and ledger is not None:
+                ledger.add_entry(
+                    "non_goals",
+                    LedgerEntry(
+                        key="non_goals.auto_mvp",
+                        value=_safe_auto_mvp_non_goal(ledger),
+                        source=LedgerSource.NON_GOAL,
+                        confidence=0.86,
+                        status=LedgerStatus.DEFAULTED,
+                        rationale="Repair loop bounded scope without contradicting the requested goal.",
+                    ),
+                )
+                applied.append(finding.fingerprint)
+            else:
+                unresolved.append(finding)
+
+        changed = bool(applied)
+        updated_seed = seed
+        if changed:
+            updated_seed = seed.model_copy(
+                update={
+                    "constraints": tuple(dict.fromkeys(constraints)),
+                    "acceptance_criteria": tuple(dict.fromkeys(acceptance)),
+                    "metadata": seed.metadata.model_copy(
+                        update={
+                            "seed_id": f"seed_{uuid4().hex[:12]}",
+                            "created_at": datetime.now(UTC),
+                            "parent_seed_id": seed.metadata.seed_id,
+                        }
+                    ),
+                }
+            )
+        return RepairResult(
+            changed=changed,
+            seed=updated_seed,
+            applied_repairs=tuple(applied),
+            unresolved_findings=tuple(unresolved),
+        )
+
+    def converge(
+        self, seed: Seed, *, ledger: SeedDraftLedger | None = None
+    ) -> tuple[Seed, SeedReview, list[RepairResult]]:
+        """Review/repair until A-grade or bounded stop."""
+        history: list[RepairResult] = []
+        previous_high_fingerprints: set[str] = set()
+        current = seed
+        review = self.reviewer.review(current, ledger=ledger)
+        for _ in range(self.max_repair_rounds):
+            if review.grade_result.grade == SeedGrade.A and review.may_run:
+                return current, review, history
+            high = {
+                finding.fingerprint for finding in review.findings if finding.severity == "high"
+            }
+            repair = self.repair_once(current, review, ledger=ledger)
+            history.append(repair)
+            if repair.blocker or not repair.changed:
+                return current, review, history
+            current = repair.seed
+            if high and high == previous_high_fingerprints:
+                review = self.reviewer.review(current, ledger=ledger)
+                return current, review, history
+            previous_high_fingerprints = high
+            review = self.reviewer.review(current, ledger=ledger)
+        return current, review, history
+
+
+def _observable_preserving_replacement(criterion: str, *, index: int) -> str:
+    """Make a criterion observable without erasing the original feature subject."""
+    normalized = criterion.strip().rstrip(".")
+    for term in VAGUE_TERMS:
+        normalized = re.sub(rf"\b{re.escape(term)}\b", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\b(should be|is|are|be)\b", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\s+(and|or)\s*$", "", normalized.strip(), flags=re.IGNORECASE)
+    normalized = re.sub(r"\s{2,}", " ", normalized).strip().strip("-:;,. ").strip()
+    subject = normalized or f"acceptance criterion {index + 1}"
+    return (
+        "A command/API check returns stable observable output or artifacts "
+        f"proving the original requirement for {subject}."
+    )
+
+
+def _target_index(target: str) -> int | None:
+    if "[" not in target or "]" not in target:
+        return None
+    try:
+        return int(target.split("[", 1)[1].split("]", 1)[0])
+    except ValueError:
+        return None
+
+
+def _safe_auto_mvp_non_goal(ledger: SeedDraftLedger) -> str:
+    goal = _latest_resolved_goal(ledger).lower()
+    excluded = ["cloud sync", "paid services"]
+    if not re.search(r"\b(auth|authentication|login|sign[- ]?in|signup|password)\b", goal):
+        excluded.append("authentication")
+    if not re.search(r"\b(production|prod|deploy|deployment|release|publish)\b", goal):
+        excluded.append("production deployment")
+    if not excluded:
+        return "No scope outside the explicitly requested goal is included in auto MVP scope."
+    return f"For auto MVP scope, {', '.join(excluded)} are non-goals unless explicitly requested."
+
+
+def _latest_resolved_goal(ledger: SeedDraftLedger) -> str:
+    section = ledger.sections.get("goal")
+    if section is None:
+        return ""
+    inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    for entry in reversed(section.entries):
+        if entry.status not in inactive and entry.value.strip():
+            return entry.value
+    return ""

--- a/src/ouroboros/auto/seed_reviewer.py
+++ b/src/ouroboros/auto/seed_reviewer.py
@@ -1,0 +1,70 @@
+"""Adversarial review primitives for auto-generated Seeds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+
+from ouroboros.auto.grading import GradeGate, GradeResult
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.core.seed import Seed
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewFinding:
+    """Stable review finding used by repair convergence guards."""
+
+    code: str
+    target: str
+    severity: str
+    message: str
+    repair_instruction: str
+    fingerprint: str
+
+    @classmethod
+    def from_parts(
+        cls,
+        *,
+        code: str,
+        target: str,
+        severity: str,
+        message: str,
+        repair_instruction: str,
+    ) -> ReviewFinding:
+        raw = f"{code}|{target}|{message}|{repair_instruction}"
+        fingerprint = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+        return cls(code, target, severity, message, repair_instruction, fingerprint)
+
+
+@dataclass(frozen=True, slots=True)
+class SeedReview:
+    """Review result with grade and stable findings."""
+
+    grade_result: GradeResult
+    findings: tuple[ReviewFinding, ...]
+
+    @property
+    def may_run(self) -> bool:
+        return self.grade_result.may_run
+
+
+class SeedReviewer:
+    """Review Seeds using deterministic GradeGate findings."""
+
+    def __init__(self, grade_gate: GradeGate | None = None) -> None:
+        self.grade_gate = grade_gate or GradeGate()
+
+    def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:
+        """Return structured review findings for ``seed``."""
+        grade = self.grade_gate.grade_seed(seed, ledger=ledger)
+        findings = tuple(
+            ReviewFinding.from_parts(
+                code=finding.code,
+                target=finding.target,
+                severity=finding.severity,
+                message=finding.message,
+                repair_instruction=finding.repair_instruction,
+            )
+            for finding in [*grade.findings, *grade.blockers]
+        )
+        return SeedReview(grade_result=grade, findings=findings)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -371,7 +371,7 @@ async def test_interview_resume_backend_error_blocks_and_persists(tmp_path) -> N
 
     assert result.status == "blocked"
     assert state.phase == AutoPhase.BLOCKED
-    assert "resume/start failed" in (result.blocker or "")
+    assert "interview resume failed" in (result.blocker or "")
 
 
 @pytest.mark.asyncio
@@ -1715,3 +1715,84 @@ async def test_pipeline_run_resume_rejects_grade_b_when_required_grade_a(tmp_pat
 
     assert result.status == "blocked"
     assert "persisted grade" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_blocker_does_not_consume_pending_final_round(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should use the persisted pending question")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("blocked auto answer should not reach backend")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.pending_question = "Should we use a billing provider for the live account?"
+    state.current_round = 1
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=2
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert result.rounds == 1
+    assert state.current_round == 1
+    assert state.pending_question == "Should we use a billing provider for the live account?"
+    persisted = AutoStore(tmp_path).load(state.auto_session_id)
+    assert persisted.current_round == 1
+    assert persisted.pending_question == state.pending_question
+
+
+@pytest.mark.asyncio
+async def test_interview_resume_backend_error_uses_resume_tool_name(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not start a new interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer without a question")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "resume interview")
+    state.interview_session_id = "interview_1"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "interview resume failed" in (result.blocker or "")
+    assert state.last_tool_name == "interview.resume"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_loader_rejects_non_seed_on_review_resume(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("review resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("review resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("review resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_path = str(tmp_path / "seed.yaml")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        seed_loader=lambda path: {"path": path},  # type: ignore[return-value]
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "seed loader returned dict, expected Seed" in (result.blocker or "")
+    assert state.last_tool_name == "seed_loader"

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1,0 +1,1717 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ouroboros.auto.grading import GradeResult, SeedGrade
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.seed_repairer import SeedRepairer
+from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _fill_ready(ledger: SeedDraftLedger) -> None:
+    for section, value in {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }.items():
+        source = (
+            LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        )
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=source,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+
+def _seed(
+    ac: tuple[str, ...] = ("`habit list` prints stable stdout containing created habits",),
+) -> Seed:
+    return Seed(
+        goal="Build a local CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=ac,
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior"),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert "unresolved gaps" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_on_backend_timeout(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        await asyncio.sleep(0.05)
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        timeout_seconds=0.001,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "timed out" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed(ac=("The CLI should be easy and user-friendly",))
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        return {"job_id": "job_1", "execution_id": "exec_1", "session_id": "session_1"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    repaired_acceptance = state.seed_artifact["acceptance_criteria"][0]
+    assert "The CLI" in repaired_acceptance
+    assert "stable observable output" in repaired_acceptance
+    assert (
+        repaired_acceptance
+        != "A command/API check returns stable observable output or artifacts proving this requirement."
+    )
+    assert result.job_id == "job_1"
+    assert result.run_session_id == "session_1"
+    assert state.execution_id == "exec_1"
+    assert state.run_session_id == "session_1"
+
+
+def test_seed_repairer_rewrites_each_acceptance_criterion_once() -> None:
+    seed = _seed(ac=("The CLI should be easy and user-friendly",))
+    ledger = SeedDraftLedger.from_goal(seed.goal)
+    _fill_ready(ledger)
+    review = SeedReviewer().review(seed, ledger=ledger)
+
+    result = SeedRepairer().repair_once(seed, review, ledger=ledger)
+
+    assert result.changed
+    repaired_acceptance = result.seed.acceptance_criteria[0]
+    assert repaired_acceptance.count("original requirement for") == 1
+    assert "The CLI" in repaired_acceptance
+    assert "original requirement for A command/API check" not in repaired_acceptance
+
+
+def test_seed_repairer_assigns_new_seed_identity_after_mutation() -> None:
+    seed = _seed(ac=("The CLI should be easy and user-friendly",))
+    ledger = SeedDraftLedger.from_goal(seed.goal)
+    _fill_ready(ledger)
+    review = SeedReviewer().review(seed, ledger=ledger)
+
+    result = SeedRepairer().repair_once(seed, review, ledger=ledger)
+
+    assert result.changed
+    assert result.seed.metadata.seed_id != seed.metadata.seed_id
+    assert result.seed.metadata.parent_seed_id == seed.metadata.seed_id
+
+
+def test_seed_repairer_non_goals_do_not_contradict_goal_scope() -> None:
+    seed = _seed()
+    ledger = SeedDraftLedger.from_goal("Add authentication and deploy this service to production")
+    finding = ReviewFinding.from_parts(
+        code="missing_non_goals",
+        target="non_goals",
+        severity="medium",
+        message="Auto-generated Seed has no explicit non-goals",
+        repair_instruction="Add MVP non-goals to bound scope.",
+    )
+    review = SeedReview(
+        grade_result=GradeResult(
+            grade=SeedGrade.B,
+            scores={
+                "coverage": 0.8,
+                "ambiguity": 0.1,
+                "testability": 0.9,
+                "execution_feasibility": 0.9,
+                "risk": 0.1,
+            },
+            findings=[],
+            blockers=[],
+            may_run=False,
+        ),
+        findings=(finding,),
+    )
+
+    result = SeedRepairer().repair_once(seed, review, ledger=ledger)
+
+    assert result.changed
+    non_goals = ledger.non_goals()
+    assert non_goals
+    assert "authentication" not in non_goals[0].lower()
+    assert "production deployment" not in non_goals[0].lower()
+
+
+def test_seed_repairer_converge_returns_latest_repair_when_high_findings_repeat() -> None:
+    original_seed_id: str | None = None
+    finding = ReviewFinding.from_parts(
+        code="vague_acceptance_criteria",
+        target="acceptance_criteria[0]",
+        severity="high",
+        message="Still vague",
+        repair_instruction="Make it observable.",
+    )
+
+    class RepeatingReviewer:
+        def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002
+            coverage = 0.1 if seed.metadata.seed_id == original_seed_id else 0.9
+            return SeedReview(
+                grade_result=GradeResult(
+                    grade=SeedGrade.B,
+                    scores={
+                        "coverage": coverage,
+                        "ambiguity": 0.2,
+                        "testability": 0.5,
+                        "execution_feasibility": 0.8,
+                        "risk": 0.1,
+                    },
+                    findings=[],
+                    blockers=[],
+                    may_run=False,
+                ),
+                findings=(finding,),
+            )
+
+    seed = _seed(ac=("The CLI should be easy and user-friendly",))
+    original_seed_id = seed.metadata.seed_id
+    repaired, final_review, history = SeedRepairer(
+        reviewer=RepeatingReviewer(), max_repair_rounds=3
+    ).converge(seed)
+
+    assert history
+    assert repaired == history[-1].seed
+    assert repaired != seed
+    assert final_review.grade_result.scores["coverage"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    assert result.job_id is None
+
+
+@pytest.mark.asyncio
+async def test_interview_resume_uses_persisted_pending_question(tmp_path) -> None:
+    calls: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not start a new interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        calls.append(text)
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "resume interview")
+    state.interview_session_id = "interview_1"
+    state.pending_question = "What should we verify?"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert calls
+    assert "Continue from persisted" not in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_non_interview_resume_blocks_without_seed_artifact(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("pipeline should not re-enter interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("pipeline should not re-enter interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("review resume without seed artifact should block")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "without persisted Seed artifact" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_resume_backend_error_blocks_and_persists(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not start a new interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer without a question")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "resume interview")
+    state.interview_session_id = "interview_1"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert "resume/start failed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generator_error_marks_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise RuntimeError("generator exploded")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "seed generation failed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_starter_error_marks_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise RuntimeError("runner exploded")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "run start failed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_serializes_blocking_review_findings(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed(ac=("The command uses clean architecture",))
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    class BlockingRepairer:
+        def converge(
+            self, seed: Seed, *, ledger: SeedDraftLedger
+        ) -> tuple[Seed, SeedReview, list[object]]:  # noqa: ARG002
+            finding = ReviewFinding.from_parts(
+                code="still_vague",
+                target="acceptance_criteria[0]",
+                severity="high",
+                message="Still not observable",
+                repair_instruction="Make it observable.",
+            )
+            review = SeedReview(
+                grade_result=GradeResult(
+                    grade=SeedGrade.B,
+                    scores={
+                        "coverage": 0.8,
+                        "ambiguity": 0.3,
+                        "testability": 0.4,
+                        "execution_feasibility": 0.8,
+                        "risk": 0.2,
+                    },
+                    findings=[],
+                    blockers=[],
+                    may_run=False,
+                ),
+                findings=(finding,),
+            )
+            return seed, review, []
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(
+        driver, generate_seed, store=AutoStore(tmp_path), repairer=BlockingRepairer(), skip_run=True
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.findings
+    assert "fingerprint" in state.findings[0]
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_when_backend_never_marks_ready(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("Another question", session_id, seed_ready=False, completed=False)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "before backend marked" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_review_from_persisted_seed_artifact(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_completed_interview_without_reanswering(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not restart")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not answer again")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.interview_completed = True
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_refuses_duplicate_unknown_run_resume(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("unknown run resume should not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.run_start_attempted = True
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "duplicate execution" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_run_start_without_tracking_handle(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        return {"job_id": None, "execution_id": None}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "tracking handle" in (result.blocker or "")
+    assert state.phase == AutoPhase.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_run_with_persisted_handle_without_restarting(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("persisted run handle should not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.job_id = "job_existing"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.job_id == "job_existing"
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_persists_blocker_ledger_entry(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What API key should the workflow use?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("blocker should stop before backend answer")
+
+    state = AutoPipelineState(goal="Deploy a service", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.ledger
+    persisted = SeedDraftLedger.from_dict(state.ledger)
+    assert any(
+        entry.status == LedgerStatus.BLOCKED for entry in persisted.sections["constraints"].entries
+    )
+    assert persisted.question_history
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_completed_interview_without_session_id(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not restart")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("missing interview session should not generate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_completed = True
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "interview_session_id" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_repair_phase_through_review(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("repair resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("repair resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("repair resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.REPAIR, "repair")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_when_backend_completes_before_ledger_ready(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=3
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "completed before auto ledger was ready" in (result.blocker or "")
+    assert state.phase == AutoPhase.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_steers_generic_questions_to_open_gaps(tmp_path) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        completed = len(answers) >= 5
+        return InterviewTurn("What else should we know?", session_id, completed=completed)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=6
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert ledger.is_seed_ready()
+    assert any("single local user" in item.lower() for item in answers)
+    assert any("non-goals" in item.lower() or "non-goal" in item.lower() for item in answers)
+    assert any("runtime" in item.lower() for item in answers)
+
+
+def test_auto_state_rejects_malformed_resume_optional_fields() -> None:
+    base = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project").to_dict()
+    base["pending_question"] = []
+
+    with pytest.raises(ValueError, match="pending_question"):
+        AutoPipelineState.from_dict(base)
+
+    base = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project").to_dict()
+    base["interview_completed"] = "yes"
+
+    with pytest.raises(ValueError, match="interview_completed"):
+        AutoPipelineState.from_dict(base)
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_does_not_persist_completion_as_pending_question(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.interview_completed is True
+    assert state.pending_question is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_completed_interview_with_unresolved_ledger(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not restart")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("unresolved completed interview should not generate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.interview_completed = True
+    state.ledger = SeedDraftLedger.from_goal(state.goal).to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "unresolved ledger gaps" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_marks_malformed_seed_generator_result_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not restart")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not answer")
+
+    async def generate_seed(session_id: str):  # noqa: ANN202, ARG001
+        return {"not": "a seed"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.interview_completed = True
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "expected Seed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_marks_malformed_run_starter_result_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed):  # noqa: ANN202, ARG001
+        return ["not", "metadata"]
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "expected dict" in (result.blocker or "")
+    assert state.run_start_attempted is False
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_duplicate_run_after_start_timeout(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    calls = 0
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return {"job_id": "job_after_timeout", "execution_id": "exec_after_timeout"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        run_start_timeout_seconds=0.001,
+    )
+
+    first = await pipeline.run(state)
+    pipeline.run_start_timeout_seconds = 1
+    second = await pipeline.run(state)
+
+    assert first.status == "blocked"
+    assert state.run_start_attempted is True
+    assert second.status == "blocked"
+    assert "duplicate execution" in (second.blocker or "")
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_retries_after_malformed_run_starter_metadata(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    calls = 0
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return {}
+        return {"job_id": "job_after_retry", "execution_id": "exec_after_retry"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    first = await pipeline.run(state)
+    second = await pipeline.run(state)
+
+    assert first.status == "blocked"
+    assert state.run_start_attempted is True
+    assert second.status == "complete"
+    assert second.job_id == "job_after_retry"
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_malformed_backend_turn(tmp_path) -> None:
+    async def start(goal: str, cwd: str):  # noqa: ANN202, ARG001
+        return {"question": "not a turn"}
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("malformed start should not answer")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "expected InterviewTurn" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_clears_pending_question_before_backend_answer(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        persisted = store.load(state.auto_session_id)
+        assert persisted.pending_question is None
+        assert persisted.last_tool_name == "auto_answerer"
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=store, max_rounds=1)
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.pending_question is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_returns_structured_failure_for_terminal_malformed_seed_artifact(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("terminal resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("terminal resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("terminal resume should not generate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = {"goal": "missing required seed fields"}
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.COMPLETE, "complete")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "persisted Seed artifact is invalid" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generation_resume_uses_persisted_seed_artifact(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("persisted seed artifact should not regenerate")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.seed_id = "seed_existing"
+    state.seed_artifact = _seed().to_dict()
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_prepared_run_before_first_attempt(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        return {"job_id": "job_after_resume", "execution_id": "exec_after_resume"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.last_grade = "A"
+    state.transition(AutoPhase.RUN, "run prepared")
+    state.run_start_attempted = False
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.job_id == "job_after_resume"
+    assert state.run_start_attempted is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_persists_seed_path_before_skip_run(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    saved: list[str] = []
+
+    def save(seed: Seed) -> str:
+        path = str(tmp_path / f"{seed.metadata.seed_id}.yaml")
+        saved.append(path)
+        return path
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(
+        driver, generate_seed, store=AutoStore(tmp_path), seed_saver=save, skip_run=True
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.seed_path == saved[0]
+    assert state.seed_path == saved[0]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_blocked_seed_generation(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.mark_blocked("seed generation timed out", tool_name="seed_generator")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_resume_rechecks_persisted_ledger_before_execution(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("unresolved ledger must not start execution")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "clear the Seed for execution" in (result.blocker or "")
+    assert result.grade == "C"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_refuses_run_resume_without_a_grade(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("non-A run resume must not start execution")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "B"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "persisted grade" in (result.blocker or "")
+    assert state.job_id is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generation_resume_requires_interview_session_id(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("missing interview session should fail before generator")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "interview_session_id" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_refuses_blocked_run_start_replay_from_seed_path(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("unknown run resume should not generate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("ambiguous run start resume should not start another run")
+
+    seed = _seed()
+    seed_path = str(tmp_path / "seed.yaml")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_path = seed_path
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.mark_blocked("run start timed out", tool_name="run_starter")
+    state.run_start_attempted = True
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_loader=lambda path: (
+            seed if path == seed_path else (_ for _ in ()).throw(AssertionError(path))
+        ),
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "duplicate execution" in (result.blocker or "")
+    assert result.job_id is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_recovers_auto_answerer_block_to_interview(tmp_path) -> None:
+    calls: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not start a new interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        calls.append(text)
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.pending_question = "What should we verify?"
+    state.mark_blocked("needs human authority", tool_name="auto_answerer")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert calls
+
+
+@pytest.mark.asyncio
+async def test_pipeline_replays_persisted_run_subagent_after_complete_resume(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed) -> dict[str, object]:  # noqa: ARG001
+        return {
+            "session_id": "session_1",
+            "_subagent": {"tool_name": "ouroboros_execute_seed", "context": {"seed": "x"}},
+        }
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    first = await pipeline.run(state)
+    resumed = await pipeline.run(state)
+
+    assert first.status == "complete"
+    assert first.run_subagent == {"tool_name": "ouroboros_execute_seed", "context": {"seed": "x"}}
+    assert state.run_subagent == first.run_subagent
+    assert resumed.run_subagent == first.run_subagent
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_save_error_marks_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    def save(seed: Seed) -> str:  # noqa: ARG001
+        raise OSError("disk full")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(
+        driver, generate_seed, store=AutoStore(tmp_path), seed_saver=save, skip_run=True
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "seed save failed" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_seed_saver_failure_from_review(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    seed = _seed()
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = seed.to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.mark_failed("seed save failed: disk full", tool_name="seed_saver")
+    saved: list[str] = []
+
+    def save(recovered: Seed) -> str:
+        saved.append(recovered.metadata.seed_id)
+        return str(tmp_path / "seed.yaml")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver, generate_seed, store=AutoStore(tmp_path), seed_saver=save, skip_run=True
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert saved == [seed.metadata.seed_id]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_grade_gate_resume_prefers_repaired_seed_path(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    stale_seed = _seed(ac=("The CLI should be easy and user-friendly",))
+    repaired_seed = _seed()
+    seed_path = str(tmp_path / "seed.yaml")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = stale_seed.to_dict()
+    state.seed_path = seed_path
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.mark_blocked("Seed did not reach A-grade", tool_name="grade_gate")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        seed_loader=lambda path: (
+            repaired_seed if path == seed_path else (_ for _ in ()).throw(AssertionError(path))
+        ),
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    assert state.seed_artifact == repaired_seed.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_review_resume_marks_malformed_seed_artifact_failed(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("review resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("review resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("review resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.seed_artifact = {"goal": "missing required fields"}
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert "persisted Seed artifact is invalid" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_does_not_send_synthetic_gap_answer_to_specific_prompt(
+    tmp_path,
+) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What output format should the export command write?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        return InterviewTurn("done", session_id, completed=True)
+
+    state = AutoPipelineState(goal="Build an export command", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert answers
+    assert "single local user" not in answers[0].lower()
+    assert "non-goals" not in answers[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_accepts_initial_completed_turn_without_answering(tmp_path) -> None:
+    answered = False
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("already complete", "interview_done", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        nonlocal answered
+        answered = True
+        raise AssertionError("completed initial turn should not be answered")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert result.rounds == 0
+    assert state.interview_completed is True
+    assert state.pending_question is None
+    assert not answered
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_does_not_replace_specific_verification_answer_with_gap_prompt(
+    tmp_path,
+) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        return InterviewTurn("done", session_id, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert answers
+    assert "observable behavior" in answers[0].lower()
+    assert "single local user" not in answers[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_recovers_seed_loader_failure_from_review(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    stale_seed = _seed(ac=("The CLI should be easy and user-friendly",))
+    repaired_seed = _seed()
+    seed_path = str(tmp_path / "seed.yaml")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = stale_seed.to_dict()
+    state.seed_path = seed_path
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.mark_failed("seed load failed: transient parse error", tool_name="seed_loader")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        seed_loader=lambda path: (
+            repaired_seed if path == seed_path else (_ for _ in ()).throw(AssertionError(path))
+        ),
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    assert state.seed_artifact == repaired_seed.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_resume_requires_may_run_even_when_required_grade_is_b(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("B-grade Seed with may_run=false must not start execution")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.required_grade = "B"
+    state.last_grade = "B"
+    state.seed_artifact = _seed(ac=("The CLI should be easy and user-friendly",)).to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "clear the Seed for execution" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_run_resume_rejects_grade_b_when_required_grade_a(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("run resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("run resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("grade B must not run when required grade is A")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.required_grade = "A"
+    state.last_grade = "B"
+    state.seed_artifact = _seed(ac=("The CLI should be easy and user-friendly",)).to_dict()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run prepared")
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "persisted grade" in (result.blocker or "")


### PR DESCRIPTION
## Summary
- Adds the bounded auto supervisor loop on top of the core quality primitives.
- Includes the interview driver, seed reviewer, repair loop, run gating, resume state handling, and supervisor tests.
- Incorporates the prior bot design-note fixes: safety-first run gates, ledger-aware resume review, timeout duplicate-run guard, and matching seed/review on repeated repairs.

## Stack
Base: #565 / `split/ooo-auto-core-quality`

1. #565 — core quality primitives
2. #566 — bounded supervisor loop
3. #567 — CLI/MCP/skill surface
4. #568 — user documentation

## Validation
- `uv run ruff format --check src/ouroboros/auto tests/unit/auto`
- `uv run ruff check src/ouroboros/auto tests/unit/auto`
- `uv run pytest tests/unit/auto -q`
- `uv run mypy src/ouroboros/auto`

Supersedes the supervisor portion of #553.
