### PR TITLE
fix(mcp): serve resources from persisted state

### DIFF
--- a/docs/contributing/repo-remediation-report.md
+++ b/docs/contributing/repo-remediation-report.md
@@ -1,0 +1,96 @@
+# Repository Remediation Report
+
+## 조사 범위
+
+- 작업 디렉터리: `/Users/jaegyu.lee/Project/ouroboros-gemini3`
+- AGENTS.md 적용 범위: 사용자 제공 컨텍스트 기준 저장소 내부 및 상위 경로에서 발견되지 않음.
+- 조사 대상:
+  - 버전 관리 대상 Python 패키지와 테스트 구성: `src/`, `tests/`, `pyproject.toml`
+  - 주요 프로젝트 문서: `README.md`, `docs/contributing/`
+  - 명시적 미완성 신호 검색: `TODO`, `FIXME`, `NotImplemented`, `placeholder`, `stub`, `pass`
+  - 정적 검사와 테스트: ruff, MCP 단위 테스트, 전체 단위/통합/e2e 테스트
+- 제외/주의 범위:
+  - 기존에 있던 다수의 untracked 파일과 디렉터리는 사용자 또는 다른 에이전트 작업일 수 있어 무관한 파일은 수정하지 않음.
+  - `apps/kart/node_modules/` 같은 생성/의존성 산출물은 코드 품질 조사 범위에서 제외함.
+
+## 발견한 불완전/위험 코드
+
+- `src/ouroboros/mcp/resources/handlers.py`의 MCP 리소스 핸들러가 실제 저장소 데이터를 읽지 않고 하드코딩된 예제 JSON을 반환하고 있었음.
+- 후속 리뷰에서 `MCPServerAdapter`가 등록된 exact URI만 조회해 `ouroboros://seeds/{id}`, `ouroboros://sessions/{id}`, `ouroboros://events/{session_id}` 요청이 리소스 핸들러의 동적 URI 분기까지 도달하지 못하는 P1 문제가 확인됨.
+- 후속 리뷰에서 `ouroboros://sessions/current`가 재구성된 `SessionTracker.last_message_time == None` 값만 기준으로 삼아 running session이 여러 개일 때 최신 activity 세션을 안정적으로 고르지 못하는 P1 문제가 확인됨.
+- 재리뷰에서 `sessions/current` activity 계산이 `aggregate_type == "session"` snapshot만 반영해, `workflow.progress.updated`처럼 `data.session_id`로 연결되는 execution-scoped event가 최신 activity인 running session을 놓칠 수 있는 문제가 확인됨.
+- 재리뷰에서 `sessions/current` 최종 선택이 offset이 섞인 ISO timestamp 문자열을 lexicographic 비교해 UTC 기준 최신 세션을 잘못 고를 수 있는 문제가 확인됨.
+- 영향:
+  - `ouroboros://seeds`, `ouroboros://sessions`, `ouroboros://events` 리소스가 실제 seed/session/event 상태와 불일치함.
+  - 특정 seed/session/event 조회도 존재 여부를 검증하지 않고 예제 데이터를 조립해 반환할 수 있었음.
+  - 같은 영역을 겨냥한 `tests/unit/mcp/resources/test_handlers.py`가 untracked 상태로 존재했고, 현재 구현과 생성자/응답 계약이 맞지 않는 상태였음.
+  - MCP 서버 어댑터 경유 호출에서는 특정 seed/session/event URI가 not found로 반환될 수 있었음.
+  - 여러 active session이 있을 때 `sessions/current`가 최신 activity가 아닌 오래된 세션을 반환할 수 있었음.
+  - 오래된 running session에 더 최신 execution-scoped progress가 있어도, 더 늦게 시작한 session aggregate activity가 우선될 수 있었음.
+
+## 수정한 파일 목록
+
+- `src/ouroboros/mcp/resources/handlers.py`
+- `src/ouroboros/mcp/server/adapter.py`
+- `tests/unit/mcp/resources/test_handlers.py`
+- `tests/unit/mcp/server/test_adapter.py`
+- `docs/contributing/repo-remediation-report.md`
+
+## 수정 요약
+
+- `SeedsResourceHandler`
+  - `seed_dir`를 주입 가능하게 추가하고 기본값을 `~/.ouroboros/seeds`로 설정함.
+  - `*.yaml`, `*.yml` seed 파일을 실제로 로드해 목록과 특정 seed 상세를 JSON으로 반환하게 변경함.
+  - 존재하지 않는 seed는 `MCPResourceNotFoundError`를 반환하게 변경함.
+- `SessionsResourceHandler`
+  - `EventStore` 주입을 지원하도록 변경함.
+  - `SessionRepository`로 세션을 재구성해 목록, 현재 세션, 특정 세션을 반환하게 변경함.
+  - 저장소가 주입되지 않은 기본 핸들러는 예제 데이터 대신 빈 상태를 반환함.
+- `EventsResourceHandler`
+  - `EventStore` 주입을 지원하도록 변경함.
+  - 최근 이벤트와 세션 관련 이벤트를 실제 EventStore 쿼리 결과로 반환하게 변경함.
+- 공통 직렬화 헬퍼를 추가해 session/event 응답 구조를 안정화함.
+- `MCPServerAdapter`
+  - exact URI 조회가 실패하면 등록된 base URI 중 가장 긴 prefix를 찾아 child URI를 해당 핸들러로 라우팅하게 변경함.
+  - FastMCP 등록 경로에서도 base resource에 `{resource_id}` 템플릿을 함께 등록해 실제 MCP transport에서 child URI가 도달할 수 있게 함.
+- `SessionsResourceHandler`
+  - `EventStore.get_session_activity_snapshots()`의 `last_activity`/`start_time`을 세션 응답에 병합하고, `sessions/current` 선택 기준을 해당 activity로 변경함.
+  - `last_message_time`이 비어 있는 재구성 세션이 여러 개여도 최신 이벤트 activity를 가진 running/paused session을 선택하도록 회귀 테스트를 추가함.
+  - 각 session snapshot에 `query_session_related_events(session_id=..., execution_id=..., limit=1)`의 최신 timestamp를 병합해 `SessionRepository.reconstruct_session()`과 같은 related-event 범위의 execution-scoped activity까지 `sessions/current` 선택 기준에 반영함.
+  - 오래된 running session의 `workflow.progress.updated` execution event가 더 최신 activity인 경우 해당 session을 current로 고르는 회귀 테스트를 추가함.
+  - `sessions/current` 최종 선택 키가 `last_activity`/`last_message_time`/`start_time`을 timezone-aware `datetime`으로 파싱해 비교하도록 변경하고, offset-equivalent 및 lexicographic 순서가 다른 timestamp 회귀 테스트를 추가함.
+
+## 수정 의도
+
+- MCP 리소스 API가 데모 데이터가 아니라 Ouroboros의 실제 영속 계층을 반영하도록 만들어 사용자와 에이전트가 잘못된 상태를 기반으로 판단하지 않게 하는 것이 목적임.
+- 기본 생성 경로는 기존 등록 코드와 호환되도록 유지하되, 실제 저장소가 없는 경우 허위 데이터 대신 빈 결과를 반환하도록 해 오진 위험을 줄였음.
+- seed 파일과 EventStore를 테스트에서 직접 주입할 수 있게 만들어 리소스 핸들러의 동작을 독립적으로 검증 가능하게 함.
+
+## 검증 결과
+
+- `uv run ruff check src/ouroboros/mcp/server/adapter.py src/ouroboros/mcp/resources/handlers.py tests/unit/mcp/server/test_adapter.py tests/unit/mcp/resources/test_handlers.py`
+  - 결과: 통과
+- `uv run mypy src/ouroboros/mcp/server/adapter.py src/ouroboros/mcp/resources/handlers.py`
+  - 결과: Success: no issues found in 2 source files
+- `uv run mypy src`
+  - 결과: Success: no issues found in 272 source files
+- `uv run pytest tests/unit/mcp/server/test_adapter.py::TestMCPServerAdapterResources tests/unit/mcp/server/test_adapter.py::TestServeTransport::test_fastmcp_registers_base_resource_uri_template tests/unit/mcp/resources/test_handlers.py`
+  - 결과: 15 passed
+- `uv run pytest tests/integration/mcp/test_server_adapter.py::TestMCPServerAdapterResourceReading`
+  - 결과: 4 passed
+- `uv run pytest tests/unit/mcp tests/integration/mcp/test_server_adapter.py::TestMCPServerAdapterResourceReading`
+  - 결과: 749 passed
+- `uv run pytest tests/unit/mcp/resources/test_handlers.py`
+  - 결과: 9 passed
+- `uv run ruff check src/ouroboros/mcp/resources/handlers.py tests/unit/mcp/resources/test_handlers.py`
+  - 결과: All checks passed!
+- `uv run mypy src/ouroboros/mcp/resources/handlers.py`
+  - 결과: Success: no issues found in 1 source file
+- `uv run pytest tests/unit/mcp`
+  - 결과: 745 passed
+
+## 남은 리스크
+
+- 저장소에는 기존 untracked 파일이 많이 남아 있으며, 그중 일부는 별도 기능 개발 또는 생성 산출물로 보인다. 이번 작업에서는 사용자/다른 에이전트 변경을 보존하기 위해 무관한 untracked 파일을 수정하지 않았다.
+- `tests/unit/mcp/resources/test_handlers.py`는 작업 시작 시점부터 untracked 상태였으나, 이번 후속 수정에서 회귀 테스트를 추가/정리했다. 해당 테스트를 정식으로 포함할지는 별도 스테이징 판단이 필요하다.
+- 기본 `OUROBOROS_RESOURCES`는 EventStore를 주입하지 않은 상태로 생성되므로 기본 등록만으로는 세션/이벤트가 빈 결과를 반환한다. 실제 MCP 서버 등록 경로에서 런타임 EventStore를 주입하는 후속 연결이 필요할 수 있다.

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -139,7 +139,6 @@ class SeedsResourceHandler:
                     "task_type": seed.task_type,
                     "created_at": seed.metadata.created_at.isoformat(),
                     "ambiguity_score": seed.metadata.ambiguity_score,
