### PR TITLE
Retry transient Claude CLI exits during seed extraction

### DIFF
--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -26,6 +26,7 @@ from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
 from ouroboros.cli.formatters.prompting import multiline_prompt_async
 from ouroboros.config import get_clarification_model, get_llm_backend
+from ouroboros.core.errors import ProviderError
 from ouroboros.core.initial_context import (
     load_pm_seed_as_context as _load_pm_seed_as_context_result,
 )
@@ -437,7 +438,11 @@ async def _generate_seed_from_interview(
             seed_result = await generator.generate(state, forced_score)
 
     if seed_result.is_err:
-        print_error(f"Failed to generate Seed: {seed_result.error.message}")
+        error = seed_result.error
+        if isinstance(error, ProviderError):
+            print_error(f"Failed to generate Seed: {error.format_details()}")
+        else:
+            print_error(f"Failed to generate Seed: {error.message}")
         return None, SeedGenerationResult.CANCELLED
 
     seed = seed_result.value

--- a/src/ouroboros/core/errors.py
+++ b/src/ouroboros/core/errors.py
@@ -116,6 +116,9 @@ class ProviderError(OuroborosError):
             "session_id",
             "claudecode_present",
             "claude_code_entrypoint",
+            "configured_cli_path",
+            "cwd",
+            "env_override_keys",
             "stderr",
         ):
             value = self.details.get(key)

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -214,6 +214,28 @@ class ClaudeCodeAdapter:
         error_lower = error_msg.lower()
         return any(pattern in error_lower for pattern in _RETRYABLE_ERROR_PATTERNS)
 
+    def _is_retryable_provider_error(self, error: ProviderError) -> bool:
+        """Check if a provider error is transient enough to retry.
+
+        Claude Code's SDK sometimes reports CLI bootstrap failures as a generic
+        subprocess exit with no stderr, especially when launched through custom
+        wrapper paths such as the macOS ``cmux.app`` Claude binary.  Retrying the
+        shared adapter keeps seed generation from failing permanently on the
+        first extraction attempt while still avoiding retries for actionable
+        stderr-bearing failures such as auth or configuration errors.
+        """
+        if self._is_retryable_error(error.message):
+            return True
+
+        error_type = str(error.details.get("error_type", ""))
+        stderr = str(error.details.get("stderr", "") or "").strip()
+        if stderr:
+            return False
+
+        message = error.message.lower()
+        is_cli_process_exit = error_type in {"ProcessError", "CalledProcessError"}
+        return is_cli_process_exit and "command failed with exit code" in message
+
     async def complete(
         self,
         messages: list[Message],
@@ -431,11 +453,12 @@ class ClaudeCodeAdapter:
 
                 # Check if error is retryable
                 error_msg = result.error.message
-                if self._is_retryable_error(error_msg) and attempt < _MAX_RETRIES - 1:
+                if self._is_retryable_provider_error(result.error) and attempt < _MAX_RETRIES - 1:
                     backoff = _INITIAL_BACKOFF_SECONDS * (2**attempt)
                     log.warning(
                         "claude_code_adapter.retryable_error",
                         error=error_msg,
+                        error_type=result.error.details.get("error_type"),
                         attempt=attempt + 1,
                         max_retries=_MAX_RETRIES,
                         backoff_seconds=backoff,
@@ -776,6 +799,10 @@ class ClaudeCodeAdapter:
                                 "errors": errors,
                                 "partial_content": partial_content or None,
                                 "partial_rejected": bool(partial_content),
+                                "configured_cli_path": (
+                                    str(self._cli_path) if self._cli_path else None
+                                ),
+                                "cwd": self._cwd,
                             },
                         )
         except asyncio.CancelledError:
@@ -805,6 +832,9 @@ class ClaudeCodeAdapter:
                         "traceback": traceback_text,
                         "claudecode_present": claudecode_present,
                         "claude_code_entrypoint": os.environ.get("CLAUDE_CODE_ENTRYPOINT"),
+                        "configured_cli_path": str(self._cli_path) if self._cli_path else None,
+                        "cwd": self._cwd,
+                        "env_override_keys": sorted(env_overrides.keys()),
                     },
                 )
             )
@@ -833,6 +863,10 @@ class ClaudeCodeAdapter:
                             "session_id": session_id,
                             "content_length": 0,
                             "stderr": stderr_tail,
