### PR TITLE
Lock packaged ooo auto dispatch metadata

### DIFF
--- a/tests/unit/router/test_packaged_auto_dispatch.py
+++ b/tests/unit/router/test_packaged_auto_dispatch.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ouroboros.router import Resolved, resolve_skill_dispatch
+
+
+def test_packaged_auto_skill_dispatches_to_ouroboros_auto(tmp_path: Path) -> None:
+    """Lock the packaged ``ooo auto`` dispatch metadata used by Codex runtimes."""
+    prompt = 'ooo auto "Audit the open PRs" --skip-run'
+
+    result = resolve_skill_dispatch(prompt, cwd=tmp_path)
+
+    assert isinstance(result, Resolved)
+    assert result.command_prefix == "ooo auto"
+    assert result.mcp_tool == "ouroboros_auto"
+    assert result.mcp_args == {
+        "goal": "Audit the open PRs",
+        "resume": "",
+        "cwd": str(tmp_path),
+        "max_interview_rounds": "",
+        "max_repair_rounds": "",
+        "skip_run": True,
+    }
+    assert result.first_argument == "Audit the open PRs --skip-run"


### PR DESCRIPTION
## Summary

- Add a router regression test for the real packaged `auto` skill
- Verify `ooo auto ... --skip-run` resolves to `ouroboros_auto` with normalized args
- Cover the public dispatch contract without relying on synthetic test-only skill fixtures

## Why

Supports #637. The project already has runtime fail-closed coverage, but the packaged skill metadata itself should also be locked so future frontmatter changes cannot silently break the `ooo auto -> ouroboros_auto` contract.

## Verification

- `PYTHONPATH=src pytest tests/unit/router/test_packaged_auto_dispatch.py -q`
