### PR TITLE
feat(agent-process): project lifecycle state from events

### DIFF
--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -183,17 +183,15 @@ def project_agent_process_snapshot(
             continue
 
         raw_intent = extra.get("intent")
-        if not isinstance(raw_intent, str) or not raw_intent:
-            continue
+        intent = raw_intent if isinstance(raw_intent, str) and raw_intent else None
         raw_reason = data.get("reason")
-        if not isinstance(raw_reason, str) or not raw_reason:
-            continue
+        reason = raw_reason if isinstance(raw_reason, str) and raw_reason else None
         snapshot = AgentProcessSnapshot(
             process_id=event_process_id,
             status=status,
-            intent=raw_intent,
+            intent=intent,
             directive_count=(snapshot.directive_count if snapshot is not None else 0) + 1,
-            last_reason=raw_reason,
+            last_reason=reason,
         )
 
     return snapshot

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -52,13 +52,14 @@ reference migrations in slices 4–6 of #518.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from enum import StrEnum
 import logging
 from typing import Any, Final, Protocol
 from uuid import uuid4
 
+from ouroboros.core.control_contract import ControlContract
 from ouroboros.core.directive import Directive
 from ouroboros.events.control import create_control_directive_emitted_event
 
@@ -84,6 +85,28 @@ class AgentProcessStatus(StrEnum):
     FAILED = "failed"
 
 
+@dataclass(frozen=True, slots=True)
+class AgentProcessSnapshot:
+    """Replayable read model for one agent-process lifecycle.
+
+    This is the durable state-model slice for #518. It intentionally projects
+    only fields already present in ``control.directive.emitted`` rows so future
+    checkpoint/replay work can build on an additive contract instead of
+    inspecting live ``AgentProcessHandle`` instances.
+    """
+
+    process_id: str
+    status: AgentProcessStatus
+    intent: str | None = None
+    directive_count: int = 0
+    last_reason: str | None = None
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the reconstructed lifecycle is terminal."""
+        return self.status in _TERMINAL_STATUSES
+
+
 _TERMINAL_STATUSES: Final[frozenset[AgentProcessStatus]] = frozenset(
     {
         AgentProcessStatus.CANCELLED,
@@ -107,6 +130,70 @@ _TRANSITION_DIRECTIVE: Final[dict[AgentProcessStatus, Directive]] = {
     # specific reason directive (e.g. RETRY exhaustion → CANCEL via
     # the evolution mapping in #525).
 }
+
+
+def project_agent_process_snapshot(
+    events: Iterable[Any], *, process_id: str | None = None
+) -> AgentProcessSnapshot | None:
+    """Project an :class:`AgentProcessSnapshot` from lifecycle directive events.
+
+    Only ``control.directive.emitted`` events targeted at ``agent_process`` are
+    considered. Malformed rows are skipped rather than corrupting replay state;
+    the raw events remain available from the EventStore for diagnostics.
+
+    Args:
+        events: EventStore rows or event-like test fakes.
+        process_id: Optional process id filter. If omitted, the first valid
+            event determines the snapshot process id and later events for other
+            processes are ignored.
+
+    Returns:
+        Reconstructed snapshot, or ``None`` when no valid agent-process
+        lifecycle event is present.
+    """
+    snapshot: AgentProcessSnapshot | None = None
+    target_process_id = process_id
+
+    for event in events:
+        if getattr(event, "type", None) != ControlContract.EVENT_TYPE:
+            continue
+        if getattr(event, "aggregate_type", None) != _TARGET_TYPE:
+            continue
+
+        event_process_id = getattr(event, "aggregate_id", None)
+        if not isinstance(event_process_id, str) or not event_process_id:
+            continue
+        if target_process_id is None:
+            target_process_id = event_process_id
+        if event_process_id != target_process_id:
+            continue
+
+        data = getattr(event, "data", None)
+        if not isinstance(data, dict):
+            continue
+        extra = data.get("extra")
+        if not isinstance(extra, dict):
+            continue
+        raw_status = extra.get("lifecycle_status")
+        if not isinstance(raw_status, str):
+            continue
+        try:
+            status = AgentProcessStatus(raw_status)
+        except ValueError:
+            continue
+
+        raw_intent = extra.get("intent")
+        intent = raw_intent if isinstance(raw_intent, str) and raw_intent else None
+        reason = data.get("reason")
+        snapshot = AgentProcessSnapshot(
+            process_id=event_process_id,
+            status=status,
+            intent=intent,
+            directive_count=(snapshot.directive_count if snapshot is not None else 0) + 1,
+            last_reason=reason if isinstance(reason, str) else None,
+        )
+
+    return snapshot
 
 
 class _AppendableEventStore(Protocol):

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -114,15 +114,6 @@ _TERMINAL_STATUSES: Final[frozenset[AgentProcessStatus]] = frozenset(
         AgentProcessStatus.FAILED,
     }
 )
-_LIFECYCLE_REPLAY_ORDER: Final[dict[AgentProcessStatus, int]] = {
-    AgentProcessStatus.RUNNING: 0,
-    AgentProcessStatus.PAUSED: 1,
-    AgentProcessStatus.CANCELLED: 2,
-    AgentProcessStatus.FAILED: 2,
-    AgentProcessStatus.COMPLETED: 2,
-}
-
-
 # Mapping from a status transition to the directive that lands on the
 # journal. Per the body of #518, only externally-observed lifecycle
 # transitions emit directives; *internal* loop semantics (RETRY,
@@ -200,7 +191,7 @@ def project_agent_process_snapshot(
     valid_events.sort(
         key=lambda item: (
             getattr(item[1], "timestamp", None),
-            _LIFECYCLE_REPLAY_ORDER[item[3]],
+            getattr(item[1], "id", ""),
             item[0],
         )
     )

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 import logging
 from typing import Any, Final, Protocol
@@ -181,6 +182,12 @@ def project_agent_process_snapshot(
             status = AgentProcessStatus(raw_status)
         except ValueError:
             continue
+        timestamp = getattr(event, "timestamp", None)
+        if not isinstance(timestamp, datetime):
+            continue
+        event_id = getattr(event, "id", None)
+        if not isinstance(event_id, str):
+            continue
 
         raw_intent = extra.get("intent")
         intent = raw_intent if isinstance(raw_intent, str) and raw_intent else None
@@ -190,8 +197,8 @@ def project_agent_process_snapshot(
 
     valid_events.sort(
         key=lambda item: (
-            getattr(item[1], "timestamp", None),
-            getattr(item[1], "id", ""),
+            item[1].timestamp,
+            item[1].id,
             item[0],
         )
     )

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -114,6 +114,13 @@ _TERMINAL_STATUSES: Final[frozenset[AgentProcessStatus]] = frozenset(
         AgentProcessStatus.FAILED,
     }
 )
+_LIFECYCLE_REPLAY_ORDER: Final[dict[AgentProcessStatus, int]] = {
+    AgentProcessStatus.RUNNING: 0,
+    AgentProcessStatus.PAUSED: 1,
+    AgentProcessStatus.CANCELLED: 2,
+    AgentProcessStatus.FAILED: 2,
+    AgentProcessStatus.COMPLETED: 2,
+}
 
 
 # Mapping from a status transition to the directive that lands on the
@@ -154,7 +161,9 @@ def project_agent_process_snapshot(
     snapshot: AgentProcessSnapshot | None = None
     target_process_id = process_id
 
-    for event in events:
+    valid_events: list[tuple[int, Any, str, AgentProcessStatus, str | None, str | None]] = []
+
+    for sequence, event in enumerate(events):
         if getattr(event, "type", None) != ControlContract.EVENT_TYPE:
             continue
         if getattr(event, "aggregate_type", None) != _TARGET_TYPE:
@@ -186,12 +195,25 @@ def project_agent_process_snapshot(
         intent = raw_intent if isinstance(raw_intent, str) and raw_intent else None
         raw_reason = data.get("reason")
         reason = raw_reason if isinstance(raw_reason, str) and raw_reason else None
+        valid_events.append((sequence, event, event_process_id, status, intent, reason))
+
+    valid_events.sort(
+        key=lambda item: (
+            getattr(item[1], "timestamp", None),
+            _LIFECYCLE_REPLAY_ORDER[item[3]],
+            item[0],
+        )
+    )
+
+    for _, _event, event_process_id, status, intent, reason in valid_events:
         snapshot = AgentProcessSnapshot(
             process_id=event_process_id,
             status=status,
-            intent=intent,
+            intent=intent if intent is not None else (snapshot.intent if snapshot else None),
             directive_count=(snapshot.directive_count if snapshot is not None else 0) + 1,
-            last_reason=reason,
+            last_reason=reason
+            if reason is not None
+            else (snapshot.last_reason if snapshot else None),
         )
 
     return snapshot

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -183,14 +183,17 @@ def project_agent_process_snapshot(
             continue
 
         raw_intent = extra.get("intent")
-        intent = raw_intent if isinstance(raw_intent, str) and raw_intent else None
-        reason = data.get("reason")
+        if not isinstance(raw_intent, str) or not raw_intent:
+            continue
+        raw_reason = data.get("reason")
+        if not isinstance(raw_reason, str) or not raw_reason:
+            continue
         snapshot = AgentProcessSnapshot(
             process_id=event_process_id,
             status=status,
-            intent=intent,
+            intent=raw_intent,
             directive_count=(snapshot.directive_count if snapshot is not None else 0) + 1,
-            last_reason=reason if isinstance(reason, str) else None,
+            last_reason=raw_reason,
         )
 
     return snapshot

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -406,6 +406,7 @@ def test_agent_process_snapshot_accepts_minimal_lifecycle_rows() -> None:
     """Replay requires lifecycle status; descriptive metadata is optional."""
     same_time = datetime(2026, 1, 1, tzinfo=UTC)
     minimal_running = BaseEvent(
+        id="00000000-0000-0000-0000-000000000001",
         type="control.directive.emitted",
         timestamp=same_time,
         aggregate_type="agent_process",
@@ -416,6 +417,7 @@ def test_agent_process_snapshot_accepts_minimal_lifecycle_rows() -> None:
         },
     )
     minimal_cancelled = BaseEvent(
+        id="ffffffff-ffff-ffff-ffff-ffffffffffff",
         type="control.directive.emitted",
         timestamp=same_time,
         aggregate_type="agent_process",

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -402,6 +402,43 @@ async def test_agent_process_snapshot_ignores_other_processes_and_malformed_rows
 
 
 @pytest.mark.asyncio
+async def test_agent_process_snapshot_skips_partial_rows_after_valid_state() -> None:
+    """Partial lifecycle rows must not erase an already valid projection."""
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):
+        return None
+
+    handle = await process.spawn(intent="evolve_step", work_fn=work, process_id="proc-wanted")
+    await handle.wait_until_complete(timeout=1.0)
+
+    partial_without_intent = BaseEvent(
+        type="control.directive.emitted",
+        aggregate_type="agent_process",
+        aggregate_id="proc-wanted",
+        data={"reason": "bad partial", "extra": {"lifecycle_status": "cancelled"}},
+    )
+    partial_without_reason = BaseEvent(
+        type="control.directive.emitted",
+        aggregate_type="agent_process",
+        aggregate_id="proc-wanted",
+        data={"extra": {"lifecycle_status": "paused", "intent": "bad"}},
+    )
+
+    snapshot = project_agent_process_snapshot(
+        [*store.appended, partial_without_intent, partial_without_reason],
+        process_id="proc-wanted",
+    )
+
+    assert snapshot is not None
+    assert snapshot.intent == "evolve_step"
+    assert snapshot.status is AgentProcessStatus.COMPLETED
+    assert snapshot.directive_count == 2
+    assert snapshot.last_reason == "evolve_step: work returned"
+
+
+@pytest.mark.asyncio
 async def test_status_is_running_immediately_after_spawn() -> None:
     process = AgentProcess(event_store=None)
     started = asyncio.Event()

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -473,6 +473,39 @@ def test_agent_process_snapshot_matches_event_store_order_for_timestamp_ties() -
     assert snapshot.last_reason == "ralph: spawned"
 
 
+def test_agent_process_snapshot_skips_rows_without_comparable_ordering() -> None:
+    """Malformed event-like rows without timestamp/id should not crash sorting."""
+
+    class _NoTimestampEvent:
+        type = "control.directive.emitted"
+        aggregate_type = "agent_process"
+        aggregate_id = "proc-wanted"
+        data = {
+            "reason": "bad",
+            "extra": {"lifecycle_status": "completed", "intent": "bad"},
+        }
+
+    valid = BaseEvent(
+        id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+        type="control.directive.emitted",
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        aggregate_type="agent_process",
+        aggregate_id="proc-wanted",
+        data={
+            "reason": "ralph: spawned",
+            "extra": {"lifecycle_status": "running", "intent": "ralph"},
+        },
+    )
+
+    snapshot = project_agent_process_snapshot(
+        [_NoTimestampEvent(), valid], process_id="proc-wanted"
+    )
+
+    assert snapshot is not None
+    assert snapshot.status is AgentProcessStatus.RUNNING
+    assert snapshot.intent == "ralph"
+
+
 @pytest.mark.asyncio
 async def test_status_is_running_immediately_after_spawn() -> None:
     process = AgentProcess(event_store=None)

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -437,8 +437,8 @@ def test_agent_process_snapshot_accepts_minimal_lifecycle_rows() -> None:
     assert snapshot.is_terminal is True
 
 
-def test_agent_process_snapshot_keeps_terminal_state_for_timestamp_ties() -> None:
-    """Replay ordering by timestamp/id must not let spawn rows overwrite terminal rows."""
+def test_agent_process_snapshot_matches_event_store_order_for_timestamp_ties() -> None:
+    """Timestamp ties should follow EventStore's timestamp/id replay contract."""
     same_time = datetime(2026, 1, 1, tzinfo=UTC)
     completed = BaseEvent(
         id="00000000-0000-0000-0000-000000000001",
@@ -466,9 +466,9 @@ def test_agent_process_snapshot_keeps_terminal_state_for_timestamp_ties() -> Non
     snapshot = project_agent_process_snapshot([completed, running], process_id="proc-wanted")
 
     assert snapshot is not None
-    assert snapshot.status is AgentProcessStatus.COMPLETED
+    assert snapshot.status is AgentProcessStatus.RUNNING
     assert snapshot.intent == "ralph"
-    assert snapshot.last_reason == "ralph: work returned"
+    assert snapshot.last_reason == "ralph: spawned"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -15,6 +15,7 @@ from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.agent_process import (
     AgentProcess,
     AgentProcessStatus,
+    project_agent_process_snapshot,
 )
 from ouroboros.persistence.event_store import EventStore
 
@@ -336,6 +337,68 @@ async def test_lifecycle_directive_carries_target_type_agent_process() -> None:
         assert event.data["emitted_by"] == "agent_process"
         assert event.data["extra"]["intent"] == "evolve_step"
         assert "lifecycle_status" in event.data["extra"]
+
+
+@pytest.mark.asyncio
+async def test_agent_process_snapshot_projects_lifecycle_status_from_events() -> None:
+    """AgentProcess state should be reconstructable from directive events."""
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    release = asyncio.Event()
+
+    async def work(handle):
+        while not release.is_set():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await handle.pause()
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+    await handle.resume()
+    release.set()
+    await handle.wait_until_complete(timeout=1.0)
+
+    snapshot = project_agent_process_snapshot(store.appended, process_id=handle.process_id)
+
+    assert snapshot is not None
+    assert snapshot.process_id == handle.process_id
+    assert snapshot.intent == "ralph"
+    assert snapshot.status is AgentProcessStatus.COMPLETED
+    assert snapshot.directive_count == 4
+    assert snapshot.last_reason == "ralph: work returned"
+    assert snapshot.is_terminal is True
+
+
+@pytest.mark.asyncio
+async def test_agent_process_snapshot_ignores_other_processes_and_malformed_rows() -> None:
+    """Projection should skip malformed/foreign rows instead of corrupting state."""
+    store = _FakeEventStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):
+        return None
+
+    wanted = await process.spawn(intent="evolve_step", work_fn=work, process_id="proc-wanted")
+    other = await process.spawn(intent="ralph", work_fn=work, process_id="proc-other")
+    await wanted.wait_until_complete(timeout=1.0)
+    await other.wait_until_complete(timeout=1.0)
+    malformed = BaseEvent(
+        type="control.directive.emitted",
+        aggregate_type="agent_process",
+        aggregate_id="proc-wanted",
+        data={"extra": {"lifecycle_status": "not-a-status", "intent": "bad"}},
+    )
+
+    snapshot = project_agent_process_snapshot(
+        [malformed, *store.appended], process_id="proc-wanted"
+    )
+
+    assert snapshot is not None
+    assert snapshot.process_id == "proc-wanted"
+    assert snapshot.intent == "evolve_step"
+    assert snapshot.status is AgentProcessStatus.COMPLETED
+    assert snapshot.directive_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -8,6 +8,7 @@ deferred-implementation surface (replay raises NotImplementedError).
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 
 import pytest
 
@@ -403,14 +404,20 @@ async def test_agent_process_snapshot_ignores_other_processes_and_malformed_rows
 
 def test_agent_process_snapshot_accepts_minimal_lifecycle_rows() -> None:
     """Replay requires lifecycle status; descriptive metadata is optional."""
+    same_time = datetime(2026, 1, 1, tzinfo=UTC)
     minimal_running = BaseEvent(
         type="control.directive.emitted",
+        timestamp=same_time,
         aggregate_type="agent_process",
         aggregate_id="proc-wanted",
-        data={"extra": {"lifecycle_status": "running"}},
+        data={
+            "reason": "ralph: spawned",
+            "extra": {"lifecycle_status": "running", "intent": "ralph"},
+        },
     )
     minimal_cancelled = BaseEvent(
         type="control.directive.emitted",
+        timestamp=same_time,
         aggregate_type="agent_process",
         aggregate_id="proc-wanted",
         data={"extra": {"lifecycle_status": "cancelled"}},
@@ -423,11 +430,45 @@ def test_agent_process_snapshot_accepts_minimal_lifecycle_rows() -> None:
 
     assert snapshot is not None
     assert snapshot.process_id == "proc-wanted"
-    assert snapshot.intent is None
+    assert snapshot.intent == "ralph"
     assert snapshot.status is AgentProcessStatus.CANCELLED
     assert snapshot.directive_count == 2
-    assert snapshot.last_reason is None
+    assert snapshot.last_reason == "ralph: spawned"
     assert snapshot.is_terminal is True
+
+
+def test_agent_process_snapshot_keeps_terminal_state_for_timestamp_ties() -> None:
+    """Replay ordering by timestamp/id must not let spawn rows overwrite terminal rows."""
+    same_time = datetime(2026, 1, 1, tzinfo=UTC)
+    completed = BaseEvent(
+        id="00000000-0000-0000-0000-000000000001",
+        type="control.directive.emitted",
+        timestamp=same_time,
+        aggregate_type="agent_process",
+        aggregate_id="proc-wanted",
+        data={
+            "reason": "ralph: work returned",
+            "extra": {"lifecycle_status": "completed", "intent": "ralph"},
+        },
+    )
+    running = BaseEvent(
+        id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+        type="control.directive.emitted",
+        timestamp=same_time,
+        aggregate_type="agent_process",
+        aggregate_id="proc-wanted",
+        data={
+            "reason": "ralph: spawned",
+            "extra": {"lifecycle_status": "running", "intent": "ralph"},
+        },
+    )
+
+    snapshot = project_agent_process_snapshot([completed, running], process_id="proc-wanted")
+
+    assert snapshot is not None
+    assert snapshot.status is AgentProcessStatus.COMPLETED
+    assert snapshot.intent == "ralph"
+    assert snapshot.last_reason == "ralph: work returned"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -401,41 +401,33 @@ async def test_agent_process_snapshot_ignores_other_processes_and_malformed_rows
     assert snapshot.directive_count == 2
 
 
-@pytest.mark.asyncio
-async def test_agent_process_snapshot_skips_partial_rows_after_valid_state() -> None:
-    """Partial lifecycle rows must not erase an already valid projection."""
-    store = _FakeEventStore()
-    process = AgentProcess(event_store=store)
-
-    async def work(handle):
-        return None
-
-    handle = await process.spawn(intent="evolve_step", work_fn=work, process_id="proc-wanted")
-    await handle.wait_until_complete(timeout=1.0)
-
-    partial_without_intent = BaseEvent(
+def test_agent_process_snapshot_accepts_minimal_lifecycle_rows() -> None:
+    """Replay requires lifecycle status; descriptive metadata is optional."""
+    minimal_running = BaseEvent(
         type="control.directive.emitted",
         aggregate_type="agent_process",
         aggregate_id="proc-wanted",
-        data={"reason": "bad partial", "extra": {"lifecycle_status": "cancelled"}},
+        data={"extra": {"lifecycle_status": "running"}},
     )
-    partial_without_reason = BaseEvent(
+    minimal_cancelled = BaseEvent(
         type="control.directive.emitted",
         aggregate_type="agent_process",
         aggregate_id="proc-wanted",
-        data={"extra": {"lifecycle_status": "paused", "intent": "bad"}},
+        data={"extra": {"lifecycle_status": "cancelled"}},
     )
 
     snapshot = project_agent_process_snapshot(
-        [*store.appended, partial_without_intent, partial_without_reason],
+        [minimal_running, minimal_cancelled],
         process_id="proc-wanted",
     )
 
     assert snapshot is not None
-    assert snapshot.intent == "evolve_step"
-    assert snapshot.status is AgentProcessStatus.COMPLETED
+    assert snapshot.process_id == "proc-wanted"
+    assert snapshot.intent is None
+    assert snapshot.status is AgentProcessStatus.CANCELLED
     assert snapshot.directive_count == 2
-    assert snapshot.last_reason == "evolve_step: work returned"
+    assert snapshot.last_reason is None
+    assert snapshot.is_terminal is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds the first #518 durable lifecycle state-model slice: `AgentProcessSnapshot` plus `project_agent_process_snapshot()`, a small read-model projection that reconstructs one agent-process lifecycle from existing `control.directive.emitted` rows.

## Why

#518 should move toward durable pause/resume/replay through additive EventStore contracts before widening live runtime behavior. The current `AgentProcessHandle` is in-memory; this PR creates the replayable read-model foundation that later CheckpointStore and replay work can depend on without inspecting live handles.

## Scope

- Adds `AgentProcessSnapshot` with process id, status, intent, directive count, last reason, and terminal helper.
- Projects only existing `target_type="agent_process"` / `aggregate_type="agent_process"` directive events.
- Skips malformed lifecycle rows instead of corrupting state.
- Adds tests for normal lifecycle projection, process filtering, and malformed-row tolerance.

## Risks

- This is intentionally not durable pause/resume yet; it only defines the read model that those slices should build on.
- It projects from the current `extra.lifecycle_status` / `extra.intent` fields, so future event-schema changes must preserve or migrate those fields.
- It does not query EventStore directly; callers still supply the replayed event rows.

## Verification

- `uv run ruff check src/ouroboros/orchestrator/agent_process.py tests/unit/orchestrator/test_agent_process.py`
- `uv run ruff format --check src/ouroboros/orchestrator/agent_process.py tests/unit/orchestrator/test_agent_process.py`
- `uv run pytest tests/unit/orchestrator/test_agent_process.py -q` → 18 passed
- `uv run mypy src/ouroboros/orchestrator/agent_process.py`

Refs #518.
