### PR TITLE
Keep Ralph mutations inside the requested project directory

### DIFF
--- a/scripts/ralph.py
+++ b/scripts/ralph.py
@@ -51,7 +51,12 @@ def _resolve_project_dir(project_dir: str | None) -> str | None:
     """Return an absolute project directory path for MCP calls."""
     if not project_dir:
         return None
-    return str(Path(project_dir).expanduser().resolve())
+    resolved = Path(project_dir).expanduser().resolve()
+    if not resolved.exists():
+        raise ValueError(f"--project-dir does not exist: {resolved}")
+    if not resolved.is_dir():
+        raise ValueError(f"--project-dir is not a directory: {resolved}")
+    return str(resolved)
 
 
 def parse_evolve_text(text: str) -> dict[str, Any]:
@@ -279,6 +284,11 @@ def main() -> None:
 
     if not args.lineage_id:
         parser.error("--lineage-id is required")
+
+    try:
+        args.project_dir = _resolve_project_dir(args.project_dir)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     try:
         output = asyncio.run(connect_and_run(args))

--- a/scripts/ralph.py
+++ b/scripts/ralph.py
@@ -47,6 +47,13 @@ _QA_SCORE_RE = re.compile(r"Score:\s*([\d.]+)")
 _QA_VERDICT_RE = re.compile(r"Verdict:\s*(\w+)")
 
 
