### PR TITLE
docs(ralph): clarify skill-driven loop contract

### DIFF
--- a/docs/guides/evolution-loop.md
+++ b/docs/guides/evolution-loop.md
@@ -76,7 +76,7 @@ Gen 3: {Task, Priority, Status, DueDate}     → similarity 1.00 → CONVERGED
 
 ## Ralph: The Persistent Loop
 
-`ooo ralph` (Claude Code skill) runs the evolutionary loop persistently -- across session boundaries -- until convergence. Each step is **stateless**: the EventStore reconstructs the full lineage, so even if your machine restarts, the serpent picks up where it left off.
+`ooo ralph` is currently a **client-driven skill loop** around background `evolve_step` jobs. The MCP server exposes `ouroboros_start_evolve_step` plus job polling tools; it does not yet expose a first-class `ouroboros_ralph` job that owns the whole loop. Each generation is recorded in the EventStore, so lineage history can be inspected and a client can continue from recorded state, but the multi-generation loop itself is not yet durable across client/session restarts.
 
 ```
 Ralph Cycle 1: evolve_step(lineage, seed) → Gen 1 → action=CONTINUE
@@ -91,8 +91,8 @@ Ralph Cycle 3: evolve_step(lineage)       → Gen 3 → action=CONVERGED
 | | `ooo evolve` | `ooo ralph` |
 |---|---|---|
 | **Scope** | Single evolution step | Loop until convergence |
-| **Session** | Within current session | Survives session restarts |
-| **Control** | Manual -- you decide when to stop | Automatic -- convergence decides |
+| **Session** | Within current session | Client must reconstruct/continue from EventStore; MCP-owned durable loop is not implemented yet |
+| **Control** | Manual -- you decide when to stop | Skill-driven automation -- the client starts each next generation until convergence/limit |
 | **Use case** | Incremental refinement | Full autonomous evolution |
 
 ---

--- a/docs/runtime-guides/codex.md
+++ b/docs/runtime-guides/codex.md
@@ -160,7 +160,7 @@ After running `ouroboros setup --runtime codex`, the bundled `ooo` skills are in
 | `ooo status` | Yes | `ouroboros status execution <execution_id>` |
 | `ooo evaluate` | Yes | *(MCP only)* |
 | `ooo evolve` | Yes | *(MCP only)* |
-| `ooo ralph` | Yes | *(MCP only)* |
+| `ooo ralph` | Yes | Skill-driven loop over `ouroboros_start_evolve_step`; no first-class `ouroboros_ralph` tool yet |
 | `ooo cancel` | Yes | `ouroboros cancel execution <execution_id>` |
 | `ooo unstuck` | Yes | *(MCP only)* |
 | `ooo tutorial` | Yes | *(MCP only)* |
@@ -170,6 +170,8 @@ After running `ouroboros setup --runtime codex`, the bundled `ooo` skills are in
 | `ooo qa` | Yes | *(MCP only)* |
 | `ooo setup` | Yes | `ouroboros setup --runtime codex` |
 | `ooo publish` | Yes | *(no direct `ouroboros publish` subcommand; skill/runtime flow uses `gh` CLI)* |
+
+> **Ralph note (#528):** `ooo ralph` currently relies on the installed skill to repeatedly call `ouroboros_start_evolve_step` and poll jobs. A dedicated MCP-owned `ouroboros_ralph` loop is planned but not implemented in this release.
 
 > **Note on `ooo seed` vs `ooo interview`:** These are two distinct skills with separate roles. `ooo interview` runs a Socratic Q&A session and returns a `session_id`. `ooo seed` accepts that `session_id` and generates a structured Seed YAML (with ambiguity scoring). From the terminal, both steps are performed in a single `ouroboros init start` invocation.
 

--- a/docs/runtime-guides/opencode.md
+++ b/docs/runtime-guides/opencode.md
@@ -210,7 +210,7 @@ After running `ouroboros setup --runtime opencode`, the Ouroboros MCP server is 
 | `ooo status` | Yes | `ouroboros status execution <execution_id>` |
 | `ooo evaluate` | Yes | *(MCP only)* |
 | `ooo evolve` | Yes | *(MCP only)* |
-| `ooo ralph` | Yes | *(MCP only)* |
+| `ooo ralph` | Yes | Skill-driven loop over `ouroboros_start_evolve_step`; no first-class `ouroboros_ralph` tool yet |
 | `ooo cancel` | Yes | `ouroboros cancel execution <execution_id>` |
 | `ooo unstuck` | Yes | *(MCP only)* |
 | `ooo tutorial` | Yes | *(MCP only)* |
@@ -220,6 +220,8 @@ After running `ouroboros setup --runtime opencode`, the Ouroboros MCP server is 
 | `ooo qa` | Yes | *(MCP only)* |
 | `ooo setup` | Yes | `ouroboros setup --runtime opencode` |
 | `ooo publish` | Yes | *(no direct `ouroboros publish` subcommand; skill/runtime flow uses `gh` CLI)* |
+
+> **Ralph note (#528):** `ooo ralph` currently relies on the installed skill to repeatedly call `ouroboros_start_evolve_step` and poll jobs. A dedicated MCP-owned `ouroboros_ralph` loop is planned but not implemented in this release.
 
 > **Note on `ooo seed` vs `ooo interview`:** These are two distinct skills with separate roles. `ooo interview` runs a Socratic Q&A session and returns a `session_id`. `ooo seed` accepts that `session_id` and generates a structured Seed YAML (with ambiguity scoring). From the terminal, both steps are performed in a single `ouroboros init start` invocation.
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -54,7 +54,7 @@ Ouroboros is a **requirement crystallization engine** for AI workflows. It trans
 | Command | Purpose | Mode |
 |---------|---------|------|
 | `ooo evolve` | Start/monitor evolutionary development loop | MCP |
-| `ooo ralph` | Self-referential loop until verified ("don't stop") | Plugin + MCP |
+| `ooo ralph` | Client-driven loop until verified (uses background evolve_step jobs) | Plugin + MCP |
 
 **Plugin** = Works immediately after `ooo setup`.
 **MCP** = Requires `ooo setup` (Python >= 3.12 auto-detected). Run setup once to unlock all features.
@@ -117,7 +117,7 @@ Ouroboros is a **requirement crystallization engine** for AI workflows. It trans
 
 | Skill | Purpose | Best For |
 |-------|---------|----------|
-| `/ouroboros:ralph` | Self-referential loop until verified | "Don't stop", must complete |
+| `/ouroboros:ralph` | Client-driven loop over background evolve_step jobs | "Don't stop", must complete |
 | `/ouroboros:evolve` | Evolutionary ontology refinement | Spec iteration until convergence |
 
 ## Available Agents

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ralph
-description: "Persistent self-referential loop until verification passes"
+description: "Client-driven Ralph loop around background evolve_step jobs"
 ---
 
 # /ouroboros:ralph
 
-Persistent self-referential loop until verification passes. "The boulder never stops."
+Client-driven Ralph loop around background `evolve_step` jobs. "The boulder never stops."
 
 ## Usage
 
@@ -16,7 +16,20 @@ ooo ralph "<your request>"
 
 **Trigger keywords:** "ralph", "don't stop", "must complete", "until it works", "keep going"
 
+> **Current implementation note (#528):** `ooo ralph` is currently a
+> skill-driven loop. The MCP server exposes `ouroboros_start_evolve_step`
+> and the job polling tools, but it does **not** yet expose a first-class
+> `ouroboros_ralph` tool that owns the whole multi-generation loop. That
+> means this skill must keep calling one generation at a time until a
+> dedicated MCP-owned Ralph loop lands.
+
 ## How It Works
+
+Ralph mode is currently coordinated by this skill. It starts one background
+`evolve_step` job per iteration, polls that job, reads the QA result, and then
+decides whether to start another iteration. The loop state lives in the client
+conversation plus EventStore/job history; it is not yet a single durable MCP
+job.
 
 Ralph mode includes parallel execution + automatic verification:
 
@@ -43,7 +56,8 @@ When the user invokes this skill:
 2. **Initialize loop**:
    - Generate a session_id (UUID)
    - Track iteration, verification_history in conversation context
-   - No file I/O needed — evolve_step stores all execution data in EventStore
+   - No file I/O needed — evolve_step stores execution data in EventStore
+   - Do not claim a dedicated `ouroboros_ralph` MCP job exists yet; use `ouroboros_start_evolve_step` plus job polling
 
 4. **Enter the loop** (non-blocking background execution):
 
@@ -130,7 +144,7 @@ When the user invokes this skill:
 
 ## The Boulder Never Stops
 
-This is the key phrase. Ralph does not give up:
+This is the key phrase. Ralph does not give up while the client continues to drive the loop:
 - Each failure is data for the next attempt
 - Verification drives the loop
 - Only complete success or max iterations stops it


### PR DESCRIPTION
## Summary

Clarifies the current Ralph contract after #528: `ooo ralph` is still a skill-driven loop over background `evolve_step` jobs, not a first-class MCP-owned `ouroboros_ralph` job yet.

## Why

Issue #528 reports real contract drift: the docs and skill copy made Ralph sound like a durable MCP-owned loop, while the implementation still depends on the installed skill repeatedly calling `ouroboros_start_evolve_step` and polling job APIs.

This PR is intentionally behavior-neutral. It makes the current state explicit so users and reviewers do not infer guarantees the runtime does not yet provide.

## Changes

- Update `skills/ralph/SKILL.md` to state that the loop is currently skill-driven.
- Update `skills/help/SKILL.md` command summaries.
- Update `docs/guides/evolution-loop.md` to remove the inaccurate session-restart durability claim.
- Update Codex/OpenCode runtime tables with a Ralph note and current implementation details.

## Verification

- `git diff --check`

## Follow-up

The implementation fix remains #528: add `RalphLoopRunner`, expose `ouroboros_ralph`, and simplify the skill to call that tool.

Fixes part of #528.
