### PR TITLE
control: add effective directive idempotency view

### DIFF
--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -422,6 +422,18 @@ class ControlDirectiveEmission(BaseModel, frozen=True):
     parent_directive_id: str | None = None
     idempotency_key: str | None = None
 
+    @property
+    def effective_idempotency_key(self) -> tuple[str, str, str, str] | None:
+        """Return the ControlContract effective-decision key when complete."""
+        if self.target_type is None or self.target_id is None or self.idempotency_key is None:
+            return None
+        return (
+            self.target_type,
+            self.target_id,
+            self.directive,
+            self.idempotency_key,
+        )
+
 
 class OntologyLineage(BaseModel, frozen=True):
     """Tracks O₁ → O₂ → O₃ evolution across generations.
@@ -476,6 +488,31 @@ class OntologyLineage(BaseModel, frozen=True):
         return self.model_copy(
             update={"directive_emissions": self.directive_emissions + (emission,)}
         )
+
+    @property
+    def effective_directive_emissions(self) -> tuple[ControlDirectiveEmission, ...]:
+        """Return the idempotency-aware directive view for consumers.
+
+        ``directive_emissions`` is the raw audit timeline and intentionally keeps
+        every projected control event. This view is narrower: when a
+        ControlContract row carries the stable effective-decision key
+        ``(target_type, target_id, directive, idempotency_key)``, repeated rows
+        with the same key collapse to the first observed emission. Rows without a
+        complete key remain visible because the projection cannot prove they are
+        duplicates.
+        """
+        seen: set[tuple[str, str, str, str]] = set()
+        effective: list[ControlDirectiveEmission] = []
+        for emission in self.directive_emissions:
+            key = emission.effective_idempotency_key
+            if key is None:
+                effective.append(emission)
+                continue
+            if key in seen:
+                continue
+            seen.add(key)
+            effective.append(emission)
+        return tuple(effective)
 
     def rewind_to(self, generation_number: int) -> OntologyLineage:
         """Return lineage truncated to the given generation.

--- a/src/ouroboros/core/lineage.py
+++ b/src/ouroboros/core/lineage.py
@@ -425,7 +425,14 @@ class ControlDirectiveEmission(BaseModel, frozen=True):
     @property
     def effective_idempotency_key(self) -> tuple[str, str, str, str] | None:
         """Return the ControlContract effective-decision key when complete."""
