### PR TITLE
fix(claude): fall back to python for hook executable

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py\"",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py\"",
             "timeout": 5
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py\"",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py\"",
             "timeout": 3
           }
         ]

--- a/tests/unit/scripts/test_claude_hook_settings.py
+++ b/tests/unit/scripts/test_claude_hook_settings.py
@@ -24,3 +24,11 @@ def test_plugin_hooks_use_plugin_root_for_bundled_scripts() -> None:
     assert any("${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py" in cmd for cmd in commands)
     assert all("CLAUDE_PROJECT_DIR" not in cmd for cmd in commands)
     assert all("cd " not in cmd for cmd in commands)
+
+
+def test_plugin_hooks_fall_back_to_unversioned_python() -> None:
+    """Prefer python3 where available, but fall back for Windows installs."""
+    commands = _hook_commands()
+
+    assert all(cmd.startswith("python3 ") for cmd in commands)
+    assert all(" || python " in cmd for cmd in commands)


### PR DESCRIPTION
## Summary
- keep `python3` as the preferred hook interpreter on Unix-like systems
- fall back to unversioned `python` when `python3` fails or is unavailable (covers the Windows Store alias case from #598)
- extends hook settings regression coverage for the interpreter fallback

References #598

Now based directly on `main` after #601 and #602 landed.

## Test Plan
- `uv run ruff format --check tests/unit/scripts/test_claude_hook_settings.py`
- `uv run ruff check tests/unit/scripts/test_claude_hook_settings.py`
- `uv run pytest tests/unit/scripts/test_claude_hook_settings.py -q`
- manual fallback simulation with a fake failing `python3` ahead of PATH for both hook commands