+                            "configured_cli_path": (
+                                str(self._cli_path) if self._cli_path else None
+                            ),
+                            "cwd": self._cwd,
                         },
                     )
                 )
@@ -851,6 +885,10 @@ class ClaudeCodeAdapter:
                             "session_id": session_id,
                             "content_length": 0,
                             "stderr": stderr_tail,
+                            "configured_cli_path": (
+                                str(self._cli_path) if self._cli_path else None
+                            ),
+                            "cwd": self._cwd,
                         },
                     )
                 )

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -6,8 +6,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
-from ouroboros.cli.commands.init import _get_adapter, _resolve_init_llm_backend, _start_workflow
+from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
+from ouroboros.bigbang.interview import InterviewState
+from ouroboros.cli.commands.init import (
+    SeedGenerationResult,
+    _generate_seed_from_interview,
+    _get_adapter,
+    _resolve_init_llm_backend,
+    _start_workflow,
+)
 from ouroboros.cli.main import app
+from ouroboros.core.errors import ProviderError
+from ouroboros.core.types import Result
 
 runner = CliRunner()
 
@@ -137,3 +147,61 @@ class TestInitWorkflowRuntimeHandoff:
         assert mock_create_adapter.call_args.kwargs["backend"] == "opencode"
         assert mock_create_adapter.call_args.kwargs["use_case"] == "interview"
         assert mock_create_adapter.call_args.kwargs["max_turns"] == 5
+
+    @pytest.mark.asyncio
+    async def test_seed_generation_prints_provider_diagnostics(self) -> None:
+        """Seed failures should show ProviderError details, not just the terse message."""
+        state = InterviewState(
+            interview_id="interview_595",
+            initial_context="Build a CLI",
+        )
+        llm_adapter = MagicMock()
+        ambiguity_score = AmbiguityScore(
+            overall_score=0.1,
+            breakdown=ScoreBreakdown(
+                goal_clarity=ComponentScore(
+                    name="Goal",
+                    clarity_score=0.9,
+                    weight=0.4,
+                    justification="clear",
+                ),
+                constraint_clarity=ComponentScore(
+                    name="Constraints",
+                    clarity_score=0.9,
+                    weight=0.3,
+                    justification="clear",
+                ),
+                success_criteria_clarity=ComponentScore(
+                    name="Success",
+                    clarity_score=0.9,
+                    weight=0.3,
+                    justification="clear",
+                ),
+            ),
+        )
+        provider_error = ProviderError(
+            message="Claude Agent SDK request failed: Command failed with exit code 1",
+            details={
+                "error_type": "ProcessError",
+                "configured_cli_path": "/Applications/cmux.app/Contents/Resources/bin/claude",
+                "stderr": "",
+            },
+        )
+
+        mock_scorer = MagicMock()
+        mock_scorer.score = AsyncMock(return_value=Result.ok(ambiguity_score))
+        mock_generator = MagicMock()
+        mock_generator.generate = AsyncMock(return_value=Result.err(provider_error))
+
+        with (
+            patch("ouroboros.cli.commands.init.AmbiguityScorer", return_value=mock_scorer),
+            patch("ouroboros.cli.commands.init.SeedGenerator", return_value=mock_generator),
+            patch("ouroboros.cli.commands.init.print_error") as mock_print_error,
+        ):
+            seed_path, result = await _generate_seed_from_interview(state, llm_adapter)
+
+        assert seed_path is None
+        assert result == SeedGenerationResult.CANCELLED
+        error_text = mock_print_error.call_args.args[0]
+        assert "configured_cli_path" in error_text
+        assert "/Applications/cmux.app/Contents/Resources/bin/claude" in error_text

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -693,6 +693,63 @@ class TestErrorDiagnostics:
     """Tests for error diagnostic paths in _execute_single_request."""
 
     @pytest.mark.asyncio
