### PR TITLE
control: define ControlContract schema boundary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ replayable execution contract on your choice of runtime backend.
 - [Contributing Guide](../CONTRIBUTING.md) - How to set up, code, test, and submit PRs
 - [Architecture for Contributors](./contributing/architecture-overview.md) - How modules connect
 - [Agent OS Kernel Terminology](./contributing/agent-os-kernel-terminology.md) - Locked vocabulary for `AgentRuntimeContext`, `ControlPlane`, `ControlContract`, `Directive`, `ControlBus`, and `IOJournal`
+- [ControlContract](./contributing/control-contract.md) - Control-plane schema, terminality, replay, and idempotency invariants
 - [Testing Guide](./contributing/testing-guide.md) - Writing and running tests
 - [Key Patterns](./contributing/key-patterns.md) - Result type, immutability, event sourcing, protocols
 - [Findings Registry](./contributing/findings-registry.md) - Documentation audit findings registry

--- a/docs/contributing/control-contract.md
+++ b/docs/contributing/control-contract.md
@@ -1,0 +1,105 @@
+# ControlContract
+
+`ControlContract` is the stable schema and invariant boundary for Agent OS
+control-plane decisions. It sits between local decision sites and durable
+`control.directive.emitted` events.
+
+The contract exists so projectors, replay, future mesh delivery, and in-process
+`ControlBus` subscribers consume the same decision shape instead of ad-hoc event
+payloads.
+
+## Layering
+
+```text
+Decision site
+  -> ControlContract validates schema + invariants
+  -> control.directive.emitted persists the durable decision
+  -> ControlBus may deliver the same decision in-process
+  -> projectors replay the persisted contract, not transport side effects
+```
+
+`ControlBus` is transport. The EventStore is the durable source of truth.
+
+## Schema version 1
+
+| Field | Required | Meaning |
+|---|---:|---|
+| `schema_version` | yes | Additive ControlContract schema version. Current value: `1`. |
+| `directive` | yes | A `Directive` member serialized by value. |
+| `target_type` | yes | The aggregate type the decision is about. |
+| `target_id` | yes | The aggregate id the decision is about. |
+| `emitted_by` | yes | Logical producer, e.g. `evolver`, `evaluator`, `job_manager`. |
+| `reason` | yes | Short audit rationale for why the decision was emitted. |
+| `is_terminal` | derived | Computed from `directive`; callers must not override it. |
+| `phase` | no | Local phase name when known. |
+| `session_id` | no | Owning session correlation when known. |
+| `execution_id` | no | Execution/run correlation when known. |
+| `lineage_id` | no | Lineage correlation when known. |
+| `generation_number` | no | Lineage generation number when known. |
+| `context_snapshot_id` | no | Context snapshot captured at emission time when known. |
+| `parent_directive_id` | no | Causal parent directive event id when a directive follows another directive. |
+| `idempotency_key` | no | Effective-decision dedupe key for replay/backfill/mesh consumers. |
+| `extra` | no | Forward-compatible supplemental metadata. Prefer stable fields when possible. |
+
+Canonical `target_type` values are `session`, `execution`, `lineage`,
+`agent_process`, `contract`, and `execution_node`. The field remains a string so
+new target kinds can land additively.
+
+## Invariants
+
+- Required string fields must be non-empty.
+- `schema_version` must be greater than or equal to `1`.
+- `generation_number`, when present, is 1-based.
+- Terminality is global: only `Directive.CANCEL` and `Directive.CONVERGE` are
+  terminal. Every other directive is non-terminal.
+- `is_terminal` is derived from the directive vocabulary and must never be a
+  caller-provided payload flag.
+- Schema evolution is additive unless a future PR explicitly declares a breaking
+  version boundary.
+
+## Idempotency
+
+Raw event UUIDs identify persisted rows. They do not identify whether two rows
+represent the same effective control decision.
+
+When a producer can compute stable decision identity, it should set
+`idempotency_key`. Consumers that need effective dedupe should use:
+
+```text
+(target_type, target_id, directive, idempotency_key)
+```
+
+Rows without `idempotency_key` are valid legacy-compatible rows. They provide raw
+replay but no projection-level dedupe guarantee beyond the event id.
+
+Backfill, mesh delivery, and contract-targeted emitters should prefer deterministic
+idempotency keys before consumers rely on at-most-once effective application.
+
+## Projector expectations
+
+Projectors consume the ControlContract fields from `control.directive.emitted`
+payloads. They should not infer terminality from local enum names, transport
+state, or `ControlBus` delivery.
+
+A projector may use `idempotency_key` to collapse duplicate effective decisions,
+but it must keep raw events available for audit. If causal ordering matters, use
+`parent_directive_id` when present and fall back to timestamp/event-id ordering
+only as a weaker legacy signal.
+
+## Mesh delivery minimum
+
+A cross-runtime mesh delivery envelope must preserve at least:
+
+- `schema_version`
+- `directive`
+- `target_type`
+- `target_id`
+- `emitted_by`
+- `reason`
+- `is_terminal`
+- every known replay correlation field (`session_id`, `execution_id`,
+  `lineage_id`, `generation_number`, `phase`)
+- `parent_directive_id` and `idempotency_key` when known
+
+Dropping these fields turns a control decision into a local notification, not a
+replayable Agent OS contract.

