### PR TITLE
test(ralph): lock job cancellation contract

### DIFF
--- a/tests/unit/mcp/tools/test_ralph_handler.py
+++ b/tests/unit/mcp/tools/test_ralph_handler.py
@@ -51,6 +51,30 @@ class _FakeEvolveHandler:
         )
 
 
+@dataclass
+class _BlockingEvolveHandler:
+    """Fake evolve handler that blocks until the Ralph job is cancelled."""
+
+    started: asyncio.Event = field(default_factory=asyncio.Event)
+    calls: int = 0
+
+    async def handle(self, arguments: dict[str, Any]):  # noqa: ARG002 - protocol fixture
+        self.calls += 1
+        self.started.set()
+        await asyncio.sleep(60)
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": self.calls,
+                    "action": "continue",
+                },
+            )
+        )
+
+
 @pytest.mark.asyncio
 async def test_ralph_loop_runs_multiple_generations_until_converged() -> None:
     evolve = _FakeEvolveHandler(["continue", "continue", "converged"])
@@ -140,6 +164,46 @@ async def test_ralph_handler_returns_job_id_and_completes_loop() -> None:
         assert snapshot.result_meta["iterations"] == 2
         assert snapshot.result_meta["actions"] == ["continue", "converged"]
         assert len(evolve.calls) == 2
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_ralph_job_can_be_cancelled_with_job_manager() -> None:
+    """Ralph jobs should use the standard job cancellation/status contract."""
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    job_manager = JobManager(store)
+    evolve = _BlockingEvolveHandler()
+    handler = RalphHandler(
+        evolve_handler=evolve,  # type: ignore[arg-type]
+        event_store=store,
+        job_manager=job_manager,
+    )
+
+    try:
+        started = await handler.handle(
+            {
+                "lineage_id": "lin_cancel",
+                "seed_content": "goal: cancel",
+                "max_generations": 5,
+            }
+        )
+        assert started.is_ok
+        job_id = started.value.meta["job_id"]
+
+        await asyncio.wait_for(evolve.started.wait(), timeout=1.0)
+        cancel_snapshot = await job_manager.cancel_job(job_id)
+        assert cancel_snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+
+        for _ in range(500):
+            snapshot = await job_manager.get_snapshot(job_id)
+            if snapshot.is_terminal:
+                break
+            await asyncio.sleep(0.01)
+
+        assert snapshot.status is JobStatus.CANCELLED
+        assert snapshot.links.lineage_id == "lin_cancel"
+        assert evolve.calls == 1
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary

Adds focused regression coverage for the MCP-owned Ralph loop introduced for #528: a running `ouroboros_ralph` background job can be cancelled through the existing `JobManager` / job-tool contract, and the terminal job snapshot reports `cancelled` with the Ralph lineage link preserved.

## Why

#528 should close with Ralph converging on the existing MCP job surface rather than adding a Ralph-specific control path. This PR verifies that the new server-owned Ralph loop can be stopped through the same cancellation/status mechanism used by other long-running MCP jobs.

## Scope

- Adds a blocking fake evolve handler for deterministic cancellation timing.
- Starts `RalphHandler`, captures its `job_id`, cancels through `JobManager.cancel_job()`, and asserts the job reaches `JobStatus.CANCELLED`.
- Confirms the linked `lineage_id` remains visible for later status/result inspection.

## Risks

- This is unit-level coverage; it does not prove a live client can interrupt a real long-running model/tool call mid-flight.
- It intentionally does not add Ralph-specific pause/resume/cancel APIs; broader lifecycle controls remain under #518 / `AgentProcess`.
- The assertion allows the immediate cancel response to be either `cancel_requested` or already `cancelled`, because the in-process runner may terminate before the caller observes the intermediate state.

## Verification

- `uv run ruff check tests/unit/mcp/tools/test_ralph_handler.py`
- `uv run ruff format --check tests/unit/mcp/tools/test_ralph_handler.py`
- `uv run mypy src/ouroboros/mcp/tools/ralph_handlers.py src/ouroboros/ralph_loop.py`
- `uv run pytest tests/unit/mcp/tools/test_ralph_handler.py tests/unit/mcp/test_job_manager.py -q` → 36 passed

Refs #528.
