### PR TITLE
fix: separate task completion from AC verdict summaries

### DIFF
--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -108,6 +108,23 @@ class ACResult(BaseModel, frozen=True):
         return None
 
 
+class TaskResult(BaseModel, frozen=True):
+    """Worker execution outcome for a task derived from an acceptance criterion.
+
+    This is intentionally separate from :class:`ACResult`: task completion
+    describes whether execution work finished, while AC results describe formal
+    evaluator/verifier verdicts about the produced artifact.
+    """
+
+    task_index: int
+    task_content: str
+    status: str
+    completed: bool
+    source_ac_index: int | None = None
+    evidence: str = ""
+    execution_method: str = "unknown"
+
+
 class FeedbackMetadata(BaseModel, frozen=True):
     """Structured evaluation feedback that downstream loops can react to."""
 
@@ -149,7 +166,17 @@ class EvaluationSummary(BaseModel, frozen=True):
         description="Suspicion that the artifact is optimized for evaluator, rubric, or test approval rather than solving the real task (0.0-1.0). Distinct from drift_score.",
     )
     failure_reason: str | None = None
-    ac_results: tuple[ACResult, ...] = ()
+    ac_results: tuple[ACResult, ...] = Field(
+        default_factory=tuple,
+        description="Formal evaluator/verifier verdicts for acceptance criteria.",
+    )
+    task_results: tuple[TaskResult, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "Worker execution outcomes for tasks/subtasks. Distinct from ac_results: "
+            "task completion is not acceptance approval."
+        ),
+    )
     feedback_metadata: tuple[FeedbackMetadata, ...] = Field(
         default_factory=tuple,
         description=(
@@ -199,7 +226,7 @@ class EvaluationSummary(BaseModel, frozen=True):
             return False
         if self.ac_results:
             return all(ac.passed for ac in self.ac_results)
-        if self.approval_status == "rejected":
+        if self.approval_status != "approved":
             return False
         return self.final_approved
 

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -208,11 +208,13 @@ class EvaluationSummary(BaseModel, frozen=True):
         """Eagerly reconcile approval fields with AC results at construction time."""
         if self.ac_results:
             ac_passed = all(ac.passed for ac in self.ac_results)
-            expected_status = "approved" if ac_passed else "rejected"
+            execution_completed = self.execution_completion_status == "completed"
+            final_approved = ac_passed and execution_completed
+            expected_status = "approved" if final_approved else "rejected"
             if self.approval_status != expected_status:
                 object.__setattr__(self, "approval_status", expected_status)
-            if self.final_approved != ac_passed:
-                object.__setattr__(self, "final_approved", ac_passed)
+            if self.final_approved != final_approved:
+                object.__setattr__(self, "final_approved", final_approved)
         return self
 
     @property

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -450,9 +450,9 @@ def _evaluation_summary_from_spec_verification(
                 "no independently verifiable assertions for AC "
                 + ", ".join(str(i + 1) for i in unverifiable_indices)
             )
-        failure_reason = " [".join([reason_parts[0], "; ".join(reason_parts[1:])])
+        failure_reason = reason_parts[0]
         if len(reason_parts) > 1:
-            failure_reason += "]"
+            failure_reason += f" [{'; '.join(reason_parts[1:])}]"
 
     return EvaluationSummary(
         final_approved=approved,

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -429,7 +429,8 @@ def _evaluation_summary_from_spec_verification(
     passed_count = sum(1 for result in ac_results if result.passed)
     score = passed_count / total if total > 0 else 0.0
     complete_coverage = bool(expected_indices) and expected_indices.issubset(reports_by_index)
-    approved = complete_coverage and passed_count == total and total > 0
+    execution_completed = mechanical.execution_completion_status == "completed"
+    approved = complete_coverage and passed_count == total and total > 0 and execution_completed
 
     failure_reason = None
     if not approved:
@@ -449,6 +450,10 @@ def _evaluation_summary_from_spec_verification(
             reason_parts.append(
                 "no independently verifiable assertions for AC "
                 + ", ".join(str(i + 1) for i in unverifiable_indices)
+            )
+        if not execution_completed:
+            reason_parts.append(
+                f"execution_completion_status={mechanical.execution_completion_status}"
             )
         failure_reason = reason_parts[0]
         if len(reason_parts) > 1:

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -345,7 +345,13 @@ def _evaluation_summary_from_spec_verification(
     mechanical: Any,
     verification_summary: Any,
 ) -> Any | None:
-    """Promote verifier-checked AC reports into formal AC verdict results."""
+    """Promote complete verifier coverage into formal AC verdict results.
+
+    Spec verification may only return reports for ACs that produced extractable
+    assertions. Missing reports and reports with no concrete verification
+    results are not formal approval: they become failed/not-evaluated AC
+    results so a partial verifier pass cannot approve the whole run.
+    """
     from ouroboros.core.lineage import ACResult, EvaluationSummary
 
     reports = tuple(getattr(verification_summary, "reports", ()) or ())
@@ -355,6 +361,7 @@ def _evaluation_summary_from_spec_verification(
     expected_ac_content: dict[int, str] = {
         ac.ac_index: ac.ac_content for ac in mechanical.ac_results
     }
+    expected_agent_results = _agent_results_from_execution_summary(mechanical)
     for task in mechanical.task_results:
         source_ac_index = task.source_ac_index
         if source_ac_index is None:
@@ -362,31 +369,48 @@ def _evaluation_summary_from_spec_verification(
         expected_ac_content.setdefault(source_ac_index, task.task_content)
 
     reports_by_index = {report.ac_index: report for report in reports}
-    expected_indices = set(expected_ac_content)
-    reported_indices = set(reports_by_index)
-    result_indices = sorted(expected_indices | reported_indices)
+    expected_indices = set(expected_ac_content) | set(expected_agent_results)
+    result_indices = sorted(expected_indices | set(reports_by_index))
 
     ac_results: list[ACResult] = []
+    missing_indices: list[int] = []
+    unverifiable_indices: list[int] = []
     for ac_index in result_indices:
         report = reports_by_index.get(ac_index)
         if report is None:
+            missing_indices.append(ac_index)
             ac_results.append(
                 ACResult(
                     ac_index=ac_index,
-                    ac_content=expected_ac_content.get(ac_index, ""),
+                    ac_content=expected_ac_content.get(
+                        ac_index, f"Acceptance criterion {ac_index + 1}"
+                    ),
                     passed=False,
                     score=0.0,
-                    evidence="No spec verification report produced for this acceptance criterion.",
+                    evidence="No spec verification report was produced for this AC.",
                     verification_method="spec_verifier",
+                    ac_verdict_state="not_evaluated",
+                    final_verdict="fail",
+                    rendered_verdict="NOT_EVALUATED",
                 )
             )
             continue
 
         details = [result.detail for result in report.results if result.detail]
         evidence = "; ".join(details)
-        if not evidence:
-            evidence = "No independently verifiable assertions; preserved legacy task report."
-        passed = bool(report.verified_pass)
+        if not report.results:
+            unverifiable_indices.append(ac_index)
+            evidence = "No independently verifiable assertions; formal AC verdict not evaluated."
+            passed = False
+            verdict_state = "not_evaluated"
+            rendered_verdict = "NOT_EVALUATED"
+        else:
+            passed = bool(report.verified_pass)
+            verdict_state = "evaluated"
+            rendered_verdict = "PASS" if passed else "FAIL"
+            if not evidence:
+                evidence = "Spec verifier produced no evidence details."
+
         ac_results.append(
             ACResult(
                 ac_index=report.ac_index,
@@ -395,26 +419,40 @@ def _evaluation_summary_from_spec_verification(
                 score=1.0 if passed else 0.0,
                 evidence=evidence,
                 verification_method="spec_verifier",
+                ac_verdict_state=verdict_state,
+                final_verdict="pass" if passed else "fail",
+                rendered_verdict=rendered_verdict,
             )
         )
 
     total = len(ac_results)
     passed_count = sum(1 for result in ac_results if result.passed)
     score = passed_count / total if total > 0 else 0.0
-    complete_coverage = bool(expected_indices) and expected_indices.issubset(reported_indices)
+    complete_coverage = bool(expected_indices) and expected_indices.issubset(reports_by_index)
     approved = complete_coverage and passed_count == total and total > 0
 
     failure_reason = None
     if not approved:
         failed_indices = [result.ac_index + 1 for result in ac_results if not result.passed]
         discrepancy_count = getattr(verification_summary, "discrepancy_count", 0)
-        suffix = (
-            f" [{discrepancy_count} spec verification override(s)]" if discrepancy_count else ""
-        )
-        failure_reason = (
+        reason_parts = [
             f"{len(failed_indices)}/{total} ACs failed "
-            f"(AC {', '.join(str(i) for i in failed_indices)}){suffix}"
-        )
+            f"(AC {', '.join(str(i) for i in failed_indices)})"
+        ]
+        if discrepancy_count:
+            reason_parts.append(f"{discrepancy_count} spec verification override(s)")
+        if missing_indices:
+            reason_parts.append(
+                "missing verifier report for AC " + ", ".join(str(i + 1) for i in missing_indices)
+            )
+        if unverifiable_indices:
+            reason_parts.append(
+                "no independently verifiable assertions for AC "
+                + ", ".join(str(i + 1) for i in unverifiable_indices)
+            )
+        failure_reason = " [".join([reason_parts[0], "; ".join(reason_parts[1:])])
+        if len(reason_parts) > 1:
+            failure_reason += "]"
 
     return EvaluationSummary(
         final_approved=approved,

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -253,6 +253,183 @@ def _looks_like_project_root(path: object) -> bool:
     return any((path / marker).exists() for marker in _PROJECT_ROOT_MARKERS)
 
 
+def _parse_legacy_execution_task_summary(artifact: str, seed: Any) -> Any | None:
+    """Parse legacy parallel execution output into task completion results.
+
+    Legacy reports render worker execution as ``### AC N: [PASS|FAIL]``.  Those
+    lines describe execution completion, not formal evaluator/verifier AC
+    verdicts, so they populate ``task_results`` instead of ``ac_results``.
+    """
+    from ouroboros.core.lineage import EvaluationSummary, TaskResult
+
+    task_line_matches = re.findall(r"### AC (\d+): \[(PASS|FAIL)\]\s*(.*)", artifact)
+    if not task_line_matches:
+        return None
+
+    seed_acs = getattr(seed, "acceptance_criteria", None) or ()
+    feedback_metadata = _extract_feedback_metadata_from_artifact(artifact)
+
+    task_results: list[TaskResult] = []
+    for ac_num_str, status, description in task_line_matches:
+        task_idx = int(ac_num_str) - 1
+        task_content = seed_acs[task_idx] if task_idx < len(seed_acs) else description.strip()
+        completed = status == "PASS"
+        task_results.append(
+            TaskResult(
+                task_index=task_idx,
+                task_content=task_content,
+                status="completed" if completed else "failed",
+                completed=completed,
+                source_ac_index=task_idx,
+                evidence=description.strip(),
+                execution_method="legacy_parallel_report",
+            )
+        )
+
+    total = len(task_results)
+    completed_count = sum(1 for result in task_results if result.completed)
+    score = completed_count / total if total > 0 else 0.0
+
+    total_expected_tasks = len(seed_acs) if seed_acs else total
+    all_expected_tasks_reported = total >= total_expected_tasks
+    all_tasks_completed = completed_count == total and all_expected_tasks_reported
+
+    failed_indices = [result.task_index + 1 for result in task_results if not result.completed]
+    failure_reason = None
+    if not all_tasks_completed:
+        if failed_indices:
+            failure_reason = (
+                f"{len(failed_indices)}/{total} tasks failed "
+                f"(Task {', '.join(str(i) for i in failed_indices)})"
+            )
+        else:
+            failure_reason = (
+                f"{completed_count}/{total_expected_tasks} tasks completed; "
+                "formal AC evaluation not run"
+            )
+
+    execution_completion_status = "completed" if all_tasks_completed else "failed"
+
+    return EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=2 if all_tasks_completed else 1,
+        score=score,
+        drift_score=None,
+        failure_reason=failure_reason,
+        ac_results=(),
+        task_results=tuple(task_results),
+        feedback_metadata=feedback_metadata,
+        execution_completion_status=execution_completion_status,
+        approval_status="not_evaluated",
+    )
+
+
+def _agent_results_from_execution_summary(mechanical: Any) -> dict[int, bool]:
+    """Return legacy agent-reported AC outcomes for spec verification.
+
+    Formal ``ACResult`` values take precedence when present.  For legacy
+    execution-only summaries, preserve the worker task completion signal via
+    ``source_ac_index`` so skipped/unverifiable assertions do not convert a
+    worker-reported failure into formal approval.
+    """
+    agent_results = {ac.ac_index: ac.passed for ac in mechanical.ac_results}
+    for task in mechanical.task_results:
+        source_ac_index = task.source_ac_index
+        if source_ac_index is None:
+            source_ac_index = task.task_index
+        agent_results.setdefault(source_ac_index, task.completed)
+    return agent_results
+
+
+def _evaluation_summary_from_spec_verification(
+    mechanical: Any,
+    verification_summary: Any,
+) -> Any | None:
+    """Promote verifier-checked AC reports into formal AC verdict results."""
+    from ouroboros.core.lineage import ACResult, EvaluationSummary
+
+    reports = tuple(getattr(verification_summary, "reports", ()) or ())
+    if not reports:
+        return None
+
+    expected_ac_content: dict[int, str] = {
+        ac.ac_index: ac.ac_content for ac in mechanical.ac_results
+    }
+    for task in mechanical.task_results:
+        source_ac_index = task.source_ac_index
+        if source_ac_index is None:
+            source_ac_index = task.task_index
+        expected_ac_content.setdefault(source_ac_index, task.task_content)
+
+    reports_by_index = {report.ac_index: report for report in reports}
+    expected_indices = set(expected_ac_content)
+    reported_indices = set(reports_by_index)
+    result_indices = sorted(expected_indices | reported_indices)
+
+    ac_results: list[ACResult] = []
+    for ac_index in result_indices:
+        report = reports_by_index.get(ac_index)
+        if report is None:
+            ac_results.append(
+                ACResult(
+                    ac_index=ac_index,
+                    ac_content=expected_ac_content.get(ac_index, ""),
+                    passed=False,
+                    score=0.0,
+                    evidence="No spec verification report produced for this acceptance criterion.",
+                    verification_method="spec_verifier",
+                )
+            )
+            continue
+
+        details = [result.detail for result in report.results if result.detail]
+        evidence = "; ".join(details)
+        if not evidence:
+            evidence = "No independently verifiable assertions; preserved legacy task report."
+        passed = bool(report.verified_pass)
+        ac_results.append(
+            ACResult(
+                ac_index=report.ac_index,
+                ac_content=report.ac_text,
+                passed=passed,
+                score=1.0 if passed else 0.0,
+                evidence=evidence,
+                verification_method="spec_verifier",
+            )
+        )
+
+    total = len(ac_results)
+    passed_count = sum(1 for result in ac_results if result.passed)
+    score = passed_count / total if total > 0 else 0.0
+    complete_coverage = bool(expected_indices) and expected_indices.issubset(reported_indices)
+    approved = complete_coverage and passed_count == total and total > 0
+
+    failure_reason = None
+    if not approved:
+        failed_indices = [result.ac_index + 1 for result in ac_results if not result.passed]
+        discrepancy_count = getattr(verification_summary, "discrepancy_count", 0)
+        suffix = (
+            f" [{discrepancy_count} spec verification override(s)]" if discrepancy_count else ""
+        )
+        failure_reason = (
+            f"{len(failed_indices)}/{total} ACs failed "
+            f"(AC {', '.join(str(i) for i in failed_indices)}){suffix}"
+        )
+
+    return EvaluationSummary(
+        final_approved=approved,
+        highest_stage_passed=3 if approved else 2,
+        score=score,
+        drift_score=None,
+        failure_reason=failure_reason,
+        ac_results=tuple(ac_results),
+        task_results=mechanical.task_results,
+        feedback_metadata=mechanical.feedback_metadata,
+        execution_completion_status=mechanical.execution_completion_status,
+        approval_status="approved" if approved else "rejected",
+    )
+
+
 def _project_dir_from_seed(seed: Any) -> str | None:
     """Extract a likely project directory from seed metadata or brownfield context."""
     if seed is None:
@@ -1018,7 +1195,7 @@ def create_ouroboros_server(
     )
 
     # Create evolution engines for evolve_step
-    from ouroboros.core.lineage import ACResult, EvaluationSummary
+    from ouroboros.core.lineage import EvaluationSummary
     from ouroboros.evaluation.artifact_collector import ArtifactCollector
     from ouroboros.evolution.loop import EvolutionaryLoop, EvolutionaryLoopConfig
     from ouroboros.evolution.reflect import ReflectEngine
@@ -1113,61 +1290,13 @@ def create_ouroboros_server(
         )
 
     def _evaluate_mechanically(artifact: str, seed: Any) -> EvaluationSummary | None:
-        """Parse structured AC results from execution output.
+        """Parse legacy execution completion output without fabricating AC verdicts.
 
-        The parallel executor emits '### AC N: [PASS/FAIL] ...' lines.
-        When these are present, we can score mechanically without an LLM call,
-        which is more reliable in MCP stdio mode where nested CLI spawning
-        is unstable.
-
-        Returns None if the output doesn't contain parseable AC results.
+        The parallel executor historically emits ``### AC N: [PASS/FAIL]`` lines
+        for worker execution completion.  Keep that output parseable, but map it
+        to task completion results rather than formal ``ACResult`` verdicts.
         """
-        import re
-
-        # Match full AC lines: "### AC 3: [PASS] Some description..."
-        ac_line_matches = re.findall(r"### AC (\d+): \[(PASS|FAIL)\]\s*(.*)", artifact)
-        if not ac_line_matches:
-            return None
-
-        seed_acs = getattr(seed, "acceptance_criteria", None) or ()
-        feedback_metadata = _extract_feedback_metadata_from_artifact(artifact)
-
-        ac_results: list[ACResult] = []
-        for ac_num_str, status, description in ac_line_matches:
-            ac_idx = int(ac_num_str) - 1  # 0-based index
-            ac_content = seed_acs[ac_idx] if ac_idx < len(seed_acs) else description.strip()
-            ac_results.append(
-                ACResult(
-                    ac_index=ac_idx,
-                    ac_content=ac_content,
-                    passed=status == "PASS",
-                    score=1.0 if status == "PASS" else 0.0,
-                    evidence=description.strip(),
-                    verification_method="mechanical",
-                )
-            )
-
-        total = len(ac_results)
-        passed = sum(1 for r in ac_results if r.passed)
-        score = passed / total if total > 0 else 0.0
-
-        total_acs = len(seed_acs) if seed_acs else total
-        approved = passed >= total_acs and passed == total
-
-        failure_reason = None
-        if not approved:
-            failed_indices = [r.ac_index + 1 for r in ac_results if not r.passed]
-            failure_reason = f"{len(failed_indices)}/{total} ACs failed (AC {', '.join(str(i) for i in failed_indices)})"
-
-        return EvaluationSummary(
-            final_approved=approved,
-            highest_stage_passed=3 if approved else 2,
-            score=score,
-            drift_score=1.0 - score,
-            failure_reason=failure_reason,
-            ac_results=tuple(ac_results),
-            feedback_metadata=feedback_metadata,
-        )
+        return _parse_legacy_execution_task_summary(artifact, seed)
 
     spec_extractor = AssertionExtractor(
         llm_adapter=llm_adapter,
@@ -1225,71 +1354,21 @@ def create_ouroboros_server(
         if not assertions:
             return None
 
-        # Build agent results map from mechanical evaluation
-        agent_results = {ac.ac_index: ac.passed for ac in mechanical.ac_results}
+        # Build agent results map from formal AC results or legacy task completion.
+        agent_results = _agent_results_from_execution_summary(mechanical)
 
         # Run verification
         verifier = SpecVerifier(project_dir=project_dir)
         summary = verifier.verify_all(assertions, agent_results)
 
-        if not summary.has_discrepancies:
-            return None
+        if summary.has_discrepancies:
+            log.warning(
+                "spec_verification.discrepancies_found",
+                count=summary.discrepancy_count,
+                project_dir=project_dir,
+            )
 
-        # Override: rebuild ac_results with verification corrections
-        log.warning(
-            "spec_verification.discrepancies_found",
-            count=summary.discrepancy_count,
-            project_dir=project_dir,
-        )
-
-        corrected_results: list[ACResult] = []
-        discrepant_indices: set[int] = set()
-        for report in summary.reports:
-            if report.has_discrepancy:
-                discrepant_indices.add(report.ac_index)
-
-        for ac in mechanical.ac_results:
-            if ac.ac_index in discrepant_indices:
-                # Find the verification detail for evidence
-                detail = ""
-                for report in summary.reports:
-                    if report.ac_index == ac.ac_index:
-                        details = [r.detail for r in report.results if r.discrepancy]
-                        detail = "; ".join(details)
-                        break
-
-                corrected_results.append(
-                    ACResult(
-                        ac_index=ac.ac_index,
-                        ac_content=ac.ac_content,
-                        passed=False,
-                        score=0.0,
-                        evidence=f"Spec verification override: {detail}",
-                        verification_method="spec_verifier",
-                    )
-                )
-            else:
-                corrected_results.append(ac)
-
-        total = len(corrected_results)
-        passed = sum(1 for r in corrected_results if r.passed)
-        score = passed / total if total > 0 else 0.0
-
-        failed_indices = [r.ac_index + 1 for r in corrected_results if not r.passed]
-        failure_reason = (
-            f"{len(failed_indices)}/{total} ACs failed "
-            f"(AC {', '.join(str(i) for i in failed_indices)}) "
-            f"[{summary.discrepancy_count} spec verification override(s)]"
-        )
-
-        return EvaluationSummary(
-            final_approved=False,
-            highest_stage_passed=2,
-            score=score,
-            drift_score=1.0 - score,
-            failure_reason=failure_reason,
-            ac_results=tuple(corrected_results),
-        )
+        return _evaluation_summary_from_spec_verification(mechanical, summary)
 
     async def _evolution_evaluator(seed: Any, execution_output: str | None) -> EvaluationSummary:
         await _ensure_evolution_store_initialized()

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -406,7 +406,8 @@ def _evaluation_summary_from_spec_verification(
             rendered_verdict = "NOT_EVALUATED"
         else:
             passed = bool(report.verified_pass)
-            verdict_state = "evaluated"
+            verifier_overrode_pass = bool(report.agent_reported_pass) and not passed
+            verdict_state = "overridden" if verifier_overrode_pass else "evaluated"
             rendered_verdict = "PASS" if passed else "FAIL"
             if not evidence:
                 evidence = "Spec verifier produced no evidence details."
@@ -436,10 +437,12 @@ def _evaluation_summary_from_spec_verification(
     if not approved:
         failed_indices = [result.ac_index + 1 for result in ac_results if not result.passed]
         discrepancy_count = getattr(verification_summary, "discrepancy_count", 0)
-        reason_parts = [
-            f"{len(failed_indices)}/{total} ACs failed "
-            f"(AC {', '.join(str(i) for i in failed_indices)})"
-        ]
+        reason_parts = []
+        if failed_indices:
+            reason_parts.append(
+                f"{len(failed_indices)}/{total} ACs failed "
+                f"(AC {', '.join(str(i) for i in failed_indices)})"
+            )
         if discrepancy_count:
             reason_parts.append(f"{discrepancy_count} spec verification override(s)")
         if missing_indices:
@@ -455,6 +458,8 @@ def _evaluation_summary_from_spec_verification(
             reason_parts.append(
                 f"execution_completion_status={mechanical.execution_completion_status}"
             )
+        if not reason_parts:
+            reason_parts.append("spec verification did not approve the run")
         failure_reason = reason_parts[0]
         if len(reason_parts) > 1:
             failure_reason += f" [{'; '.join(reason_parts[1:])}]"

--- a/tests/unit/core/test_lineage.py
+++ b/tests/unit/core/test_lineage.py
@@ -222,11 +222,12 @@ class TestEvaluationSummary:
         assert summary.run_verdict == "FAIL"
 
     def test_run_verdict_fails_when_execution_incomplete(self) -> None:
-        """Execution failure overrides AC results — run must be FAIL."""
+        """Execution failure overrides AC results and legacy approval fields."""
         summary = EvaluationSummary(
-            final_approved=False,
+            final_approved=True,
             highest_stage_passed=2,
             execution_completion_status="failed",
+            approval_status="approved",
             ac_results=(
                 ACResult(
                     ac_index=0,
@@ -241,6 +242,8 @@ class TestEvaluationSummary:
 
         assert summary.run_verdict_passed is False
         assert summary.run_verdict == "FAIL"
+        assert summary.final_approved is False
+        assert summary.approval_status == "rejected"
 
     def test_run_verdict_fails_when_approval_rejected_no_ac_results(self) -> None:
         """Rejected approval without AC results must be FAIL."""
@@ -322,6 +325,30 @@ class TestEvaluationSummary:
         payload = summary.model_dump(mode="json")
         assert payload["approval_status"] == "approved"
         assert payload["final_approved"] is True
+
+    def test_serialized_approval_is_execution_aware_with_passing_acs(self) -> None:
+        """model_dump() must not expose approved legacy fields after execution failure."""
+        summary = EvaluationSummary(
+            final_approved=True,
+            highest_stage_passed=2,
+            execution_completion_status="failed",
+            approval_status="approved",
+            ac_results=(
+                ACResult(
+                    ac_index=0,
+                    ac_content="Feature works",
+                    passed=True,
+                    score=1.0,
+                    evidence="OK",
+                    verification_method="semantic",
+                ),
+            ),
+        )
+
+        payload = summary.model_dump(mode="json")
+        assert payload["approval_status"] == "rejected"
+        assert payload["final_approved"] is False
+        assert summary.run_verdict == "FAIL"
 
 
 class TestACResult:

--- a/tests/unit/core/test_lineage.py
+++ b/tests/unit/core/test_lineage.py
@@ -5,6 +5,7 @@ from ouroboros.core.lineage import (
     EvaluationSummary,
     FeedbackMetadata,
     GenerationRecord,
+    TaskResult,
 )
 from ouroboros.core.seed import OntologySchema
 
@@ -49,6 +50,46 @@ class TestEvaluationSummary:
 
         assert payload["execution_completion_status"] == "completed"
         assert payload["approval_status"] == "rejected"
+
+    def test_summary_serializes_task_results_separately_from_ac_results(self) -> None:
+        """Worker task completion should not masquerade as formal AC verdicts."""
+        summary = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Implement feature",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    evidence="Worker finished the implementation task",
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            ac_results=(),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+
+        payload = summary.model_dump(mode="json")
+
+        assert payload["task_results"][0]["status"] == "completed"
+        assert payload["task_results"][0]["source_ac_index"] == 0
+        assert payload["ac_results"] == []
+        assert summary.run_verdict_passed is False
+
+    def test_run_verdict_fails_when_approval_not_evaluated(self) -> None:
+        """Completion without formal approval must not become a passing run verdict."""
+        summary = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+
+        assert summary.run_verdict_passed is False
+        assert summary.run_verdict == "FAIL"
 
     def test_feedback_metadata_serializes_as_structured_output(self) -> None:
         """Structured feedback metadata should survive round-trip serialization."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -381,6 +381,53 @@ Parallel Execution Verification Report
         assert summary.drift_score is None
         assert summary.run_verdict == "PASS"
 
+    def test_spec_verification_plain_failure_reason_has_no_dangling_bracket(self) -> None:
+        """Ordinary verifier failures should render a clean failure reason."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="config",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Create config",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            verified=False,
+                            detail="Structure 'config' not found",
+                        ),
+                    ),
+                    agent_reported_pass=False,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.failure_reason == "1/1 ACs failed (AC 1)"
+
     def test_spec_verification_discrepancy_becomes_formal_ac_failure(self) -> None:
         """False-positive legacy PASS claims remain catchable by spec verification."""
         mechanical = EvaluationSummary(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from ouroboros.core.lineage import EvaluationSummary, TaskResult
 from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.io_recorder import get_current_io_journal_recorder
@@ -14,8 +15,11 @@ from ouroboros.mcp.errors import MCPResourceNotFoundError, MCPServerError
 from ouroboros.mcp.server.adapter import (
     VALID_TRANSPORTS,
     MCPServerAdapter,
+    _agent_results_from_execution_summary,
     _build_tool_signature_with_aliases,
+    _evaluation_summary_from_spec_verification,
     _extract_feedback_metadata_from_artifact,
+    _parse_legacy_execution_task_summary,
     _project_dir_from_artifact,
     _project_dir_from_seed,
     _safe_cwd,
@@ -33,6 +37,13 @@ from ouroboros.mcp.types import (
 )
 from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
 from ouroboros.orchestrator.control_bus import ControlBus, ControlBusDrainError
+from ouroboros.verification.models import (
+    ACVerificationReport,
+    SpecAssertion,
+    SpecVerificationResult,
+    SpecVerificationSummary,
+    VerificationTier,
+)
 
 
 class _FakeEventStore:
@@ -158,6 +169,270 @@ class TestMCPServerAdapter:
             "max_tokens": "max.tokens",
             "_class": "class",
         }
+
+    def test_legacy_execution_report_maps_to_task_results_not_ac_verdicts(self) -> None:
+        """Legacy AC PASS/FAIL execution lines are worker task completion signals."""
+        seed = SimpleNamespace(acceptance_criteria=("Implement feature", "Add tests"))
+        artifact = """
+Parallel Execution Verification Report
+
+## AC Results
+### AC 1: [PASS] Implement feature
+### AC 2: [FAIL] Add tests
+""".strip()
+
+        summary = _parse_legacy_execution_task_summary(artifact, seed)
+
+        assert summary is not None
+        assert summary.ac_results == ()
+        assert [task.status for task in summary.task_results] == ["completed", "failed"]
+        assert [task.source_ac_index for task in summary.task_results] == [0, 1]
+        assert summary.score == 0.5
+        assert summary.drift_score is None
+        assert summary.approval_status == "not_evaluated"
+        assert summary.execution_completion_status == "failed"
+        assert summary.run_verdict_passed is False
+
+    def test_legacy_execution_report_completion_does_not_approve_without_evaluation(self) -> None:
+        """All worker tasks completing still requires a separate formal AC verdict."""
+        seed = SimpleNamespace(acceptance_criteria=("Implement feature",))
+        artifact = "### AC 1: [PASS] Implement feature"
+
+        summary = _parse_legacy_execution_task_summary(artifact, seed)
+
+        assert summary is not None
+        assert len(summary.task_results) == 1
+        assert summary.task_results[0].completed is True
+        assert summary.ac_results == ()
+        assert summary.execution_completion_status == "completed"
+        assert summary.approval_status == "not_evaluated"
+        assert summary.drift_score is None
+        assert summary.run_verdict == "FAIL"
+
+    def test_agent_results_preserve_failed_legacy_task_for_spec_verification(self) -> None:
+        """Legacy task failures must remain visible to the verifier input map."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=1,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Implement feature",
+                    status="failed",
+                    completed=False,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="failed",
+            approval_status="not_evaluated",
+        )
+
+        assert _agent_results_from_execution_summary(mechanical) == {0: False}
+
+    def test_unverifiable_report_preserves_legacy_task_failure_as_ac_failure(self) -> None:
+        """Skipped verifier assertions must not upgrade a failed task to approval."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=1,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Implement feature",
+                    status="failed",
+                    completed=False,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="failed",
+            approval_status="not_evaluated",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Implement feature",
+                    results=(),
+                    agent_reported_pass=False,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.task_results[0].completed is False
+        assert summary.ac_results[0].passed is False
+        assert summary.execution_completion_status == "failed"
+        assert summary.approval_status == "rejected"
+        assert summary.run_verdict == "FAIL"
+
+    def test_partial_spec_verification_coverage_does_not_approve_run(self) -> None:
+        """Verifier reports must cover every expected AC before run approval."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+                TaskResult(
+                    task_index=1,
+                    task_content="Add docs",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=1,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="config",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Create config",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            verified=True,
+                            detail="Found file: config.py",
+                        ),
+                    ),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert [ac.passed for ac in summary.ac_results] == [True, False]
+        assert summary.ac_results[1].ac_content == "Add docs"
+        assert "No spec verification report" in summary.ac_results[1].evidence
+        assert summary.approval_status == "rejected"
+        assert summary.run_verdict == "FAIL"
+
+    def test_spec_verification_promotes_checked_reports_to_formal_ac_results(self) -> None:
+        """Verifier-checked reports become formal AC verdicts without synthetic drift."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="config",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Create config",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            verified=True,
+                            detail="Found file: config.py",
+                        ),
+                    ),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert len(summary.task_results) == 1
+        assert len(summary.ac_results) == 1
+        assert summary.ac_results[0].passed is True
+        assert summary.ac_results[0].verification_method == "spec_verifier"
+        assert summary.approval_status == "approved"
+        assert summary.drift_score is None
+        assert summary.run_verdict == "PASS"
+
+    def test_spec_verification_discrepancy_becomes_formal_ac_failure(self) -> None:
+        """False-positive legacy PASS claims remain catchable by spec verification."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="config",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Create config",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            verified=False,
+                            discrepancy=True,
+                            detail="Structure 'config' not found",
+                        ),
+                    ),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.task_results[0].completed is True
+        assert summary.ac_results[0].passed is False
+        assert summary.approval_status == "rejected"
+        assert summary.failure_reason == "1/1 ACs failed (AC 1) [1 spec verification override(s)]"
+        assert summary.drift_score is None
+        assert summary.run_verdict == "FAIL"
 
     def test_extract_feedback_metadata_from_artifact_parses_structured_warning(self) -> None:
         """Execution artifacts should expose structured evaluation feedback metadata."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -434,6 +434,108 @@ Parallel Execution Verification Report
         assert summary.drift_score is None
         assert summary.run_verdict == "FAIL"
 
+    def test_spec_verification_rejects_partial_ac_coverage(self) -> None:
+        """A subset of verifier reports must not approve unverified ACs."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+                TaskResult(
+                    task_index=1,
+                    task_content="Add docs",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=1,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="config",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Create config",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            verified=True,
+                            detail="Found file: config.py",
+                        ),
+                    ),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert len(summary.ac_results) == 2
+        assert summary.ac_results[0].passed is True
+        assert summary.ac_results[1].passed is False
+        assert summary.ac_results[1].ac_verdict_state == "not_evaluated"
+        assert summary.ac_results[1].rendered_verdict == "NOT_EVALUATED"
+        assert summary.approval_status == "rejected"
+        assert "missing verifier report for AC 2" in (summary.failure_reason or "")
+        assert summary.run_verdict == "FAIL"
+
+    def test_spec_verification_rejects_unverifiable_completed_task(self) -> None:
+        """A completed task is not an AC approval when no assertions ran."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Improve UX",
+                    status="completed",
+                    completed=True,
+                    source_ac_index=0,
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="completed",
+            approval_status="not_evaluated",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Improve UX",
+                    results=(),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].ac_verdict_state == "not_evaluated"
+        assert summary.ac_results[0].rendered_verdict == "NOT_EVALUATED"
+        assert summary.approval_status == "rejected"
+        assert "no independently verifiable assertions for AC 1" in (summary.failure_reason or "")
+        assert summary.run_verdict == "FAIL"
+
     def test_extract_feedback_metadata_from_artifact_parses_structured_warning(self) -> None:
         """Execution artifacts should expose structured evaluation feedback metadata."""
         artifact = """

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -428,6 +428,59 @@ Parallel Execution Verification Report
         assert summary is not None
         assert summary.failure_reason == "1/1 ACs failed (AC 1)"
 
+    def test_spec_verification_does_not_approve_failed_execution(self) -> None:
+        """Passing verifier results must not approve a run whose execution failed."""
+        mechanical = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            task_results=(
+                TaskResult(
+                    task_index=0,
+                    task_content="Create config",
+                    status="failed",
+                    completed=False,
+                    source_ac_index=0,
+                    evidence="Worker failed before completing the task",
+                    execution_method="legacy_parallel_report",
+                ),
+            ),
+            execution_completion_status="failed",
+            approval_status="not_evaluated",
+        )
+        assertion = SpecAssertion(
+            ac_index=0,
+            ac_text="Create config",
+            tier=VerificationTier.T2_STRUCTURAL,
+            pattern="config",
+        )
+        verification = SpecVerificationSummary.from_reports(
+            (
+                ACVerificationReport(
+                    ac_index=0,
+                    ac_text="Create config",
+                    results=(
+                        SpecVerificationResult(
+                            assertion=assertion,
+                            verified=True,
+                            detail="Found file: config.py",
+                        ),
+                    ),
+                    agent_reported_pass=True,
+                ),
+            ),
+            project_dir="/tmp/project",
+        )
+
+        summary = _evaluation_summary_from_spec_verification(mechanical, verification)
+
+        assert summary is not None
+        assert summary.ac_results[0].passed is True
+        assert summary.execution_completion_status == "failed"
+        assert summary.approval_status == "rejected"
+        assert summary.final_approved is False
+        assert summary.run_verdict == "FAIL"
+        assert "execution_completion_status=failed" in (summary.failure_reason or "")
+
     def test_spec_verification_discrepancy_becomes_formal_ac_failure(self) -> None:
         """False-positive legacy PASS claims remain catchable by spec verification."""
         mechanical = EvaluationSummary(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -479,7 +479,7 @@ Parallel Execution Verification Report
         assert summary.approval_status == "rejected"
         assert summary.final_approved is False
         assert summary.run_verdict == "FAIL"
-        assert "execution_completion_status=failed" in (summary.failure_reason or "")
+        assert summary.failure_reason == "execution_completion_status=failed"
 
     def test_spec_verification_discrepancy_becomes_formal_ac_failure(self) -> None:
         """False-positive legacy PASS claims remain catchable by spec verification."""
@@ -529,6 +529,10 @@ Parallel Execution Verification Report
         assert summary is not None
         assert summary.task_results[0].completed is True
         assert summary.ac_results[0].passed is False
+        assert summary.ac_results[0].ac_verdict_state == "overridden"
+        assert summary.ac_results[0].provisional_verdict == "pass"
+        assert summary.ac_results[0].override_source == "spec_verifier"
+        assert summary.ac_results[0].override_reason == "Structure 'config' not found"
         assert summary.approval_status == "rejected"
         assert summary.failure_reason == "1/1 ACs failed (AC 1) [1 spec verification override(s)]"
         assert summary.drift_score is None


### PR DESCRIPTION
## Summary

First compatibility-preserving slice for #608.

This PR starts separating worker execution completion from formal AC verdicts at the shared model / MCP adapter boundary:

- adds `TaskResult` and `EvaluationSummary.task_results` for worker execution outcomes
- keeps `ACResult` reserved for formal evaluator/verifier acceptance-criterion verdicts
- maps legacy mechanical execution report lines (`### AC N: [PASS|FAIL]`) into `task_results` rather than `ac_results`
- leaves `drift_score` unset for mechanical task-completion parsing, because semantic drift was not evaluated
- keeps a task-completion `score` for the cheap mechanical gate while making `approval_status="not_evaluated"`
- adds regression coverage for completion-without-approval and mixed task completion

## Why

Issue #608 points out that worker completion, AC approval, and drift are different contracts. If all three are expressed as AC pass/fail, downstream consumers cannot reliably decide whether to retry execution, run formal verification, or investigate semantic drift.

This PR enforces the core invariant:

> Execution is not evaluation. Completion is not approval. Task failure is not drift.

## Scope

This intentionally does **not** rename every UI/event/docs surface yet. It establishes the model and parser contract first so follow-up PRs can safely update HUD/event/docs terminology without losing compatibility with legacy execution reports.

## Verification

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/ouroboros`
- `uv run pytest tests/unit/core/test_lineage.py tests/unit/mcp/server/test_adapter.py -q`
- `uv run pytest -q` (`6225 passed, 2 skipped`)

Fixes #608