--- a/docs/contributing/control-contract.md
+++ b/docs/contributing/control-contract.md
@@ -75,6 +75,23 @@ replay but no projection-level dedupe guarantee beyond the event id.
 Backfill, mesh delivery, and contract-targeted emitters should prefer deterministic
 idempotency keys before consumers rely on at-most-once effective application.
 
+## Local enum mapping
+
+Local workflow enums may remain in their owning subsystem, but any control-plane
+emission must map them into the global `Directive` vocabulary without semantic
+loss. The current evolution emission site uses
+`ouroboros.evolution.directive_mapping.step_action_to_directive()` as the single
+authority for `StepAction` outcomes:
+
+| Local action | Directive | Notes |
+|---|---|---|
+| `StepAction.CONTINUE` | no directive emission | No-op continuation; `lineage.generation.completed` already records progress. |
+| `StepAction.CONVERGED` | `CONVERGE` | Terminal success. |
+| `StepAction.STAGNATED` | `UNSTUCK` | Non-terminal recovery path; never terminal success. |
+| `StepAction.EXHAUSTED` | `CANCEL` | Terminal stop without claiming convergence. |
+| `StepAction.INTERRUPTED` | `CANCEL` | Current runtime stops the interrupted step and relies on resume state for continuation. |
+| `StepAction.FAILED` | `RETRY` or `CANCEL` | Depends on remaining retry budget; default live behavior emits `RETRY` until the resilience layer owns the budget. |
+
 ## Projector expectations
 
 Projectors consume the ControlContract fields from `control.directive.emitted`

--- a/src/ouroboros/core/__init__.py
+++ b/src/ouroboros/core/__init__.py
@@ -16,7 +16,8 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "EventPayload": ("ouroboros.core.types", "EventPayload"),
     "CostUnits": ("ouroboros.core.types", "CostUnits"),
     "DriftScore": ("ouroboros.core.types", "DriftScore"),
-    # Control-plane directive vocabulary
+    # Control-plane directive vocabulary and contract
+    "ControlContract": ("ouroboros.core.control_contract", "ControlContract"),
     "Directive": ("ouroboros.core.directive", "Directive"),
     # Errors
     "OuroborosError": ("ouroboros.core.errors", "OuroborosError"),

