### PR TITLE
fix(interview): include initial user turn on first question

### DIFF
--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -901,15 +901,21 @@ class InterviewEngine:
             initial_context if initial_context is not None else state.initial_context
         )
 
+        has_conversation_rounds = any(
+            round_data.question != self._INITIAL_CONTEXT_SUMMARY_QUESTION
+            for round_data in state.rounds
+        )
         overflow = self._initial_context_overflow_message(context_for_prompt)
         if overflow:
             messages.append(Message(role=MessageRole.USER, content=overflow))
-        elif not state.rounds and context_for_prompt:
+        elif not has_conversation_rounds and context_for_prompt:
             # Some chat providers reject a first request that contains only a
             # system message. Mirror the user's initial context as the first
             # user turn so provider adapters always receive a non-system
-            # conversation message on round one. Long contexts keep using the
-            # overflow path above to preserve prompt-budget caps.
+            # conversation message on round one. Summary-recovery sentinel
+            # rounds do not count as conversation because they are skipped
+            # below. Long contexts keep using the overflow path above to
+            # preserve prompt-budget caps.
             user_content = context_for_prompt
             if len(user_content) > self._MAX_USER_RESPONSE_CHARS:
                 user_content = user_content[: self._MAX_USER_RESPONSE_CHARS] + "..."

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -904,6 +904,16 @@ class InterviewEngine:
         overflow = self._initial_context_overflow_message(context_for_prompt)
         if overflow:
             messages.append(Message(role=MessageRole.USER, content=overflow))
+        elif not state.rounds and context_for_prompt:
+            # Some chat providers reject a first request that contains only a
+            # system message. Mirror the user's initial context as the first
+            # user turn so provider adapters always receive a non-system
+            # conversation message on round one. Long contexts keep using the
+            # overflow path above to preserve prompt-budget caps.
+            user_content = context_for_prompt
+            if len(user_content) > self._MAX_USER_RESPONSE_CHARS:
+                user_content = user_content[: self._MAX_USER_RESPONSE_CHARS] + "..."
+            messages.append(Message(role=MessageRole.USER, content=user_content))
 
         for round_data in state.rounds:
             if round_data.question == self._INITIAL_CONTEXT_SUMMARY_QUESTION:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -629,7 +629,8 @@ class InterviewEngine:
         from ouroboros.agents.loader import load_agent_prompt
 
         max_prompt_chars = max_chars or self._MAX_SYSTEM_PROMPT_CHARS
-        round_info = f"Round {state.current_round_number}"
+        effective_round_number = self._next_conversation_round_number(state)
+        round_info = f"Round {effective_round_number}"
 
         base_prompt = load_agent_prompt("socratic-interviewer")
 
@@ -639,7 +640,7 @@ class InterviewEngine:
         prompt_initial_context = self._initial_context_for_system_prompt(context_for_prompt)
 
         # For first round, add explicit instruction to start directly with a question
