### PR TITLE
feat(events): scope IO journal recorders per MCP call

### DIFF
--- a/src/ouroboros/events/io_recorder.py
+++ b/src/ouroboros/events/io_recorder.py
@@ -28,8 +28,9 @@ That keeps it cheaply testable with a ``list``-backed fake.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Awaitable
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Awaitable, Iterator
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 import logging
 import time
@@ -51,11 +52,36 @@ from ouroboros.events.io import (
 
 logger = logging.getLogger(__name__)
 
+_CURRENT_IO_JOURNAL_RECORDER: ContextVar[IOJournalRecorder | None] = ContextVar(
+    "ouroboros_current_io_journal_recorder",
+    default=None,
+)
+
 
 class _AppendableEventStore(Protocol):
     """Structural type for the recorder's ``event_store`` argument."""
 
     def append(self, event: BaseEvent) -> Awaitable[None]: ...
+
+
+def get_current_io_journal_recorder() -> IOJournalRecorder | None:
+    """Return the recorder scoped to the current async task, if any."""
+    return _CURRENT_IO_JOURNAL_RECORDER.get()
+
+
+@contextmanager
+def use_io_journal_recorder(recorder: IOJournalRecorder | None) -> Iterator[None]:
+    """Temporarily scope *recorder* to adapter calls in the current task.
+
+    This lets a shared LLM adapter resolve the right per-call
+    ``target_type`` / ``target_id`` without storing that target on the
+    adapter itself.
+    """
+    token = _CURRENT_IO_JOURNAL_RECORDER.set(recorder)
+    try:
+        yield
+    finally:
+        _CURRENT_IO_JOURNAL_RECORDER.reset(token)
 
 
 @dataclass(slots=True)

--- a/src/ouroboros/events/io_recorder.py
+++ b/src/ouroboros/events/io_recorder.py
@@ -75,7 +75,9 @@ def use_io_journal_recorder(recorder: IOJournalRecorder | None) -> Iterator[None
 
     This lets a shared LLM adapter resolve the right per-call
     ``target_type`` / ``target_id`` without storing that target on the
-    adapter itself.
+    adapter itself. Python copies ``ContextVar`` state into child tasks
+    created inside the scope; detached jobs that need a different
+    runtime identity should install their own recorder scope.
     """
     token = _CURRENT_IO_JOURNAL_RECORDER.set(recorder)
     try:

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -17,6 +17,8 @@ from typing import Any
 import structlog
 
 from ouroboros.core.types import Result
+from ouroboros.events.io import new_call_id
+from ouroboros.events.io_recorder import IOJournalRecorder, use_io_journal_recorder
 from ouroboros.mcp.errors import (
     MCPResourceNotFoundError,
     MCPServerError,
@@ -61,6 +63,24 @@ def _default_interview_state_dir() -> Path:
     from ouroboros.config.models import get_config_dir
 
     return get_config_dir() / "data"
+
+
+def _string_argument(arguments: dict[str, Any], *names: str) -> str | None:
+    """Return the first non-empty string argument among *names*."""
+    for name in names:
+        value = arguments.get(name)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _int_argument(arguments: dict[str, Any], *names: str) -> int | None:
+    """Return the first integer argument among *names*."""
+    for name in names:
+        value = arguments.get(name)
+        if isinstance(value, int):
+            return value
+    return None
 
 
 def validate_transport(transport: str) -> str:
@@ -449,10 +469,18 @@ class MCPServerAdapter:
 
         try:
             timeout = getattr(handler, "TIMEOUT_SECONDS", None)
-            if timeout is not None and timeout > 0:
-                result = await asyncio.wait_for(handler.handle(arguments), timeout=timeout)
+
+            async def invoke_handler() -> Result[MCPToolResult, MCPServerError]:
+                if timeout is not None and timeout > 0:
+                    return await asyncio.wait_for(handler.handle(arguments), timeout=timeout)
+                return await handler.handle(arguments)
+
+            recorder = self._io_recorder_for_tool_call(name, arguments)
+            if recorder is not None:
+                with use_io_journal_recorder(recorder):
+                    result = await invoke_handler()
             else:
-                result = await handler.handle(arguments)
+                result = await invoke_handler()
             return result
         except TimeoutError:
             log.error("mcp.server.tool_timeout", tool=name)
@@ -712,6 +740,49 @@ class MCPServerAdapter:
     def register_owned_resource(self, resource: Any) -> None:
         """Register a resource whose ``close()`` will be called on shutdown."""
         self._owned_resources.append(resource)
+
+    def _io_recorder_for_tool_call(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> IOJournalRecorder | None:
+        """Build a per-MCP-call recorder for shared LLM adapters."""
+        context = self._runtime_context
+        if context is None:
+            return None
+        event_store = getattr(context, "event_store", None)
+        if event_store is None:
+            return None
+
+        session_id = _string_argument(arguments, "session_id", "qa_session_id")
+        execution_id = _string_argument(arguments, "execution_id")
+        lineage_id = _string_argument(arguments, "lineage_id")
+        generation_number = _int_argument(arguments, "generation_number", "generation")
+        phase = _string_argument(arguments, "phase", "current_phase")
+
+        if execution_id is not None:
+            target_type = "execution"
+            target_id = execution_id
+        elif lineage_id is not None:
+            target_type = "lineage"
+            target_id = lineage_id
+        elif session_id is not None:
+            target_type = "session"
+            target_id = session_id
+        else:
+            target_type = "mcp_tool"
+            target_id = f"{name}:{new_call_id()}"
+
+        return IOJournalRecorder(
+            event_store=event_store,
+            target_type=target_type,
+            target_id=target_id,
+            session_id=session_id,
+            execution_id=execution_id,
+            lineage_id=lineage_id,
+            generation_number=generation_number,
+            phase=phase,
+        )
 
     async def shutdown(self) -> None:
         """Shutdown the server gracefully, closing owned resources."""

--- a/src/ouroboros/providers/anthropic_adapter.py
+++ b/src/ouroboros/providers/anthropic_adapter.py
@@ -13,7 +13,7 @@ import structlog
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH, InputValidator
 from ouroboros.core.types import Result
-from ouroboros.events.io_recorder import IOJournalRecorder
+from ouroboros.events.io_recorder import IOJournalRecorder, get_current_io_journal_recorder
 from ouroboros.providers.base import (
     CompletionConfig,
     CompletionResponse,
@@ -240,13 +240,14 @@ class AnthropicAdapter:
         )
 
         try:
-            if self._io_recorder is not None and self._io_recorder.is_active:
+            io_recorder = get_current_io_journal_recorder() or self._io_recorder
+            if io_recorder is not None and io_recorder.is_active:
                 prompt_text = _serialise_prompt_for_hash(
                     api_messages,
                     system_parts,
                     {"top_p": config.top_p, "stop_sequences": config.stop},
                 )
-                async with self._io_recorder.record_llm_call(
+                async with io_recorder.record_llm_call(
                     model_id=model,
                     prompt_text=prompt_text,
                     caller="anthropic_adapter",

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import structlog
 
@@ -19,6 +19,9 @@ from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 from ouroboros.providers.gemini_cli_adapter import GeminiCLIAdapter
 from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
+
+if TYPE_CHECKING:
+    from ouroboros.events.io_recorder import IOJournalRecorder
 
 log = structlog.get_logger(__name__)
 
@@ -113,6 +116,7 @@ def create_llm_adapter(
     api_base: str | None = None,
     timeout: float | None = None,
     max_retries: int = 3,
+    io_recorder: IOJournalRecorder | None = None,
 ) -> LLMAdapter:
     """Create an LLM adapter from config or explicit options."""
     resolved_backend = resolve_llm_backend(backend)
@@ -140,6 +144,12 @@ def create_llm_adapter(
         permission_mode=permission_mode,
         use_case=use_case,
     )
+    if io_recorder is not None and resolved_backend != "litellm":
+        log.warning(
+            "create_llm_adapter.io_recorder_unsupported_backend",
+            backend=resolved_backend,
+            hint="Only LiteLLM currently accepts adapter-level IOJournalRecorder wiring.",
+        )
     if resolved_backend == "claude_code":
         return ClaudeCodeAdapter(
             permission_mode=resolved_permission_mode,
@@ -197,6 +207,7 @@ def create_llm_adapter(
         api_base=api_base,
         timeout=timeout,
         max_retries=max_retries,
+        io_recorder=io_recorder,
     )
 
 

--- a/src/ouroboros/providers/litellm_adapter.py
+++ b/src/ouroboros/providers/litellm_adapter.py
@@ -15,6 +15,7 @@ from ouroboros.core.errors import ProviderError
 from ouroboros.core.retry import retry_async
 from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH, InputValidator
 from ouroboros.core.types import Result
+from ouroboros.events.io_recorder import get_current_io_journal_recorder
 from ouroboros.providers.base import (
     CompletionConfig,
     CompletionResponse,
@@ -398,7 +399,7 @@ class LiteLLMAdapter:
             wait_jitter=1.0,
         )
         async def _with_retry() -> CompletionResponse:
-            recorder = self._io_recorder
+            recorder = get_current_io_journal_recorder() or self._io_recorder
             if recorder is None or not recorder.is_active:
                 response = await self._raw_complete(messages, config)
                 return self._parse_response(response, config)

--- a/tests/unit/events/test_io_recorder.py
+++ b/tests/unit/events/test_io_recorder.py
@@ -64,6 +64,27 @@ def test_scoped_recorder_context_resets_after_exit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_scoped_recorder_context_is_inherited_by_child_tasks() -> None:
+    recorder = IOJournalRecorder(
+        event_store=_FakeEventStore(),
+        target_type="execution",
+        target_id="exec_child",
+    )
+    release = asyncio.Event()
+
+    async def child() -> IOJournalRecorder | None:
+        await release.wait()
+        return get_current_io_journal_recorder()
+
+    with use_io_journal_recorder(recorder):
+        task = asyncio.create_task(child())
+
+    assert get_current_io_journal_recorder() is None
+    release.set()
+    assert await task is recorder
+
+
+@pytest.mark.asyncio
 async def test_record_llm_call_emits_started_and_returned() -> None:
     store = _FakeEventStore()
     recorder = IOJournalRecorder(

--- a/tests/unit/events/test_io_recorder.py
+++ b/tests/unit/events/test_io_recorder.py
@@ -30,7 +30,11 @@ from ouroboros.events.io import (
     PrivacyMode,
     content_hash,
 )
-from ouroboros.events.io_recorder import IOJournalRecorder
+from ouroboros.events.io_recorder import (
+    IOJournalRecorder,
+    get_current_io_journal_recorder,
+    use_io_journal_recorder,
+)
 
 
 class _FakeEventStore:
@@ -44,6 +48,19 @@ class _FakeEventStore:
 class _BrokenEventStore:
     async def append(self, event: BaseEvent) -> None:
         raise RuntimeError("simulated EventStore outage")
+
+
+def test_scoped_recorder_context_resets_after_exit() -> None:
+    recorder = IOJournalRecorder(
+        event_store=_FakeEventStore(),
+        target_type="execution",
+        target_id="exec_ctx",
+    )
+
+    assert get_current_io_journal_recorder() is None
+    with use_io_journal_recorder(recorder):
+        assert get_current_io_journal_recorder() is recorder
+    assert get_current_io_journal_recorder() is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -9,6 +9,7 @@ import pytest
 
 from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
+from ouroboros.events.io_recorder import get_current_io_journal_recorder
 from ouroboros.mcp.errors import MCPResourceNotFoundError, MCPServerError
 from ouroboros.mcp.server.adapter import (
     VALID_TRANSPORTS,
@@ -30,6 +31,7 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
+from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
 from ouroboros.orchestrator.control_bus import ControlBus, ControlBusDrainError
 
 
@@ -209,6 +211,59 @@ class TestMCPServerAdapterTools:
         assert result.is_ok
         assert result.value.text_content == "Success"
         handler.handle_mock.assert_called_once_with({"input": "test"})
+
+    async def test_call_tool_scopes_io_journal_recorder_from_runtime_context(self) -> None:
+        """MCP tool calls provide per-call journal identity to shared adapters."""
+
+        class _FakeEventStore:
+            async def append(self, event: object) -> None:
+                pass
+
+        class _RecorderProbeHandler(MockToolHandler):
+            def __init__(self) -> None:
+                super().__init__("probe_tool")
+                self.recorder = None
+
+            async def handle(
+                self, arguments: dict[str, Any]
+            ) -> Result[MCPToolResult, MCPServerError]:
+                self.recorder = get_current_io_journal_recorder()
+                return Result.ok(
+                    MCPToolResult(
+                        content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                    )
+                )
+
+        adapter = MCPServerAdapter()
+        adapter.set_runtime_context(
+            AgentRuntimeContext(
+                event_store=_FakeEventStore(),
+                runtime_backend="codex",
+                llm_backend="litellm",
+            )
+        )
+        handler = _RecorderProbeHandler()
+        adapter.register_tool(handler)
+
+        result = await adapter.call_tool(
+            "probe_tool",
+            {
+                "execution_id": "exec_123",
+                "session_id": "sess_123",
+                "phase": "reflect",
+                "generation_number": 2,
+            },
+        )
+
+        assert result.is_ok
+        assert handler.recorder is not None
+        assert handler.recorder.target_type == "execution"
+        assert handler.recorder.target_id == "exec_123"
+        assert handler.recorder.session_id == "sess_123"
+        assert handler.recorder.execution_id == "exec_123"
+        assert handler.recorder.phase == "reflect"
+        assert handler.recorder.generation_number == 2
+        assert get_current_io_journal_recorder() is None
 
     async def test_call_tool_not_found(self) -> None:
         """call_tool returns error for unknown tool."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -35,6 +35,11 @@ from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
 from ouroboros.orchestrator.control_bus import ControlBus, ControlBusDrainError
 
 
+class _FakeEventStore:
+    async def append(self, event: object) -> None:
+        pass
+
+
 class MockToolHandler:
     """Mock tool handler for testing."""
 
@@ -215,10 +220,6 @@ class TestMCPServerAdapterTools:
     async def test_call_tool_scopes_io_journal_recorder_from_runtime_context(self) -> None:
         """MCP tool calls provide per-call journal identity to shared adapters."""
 
-        class _FakeEventStore:
-            async def append(self, event: object) -> None:
-                pass
-
         class _RecorderProbeHandler(MockToolHandler):
             def __init__(self) -> None:
                 super().__init__("probe_tool")
@@ -264,6 +265,75 @@ class TestMCPServerAdapterTools:
         assert handler.recorder.phase == "reflect"
         assert handler.recorder.generation_number == 2
         assert get_current_io_journal_recorder() is None
+
+    def test_io_recorder_for_tool_call_uses_lineage_identity(self) -> None:
+        adapter = MCPServerAdapter()
+        adapter.set_runtime_context(
+            AgentRuntimeContext(
+                event_store=_FakeEventStore(),
+                runtime_backend="codex",
+                llm_backend="litellm",
+            )
+        )
+
+        recorder = adapter._io_recorder_for_tool_call(
+            "ouroboros_evolve_step",
+            {
+                "lineage_id": "lin_123",
+                "session_id": "sess_123",
+                "generation": 3,
+                "current_phase": "reflect",
+            },
+        )
+
+        assert recorder is not None
+        assert recorder.target_type == "lineage"
+        assert recorder.target_id == "lin_123"
+        assert recorder.lineage_id == "lin_123"
+        assert recorder.session_id == "sess_123"
+        assert recorder.generation_number == 3
+        assert recorder.phase == "reflect"
+
+    def test_io_recorder_for_tool_call_uses_session_identity(self) -> None:
+        adapter = MCPServerAdapter()
+        adapter.set_runtime_context(
+            AgentRuntimeContext(
+                event_store=_FakeEventStore(),
+                runtime_backend="codex",
+                llm_backend="litellm",
+            )
+        )
+
+        recorder = adapter._io_recorder_for_tool_call(
+            "ouroboros_qa",
+            {"qa_session_id": "qa_123"},
+        )
+
+        assert recorder is not None
+        assert recorder.target_type == "session"
+        assert recorder.target_id == "qa_123"
+        assert recorder.session_id == "qa_123"
+        assert recorder.execution_id is None
+        assert recorder.lineage_id is None
+
+    def test_io_recorder_for_tool_call_uses_mcp_tool_fallback_identity(self) -> None:
+        adapter = MCPServerAdapter()
+        adapter.set_runtime_context(
+            AgentRuntimeContext(
+                event_store=_FakeEventStore(),
+                runtime_backend="codex",
+                llm_backend="litellm",
+            )
+        )
+
+        recorder = adapter._io_recorder_for_tool_call("plain_tool", {})
+
+        assert recorder is not None
+        assert recorder.target_type == "mcp_tool"
+        assert recorder.target_id.startswith("plain_tool:")
+        assert recorder.session_id is None
+        assert recorder.execution_id is None
+        assert recorder.lineage_id is None
 
     async def test_call_tool_not_found(self) -> None:
         """call_tool returns error for unknown tool."""

--- a/tests/unit/providers/test_anthropic_adapter_io_recorder.py
+++ b/tests/unit/providers/test_anthropic_adapter_io_recorder.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.events.io_recorder import IOJournalRecorder
+from ouroboros.events.io_recorder import IOJournalRecorder, use_io_journal_recorder
 from ouroboros.providers.anthropic_adapter import (
     AnthropicAdapter,
     _record_completion,
@@ -144,6 +144,42 @@ async def test_complete_emits_paired_events_when_recorder_present() -> None:
     assert returned.data["token_count_in"] == 10
     assert returned.data["token_count_out"] == 4
     assert returned.data["is_error"] is False
+
+
+@pytest.mark.asyncio
+async def test_complete_uses_scoped_recorder_for_shared_adapter() -> None:
+    store = _FakeEventStore()
+    recorder = IOJournalRecorder(
+        event_store=store,
+        target_type="execution",
+        target_id="exec_scoped",
+        execution_id="exec_scoped",
+    )
+    adapter = AnthropicAdapter(api_key="dummy")
+
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = "hi scoped"
+    stub_response = _StubAnthropicResponse(
+        content=[text_block],
+        model="claude-sonnet-4-6",
+        stop_reason="end_turn",
+        usage=MagicMock(input_tokens=10, output_tokens=4),
+    )
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=stub_response)
+    adapter._client = fake_client
+
+    with use_io_journal_recorder(recorder):
+        result = await adapter.complete(
+            messages=[Message(role=MessageRole.USER, content="hello")],
+            config=CompletionConfig(model="claude-sonnet-4-6", max_tokens=128),
+        )
+
+    assert result.is_ok
+    assert store.appended[0].data["target_id"] == "exec_scoped"
+    assert store.appended[1].data["execution_id"] == "exec_scoped"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/providers/test_factory.py
+++ b/tests/unit/providers/test_factory.py
@@ -5,6 +5,8 @@ import sys
 
 import pytest
 
+from ouroboros.events.base import BaseEvent
+from ouroboros.events.io_recorder import IOJournalRecorder
 from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
 from ouroboros.providers.codex_cli_adapter import CodexCliLLMAdapter
 from ouroboros.providers.factory import (
@@ -14,6 +16,11 @@ from ouroboros.providers.factory import (
 )
 from ouroboros.providers.litellm_adapter import LiteLLMAdapter
 from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
+
+
+class _FakeEventStore:
+    async def append(self, event: BaseEvent) -> None:
+        pass
 
 
 class TestResolveLLMBackend:
@@ -80,6 +87,19 @@ class TestCreateLLMAdapter:
         """LiteLLM backend returns LiteLLMAdapter."""
         adapter = create_llm_adapter(backend="litellm")
         assert isinstance(adapter, LiteLLMAdapter)
+
+    def test_forwards_io_recorder_to_litellm_adapter(self) -> None:
+        """LiteLLM factory path preserves explicit recorder wiring."""
+        recorder = IOJournalRecorder(
+            event_store=_FakeEventStore(),
+            target_type="execution",
+            target_id="exec_factory",
+        )
+
+        adapter = create_llm_adapter(backend="litellm", io_recorder=recorder)
+
+        assert isinstance(adapter, LiteLLMAdapter)
+        assert adapter._io_recorder is recorder
 
     def test_litellm_import_error_raises_runtime_error(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/providers/test_litellm_adapter_io_recorder.py
+++ b/tests/unit/providers/test_litellm_adapter_io_recorder.py
@@ -16,7 +16,11 @@ import pytest
 from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.io import content_hash
-from ouroboros.events.io_recorder import IOJournalRecorder, LLMCallRecord
+from ouroboros.events.io_recorder import (
+    IOJournalRecorder,
+    LLMCallRecord,
+    use_io_journal_recorder,
+)
 from ouroboros.providers.base import (
     CompletionConfig,
     CompletionResponse,
@@ -224,6 +228,51 @@ async def test_complete_emits_paired_events_when_recorder_present(
     assert returned.data["finish_reason"] == "stop"
     assert returned.data["token_count_in"] == 10
     assert returned.data["is_error"] is False
+
+
+@pytest.mark.asyncio
+async def test_complete_uses_scoped_recorder_for_shared_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store_a = _FakeEventStore()
+    store_b = _FakeEventStore()
+    recorder_a = IOJournalRecorder(
+        event_store=store_a,
+        target_type="execution",
+        target_id="exec_a",
+        execution_id="exec_a",
+    )
+    recorder_b = IOJournalRecorder(
+        event_store=store_b,
+        target_type="lineage",
+        target_id="lin_b",
+        lineage_id="lin_b",
+    )
+    adapter = LiteLLMAdapter(api_key="dummy")
+
+    monkeypatch.setattr(
+        adapter,
+        "_raw_complete",
+        AsyncMock(side_effect=[_stub_response(content="a"), _stub_response(content="b")]),
+    )
+
+    with use_io_journal_recorder(recorder_a):
+        result_a = await adapter.complete(
+            messages=[Message(role=MessageRole.USER, content="hello a")],
+            config=CompletionConfig(model="openrouter/openai/gpt-4", max_tokens=64),
+        )
+    with use_io_journal_recorder(recorder_b):
+        result_b = await adapter.complete(
+            messages=[Message(role=MessageRole.USER, content="hello b")],
+            config=CompletionConfig(model="openrouter/openai/gpt-4", max_tokens=64),
+        )
+
+    assert result_a.is_ok
+    assert result_b.is_ok
+    assert store_a.appended[0].data["target_id"] == "exec_a"
+    assert store_a.appended[1].data["execution_id"] == "exec_a"
+    assert store_b.appended[0].data["target_id"] == "lin_b"
+    assert store_b.appended[1].data["lineage_id"] == "lin_b"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add task-local I/O Journal recorder scoping for shared LLM adapters
- make LiteLLM and Anthropic adapters prefer the scoped recorder over a fixed adapter recorder
- scope MCP `call_tool()` execution with a per-call recorder inferred from `execution_id`, `lineage_id`, `session_id`, or a generated MCP tool target
- forward explicit `io_recorder` through the LiteLLM factory path and warn when unsupported backends receive adapter-level recorder wiring

Closes #581.

## Why this shape

The server uses shared LLM adapter instances, so attaching a fixed `IOJournalRecorder` to the adapter would misattribute calls across sessions/executions. The scoped recorder keeps the adapter shared while binding journal events to the current MCP call/runtime identity.

## Verification

- `uv run pytest tests/unit/events/test_io_recorder.py -q`
- `uv run pytest tests/unit/providers/test_litellm_adapter_io_recorder.py tests/unit/providers/test_anthropic_adapter_io_recorder.py tests/unit/providers/test_factory.py -q`
- `uv run pytest tests/unit/mcp/server/test_adapter.py -q`
- `uv run pytest tests/unit/events/test_io_recorder.py tests/unit/providers/test_litellm_adapter_io_recorder.py tests/unit/providers/test_anthropic_adapter_io_recorder.py tests/unit/providers/test_factory.py tests/unit/mcp/server/test_adapter.py -q`
- `uv run ruff check src/ouroboros/events/io_recorder.py src/ouroboros/providers/litellm_adapter.py src/ouroboros/providers/anthropic_adapter.py src/ouroboros/providers/factory.py src/ouroboros/mcp/server/adapter.py tests/unit/events/test_io_recorder.py tests/unit/providers/test_litellm_adapter_io_recorder.py tests/unit/providers/test_anthropic_adapter_io_recorder.py tests/unit/providers/test_factory.py tests/unit/mcp/server/test_adapter.py`
