### PR TITLE
fix(claude): resolve plugin hooks from plugin root

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && python3 scripts/keyword-detector.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py\"",
             "timeout": 5
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && python3 scripts/drift-monitor.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py\"",
             "timeout": 3
           }
         ]

--- a/tests/unit/scripts/test_claude_hook_settings.py
+++ b/tests/unit/scripts/test_claude_hook_settings.py
@@ -1,0 +1,26 @@
+"""Regression tests for Claude plugin hook command wiring."""
+
+import json
+from pathlib import Path
+
+_SETTINGS_PATH = Path(__file__).resolve().parents[3] / ".claude" / "settings.json"
+
+
+def _hook_commands() -> list[str]:
+    settings = json.loads(_SETTINGS_PATH.read_text(encoding="utf-8"))
+    commands: list[str] = []
+    for hook_entries in settings["hooks"].values():
+        for entry in hook_entries:
+            for hook in entry["hooks"]:
+                commands.append(hook["command"])
+    return commands
+
+
+def test_plugin_hooks_use_plugin_root_for_bundled_scripts() -> None:
+    """Hooks must not resolve bundled scripts relative to the user's project cwd."""
+    commands = _hook_commands()
+
+    assert any("${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py" in cmd for cmd in commands)
+    assert any("${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py" in cmd for cmd in commands)
+    assert all("CLAUDE_PROJECT_DIR" not in cmd for cmd in commands)
+    assert all("cd " not in cmd for cmd in commands)


### PR DESCRIPTION
## Summary
- restore plugin hook script resolution through `${CLAUDE_PLUGIN_ROOT}`
- remove project-cwd-dependent `cd "${CLAUDE_PROJECT_DIR:-.}"` from bundled hook commands
- add regression coverage for Claude hook settings

References #598

## Test Plan
- `uv run ruff check tests/unit/scripts/test_claude_hook_settings.py`
- `uv run pytest tests/unit/scripts/test_claude_hook_settings.py -q`
