### PR TITLE
control: map evolve StepAction to Directive

### DIFF
--- a/docs/contributing/control-contract.md
+++ b/docs/contributing/control-contract.md
@@ -75,6 +75,23 @@ replay but no projection-level dedupe guarantee beyond the event id.
 Backfill, mesh delivery, and contract-targeted emitters should prefer deterministic
 idempotency keys before consumers rely on at-most-once effective application.
 
+## Local enum mapping
+
+Local workflow enums may remain in their owning subsystem, but any control-plane
+emission must map them into the global `Directive` vocabulary without semantic
+loss. The current evolution emission site uses
+`ouroboros.evolution.directive_mapping.step_action_to_directive()` as the single
+authority for `StepAction` outcomes:
+
+| Local action | Directive | Notes |
+|---|---|---|
+| `StepAction.CONTINUE` | no directive emission | No-op continuation; `lineage.generation.completed` already records progress. |
+| `StepAction.CONVERGED` | `CONVERGE` | Terminal success. |
+| `StepAction.STAGNATED` | `UNSTUCK` | Non-terminal recovery path; never terminal success. |
+| `StepAction.EXHAUSTED` | `CANCEL` | Terminal stop without claiming convergence. |
+| `StepAction.INTERRUPTED` | `CANCEL` | Current runtime stops the interrupted step and relies on resume state for continuation. |
+| `StepAction.FAILED` | `RETRY` or `CANCEL` | Depends on remaining retry budget; default live behavior emits `RETRY` until the resilience layer owns the budget. |
+
 ## Projector expectations
 
 Projectors consume the ControlContract fields from `control.directive.emitted`

--- a/tests/unit/evolution/test_directive_mapping.py
+++ b/tests/unit/evolution/test_directive_mapping.py
@@ -22,8 +22,13 @@ class TestStepActionMapping:
     def test_converged_maps_to_converge(self) -> None:
         assert step_action_to_directive(StepAction.CONVERGED) == Directive.CONVERGE
 
-    def test_stagnated_maps_to_unstuck(self) -> None:
-        assert step_action_to_directive(StepAction.STAGNATED) == Directive.UNSTUCK
+    def test_stagnated_maps_to_unstuck_not_terminal_success(self) -> None:
+        directive = step_action_to_directive(StepAction.STAGNATED)
+
+        assert directive == Directive.UNSTUCK
+        assert directive is not Directive.CONVERGE
+        assert directive is not None
+        assert directive.is_terminal is False
 
     def test_exhausted_maps_to_cancel(self) -> None:
         assert step_action_to_directive(StepAction.EXHAUSTED) == Directive.CANCEL


### PR DESCRIPTION
## Summary

Adds the second #574 ControlContract slice on top of #621:

- documents the existing live `StepAction` → `Directive` authority: `ouroboros.evolution.directive_mapping.step_action_to_directive()`
- locks the important #574 invariant that `StepAction.STAGNATED` maps to non-terminal `Directive.UNSTUCK`, never terminal `CONVERGE`
- documents current runtime semantics for no-op `CONTINUE`, interrupted steps, exhausted steps, and budget-dependent failed steps
- adds a focused regression assertion to the existing directive-mapping tests instead of introducing a second mapper

## Stack

Base branch: `feat/574-control-contract` (#621). This PR is intentionally stacked so reviewers can review the StepAction mapping documentation/regression separately from the ControlContract schema/factory enforcement.

## Verification

- `PYTHONPATH=src pytest tests/unit/evolution/test_directive_mapping.py tests/unit/core/test_control_contract.py tests/unit/events/test_control_events.py`
- `PYTHONPATH=src ruff check tests/unit/evolution/test_directive_mapping.py docs/contributing/control-contract.md`
- `ruff format --check tests/unit/evolution/test_directive_mapping.py`
- `git diff --check`

Not run locally: `mypy` (not available in this shell); full CI matrix.

Refs #574.
Depends on #621.