-                    "path": str(path),
                 }
             )
         return seeds

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -117,7 +117,11 @@ class SeedsResourceHandler:
         seed_dir = self.seed_dir
         if seed_dir is None or not seed_dir.exists():
             return []
-        paths = [*seed_dir.glob("*.yaml"), *seed_dir.glob("*.yml")]
+        paths = [
+            *seed_dir.glob("*.yaml"),
+            *seed_dir.glob("*.yml"),
+            *seed_dir.glob("*.json"),
+        ]
         return sorted({path.resolve() for path in paths}, key=lambda path: path.name)
 
     async def _list_seeds(self) -> list[dict[str, Any]]:

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -295,10 +295,9 @@ class SessionsResourceHandler:
         active_sessions = [
             session for session in sessions if session.get("status") in {"running", "paused"}
         ]
-        candidates = active_sessions or sessions
-        if not candidates:
+        if not active_sessions:
             return None
-        return max(candidates, key=_session_activity_key)
+        return max(active_sessions, key=_session_activity_key)
 
     async def _session_activity_by_id(self) -> dict[str, object]:
         if self.event_store is None:
@@ -381,6 +380,14 @@ class EventsResourceHandler:
             if uri.startswith("ouroboros://events/"):
                 session_id = uri.replace("ouroboros://events/", "")
                 events = await self._session_events(session_id)
+                if events is None:
+                    return Result.err(
+                        MCPResourceNotFoundError(
+                            f"Session events not found: {session_id}",
+                            resource_type="events",
+                            resource_id=session_id,
+                        )
+                    )
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
@@ -409,13 +416,15 @@ class EventsResourceHandler:
         events = await self.event_store.get_recent_events(limit=100)
         return [_event_to_dict(event) for event in events]
 
-    async def _session_events(self, session_id: str) -> list[dict[str, Any]]:
+    async def _session_events(self, session_id: str) -> list[dict[str, Any]] | None:
         if self.event_store is None:
-            return []
+            return None
         events = await self.event_store.query_session_related_events(
             session_id=session_id,
             limit=100,
         )
+        if not events:
+            return None
         return [_event_to_dict(event) for event in events]
 
 

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -8,12 +8,19 @@ This module defines resource handlers for exposing Ouroboros data:
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
 
 import structlog
 
+from ouroboros.bigbang.seed_generator import load_seed
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPResourceNotFoundError, MCPServerError
 from ouroboros.mcp.types import MCPResourceContent, MCPResourceDefinition
+from ouroboros.orchestrator.session import SessionRepository, SessionTracker
+from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
 