--- a/src/ouroboros/core/control_contract.py
+++ b/src/ouroboros/core/control_contract.py
@@ -1,0 +1,154 @@
+"""ControlContract schema and invariants for control-plane decisions.
+
+The ControlContract is the stable payload contract behind
+``control.directive.emitted`` events. It keeps the global ``Directive``
+vocabulary, target identity, terminality, replay correlation, and idempotency
+metadata in one validated shape before any transport or event factory serializes
+it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+from ouroboros.core.directive import Directive
+
+CONTROL_CONTRACT_SCHEMA_VERSION = 1
+"""Current additive ControlContract schema version."""
+
+CANONICAL_CONTROL_TARGET_TYPES: frozenset[str] = frozenset(
+    {
+        "session",
+        "execution",
+        "lineage",
+        "agent_process",
+        "contract",
+        "execution_node",
+    }
+)
+"""Documented target types for ControlContract producers.
+
+The set is advisory rather than closed: target_type remains a string so future
+Agent OS targets can land additively without changing stored event schemas.
+"""
+
+
+def _require_non_empty(name: str, value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"ControlContract {name} must be non-empty")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class ControlContract:
+    """Validated control-plane decision contract.
+
+    ``is_terminal`` is intentionally derived from ``directive`` instead of being
+    caller-provided. That prevents payloads from claiming terminal semantics that
+    disagree with the global directive vocabulary.
+    """
+
+    directive: Directive
+    target_type: str
+    target_id: str
+    emitted_by: str
+    reason: str
+    schema_version: int = CONTROL_CONTRACT_SCHEMA_VERSION
+    phase: str | None = None
+    context_snapshot_id: str | None = None
+    session_id: str | None = None
+    execution_id: str | None = None
+    lineage_id: str | None = None
+    generation_number: int | None = None
+    parent_directive_id: str | None = None
+    idempotency_key: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    EVENT_TYPE: ClassVar[str] = "control.directive.emitted"
+
+    def __post_init__(self) -> None:
+        if self.schema_version < 1:
+            raise ValueError("ControlContract schema_version must be >= 1")
+        if not isinstance(self.directive, Directive):
+            raise TypeError("ControlContract directive must be a Directive")
+
+        object.__setattr__(self, "target_type", _require_non_empty("target_type", self.target_type))
+        object.__setattr__(self, "target_id", _require_non_empty("target_id", self.target_id))
+        object.__setattr__(self, "emitted_by", _require_non_empty("emitted_by", self.emitted_by))
+        object.__setattr__(self, "reason", _require_non_empty("reason", self.reason))
+
+        if self.generation_number is not None and self.generation_number < 1:
+            raise ValueError("ControlContract generation_number must be >= 1 when provided")
+        if self.lineage_id is not None and not self.lineage_id.strip():
+            raise ValueError("ControlContract lineage_id must be non-empty when provided")
+        if self.execution_id is not None and not self.execution_id.strip():
+            raise ValueError("ControlContract execution_id must be non-empty when provided")
+        if self.session_id is not None and not self.session_id.strip():
+            raise ValueError("ControlContract session_id must be non-empty when provided")
+        if self.phase is not None and not self.phase.strip():
+            raise ValueError("ControlContract phase must be non-empty when provided")
+        if self.context_snapshot_id is not None and not self.context_snapshot_id.strip():
+            raise ValueError("ControlContract context_snapshot_id must be non-empty when provided")
+        if self.parent_directive_id is not None and not self.parent_directive_id.strip():
+            raise ValueError("ControlContract parent_directive_id must be non-empty when provided")
+        if self.idempotency_key is not None and not self.idempotency_key.strip():
+            raise ValueError("ControlContract idempotency_key must be non-empty when provided")
+
+        if not isinstance(self.extra, dict):
+            raise TypeError("ControlContract extra must be a dict")
+        object.__setattr__(self, "extra", dict(self.extra))
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return the global terminality for this decision's directive."""
+        return self.directive.is_terminal
+
+    @property
+    def effective_idempotency_key(self) -> tuple[str, str, str, str] | None:
+        """Projection-level effective decision key when idempotency metadata exists.
+
+        Event UUIDs identify raw rows. This key identifies the effective control
+        decision for replay/backfill/mesh consumers that must dedupe repeated
+        delivery or reconstruction.
+        """
+        if self.idempotency_key is None:
+            return None
+        return (
+            self.target_type,
+            self.target_id,
+            self.directive.value,
+            self.idempotency_key,
+        )
+
+    def to_event_data(self) -> dict[str, Any]:
+        """Serialize the contract to a JSON-safe event payload."""
+        data: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "target_type": self.target_type,
+            "target_id": self.target_id,
+            "emitted_by": self.emitted_by,
+            "directive": self.directive.value,
+            "is_terminal": self.is_terminal,
+            "reason": self.reason,
+        }
+        if self.phase is not None:
+            data["phase"] = self.phase
+        if self.context_snapshot_id is not None:
+            data["context_snapshot_id"] = self.context_snapshot_id
+        if self.session_id is not None:
+            data["session_id"] = self.session_id
+        if self.execution_id is not None:
+            data["execution_id"] = self.execution_id
+        if self.lineage_id is not None:
+            data["lineage_id"] = self.lineage_id
+        if self.generation_number is not None:
+            data["generation_number"] = self.generation_number
+        if self.parent_directive_id is not None:
+            data["parent_directive_id"] = self.parent_directive_id
+        if self.idempotency_key is not None:
+            data["idempotency_key"] = self.idempotency_key
+        if self.extra:
+            data["extra"] = dict(self.extra)
+        return data

