### PR TITLE
Add Codex doctor checks for ooo auto dispatch

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -15,6 +15,8 @@ mcp_args:
 
 Run the full-quality auto pipeline from a single task description.
 
+This skill requires MCP dispatch to `ouroboros_auto`. If that tool is unavailable, stop and report a dispatch failure; do not manually emulate the auto pipeline or continue with ordinary agent work.
+
 ## Usage
 
 ```text

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+import tomllib
+from typing import Annotated
 
 import typer
 
-from ouroboros.cli.formatters.panels import print_error, print_success
+from ouroboros.cli.formatters.panels import print_error, print_success, print_warning
 from ouroboros.codex import install_codex_artifacts
 
 app = typer.Typer(
@@ -33,3 +35,97 @@ def refresh() -> None:
 
     print_success(f"Installed Codex rules → {result.rules_path}")
     print_success(f"Installed {len(result.skill_paths)} Codex skills → {codex_dir / 'skills'}")
+
+
+@app.command("doctor")
+def doctor(
+    codex_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--codex-dir",
+            help="Codex configuration directory to inspect. Defaults to ~/.codex.",
+        ),
+    ] = None,
+) -> None:
+    """Verify installed Codex artifacts can route ``ooo auto`` to Ouroboros."""
+    resolved_codex_dir = codex_dir or Path.home() / ".codex"
+    failures = _check_auto_dispatch_surface(resolved_codex_dir)
+
+    if failures:
+        print_error(
+            "Codex ooo auto dispatch: BROKEN\n"
+            + "\n".join(f"- {failure}" for failure in failures)
+            + "\n\nRun `ouroboros codex refresh` and ensure the `ouroboros` MCP server is enabled.",
+            title="Codex Doctor",
+        )
+        raise typer.Exit(1)
+
+    print_success(
+        "Codex ooo auto dispatch: OK\n"
+        "- rule maps `ooo auto` to `ouroboros_auto`\n"
+        "- auto skill declares MCP dispatch through `ouroboros_auto`\n"
+        "- Codex config contains an `ouroboros` MCP server entry",
+        title="Codex Doctor",
+    )
+
+
+def _check_auto_dispatch_surface(codex_dir: Path) -> list[str]:
+    """Return configuration failures that can silently bypass ``ooo auto`` dispatch."""
+    failures: list[str] = []
+
+    rules_path = codex_dir / "rules" / "ouroboros.md"
+    if not rules_path.is_file():
+        failures.append(f"missing Codex rules file: {rules_path}")
+    else:
+        rules = rules_path.read_text(encoding="utf-8")
+        if "`ooo auto" not in rules or "ouroboros_auto" not in rules:
+            failures.append("Codex rules do not map `ooo auto` to `ouroboros_auto`")
+        if "manual" not in rules.lower() or "unavailable" not in rules.lower():
+            failures.append("Codex rules do not describe fail-closed behavior for `ooo auto`")
+
+    skill_path = codex_dir / "skills" / "ouroboros-auto" / "SKILL.md"
+    if not skill_path.is_file():
+        failures.append(f"missing auto skill file: {skill_path}")
+    else:
+        skill = skill_path.read_text(encoding="utf-8")
+        if "mcp_tool: ouroboros_auto" not in skill:
+            failures.append("auto skill does not declare `mcp_tool: ouroboros_auto`")
+        if "manual" not in skill.lower() or "unavailable" not in skill.lower():
+            failures.append("auto skill does not forbid manual fallback when dispatch is unavailable")
+
+    config_path = codex_dir / "config.toml"
+    if not config_path.is_file():
+        failures.append(f"missing Codex config file: {config_path}")
+        return failures
+
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        failures.append(f"Codex config is not valid TOML: {exc}")
+        return failures
+
+    mcp_servers = config.get("mcp_servers")
+    if not isinstance(mcp_servers, dict):
+        failures.append("Codex config does not contain an [mcp_servers] table")
+        return failures
+
+    ouroboros_entry = mcp_servers.get("ouroboros")
+    if not isinstance(ouroboros_entry, dict):
+        failures.append("Codex config does not contain [mcp_servers.ouroboros]")
+        return failures
+
+    command = str(ouroboros_entry.get("command", ""))
+    args = ouroboros_entry.get("args")
+    args_text = " ".join(str(arg) for arg in args) if isinstance(args, list) else ""
+    if not command:
+        failures.append("[mcp_servers.ouroboros] is missing `command`")
+    if "ouroboros" not in f"{command} {args_text}" or "mcp" not in args_text:
+        failures.append("[mcp_servers.ouroboros] does not appear to start `ouroboros mcp serve`")
+
+    if failures:
+        print_warning(
+            "Detected a Codex surface where `ooo auto` may be interpreted as normal text.",
+            title="Codex Doctor",
+        )
+
+    return failures

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -77,29 +77,39 @@ def _check_auto_dispatch_surface(codex_dir: Path) -> list[str]:
     if not rules_path.is_file():
         failures.append(f"missing Codex rules file: {rules_path}")
     else:
-        rules = rules_path.read_text(encoding="utf-8")
-        if "`ooo auto" not in rules or "ouroboros_auto" not in rules:
+        rules = _read_codex_text(rules_path, "Codex rules", failures)
+        if rules is not None and ("`ooo auto" not in rules or "ouroboros_auto" not in rules):
             failures.append("Codex rules do not map `ooo auto` to `ouroboros_auto`")
-        if "manual" not in rules.lower() or "unavailable" not in rules.lower():
+        if rules is not None and (
+            "manual" not in rules.lower() or "unavailable" not in rules.lower()
+        ):
             failures.append("Codex rules do not describe fail-closed behavior for `ooo auto`")
 
     skill_path = codex_dir / "skills" / "ouroboros-auto" / "SKILL.md"
     if not skill_path.is_file():
         failures.append(f"missing auto skill file: {skill_path}")
     else:
-        skill = skill_path.read_text(encoding="utf-8")
-        if "mcp_tool: ouroboros_auto" not in skill:
+        skill = _read_codex_text(skill_path, "auto skill", failures)
+        if skill is not None and "mcp_tool: ouroboros_auto" not in skill:
             failures.append("auto skill does not declare `mcp_tool: ouroboros_auto`")
-        if "manual" not in skill.lower() or "unavailable" not in skill.lower():
-            failures.append("auto skill does not forbid manual fallback when dispatch is unavailable")
+        if skill is not None and (
+            "manual" not in skill.lower() or "unavailable" not in skill.lower()
+        ):
+            failures.append(
+                "auto skill does not forbid manual fallback when dispatch is unavailable"
+            )
 
     config_path = codex_dir / "config.toml"
     if not config_path.is_file():
         failures.append(f"missing Codex config file: {config_path}")
         return failures
 
+    config_text = _read_codex_text(config_path, "Codex config", failures)
+    if config_text is None:
+        return failures
+
     try:
-        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        config = tomllib.loads(config_text)
     except tomllib.TOMLDecodeError as exc:
         failures.append(f"Codex config is not valid TOML: {exc}")
         return failures
@@ -114,13 +124,13 @@ def _check_auto_dispatch_surface(codex_dir: Path) -> list[str]:
         failures.append("Codex config does not contain [mcp_servers.ouroboros]")
         return failures
 
-    command = str(ouroboros_entry.get("command", ""))
-    args = ouroboros_entry.get("args")
-    args_text = " ".join(str(arg) for arg in args) if isinstance(args, list) else ""
-    if not command:
-        failures.append("[mcp_servers.ouroboros] is missing `command`")
-    if "ouroboros" not in f"{command} {args_text}" or "mcp" not in args_text:
-        failures.append("[mcp_servers.ouroboros] does not appear to start `ouroboros mcp serve`")
+    url = ouroboros_entry.get("url")
+    if isinstance(url, str) and url.strip():
+        return failures
+
+    command = ouroboros_entry.get("command")
+    if not isinstance(command, str) or not command.strip():
+        failures.append("[mcp_servers.ouroboros] is missing `command` or `url`")
 
     if failures:
         print_warning(
@@ -129,3 +139,14 @@ def _check_auto_dispatch_surface(codex_dir: Path) -> list[str]:
         )
 
     return failures