@@ -27,6 +34,12 @@ class SeedsResourceHandler:
     - ouroboros://seeds - List all seeds
     - ouroboros://seeds/{seed_id} - Get specific seed
     """
+
+    seed_dir: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.seed_dir is None:
+            self.seed_dir = Path.home() / ".ouroboros" / "seeds"
 
     @property
     def definitions(self) -> Sequence[MCPResourceDefinition]:
@@ -56,17 +69,14 @@ class SeedsResourceHandler:
 
         try:
             if uri == "ouroboros://seeds":
-                # TODO: Integrate with actual seed storage
-                content = (
-                    '{"seeds": [\n'
-                    '  {"id": "seed-001", "name": "Example Seed", "status": "active"},\n'
-                    '  {"id": "seed-002", "name": "Another Seed", "status": "completed"}\n'
-                    "]}"
-                )
+                seeds = await self._list_seeds()
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
-                        text=content,
+                        text=json.dumps(
+                            {"count": len(seeds), "seeds": seeds},
+                            sort_keys=True,
+                        ),
                         mime_type="application/json",
                     )
                 )
@@ -74,17 +84,24 @@ class SeedsResourceHandler:
             # Handle specific seed ID
             if uri.startswith("ouroboros://seeds/"):
                 seed_id = uri.replace("ouroboros://seeds/", "")
-                # TODO: Fetch actual seed
-                content = (
-                    f'{{"id": "{seed_id}", '
-                    f'"name": "Seed {seed_id}", '
-                    f'"content": "Example seed content...", '
-                    f'"status": "active"}}'
+                seed = await self._load_seed_by_id(seed_id)
+                if seed is None:
+                    return Result.err(
+                        MCPResourceNotFoundError(
+                            f"Seed not found: {seed_id}",
+                            resource_type="seed",
+                            resource_id=seed_id,
+                        )
+                    )
+                payload = (
+                    {"id": seed_id, "seed": seed.to_dict()}
+                    if seed.metadata.seed_id == seed_id
+                    else {"id": seed.metadata.seed_id, "requested_id": seed_id, "seed": seed.to_dict()}
                 )
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
-                        text=content,
+                        text=json.dumps(payload, sort_keys=True),
                         mime_type="application/json",
                     )
                 )
@@ -100,6 +117,54 @@ class SeedsResourceHandler:
             log.error("mcp.resource.seeds.error", uri=uri, error=str(e))
             return Result.err(MCPServerError(f"Failed to read seed resource: {e}"))
 
+    def _seed_paths(self) -> list[Path]:
+        seed_dir = self.seed_dir
+        if seed_dir is None or not seed_dir.exists():
+            return []
+        paths = [*seed_dir.glob("*.yaml"), *seed_dir.glob("*.yml")]
+        return sorted({path.resolve() for path in paths}, key=lambda path: path.name)
+
+    async def _list_seeds(self) -> list[dict[str, Any]]:
+        seeds: list[dict[str, Any]] = []
+        for path in self._seed_paths():
+            result = await load_seed(path)
+            if result.is_err:
+                log.warning("mcp.resource.seeds.skip_invalid", path=str(path))
+                continue
+            seed = result.value
+            seeds.append(
+                {
+                    "id": seed.metadata.seed_id,
+                    "goal": seed.goal,
+                    "task_type": seed.task_type,
+                    "created_at": seed.metadata.created_at.isoformat(),
+                    "ambiguity_score": seed.metadata.ambiguity_score,
+                    "path": str(path),
+                }
+            )
+        return seeds
+
+    async def _load_seed_by_id(self, seed_id: str):
+        for path in self._seed_paths():
+            if path.stem != seed_id and path.name != seed_id:
+                # Metadata is authoritative, but this cheap name filter handles
+                # the common path without reading every file when names differ.
+                result = await load_seed(path)
+                if result.is_err:
+                    log.warning("mcp.resource.seeds.skip_invalid", path=str(path))
+                    continue
+                seed = result.value
+                if seed.metadata.seed_id == seed_id:
+                    return seed
+                continue
+
+            result = await load_seed(path)
+            if result.is_err:
+                log.warning("mcp.resource.seeds.skip_invalid", path=str(path))
+                continue
+            return result.value
+        return None
+
 
 @dataclass
 class SessionsResourceHandler:
@@ -111,6 +176,8 @@ class SessionsResourceHandler:
     - ouroboros://sessions/current - Get current active session
     - ouroboros://sessions/{session_id} - Get specific session
     """
+
+    event_store: EventStore | None = None
 
     @property
     def definitions(self) -> Sequence[MCPResourceDefinition]:
@@ -146,35 +213,24 @@ class SessionsResourceHandler:
 
         try:
             if uri == "ouroboros://sessions":
-                # TODO: Integrate with actual session management
-                content = (
-                    '{"sessions": [\n'
-                    '  {"id": "session-001", "status": "active", "phase": "execution"},\n'
-                    '  {"id": "session-002", "status": "completed", "phase": "done"}\n'
-                    "]}"
-                )
+                sessions = await self._list_sessions()
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
-                        text=content,
+                        text=json.dumps(
+                            {"count": len(sessions), "sessions": sessions},
+                            sort_keys=True,
+                        ),
                         mime_type="application/json",
                     )
                 )
 
             if uri == "ouroboros://sessions/current":
-                # TODO: Get actual current session
-                content = (
-                    '{"id": "session-001", '
-                    '"status": "active", '
-                    '"phase": "execution", '
-                    '"progress": 0.6, '
-                    '"current_iteration": 3, '
-                    '"max_iterations": 10}'
-                )
+                session = await self._current_session()
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
-                        text=content,
+                        text=json.dumps({"session": session}, sort_keys=True),
                         mime_type="application/json",
                     )
                 )
@@ -182,17 +238,19 @@ class SessionsResourceHandler:
             # Handle specific session ID
             if uri.startswith("ouroboros://sessions/"):
                 session_id = uri.replace("ouroboros://sessions/", "")
-                # TODO: Fetch actual session
-                content = (
-                    f'{{"id": "{session_id}", '
-                    f'"status": "active", '
-                    f'"phase": "execution", '
-                    f'"seed_id": "seed-001"}}'
-                )
+                session = await self._load_session(session_id)
+                if session is None:
+                    return Result.err(
+                        MCPResourceNotFoundError(
+                            f"Session not found: {session_id}",
+                            resource_type="session",
+                            resource_id=session_id,
+                        )
+                    )
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
-                        text=content,
+                        text=json.dumps({"session": session}, sort_keys=True),
                         mime_type="application/json",
                     )
                 )
@@ -208,6 +266,68 @@ class SessionsResourceHandler:
             log.error("mcp.resource.sessions.error", uri=uri, error=str(e))
             return Result.err(MCPServerError(f"Failed to read session resource: {e}"))
 
+    async def _list_sessions(self) -> list[dict[str, Any]]:
+        if self.event_store is None:
+            return []
+
+        repo = SessionRepository(self.event_store)
+        activity_by_session = await self._session_activity_by_id()
+        start_events = await self.event_store.get_all_sessions()
+        session_ids = list(dict.fromkeys(event.aggregate_id for event in start_events))
+        sessions: list[dict[str, Any]] = []
+        for session_id in session_ids:
+            result = await repo.reconstruct_session(session_id)
+            if result.is_ok:
+                session = _session_to_dict(result.value)
+                last_activity = activity_by_session.get(session_id)
+                if last_activity is not None:
+                    session["last_activity"] = _timestamp_to_string(last_activity)
+                sessions.append(session)
+        return sessions
+
+    async def _load_session(self, session_id: str) -> dict[str, Any] | None:
+        if self.event_store is None:
+            return None
+
+        result = await SessionRepository(self.event_store).reconstruct_session(session_id)
+        if result.is_err:
+            return None
+        return _session_to_dict(result.value)
+
+    async def _current_session(self) -> dict[str, Any] | None:
+        sessions = await self._list_sessions()
+        active_sessions = [
+            session for session in sessions if session.get("status") in {"running", "paused"}
+        ]
+        candidates = active_sessions or sessions
+        if not candidates:
+            return None
+        return max(candidates, key=_session_activity_key)
+
+    async def _session_activity_by_id(self) -> dict[str, object]:
+        if self.event_store is None:
+            return {}
+
+        snapshots = await self.event_store.get_session_activity_snapshots()
+        activity_by_session: dict[str, object] = {}
+        for snapshot in snapshots:
+            activity = snapshot.last_activity or snapshot.start_time
+            if activity is not None:
+                activity_by_session[snapshot.session_id] = activity
+            related_events = await self.event_store.query_session_related_events(
+                session_id=snapshot.session_id,
+                execution_id=snapshot.execution_id,
+                limit=1,
+            )
+            if related_events:
+                related_activity = related_events[0].timestamp
+                current_activity = activity_by_session.get(snapshot.session_id)
+                activity_by_session[snapshot.session_id] = _latest_timestamp(
+                    current_activity,
+                    related_activity,
+                )
+        return activity_by_session
+
 
 @dataclass
 class EventsResourceHandler:
