### PR TITLE
fix(orchestrator): own ControlBus shutdown lifecycle

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -36,7 +36,7 @@ from ouroboros.mcp.types import (
     ToolInputType,
 )
 from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
-from ouroboros.orchestrator.control_bus import ControlBus
+from ouroboros.orchestrator.control_bus import ControlBus, ControlBusDrainError
 
 log = structlog.get_logger(__name__)
 
@@ -721,6 +721,12 @@ class MCPServerAdapter:
             if callable(close_fn):
                 try:
                     await close_fn()
+                except ControlBusDrainError:
+                    log.error(
+                        "mcp.server.control_bus_close_failed",
+                        resource=type(resource).__name__,
+                    )
+                    raise
                 except Exception as exc:
                     log.warning(
                         "mcp.server.resource_close_failed",

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1467,24 +1467,27 @@ def create_ouroboros_server(
         rate_limit_config=rate_limit_config,
     )
 
-    # The server owns the shared event store lifecycle
-    server.register_owned_resource(event_store)
-    if brownfield_store is not None:
-        server.register_owned_resource(brownfield_store)
-
     # Build the AgentRuntimeContext that #474 funnels through every
     # handler. For now the context only exposes the EventStore, the
     # backend labels, the optional MCP bridge, and a fresh ControlBus
     # for #515. Subsequent migration slices move handler internals to
     # consume context.mcp_bridge directly instead of self.mcp_manager.
+    control_bus = ControlBus()
     agent_runtime_context = AgentRuntimeContext(
         event_store=event_store,
         runtime_backend=resolved_runtime_backend,
         llm_backend=llm_backend,
         mcp_bridge=mcp_bridge,
-        control=ControlBus(),
+        control=control_bus,
     )
     server.set_runtime_context(agent_runtime_context)
+
+    # Close the reactive control surface before stores/bridges it may
+    # reference from subscriber tasks.
+    server.register_owned_resource(control_bus)
+    server.register_owned_resource(event_store)
+    if brownfield_store is not None:
+        server.register_owned_resource(brownfield_store)
 
     # Inject the bridge from the runtime context into every
     # BridgeAwareMixin handler. ``inject_runtime_context`` is byte-

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_CLOSE_TIMEOUT_S = 1.0
+DEFAULT_CANCEL_TIMEOUT_S = 0.1
 
 
 Predicate = Callable[["BaseEvent"], bool]
@@ -90,6 +91,7 @@ class ControlBus:
     _spawn: Callable[[Awaitable[None]], asyncio.Task[None]] | None = None
     _closed: bool = False
     _close_timeout_s: float | None = DEFAULT_CLOSE_TIMEOUT_S
+    _cancel_timeout_s: float | None = DEFAULT_CANCEL_TIMEOUT_S
 
     def subscribe(self, predicate: Predicate, handler: Handler) -> SubscriptionHandle:
         """Register *handler* to be invoked when *predicate* returns ``True``.
@@ -186,14 +188,23 @@ class ControlBus:
             return
         self._closed = True
         self._subscriptions.clear()
-        await self.drain(timeout=self._close_timeout_s)
+        await self.drain(
+            timeout=self._close_timeout_s,
+            cancel_timeout=self._cancel_timeout_s,
+        )
 
-    async def drain(self, *, timeout: float | None = DEFAULT_CLOSE_TIMEOUT_S) -> None:
+    async def drain(
+        self,
+        *,
+        timeout: float | None = DEFAULT_CLOSE_TIMEOUT_S,
+        cancel_timeout: float | None = DEFAULT_CANCEL_TIMEOUT_S,
+    ) -> None:
         """Await pending subscriber tasks, cancelling stragglers after *timeout*.
 
-        ``timeout=None`` waits indefinitely. Any task exceptions are
-        collected so drain itself remains a lifecycle cleanup primitive,
-        not a second error channel.
+        ``timeout=None`` waits indefinitely before cancellation.
+        ``cancel_timeout=None`` waits indefinitely after cancellation.
+        Any task exceptions are collected so drain itself remains a
+        lifecycle cleanup primitive, not a second error channel.
         """
         pending = tuple(task for task in self._tasks if not task.done())
         if not pending:
@@ -215,5 +226,21 @@ class ControlBus:
             )
             for task in still_pending:
                 task.cancel()
-            await asyncio.gather(*still_pending, return_exceptions=True)
+            if cancel_timeout is None:
+                await asyncio.gather(*still_pending, return_exceptions=True)
+            else:
+                cancelled_done, still_running = await asyncio.wait(
+                    still_pending,
+                    timeout=max(cancel_timeout, 0.0),
+                )
+                if cancelled_done:
+                    await asyncio.gather(*cancelled_done, return_exceptions=True)
+                if still_running:
+                    logger.error(
+                        "control_bus.cancel_timeout",
+                        extra={
+                            "pending_tasks": len(still_running),
+                            "timeout_s": cancel_timeout,
+                        },
+                    )
         self._tasks.difference_update(task for task in self._tasks if task.done())

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -53,6 +53,10 @@ Predicate = Callable[["BaseEvent"], bool]
 Handler = Callable[["BaseEvent"], Awaitable[None]]
 
 
+class ControlBusDrainError(RuntimeError):
+    """Raised when subscriber tasks refuse to quiesce during shutdown."""
+
+
 @dataclass(frozen=True, slots=True)
 class SubscriptionHandle:
     """Opaque token returned by :meth:`ControlBus.subscribe`.
@@ -243,4 +247,10 @@ class ControlBus:
                             "timeout_s": cancel_timeout,
                         },
                     )