--- a/src/ouroboros/events/control.py
+++ b/src/ouroboros/events/control.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ouroboros.core.control_contract import ControlContract
 from ouroboros.core.directive import Directive
 from ouroboros.events.base import BaseEvent
 
@@ -69,6 +70,8 @@ def create_control_directive_emitted_event(
     generation_number: int | None = None,
     phase: str | None = None,
     context_snapshot_id: str | None = None,
+    parent_directive_id: str | None = None,
+    idempotency_key: str | None = None,
     extra: dict[str, Any] | None = None,
 ) -> BaseEvent:
     """Create an event recording a control-plane directive emission.
@@ -102,6 +105,9 @@ def create_control_directive_emitted_event(
         context_snapshot_id: Optional reference to a context snapshot
             captured at emission time. Omitted from the payload when
             ``None`` to keep stored rows compact.
+        parent_directive_id: Optional causal parent directive event id.
+        idempotency_key: Optional effective decision key for projection-level
+            dedupe across replay/backfill/mesh delivery.
         extra: Optional forward-compatibility slot. Prefer promoting
             fields to named arguments as they stabilize.
 
@@ -121,35 +127,26 @@ def create_control_directive_emitted_event(
             phase="reflecting",
         )
     """
-    data: dict[str, Any] = {
-        "target_type": target_type,
-        "target_id": target_id,
-        "emitted_by": emitted_by,
-        "directive": directive.value,
-        "is_terminal": directive.is_terminal,
-        "reason": reason,
-    }
-    # Optional correlation + context fields land in the payload only when
-    # provided, so absence is distinguishable from an explicit None and
-    # stored rows stay compact.
-    if session_id is not None:
-        data["session_id"] = session_id
-    if execution_id is not None:
-        data["execution_id"] = execution_id
-    if lineage_id is not None:
-        data["lineage_id"] = lineage_id
-    if generation_number is not None:
-        data["generation_number"] = generation_number
-    if phase is not None:
-        data["phase"] = phase
-    if context_snapshot_id is not None:
-        data["context_snapshot_id"] = context_snapshot_id
-    if extra:
-        data["extra"] = dict(extra)
+    contract = ControlContract(
+        target_type=target_type,
+        target_id=target_id,
+        emitted_by=emitted_by,
+        directive=directive,
+        reason=reason,
+        session_id=session_id,
+        execution_id=execution_id,
+        lineage_id=lineage_id,
+        generation_number=generation_number,
+        phase=phase,
+        context_snapshot_id=context_snapshot_id,
+        parent_directive_id=parent_directive_id,
+        idempotency_key=idempotency_key,
+        extra=extra or {},
+    )
 
     return BaseEvent(
-        type="control.directive.emitted",
-        aggregate_type=target_type,
-        aggregate_id=target_id,
-        data=data,
+        type=ControlContract.EVENT_TYPE,
+        aggregate_type=contract.target_type,
+        aggregate_id=contract.target_id,
+        data=contract.to_event_data(),
     )

