### PR TITLE
fix(claude): use partial content on max turns

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -639,6 +639,8 @@ class ClaudeCodeAdapter:
         content = ""
         session_id = None
         error_result: ProviderError | None = None
+        finish_reason = "stop"
+        raw_response: dict[str, object] = {"session_id": None}
 
         # Wrap query() to skip unknown message types (e.g., rate_limit_event)
         # that the SDK doesn't recognize yet. Without this, a single
@@ -703,17 +705,29 @@ class ClaudeCodeAdapter:
                     is_error = getattr(sdk_message, "is_error", False)
                     if is_error:
                         subtype = getattr(sdk_message, "subtype", None)
+                        stop_reason = getattr(sdk_message, "stop_reason", None)
+                        errors = getattr(sdk_message, "errors", None)
                         if subtype == "error_max_turns" and content.strip():
                             # Claude Code can emit a useful AssistantMessage and then
                             # finish with ResultMessage(error_max_turns) after trying
-                            # to continue with tools. Treat the already-streamed text
-                            # as a graceful partial result instead of crashing the
-                            # interview loop.
+                            # to continue with tools. Surface the already-streamed
+                            # text as a truncated partial result instead of crashing
+                            # the interview loop or pretending completion was clean.
+                            finish_reason = "length"
+                            raw_response.update(
+                                {
+                                    "subtype": subtype,
+                                    "stop_reason": stop_reason,
+                                    "errors": errors,
+                                    "partial_result": True,
+                                }
+                            )
                             log.warning(
                                 "claude_code_adapter.max_turns_partial_result",
                                 session_id=session_id,
                                 content_length=len(content),
                                 max_turns=self._max_turns,
+                                stop_reason=stop_reason,
                             )
                             continue
 
@@ -736,8 +750,8 @@ class ClaudeCodeAdapter:
                                 "claudecode_present": claudecode_present,
                                 "claude_code_entrypoint": os.environ.get("CLAUDE_CODE_ENTRYPOINT"),
                                 "subtype": subtype,
-                                "stop_reason": getattr(sdk_message, "stop_reason", None),
-                                "errors": getattr(sdk_message, "errors", None),
+                                "stop_reason": stop_reason,
+                                "errors": errors,
                             },
                         )
         except asyncio.CancelledError:
@@ -819,9 +833,11 @@ class ClaudeCodeAdapter:
             "claude_code_adapter.request_completed",
             content_length=len(content),
             session_id=session_id,
+            finish_reason=finish_reason,
         )
 
         # Build response
+        raw_response["session_id"] = session_id
         response = CompletionResponse(
             content=content,
             model=config.model,
@@ -830,8 +846,8 @@ class ClaudeCodeAdapter:
                 completion_tokens=0,
                 total_tokens=0,
             ),
-            finish_reason="stop",
-            raw_response={"session_id": session_id},
+            finish_reason=finish_reason,
+            raw_response=raw_response,
         )
 
         return Result.ok(response)

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -707,7 +707,10 @@ class ClaudeCodeAdapter:
                         subtype = getattr(sdk_message, "subtype", None)
                         stop_reason = getattr(sdk_message, "stop_reason", None)
                         errors = getattr(sdk_message, "errors", None)
-                        if subtype == "error_max_turns" and content.strip():
+                        if subtype == "error_max_turns" and self._is_usable_max_turns_partial(
+                            content,
+                            stop_reason=stop_reason,
+                        ):
                             # Claude Code can emit a useful AssistantMessage and then
                             # finish with ResultMessage(error_max_turns) after trying
                             # to continue with tools. Surface the already-streamed
@@ -735,12 +738,19 @@ class ClaudeCodeAdapter:
                             getattr(sdk_message, "result", "")
                             or "Unknown error from Claude Agent SDK"
                         )
+                        partial_content = content.strip() if subtype == "error_max_turns" else ""
+                        if subtype == "error_max_turns" and partial_content:
+                            error_msg = (
+                                "Claude Agent SDK reached max turns before producing "
+                                "a usable final response"
+                            )
                         log.warning(
                             "claude_code_adapter.sdk_error",
                             error=error_msg,
                             session_id=session_id,
                             stderr_lines=len(stderr_lines),
                             subtype=subtype,
+                            partial_rejected=bool(partial_content),
                         )
                         error_result = ProviderError(
                             message=error_msg,
@@ -752,6 +762,8 @@ class ClaudeCodeAdapter:
                                 "subtype": subtype,
                                 "stop_reason": stop_reason,
                                 "errors": errors,
+                                "partial_content": partial_content or None,
+                                "partial_rejected": bool(partial_content),
                             },
                         )
         except asyncio.CancelledError:
@@ -851,6 +863,48 @@ class ClaudeCodeAdapter:
         )
 
         return Result.ok(response)
+
+    @staticmethod
+    def _is_usable_max_turns_partial(content: str, *, stop_reason: object) -> bool:
+        """Return whether max-turn partial text is safe to surface as a completion.
+
+        Claude Code may stream natural-language preambles before attempting a tool
+        call and then finish with ``error_max_turns``. Those preambles are not a
+        final answer, so only accept tool-use-stopped partials when they look like
+        a standalone user-facing response rather than planning/tool setup.
+        """
+        text = content.strip()
+        if not text:
+            return False
+        if stop_reason != "tool_use":
+            return True
+
+        lowered = text.lower()
+        planning_prefixes = (
+            "i'll ",
+            "i will ",
+            "i need to ",
+            "let me ",
+            "first, i'll ",
+            "first i'll ",
+            "we need to ",
+            "i should ",
+        )
+        planning_markers = (
+            " use the ",
+            " run the ",
+            " inspect ",
+            " check the ",
+            " look at ",
+            " read the ",
+            " search ",
+        )
+        if lowered.startswith(planning_prefixes) or any(
+            marker in lowered for marker in planning_markers
+        ):
+            return False
+
+        return "?" in text or "\n" in text or len(text.split()) >= 8
 
     def _format_tool_info(self, tool_name: str, tool_input: dict) -> str:
         """Format tool name and input for display.

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -699,9 +699,24 @@ class ClaudeCodeAdapter:
                     elif not content:
                         content = getattr(sdk_message, "result", "") or ""
 
-                    # Check for errors - don't break, just record
+                    # Check for errors - don't break, just record.
                     is_error = getattr(sdk_message, "is_error", False)
                     if is_error:
+                        subtype = getattr(sdk_message, "subtype", None)
+                        if subtype == "error_max_turns" and content.strip():
+                            # Claude Code can emit a useful AssistantMessage and then
+                            # finish with ResultMessage(error_max_turns) after trying
+                            # to continue with tools. Treat the already-streamed text
+                            # as a graceful partial result instead of crashing the
+                            # interview loop.
+                            log.warning(
+                                "claude_code_adapter.max_turns_partial_result",
+                                session_id=session_id,
+                                content_length=len(content),
+                                max_turns=self._max_turns,
+                            )
+                            continue
+
                         error_msg = (
                             getattr(sdk_message, "result", "")
                             or "Unknown error from Claude Agent SDK"
@@ -711,6 +726,7 @@ class ClaudeCodeAdapter:
                             error=error_msg,
                             session_id=session_id,
                             stderr_lines=len(stderr_lines),
+                            subtype=subtype,
                         )
                         error_result = ProviderError(
                             message=error_msg,
@@ -719,6 +735,9 @@ class ClaudeCodeAdapter:
                                 "stderr": "\n".join(stderr_lines[-20:]) if stderr_lines else "",
                                 "claudecode_present": claudecode_present,
                                 "claude_code_entrypoint": os.environ.get("CLAUDE_CODE_ENTRYPOINT"),
+                                "subtype": subtype,
+                                "stop_reason": getattr(sdk_message, "stop_reason", None),
+                                "errors": getattr(sdk_message, "errors", None),
                             },
                         )
         except asyncio.CancelledError:

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -870,41 +870,14 @@ class ClaudeCodeAdapter:
 
         Claude Code may stream natural-language preambles before attempting a tool
         call and then finish with ``error_max_turns``. Those preambles are not a
-        final answer, so only accept tool-use-stopped partials when they look like
-        a standalone user-facing response rather than planning/tool setup.
+        final answer, and this provider layer cannot reliably distinguish them by
+        inspecting text shape. Keep tool-use-stopped max-turns on the error path
+        and only surface non-tool-use partials as length-limited completions.
         """
         text = content.strip()
         if not text:
             return False