+    async def test_empty_stderr_cli_process_exit_is_retried(self) -> None:
+        """Transient Claude CLI exits without stderr are retried by the shared adapter."""
+        adapter = ClaudeCodeAdapter()
+        config = CompletionConfig(model="claude-sonnet-4-6")
+        transient_error = ProviderError(
+            message="Claude Agent SDK request failed: Command failed with exit code 1",
+            details={
+                "error_type": "ProcessError",
+                "stderr": "",
+                "configured_cli_path": "/Applications/cmux.app/Contents/Resources/bin/claude",
+            },
+        )
+
+        adapter._execute_single_request = AsyncMock(
+            side_effect=[
+                Result.err(transient_error),
+                _ok_completion_result("seed requirements"),
+            ]
+        )
+
+        with patch("ouroboros.providers.claude_code_adapter.asyncio.sleep", new=AsyncMock()):
+            result = await adapter._complete_with_transient_retry(
+                "test prompt",
+                config,
+                system_prompt=None,
+            )
+
+        assert result.is_ok
+        assert result.value.content == "seed requirements"
+        assert adapter._execute_single_request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stderr_cli_process_exit_is_not_retried(self) -> None:
+        """Actionable CLI failures with stderr should surface immediately."""
+        adapter = ClaudeCodeAdapter()
+        config = CompletionConfig(model="claude-sonnet-4-6")
+        auth_error = ProviderError(
+            message="Claude Agent SDK request failed: Command failed with exit code 1",
+            details={
+                "error_type": "ProcessError",
+                "stderr": "error: authentication required",
+            },
+        )
+
+        adapter._execute_single_request = AsyncMock(return_value=Result.err(auth_error))
+
+        result = await adapter._complete_with_transient_retry(
+            "test prompt",
+            config,
+            system_prompt=None,
+        )
+
+        assert result.is_err
+        assert result.error is auth_error
+        adapter._execute_single_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_sdk_exception_produces_provider_error_with_details(self) -> None:
         """SDK exception is caught and returns ProviderError with diagnostic details."""
         adapter = ClaudeCodeAdapter()
@@ -1041,6 +1098,7 @@ class TestProviderErrorFormatDetails:
                 "session_id": "sess_abc",
                 "claudecode_present": True,
                 "claude_code_entrypoint": "sdk-py",
+                "configured_cli_path": "/Applications/cmux.app/Contents/Resources/bin/claude",
                 "stderr": "error: auth failed",
             },
         )
@@ -1048,6 +1106,9 @@ class TestProviderErrorFormatDetails:
         assert "SDK failed" in rendered
         assert "error_type: RuntimeError" in rendered
         assert "session_id: sess_abc" in rendered
+        assert (
+            "configured_cli_path: /Applications/cmux.app/Contents/Resources/bin/claude" in rendered
+        )
         assert "stderr tail:\nerror: auth failed" in rendered
 
     def test_format_details_without_details(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #595 by making the shared Claude Code adapter resilient to the empty-stderr SDK subprocess exit pattern that can occur during seed extraction with custom Claude CLI wrappers such as the macOS `cmux.app` path.

## Changes

- Retry `ProcessError`/`CalledProcessError` provider failures when the Claude SDK exits with `Command failed with exit code ...` and provides no stderr.
- Keep stderr-bearing process exits non-retryable so auth/configuration failures still surface immediately.
- Include `configured_cli_path`, `cwd`, and `env_override_keys` in provider diagnostics.
- Surface formatted provider diagnostics from `ouroboros init start` seed generation errors instead of only the terse error message.
- Add regression coverage for the retry and diagnostic paths.

## Rationale

Issue #595 fails at seed extraction `attempt=1`, before parsing or seed-building logic can run. The failing signature is a Claude Agent SDK subprocess exit with empty stderr and a configured `/Applications/cmux.app/Contents/Resources/bin/claude` path. Handling this in `ClaudeCodeAdapter` fixes the shared provider failure path rather than adding a seed-generator-only retry loop.

## Verification

- `uv run ruff format --check src/ouroboros/providers/claude_code_adapter.py src/ouroboros/cli/commands/init.py src/ouroboros/core/errors.py tests/unit/providers/test_claude_code_adapter.py tests/unit/cli/test_init_runtime.py`
- `uv run ruff check src/ouroboros/providers/claude_code_adapter.py src/ouroboros/cli/commands/init.py src/ouroboros/core/errors.py tests/unit/providers/test_claude_code_adapter.py tests/unit/cli/test_init_runtime.py`
- `uv run mypy src/ouroboros/providers/claude_code_adapter.py src/ouroboros/cli/commands/init.py src/ouroboros/core/errors.py`
- `uv run pytest tests/unit/providers tests/unit/cli/test_init_runtime.py tests/unit/bigbang/test_seed_generator.py -q` (`304 passed`)

## Not tested

- Live macOS `cmux.app` Claude Code invocation.