--- a/tests/unit/core/test_control_contract.py
+++ b/tests/unit/core/test_control_contract.py
@@ -1,0 +1,145 @@
+"""Unit tests for the ControlContract schema."""
+
+import pytest
+
+from ouroboros.core import ControlContract as CoreControlContract
+from ouroboros.core.control_contract import (
+    CONTROL_CONTRACT_SCHEMA_VERSION,
+    ControlContract,
+)
+from ouroboros.core.directive import Directive
+
+
+class TestControlContractRequiredFields:
+    """Required identity and audit fields are enforced before event serialization."""
+
+    def test_minimal_contract_derives_terminality(self) -> None:
+        contract = ControlContract(
+            target_type="lineage",
+            target_id="lin_1",
+            emitted_by="evolver",
+            directive=Directive.UNSTUCK,
+            reason="Stagnation detected.",
+        )
+
+        assert contract.schema_version == CONTROL_CONTRACT_SCHEMA_VERSION
+        assert contract.is_terminal is False
+        assert contract.to_event_data()["is_terminal"] is False
+
+    @pytest.mark.parametrize("field", ["target_type", "target_id", "emitted_by", "reason"])
+    def test_blank_required_fields_are_rejected(self, field: str) -> None:
+        kwargs = {
+            "target_type": "execution",
+            "target_id": "exec_1",
+            "emitted_by": "evaluator",
+            "directive": Directive.RETRY,
+            "reason": "Retry budget remains.",
+        }
+        kwargs[field] = "  "
+
+        with pytest.raises(ValueError, match=field):
+            ControlContract(**kwargs)
+
+    def test_schema_version_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="schema_version"):
+            ControlContract(
+                schema_version=0,
+                target_type="execution",
+                target_id="exec_1",
+                emitted_by="evaluator",
+                directive=Directive.RETRY,
+                reason="Retry budget remains.",
+            )
+
+    def test_directive_must_be_directive_member(self) -> None:
+        with pytest.raises(TypeError, match="Directive"):
+            ControlContract(
+                target_type="execution",
+                target_id="exec_1",
+                emitted_by="evaluator",
+                directive="retry",  # type: ignore[arg-type]
+                reason="Retry budget remains.",
+            )
+
+
+class TestControlContractSerialization:
+    """Stable event payload semantics for projectors and future mesh delivery."""
+
+    def test_terminality_cannot_drift_from_directive(self) -> None:
+        cancel = ControlContract(
+            target_type="execution",
+            target_id="exec_1",
+            emitted_by="job_manager",
+            directive=Directive.CANCEL,
+            reason="User requested cancellation.",
+        )
+
+        assert cancel.is_terminal is True
+        assert cancel.to_event_data()["is_terminal"] is True
+
+    def test_optional_fields_are_serialized_when_present(self) -> None:
+        contract = ControlContract(
+            target_type="lineage",
+            target_id="lin_1",
+            emitted_by="evolver",
+            directive=Directive.RETRY,
+            reason="Reflect failed; retry budget remains.",
+            phase="reflecting",
+            session_id="sess_1",
+            execution_id="exec_1",
+            lineage_id="lin_1",
+            generation_number=2,
+            context_snapshot_id="snap_1",
+            parent_directive_id="parent_evt_1",
+            idempotency_key="lin_1:gen2:reflect:retry1",
+            extra={"retry_budget_remaining": 1},
+        )
+
+        data = contract.to_event_data()
+
+        assert data["schema_version"] == 1
+        assert data["phase"] == "reflecting"
+        assert data["session_id"] == "sess_1"
+        assert data["execution_id"] == "exec_1"
+        assert data["lineage_id"] == "lin_1"
+        assert data["generation_number"] == 2
+        assert data["context_snapshot_id"] == "snap_1"
+        assert data["parent_directive_id"] == "parent_evt_1"
+        assert data["idempotency_key"] == "lin_1:gen2:reflect:retry1"
+        assert data["extra"] == {"retry_budget_remaining": 1}
+
+    def test_idempotency_key_builds_effective_decision_key(self) -> None:
+        contract = ControlContract(
+            target_type="execution",
+            target_id="exec_1",
+            emitted_by="evaluator",
+            directive=Directive.RETRY,
+            reason="Stage 1 failed.",
+            idempotency_key="stage1:retry:1",
+        )
+
+        assert contract.effective_idempotency_key == (
+            "execution",
+            "exec_1",
+            "retry",
+            "stage1:retry:1",
+        )
+
+    def test_missing_idempotency_key_preserves_legacy_row_semantics(self) -> None:
+        contract = ControlContract(
+            target_type="execution",
+            target_id="exec_1",
+            emitted_by="evaluator",
+            directive=Directive.CONTINUE,
+            reason="Checks passed.",
+        )
+
+        assert contract.effective_idempotency_key is None
+        assert "idempotency_key" not in contract.to_event_data()
+
+
+class TestControlContractCoreReExport:
+    """ControlContract is exposed at the core package boundary."""
+
+    def test_control_contract_importable_from_core(self) -> None:
+        assert CoreControlContract is ControlContract