-        if stop_reason != "tool_use":
-            return True
-
-        lowered = text.lower()
-        planning_prefixes = (
-            "i'll ",
-            "i will ",
-            "i need to ",
-            "let me ",
-            "first, i'll ",
-            "first i'll ",
-            "we need to ",
-            "i should ",
-        )
-        planning_markers = (
-            " use the ",
-            " run the ",
-            " inspect ",
-            " check the ",
-            " look at ",
-            " read the ",
-            " search ",
-        )
-        if lowered.startswith(planning_prefixes) or any(
-            marker in lowered for marker in planning_markers
-        ):
-            return False
-
-        return "?" in text or "\n" in text or len(text.split()) >= 8
+        return stop_reason != "tool_use"
 
     def _format_tool_info(self, tool_name: str, tool_input: dict) -> str:
         """Format tool name and input for display.

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -901,6 +901,52 @@ class TestErrorDiagnostics:
         assert result.error.details["stop_reason"] == "tool_use"
 
     @pytest.mark.asyncio
+    async def test_error_max_turns_rejects_tool_preamble_partial(self) -> None:
+        """Tool preambles before max-turns are not treated as final answers."""
+        adapter = ClaudeCodeAdapter(max_turns=5)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        class TextBlock:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+        async def preamble_then_max_turns_query(*args, **kwargs):
+            assistant_msg = MagicMock()
+            type(assistant_msg).__name__ = "AssistantMessage"
+            assistant_msg.content = [TextBlock("I'll inspect the project files first.")]
+            yield assistant_msg
+
+            result_msg = MagicMock()
+            type(result_msg).__name__ = "ResultMessage"
+            result_msg.structured_output = None
+            result_msg.result = ""
+            result_msg.is_error = True
+            result_msg.subtype = "error_max_turns"
+            result_msg.errors = ["Reached maximum number of turns (5)"]
+            result_msg.stop_reason = "tool_use"
+            yield result_msg
+
+        sdk_module = _make_sdk_mock(
+            mock_options_cls, MagicMock(side_effect=preamble_then_max_turns_query)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_err
+        assert "usable final response" in result.error.message
+        assert result.error.details["partial_rejected"] is True
+        assert result.error.details["partial_content"] == "I'll inspect the project files first."
+
+    @pytest.mark.asyncio
     async def test_sdk_error_message_includes_stderr(self) -> None:
         """SDK is_error result includes stderr in ProviderError details."""
         adapter = ClaudeCodeAdapter()

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -842,7 +842,7 @@ class TestErrorDiagnostics:
             result_msg.is_error = True
             result_msg.subtype = "error_max_turns"
             result_msg.errors = ["Reached maximum number of turns (5)"]
-            result_msg.stop_reason = "tool_use"
+            result_msg.stop_reason = "max_turns"
             yield result_msg
 
         sdk_module = _make_sdk_mock(
@@ -862,7 +862,7 @@ class TestErrorDiagnostics:
         assert result.value.content == "What should the app do first?"
         assert result.value.finish_reason == "length"
         assert result.value.raw_response["subtype"] == "error_max_turns"
-        assert result.value.raw_response["stop_reason"] == "tool_use"
+        assert result.value.raw_response["stop_reason"] == "max_turns"
         assert result.value.raw_response["errors"] == ["Reached maximum number of turns (5)"]
         assert result.value.raw_response["partial_result"] is True
 
@@ -901,8 +901,8 @@ class TestErrorDiagnostics:
         assert result.error.details["stop_reason"] == "tool_use"
 
     @pytest.mark.asyncio
-    async def test_error_max_turns_rejects_tool_preamble_partial(self) -> None:
-        """Tool preambles before max-turns are not treated as final answers."""
+    async def test_error_max_turns_rejects_tool_use_partial(self) -> None:
+        """Tool-use-stopped partials are not guessed into final answers."""
         adapter = ClaudeCodeAdapter(max_turns=5)
         config = CompletionConfig(model="claude-sonnet-4-6")
 
@@ -915,7 +915,7 @@ class TestErrorDiagnostics:
         async def preamble_then_max_turns_query(*args, **kwargs):
             assistant_msg = MagicMock()
             type(assistant_msg).__name__ = "AssistantMessage"
-            assistant_msg.content = [TextBlock("I'll inspect the project files first.")]
+            assistant_msg.content = [TextBlock("What should the app do first?")]
             yield assistant_msg
 
             result_msg = MagicMock()
@@ -944,7 +944,7 @@ class TestErrorDiagnostics:
         assert result.is_err
         assert "usable final response" in result.error.message
         assert result.error.details["partial_rejected"] is True
-        assert result.error.details["partial_content"] == "I'll inspect the project files first."
+        assert result.error.details["partial_content"] == "What should the app do first?"
 
     @pytest.mark.asyncio
     async def test_sdk_error_message_includes_stderr(self) -> None:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -818,6 +818,84 @@ class TestErrorDiagnostics:
         assert "retry" in result.error.message.lower()
 
     @pytest.mark.asyncio
+    async def test_error_max_turns_uses_streamed_partial_content(self) -> None:
+        """error_max_turns with assistant text returns the partial result."""
+        adapter = ClaudeCodeAdapter(max_turns=5)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        class TextBlock:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+        async def partial_then_max_turns_query(*args, **kwargs):
+            assistant_msg = MagicMock()
+            type(assistant_msg).__name__ = "AssistantMessage"
+            assistant_msg.content = [TextBlock("What should the app do first?")]
+            yield assistant_msg
+
+            result_msg = MagicMock()
+            type(result_msg).__name__ = "ResultMessage"
+            result_msg.structured_output = None
+            result_msg.result = ""
+            result_msg.is_error = True
+            result_msg.subtype = "error_max_turns"
+            result_msg.errors = ["Reached maximum number of turns (5)"]
+            result_msg.stop_reason = "tool_use"
+            yield result_msg
+
+        sdk_module = _make_sdk_mock(
+            mock_options_cls, MagicMock(side_effect=partial_then_max_turns_query)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_ok
+        assert result.value.content == "What should the app do first?"
+
+    @pytest.mark.asyncio
+    async def test_error_max_turns_without_partial_content_remains_error(self) -> None:
+        """error_max_turns still fails when there is no usable content."""
+        adapter = ClaudeCodeAdapter(max_turns=5)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def max_turns_only_query(*args, **kwargs):
+            result_msg = MagicMock()
+            type(result_msg).__name__ = "ResultMessage"
+            result_msg.structured_output = None
+            result_msg.result = ""
+            result_msg.is_error = True
+            result_msg.subtype = "error_max_turns"
+            result_msg.errors = ["Reached maximum number of turns (5)"]
+            result_msg.stop_reason = "tool_use"
+            yield result_msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=max_turns_only_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_err
+        assert result.error.details["subtype"] == "error_max_turns"
+        assert result.error.details["stop_reason"] == "tool_use"
+
+    @pytest.mark.asyncio
     async def test_sdk_error_message_includes_stderr(self) -> None:
         """SDK is_error result includes stderr in ProviderError details."""
         adapter = ClaudeCodeAdapter()

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -860,6 +860,11 @@ class TestErrorDiagnostics:
 
         assert result.is_ok
         assert result.value.content == "What should the app do first?"
+        assert result.value.finish_reason == "length"
+        assert result.value.raw_response["subtype"] == "error_max_turns"
+        assert result.value.raw_response["stop_reason"] == "tool_use"
+        assert result.value.raw_response["errors"] == ["Reached maximum number of turns (5)"]
+        assert result.value.raw_response["partial_result"] is True
 
     @pytest.mark.asyncio
     async def test_error_max_turns_without_partial_content_remains_error(self) -> None:


### PR DESCRIPTION
## Summary

- Treat Claude SDK `ResultMessage(subtype="error_max_turns")` as a graceful partial success only when assistant text was already streamed
- Preserve fatal error behavior when no usable partial content exists
- Add diagnostics for SDK error subtype/stop reason/errors and regression tests for both branches

## Verification

- `uv run ruff check src/ouroboros/providers/claude_code_adapter.py tests/unit/providers/test_claude_code_adapter.py`
- `uv run mypy src/ouroboros/providers/claude_code_adapter.py`
- `uv run pytest tests/unit/providers/test_claude_code_adapter.py::TestErrorDiagnostics -q`

Closes #587.
