### PR TITLE
Fail closed when auto MCP dispatch is unavailable

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -563,13 +563,33 @@ class CodexCliRuntime:
         try:
             dispatched_messages = await dispatcher(intercept, current_handle)
         except Exception as e:
+            failure_context = self._build_intercept_failure_context(intercept)
             log.warning(
                 f"{self._log_namespace}.skill_intercept_dispatch_failed",
-                **self._build_intercept_failure_context(intercept),
+                **failure_context,
                 error_type=type(e).__name__,
                 error=str(e),
                 exc_info=True,
             )
+            if intercept.skill_name == "auto":
+                return (
+                    AgentMessage(
+                        type="result",
+                        content=(
+                            "Cannot run ooo auto: required MCP tool "
+                            f"`{intercept.mcp_tool}` is unavailable. "
+                            "Run `ouroboros doctor` / setup to register the MCP server."
+                        ),
+                        data={
+                            "subtype": "error",
+                            "error_type": "SkillDispatchUnavailable",
+                            "skill_name": intercept.skill_name,
+                            "tool_name": intercept.mcp_tool,
+                            "command_prefix": intercept.command_prefix,
+                        },
+                        resume_handle=current_handle,
+                    ),
+                )
             return None
 
         recoverable_error = self._extract_recoverable_dispatch_error(dispatched_messages)

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -539,6 +539,73 @@ class CodexCliRuntime:
             error=self._invalid_skill_log_error(dispatch_result),
         )
 