+
+
+def _read_codex_text(path: Path, label: str, failures: list[str]) -> str | None:
+    """Read a Codex artifact for doctor checks without crashing on broken files."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        failures.append(f"{label} is not valid UTF-8: {path}: {exc}")
+    except OSError as exc:
+        failures.append(f"could not read {label}: {path}: {exc}")
+    return None

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -18,6 +18,9 @@ Do NOT interpret `ooo` commands as natural language. ALWAYS route to the MCP too
 | `ooo evolve ...` | `ouroboros_evolve_step` |
 | `ooo cancel [execution_id]` | `ouroboros_cancel_execution` |
 | `ooo unstuck` / `ooo lateral` | `ouroboros_lateral_think` |
+| `ooo auto ...` | `ouroboros_auto` |
+
+If `ouroboros_auto` is unavailable, stop and report that the MCP dispatch surface is broken. Do not manually emulate `ooo auto` with ordinary shell, GitHub, or coding work.
 
 ## Natural Language Mapping
 

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands.codex import _check_auto_dispatch_surface, app
-from ouroboros.codex import CodexArtifactInstallResult
+from ouroboros.codex import CodexArtifactInstallResult, install_codex_artifacts
 
 runner = CliRunner()
 
@@ -80,6 +80,45 @@ class TestCodexDoctor:
 
         assert _check_auto_dispatch_surface(codex_dir) == []
 
+    def test_check_auto_dispatch_surface_accepts_url_mcp_server_entry(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n',
+            encoding="utf-8",
+        )
+
+        assert _check_auto_dispatch_surface(codex_dir) == []
+
+    def test_check_auto_dispatch_surface_accepts_custom_command_mcp_entry(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            '[mcp_servers.ouroboros]\ncommand = "/opt/bin/ob-mcp-wrapper"\nargs = ["--stdio"]\n',
+            encoding="utf-8",
+        )
+
+        assert _check_auto_dispatch_surface(codex_dir) == []
+
+    def test_packaged_codex_artifacts_satisfy_doctor_contract(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        install_codex_artifacts(codex_dir=codex_dir, prune=False)
+        (codex_dir / "config.toml").write_text(
+            '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n',
+            encoding="utf-8",
+        )
+
+        assert _check_auto_dispatch_surface(codex_dir) == []
+
     def test_check_auto_dispatch_surface_reports_missing_auto_contract(
         self,
         tmp_path: Path,
@@ -115,6 +154,20 @@ class TestCodexDoctor:
         assert cli_result.exit_code == 1
         assert "Codex ooo auto dispatch: BROKEN" in cli_result.output
         assert "missing Codex rules file" in cli_result.output
+
+    def test_doctor_command_reports_unreadable_artifact_without_traceback(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "skills" / "ouroboros-auto" / "SKILL.md").write_bytes(b"\xff")
+
+        cli_result = runner.invoke(app, ["doctor", "--codex-dir", str(codex_dir)])
+
+        assert cli_result.exit_code == 1
+        assert "auto skill is not valid UTF-8" in cli_result.output
+        assert not isinstance(cli_result.exception, UnicodeDecodeError)
 
     def test_doctor_command_reports_ok_for_healthy_install(self, tmp_path: Path) -> None:
         codex_dir = tmp_path / ".codex"

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner
 
-from ouroboros.cli.commands.codex import app
+from ouroboros.cli.commands.codex import _check_auto_dispatch_surface, app
 from ouroboros.codex import CodexArtifactInstallResult
 
 runner = CliRunner()
@@ -38,3 +38,89 @@ class TestCodexRefresh:
         assert "Installed 2 Codex skills" in cli_result.output
         assert not (tmp_path / ".codex" / "config.toml").exists()
         assert not (tmp_path / ".ouroboros" / "config.yaml").exists()
+
+
+class TestCodexDoctor:
+    """Tests for `ouroboros codex doctor`."""
+
+    @staticmethod
+    def _write_healthy_codex_surface(codex_dir: Path) -> None:
+        rules_path = codex_dir / "rules" / "ouroboros.md"
+        rules_path.parent.mkdir(parents=True, exist_ok=True)
+        rules_path.write_text(
+            "| `ooo auto ...` | `ouroboros_auto` |\n"
+            "Do not emulate it with manual work. If unavailable, stop.\n",
+            encoding="utf-8",
+        )
+
+        skill_path = codex_dir / "skills" / "ouroboros-auto" / "SKILL.md"
+        skill_path.parent.mkdir(parents=True, exist_ok=True)
+        skill_path.write_text(
+            "---\n"
+            "name: auto\n"
+            "mcp_tool: ouroboros_auto\n"
+            "---\n"
+            "Manual fallback is not allowed when the tool is unavailable.\n",
+            encoding="utf-8",
+        )
+
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "uvx"\n'
+            'args = ["--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"]\n',
+            encoding="utf-8",
+        )
+
+    def test_check_auto_dispatch_surface_passes_for_healthy_install(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+
+        assert _check_auto_dispatch_surface(codex_dir) == []
+
+    def test_check_auto_dispatch_surface_reports_missing_auto_contract(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        (codex_dir / "rules").mkdir(parents=True)
+        (codex_dir / "rules" / "ouroboros.md").write_text(
+            "| `ooo run <seed.yaml>` | `ouroboros_execute_seed` |\n",
+            encoding="utf-8",
+        )
+        (codex_dir / "skills" / "ouroboros-auto").mkdir(parents=True)
+        (codex_dir / "skills" / "ouroboros-auto" / "SKILL.md").write_text(
+            "---\nname: auto\n---\n# Auto\n",
+            encoding="utf-8",
+        )
+        (codex_dir / "config.toml").write_text("[mcp_servers]\n", encoding="utf-8")
+
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert "Codex rules do not map `ooo auto` to `ouroboros_auto`" in failures
+        assert "auto skill does not declare `mcp_tool: ouroboros_auto`" in failures
+        assert "Codex config does not contain [mcp_servers.ouroboros]" in failures
+
+    def test_doctor_command_exits_nonzero_when_dispatch_surface_is_broken(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+
+        cli_result = runner.invoke(app, ["doctor", "--codex-dir", str(codex_dir)])
+
+        assert cli_result.exit_code == 1
+        assert "Codex ooo auto dispatch: BROKEN" in cli_result.output
+        assert "missing Codex rules file" in cli_result.output
+
+    def test_doctor_command_reports_ok_for_healthy_install(self, tmp_path: Path) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+
+        cli_result = runner.invoke(app, ["doctor", "--codex-dir", str(codex_dir)])
+
+        assert cli_result.exit_code == 0
+        assert "Codex ooo auto dispatch: OK" in cli_result.output


### PR DESCRIPTION
## Summary

- Add `ouroboros codex doctor` to inspect installed Codex rules, auto skill, and MCP config
- Report a broken `ooo auto` dispatch surface before users can mistake manual fallback for auto
- Cover healthy and broken install surfaces with unit tests

## Why

Follows #637. `ooo auto` can only be trusted in plain Codex sessions when installed rules, the packaged auto skill, and the Ouroboros MCP server entry all agree on `ouroboros_auto`. This command gives users a side-effect-free way to detect a broken surface.

## Verification

- `PYTHONPATH=src pytest tests/unit/cli/test_codex_command.py -q`
