### PR TITLE
fix(events): fail closed for invalid IO journal preview mode

### DIFF
--- a/src/ouroboros/events/io.py
+++ b/src/ouroboros/events/io.py
@@ -46,6 +46,7 @@ from typing import Any, Final
 from ouroboros.events.base import BaseEvent
 
 logger = logging.getLogger(__name__)
+_WARNED_INVALID_PRIVACY_VALUES: set[str] = set()
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -111,12 +112,14 @@ def get_privacy_mode() -> PrivacyMode:
     try:
         return PrivacyMode(raw)
     except ValueError:
-        logger.warning(
-            "Invalid %s=%r; falling back to %s to avoid preserving I/O previews",
-            PRIVACY_ENV_VAR,
-            configured,
-            PrivacyMode.OFF.value,
-        )
+        if raw not in _WARNED_INVALID_PRIVACY_VALUES:
+            _WARNED_INVALID_PRIVACY_VALUES.add(raw)
+            logger.warning(
+                "Invalid %s=%r; falling back to %s to avoid preserving I/O previews",
+                PRIVACY_ENV_VAR,
+                configured,
+                PrivacyMode.OFF.value,
+            )
         return PrivacyMode.OFF
 
 

--- a/src/ouroboros/events/io.py
+++ b/src/ouroboros/events/io.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 import hashlib
+import logging
 import os
 import re
 import secrets
@@ -43,6 +44,8 @@ import time
 from typing import Any, Final
 
 from ouroboros.events.base import BaseEvent
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -94,15 +97,27 @@ class PrivacyMode(StrEnum):
 def get_privacy_mode() -> PrivacyMode:
     """Resolve the active privacy mode from the environment.
 
-    Unknown values fall back to :attr:`PrivacyMode.ON`. The env var is
-    read on every call so tests can flip it without restarting the
-    process; this is fine because the read is `os.environ.get`-cheap.
+    Unset values preserve the cooperative-trust default
+    (:attr:`PrivacyMode.ON`). Explicit but unknown values fail closed to
+    :attr:`PrivacyMode.OFF` so a typo never preserves raw previews. The
+    env var is read on every call so tests can flip it without
+    restarting the process; this is fine because the read is
+    `os.environ.get`-cheap.
     """
-    raw = os.environ.get(PRIVACY_ENV_VAR, PrivacyMode.ON.value).lower()
+    configured = os.environ.get(PRIVACY_ENV_VAR)
+    if configured is None:
+        return PrivacyMode.ON
+    raw = configured.strip().lower()
     try:
         return PrivacyMode(raw)
     except ValueError:
-        return PrivacyMode.ON
+        logger.warning(
+            "Invalid %s=%r; falling back to %s to avoid preserving I/O previews",
+            PRIVACY_ENV_VAR,
+            configured,
+            PrivacyMode.OFF.value,
+        )
+        return PrivacyMode.OFF
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/events/test_io_events.py
+++ b/tests/unit/events/test_io_events.py
@@ -108,10 +108,23 @@ class TestPrivacyMode:
             assert get_privacy_mode() is mode
         monkeypatch.setenv(PRIVACY_ENV_VAR, "OFF")
         assert get_privacy_mode() is PrivacyMode.OFF
+        monkeypatch.setenv(PRIVACY_ENV_VAR, " redacted ")
+        assert get_privacy_mode() is PrivacyMode.REDACTED
 
-    def test_unknown_value_falls_back_to_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unknown_value_fails_closed_to_off(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         monkeypatch.setenv(PRIVACY_ENV_VAR, "loud")
-        assert get_privacy_mode() is PrivacyMode.ON
+        assert get_privacy_mode() is PrivacyMode.OFF
+        assert PRIVACY_ENV_VAR in caplog.text
+
+    def test_invalid_env_value_does_not_preserve_preview(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PRIVACY_ENV_VAR, "of")
+        assert shape_preview("SECRET prompt") is None
 
 
 class TestTruncatePreview:

--- a/tests/unit/events/test_io_events.py
+++ b/tests/unit/events/test_io_events.py
@@ -126,6 +126,24 @@ class TestPrivacyMode:
         monkeypatch.setenv(PRIVACY_ENV_VAR, "of")
         assert shape_preview("SECRET prompt") is None
 
+    def test_invalid_value_warns_once_per_normalised_value(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setenv(PRIVACY_ENV_VAR, " noisy ")
+        assert get_privacy_mode() is PrivacyMode.OFF
+        assert get_privacy_mode() is PrivacyMode.OFF
+        monkeypatch.setenv(PRIVACY_ENV_VAR, "NOISY")
+        assert get_privacy_mode() is PrivacyMode.OFF
+
+        warnings = [
+            record
+            for record in caplog.records
+            if "Invalid OUROBOROS_IO_JOURNAL_PREVIEWS" in record.message
+        ]
+        assert len(warnings) == 1
+
 
 class TestTruncatePreview:
     def test_short_text_passes_through(self) -> None:


### PR DESCRIPTION
## Summary

- normalize `OUROBOROS_IO_JOURNAL_PREVIEWS` with `strip().lower()`
- keep unset env defaulting to `on`
- fail closed to `off` for explicit invalid values and log a warning
- add coverage that invalid values do not preserve raw previews

Closes #580.

## Verification

- `uv run pytest tests/unit/events/test_io_events.py -q`
- `uv run pytest tests/unit/events/test_io_recorder.py -q`
- `uv run ruff check src/ouroboros/events/io.py tests/unit/events/test_io_events.py`
