### PR TITLE
fix(init): respect configured interview backend

### DIFF
--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -25,7 +25,7 @@ from ouroboros.bigbang.seed_generator import SeedGenerator
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
 from ouroboros.cli.formatters.prompting import multiline_prompt_async
-from ouroboros.config import get_clarification_model
+from ouroboros.config import get_clarification_model, get_llm_backend
 from ouroboros.core.initial_context import (
     load_pm_seed_as_context as _load_pm_seed_as_context_result,
 )
@@ -33,7 +33,7 @@ from ouroboros.core.initial_context import (
     resolve_initial_context_input,
 )
 from ouroboros.observability import LoggingConfig, configure_logging
-from ouroboros.providers import create_llm_adapter
+from ouroboros.providers import create_llm_adapter, resolve_llm_backend
 from ouroboros.providers.base import LLMAdapter
 
 
@@ -114,6 +114,20 @@ def _make_message_callback(debug: bool):
     return callback
 
 
+def _resolve_init_llm_backend(use_orchestrator: bool, backend: str | None = None) -> str:
+    """Resolve the interview LLM backend for ``init start``.
+
+    Explicit ``--llm-backend`` wins. ``--orchestrator`` remains a
+    compatibility shortcut for Claude Code. Without either flag, respect the
+    persisted ``llm.backend`` config instead of forcing LiteLLM.
+    """
+    if backend:
+        return backend
+    if use_orchestrator:
+        return "claude_code"
+    return get_llm_backend()
+
+
 def _get_adapter(
     use_orchestrator: bool,
     backend: str | None = None,
@@ -131,7 +145,7 @@ def _get_adapter(
     Returns:
         LLM adapter instance.
     """
-    resolved_backend = backend or ("claude_code" if use_orchestrator else "litellm")
+    resolved_backend = _resolve_init_llm_backend(use_orchestrator, backend)
 
     if for_interview:
         # Interview mode: request the interview-specific permission policy and
@@ -782,12 +796,20 @@ def start(
         )
 
     # Show mode info
-    if orchestrator:
+    selected_llm_backend = _resolve_init_llm_backend(
+        orchestrator,
+        llm_backend.value if llm_backend else None,
+    )
+    resolved_llm_backend = resolve_llm_backend(selected_llm_backend)
+    if resolved_llm_backend == "claude_code":
         print_info("Using Claude Code (Max Plan) - no API key required")
-        if runtime:
-            print_info(f"Workflow runtime backend: {runtime.value}")
-    else:
+    elif resolved_llm_backend == "litellm":
         print_info("Using LiteLLM - API key required")
+    else:
+        print_info(f"Using {resolved_llm_backend} interview backend")
+
+    if orchestrator and runtime:
+        print_info(f"Workflow runtime backend: {runtime.value}")
 
     if llm_backend:
         print_info(f"Interview LLM backend: {llm_backend.value}")

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
-from ouroboros.cli.commands.init import _get_adapter, _start_workflow
+from ouroboros.cli.commands.init import _get_adapter, _resolve_init_llm_backend, _start_workflow
 from ouroboros.cli.main import app
 
 runner = CliRunner()
@@ -56,6 +56,33 @@ class TestInitWorkflowRuntimeHandoff:
         assert mock_run_interview.await_args.args[6] == "codex"
         assert mock_run_interview.await_args.args[5] == "codex"
 
+    def test_get_adapter_respects_configured_llm_backend_without_flags(self) -> None:
+        """init start without flags uses llm.backend config instead of forcing LiteLLM."""
+        mock_adapter = MagicMock()
+
+        with (
+            patch("ouroboros.cli.commands.init.get_llm_backend", return_value="claude"),
+            patch(
+                "ouroboros.cli.commands.init.create_llm_adapter",
+                return_value=mock_adapter,
+            ) as mock_create_adapter,
+        ):
+            adapter = _get_adapter(use_orchestrator=False, for_interview=True)
+
+        assert adapter is mock_adapter
+        assert mock_create_adapter.call_args.kwargs["backend"] == "claude"
+        assert mock_create_adapter.call_args.kwargs["use_case"] == "interview"
+
+    def test_orchestrator_flag_still_defaults_to_claude_code(self) -> None:
+        """--orchestrator keeps its compatibility default independent of config."""
+        with patch("ouroboros.cli.commands.init.get_llm_backend", return_value="litellm"):
+            assert _resolve_init_llm_backend(use_orchestrator=True) == "claude_code"
+
+    def test_explicit_llm_backend_overrides_config_and_orchestrator(self) -> None:
+        """--llm-backend remains the highest-priority backend selection."""
+        with patch("ouroboros.cli.commands.init.get_llm_backend", return_value="claude"):
+            assert _resolve_init_llm_backend(use_orchestrator=True, backend="codex") == "codex"
+
     def test_get_adapter_uses_interview_use_case_for_codex(self) -> None:
         """Interview adapter creation stays backend-neutral for Codex."""
         mock_adapter = MagicMock()
@@ -75,6 +102,21 @@ class TestInitWorkflowRuntimeHandoff:
         assert mock_create_adapter.call_args.kwargs["backend"] == "codex"
         assert mock_create_adapter.call_args.kwargs["use_case"] == "interview"
         assert mock_create_adapter.call_args.kwargs["max_turns"] == 5
+
+    def test_cli_reports_configured_claude_backend_without_orchestrator_flag(self) -> None:
+        """CLI UX no longer claims LiteLLM when config selects Claude."""
+        mock_run_interview = AsyncMock()
+
+        with (
+            patch("ouroboros.cli.commands.init.get_llm_backend", return_value="claude"),
+            patch("ouroboros.cli.commands.init._run_interview", new=mock_run_interview),
+        ):
+            result = runner.invoke(app, ["init", "start", "Build a REST API"])
+
+        assert result.exit_code == 0
+        assert "Using Claude Code" in result.output
+        assert "Using LiteLLM" not in result.output
+        assert mock_run_interview.await_args.args[6] is None
 
     def test_get_adapter_uses_interview_use_case_for_opencode(self) -> None:
         """Interview adapter creation stays backend-neutral for OpenCode."""


### PR DESCRIPTION
## Summary

- Resolve `ouroboros init start` interview backend from explicit `--llm-backend`, then `--orchestrator`, then persisted `llm.backend`
- Stop claiming LiteLLM is in use when config selects Claude/Claude Code
- Add CLI/runtime tests for config-backed backend selection and priority order

## Verification

- `uv run ruff check src/ouroboros/cli/commands/init.py tests/unit/cli/test_init_runtime.py`
- `uv run mypy src/ouroboros/cli/commands/init.py`
- `uv run pytest tests/unit/cli/test_init_runtime.py -q`

Closes #586.
