### PR TITLE
fix(ralph): add --project-dir to specify explicit target for evolve_step

### DIFF
--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -119,13 +119,16 @@ tag_generation() {
         return 0
     fi
 
-    # Auto-commit: commit any changes from this generation
+    # Auto-commit: commit any changes from this generation. Keep the dirty
+    # predicate explicit so clean trees are not reported as committed and
+    # staged-only changes still trigger a snapshot.
     if ! git_in_project diff --quiet HEAD 2>/dev/null || \
        ! git_in_project diff --cached --quiet 2>/dev/null || \
        [ -n "$(git_in_project ls-files --others --exclude-standard 2>/dev/null)" ]; then
         git_in_project add -A >/dev/null 2>&1 || true
-        git_in_project commit -m "ooo: gen ${gen} [${LINEAGE_ID}]" >/dev/null 2>&1 || true
-        log "Committed changes for gen ${gen}"
+        if git_in_project commit -m "ooo: gen ${gen} [${LINEAGE_ID}]" >/dev/null 2>&1; then
+            log "Committed changes for gen ${gen}"
+        fi
     fi
 
     # Overwrite tag if it already exists (re-run scenario)

--- a/tests/unit/test_ralph_shell.py
+++ b/tests/unit/test_ralph_shell.py
@@ -1,0 +1,121 @@
+"""Unit tests for scripts/ralph.sh wrapper behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[2]
+RALPH_SH = ROOT / "scripts" / "ralph.sh"
+
+
+def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True)
+    _run(["git", "init"], cwd=path)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=path)
+    _run(["git", "config", "user.name", "Test User"], cwd=path)
+    (path / "README.md").write_text("initial\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=path)
+    _run(["git", "commit", "-m", "initial"], cwd=path)
+
+
+def _copy_wrapper(script_dir: Path) -> None:
+    script_dir.mkdir(parents=True)
+    target = script_dir / "ralph.sh"
+    shutil.copy2(RALPH_SH, target)
+    target.chmod(0o755)
+
+
+def _write_fake_ralph_py(script_dir: Path, argv_file: Path, *, mutate: bool = False) -> None:
+    lines = [
+        "import json",
+        "import sys",
+        "from pathlib import Path",
+        "",
+        "args = sys.argv[1:]",
+        f"Path({str(argv_file)!r}).write_text(json.dumps(args), encoding='utf-8')",
+    ]
+    if mutate:
+        lines.extend(
+            [
+                "project_dir = args[args.index('--project-dir') + 1]",
+                "Path(project_dir, 'generated.txt').write_text('changed\\n', encoding='utf-8')",
+            ]
+        )
+    lines.append("print(json.dumps({'action': 'converged', 'generation': 1, 'similarity': 1.0}))")
+    (script_dir / "ralph.py").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_project_dir_with_spaces_is_preserved_as_single_python_arg(tmp_path: Path) -> None:
+    script_dir = tmp_path / "scripts"
+    project_dir = tmp_path / "target project"
+    other_cwd = tmp_path / "launcher cwd"
+    argv_file = tmp_path / "argv.json"
+    _init_repo(project_dir)
+    other_cwd.mkdir()
+    _copy_wrapper(script_dir)
+    _write_fake_ralph_py(script_dir, argv_file)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_dir / "ralph.sh"),
+            "--lineage-id",
+            "lin_space",
+            "--project-dir",
+            str(project_dir),
+            "--max-cycles",
+            "1",
+        ],
+        cwd=other_cwd,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    argv = json.loads(argv_file.read_text(encoding="utf-8"))
+    assert argv[argv.index("--project-dir") + 1] == str(project_dir.resolve())
+    assert "Committed changes" not in result.stderr
+    assert _run(["git", "rev-list", "--count", "HEAD"], cwd=project_dir).stdout.strip() == "1"
+
+
+def test_project_dir_git_snapshot_commits_target_repo_changes(tmp_path: Path) -> None:
+    script_dir = tmp_path / "scripts"
+    project_dir = tmp_path / "target project"
+    other_cwd = tmp_path / "launcher cwd"
+    argv_file = tmp_path / "argv.json"
+    _init_repo(project_dir)
+    other_cwd.mkdir()
+    _copy_wrapper(script_dir)
+    _write_fake_ralph_py(script_dir, argv_file, mutate=True)
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_dir / "ralph.sh"),
+            "--lineage-id",
+            "lin_commit",
+            "--project-dir",
+            str(project_dir),
+            "--max-cycles",
+            "1",
+        ],
+        cwd=other_cwd,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "Committed changes for gen 1" in result.stderr
+    assert _run(["git", "rev-list", "--count", "HEAD"], cwd=project_dir).stdout.strip() == "2"
+    assert (
+        _run(["git", "tag", "--list", "ooo/lin_commit/gen_1"], cwd=project_dir).stdout.strip()
+        == "ooo/lin_commit/gen_1"
+    )
+    assert (project_dir / "generated.txt").read_text(encoding="utf-8") == "changed\n"


### PR DESCRIPTION
Adds --project-dir option to both ralph.py and ralph.sh to specify the explicit target project directory instead of relying on MCP server's implicit cwd.

The bug report (issue #594) noted that Ralph can silently operate on the wrong repository when the MCP server's cwd differs from the intended target. This fix:

- ralph.py: accepts --project-dir, passes it to evolve_step calls (initial + retry)
- ralph.sh: accepts --project-dir, passes to ralph.py, runs git operations (commit/tag/rollback) against the explicit directory

Fixes Q00/ouroboros#594