+def _resolve_project_dir(project_dir: str | None) -> str | None:
+    """Return an absolute project directory path for MCP calls."""
+    if not project_dir:
+        return None
+    return str(Path(project_dir).expanduser().resolve())
+
+
 def parse_evolve_text(text: str) -> dict[str, Any]:
     """Parse the markdown text returned by ouroboros_evolve_step.
 
@@ -111,6 +118,9 @@ async def _call_evolve(session: Any, args: argparse.Namespace) -> dict[str, Any]
     """Invoke evolve_step, handle stagnation with lateral_think retries."""
     # Build arguments for evolve_step
     tool_args: dict[str, Any] = {"lineage_id": args.lineage_id}
+    project_dir = _resolve_project_dir(getattr(args, "project_dir", None))
+    if project_dir:
+        tool_args["project_dir"] = project_dir
     if args.seed_file:
         seed_path = Path(args.seed_file)
         if not seed_path.exists():
@@ -164,8 +174,14 @@ async def _call_evolve(session: Any, args: argparse.Namespace) -> dict[str, Any]
 
             # Re-run evolve_step after lateral thinking
             retry_args: dict[str, Any] = {"lineage_id": lineage_id}
+            if project_dir:
+                retry_args["project_dir"] = project_dir
             if args.no_execute:
                 retry_args["execute"] = False
+            if args.no_parallel:
+                retry_args["parallel"] = False
+            if args.no_qa:
+                retry_args["skip_qa"] = True
             result = await session.call_tool("ouroboros_evolve_step", retry_args)
             text = _extract_text(result)
             if text is None:
@@ -224,6 +240,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--lineage-id", required=True, help="Lineage ID to evolve")
     p.add_argument("--seed-file", default=None, help="Path to seed YAML (Gen 1 only)")
+    p.add_argument(
+        "--project-dir",
+        default=None,
+        help="Target project directory for evolve_step operations",
+    )
     p.add_argument(
         "--no-execute", action="store_true", help="Ontology-only evolution (skip execution)"
     )

--- a/scripts/ralph.py
+++ b/scripts/ralph.py
@@ -48,7 +48,7 @@ _QA_VERDICT_RE = re.compile(r"Verdict:\s*(\w+)")
 
 
 def _resolve_project_dir(project_dir: str | None) -> str | None:
-    """Return an absolute project directory path for MCP calls."""
+    """Return the containing git worktree root for MCP calls."""
     if not project_dir:
         return None
     resolved = Path(project_dir).expanduser().resolve()
@@ -56,7 +56,19 @@ def _resolve_project_dir(project_dir: str | None) -> str | None:
         raise ValueError(f"--project-dir does not exist: {resolved}")
     if not resolved.is_dir():
         raise ValueError(f"--project-dir is not a directory: {resolved}")
-    return str(resolved)
+
+    import subprocess
+
+    try:
+        repo_root = subprocess.check_output(
+            ["git", "-C", str(resolved), "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError(f"--project-dir must be inside a git worktree: {resolved}") from exc
+
+    return str(Path(repo_root).resolve())
 
 
 def parse_evolve_text(text: str) -> dict[str, Any]:

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -26,6 +26,7 @@ NO_PARALLEL=false
 NO_QA=false
 SERVER_COMMAND=""
 SERVER_ARGS=""
+PROJECT_DIR=""
 
 # ── Usage ───────────────────────────────────────────────────────────────────
 usage() {
@@ -42,6 +43,7 @@ Options:
   --no-qa                Skip post-execution QA evaluation
   --server-command CMD   MCP server executable (default: ouroboros)
   --server-args ARGS     MCP server arguments (default: mcp)
+  --project-dir PATH     Target repo/worktree for evolve_step and git snapshots
   -h, --help             Show this help
 
 Exit codes:
@@ -65,6 +67,7 @@ while [[ $# -gt 0 ]]; do
         --no-parallel)  NO_PARALLEL=true; shift ;;
         --no-qa)        NO_QA=true; shift ;;
         --server-command) SERVER_COMMAND="$2"; shift 2 ;;
+        --project-dir)  PROJECT_DIR="$2"; shift 2 ;;
         --server-args)  shift; SERVER_ARGS="$*"; break ;;
         -h|--help)      usage ;;
         *)              echo "Unknown option: $1" >&2; exit 2 ;;
@@ -76,9 +79,25 @@ if [[ -z "$LINEAGE_ID" ]]; then
     exit 2
 fi
 
+if [[ -n "$PROJECT_DIR" ]]; then
+    if [[ ! -d "$PROJECT_DIR" ]]; then
+        echo "Error: --project-dir does not exist or is not a directory: $PROJECT_DIR" >&2
+        exit 2
+    fi
+    PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd -P)"
+fi
+
 # ── Helpers ─────────────────────────────────────────────────────────────────
 log() {
     echo "[ralph] $(date '+%H:%M:%S') $*" >&2
+}
+
+git_in_project() {
+    if [[ -n "$PROJECT_DIR" ]]; then
+        git -C "$PROJECT_DIR" "$@"
+    else
+        git "$@"
+    fi
 }
 
 # Commit changes and create a git tag for the generation.
@@ -91,21 +110,21 @@ tag_generation() {
         return 0
     fi
 
-    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if ! git_in_project rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         return 0
     fi
 
     # Auto-commit: commit any changes from this generation
-    if ! git diff --quiet HEAD 2>/dev/null || \
-       ! git diff --cached --quiet 2>/dev/null || \
-       [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
-        git add -A >/dev/null 2>&1 || true
-        git commit -m "ooo: gen ${gen} [${LINEAGE_ID}]" >/dev/null 2>&1 || true
+    if ! git_in_project diff --quiet HEAD 2>/dev/null || \
+       ! git_in_project diff --cached --quiet 2>/dev/null || \
+       [ -n "$(git_in_project ls-files --others --exclude-standard 2>/dev/null)" ]; then
+        git_in_project add -A >/dev/null 2>&1 || true
+        git_in_project commit -m "ooo: gen ${gen} [${LINEAGE_ID}]" >/dev/null 2>&1 || true
         log "Committed changes for gen ${gen}"
     fi
 
     # Overwrite tag if it already exists (re-run scenario)
-    git tag -f "$tag" >/dev/null 2>&1 || true
+    git_in_project tag -f "$tag" >/dev/null 2>&1 || true
     log "Tagged ${tag}"
 }
 
@@ -123,19 +142,19 @@ rollback_to_previous() {
         return 0
     fi
 
-    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if ! git_in_project rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         return 0
     fi
 
     local prev_tag="ooo/${LINEAGE_ID}/gen_${prev_gen}"
-    if git rev-parse "$prev_tag" >/dev/null 2>&1; then
+    if git_in_project rev-parse "$prev_tag" >/dev/null 2>&1; then
         log "Rolling back to ${prev_tag} after failure"
-        git checkout "$prev_tag" -- . >/dev/null 2>&1 || {
+        git_in_project checkout "$prev_tag" -- . >/dev/null 2>&1 || {
             log "WARNING: rollback to ${prev_tag} failed"
             return 0
         }
-        git reset HEAD >/dev/null 2>&1 || true
-        git clean -fd >/dev/null 2>&1 || true
+        git_in_project reset HEAD >/dev/null 2>&1 || true
+        git_in_project clean -fd >/dev/null 2>&1 || true
         log "Rollback complete"
     else
         log "No tag ${prev_tag} found, skipping rollback"
@@ -144,7 +163,7 @@ rollback_to_previous() {
 
 # ── Build common python args ────────────────────────────────────────────────
 build_py_args() {
-    local -a py_args=("--lineage-id" "$LINEAGE_ID" "--max-retries" "$MAX_RETRIES")
+    py_args=("--lineage-id" "$LINEAGE_ID" "--max-retries" "$MAX_RETRIES")
 
     if [[ "$NO_EXECUTE" == "true" ]]; then
         py_args+=("--no-execute")
@@ -158,23 +177,25 @@ build_py_args() {
     if [[ -n "$SERVER_COMMAND" ]]; then
         py_args+=("--server-command" "$SERVER_COMMAND")
     fi
+    if [[ -n "$PROJECT_DIR" ]]; then
+        py_args+=("--project-dir" "$PROJECT_DIR")
+    fi
     # NOTE: --server-args is NOT included here.
     # It uses REMAINDER and must be appended LAST in the main loop.
 
-    echo "${py_args[@]}"
 }
 
 # ── Main loop ───────────────────────────────────────────────────────────────
 cycle=0
 stagnation_count=0
 
-log "Starting Ralph loop for lineage=${LINEAGE_ID} max_cycles=${MAX_CYCLES}"
+log "Starting Ralph loop for lineage=${LINEAGE_ID} max_cycles=${MAX_CYCLES} project_dir=${PROJECT_DIR:-$PWD}"
 
 while (( cycle < MAX_CYCLES )); do
     cycle=$((cycle + 1))
 
     # Build per-cycle args
-    py_args=($(build_py_args))
+    build_py_args
 
     # Cycle 1: include seed file; Cycle 2+: omit it
     if (( cycle == 1 )) && [[ -n "$SEED_FILE" ]]; then

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -85,6 +85,11 @@ if [[ -n "$PROJECT_DIR" ]]; then
         exit 2
     fi
     PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd -P)"
+    if ! PROJECT_REPO_ROOT="$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+        echo "Error: --project-dir must be inside a git worktree: $PROJECT_DIR" >&2
+        exit 2
+    fi
+    PROJECT_DIR="$(cd "$PROJECT_REPO_ROOT" && pwd -P)"
 fi
 
 # ── Helpers ─────────────────────────────────────────────────────────────────

--- a/tests/unit/scripts/test_ralph_shell_project_dir.py
+++ b/tests/unit/scripts/test_ralph_shell_project_dir.py
@@ -1,0 +1,97 @@
+"""Tests for scripts/ralph.sh project directory handling."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import textwrap
+
+ROOT = Path(__file__).resolve().parents[3]
+RALPH_SH = ROOT / "scripts" / "ralph.sh"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir()
+    subprocess.run(["git", "init"], cwd=path, check=True, stdout=subprocess.DEVNULL)
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test User")
+    (path / "README.md").write_text("initial\n", encoding="utf-8")
+    _git(path, "add", "README.md")
+    _git(path, "commit", "-m", "initial")
+
+
+def test_ralph_sh_help_documents_project_dir() -> None:
+    result = subprocess.run(
+        ["bash", str(RALPH_SH), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "--project-dir PATH" in result.stdout
+
+
+def test_ralph_sh_scopes_git_snapshot_to_project_dir(tmp_path: Path) -> None:
+    script_dir = tmp_path / "scripts"
+    script_dir.mkdir()
+    shutil.copy2(RALPH_SH, script_dir / "ralph.sh")
+    (script_dir / "ralph.py").write_text(
+        textwrap.dedent(
+            """
+            #!/usr/bin/env python3
+            import argparse, json
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument('--lineage-id', required=True)
+            parser.add_argument('--max-retries')
+            parser.add_argument('--project-dir', required=True)
+            args = parser.parse_args()
+
+            Path(args.project_dir, 'ralph-output.txt').write_text('from fake ralph\\n')
+            print(json.dumps({
+                'action': 'converged',
+                'generation': 1,
+                'similarity': 1.0,
+                'lineage_id': args.lineage_id,
+            }))
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cwd_repo = tmp_path / "cwd-repo"
+    target_repo = tmp_path / "target repo"
+    _init_repo(cwd_repo)
+    _init_repo(target_repo)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_dir / "ralph.sh"),
+            "--lineage-id",
+            "lin_scope",
+            "--max-cycles",
+            "1",
+            "--project-dir",
+            str(target_repo),
+        ],
+        cwd=cwd_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+
+    assert '"action": "converged"' in result.stdout
+    assert "ooo/lin_scope/gen_1" in _git(target_repo, "tag", "--list")
+    assert "ooo/lin_scope/gen_1" not in _git(cwd_repo, "tag", "--list")
+    assert (target_repo / "ralph-output.txt").exists()
+    assert not (cwd_repo / "ralph-output.txt").exists()

--- a/tests/unit/scripts/test_ralph_shell_project_dir.py
+++ b/tests/unit/scripts/test_ralph_shell_project_dir.py
@@ -95,3 +95,63 @@ def test_ralph_sh_scopes_git_snapshot_to_project_dir(tmp_path: Path) -> None:
     assert "ooo/lin_scope/gen_1" not in _git(cwd_repo, "tag", "--list")
     assert (target_repo / "ralph-output.txt").exists()
     assert not (cwd_repo / "ralph-output.txt").exists()
+
+
+def test_ralph_sh_scopes_rollback_to_project_dir(tmp_path: Path) -> None:
+    script_dir = tmp_path / "scripts"
+    script_dir.mkdir()
+    shutil.copy2(RALPH_SH, script_dir / "ralph.sh")
+    (script_dir / "ralph.py").write_text(
+        textwrap.dedent(
+            """
+            #!/usr/bin/env python3
+            import argparse, json
+            from pathlib import Path
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument('--lineage-id', required=True)
+            parser.add_argument('--max-retries')
+            parser.add_argument('--project-dir', required=True)
+            args = parser.parse_args()
+
+            Path(args.project_dir, 'README.md').write_text('bad generation\\n')
+            Path(args.project_dir, 'untracked.txt').write_text('remove me\\n')
+            print(json.dumps({
+                'action': 'failed',
+                'generation': 2,
+                'lineage_id': args.lineage_id,
+                'error': 'fake failure',
+            }))
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cwd_repo = tmp_path / "cwd-repo"
+    target_repo = tmp_path / "rollback target"
+    _init_repo(cwd_repo)
+    _init_repo(target_repo)
+    _git(target_repo, "tag", "ooo/lin_scope/gen_1")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_dir / "ralph.sh"),
+            "--lineage-id",
+            "lin_scope",
+            "--max-cycles",
+            "1",
+            "--project-dir",
+            str(target_repo),
+        ],
+        cwd=cwd_repo,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+
+    assert result.returncode == 12
+    assert (target_repo / "README.md").read_text(encoding="utf-8") == "initial\n"
+    assert not (target_repo / "untracked.txt").exists()
+    assert not (cwd_repo / "untracked.txt").exists()

--- a/tests/unit/scripts/test_ralph_shell_project_dir.py
+++ b/tests/unit/scripts/test_ralph_shell_project_dir.py
@@ -37,6 +37,27 @@ def test_ralph_sh_help_documents_project_dir() -> None:
     assert "--project-dir PATH" in result.stdout
 
 
+def test_ralph_sh_rejects_project_dir_outside_git_worktree(tmp_path: Path) -> None:
+    project_dir = tmp_path / "plain-dir"
+    project_dir.mkdir()
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(RALPH_SH),
+            "--lineage-id",
+            "lin_scope",
+            "--project-dir",
+            str(project_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "must be inside a git worktree" in result.stderr
+
+
 def test_ralph_sh_scopes_git_snapshot_to_project_dir(tmp_path: Path) -> None:
     script_dir = tmp_path / "scripts"
     script_dir.mkdir()
@@ -130,8 +151,13 @@ def test_ralph_sh_scopes_rollback_to_project_dir(tmp_path: Path) -> None:
 
     cwd_repo = tmp_path / "cwd-repo"
     target_repo = tmp_path / "rollback target"
+    nested_project_dir = target_repo / "packages" / "app"
     _init_repo(cwd_repo)
     _init_repo(target_repo)
+    nested_project_dir.mkdir(parents=True)
+    (target_repo / "outside-nested.txt").write_text("safe baseline\n", encoding="utf-8")
+    _git(target_repo, "add", "outside-nested.txt")
+    _git(target_repo, "commit", "-m", "add outside nested baseline")
     _git(target_repo, "tag", "ooo/lin_scope/gen_1")
 
     result = subprocess.run(
@@ -143,7 +169,7 @@ def test_ralph_sh_scopes_rollback_to_project_dir(tmp_path: Path) -> None:
             "--max-cycles",
             "1",
             "--project-dir",
-            str(target_repo),
+            str(nested_project_dir),
         ],
         cwd=cwd_repo,
         capture_output=True,
@@ -153,5 +179,6 @@ def test_ralph_sh_scopes_rollback_to_project_dir(tmp_path: Path) -> None:
 
     assert result.returncode == 12
     assert (target_repo / "README.md").read_text(encoding="utf-8") == "initial\n"
+    assert (target_repo / "outside-nested.txt").read_text(encoding="utf-8") == "safe baseline\n"
     assert not (target_repo / "untracked.txt").exists()
     assert not (cwd_repo / "untracked.txt").exists()

--- a/tests/unit/test_ralph_parser.py
+++ b/tests/unit/test_ralph_parser.py
@@ -215,6 +215,13 @@ class _FakeSession:
         return _ToolResult(self._responses.pop(0))
 
 
+def test_resolve_project_dir_rejects_missing_path(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+
+    with pytest.raises(ValueError, match="does not exist"):
+        _ralph._resolve_project_dir(str(missing))
+
+
 @pytest.mark.asyncio
 async def test_call_evolve_forwards_project_dir(tmp_path: Path) -> None:
     project_dir = tmp_path / "target repo"

--- a/tests/unit/test_ralph_parser.py
+++ b/tests/unit/test_ralph_parser.py
@@ -182,3 +182,99 @@ class TestParseEvolveText:
 """
         result = parse_evolve_text(text)
         assert result["similarity"] == pytest.approx(0.0, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Project directory forwarding
+# ---------------------------------------------------------------------------
+
+
+class _TextContent:
+    type = "text"
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _ToolResult:
+    isError = False
+
+    def __init__(self, text: str) -> None:
+        self.content = [_TextContent(text)]
+
+
+class _FakeSession:
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def call_tool(self, name: str, arguments: dict[str, object]) -> _ToolResult:
+        self.calls.append((name, arguments))
+        if name == "ouroboros_lateral_think":
+            return _ToolResult("lateral thinking applied")
+        return _ToolResult(self._responses.pop(0))
+
+
+@pytest.mark.asyncio
+async def test_call_evolve_forwards_project_dir(tmp_path: Path) -> None:
+    project_dir = tmp_path / "target repo"
+    project_dir.mkdir()
+    session = _FakeSession([CONTINUE_TEXT])
+    args = _ralph.build_parser().parse_args(
+        ["--lineage-id", "lin_task_mgr", "--project-dir", str(project_dir)]
+    )
+
+    result = await _ralph._call_evolve(session, args)
+
+    assert result["action"] == "continue"
+    assert session.calls == [
+        (
+            "ouroboros_evolve_step",
+            {"lineage_id": "lin_task_mgr", "project_dir": str(project_dir.resolve())},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stagnation_retry_preserves_project_dir_and_execution_flags(tmp_path: Path) -> None:
+    project_dir = tmp_path / "target"
+    project_dir.mkdir()
+    session = _FakeSession([STAGNATED_TEXT, CONTINUE_TEXT])
+    args = _ralph.build_parser().parse_args(
+        [
+            "--lineage-id",
+            "lin_stuck",
+            "--project-dir",
+            str(project_dir),
+            "--no-execute",
+            "--no-parallel",
+            "--no-qa",
+            "--max-retries",
+            "1",
+        ]
+    )
+
+    result = await _ralph._call_evolve(session, args)
+
+    assert result["action"] == "continue"
+    assert session.calls[0] == (
+        "ouroboros_evolve_step",
+        {
+            "lineage_id": "lin_stuck",
+            "project_dir": str(project_dir.resolve()),
+            "execute": False,
+            "parallel": False,
+            "skip_qa": True,
+        },
+    )
+    assert session.calls[1][0] == "ouroboros_lateral_think"
+    assert session.calls[2] == (
+        "ouroboros_evolve_step",
+        {
+            "lineage_id": "lin_stuck",
+            "project_dir": str(project_dir.resolve()),
+            "execute": False,
+            "parallel": False,
+            "skip_qa": True,
+        },
+    )

--- a/tests/unit/test_ralph_parser.py
+++ b/tests/unit/test_ralph_parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
 import sys
 
 import pytest
@@ -18,6 +19,11 @@ sys.modules["ralph"] = _ralph
 _spec.loader.exec_module(_ralph)
 
 parse_evolve_text = _ralph.parse_evolve_text
+
+
+def _init_git_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, stdout=subprocess.DEVNULL)
 
 
 # ---------------------------------------------------------------------------
@@ -222,10 +228,27 @@ def test_resolve_project_dir_rejects_missing_path(tmp_path: Path) -> None:
         _ralph._resolve_project_dir(str(missing))
 
 
+def test_resolve_project_dir_rejects_non_git_directory(tmp_path: Path) -> None:
+    project_dir = tmp_path / "not-a-repo"
+    project_dir.mkdir()
+
+    with pytest.raises(ValueError, match="git worktree"):
+        _ralph._resolve_project_dir(str(project_dir))
+
+
+def test_resolve_project_dir_normalizes_nested_path_to_repo_root(tmp_path: Path) -> None:
+    project_dir = tmp_path / "target repo"
+    nested_dir = project_dir / "nested" / "pkg"
+    _init_git_repo(project_dir)
+    nested_dir.mkdir(parents=True)
+
+    assert _ralph._resolve_project_dir(str(nested_dir)) == str(project_dir.resolve())
+
+
 @pytest.mark.asyncio
 async def test_call_evolve_forwards_project_dir(tmp_path: Path) -> None:
     project_dir = tmp_path / "target repo"
-    project_dir.mkdir()
+    _init_git_repo(project_dir)
     session = _FakeSession([CONTINUE_TEXT])
     args = _ralph.build_parser().parse_args(
         ["--lineage-id", "lin_task_mgr", "--project-dir", str(project_dir)]
@@ -245,7 +268,7 @@ async def test_call_evolve_forwards_project_dir(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_stagnation_retry_preserves_project_dir_and_execution_flags(tmp_path: Path) -> None:
     project_dir = tmp_path / "target"
-    project_dir.mkdir()
+    _init_git_repo(project_dir)
     session = _FakeSession([STAGNATED_TEXT, CONTINUE_TEXT])
     args = _ralph.build_parser().parse_args(
         [


### PR DESCRIPTION
## Summary

Fixes #594 by making Ralph's target project directory explicit across the shell wrapper, Python MCP client, and git snapshot/rollback operations.

## What changed

- Add `--project-dir PATH` to `scripts/ralph.sh` and `scripts/ralph.py`.
- Canonicalize the project directory before forwarding it to `ouroboros_evolve_step`.
- Preserve the same `project_dir` on stagnation retry calls after lateral thinking.
- Preserve execution flags (`--no-execute`, `--no-parallel`, `--no-qa`) on retry calls as well.
- Scope Ralph shell git side effects through `git -C "$PROJECT_DIR"` when a target directory is provided, so commits/tags/rollback no longer depend on the caller's cwd.
- Add tests for Python argument forwarding and shell git scoping, including a target repo path containing spaces.

## Verification

- `uv run ruff check scripts/ralph.py tests/unit/test_ralph_parser.py tests/unit/scripts/test_ralph_shell_project_dir.py`
- `bash -n scripts/ralph.sh`
- `uv run pytest tests/unit/test_ralph_parser.py tests/unit/scripts/test_ralph_shell_project_dir.py -q`

## Notes

I kept `--project-dir` optional for backward compatibility. When omitted, Ralph keeps the existing cwd-based behavior; when provided, both MCP evolution and shell git snapshots use the explicit target.