+    @staticmethod
+    def _is_auto_recoverable_dispatch_unavailable(recoverable_error: AgentMessage) -> bool:
+        """Return whether a recoverable auto dispatch error means the tool is unavailable."""
+        error_type = recoverable_error.data.get("error_type")
+        if error_type == "MCPResourceNotFoundError":
+            return True
+
+        error_text = recoverable_error.content.lower()
+        if error_type == "MCPClientError":
+            return any(
+                marker in error_text
+                for marker in (
+                    "unavailable",
+                    "not found",
+                    "not registered",
+                    "unknown tool",
+                    "no such tool",
+                )
+            )
+        if error_type != "MCPToolError":
+            return False
+
+        if error_text.startswith("auto pipeline failed:"):
+            return False
+        return any(
+            marker in error_text
+            for marker in (
+                "unavailable",
+                "not found",
+                "not registered",
+                "unknown tool",
+                "no such tool",
+            )
+        )
+
+    def _build_auto_dispatch_unavailable_message(
+        self,
+        intercept: Resolved,
+        current_handle: RuntimeHandle | None,
+        *,
+        dispatch_error_type: str | None = None,
+        dispatch_error: str | None = None,
+    ) -> AgentMessage:
+        """Build the fail-closed result for unavailable `ooo auto` dispatch."""
+        data: dict[str, Any] = {
+            "subtype": "error",
+            "error_type": "SkillDispatchUnavailable",
+            "skill_name": intercept.skill_name,
+            "tool_name": intercept.mcp_tool,
+            "command_prefix": intercept.command_prefix,
+        }
+        if dispatch_error_type:
+            data["dispatch_error_type"] = dispatch_error_type
+        if dispatch_error:
+            data["dispatch_error"] = dispatch_error
+
+        return AgentMessage(
+            type="result",
+            content=(
+                "Cannot run ooo auto: required MCP tool "
+                f"`{intercept.mcp_tool}` is unavailable. "
+                "Run `ouroboros mcp doctor` / setup to register the MCP server."
+            ),
+            data=data,
+            resume_handle=current_handle,
+        )
+
     async def _maybe_dispatch_skill_intercept(
         self,
         prompt: str,
@@ -564,6 +631,13 @@ class CodexCliRuntime:
             dispatched_messages = await dispatcher(intercept, current_handle)
         except Exception as e:
             failure_context = self._build_intercept_failure_context(intercept)
+            auto_handler_missing = (
+                intercept.skill_name == "auto"
+                and type(e) is LookupError
+                and "No local handler registered" in str(e)
+            )
+            if auto_handler_missing:
+                failure_context["fallback"] = "terminal_error"
             log.warning(
                 f"{self._log_namespace}.skill_intercept_dispatch_failed",
                 **failure_context,
@@ -571,36 +645,40 @@ class CodexCliRuntime:
                 error=str(e),
                 exc_info=True,
             )
-            if intercept.skill_name == "auto":
+            if auto_handler_missing:
                 return (
-                    AgentMessage(
-                        type="result",
-                        content=(
-                            "Cannot run ooo auto: required MCP tool "
-                            f"`{intercept.mcp_tool}` is unavailable. "
-                            "Run `ouroboros doctor` / setup to register the MCP server."
-                        ),
-                        data={
-                            "subtype": "error",
-                            "error_type": "SkillDispatchUnavailable",
-                            "skill_name": intercept.skill_name,
-                            "tool_name": intercept.mcp_tool,
-                            "command_prefix": intercept.command_prefix,
-                        },
-                        resume_handle=current_handle,
+                    self._build_auto_dispatch_unavailable_message(
+                        intercept,
+                        current_handle,
+                        dispatch_error_type=type(e).__name__,
+                        dispatch_error=str(e),
                     ),
                 )
             return None
 
         recoverable_error = self._extract_recoverable_dispatch_error(dispatched_messages)
         if recoverable_error is not None:
+            failure_context = self._build_intercept_failure_context(intercept)
+            if intercept.skill_name == "auto":
+                failure_context["fallback"] = "terminal_error"
             log.warning(
                 f"{self._log_namespace}.skill_intercept_dispatch_failed",
-                **self._build_intercept_failure_context(intercept),
+                **failure_context,
                 error_type=recoverable_error.data.get("error_type"),
                 error=recoverable_error.content,
                 recoverable=True,
             )
+            if intercept.skill_name == "auto":
+                if self._is_auto_recoverable_dispatch_unavailable(recoverable_error):
+                    return (
+                        self._build_auto_dispatch_unavailable_message(
+                            intercept,
+                            current_handle,
+                            dispatch_error_type=str(recoverable_error.data.get("error_type") or ""),
+                            dispatch_error=recoverable_error.content,
+                        ),
+                    )
+                return dispatched_messages
             return None
 
         return dispatched_messages

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -1695,13 +1695,292 @@ class TestCodexCliRuntime:
         assert messages[0].is_error is True
         assert messages[0].content.startswith("Cannot run ooo auto")
         assert "`ouroboros_auto` is unavailable" in messages[0].content
+        assert "ouroboros mcp doctor" in messages[0].content
+        assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
         assert messages[0].data == {
             "subtype": "error",
             "error_type": "SkillDispatchUnavailable",
             "skill_name": "auto",
             "tool_name": "ouroboros_auto",
             "command_prefix": "ooo auto",
+            "dispatch_error_type": "LookupError",
+            "dispatch_error": "No local handler registered",
         }
+
+    @pytest.mark.asyncio
+    async def test_execute_task_auto_connection_error_preserves_real_cause(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Auto transport failures must fail closed without being rewritten as setup issues."""
+        self._write_skill(
+            tmp_path,
+            "auto",
+            [
+                "name: auto",
+                'description: "Automatically converge from goal to A-grade Seed and execute it"',
+                "mcp_tool: ouroboros_auto",
+                "mcp_args:",
+                '  goal: "$goal"',
+                '  cwd: "$CWD"',
+            ],
+        )
+        dispatcher = AsyncMock(
+            return_value=(
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(
+                    type="result",
+                    content="Auto MCP server unavailable",
+                    data={
+                        "subtype": "error",
+                        "recoverable": True,
+                        "error_type": "MCPConnectionError",
+                    },
+                ),
+            )
+        )
+        runtime = CodexCliRuntime(
+            cli_path="codex",
+            cwd="/tmp/project",
+            skills_dir=tmp_path,
+            skill_dispatcher=dispatcher,
+        )
+
+        with (
+            patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
+            patch(
+                "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec",
+            ) as mock_exec,
+        ):
+            messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
+
+        dispatcher.assert_awaited_once()
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args.kwargs["recoverable"] is True
+        assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
+        assert mock_warning.call_args.kwargs["error_type"] == "MCPConnectionError"
+        mock_exec.assert_not_called()
+        assert [message.content for message in messages] == [
+            "Calling tool: ouroboros_auto",
+            "Auto MCP server unavailable",
+        ]
+        assert messages[-1].data["error_type"] == "MCPConnectionError"
+        assert messages[-1].data["error_type"] != "SkillDispatchUnavailable"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_auto_resource_not_found_dispatch_error_does_not_fall_back(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Missing production MCP tool registrations hard-fail as dispatch unavailable."""
+        self._write_skill(
+            tmp_path,
+            "auto",
+            [
+                "name: auto",
+                'description: "Automatically converge from goal to A-grade Seed and execute it"',
+                "mcp_tool: ouroboros_auto",
+                "mcp_args:",
+                '  goal: "$goal"',
+                '  cwd: "$CWD"',
+            ],
+        )
+        dispatcher = AsyncMock(
+            return_value=(
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(
+                    type="result",
+                    content="Tool ouroboros_auto not found",
+                    data={
+                        "subtype": "error",
+                        "recoverable": True,
+                        "error_type": "MCPResourceNotFoundError",
+                    },
+                ),
+            )
+        )
+        runtime = CodexCliRuntime(
+            cli_path="codex",
+            cwd="/tmp/project",
+            skills_dir=tmp_path,
+            skill_dispatcher=dispatcher,
+        )
+
+        with (
+            patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
+            patch(
+                "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec",
+            ) as mock_exec,
+        ):
+            messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
+
+        dispatcher.assert_awaited_once()
+        assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
+        mock_exec.assert_not_called()
+        assert len(messages) == 1
+        assert messages[0].data["error_type"] == "SkillDispatchUnavailable"
+        assert messages[0].data["dispatch_error_type"] == "MCPResourceNotFoundError"
+        assert messages[0].data["dispatch_error"] == "Tool ouroboros_auto not found"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_auto_recoverable_pipeline_error_preserves_real_cause(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Auto pipeline failures must not be rewritten as dispatch-unavailable errors."""
+        self._write_skill(
+            tmp_path,
+            "auto",
+            [
+                "name: auto",
+                'description: "Automatically converge from goal to A-grade Seed and execute it"',
+                "mcp_tool: ouroboros_auto",
+                "mcp_args:",
+                '  goal: "$goal"',
+                '  cwd: "$CWD"',
+            ],
+        )
+        dispatcher = AsyncMock(
+            return_value=(
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(
+                    type="result",
+                    content="Auto pipeline failed: model provider crashed",
+                    data={
+                        "subtype": "error",
+                        "recoverable": True,
+                        "error_type": "MCPToolError",
+                    },
+                ),
+            )
+        )
+        runtime = CodexCliRuntime(
+            cli_path="codex",
+            cwd="/tmp/project",
+            skills_dir=tmp_path,
+            skill_dispatcher=dispatcher,
+        )
+
+        with (
+            patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
+            patch(
+                "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec",
+            ) as mock_exec,
+        ):
+            messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
+
+        dispatcher.assert_awaited_once()
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args.kwargs["recoverable"] is True
+        assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
+        assert mock_warning.call_args.kwargs["error_type"] == "MCPToolError"
+        mock_exec.assert_not_called()
+        assert [message.content for message in messages] == [
+            "Calling tool: ouroboros_auto",
+            "Auto pipeline failed: model provider crashed",
+        ]
+        assert messages[-1].data["error_type"] == "MCPToolError"
+        assert messages[-1].data["error_type"] != "SkillDispatchUnavailable"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_auto_key_error_falls_back_with_real_cause(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """LookupError subclasses such as KeyError must not be treated as missing tools."""
+        self._write_skill(
+            tmp_path,
+            "auto",
+            [
+                "name: auto",
+                'description: "Automatically converge from goal to A-grade Seed and execute it"',
+                "mcp_tool: ouroboros_auto",
+                "mcp_args:",
+                '  goal: "$goal"',
+                '  cwd: "$CWD"',
+            ],
+        )
+        dispatcher = AsyncMock(side_effect=KeyError("internal_state"))
+        runtime = CodexCliRuntime(
+            cli_path="codex",
+            cwd="/tmp/project",
+            skills_dir=tmp_path,
+            skill_dispatcher=dispatcher,
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> _FakeProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("Codex fallback", encoding="utf-8")
+            return _FakeProcess(stdout_lines=[], stderr_lines=[], returncode=0)
+
+        with (
+            patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
+            patch(
+                "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec",
+                side_effect=fake_create_subprocess_exec,
+            ) as mock_exec,
+        ):
+            messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
+
+        dispatcher.assert_awaited_once()
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args.kwargs["error_type"] == "KeyError"
+        assert mock_warning.call_args.kwargs["fallback"] == "pass_through_to_codex"
+        mock_exec.assert_called_once()
+        assert messages[-1].content == "Codex fallback"
+        assert all(
+            message.data.get("error_type") != "SkillDispatchUnavailable" for message in messages
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_task_auto_unexpected_dispatch_error_falls_back_with_real_cause(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Unexpected auto dispatch errors must not be misreported as missing MCP tools."""
+        self._write_skill(
+            tmp_path,
+            "auto",
+            [
+                "name: auto",
+                'description: "Automatically converge from goal to A-grade Seed and execute it"',
+                "mcp_tool: ouroboros_auto",
+                "mcp_args:",
+                '  goal: "$goal"',
+                '  cwd: "$CWD"',
+            ],
+        )
+        dispatcher = AsyncMock(side_effect=RuntimeError("handler crashed"))
+        runtime = CodexCliRuntime(
+            cli_path="codex",
+            cwd="/tmp/project",
+            skills_dir=tmp_path,
+            skill_dispatcher=dispatcher,
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> _FakeProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("Codex fallback", encoding="utf-8")
+            return _FakeProcess(stdout_lines=[], stderr_lines=[], returncode=0)
+
+        with (
+            patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
+            patch(
+                "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec",
+                side_effect=fake_create_subprocess_exec,
+            ) as mock_exec,
+        ):
+            messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
+
+        dispatcher.assert_awaited_once()
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args.kwargs["error_type"] == "RuntimeError"
+        assert mock_warning.call_args.kwargs["error"] == "handler crashed"
+        mock_exec.assert_called_once()
+        assert messages[-1].content == "Codex fallback"
+        assert all(
+            message.data.get("error_type") != "SkillDispatchUnavailable" for message in messages
+        )
 
     @pytest.mark.asyncio
     async def test_execute_task_falls_through_when_interview_intercept_dispatcher_raises(

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -1655,6 +1655,55 @@ class TestCodexCliRuntime:
         assert messages[-1].content == "Codex fallback"
 
     @pytest.mark.asyncio
+    async def test_execute_task_auto_dispatch_failure_does_not_fall_back(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`ooo auto` must fail closed when the MCP dispatch tool is unavailable."""
+        self._write_skill(
+            tmp_path,
+            "auto",
+            [
+                "name: auto",
+                'description: "Automatically converge from goal to A-grade Seed and execute it"',
+                "mcp_tool: ouroboros_auto",
+                "mcp_args:",
+                '  goal: "$goal"',
+                '  cwd: "$CWD"',
+            ],
+        )
+        dispatcher = AsyncMock(side_effect=LookupError("No local handler registered"))
+        runtime = CodexCliRuntime(
+            cli_path="codex",
+            cwd="/tmp/project",
+            skills_dir=tmp_path,
+            skill_dispatcher=dispatcher,
+        )
+
+        with (
+            patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
+            patch(
+                "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec",
+            ) as mock_exec,
+        ):
+            messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
+
+        dispatcher.assert_awaited_once()
+        mock_warning.assert_called_once()
+        mock_exec.assert_not_called()
+        assert len(messages) == 1
+        assert messages[0].is_error is True
+        assert messages[0].content.startswith("Cannot run ooo auto")
+        assert "`ouroboros_auto` is unavailable" in messages[0].content
+        assert messages[0].data == {
+            "subtype": "error",
+            "error_type": "SkillDispatchUnavailable",
+            "skill_name": "auto",
+            "tool_name": "ouroboros_auto",
+            "command_prefix": "ooo auto",
+        }
+
+    @pytest.mark.asyncio
     async def test_execute_task_falls_through_when_interview_intercept_dispatcher_raises(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

Fixes #638.

`ooo auto` has a stricter product contract than ordinary skill prompts: it must enter the real `ouroboros_auto` pipeline or fail clearly. This PR adds a Codex-runtime fail-closed path when the `auto` skill is resolved but its MCP dispatch is unavailable.

## Changes

- When Codex resolves `ooo auto ...` but the skill dispatcher raises, return a terminal error message instead of passing the prompt through to generic Codex execution.
- Keep existing fallback behavior for other skills such as `run` and `interview`.
- Add a regression test proving `ooo auto` does not spawn the Codex subprocess when `ouroboros_auto` dispatch is unavailable.

## Validation

- `uv run pytest tests/unit/orchestrator/test_codex_cli_runtime.py -k 'auto_dispatch_failure or logs_dispatch_failure_context_and_falls_back or falls_through_when_interview'`
- `uv run ruff check src/ouroboros/orchestrator/codex_cli_runtime.py tests/unit/orchestrator/test_codex_cli_runtime.py`

## Risks

- Scope is deliberately limited to the Codex CLI runtime path. Hermes/OpenCode still need separate tests before changing their fallback behavior.
- The PR hard-fails only `auto`, not every `mcp_tool` skill, to avoid breaking existing recoverable fallback flows.
- If callers rely on generic Codex fallback for `ooo auto`, this changes that behavior intentionally because silent manual emulation is the bug.