@@ -218,6 +338,8 @@ class EventsResourceHandler:
     - ouroboros://events - List recent events
     - ouroboros://events/{session_id} - Events for a specific session
     """
+
+    event_store: EventStore | None = None
 
     @property
     def definitions(self) -> Sequence[MCPResourceDefinition]:
@@ -247,19 +369,14 @@ class EventsResourceHandler:
 
         try:
             if uri == "ouroboros://events":
-                # TODO: Integrate with actual event store
-                content = (
-                    '{"events": [\n'
-                    '  {"id": "evt-001", "type": "execution", "session_id": "session-001", '
-                    '"timestamp": "2025-01-25T10:00:00Z"},\n'
-                    '  {"id": "evt-002", "type": "evaluation", "session_id": "session-001", '
-                    '"timestamp": "2025-01-25T10:01:00Z"}\n'
-                    "]}"
-                )
+                events = await self._recent_events()
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
-                        text=content,
+                        text=json.dumps(
+                            {"count": len(events), "events": events},
+                            sort_keys=True,
+                        ),
                         mime_type="application/json",
                     )
                 )
@@ -267,19 +384,14 @@ class EventsResourceHandler:
             # Handle session-specific events
             if uri.startswith("ouroboros://events/"):
                 session_id = uri.replace("ouroboros://events/", "")
-                # TODO: Fetch actual events for session
-                content = (
-                    f'{{"session_id": "{session_id}", "events": [\n'
-                    f'  {{"id": "evt-001", "type": "execution", '
-                    f'"timestamp": "2025-01-25T10:00:00Z"}},\n'
-                    f'  {{"id": "evt-002", "type": "evaluation", '
-                    f'"timestamp": "2025-01-25T10:01:00Z"}}\n'
-                    f"]}}"
-                )
+                events = await self._session_events(session_id)
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
-                        text=content,
+                        text=json.dumps(
+                            {"session_id": session_id, "count": len(events), "events": events},
+                            sort_keys=True,
+                        ),
                         mime_type="application/json",
                     )
                 )
@@ -294,6 +406,86 @@ class EventsResourceHandler:
         except Exception as e:
             log.error("mcp.resource.events.error", uri=uri, error=str(e))
             return Result.err(MCPServerError(f"Failed to read events resource: {e}"))
+
+    async def _recent_events(self) -> list[dict[str, Any]]:
+        if self.event_store is None:
+            return []
+        events = await self.event_store.get_recent_events(limit=100)
+        return [_event_to_dict(event) for event in events]
+
+    async def _session_events(self, session_id: str) -> list[dict[str, Any]]:
+        if self.event_store is None:
+            return []
+        events = await self.event_store.query_session_related_events(
+            session_id=session_id,
+            limit=100,
+        )
+        return [_event_to_dict(event) for event in events]
+
+
+def _session_to_dict(session: SessionTracker) -> dict[str, Any]:
+    data = session.to_dict()
+    data.update(session.progress)
+    return data
+
+
+def _event_to_dict(event: Any) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "type": event.type,
+        "timestamp": event.timestamp.isoformat() if event.timestamp else None,
+        "aggregate_type": event.aggregate_type,
+        "aggregate_id": event.aggregate_id,
+        "data": event.data,
+        "consensus_id": event.consensus_id,
+        "event_version": event.event_version,
+    }
+
+
+def _timestamp_to_string(value: object) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.isoformat()
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value)
+
+
+def _latest_timestamp(current: object | None, candidate: object | None) -> object:
+    if current is None:
+        return candidate or ""
+    if candidate is None:
+        return current
+    if _timestamp_sort_key(candidate) > _timestamp_sort_key(current):
+        return candidate
+    return current
+
+
+def _timestamp_sort_key(value: object) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return datetime.min.replace(tzinfo=UTC)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed
+    return datetime.min.replace(tzinfo=UTC)
+
+
+def _session_activity_key(session: dict[str, Any]) -> datetime:
+    activity = (
+        session.get("last_activity")
+        or session.get("last_message_time")
+        or session.get("start_time")
+    )
+    return _timestamp_sort_key(activity)
 
 
 # Convenience functions for handler access

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -93,11 +93,7 @@ class SeedsResourceHandler:
                             resource_id=seed_id,
                         )
                     )
-                payload = (
-                    {"id": seed_id, "seed": seed.to_dict()}
-                    if seed.metadata.seed_id == seed_id
-                    else {"id": seed.metadata.seed_id, "requested_id": seed_id, "seed": seed.to_dict()}
-                )
+                payload = {"id": seed.metadata.seed_id, "seed": seed.to_dict()}
                 return Result.ok(
                     MCPResourceContent(
                         uri=uri,
@@ -146,23 +142,23 @@ class SeedsResourceHandler:
 
     async def _load_seed_by_id(self, seed_id: str):
         for path in self._seed_paths():
-            if path.stem != seed_id and path.name != seed_id:
-                # Metadata is authoritative, but this cheap name filter handles
-                # the common path without reading every file when names differ.
-                result = await load_seed(path)
-                if result.is_err:
-                    log.warning("mcp.resource.seeds.skip_invalid", path=str(path))
-                    continue
-                seed = result.value
-                if seed.metadata.seed_id == seed_id:
-                    return seed
-                continue
-
+            name_matches = path.stem == seed_id or path.name == seed_id
             result = await load_seed(path)
             if result.is_err:
                 log.warning("mcp.resource.seeds.skip_invalid", path=str(path))
                 continue
-            return result.value
+
+            seed = result.value
+            if seed.metadata.seed_id == seed_id:
+                return seed
+
+            if name_matches:
+                log.warning(
+                    "mcp.resource.seeds.metadata_mismatch",
+                    path=str(path),
+                    requested_seed_id=seed_id,
+                    actual_seed_id=seed.metadata.seed_id,
+                )
         return None
 
 

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -266,12 +266,13 @@ class SessionsResourceHandler:
             return Result.err(MCPServerError(f"Failed to read session resource: {e}"))
 
     async def _list_sessions(self) -> list[dict[str, Any]]:
-        if self.event_store is None:
+        event_store = await self._ensure_event_store()
+        if event_store is None:
             return []
 
-        repo = SessionRepository(self.event_store)
+        repo = SessionRepository(event_store)
         activity_by_session = await self._session_activity_by_id()
-        start_events = await self.event_store.get_all_sessions()
+        start_events = await event_store.get_all_sessions()
         session_ids = list(dict.fromkeys(event.aggregate_id for event in start_events))
         sessions: list[dict[str, Any]] = []
         for session_id in session_ids:
@@ -285,10 +286,11 @@ class SessionsResourceHandler:
         return sessions
 
     async def _load_session(self, session_id: str) -> dict[str, Any] | None:
-        if self.event_store is None:
+        event_store = await self._ensure_event_store()
+        if event_store is None:
             return None
 
-        result = await SessionRepository(self.event_store).reconstruct_session(session_id)
+        result = await SessionRepository(event_store).reconstruct_session(session_id)
         if result.is_err:
             return None
         return _session_to_dict(result.value)
@@ -303,16 +305,17 @@ class SessionsResourceHandler:
         return max(active_sessions, key=_session_activity_key)
 
     async def _session_activity_by_id(self) -> dict[str, object]:
-        if self.event_store is None:
+        event_store = await self._ensure_event_store()
+        if event_store is None:
             return {}
 
-        snapshots = await self.event_store.get_session_activity_snapshots()
+        snapshots = await event_store.get_session_activity_snapshots()
         activity_by_session: dict[str, object] = {}
         for snapshot in snapshots:
             activity = snapshot.last_activity or snapshot.start_time
             if activity is not None:
                 activity_by_session[snapshot.session_id] = activity
-            related_events = await self.event_store.query_session_related_events(
+            related_events = await event_store.query_session_related_events(
                 session_id=snapshot.session_id,
                 execution_id=snapshot.execution_id,
                 limit=1,
@@ -325,6 +328,13 @@ class SessionsResourceHandler:
                     related_activity,
                 )
         return activity_by_session
+
+    async def _ensure_event_store(self) -> EventStore | None:
+        if self.event_store is None:
+            self.event_store = EventStore()
+        if getattr(self.event_store, "_engine", None) is None:
+            await self.event_store.initialize()
+        return self.event_store
 
 
 @dataclass
@@ -414,21 +424,30 @@ class EventsResourceHandler:
             return Result.err(MCPServerError(f"Failed to read events resource: {e}"))
 
     async def _recent_events(self) -> list[dict[str, Any]]:
-        if self.event_store is None:
+        event_store = await self._ensure_event_store()
+        if event_store is None:
             return []
-        events = await self.event_store.get_recent_events(limit=100)
+        events = await event_store.get_recent_events(limit=100)
         return [_event_to_dict(event) for event in events]
 
     async def _session_events(self, session_id: str) -> list[dict[str, Any]] | None:
-        if self.event_store is None:
+        event_store = await self._ensure_event_store()
+        if event_store is None:
             return None
-        events = await self.event_store.query_session_related_events(
+        events = await event_store.query_session_related_events(
             session_id=session_id,
             limit=100,
         )
         if not events:
             return None
         return [_event_to_dict(event) for event in events]
+
+    async def _ensure_event_store(self) -> EventStore | None:
+        if self.event_store is None:
+            self.event_store = EventStore()
+        if getattr(self.event_store, "_engine", None) is None:
+            await self.event_store.initialize()
+        return self.event_store
 
 
 def _session_to_dict(session: SessionTracker) -> dict[str, Any]:
@@ -502,21 +521,21 @@ def seeds_handler() -> SeedsResourceHandler:
     return SeedsResourceHandler()
 
 
-def sessions_handler() -> SessionsResourceHandler:
+def sessions_handler(event_store: EventStore | None = None) -> SessionsResourceHandler:
     """Create a SessionsResourceHandler instance."""
-    return SessionsResourceHandler()
+    return SessionsResourceHandler(event_store=event_store or EventStore())
 
 
-def events_handler() -> EventsResourceHandler:
+def events_handler(event_store: EventStore | None = None) -> EventsResourceHandler:
     """Create an EventsResourceHandler instance."""
-    return EventsResourceHandler()
+    return EventsResourceHandler(event_store=event_store or EventStore())
 
 
 # List of all Ouroboros resources for registration
 OUROBOROS_RESOURCES: tuple[
     SeedsResourceHandler | SessionsResourceHandler | EventsResourceHandler, ...
 ] = (
-    SeedsResourceHandler(),
-    SessionsResourceHandler(),
-    EventsResourceHandler(),
+    seeds_handler(),
+    sessions_handler(),
+    events_handler(),
 )

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -922,6 +922,11 @@ def create_ouroboros_server(
         SemanticConfig,
     )
     from ouroboros.mcp.job_manager import JobManager
+    from ouroboros.mcp.resources.handlers import (
+        EventsResourceHandler,
+        SeedsResourceHandler,
+        SessionsResourceHandler,
+    )
     from ouroboros.mcp.tools.brownfield_handler import BrownfieldHandler
     from ouroboros.mcp.tools.definitions import (
         ACDashboardHandler,
@@ -1594,6 +1599,12 @@ def create_ouroboros_server(
         ),
     ]
 
+    resource_handlers = [
+        SeedsResourceHandler(),
+        SessionsResourceHandler(event_store=event_store),
+        EventsResourceHandler(event_store=event_store),
+    ]
+
     # Create server adapter
     server = MCPServerAdapter(
         name=name,
@@ -1647,11 +1658,15 @@ def create_ouroboros_server(
         server.register_tool(handler)
         registry.register(handler, category="ouroboros")
 
+    for handler in resource_handlers:
+        server.register_resource(handler)
+
     log.info(
         "mcp.server.composition_root_complete",
         name=name,
         version=version,
         tools_registered=len(tool_handlers),
+        resources_registered=len(resource_handlers),
         tool_names=[h.definition.name for h in tool_handlers],
     )
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -45,6 +45,14 @@ log = structlog.get_logger(__name__)
 VALID_TRANSPORTS: frozenset[str] = frozenset({"stdio", "sse", "streamable-http"})
 
 
+def _is_single_segment_resource_uri(uri: str) -> bool:
+    """Return True for base URIs like ``scheme://name``."""
+    _scheme, separator, rest = uri.partition("://")
+    if not separator:
+        return "/" not in uri
+    return "/" not in rest
+
+
 def _safe_cwd() -> Path:
     """Return cwd if it looks like a usable project directory, else fall back to home.
 
@@ -391,6 +399,25 @@ class MCPServerAdapter:
             self._resource_handlers[defn.uri] = handler
             log.info("mcp.server.resource_registered", uri=defn.uri)
 
+    def _find_resource_handler(self, uri: str) -> ResourceHandler | None:
+        """Find a resource handler by exact URI or registered base URI prefix."""
+        exact_handler = self._resource_handlers.get(uri)
+        if exact_handler is not None:
+            return exact_handler
+
+        matching_base_uri = max(
+            (
+                registered_uri
+                for registered_uri in self._resource_handlers
+                if uri.startswith(f"{registered_uri}/")
+            ),
+            key=len,
+            default=None,
+        )
+        if matching_base_uri is None:
+            return None
+        return self._resource_handlers[matching_base_uri]
+
     def register_prompt(self, handler: PromptHandler) -> None:
         """Register a prompt handler.
 
