### PR TITLE
refactor(mcp): consolidate seed-path containment into a shared helper

### DIFF
--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -233,55 +233,14 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             Result containing execution result or error.
         """
         resolved_cwd = self._resolve_dispatch_cwd(arguments.get("cwd"))
-        seed_content = arguments.get("seed_content")
-        seed_path = arguments.get("seed_path")
-        if not seed_content and seed_path:
-            seed_candidate = Path(str(seed_path)).expanduser()
-            if not seed_candidate.is_absolute():
-                seed_candidate = resolved_cwd / seed_candidate
-
-            # Allow seeds from cwd and the dedicated ~/.ouroboros/seeds/ directory
-            ouroboros_seeds = Path.home() / ".ouroboros" / "seeds"
-            valid_cwd, _ = InputValidator.validate_path_containment(
-                seed_candidate,
-                resolved_cwd,
-            )
-            valid_home, _ = InputValidator.validate_path_containment(
-                seed_candidate,
-                ouroboros_seeds,
-            )
-            if not valid_cwd and not valid_home:
-                return Result.err(
-                    MCPToolError(
-                        f"Seed path escapes allowed directories: "
-                        f"{seed_candidate} is not under {resolved_cwd} or {ouroboros_seeds}",
-                        tool_name="ouroboros_execute_seed",
-                    )
-                )
-
-            try:
-                seed_content = await asyncio.to_thread(
-                    seed_candidate.read_text,
-                    encoding="utf-8",
-                )
-            except FileNotFoundError:
-                # Per tool contract: treat non-existent path as inline YAML
-                seed_content = str(seed_path)
-            except OSError as e:
-                return Result.err(
-                    MCPToolError(
-                        f"Failed to read seed file: {e}",
-                        tool_name="ouroboros_execute_seed",
-                    )
-                )
-
-        if not seed_content:
-            return Result.err(
-                MCPToolError(
-                    "seed_content or seed_path is required",
-                    tool_name="ouroboros_execute_seed",
-                )
-            )
+        seed_result = await self._resolve_seed_content(
+            arguments=arguments,
+            resolved_cwd=resolved_cwd,
+            tool_name="ouroboros_execute_seed",
+        )
+        if seed_result.is_err:
+            return seed_result
+        seed_content = seed_result.value
 
         session_id = arguments.get("session_id")
         is_resume = bool(session_id)
@@ -745,6 +704,70 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         return Path.cwd()
 
     @staticmethod
+    async def _resolve_seed_content(
+        *,
+        arguments: dict[str, Any],
+        resolved_cwd: Path,
+        tool_name: str,
+    ) -> Result[str, MCPServerError]:
+        """Resolve seed YAML from inline ``seed_content`` or a contained ``seed_path``.
+
+        Single source of truth for both ``ExecuteSeedHandler`` and
+        ``StartExecuteSeedHandler`` so the seed-path containment policy stays
+        in one place. The candidate path must live inside ``resolved_cwd`` or
+        ``~/.ouroboros/seeds``; non-existent paths fall back to inline YAML
+        per the tool contract; ``OSError``s become :class:`MCPToolError`.
+        """
+        seed_content = arguments.get("seed_content")
+        if seed_content:
+            return Result.ok(seed_content)
+
+        seed_path = arguments.get("seed_path")
+        if not seed_path:
+            return Result.err(
+                MCPToolError(
+                    "seed_content or seed_path is required",
+                    tool_name=tool_name,
+                )
+            )
+
+        seed_candidate = Path(str(seed_path)).expanduser()
+        if not seed_candidate.is_absolute():
+            seed_candidate = resolved_cwd / seed_candidate
+
+        # Allow seeds from cwd and the dedicated ~/.ouroboros/seeds/ directory
+        ouroboros_seeds = Path.home() / ".ouroboros" / "seeds"
+        valid_cwd, _ = InputValidator.validate_path_containment(
+            seed_candidate,
+            resolved_cwd,
+        )
+        valid_home, _ = InputValidator.validate_path_containment(
+            seed_candidate,
+            ouroboros_seeds,
+        )
+        if not valid_cwd and not valid_home:
+            return Result.err(
+                MCPToolError(
+                    f"Seed path escapes allowed directories: "
+                    f"{seed_candidate} is not under {resolved_cwd} or {ouroboros_seeds}",
+                    tool_name=tool_name,
+                )
+            )
+
+        try:
+            return Result.ok(await asyncio.to_thread(seed_candidate.read_text, encoding="utf-8"))
+        except FileNotFoundError:
+            # Per tool contract: treat non-existent path as inline YAML
+            return Result.ok(str(seed_path))
+        except OSError as e:
+            return Result.err(
+                MCPToolError(
+                    f"Failed to read seed file: {e}",
+                    tool_name=tool_name,
+                )
+            )
+
+    @staticmethod
     def _derive_quality_bar(seed: Seed) -> str:
         """Derive a quality bar string from seed acceptance criteria."""
         ac_lines = [f"- {ac}" for ac in seed.acceptance_criteria]
@@ -862,57 +885,18 @@ class StartExecuteSeedHandler:
         self,
         arguments: dict[str, Any],
     ) -> Result[MCPToolResult, MCPServerError]:
-        seed_content = arguments.get("seed_content")
-        seed_path = arguments.get("seed_path")
-        if not seed_content and seed_path:
-            resolved_cwd = ExecuteSeedHandler._resolve_dispatch_cwd(
-                arguments.get("cwd"),
-            )
-            seed_candidate = Path(str(seed_path)).expanduser()
-            if not seed_candidate.is_absolute():
-                seed_candidate = resolved_cwd / seed_candidate
-
-            # Allow seeds from cwd and the dedicated ~/.ouroboros/seeds/ directory
-            ouroboros_seeds = Path.home() / ".ouroboros" / "seeds"
-            valid_cwd, _ = InputValidator.validate_path_containment(
-                seed_candidate,
-                resolved_cwd,
-            )
-            valid_home, _ = InputValidator.validate_path_containment(
-                seed_candidate,
-                ouroboros_seeds,
-            )
-            if not valid_cwd and not valid_home:
-                return Result.err(
-                    MCPToolError(
-                        f"Seed path escapes allowed directories: "
-                        f"{seed_candidate} is not under {resolved_cwd} or {ouroboros_seeds}",
-                        tool_name="ouroboros_start_execute_seed",
-                    )
-                )
-
-            try:
-                seed_content = await asyncio.to_thread(seed_candidate.read_text, encoding="utf-8")
-                arguments = {**arguments, "seed_content": seed_content}
-            except FileNotFoundError:
-                # Per tool contract: treat non-existent path as inline YAML
-                seed_content = str(seed_path)
-                arguments = {**arguments, "seed_content": seed_content}
-            except OSError as e:
-                return Result.err(
-                    MCPToolError(
-                        f"Failed to read seed file: {e}",
-                        tool_name="ouroboros_start_execute_seed",
-                    )
-                )
-
-        if not seed_content:
-            return Result.err(
-                MCPToolError(
-                    "seed_content or seed_path is required",
-                    tool_name="ouroboros_start_execute_seed",
-                )
-            )
+        resolved_cwd = ExecuteSeedHandler._resolve_dispatch_cwd(arguments.get("cwd"))
+        seed_result = await ExecuteSeedHandler._resolve_seed_content(
+            arguments=arguments,
+            resolved_cwd=resolved_cwd,
+            tool_name="ouroboros_start_execute_seed",
+        )
+        if seed_result.is_err:
+            return seed_result
+        seed_content = seed_result.value
+        # Forward the resolved YAML so the inner ExecuteSeedHandler skips its
+        # own path-resolution branch (the contract is now centralised here).
+        arguments = {**arguments, "seed_content": seed_content}
 
         # Resolve worker cap up front so plugin and background paths agree.
         try:

--- a/tests/unit/mcp/tools/test_execute_seed_path_resolution.py
+++ b/tests/unit/mcp/tools/test_execute_seed_path_resolution.py
@@ -1,0 +1,120 @@
+"""Tests for ``ExecuteSeedHandler._resolve_seed_content`` — seed-path
+containment policy shared by the synchronous and background handlers.
+
+Prior to refactor each handler reimplemented the same containment check;
+these tests pin the contract to the consolidated helper.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler
+
+
+async def _resolve(
+    arguments: dict[str, Any],
+    *,
+    cwd: Path,
+    tool_name: str = "ouroboros_execute_seed",
+) -> Any:
+    return await ExecuteSeedHandler._resolve_seed_content(
+        arguments=arguments,
+        resolved_cwd=cwd,
+        tool_name=tool_name,
+    )
+
+
+class TestResolveSeedContent:
+    async def test_inline_seed_content_short_circuits(self, tmp_path: Path) -> None:
+        result = await _resolve(
+            {"seed_content": "goal: ship\nacceptance_criteria: []\n"},
+            cwd=tmp_path,
+        )
+        assert result.is_ok
+        assert "goal: ship" in result.value
+
+    async def test_missing_inputs_returns_error(self, tmp_path: Path) -> None:
+        result = await _resolve({}, cwd=tmp_path)
+        assert result.is_err
+        assert "seed_content or seed_path is required" in str(result.error)
+
+    async def test_relative_path_inside_cwd_is_read(self, tmp_path: Path) -> None:
+        seed_file = tmp_path / "my_seed.yaml"
+        seed_file.write_text("goal: relative\n", encoding="utf-8")
+
+        result = await _resolve({"seed_path": "my_seed.yaml"}, cwd=tmp_path)
+        assert result.is_ok
+        assert result.value == "goal: relative\n"
+
+    async def test_absolute_path_inside_cwd_is_read(self, tmp_path: Path) -> None:
+        seed_file = tmp_path / "absolute_seed.yaml"
+        seed_file.write_text("goal: absolute\n", encoding="utf-8")
+
+        result = await _resolve({"seed_path": str(seed_file)}, cwd=tmp_path)
+        assert result.is_ok
+        assert result.value == "goal: absolute\n"
+
+    async def test_absolute_path_outside_allowed_dirs_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force ``~/.ouroboros/seeds`` to a location that does not contain the candidate.
+        fake_home = tmp_path / "fake_home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        outside = tmp_path.parent / "outside_seed.yaml"
+        outside.write_text("goal: escape\n", encoding="utf-8")
+
+        try:
+            result = await _resolve({"seed_path": str(outside)}, cwd=tmp_path)
+            assert result.is_err
+            assert "Seed path escapes allowed directories" in str(result.error)
+        finally:
+            outside.unlink(missing_ok=True)
+
+    async def test_non_existent_path_falls_through_to_inline_yaml(self, tmp_path: Path) -> None:
+        # ``seed_path`` doubles as inline YAML when no file exists at the location;
+        # the candidate must still be inside the cwd so containment is satisfied.
+        inline = "goal: inline\nacceptance_criteria: []"
+        result = await _resolve({"seed_path": inline}, cwd=tmp_path)
+        assert result.is_ok
+        assert result.value == inline
+
+    async def test_path_in_dedicated_seeds_dir_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_home = tmp_path / "fake_home"
+        seeds_dir = fake_home / ".ouroboros" / "seeds"
+        seeds_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        seed_file = seeds_dir / "shared.yaml"
+        seed_file.write_text("goal: shared\n", encoding="utf-8")
+
+        # cwd is unrelated; allowed because ``~/.ouroboros/seeds`` contains it.
+        result = await _resolve({"seed_path": str(seed_file)}, cwd=tmp_path)
+        assert result.is_ok
+        assert result.value == "goal: shared\n"
+
+    async def test_tool_name_propagates_to_error(self, tmp_path: Path) -> None:
+        result = await _resolve(
+            {},
+            cwd=tmp_path,
+            tool_name="ouroboros_start_execute_seed",
+        )
+        assert result.is_err
+        assert getattr(result.error, "tool_name", None) == "ouroboros_start_execute_seed"
+
+    async def test_inline_seed_content_takes_priority_over_seed_path(self, tmp_path: Path) -> None:
+        seed_file = tmp_path / "ignored.yaml"
+        seed_file.write_text("goal: from_file\n", encoding="utf-8")
+        result = await _resolve(
+            {"seed_content": "goal: inline\n", "seed_path": str(seed_file)},
+            cwd=tmp_path,
+        )
+        assert result.is_ok
+        assert result.value == "goal: inline\n"


