### PR TITLE
refactor(mcp): tighten JobManager runner cleanup boundary

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -125,31 +125,49 @@ class JobManager:
         )
 
         self._known_job_ids.add(job_id)
-        if inspect.iscoroutine(runner):
-            runner = asyncio.create_task(runner)
-            self._runner_tasks[job_id] = runner
-        task = asyncio.create_task(self._run_job(job_id, job_type, runner))
+        # Normalise ``runner`` to a Task so ``_run_job`` can rely on Task
+        # semantics (cancellation, ``done()``). Coroutines are wrapped via
+        # ``create_task``; pre-built Tasks are reused; bare awaitables (e.g.
+        # ``Future``) are wrapped through an inner coroutine so cancellation
+        # and GC remain consistent.
+        if isinstance(runner, asyncio.Task):
+            runner_task = runner
+        elif inspect.iscoroutine(runner):
+            runner_task = asyncio.create_task(runner)
+        else:
+
+            async def _await_runner(_awaitable: Any = runner) -> Any:
+                return await _awaitable
+
+            runner_task = asyncio.create_task(_await_runner())
+        self._runner_tasks[job_id] = runner_task
+        task = asyncio.create_task(self._run_job(job_id, job_type, runner_task))
         self._tasks[job_id] = task
         self._monitors[job_id] = asyncio.create_task(self._monitor_job(job_id))
 
         return await self.get_snapshot(job_id)
 
-    async def _run_job(self, job_id: str, job_type: str, runner: Any) -> None:
-        """Run the actual background job and persist terminal state."""
-        runner_task: asyncio.Task[Any] | None = runner if isinstance(runner, asyncio.Task) else None
-        runner_awaitable = runner_task or runner
+    async def _run_job(
+        self,
+        job_id: str,
+        job_type: str,
+        runner: asyncio.Task[Any],
+    ) -> None:
+        """Run the actual background job and persist terminal state.
+
+        ``runner`` is always a Task — :meth:`start_job` converts coroutines
+        at the boundary, so the finally-block here does not need to manage
+        coroutine ``close()`` cleanup.
+        """
         await self.update_status(job_id, JobStatus.RUNNING, f"Running {job_type}")
 
         try:
-            if runner_task is None and inspect.iscoroutine(runner):
-                runner_task = asyncio.create_task(runner)
-                runner_awaitable = runner_task
-            result = await runner_awaitable
+            result = await runner
         except asyncio.CancelledError:
-            if runner_task is not None and not runner_task.done():
-                runner_task.cancel()
+            if not runner.done():
+                runner.cancel()
                 try:
-                    await runner_task
+                    await runner
                 except asyncio.CancelledError:
                     pass
             await self._append_event(
@@ -201,8 +219,6 @@ class JobManager:
                 },
             )
         finally:
-            if runner_task is None and inspect.iscoroutine(runner):
-                runner.close()
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
             monitor = self._monitors.pop(job_id, None)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -141,6 +141,37 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_start_job_tracks_externally_created_task(self, tmp_path) -> None:
+        """A pre-built Task is registered in ``_runner_tasks`` for cancellation routing."""
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                await asyncio.sleep(0.02)
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="ext"),),
+                    is_error=False,
+                )
+
+            external_task = asyncio.create_task(_runner())
+            started = await manager.start_job(
+                job_type="external",
+                initial_message="queued",
+                runner=external_task,
+                links=JobLinks(),
+            )
+
+            assert manager._runner_tasks.get(started.job_id) is external_task
+
+            await asyncio.sleep(0.1)
+            snapshot = await manager.get_snapshot(started.job_id)
+            assert snapshot.status == JobStatus.COMPLETED
+            assert started.job_id not in manager._runner_tasks
+        finally:
+            await store.close()
+
     async def test_wait_for_change_returns_new_cursor(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -172,6 +172,80 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_start_job_wraps_bare_future_runner(self, tmp_path) -> None:
+        """A bare Future is wrapped in a Task and still completes the job."""
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        future: asyncio.Future[MCPToolResult] = asyncio.get_running_loop().create_future()
+
+        try:
+            started = await manager.start_job(
+                job_type="future",
+                initial_message="queued",
+                runner=future,
+                links=JobLinks(),
+            )
+            runner_task = manager._runner_tasks.get(started.job_id)
+
+            assert isinstance(runner_task, asyncio.Task)
+            assert runner_task is not future
+
+            future.set_result(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="future"),),
+                    is_error=False,
+                    meta={"kind": "future"},
+                )
+            )
+            await asyncio.sleep(0.05)
+            snapshot = await manager.get_snapshot(started.job_id)
+
+            assert snapshot.status == JobStatus.COMPLETED
+            assert snapshot.result_text == "future"
+            assert snapshot.result_meta["kind"] == "future"
+            assert started.job_id not in manager._runner_tasks
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_cancels_externally_created_task(self, tmp_path) -> None:
+        """Cancellation reaches a pre-built Task registered as the runner."""
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        runner_cancelled = asyncio.Event()
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    runner_cancelled.set()
+                    raise
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                    is_error=False,
+                )
+
+            external_task = asyncio.create_task(_runner())
+            started = await manager.start_job(
+                job_type="external-cancel",
+                initial_message="queued",
+                runner=external_task,
+                links=JobLinks(),
+            )
+
+            await manager.cancel_job(started.job_id)
+            await asyncio.wait_for(runner_cancelled.wait(), timeout=1)
+            await asyncio.sleep(0)
+            snapshot = await manager.get_snapshot(started.job_id)
+
+            assert external_task.cancelled()
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_wait_for_change_returns_new_cursor(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)


### PR DESCRIPTION
## Summary

`_run_job` carried two unreachable branches — a coroutine→Task conversion in the try block and a `runner.close()` call in the finally block — both gated on `runner_task is None and inspect.iscoroutine(runner)`. Since `start_job` already converted coroutines to Tasks before invoking `_run_job`, that condition could never hold during cleanup.

## Changes

| File | Change |
|------|--------|
| `src/ouroboros/mcp/job_manager.py` | `start_job` now normalises every input — pre-built Task, coroutine, or bare awaitable — into a Task at the boundary. `_runner_tasks` registration consolidated to a single statement. `_run_job` signature narrowed to `asyncio.Task[Any]`; the `runner_task` ceremony is removed in favour of `runner.done()` / `runner.cancel()` directly. |
| `tests/unit/mcp/test_job_manager.py` | New coverage verifies externally-created Task tracking/cleanup, bare Future wrapping, and cancellation reaching externally-created runner Tasks. |

## Why

- Removes dead code that obscured the actual cleanup contract.
- Eliminates a Future-vs-Task gap in the cancellation handler (Future inputs would have skipped runner cancel under the old typing).
- Centralises the "always a Task" invariant so future contributors do not reintroduce coroutine cleanup paths.

## Test plan

- [x] `uv run pytest tests/unit/mcp/test_job_manager.py -q` — 30 passed
- [x] Wider regression `tests/unit/mcp/` — 781 passed
- [x] `ruff format` / `ruff check` clean
- [x] `ouroboros-agent` review — APPROVED after edge-case test hardening

## Out of scope

`_append_event` failure before runner conversion can still strand a coroutine for GC. Separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
