### PR TITLE
Fix interview Claude tool envelope

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -33,6 +33,7 @@ from dataclasses import replace
 import json
 import os
 from pathlib import Path
+import traceback
 
 import structlog
 
@@ -592,7 +593,12 @@ class ClaudeCodeAdapter:
             "env": env_overrides,
         }
         if self._allowed_tools is not None:
-            options_kwargs["allowed_tools"] = self._allowed_tools
+            # The SDK distinguishes the visible tool catalog (tools) from
+            # permission filtering (allowed_tools). Passing both keeps explicit
+            # envelopes, such as the interview read-only tool set, from exposing
+            # default built-ins like AskUserQuestion/ToolSearch.
+            options_kwargs["allowed_tools"] = list(self._allowed_tools)
+            options_kwargs["tools"] = list(self._allowed_tools)
 
         # Pass model from CompletionConfig if specified
         # "default" is not a valid SDK model — treat it as None (use SDK default)
@@ -725,6 +731,7 @@ class ClaudeCodeAdapter:
             raise
         except Exception as exc:
             stderr_tail = "\n".join(stderr_lines[-20:]) if stderr_lines else ""
+            traceback_text = traceback.format_exc()
             error_message = f"Claude Agent SDK request failed: {exc}"
             if stderr_tail and "Check stderr output for details" in str(exc):
                 error_message = f"{error_message}\nstderr tail:\n{stderr_tail}"
@@ -744,6 +751,7 @@ class ClaudeCodeAdapter:
                         "error_type": type(exc).__name__,
                         "session_id": session_id,
                         "stderr": stderr_tail,
+                        "traceback": traceback_text,
                         "claudecode_present": claudecode_present,
                         "claude_code_entrypoint": os.environ.get("CLAUDE_CODE_ENTRYPOINT"),
                     },

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -615,6 +615,7 @@ class TestJsonSchemaHandling:
 
         options_call_kwargs = mock_options_cls.call_args.kwargs
         assert "allowed_tools" not in options_call_kwargs
+        assert "tools" not in options_call_kwargs
         assert options_call_kwargs["cwd"] == "/tmp/project"
         assert "Write" in options_call_kwargs["disallowed_tools"]
 
@@ -647,7 +648,45 @@ class TestJsonSchemaHandling:
 
         options_call_kwargs = mock_options_cls.call_args.kwargs
         assert options_call_kwargs["allowed_tools"] == []
+        assert options_call_kwargs["tools"] == []
         assert "Read" in options_call_kwargs["disallowed_tools"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_allowed_tools_sets_visible_sdk_tools(self) -> None:
+        """Explicit tool envelopes restrict both permissions and exposed SDK tools."""
+        allowed_tools = ["Read", "Grep", "mcp__ouroboros__qa"]
+        adapter = ClaudeCodeAdapter(allowed_tools=allowed_tools)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        assert options_call_kwargs["allowed_tools"] == allowed_tools
+        assert options_call_kwargs["tools"] == allowed_tools
+        assert "Read" not in options_call_kwargs["disallowed_tools"]
+        assert "Grep" not in options_call_kwargs["disallowed_tools"]
+        assert "ToolSearch" not in options_call_kwargs["tools"]
+        assert "AskUserQuestion" not in options_call_kwargs["tools"]
+        assert "Write" in options_call_kwargs["disallowed_tools"]
 
 
 class TestErrorDiagnostics:
@@ -682,6 +721,8 @@ class TestErrorDiagnostics:
         assert isinstance(error, ProviderError)
         assert "SDK connection lost" in error.message
         assert error.details["error_type"] == "RuntimeError"
+        assert "traceback" in error.details
+        assert "RuntimeError: SDK connection lost" in error.details["traceback"]
 
     @pytest.mark.asyncio
     async def test_sdk_exception_includes_stderr_in_details(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #588 by tightening the Claude Code adapter's explicit tool envelope for interview-style calls.

When `allowed_tools` is explicitly provided, the adapter now passes the same list to the SDK `tools` option as well as `allowed_tools`. This restricts the visible SDK tool catalog instead of only applying permission filtering, preventing the interview path from seeing default built-ins such as `ToolSearch`/`AskUserQuestion` that caused the macOS exit-1/empty-stderr failure signature.

This PR also adds traceback text to `ProviderError.details` for SDK exceptions so empty-stderr exits remain actionable.

## Validation

- `uv run ruff check src/ouroboros/providers/claude_code_adapter.py tests/unit/providers/test_claude_code_adapter.py`
- `uv run pytest tests/unit/providers/test_claude_code_adapter.py -q`
- `uv run mypy src/ouroboros/providers/claude_code_adapter.py`
- `git diff --check`

## Notes

I could not run the live macOS Claude Code CLI reproduction in this worktree, so the change is covered by targeted adapter unit tests for the SDK option envelope and exception diagnostics.