-        if self.target_type is None or self.target_id is None or self.idempotency_key is None:
+        if (
+            self.target_type is None
+            or self.target_id is None
+            or self.idempotency_key is None
+            or not self.target_type.strip()
+            or not self.target_id.strip()
+            or not self.idempotency_key.strip()
+        ):
             return None
         return (
             self.target_type,

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -391,3 +391,91 @@ class TestDirectiveProjection:
 
         assert lineage is not None
         assert [e.directive for e in lineage.directive_emissions] == ["continue"]
+
+    def test_effective_directive_view_dedupes_stable_idempotency_keys(self) -> None:
+        """The effective view collapses repeated delivery without hiding raw audit."""
+        projector = LineageProjector()
+        duplicate_key = "lin:gen2:reflect:retry1"
+        events = [
+            _event("lineage.created", {"goal": "idempotency view"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "schema_version": 1,
+                    "target_type": "lineage",
+                    "target_id": LINEAGE_ID,
+                    "directive": "retry",
+                    "reason": "First retry delivery.",
+                    "emitted_by": "evolver",
+                    "idempotency_key": duplicate_key,
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "schema_version": 1,
+                    "target_type": "lineage",
+                    "target_id": LINEAGE_ID,
+                    "directive": "retry",
+                    "reason": "Duplicate retry delivery.",
+                    "emitted_by": "evolver",
+                    "idempotency_key": duplicate_key,
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "schema_version": 1,
+                    "target_type": "lineage",
+                    "target_id": LINEAGE_ID,
+                    "directive": "unstuck",
+                    "reason": "Distinct decision.",
+                    "emitted_by": "resilience",
+                    "idempotency_key": "lin:gen2:unstuck1",
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        assert [e.reason for e in lineage.directive_emissions] == [
+            "First retry delivery.",
+            "Duplicate retry delivery.",
+            "Distinct decision.",
+        ]
+        assert [e.reason for e in lineage.effective_directive_emissions] == [
+            "First retry delivery.",
+            "Distinct decision.",
+        ]
+
+    def test_effective_directive_view_keeps_rows_without_complete_keys(self) -> None:
+        """Legacy rows are not deduped when stable identity is incomplete."""
+        projector = LineageProjector()
+        events = [
+            _event("lineage.created", {"goal": "legacy idempotency"}),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Legacy retry 1.",
+                    "emitted_by": "evolver",
+                },
+            ),
+            _event(
+                "control.directive.emitted",
+                {
+                    "directive": "retry",
+                    "reason": "Legacy retry 2.",
+                    "emitted_by": "evolver",
+                },
+            ),
+        ]
+
+        lineage = projector.project(events)
+
+        assert lineage is not None
+        assert [e.reason for e in lineage.effective_directive_emissions] == [
+            "Legacy retry 1.",
+            "Legacy retry 2.",
+        ]

--- a/tests/unit/test_projector_directives.py
+++ b/tests/unit/test_projector_directives.py
@@ -14,7 +14,7 @@ Covers (issue #514, closes #473):
 
 from datetime import UTC, datetime
 
-from ouroboros.core.lineage import LineageStatus
+from ouroboros.core.lineage import ControlDirectiveEmission, LineageStatus, OntologyLineage
 from ouroboros.events.base import BaseEvent
 from ouroboros.evolution.projector import LineageProjector
 
@@ -478,4 +478,37 @@ class TestDirectiveProjection:
         assert [e.reason for e in lineage.effective_directive_emissions] == [
             "Legacy retry 1.",
             "Legacy retry 2.",
+        ]
+
+    def test_effective_key_requires_non_empty_identity_fields(self) -> None:
+        """Blank identity fields are incomplete even if they are strings."""
+        lineage = OntologyLineage(
+            lineage_id=LINEAGE_ID,
+            goal="blank identity",
+            directive_emissions=(
+                ControlDirectiveEmission(
+                    directive="retry",
+                    reason="Blank target type.",
+                    emitted_by="evolver",
+                    timestamp=datetime.now(UTC),
+                    target_type=" ",
+                    target_id=LINEAGE_ID,
+                    idempotency_key="same",
+                ),
+                ControlDirectiveEmission(
+                    directive="retry",
+                    reason="Blank idempotency key.",
+                    emitted_by="evolver",
+                    timestamp=datetime.now(UTC),
+                    target_type="lineage",
+                    target_id=LINEAGE_ID,
+                    idempotency_key="",
+                ),
+            ),
+        )
+
+        assert [e.effective_idempotency_key for e in lineage.directive_emissions] == [None, None]
+        assert [e.reason for e in lineage.effective_directive_emissions] == [
+            "Blank target type.",
+            "Blank idempotency key.",
         ]


### PR DESCRIPTION
## Summary

Adds an additive, idempotency-aware read view for projected control directives.

- `ControlDirectiveEmission.effective_idempotency_key` returns `(target_type, target_id, directive, idempotency_key)` when complete.
- `OntologyLineage.effective_directive_emissions` collapses repeated projected directives with the same complete effective key.
- `OntologyLineage.directive_emissions` remains the raw projected audit timeline and still includes every row.

This PR is stacked on #630 because it uses the projected ControlContract identity fields added there.

## Why this is valid for Ouroboros

#574 defines `idempotency_key` so replay/backfill/mesh consumers can avoid duplicate effective decisions. This PR makes that metadata usable without mutating the raw audit timeline.

The Agent OS layering remains intact:

- EventStore keeps every durable row.
- `directive_emissions` keeps raw projected audit history.
- `effective_directive_emissions` is the opt-in consumer view for idempotent behavior.

## Risks

- **First-observed duplicate wins:** repeated rows with the same effective key collapse to the first projected emission. Mitigation: raw audit remains available in `directive_emissions` for postmortem inspection.
- **Incomplete keys are not deduped:** legacy rows or malformed producer rows remain visible. Mitigation: this avoids unsafe collapse when stable identity is absent.
- **Stacked PR dependency:** this depends on #630's projected contract identity fields. Mitigation: the base branch is `feat/574-projector-contract-conformance`.

## Validation

- `uv run pytest tests/unit/test_projector_directives.py tests/unit/core/test_control_contract.py -q`
- Result: `23 passed`
- `uv run mypy src/ouroboros/core/lineage.py src/ouroboros/evolution/projector.py`
- Result: `Success: no issues found in 2 source files`
