### PR TITLE
docs: clarify legacy execution AC events

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -387,7 +387,7 @@ else:
 ### Event Sourcing
 
 All state changes are persisted as immutable events in a single SQLite table (`events`) via SQLAlchemy Core:
-- **Event types** use dot-notation past tense (e.g., `orchestrator.session.started`, `execution.ac.completed`)
+- **Event types** use dot-notation past tense (e.g., `orchestrator.session.started`, `orchestrator.session.completed`)
 - **Append-only** — events can never be modified or deleted
 - **Unit of Work** pattern groups events + checkpoint into atomic commits
 - **Replay** capability — reconstruct any session by replaying its events

--- a/docs/events.md
+++ b/docs/events.md
@@ -77,12 +77,21 @@ Emitted when a session terminates due to an error.
 
 ### execution.ac.completed
 
-Emitted when an individual Acceptance Criterion finishes execution.
+Legacy execution event emitted when a worker execution unit associated with a
+source acceptance criterion finishes. Despite the `ac` name and the historical
+`passed`/`failed` status values, this event records **worker task completion**,
+not a formal acceptance-criterion verdict. Formal AC verdicts are produced by
+the evaluation pipeline (`ACResult` / `EvaluationSummary.ac_results`).
+
+The event name and payload remain documented for compatibility with existing
+EventStore consumers. New code that needs task-native execution events should
+prefer an additive task/node event family instead of overloading this legacy
+name further.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `ac_id` | `string` | Acceptance criterion identifier |
-| `status` | `string` | `"passed"` or `"failed"` |
+| `ac_id` | `string` | Legacy source acceptance-criterion identifier for the execution unit |
+| `status` | `string` | Legacy worker completion status: `"passed"` means completed, `"failed"` means failed |
 
 ### mcp.job.cancelled
 

--- a/src/ouroboros/events/base.py
+++ b/src/ouroboros/events/base.py
@@ -68,7 +68,7 @@ class BaseEvent(BaseModel, frozen=True):
     Attributes:
         id: Unique event identifier (UUID).
         type: Event type following dot.notation.past_tense convention.
-              Examples: "ontology.concept.added", "execution.ac.completed"
+              Examples: "ontology.concept.added", "orchestrator.session.completed"
         timestamp: When the event occurred (UTC).
         aggregate_type: Type of aggregate this event belongs to.
         aggregate_id: Unique identifier of the aggregate.


### PR DESCRIPTION
## Summary
- document `execution.ac.completed` as a legacy worker task-completion event, not a formal AC verdict
- point formal acceptance-criterion verdict semantics at `ACResult` / `EvaluationSummary.ac_results`
- remove `execution.ac.completed` from generic event-type examples so new code does not copy the legacy name

Refs #608.

## Verification
- `PYTHONPATH=src ruff check src/ouroboros/events/base.py`
- `ruff format --check src/ouroboros/events/base.py`
- `rg -n "execution\.ac\.completed" docs/events.md docs/architecture.md src/ouroboros/events/base.py` now only finds the intentional legacy schema section
- `git diff --check`

## Notes for reviewers
This is intentionally compatibility-preserving. It does not rename persisted event types; it only documents their legacy meaning and leaves room for a future additive task/node event family.