### PR TITLE
fix(claude): force UTF-8 stdio for hook scripts

### DIFF
--- a/scripts/drift-monitor.py
+++ b/scripts/drift-monitor.py
@@ -12,7 +12,20 @@ requires calling /ouroboros:status with the MCP server.
 """
 
 from pathlib import Path
+import sys
 import time
+
+
+def _configure_utf8_stdio() -> None:
+    """Keep hook output safe on non-UTF-8 Windows locales."""
+    for stream in (sys.stdout, sys.stderr):
+        encoding = getattr(stream, "encoding", None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if encoding and encoding.lower().replace("-", "") != "utf8" and reconfigure:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
+_configure_utf8_stdio()
 
 
 def check_active_session() -> dict:

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -17,6 +17,18 @@ from pathlib import Path
 import re
 import sys
 
+
+def _configure_utf8_stdio() -> None:
+    """Keep hook output safe on non-UTF-8 Windows locales."""
+    for stream in (sys.stdout, sys.stderr):
+        encoding = getattr(stream, "encoding", None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if encoding and encoding.lower().replace("-", "") != "utf8" and reconfigure:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
+_configure_utf8_stdio()
+
 # Skills that work without MCP setup (bypass the setup gate)
 # qa has a built-in fallback that adopts the qa-judge agent directly
 SETUP_BYPASS_SKILLS = [

--- a/tests/unit/scripts/test_hook_script_stdio.py
+++ b/tests/unit/scripts/test_hook_script_stdio.py
@@ -1,0 +1,43 @@
+"""Regression tests for hook script output encodings."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _run_script_with_cp949_stdout(
+    script_name: str, tmp_path: Path, stdin: str = ""
+) -> subprocess.CompletedProcess[bytes]:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["PYTHONIOENCODING"] = "cp949"
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / script_name)],
+        input=stdin.encode("utf-8"),
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_keyword_detector_emits_utf8_when_parent_stdout_is_cp949(tmp_path: Path) -> None:
+    """Windows Korean code pages must not crash on emoji skill suggestions."""
+    result = _run_script_with_cp949_stdout("keyword-detector.py", tmp_path, "hello\n")
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert "🎯 MATCHED SKILLS" in result.stdout.decode("utf-8")
+
+
+def test_drift_monitor_emits_utf8_when_parent_stdout_is_cp949(tmp_path: Path) -> None:
+    """PostToolUse hook should also normalize stdout/stderr for non-UTF-8 locales."""
+    data_dir = tmp_path / ".ouroboros" / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "interview_active.json").write_text("{}", encoding="utf-8")
+
+    result = _run_script_with_cp949_stdout("drift-monitor.py", tmp_path)
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert result.stdout.decode("utf-8").startswith("Ouroboros session active")


### PR DESCRIPTION
## Summary
- normalize hook script stdout/stderr to UTF-8 with replacement errors
- prevents `UnicodeEncodeError` on non-UTF-8 Windows locales such as cp949
- add subprocess regression coverage for cp949 hook execution

References #598

## Test Plan
- `uv run ruff check scripts/keyword-detector.py scripts/drift-monitor.py tests/unit/scripts/test_hook_script_stdio.py`
- `uv run pytest tests/unit/scripts/test_hook_script_stdio.py tests/unit/scripts/test_keyword_detector.py -q`