-        if state.current_round_number == 1:
+        if effective_round_number == 1:
             dynamic_header = (
                 f"You are an expert requirements engineer conducting a Socratic interview.\n\n"
                 f"CRITICAL: Start your FIRST response with a DIRECT QUESTION about the project. "
@@ -801,14 +802,15 @@ class InterviewEngine:
 
         perspectives: list[InterviewPerspective] = [InterviewPerspective.BREADTH_KEEPER]
 
-        if state.current_round_number <= 2:
+        effective_round_number = self._next_conversation_round_number(state)
+        if effective_round_number <= 2:
             perspectives.extend(
                 [
                     InterviewPerspective.RESEARCHER,
                     InterviewPerspective.SIMPLIFIER,
                 ]
             )
-        elif state.current_round_number <= 5:
+        elif effective_round_number <= 5:
             perspectives.extend(
                 [
                     InterviewPerspective.RESEARCHER,
@@ -873,6 +875,17 @@ class InterviewEngine:
 
         return "\n".join(sections)
 
+    def _next_conversation_round_number(self, state: InterviewState) -> int:
+        """Return the next real interview round, ignoring summary sentinels."""
+        return (
+            sum(
+                1
+                for round_data in state.rounds
+                if round_data.question != self._INITIAL_CONTEXT_SUMMARY_QUESTION
+            )
+            + 1
+        )
+
     # Agent SDK CLI can return empty responses when the combined prompt
     # (system_prompt + conversation history) exceeds an internal threshold.
     # Cap each user response to keep the total prompt within safe limits.
@@ -901,10 +914,7 @@ class InterviewEngine:
             initial_context if initial_context is not None else state.initial_context
         )
 
-        has_conversation_rounds = any(
-            round_data.question != self._INITIAL_CONTEXT_SUMMARY_QUESTION
-            for round_data in state.rounds
-        )
+        has_conversation_rounds = self._next_conversation_round_number(state) > 1
         overflow = self._initial_context_overflow_message(context_for_prompt)
         if overflow:
             messages.append(Message(role=MessageRole.USER, content=overflow))

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -1140,6 +1140,31 @@ class TestInterviewEngineConversationHistory:
         assert history[0].role == MessageRole.USER
         assert history[0].content == "Build an iOS calculator"
 
+    def test_summary_recovery_context_becomes_first_user_message(self) -> None:
+        """Summary sentinel rounds should not make the first provider call system-only."""
+        mock_adapter = MagicMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+        state = InterviewState(
+            interview_id="test_summary_recovery_first_turn",
+            initial_context="A" * 4_000,
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                user_response="Short project summary",
+            )
+        )
+
+        history = engine._build_conversation_history(
+            state,
+            initial_context=prompt_safe_initial_context(state),
+        )
+
+        assert len(history) == 1
+        assert history[0].role == MessageRole.USER
+        assert history[0].content == "Short project summary"
+
     def test_history_with_rounds(self) -> None:
         """_build_conversation_history creates message pairs."""
         mock_adapter = MagicMock()

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -983,6 +983,62 @@ class TestInterviewEngineSystemPrompt:
         # Now just shows "Round N" without max limit
         assert "Round 1" in prompt
 
+    def test_system_prompt_treats_summary_recovery_as_first_real_round(self) -> None:
+        """Summary sentinel rounds should not remove first-question prompt guards."""
+        mock_adapter = MagicMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+
+        state = InterviewState(
+            interview_id="test_summary_recovery_prompt",
+            initial_context="A" * 4_000,
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                    user_response="Short project summary",
+                )
+            ],
+        )
+
+        prompt = engine._build_system_prompt(
+            state,
+            initial_context=prompt_safe_initial_context(state),
+        )
+
+        assert "Round 1" in prompt
+        assert "Round 2" not in prompt
+        assert "CRITICAL: Start your FIRST response with a DIRECT QUESTION" in prompt
+
+    def test_system_prompt_counts_real_rounds_after_summary_recovery(self) -> None:
+        """Real rounds after a summary sentinel should advance prompt round behavior."""
+        mock_adapter = MagicMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+
+        state = InterviewState(
+            interview_id="test_summary_recovery_round_two",
+            initial_context="A" * 4_000,
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                    user_response="Short project summary",
+                ),
+                InterviewRound(
+                    round_number=2,
+                    question="What platform should this target?",
+                    user_response="CLI",
+                ),
+            ],
+        )
+
+        prompt = engine._build_system_prompt(
+            state,
+            initial_context=prompt_safe_initial_context(state),
+        )
+
+        assert "Round 2" in prompt
+        assert "CRITICAL: Start your FIRST response with a DIRECT QUESTION" not in prompt
+
     def test_system_prompt_includes_context(self) -> None:
         """_build_system_prompt includes initial context."""
         mock_adapter = MagicMock()

--- a/tests/unit/bigbang/test_interview.py
+++ b/tests/unit/bigbang/test_interview.py
@@ -337,6 +337,8 @@ class TestInterviewEngineAskNextQuestion:
 
         assert system_message.role == MessageRole.SYSTEM
         assert "Build a task manager" in system_message.content
+        assert messages[1].role == MessageRole.USER
+        assert messages[1].content == "Build a task manager"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("context_length", [2500, 3500])
@@ -1121,6 +1123,22 @@ class TestInterviewEngineConversationHistory:
         history = engine._build_conversation_history(state)
 
         assert history == []
+
+    def test_initial_context_becomes_first_user_message_for_empty_history(self) -> None:
+        """First question generation includes a user turn for provider compatibility."""
+        mock_adapter = MagicMock()
+        engine = InterviewEngine(llm_adapter=mock_adapter)
+
+        state = InterviewState(
+            interview_id="test_001",
+            initial_context="Build an iOS calculator",
+        )
+
+        history = engine._build_conversation_history(state, initial_context=state.initial_context)
+
+        assert len(history) == 1
+        assert history[0].role == MessageRole.USER
+        assert history[0].content == "Build an iOS calculator"
 
     def test_history_with_rounds(self) -> None:
         """_build_conversation_history creates message pairs."""


### PR DESCRIPTION
## Summary

- Mirror the initial interview context as the first user message when generating the first question
- Keep existing overflow-message behavior for long initial contexts so prompt-budget safeguards remain intact
- Add tests proving first-question calls include a non-system user turn

## Verification

- `uv run ruff check src/ouroboros/bigbang/interview.py tests/unit/bigbang/test_interview.py`
- `uv run mypy src/ouroboros/bigbang/interview.py`
- `uv run pytest tests/unit/bigbang/test_interview.py::TestInterviewEngineAskNextQuestion tests/unit/bigbang/test_interview.py::TestInterviewEngineConversationHistory -q`

Closes #564.
