### PR TITLE
control: preserve contract identity in lineage projection

### DIFF
--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -404,16 +404,23 @@ class ControlDirectiveEmission(BaseModel, frozen=True):
     Captures the audit-level "who/what/why/when" of a control-plane
     decision so it appears in the lineage timeline alongside state events
     (per RFC #476 M2 / sub-RFC #511). The full event row remains in the
-    EventStore; this is the projected view used by callers.
+    EventStore; this projected view preserves the stable ControlContract
+    identity fields callers need for replay, idempotency inspection, and
+    future UI rendering without pretending to be the durable source of truth.
     """
 
     directive: str
     reason: str
     emitted_by: str
     timestamp: datetime
+    schema_version: int | None = None
+    target_type: str | None = None
+    target_id: str | None = None
     generation_number: int | None = None
     phase: str | None = None
     is_terminal: bool = False
+    parent_directive_id: str | None = None
+    idempotency_key: str | None = None
 
 
 class OntologyLineage(BaseModel, frozen=True):

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -218,13 +218,19 @@ class LineageProjector:
                     # via event_store directly for postmortem.
                     continue
                 schema_version = data.get("schema_version")
-                if schema_version is not None and not isinstance(schema_version, int):
+                if schema_version is not None and (
+                    not isinstance(schema_version, int) or schema_version < 1
+                ):
                     continue
                 target_type = data.get("target_type")
-                if target_type is not None and not isinstance(target_type, str):
+                if target_type is not None and (
+                    not isinstance(target_type, str) or not target_type.strip()
+                ):
                     continue
                 target_id = data.get("target_id")
-                if target_id is not None and not isinstance(target_id, str):
+                if target_id is not None and (
+                    not isinstance(target_id, str) or not target_id.strip()
+                ):
                     continue
                 generation_number = data.get("generation_number")
                 if generation_number is not None and not isinstance(generation_number, int):
@@ -236,10 +242,14 @@ class LineageProjector:
                 if not isinstance(is_terminal, bool):
                     continue
                 parent_directive_id = data.get("parent_directive_id")
-                if parent_directive_id is not None and not isinstance(parent_directive_id, str):
+                if parent_directive_id is not None and (
+                    not isinstance(parent_directive_id, str) or not parent_directive_id.strip()
+                ):
                     continue
                 idempotency_key = data.get("idempotency_key")
-                if idempotency_key is not None and not isinstance(idempotency_key, str):
+                if idempotency_key is not None and (
+                    not isinstance(idempotency_key, str) or not idempotency_key.strip()
+                ):
                     continue
                 directive_emissions.append(
                     ControlDirectiveEmission(

--- a/src/ouroboros/evolution/projector.py
+++ b/src/ouroboros/evolution/projector.py
@@ -217,6 +217,15 @@ class LineageProjector:
                     # corrupt the projection; the raw row is still queryable
                     # via event_store directly for postmortem.
                     continue
+                schema_version = data.get("schema_version")
+                if schema_version is not None and not isinstance(schema_version, int):
+                    continue
+                target_type = data.get("target_type")
+                if target_type is not None and not isinstance(target_type, str):
+                    continue
+                target_id = data.get("target_id")
+                if target_id is not None and not isinstance(target_id, str):
+                    continue
                 generation_number = data.get("generation_number")
                 if generation_number is not None and not isinstance(generation_number, int):
                     continue
@@ -226,15 +235,26 @@ class LineageProjector:
                 is_terminal = data.get("is_terminal", False)
                 if not isinstance(is_terminal, bool):
                     continue
+                parent_directive_id = data.get("parent_directive_id")
+                if parent_directive_id is not None and not isinstance(parent_directive_id, str):
+                    continue
+                idempotency_key = data.get("idempotency_key")
+                if idempotency_key is not None and not isinstance(idempotency_key, str):
+                    continue
                 directive_emissions.append(
                     ControlDirectiveEmission(
                         directive=directive_value,
                         reason=str(data.get("reason", "")),
                         emitted_by=str(data.get("emitted_by", "")),
                         timestamp=event.timestamp,
+                        schema_version=schema_version,
+                        target_type=target_type,
+                        target_id=target_id,
                         generation_number=generation_number,
                         phase=phase,
                         is_terminal=is_terminal,
+                        parent_directive_id=parent_directive_id,
+                        idempotency_key=idempotency_key,
                     )
                 )
 

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -110,8 +110,8 @@ class TestDirectiveProjection:
         assert emitted == ["evolve", "retry", "converge"]
         assert lineage.directive_emissions[-1].is_terminal is True
 
-    def test_optional_correlation_fields_default_to_none(self) -> None:
-        """generation_number and phase are None when absent from the payload."""
+    def test_optional_contract_fields_default_to_none(self) -> None:
+        """Optional ControlContract fields are None when absent from the payload."""
         projector = LineageProjector()
         events = [
             _event("lineage.created", {"goal": "no correlations"}),
@@ -129,8 +129,46 @@ class TestDirectiveProjection:
 
         assert lineage is not None
         emission = lineage.directive_emissions[0]
+        assert emission.schema_version is None
+        assert emission.target_type is None
+        assert emission.target_id is None
         assert emission.generation_number is None
         assert emission.phase is None
+        assert emission.parent_directive_id is None
+        assert emission.idempotency_key is None
+
+    def test_control_contract_identity_fields_are_projected(self) -> None:
+        """The lineage view preserves stable ControlContract identity metadata."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "contract metadata"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "schema_version": 1,
+                    "target_type": "lineage",
+                    "target_id": LINEAGE_ID,
+                    "directive": "retry",
+                    "reason": "Retry budget remains.",
+                    "emitted_by": "evolver",
+                    "generation_number": 2,
+                    "phase": "reflecting",
+                    "is_terminal": False,
+                    "parent_directive_id": "evt_parent",
+                    "idempotency_key": "lin:gen2:reflect:retry1",
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        emission = lineage.directive_emissions[0]
+        assert emission.schema_version == 1
+        assert emission.target_type == "lineage"
+        assert emission.target_id == LINEAGE_ID
+        assert emission.parent_directive_id == "evt_parent"
+        assert emission.idempotency_key == "lin:gen2:reflect:retry1"
 
     def test_malformed_directive_event_is_skipped(self) -> None:
         """A directive event without a usable directive payload is silently skipped."""
@@ -268,6 +306,47 @@ class TestDirectiveProjection:
                     "reason": "Healthy row.",
                     "emitted_by": "evolver",
                     "generation_number": 1,
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        assert [e.directive for e in lineage.directive_emissions] == ["continue"]
+
+    def test_invalid_contract_identity_shape_is_skipped(self) -> None:
+        """Malformed ControlContract metadata should not corrupt projection."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "invalid contract metadata"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Bad schema version.",
+                    "emitted_by": "evolver",
+                    "schema_version": "1",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "wait",
+                    "reason": "Bad target type.",
+                    "emitted_by": "orchestrator",
+                    "target_type": 42,
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "continue",
+                    "reason": "Healthy row.",
+                    "emitted_by": "evolver",
+                    "schema_version": 1,
+                    "target_type": "lineage",
+                    "target_id": LINEAGE_ID,
                 },
             ),
         ]

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -341,6 +341,42 @@ class TestDirectiveProjection:
             _event(
                 "control.directive.emitted",
                 {
+                    "directive": "cancel",
+                    "reason": "Bad schema version value.",
+                    "emitted_by": "orchestrator",
+                    "schema_version": 0,
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Empty target id.",
+                    "emitted_by": "evolver",
+                    "target_id": "  ",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Empty parent directive id.",
+                    "emitted_by": "evolver",
+                    "parent_directive_id": "",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Empty idempotency key.",
+                    "emitted_by": "evolver",
+                    "idempotency_key": " ",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
                     "directive": "continue",
                     "reason": "Healthy row.",
                     "emitted_by": "evolver",


### PR DESCRIPTION
## Summary

Extends the lineage directive projection so `control.directive.emitted` rows preserve the stable `ControlContract` identity metadata needed by replay/idempotency/UI consumers.

Projected `ControlDirectiveEmission` now carries:

- `schema_version`
- `target_type`
- `target_id`
- `parent_directive_id`
- `idempotency_key`

The existing raw `directive_emissions` timeline remains event-order audit history; this PR does **not** dedupe or reinterpret the stream.

## Why this is valid for Ouroboros

#574 states that projectors should consume the `ControlContract`, not ad-hoc directive payload fragments. Before this PR, lineage projection kept the human summary fields but dropped contract identity fields that future replay, idempotency inspection, and UI work need.

This keeps the Agent OS layering intact:

- EventStore remains the durable source of truth.
- Lineage projection is an additive read model.
- Idempotency semantics are preserved for a later explicit effective-decision view rather than hidden inside the raw audit timeline.

## Risks

- **Read-model API growth:** `ControlDirectiveEmission` gains optional fields. Mitigation: all fields default to `None`, preserving legacy rows.
- **Malformed event handling:** malformed optional contract metadata is skipped like existing malformed correlation metadata. Mitigation: raw rows remain queryable in EventStore for postmortem inspection.
- **No dedupe yet:** this intentionally does not collapse duplicate effective decisions. Mitigation: the PR keeps `idempotency_key` visible so the next PR can add an additive effective view safely.

## Validation

- `uv run pytest tests/unit/test_projector_directives.py tests/unit/events/test_control_events.py tests/unit/core/test_control_contract.py -q`
- Result: `44 passed`
- `uv run mypy src/ouroboros/core/lineage.py src/ouroboros/evolution/projector.py`
- Result: `Success: no issues found in 2 source files`