### PR DESCRIPTION
## Summary

`ExecuteSeedHandler.handle` and `StartExecuteSeedHandler.handle` each carried a copy of the same ~47-line seed-path containment block. Any future change to the policy (allowed dirs, error wording, fallback semantics) had to be applied in two places — and there were no direct tests pinning the contract.

## Changes

| File | Change |
|------|--------|
| `src/ouroboros/mcp/tools/execution_handlers.py` | Extract `ExecuteSeedHandler._resolve_seed_content` as a `staticmethod` returning `Result[str, MCPServerError]`. Both handlers now invoke the helper with their own `tool_name`, and `StartExecuteSeedHandler` forwards the resolved YAML through `arguments["seed_content"]` so the inner `ExecuteSeedHandler` short-circuits its own resolution branch. |
| `tests/unit/mcp/tools/test_execute_seed_path_resolution.py` (new, 9 tests) | Pin the policy: inline priority, missing inputs error, relative/absolute paths inside cwd, the dedicated `~/.ouroboros/seeds` dir, traversal rejection, non-existent path → inline YAML fallback, `tool_name` propagation, `seed_content` > `seed_path` priority. |

## Behaviour preservation

- `if not seed_content and seed_path:` (old) ≡ `if seed_content: return ok` then `if not seed_path: error` (new). Empty string is falsy in both — path branch is taken.
- Allowed directories unchanged: `resolved_cwd` ∪ `~/.ouroboros/seeds`.
- Error wording unchanged: `\"Seed path escapes allowed directories: ... is not under ... or ...\"`.
- `FileNotFoundError` still falls through to inline YAML.
- `OSError` still maps to `MCPToolError` with the caller's `tool_name`.

## Test plan

- [x] `uv run pytest tests/unit/mcp/tools/test_execute_seed_path_resolution.py -v` — 9 passed
- [x] Wider regression `tests/unit/mcp/` — 787 passed (778 baseline + 9 new)
- [x] `ruff format` / `ruff check` clean
- [x] Code review (sub-agent) — APPROVED, no rounds of changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)