### PR TITLE
fix(persistence): include sessions without started events

### DIFF
--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -535,12 +535,15 @@ class EventStore:
             func.json_extract(events_table.c.payload, "$.runtime_status"),
         )
 
-        started_ranked = (
+        first_session_event_ranked = (
             select(
                 events_table.c.aggregate_id.label("session_id"),
                 func.json_extract(events_table.c.payload, "$.execution_id").label("execution_id"),
                 func.json_extract(events_table.c.payload, "$.seed_id").label("seed_id"),
-                func.json_extract(events_table.c.payload, "$.start_time").label("start_time"),
+                func.coalesce(
+                    func.json_extract(events_table.c.payload, "$.start_time"),
+                    events_table.c.timestamp,
+                ).label("start_time"),
                 func.row_number()
                 .over(
                     partition_by=events_table.c.aggregate_id,
@@ -549,7 +552,6 @@ class EventStore:
                 .label("rn"),
             )
             .where(events_table.c.aggregate_type == "session")
-            .where(events_table.c.event_type == "orchestrator.session.started")
             .subquery()
         )
 
@@ -609,31 +611,33 @@ class EventStore:
             async with self._engine.begin() as conn:
                 query = (
                     select(
-                        started_ranked.c.session_id,
-                        started_ranked.c.execution_id,
-                        started_ranked.c.seed_id,
-                        started_ranked.c.start_time,
+                        first_session_event_ranked.c.session_id,
+                        first_session_event_ranked.c.execution_id,
+                        first_session_event_ranked.c.seed_id,
+                        first_session_event_ranked.c.start_time,
                         latest_activity_ranked.c.last_activity,
                         latest_status_ranked.c.status_event_type,
                         latest_status_ranked.c.runtime_status,
                     )
-                    .select_from(started_ranked)
+                    .select_from(first_session_event_ranked)
                     .join(
                         latest_activity_ranked,
                         and_(
-                            latest_activity_ranked.c.session_id == started_ranked.c.session_id,
+                            latest_activity_ranked.c.session_id
+                            == first_session_event_ranked.c.session_id,
                             latest_activity_ranked.c.rn == 1,
                         ),
                     )
                     .outerjoin(
                         latest_status_ranked,
                         and_(
-                            latest_status_ranked.c.session_id == started_ranked.c.session_id,
+                            latest_status_ranked.c.session_id
+                            == first_session_event_ranked.c.session_id,
                             latest_status_ranked.c.rn == 1,
                         ),
                     )
-                    .where(started_ranked.c.rn == 1)
-                    .order_by(started_ranked.c.session_id.asc())
+                    .where(first_session_event_ranked.c.rn == 1)
+                    .order_by(first_session_event_ranked.c.session_id.asc())
                 )
 
                 result = await conn.execute(query)

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -610,6 +610,53 @@ class TestSessionActivitySnapshots:
         assert by_id["sess-completed"].status_event_type == "orchestrator.progress.updated"
         assert by_id["sess-completed"].runtime_status == "completed"
 
+    async def test_includes_terminal_session_without_started_event(
+        self, event_store: EventStore
+    ) -> None:
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.session.completed",
+                aggregate_type="session",
+                aggregate_id="sess-imported-complete",
+                data={"summary": "imported terminal event"},
+            )
+        )
+
+        snapshots = await event_store.get_session_activity_snapshots()
+        by_id = {snapshot.session_id: snapshot for snapshot in snapshots}
+
+        assert set(by_id) == {"sess-imported-complete"}
+        snapshot = by_id["sess-imported-complete"]
+        assert snapshot.execution_id is None
+        assert snapshot.seed_id is None
+        assert snapshot.start_time is not None
+        assert snapshot.last_activity is not None
+        assert snapshot.status_event_type == "orchestrator.session.completed"
+
+    async def test_includes_progress_only_session_without_started_event(
+        self, event_store: EventStore
+    ) -> None:
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.progress.updated",
+                aggregate_type="session",
+                aggregate_id="sess-imported-progress",
+                data={"progress": {"step": 1, "runtime_status": "running"}},
+            )
+        )
+
+        snapshots = await event_store.get_session_activity_snapshots()
+        by_id = {snapshot.session_id: snapshot for snapshot in snapshots}
+
+        assert set(by_id) == {"sess-imported-progress"}
+        snapshot = by_id["sess-imported-progress"]
+        assert snapshot.execution_id is None
+        assert snapshot.seed_id is None
+        assert snapshot.start_time is not None
+        assert snapshot.last_activity is not None
+        assert snapshot.status_event_type == "orchestrator.progress.updated"
+        assert snapshot.runtime_status == "running"
+
 
 class TestGetAllSessions:
     """Test get_all_sessions returns all session lifecycle events."""


### PR DESCRIPTION
## Summary

- Enumerate session snapshots from all `aggregate_type == "session"` streams instead of anchoring only on `orchestrator.session.started`
- Preserve started-event metadata when present, with timestamp fallback for imported/partial streams
- Add regression coverage for terminal-only and progress-only session aggregates

## Verification

- `uv run ruff check src/ouroboros/persistence/event_store.py tests/unit/persistence/test_event_store.py`
- `uv run mypy src/ouroboros/persistence/event_store.py`
- `uv run pytest tests/unit/persistence/test_event_store.py::TestSessionActivitySnapshots -q`

Closes #508.
