### PR TITLE
Fail closed for ooo auto in Codex rule surfaces

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -15,6 +15,15 @@ mcp_args:
 
 Run the full-quality auto pipeline from a single task description.
 
+## Dispatch requirement
+
+This skill must be executed by invoking MCP tool `ouroboros_auto`. Do not
+manually inspect repositories, run shell commands, query GitHub, edit files, or
+otherwise emulate the auto pipeline as a substitute.
+
+If `ouroboros_auto` is unavailable, stop and report that the required MCP tool
+is unavailable. A manual fallback is not an `ooo auto` run.
+
 ## Usage
 
 ```text

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -13,6 +13,7 @@ Do NOT interpret `ooo` commands as natural language. ALWAYS route to the MCP too
 | `ooo interview "<answer>"` (follow-up) | `ouroboros_interview` with `answer` and `session_id` |
 | `ooo seed [session_id]` | `ouroboros_generate_seed` |
 | `ooo run <seed.yaml>` | `ouroboros_execute_seed` with `seed_path` |
+| `ooo auto ...` | `ouroboros_auto` with the resolved `goal` / `resume` / option arguments |
 | `ooo status [session_id]` | `ouroboros_session_status` |
 | `ooo evaluate <session_id>` | `ouroboros_evaluate` |
 | `ooo evolve ...` | `ouroboros_evolve_step` |
@@ -27,6 +28,16 @@ For natural-language requests, map to the corresponding MCP tool:
 - "run the seed", "execute the workflow" → call `ouroboros_execute_seed`
 - "check status", "am I drifting?" → call `ouroboros_session_status`
 - "evaluate", "verify the result" → call `ouroboros_evaluate`
+
+## Auto Dispatch Safety
+
+`ooo auto` has a strict product contract: bounded interview, Seed generation,
+A-grade review/repair, and execution handoff. Do not emulate it with manual
+shell, repository, or GitHub work.
+
+If a user input starts with `ooo auto`, call `ouroboros_auto`. If that MCP tool
+is unavailable, stop and report that `ouroboros_auto` is unavailable instead of
+continuing as a normal Codex task.
 
 ## Setup & Update
 

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -108,6 +108,14 @@ class TestInstallCodexRules:
         assert not stale_namespaced_rule.exists()
         assert unrelated_rule.read_text(encoding="utf-8") == "keep me"
 
+    def test_packaged_rules_fail_closed_for_ooo_auto(self) -> None:
+        """Codex rules must route ``ooo auto`` to the real MCP tool, not manual work."""
+        rules = load_packaged_codex_rules()
+
+        assert "| `ooo auto ...` | `ouroboros_auto`" in rules
+        assert "Do not emulate it with manual" in rules
+        assert "If that MCP tool\nis unavailable" in rules
+
 
 class TestLoadPackagedCodexSkills:
     """Test packaged Codex skill entrypoint resolution helpers."""
@@ -138,6 +146,13 @@ class TestLoadPackagedCodexSkills:
         with resolve_packaged_codex_skill_path("run") as skill_md_path:
             assert skill_md_path.name == "SKILL.md"
             assert skill_md_path.read_text(encoding="utf-8").startswith("---\nname: run\n")
+
+    def test_packaged_auto_skill_forbids_manual_fallback(self) -> None:
+        """The auto skill body must not allow silent manual emulation."""
+        skill = load_packaged_codex_skill("auto")
+
+        assert "must be executed by invoking MCP tool `ouroboros_auto`" in skill
+        assert "manual fallback is not an `ooo auto` run" in skill
 
     def test_raises_when_explicit_packaged_skill_is_missing(self, tmp_path: Path) -> None:
         """Missing skill entrypoints should fail fast."""


### PR DESCRIPTION
## Summary

- Add `ooo auto -> ouroboros_auto` to the packaged Codex routing table
- Tell plain Codex sessions not to emulate `ooo auto` with manual shell/GitHub/repo work
- Add packaged artifact tests that lock the rule and skill fail-closed contract

## Why

Closes part of #637. `CodexCliRuntime` already fails closed when the auto MCP dispatch path is unavailable, but installed Codex rules/skills can still be read in sessions that are not running through that runtime. Those surfaces should explicitly preserve the MCP-only contract.

## Verification

- `PYTHONPATH=src pytest tests/unit/test_codex_artifacts.py -q`