@@ -513,7 +540,7 @@ class MCPServerAdapter:
         Returns:
             Result containing the resource content or an error.
         """
-        handler = self._resource_handlers.get(uri)
+        handler = self._find_resource_handler(uri)
         if not handler:
             return Result.err(
                 MCPResourceNotFoundError(
@@ -697,6 +724,24 @@ class MCPServerAdapter:
 
             wrapper = _make_resource_wrapper(res_handler, uri)
             self._mcp_server.resource(uri)(wrapper)
+
+            if _is_single_segment_resource_uri(uri):
+
+                def _make_resource_template_wrapper(h: ResourceHandler, base_uri: str) -> Any:
+                    async def resource_template_wrapper(resource_id: str) -> str:
+                        resource_uri = f"{base_uri}/{resource_id}"
+                        result = await h.handle(resource_uri)
+                        if result.is_ok:
+                            content = result.value
+                            return content.text or ""
+                        else:
+                            raise RuntimeError(str(result.error))
+
+                    return resource_template_wrapper
+
+                template = f"{uri}/{{resource_id}}"
+                template_wrapper = _make_resource_template_wrapper(res_handler, uri)
+                self._mcp_server.resource(template)(template_wrapper)
 
         log.info(
             "mcp.server.starting",

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -57,6 +57,46 @@ async def test_seeds_handler_reads_specific_seed_by_id(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_seeds_handler_uses_metadata_identity_for_specific_seed(
+    tmp_path: Path,
+) -> None:
+    seeds_dir = tmp_path / "seeds"
+    mismatched_save = save_seed_sync(
+        _demo_seed("seed_actual"),
+        seeds_dir / "seed_alias.yaml",
+    )
+    assert mismatched_save.is_ok
+    matching_save = save_seed_sync(
+        _demo_seed("seed_alias"),
+        seeds_dir / "other_name.yaml",
+    )
+    assert matching_save.is_ok
+
+    handler = SeedsResourceHandler(seed_dir=seeds_dir)
+    result = await handler.handle("ouroboros://seeds/seed_alias")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["id"] == "seed_alias"
+    assert payload["seed"]["metadata"]["seed_id"] == "seed_alias"
+
+
+@pytest.mark.asyncio
+async def test_seeds_handler_rejects_filename_match_with_wrong_metadata(
+    tmp_path: Path,
+) -> None:
+    seeds_dir = tmp_path / "seeds"
+    save_result = save_seed_sync(_demo_seed("seed_actual"), seeds_dir / "seed_alias.yaml")
+    assert save_result.is_ok
+
+    handler = SeedsResourceHandler(seed_dir=seeds_dir)
+    result = await handler.handle("ouroboros://seeds/seed_alias")
+
+    assert result.is_err
+    assert "Seed not found: seed_alias" in str(result.error)
+
+
+@pytest.mark.asyncio
 async def test_sessions_handler_reads_event_store_sessions(tmp_path: Path) -> None:
     store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
     await store.initialize()

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -42,6 +42,30 @@ async def test_seeds_handler_lists_real_seed_files(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_seeds_handler_reads_json_seed_files(tmp_path: Path) -> None:
+    seeds_dir = tmp_path / "seeds"
+    seeds_dir.mkdir()
+    (seeds_dir / "seed_json.json").write_text(
+        json.dumps(_demo_seed("seed_json").to_dict(), default=str),
+        encoding="utf-8",
+    )
+
+    handler = SeedsResourceHandler(seed_dir=seeds_dir)
+    list_result = await handler.handle("ouroboros://seeds")
+    detail_result = await handler.handle("ouroboros://seeds/seed_json")
+
+    assert list_result.is_ok
+    list_payload = json.loads(list_result.value.text or "{}")
+    assert list_payload["count"] == 1
+    assert list_payload["seeds"][0]["id"] == "seed_json"
+
+    assert detail_result.is_ok
+    detail_payload = json.loads(detail_result.value.text or "{}")
+    assert detail_payload["id"] == "seed_json"
+    assert detail_payload["seed"]["goal"] == "Demo goal"
+
+
+@pytest.mark.asyncio
 async def test_seeds_handler_reads_specific_seed_by_id(tmp_path: Path) -> None:
     seeds_dir = tmp_path / "seeds"
     save_result = save_seed_sync(_demo_seed("seed_demo"), seeds_dir / "seed_demo.yaml")

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -38,6 +38,7 @@ async def test_seeds_handler_lists_real_seed_files(tmp_path: Path) -> None:
     assert payload["count"] == 1
     assert payload["seeds"][0]["id"] == "seed_demo"
     assert payload["seeds"][0]["goal"] == "Demo goal"
+    assert "path" not in payload["seeds"][0]
     assert "Example Seed" not in (result.value.text or "")
 
 
@@ -58,6 +59,7 @@ async def test_seeds_handler_reads_json_seed_files(tmp_path: Path) -> None:
     list_payload = json.loads(list_result.value.text or "{}")
     assert list_payload["count"] == 1
     assert list_payload["seeds"][0]["id"] == "seed_json"
+    assert "path" not in list_payload["seeds"][0]
 
     assert detail_result.is_ok
     detail_payload = json.loads(detail_result.value.text or "{}")

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -1,0 +1,314 @@
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.bigbang.seed_generator import save_seed_sync
+from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.resources.handlers import (
+    EventsResourceHandler,
+    SeedsResourceHandler,
+    SessionsResourceHandler,
+)
+from ouroboros.orchestrator.session import SessionRepository
+from ouroboros.persistence.event_store import EventStore
+
+
+def _demo_seed(seed_id: str) -> Seed:
+    return Seed(
+        goal="Demo goal",
+        ontology_schema=OntologySchema(name="demo", description="demo ontology"),
+        metadata=SeedMetadata(seed_id=seed_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_seeds_handler_lists_real_seed_files(tmp_path: Path) -> None:
+    seeds_dir = tmp_path / "seeds"
+    save_result = save_seed_sync(_demo_seed("seed_demo"), seeds_dir / "seed_demo.yaml")
+    assert save_result.is_ok
+
+    handler = SeedsResourceHandler(seed_dir=seeds_dir)
+    result = await handler.handle("ouroboros://seeds")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["count"] == 1
+    assert payload["seeds"][0]["id"] == "seed_demo"
+    assert payload["seeds"][0]["goal"] == "Demo goal"
+    assert "Example Seed" not in (result.value.text or "")
+
+
+@pytest.mark.asyncio
+async def test_seeds_handler_reads_specific_seed_by_id(tmp_path: Path) -> None:
+    seeds_dir = tmp_path / "seeds"
+    save_result = save_seed_sync(_demo_seed("seed_demo"), seeds_dir / "seed_demo.yaml")
+    assert save_result.is_ok
+
+    handler = SeedsResourceHandler(seed_dir=seeds_dir)
+    result = await handler.handle("ouroboros://seeds/seed_demo")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["id"] == "seed_demo"
+    assert payload["seed"]["goal"] == "Demo goal"
+
+
+@pytest.mark.asyncio
+async def test_sessions_handler_reads_event_store_sessions(tmp_path: Path) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    repo = SessionRepository(store)
+    created = await repo.create_session("exec_1", "seed_1", "orch_1")
+    assert created.is_ok
+    progress = await repo.track_progress(
+        "orch_1",
+        {"messages_processed": 3, "current_phase": "design"},
+    )
+    assert progress.is_ok
+
+    handler = SessionsResourceHandler(event_store=store)
+
+    sessions_result = await handler.handle("ouroboros://sessions")
+    current_result = await handler.handle("ouroboros://sessions/current")
+
+    assert sessions_result.is_ok
+    assert current_result.is_ok
+
+    sessions_payload = json.loads(sessions_result.value.text or "{}")
+    current_payload = json.loads(current_result.value.text or "{}")
+
+    assert sessions_payload["count"] == 1
+    assert sessions_payload["sessions"][0]["session_id"] == "orch_1"
+    assert sessions_payload["sessions"][0]["status"] == "running"
+    assert sessions_payload["sessions"][0]["messages_processed"] == 3
+    assert current_payload["session"]["session_id"] == "orch_1"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_sessions_current_uses_latest_event_activity_when_reconstructed_times_are_empty(
+    tmp_path: Path,
+) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    await store.append(
+        BaseEvent(
+            type="orchestrator.session.started",
+            timestamp=datetime(2026, 4, 1, 0, 0, tzinfo=UTC),
+            aggregate_type="session",
+            aggregate_id="orch_old",
+            data={
+                "execution_id": "exec_old",
+                "seed_id": "seed_old",
+                "start_time": "2026-04-01T00:00:00+00:00",
+            },
+        )
+    )
+    await store.append(
+        BaseEvent(
+            type="orchestrator.session.started",
+            timestamp=datetime(2026, 4, 1, 0, 1, tzinfo=UTC),
+            aggregate_type="session",
+            aggregate_id="orch_new",
+            data={
+                "execution_id": "exec_new",
+                "seed_id": "seed_new",
+                "start_time": "2026-04-01T00:01:00+00:00",
+            },
+        )
+    )
+    await store.append(
+        BaseEvent(
+            type="orchestrator.progress.updated",
+            timestamp=datetime(2026, 4, 1, 0, 2, tzinfo=UTC),
+            aggregate_type="session",
+            aggregate_id="orch_new",
+            data={"progress": {"messages_processed": 2}},
+        )
+    )
+
+    handler = SessionsResourceHandler(event_store=store)
+    result = await handler.handle("ouroboros://sessions/current")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["session"]["session_id"] == "orch_new"
+    assert payload["session"]["last_message_time"] is None
+    assert payload["session"]["last_activity"] == "2026-04-01T00:02:00+00:00"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_sessions_current_uses_related_execution_activity(
+    tmp_path: Path,
+) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    await store.append(
+        BaseEvent(
+            type="orchestrator.session.started",
+            timestamp=datetime(2026, 4, 1, 0, 0, tzinfo=UTC),
+            aggregate_type="session",
+            aggregate_id="orch_old",
+            data={
+                "execution_id": "exec_old",
+                "seed_id": "seed_old",
+                "start_time": "2026-04-01T00:00:00+00:00",
+            },
+        )
+    )
+    await store.append(
+        BaseEvent(
+            type="orchestrator.session.started",
+            timestamp=datetime(2026, 4, 1, 0, 5, tzinfo=UTC),
+            aggregate_type="session",
+            aggregate_id="orch_new",
+            data={
+                "execution_id": "exec_new",
+                "seed_id": "seed_new",
+                "start_time": "2026-04-01T00:05:00+00:00",
+            },
+        )
+    )
+    await store.append(
+        BaseEvent(
+            type="orchestrator.progress.updated",
+            timestamp=datetime(2026, 4, 1, 0, 6, tzinfo=UTC),
+            aggregate_type="session",
+            aggregate_id="orch_new",
+            data={"progress": {"messages_processed": 1}},
+        )
+    )
+    await store.append(
+        BaseEvent(
+            type="workflow.progress.updated",
+            timestamp=datetime(2026, 4, 1, 0, 10, tzinfo=UTC),
+            aggregate_type="execution",
+            aggregate_id="exec_old",
+            data={
+                "session_id": "orch_old",
+                "messages_count": 4,
+                "current_phase": "execute",
+            },
+        )
+    )
+
+    handler = SessionsResourceHandler(event_store=store)
+    result = await handler.handle("ouroboros://sessions/current")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["session"]["session_id"] == "orch_old"
+    assert payload["session"]["status"] == "running"
+    assert payload["session"]["last_activity"] == "2026-04-01T00:10:00+00:00"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_sessions_current_sorts_mixed_offset_activity_as_datetimes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = SessionsResourceHandler()
+
+    async def list_sessions() -> list[dict[str, object]]:
+        return [
+            {
+                "session_id": "utc_equivalent",
+                "status": "running",
+                "last_activity": "2026-04-01T01:00:00+00:00",
+            },
+            {
+                "session_id": "offset_equivalent",
+                "status": "running",
+                "last_activity": "2026-04-01T10:00:00+09:00",
+            },
+            {
+                "session_id": "actual_latest",
+                "status": "running",
+                "last_activity": "2026-04-01T01:01:00+00:00",
+            },
+        ]
+
+    monkeypatch.setattr(handler, "_list_sessions", list_sessions)
+
+    result = await handler.handle("ouroboros://sessions/current")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["session"]["session_id"] == "actual_latest"
+
+
+@pytest.mark.asyncio
+async def test_sessions_handler_reads_specific_session(tmp_path: Path) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    repo = SessionRepository(store)
+    created = await repo.create_session("exec_1", "seed_1", "orch_1")
+    assert created.is_ok
+
+    handler = SessionsResourceHandler(event_store=store)
+    result = await handler.handle("ouroboros://sessions/orch_1")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["session"]["session_id"] == "orch_1"
+    assert payload["session"]["execution_id"] == "exec_1"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_events_handler_reads_recent_events(tmp_path: Path) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    repo = SessionRepository(store)
+    created = await repo.create_session("exec_1", "seed_1", "orch_1")
+    assert created.is_ok
+
+    handler = EventsResourceHandler(event_store=store)
+    result = await handler.handle("ouroboros://events")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["count"] >= 1
+    assert payload["events"][0]["aggregate_id"] == "orch_1"
+    assert payload["events"][0]["type"] == "orchestrator.session.started"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_events_handler_reads_session_related_events(tmp_path: Path) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    repo = SessionRepository(store)
+    created = await repo.create_session("exec_1", "seed_1", "orch_1")
+    assert created.is_ok
+    progress = await repo.track_progress("orch_1", {"messages_processed": 1})
+    assert progress.is_ok
+
+    handler = EventsResourceHandler(event_store=store)
+    result = await handler.handle("ouroboros://events/orch_1")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["session_id"] == "orch_1"
+    assert payload["count"] >= 2
+    assert {event["type"] for event in payload["events"]} >= {
+        "orchestrator.session.started",
+        "orchestrator.progress.updated",
+    }
+
+    await store.close()

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -11,6 +11,8 @@ from ouroboros.mcp.resources.handlers import (
     EventsResourceHandler,
     SeedsResourceHandler,
     SessionsResourceHandler,
+    events_handler,
+    sessions_handler,
 )
 from ouroboros.orchestrator.session import SessionRepository
 from ouroboros.persistence.event_store import EventStore
@@ -22,6 +24,14 @@ def _demo_seed(seed_id: str) -> Seed:
         ontology_schema=OntologySchema(name="demo", description="demo ontology"),
         metadata=SeedMetadata(seed_id=seed_id),
     )
+
+
+def test_session_and_event_factories_wire_default_event_stores() -> None:
+    session_resource = sessions_handler()
+    event_resource = events_handler()
+
+    assert session_resource.event_store is not None
+    assert event_resource.event_store is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -288,6 +288,29 @@ async def test_sessions_current_sorts_mixed_offset_activity_as_datetimes(
 
 
 @pytest.mark.asyncio
+async def test_sessions_current_returns_null_when_no_session_is_active(
+    tmp_path: Path,
+) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    repo = SessionRepository(store)
+    created = await repo.create_session("exec_done", "seed_done", "orch_done")
+    assert created.is_ok
+    completed = await repo.mark_completed("orch_done")
+    assert completed.is_ok
+
+    handler = SessionsResourceHandler(event_store=store)
+    result = await handler.handle("ouroboros://sessions/current")
+
+    assert result.is_ok
+    payload = json.loads(result.value.text or "{}")
+    assert payload["session"] is None
+
+    await store.close()
+
+
+@pytest.mark.asyncio
 async def test_sessions_handler_reads_specific_session(tmp_path: Path) -> None:
     store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
     await store.initialize()
@@ -324,6 +347,22 @@ async def test_events_handler_reads_recent_events(tmp_path: Path) -> None:
     assert payload["count"] >= 1
     assert payload["events"][0]["aggregate_id"] == "orch_1"
     assert payload["events"][0]["type"] == "orchestrator.session.started"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_events_handler_rejects_unknown_session_events(
+    tmp_path: Path,
+) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    handler = EventsResourceHandler(event_store=store)
+    result = await handler.handle("ouroboros://events/missing_session")
+
+    assert result.is_err
+    assert "Session events not found: missing_session" in str(result.error)
 
     await store.close()
 

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -391,6 +391,17 @@ class TestMCPServerAdapterResources:
         assert result.is_ok
         assert result.value.text == "Resource content"
 
+    async def test_read_resource_routes_registered_base_uri_prefix(self) -> None:
+        """read_resource routes child URIs to handlers registered at the base URI."""
+        adapter = MCPServerAdapter()
+        handler = MockResourceHandler("test://resource")
+        adapter.register_resource(handler)
+
+        result = await adapter.read_resource("test://resource/child")
+
+        assert result.is_ok
+        handler.handle_mock.assert_awaited_once_with("test://resource/child")
+
     async def test_read_resource_not_found(self) -> None:
         """read_resource returns error for unknown resource."""
         adapter = MCPServerAdapter()
@@ -644,6 +655,51 @@ class TestServeTransport:
         # Test: Path traversal should be rejected by input validation
         with pytest.raises(RuntimeError, match="Path traversal detected"):
             await captured_wrapper(input="../../../etc/passwd")
+
+    @pytest.mark.asyncio
+    async def test_fastmcp_registers_base_resource_uri_template(self) -> None:
+        """FastMCP path exposes child URIs for base resource handlers."""
+        from unittest.mock import MagicMock, patch
+
+        adapter = MCPServerAdapter()
+        handler = MockResourceHandler("test://resource")
+        adapter.register_resource(handler)
+
+        mock_fastmcp_cls = MagicMock()
+        mock_instance = MagicMock()
+        captured_resources: dict[str, Any] = {}
+
+        def capture_resource_decorator(uri: str):
+            def decorator(func):
+                captured_resources[uri] = func
+                return func
+
+            return decorator
+
+        mock_instance.tool = MagicMock(return_value=lambda f: f)
+        mock_instance.resource = capture_resource_decorator
+        mock_instance.run_stdio_async = AsyncMock()
+        mock_fastmcp_cls.return_value = mock_instance
+
+        with (
+            patch(
+                "ouroboros.mcp.server.adapter.FastMCP",
+                mock_fastmcp_cls,
+                create=True,
+            ),
+            patch.dict(
+                "sys.modules",
+                {"mcp.server.fastmcp": MagicMock(FastMCP=mock_fastmcp_cls)},
+            ),
+        ):
+            await adapter.serve(transport="stdio")
+
+        assert "test://resource" in captured_resources
+        assert "test://resource/{resource_id}" in captured_resources
+
+        text = await captured_resources["test://resource/{resource_id}"]("child")
+        assert text == "Resource content"
+        handler.handle_mock.assert_awaited_with("test://resource/child")
 
     @pytest.mark.asyncio
     async def test_fastmcp_rejects_auth_config_at_startup(self):


### PR DESCRIPTION
## Summary

- Replace placeholder MCP seed/session/event resource responses with persisted seed files and EventStore-backed data.
- Route child resource URIs through the MCP adapter and FastMCP template registration so specific resource reads reach the proper handlers.
- Fix current-session selection to use related execution activity and timezone-aware timestamp comparison.

## Changes

- Added seed loading for `ouroboros://seeds` and `ouroboros://seeds/{id}`.
- Added EventStore-backed session and event reads for base and specific MCP resource URIs.
- Added adapter prefix routing and FastMCP `{resource_id}` resource template registration.
- Added regression tests for child URI routing, related execution activity, and mixed-offset timestamp ordering.
- Added a remediation report documenting findings, intent, verification, and residual risks.

## Notes

Unrelated untracked workspace files were intentionally excluded. `tests/unit/mcp/resources/test_handlers.py` is included because it covers the new MCP resource behavior.