+                    self._tasks.difference_update(task for task in self._tasks if task.done())
+                    msg = (
+                        f"{len(still_running)} ControlBus subscriber task(s) "
+                        "ignored cancellation during shutdown"
+                    )
+                    raise ControlBusDrainError(msg)
         self._tasks.difference_update(task for task in self._tasks if task.done())

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CLOSE_TIMEOUT_S = 1.0
+
 
 Predicate = Callable[["BaseEvent"], bool]
 Handler = Callable[["BaseEvent"], Awaitable[None]]
@@ -86,6 +88,8 @@ class ControlBus:
     _owner: object = field(default_factory=object)
     _tasks: set[asyncio.Task[None]] = field(default_factory=set)
     _spawn: Callable[[Awaitable[None]], asyncio.Task[None]] | None = None
+    _closed: bool = False
+    _close_timeout_s: float | None = DEFAULT_CLOSE_TIMEOUT_S
 
     def subscribe(self, predicate: Predicate, handler: Handler) -> SubscriptionHandle:
         """Register *handler* to be invoked when *predicate* returns ``True``.
@@ -102,6 +106,9 @@ class ControlBus:
             A :class:`SubscriptionHandle` accepted by
             :meth:`unsubscribe`.
         """
+        if self._closed:
+            msg = "Cannot subscribe to a closed ControlBus"
+            raise RuntimeError(msg)
         handle = SubscriptionHandle(_id=self._next_id, _owner=self._owner)
         self._next_id += 1
         self._subscriptions.append(
@@ -129,6 +136,12 @@ class ControlBus:
         A subscription whose predicate raises an exception is treated as
         non-matching for that event; the predicate is not unsubscribed.
         """
+        if self._closed:
+            logger.debug(
+                "control_bus.publish_after_close",
+                extra={"event_type": event.type},
+            )
+            return ()
         spawned: list[asyncio.Task[None]] = []
         for sub in tuple(self._subscriptions):
             try:
@@ -161,3 +174,46 @@ class ControlBus:
                 "control_bus.handler_raised",
                 extra={"event_type": event.type, "error": repr(exc)},
             )
+
+    async def close(self) -> None:
+        """Close the bus and drain in-flight subscriber tasks.
+
+        Shutdown is idempotent. Once closed, the bus rejects new
+        subscriptions and turns publishes into no-ops so server teardown
+        cannot fan out new work while owned resources are closing.
+        """
+        if self._closed and not self._tasks:
+            return
+        self._closed = True
+        self._subscriptions.clear()
+        await self.drain(timeout=self._close_timeout_s)
+
+    async def drain(self, *, timeout: float | None = DEFAULT_CLOSE_TIMEOUT_S) -> None:
+        """Await pending subscriber tasks, cancelling stragglers after *timeout*.
+
+        ``timeout=None`` waits indefinitely. Any task exceptions are
+        collected so drain itself remains a lifecycle cleanup primitive,
+        not a second error channel.
+        """
+        pending = tuple(task for task in self._tasks if not task.done())
+        if not pending:
+            self._tasks.difference_update(task for task in self._tasks if task.done())
+            return
+
+        if timeout is None:
+            await asyncio.gather(*pending, return_exceptions=True)
+            self._tasks.difference_update(task for task in self._tasks if task.done())
+            return
+
+        done, still_pending = await asyncio.wait(pending, timeout=max(timeout, 0.0))
+        if done:
+            await asyncio.gather(*done, return_exceptions=True)
+        if still_pending:
+            logger.warning(
+                "control_bus.drain_timeout",
+                extra={"pending_tasks": len(still_pending), "timeout_s": timeout},
+            )
+            for task in still_pending:
+                task.cancel()
+            await asyncio.gather(*still_pending, return_exceptions=True)
+        self._tasks.difference_update(task for task in self._tasks if task.done())

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -243,9 +243,7 @@ class ControlBus:
                     finished_after_wait = tuple(task for task in still_running if task.done())
                     if finished_after_wait:
                         await asyncio.gather(*finished_after_wait, return_exceptions=True)
-                    still_running = {
-                        task for task in still_running if not task.done()
-                    }
+                    still_running = {task for task in still_running if not task.done()}
                 if still_running:
                     logger.error(
                         "control_bus.cancel_timeout",

--- a/src/ouroboros/orchestrator/control_bus.py
+++ b/src/ouroboros/orchestrator/control_bus.py
@@ -240,6 +240,13 @@ class ControlBus:
                 if cancelled_done:
                     await asyncio.gather(*cancelled_done, return_exceptions=True)
                 if still_running:
+                    finished_after_wait = tuple(task for task in still_running if task.done())
+                    if finished_after_wait:
+                        await asyncio.gather(*finished_after_wait, return_exceptions=True)
+                    still_running = {
+                        task for task in still_running if not task.done()
+                    }
+                if still_running:
                     logger.error(
                         "control_bus.cancel_timeout",
                         extra={

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -30,7 +30,7 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
-from ouroboros.orchestrator.control_bus import ControlBus
+from ouroboros.orchestrator.control_bus import ControlBus, ControlBusDrainError
 
 
 class MockToolHandler:
@@ -1083,3 +1083,48 @@ async def test_server_shutdown_drains_runtime_control_bus() -> None:
     assert tasks[0].cancelled()
     assert bus._tasks == set()
     assert server._owned_resources == []
+
+
+@pytest.mark.asyncio
+async def test_server_shutdown_stops_before_dependents_when_control_bus_refuses_drain() -> None:
+    """Do not close dependent resources while control subscribers are still live."""
+    server = MCPServerAdapter()
+    bus = ControlBus(_close_timeout_s=0.01, _cancel_timeout_s=0.01)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _DependentResource:
+        closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    resource = _DependentResource()
+
+    async def stubborn(_event: BaseEvent) -> None:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            await release.wait()
+
+    server.register_owned_resource(bus)
+    server.register_owned_resource(resource)
+    bus.subscribe(lambda _event: True, stubborn)
+    tasks = bus.publish(
+        BaseEvent(
+            type="control.directive.emitted",
+            aggregate_type="lineage",
+            aggregate_id="lin_shutdown_probe",
+            data={"directive": "cancel"},
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=0.5)
+
+    with pytest.raises(ControlBusDrainError):
+        await asyncio.wait_for(server.shutdown(), timeout=0.5)
+
+    assert resource.closed is False
+
+    release.set()
+    await asyncio.wait_for(tasks[0], timeout=0.5)

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1,5 +1,6 @@
 """Tests for MCP server adapter."""
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from ouroboros.core.types import Result
+from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.errors import MCPResourceNotFoundError, MCPServerError
 from ouroboros.mcp.server.adapter import (
     VALID_TRANSPORTS,
@@ -28,6 +30,7 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
+from ouroboros.orchestrator.control_bus import ControlBus
 
 
 class MockToolHandler:
@@ -1031,7 +1034,8 @@ class TestCreateOuroborosServerBrownfieldStore:
             )
 
         assert captured_handler_kwargs["_store"] is mock_brownfield_store
-        assert server._owned_resources == [mock_event_store, mock_brownfield_store]
+        assert isinstance(server._owned_resources[0], ControlBus)
+        assert server._owned_resources[1:] == [mock_event_store, mock_brownfield_store]
 
 
 def test_create_ouroboros_server_retains_runtime_context() -> None:
@@ -1044,3 +1048,38 @@ def test_create_ouroboros_server_retains_runtime_context() -> None:
     assert server.runtime_context.runtime_backend == "codex"
     assert server.runtime_context.llm_backend == "claude_code"
     assert server.runtime_context.control is not None
+
+
+@pytest.mark.asyncio
+async def test_server_shutdown_drains_runtime_control_bus() -> None:
+    """Server-owned ControlBus must not leave subscriber tasks behind."""
+    from ouroboros.mcp.server.adapter import create_ouroboros_server
+
+    server = create_ouroboros_server(runtime_backend="codex", llm_backend="claude_code")
+    assert server.runtime_context is not None
+    bus = server.runtime_context.control
+    assert bus is not None
+    bus._close_timeout_s = 0.01
+
+    started = asyncio.Event()
+
+    async def blocked(_event: BaseEvent) -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    bus.subscribe(lambda _event: True, blocked)
+    tasks = bus.publish(
+        BaseEvent(
+            type="control.directive.emitted",
+            aggregate_type="lineage",
+            aggregate_id="lin_shutdown_probe",
+            data={"directive": "cancel"},
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=0.5)
+
+    await server.shutdown()
+
+    assert tasks[0].cancelled()
+    assert bus._tasks == set()
+    assert server._owned_resources == []

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -314,3 +314,33 @@ async def test_close_cancels_stragglers_after_timeout() -> None:
 
     assert tasks[0].cancelled()
     assert bus._tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_close_does_not_hang_when_cancel_is_ignored() -> None:
+    bus = ControlBus(_close_timeout_s=0.01, _cancel_timeout_s=0.01)
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    release = asyncio.Event()
+
+    async def stubborn(event: BaseEvent) -> None:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            await release.wait()
+
+    bus.subscribe(_is_directive, stubborn)
+    tasks = bus.publish(_directive_event())
+    await asyncio.wait_for(started.wait(), timeout=0.5)
+
+    await asyncio.wait_for(bus.close(), timeout=0.5)
+
+    assert cancelled.is_set()
+    assert not tasks[0].done()
+
+    release.set()
+    await asyncio.wait_for(tasks[0], timeout=0.5)
+    await asyncio.sleep(0)
+    assert bus._tasks == set()

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -25,7 +25,11 @@ import asyncio
 import pytest
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.control_bus import ControlBus, SubscriptionHandle
+from ouroboros.orchestrator.control_bus import (
+    ControlBus,
+    ControlBusDrainError,
+    SubscriptionHandle,
+)
 
 
 def _directive_event(directive: str = "retry") -> BaseEvent:
@@ -335,7 +339,8 @@ async def test_close_does_not_hang_when_cancel_is_ignored() -> None:
     tasks = bus.publish(_directive_event())
     await asyncio.wait_for(started.wait(), timeout=0.5)
 
-    await asyncio.wait_for(bus.close(), timeout=0.5)
+    with pytest.raises(ControlBusDrainError, match="ignored cancellation"):
+        await asyncio.wait_for(bus.close(), timeout=0.5)
 
     assert cancelled.is_set()
     assert not tasks[0].done()

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -349,3 +349,49 @@ async def test_close_does_not_hang_when_cancel_is_ignored() -> None:
     await asyncio.wait_for(tasks[0], timeout=0.5)
     await asyncio.sleep(0)
     assert bus._tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_close_does_not_raise_when_cancelled_task_finishes_after_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale ``asyncio.wait`` pending set must not cause a false drain failure."""
+    bus = ControlBus(_close_timeout_s=0.01, _cancel_timeout_s=0.01)
+    started = asyncio.Event()
+    real_wait = asyncio.wait
+    wait_calls = 0
+
+    async def stale_second_wait(
+        awaitables: set[asyncio.Task[None]] | tuple[asyncio.Task[None], ...],
+        *,
+        timeout: float | None = None,
+    ) -> tuple[set[asyncio.Task[None]], set[asyncio.Task[None]]]:
+        nonlocal wait_calls
+        wait_calls += 1
+        done, pending = await real_wait(awaitables, timeout=timeout)
+        if wait_calls == 2 and pending:
+            stale_pending = set(pending)
+            await asyncio.wait_for(
+                asyncio.gather(*stale_pending, return_exceptions=True),
+                timeout=0.5,
+            )
+            return done, stale_pending
+        return done, pending
+
+    async def exits_after_cancel(event: BaseEvent) -> None:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            await asyncio.sleep(0)
+
+    monkeypatch.setattr(asyncio, "wait", stale_second_wait)
+    bus.subscribe(_is_directive, exits_after_cancel)
+    tasks = bus.publish(_directive_event())
+    await asyncio.wait_for(started.wait(), timeout=0.5)
+
+    await bus.close()
+
+    assert tasks[0].done()
+    assert not tasks[0].cancelled()
+    assert bus._tasks == set()

--- a/tests/unit/orchestrator/test_control_bus.py
+++ b/tests/unit/orchestrator/test_control_bus.py
@@ -269,3 +269,48 @@ async def test_publish_retains_fire_and_forget_tasks_until_done() -> None:
     await asyncio.gather(*tasks)
     await asyncio.sleep(0)
     assert bus._tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_close_drains_pending_tasks_and_stops_delivery() -> None:
+    bus = ControlBus()
+    release = asyncio.Event()
+    seen: list[str] = []
+
+    async def slow(event: BaseEvent) -> None:
+        await release.wait()
+        seen.append(event.type)
+
+    bus.subscribe(_is_directive, slow)
+    tasks = bus.publish(_directive_event())
+
+    assert len(tasks) == 1
+    assert len(bus._tasks) == 1
+
+    release.set()
+    await bus.close()
+
+    assert seen == ["control.directive.emitted"]
+    assert bus._tasks == set()
+    assert bus.publish(_directive_event()) == ()
+    with pytest.raises(RuntimeError, match="closed ControlBus"):
+        bus.subscribe(_is_directive, slow)
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_stragglers_after_timeout() -> None:
+    bus = ControlBus(_close_timeout_s=0.01)
+    started = asyncio.Event()
+
+    async def blocked(event: BaseEvent) -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    bus.subscribe(_is_directive, blocked)
+    tasks = bus.publish(_directive_event())
+    await asyncio.wait_for(started.wait(), timeout=0.5)
+
+    await bus.close()
+
+    assert tasks[0].cancelled()
+    assert bus._tasks == set()


### PR DESCRIPTION
## Summary

- add idempotent `ControlBus.close()` / `drain()` lifecycle cleanup
- reject new subscriptions after close and make publish-after-close a no-op
- await subscriber tasks with a bounded timeout, then cancel stragglers
- register the runtime `ControlBus` as a server-owned resource before stores/bridges it may be used with

Closes #582.

## Verification

- `uv run pytest tests/unit/orchestrator/test_control_bus.py -q`
- `uv run pytest tests/unit/mcp/server/test_adapter.py -q`
- `uv run pytest tests/unit/mcp/bridge/test_handler_wiring.py tests/unit/mcp/tools/test_mcp_manager_wiring.py tests/unit/orchestrator/test_agent_runtime_context.py -q`
- `uv run ruff check src/ouroboros/orchestrator/control_bus.py src/ouroboros/mcp/server/adapter.py tests/unit/orchestrator/test_control_bus.py tests/unit/mcp/server/test_adapter.py`