--- a/tests/unit/events/test_control_events.py
+++ b/tests/unit/events/test_control_events.py
@@ -8,6 +8,8 @@ Tests cover:
 - Coverage across every Directive member
 """
 
+import pytest
+
 from ouroboros.core.directive import Directive
 from ouroboros.events.control import create_control_directive_emitted_event
 
@@ -52,6 +54,7 @@ class TestControlDirectiveEmittedCoreShape:
             reason="All checks passed.",
         )
 
+        assert event.data["schema_version"] == 1
         assert event.data["target_type"] == "execution"
         assert event.data["target_id"] == "exec_xyz"
 
@@ -211,6 +214,49 @@ class TestOptionalCorrelationFields:
         )
 
         assert "extra" not in event.data
+
+
+class TestControlContractValidation:
+    """The event factory enforces the ControlContract before persistence."""
+
+    @pytest.mark.parametrize("field", ["target_type", "target_id", "emitted_by", "reason"])
+    def test_blank_required_fields_are_rejected(self, field: str) -> None:
+        kwargs = {
+            "target_type": "execution",
+            "target_id": "exec_1",
+            "emitted_by": "evaluator",
+            "directive": Directive.RETRY,
+            "reason": "Retry budget remains.",
+        }
+        kwargs[field] = ""
+
+        with pytest.raises(ValueError, match=field):
+            create_control_directive_emitted_event(**kwargs)
+
+    def test_invalid_generation_number_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="generation_number"):
+            create_control_directive_emitted_event(
+                target_type="lineage",
+                target_id="lin_1",
+                emitted_by="evolver",
+                directive=Directive.RETRY,
+                reason="retry",
+                generation_number=0,
+            )
+
+    def test_idempotency_metadata_is_recorded(self) -> None:
+        event = create_control_directive_emitted_event(
+            target_type="execution",
+            target_id="exec_1",
+            emitted_by="evaluator",
+            directive=Directive.RETRY,
+            reason="Stage 1 failed.",
+            parent_directive_id="evt_parent",
+            idempotency_key="exec_1:stage1:retry1",
+        )
+
+        assert event.data["parent_directive_id"] == "evt_parent"
+        assert event.data["idempotency_key"] == "exec_1:stage1:retry1"
 
 
 class TestTargetTypeIsForwardCompatible:

--- a/tests/unit/evolution/test_directive_mapping.py
+++ b/tests/unit/evolution/test_directive_mapping.py
@@ -22,8 +22,13 @@ class TestStepActionMapping:
     def test_converged_maps_to_converge(self) -> None:
         assert step_action_to_directive(StepAction.CONVERGED) == Directive.CONVERGE
 
-    def test_stagnated_maps_to_unstuck(self) -> None:
-        assert step_action_to_directive(StepAction.STAGNATED) == Directive.UNSTUCK
+    def test_stagnated_maps_to_unstuck_not_terminal_success(self) -> None:
+        directive = step_action_to_directive(StepAction.STAGNATED)
+
+        assert directive == Directive.UNSTUCK
+        assert directive is not Directive.CONVERGE
+        assert directive is not None
+        assert directive.is_terminal is False
 
     def test_exhausted_maps_to_cancel(self) -> None:
         assert step_action_to_directive(StepAction.EXHAUSTED) == Directive.CANCEL


### PR DESCRIPTION
## Summary

Adds the first reviewable #574 ControlContract slice:

- introduces `ControlContract` as the validated schema boundary behind `control.directive.emitted`
- derives terminality from the global `Directive` vocabulary instead of caller-provided payload flags
- adds schema version, causal parent, and idempotency metadata to control directive payloads
- keeps existing target-oriented event aggregation and backward-compatible optional correlation fields
- documents projector, replay, idempotency, and mesh-delivery expectations

## Why this is separate

#574 is a multi-PR control-plane contract effort. This PR only defines and enforces the stable decision schema at the factory/test boundary. It intentionally does **not** wire new runtime emission sites or change StepAction behavior; those can be reviewed in smaller follow-up PRs.

## Verification

- `PYTHONPATH=src pytest tests/unit/core/test_control_contract.py tests/unit/core/test_directive.py tests/unit/events/test_control_events.py`
- `PYTHONPATH=src ruff check src/ouroboros/core/control_contract.py src/ouroboros/core/__init__.py src/ouroboros/events/control.py tests/unit/core/test_control_contract.py tests/unit/events/test_control_events.py`
- `ruff format --check src/ouroboros/core/control_contract.py src/ouroboros/core/__init__.py src/ouroboros/events/control.py tests/unit/core/test_control_contract.py tests/unit/events/test_control_events.py`
- `git diff --check`

Not run locally: `mypy` (not available in this shell); full CI matrix.

Refs #574.
