### PR TITLE
Preserve explicit auto goal facts through Seed gating

### DIFF
--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -418,7 +418,7 @@ _EXPLICIT_GOAL_SECTION_LABEL_PATTERN = "|".join(
     f"(?:{label_pattern})"
     for _section_name, _key, label_pattern, _source in _EXPLICIT_GOAL_SECTION_PATTERNS
 )
-_EXPLICIT_GOAL_SECTION_START = r"(?:^|(?<=[.;!?])\s+|(?:\r?\n)\s*(?:[-*]\s*)?)"
+_EXPLICIT_GOAL_SECTION_START = r"(?:^\s*(?:[-*]\s*)?|(?<=[.;!?])\s+|(?:\r?\n)\s*(?:[-*]\s*)?)"
 _EXPLICIT_GOAL_SECTION_BOUNDARY = (
     rf"(?=(?:[.;!?]\s+|(?:\r?\n)\s*(?:[-*]\s*)?)"
     rf"(?:{_EXPLICIT_GOAL_SECTION_LABEL_PATTERN})\s+(?:is|are)\s+|\s*$)"

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -418,8 +418,10 @@ _EXPLICIT_GOAL_SECTION_LABEL_PATTERN = "|".join(
     f"(?:{label_pattern})"
     for _section_name, _key, label_pattern, _source in _EXPLICIT_GOAL_SECTION_PATTERNS
 )
+_EXPLICIT_GOAL_SECTION_START = r"(?:^|(?<=[.;!?])\s+|(?:\r?\n)\s*(?:[-*]\s*)?)"
 _EXPLICIT_GOAL_SECTION_BOUNDARY = (
-    rf"(?=\s+(?:{_EXPLICIT_GOAL_SECTION_LABEL_PATTERN})\s+(?:is|are)\s+|\s*$)"
+    rf"(?=(?:[.;!?]\s+|(?:\r?\n)\s*(?:[-*]\s*)?)"
+    rf"(?:{_EXPLICIT_GOAL_SECTION_LABEL_PATTERN})\s+(?:is|are)\s+|\s*$)"
 )
 
 
@@ -437,7 +439,7 @@ def _hydrate_explicit_goal_sections(ledger: SeedDraftLedger, goal: str) -> None:
         return
     for section_name, key, label_pattern, source in _EXPLICIT_GOAL_SECTION_PATTERNS:
         pattern = (
-            rf"\b(?:{label_pattern})\s+(?:is|are)\s+"
+            rf"{_EXPLICIT_GOAL_SECTION_START}\b(?:{label_pattern})\s+(?:is|are)\s+"
             rf"(?P<value>.*?)"
             rf"{_EXPLICIT_GOAL_SECTION_BOUNDARY}"
         )

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -207,7 +207,7 @@ class SeedDraftLedger:
         ]
         if (
             same_key_entries
-            and entry.source == LedgerSource.USER_GOAL
+            and entry.source in {LedgerSource.USER_GOAL, LedgerSource.NON_GOAL}
             and entry.status == LedgerStatus.CONFIRMED
         ):
             for existing in same_key_entries:

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
+import re
 from typing import Any
 
 
@@ -186,6 +187,7 @@ class SeedDraftLedger:
                 ),
             ),
         )
+        _hydrate_explicit_goal_sections(ledger, clean_goal)
         return ledger
 
     def add_entry(self, section_name: str, entry: LedgerEntry) -> None:
@@ -383,6 +385,101 @@ class SeedDraftLedger:
 
 def _normalize_conflict_value(value: str) -> str:
     return " ".join(value.strip().casefold().split())
+
+
+_EXPLICIT_GOAL_SECTION_PATTERNS: tuple[tuple[str, str, str, LedgerSource], ...] = (
+    (
+        "actors",
+        "actors.user_goal",
+        r"\bactors?\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.USER_GOAL,
+    ),
+    (
+        "inputs",
+        "inputs.user_goal",
+        r"\binputs?\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.USER_GOAL,
+    ),
+    (
+        "outputs",
+        "outputs.user_goal",
+        r"\boutputs?\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.USER_GOAL,
+    ),
+    (
+        "runtime_context",
+        "runtime_context.user_goal",
+        r"\bruntime context\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.USER_GOAL,
+    ),
+    (
+        "non_goals",
+        "non_goals.user_goal",
+        r"\bnon[- ]goals?\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.NON_GOAL,
+    ),
+    (
+        "acceptance_criteria",
+        "acceptance_criteria.user_goal",
+        r"\bacceptance criteria\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.USER_GOAL,
+    ),
+    (
+        "verification_plan",
+        "verification_plan.user_goal",
+        r"\bverification plan\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.USER_GOAL,
+    ),
+    (
+        "failure_modes",
+        "failure_modes.user_goal",
+        r"\bfailure modes?\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.USER_GOAL,
+    ),
+    (
+        "constraints",
+        "constraints.user_goal",
+        r"\bconstraints?\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        LedgerSource.USER_GOAL,
+    ),
+)
+
+
+def _hydrate_explicit_goal_sections(ledger: SeedDraftLedger, goal: str) -> None:
+    """Populate required ledger sections from explicit structured goal facts.
+
+    ``ooo auto`` callers often provide a complete, sentence-shaped brief such as
+    "Actor is ... Inputs are ... Outputs are ...".  The interview answerer only
+    updates sections when the backend asks matching questions, so a completed
+    interview could otherwise block with empty required sections even though the
+    user goal already contained the facts.  Keep this parser deliberately
+    narrow: it only confirms sections with explicit ``<section> is/are`` labels.
+    """
+    if not goal:
+        return
+    for section_name, key, pattern, source in _EXPLICIT_GOAL_SECTION_PATTERNS:
+        match = re.search(pattern, goal, flags=re.IGNORECASE)
+        if match is None:
+            continue
+        value = _clean_goal_fact(match.group("value"))
+        if not value:
+            continue
+        ledger.add_entry(
+            section_name,
+            LedgerEntry(
+                key=key,
+                value=value,
+                source=source,
+                confidence=0.93,
+                status=LedgerStatus.CONFIRMED,
+                reversible=False,
+                rationale=f"Explicitly supplied in the initial auto goal for {section_name}.",
+            ),
+        )
+
+
+def _clean_goal_fact(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip(" ,:")
 
 
 def _truncate(value: str, *, limit: int = 500) -> str:

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -443,24 +443,22 @@ def _hydrate_explicit_goal_sections(ledger: SeedDraftLedger, goal: str) -> None:
             rf"(?P<value>.*?)"
             rf"{_EXPLICIT_GOAL_SECTION_BOUNDARY}"
         )
-        match = re.search(pattern, goal, flags=re.IGNORECASE | re.DOTALL)
-        if match is None:
-            continue
-        value = _clean_goal_fact(match.group("value"))
-        if not value:
-            continue
-        ledger.add_entry(
-            section_name,
-            LedgerEntry(
-                key=key,
-                value=value,
-                source=source,
-                confidence=0.93,
-                status=LedgerStatus.CONFIRMED,
-                reversible=False,
-                rationale=f"Explicitly supplied in the initial auto goal for {section_name}.",
-            ),
-        )
+        for match in re.finditer(pattern, goal, flags=re.IGNORECASE | re.DOTALL):
+            value = _clean_goal_fact(match.group("value"))
+            if not value:
+                continue
+            ledger.add_entry(
+                section_name,
+                LedgerEntry(
+                    key=key,
+                    value=value,
+                    source=source,
+                    confidence=0.93,
+                    status=LedgerStatus.CONFIRMED,
+                    reversible=False,
+                    rationale=f"Explicitly supplied in the initial auto goal for {section_name}.",
+                ),
+            )
 
 
 def _clean_goal_fact(value: str) -> str:

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -388,60 +388,38 @@ def _normalize_conflict_value(value: str) -> str:
 
 
 _EXPLICIT_GOAL_SECTION_PATTERNS: tuple[tuple[str, str, str, LedgerSource], ...] = (
-    (
-        "actors",
-        "actors.user_goal",
-        r"\bactors?\s+(?:is|are)\s+(?P<value>[^.;]+)",
-        LedgerSource.USER_GOAL,
-    ),
-    (
-        "inputs",
-        "inputs.user_goal",
-        r"\binputs?\s+(?:is|are)\s+(?P<value>[^.;]+)",
-        LedgerSource.USER_GOAL,
-    ),
-    (
-        "outputs",
-        "outputs.user_goal",
-        r"\boutputs?\s+(?:is|are)\s+(?P<value>[^.;]+)",
-        LedgerSource.USER_GOAL,
-    ),
+    ("actors", "actors.user_goal", r"actors?", LedgerSource.USER_GOAL),
+    ("inputs", "inputs.user_goal", r"inputs?", LedgerSource.USER_GOAL),
+    ("outputs", "outputs.user_goal", r"outputs?", LedgerSource.USER_GOAL),
     (
         "runtime_context",
         "runtime_context.user_goal",
-        r"\bruntime context\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        r"runtime context",
         LedgerSource.USER_GOAL,
     ),
-    (
-        "non_goals",
-        "non_goals.user_goal",
-        r"\bnon[- ]goals?\s+(?:is|are)\s+(?P<value>[^.;]+)",
-        LedgerSource.NON_GOAL,
-    ),
+    ("non_goals", "non_goals.user_goal", r"non[- ]goals?", LedgerSource.NON_GOAL),
     (
         "acceptance_criteria",
         "acceptance_criteria.user_goal",
-        r"\bacceptance criteria\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        r"acceptance criteria",
         LedgerSource.USER_GOAL,
     ),
     (
         "verification_plan",
         "verification_plan.user_goal",
-        r"\bverification plan\s+(?:is|are)\s+(?P<value>[^.;]+)",
+        r"verification plan",
         LedgerSource.USER_GOAL,
     ),
-    (
-        "failure_modes",
-        "failure_modes.user_goal",
-        r"\bfailure modes?\s+(?:is|are)\s+(?P<value>[^.;]+)",
-        LedgerSource.USER_GOAL,
-    ),
-    (
-        "constraints",
-        "constraints.user_goal",
-        r"\bconstraints?\s+(?:is|are)\s+(?P<value>[^.;]+)",
-        LedgerSource.USER_GOAL,
-    ),
+    ("failure_modes", "failure_modes.user_goal", r"failure modes?", LedgerSource.USER_GOAL),
+    ("constraints", "constraints.user_goal", r"constraints?", LedgerSource.USER_GOAL),
+)
+
+_EXPLICIT_GOAL_SECTION_LABEL_PATTERN = "|".join(
+    f"(?:{label_pattern})"
+    for _section_name, _key, label_pattern, _source in _EXPLICIT_GOAL_SECTION_PATTERNS
+)
+_EXPLICIT_GOAL_SECTION_BOUNDARY = (
+    rf"(?=\s+(?:{_EXPLICIT_GOAL_SECTION_LABEL_PATTERN})\s+(?:is|are)\s+|\s*$)"
 )
 
 
@@ -457,8 +435,13 @@ def _hydrate_explicit_goal_sections(ledger: SeedDraftLedger, goal: str) -> None:
     """
     if not goal:
         return
-    for section_name, key, pattern, source in _EXPLICIT_GOAL_SECTION_PATTERNS:
-        match = re.search(pattern, goal, flags=re.IGNORECASE)
+    for section_name, key, label_pattern, source in _EXPLICIT_GOAL_SECTION_PATTERNS:
+        pattern = (
+            rf"\b(?:{label_pattern})\s+(?:is|are)\s+"
+            rf"(?P<value>.*?)"
+            rf"{_EXPLICIT_GOAL_SECTION_BOUNDARY}"
+        )
+        match = re.search(pattern, goal, flags=re.IGNORECASE | re.DOTALL)
         if match is None:
             continue
         value = _clean_goal_fact(match.group("value"))
@@ -479,7 +462,7 @@ def _hydrate_explicit_goal_sections(ledger: SeedDraftLedger, goal: str) -> None:
 
 
 def _clean_goal_fact(value: str) -> str:
-    return re.sub(r"\s+", " ", value).strip(" ,:")
+    return re.sub(r"\s+", " ", value).strip(" ,:;")
 
 
 def _truncate(value: str, *, limit: int = 500) -> str:

--- a/src/ouroboros/mcp/server/security.py
+++ b/src/ouroboros/mcp/server/security.py
@@ -449,6 +449,7 @@ class InputValidator:
         "seed_content",
         "current_output",
         "prompt",
+        "goal",
         "initial_context",
         "answer",
         "current_approach",

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -190,6 +190,28 @@ def test_seed_draft_ledger_uses_later_repeated_goal_label_as_correction() -> Non
     ]
 
 
+def test_seed_draft_ledger_uses_later_repeated_non_goal_as_correction() -> None:
+    ledger = SeedDraftLedger.from_goal(
+        "Actor is a local developer. "
+        "Inputs are no CLI arguments. "
+        "Outputs are stable stdout. "
+        "Runtime context is local Python 3.11. "
+        "Constraints are stdlib only. "
+        "Non-goals are network calls. "
+        "Non-goals are network calls and package publishing. "
+        "Acceptance criteria are stdout includes hello. "
+        "Verification plan is run pytest. "
+        "Failure modes are missing stdout assertion."
+    )
+
+    assert ledger.is_seed_ready()
+    non_goals = ledger.sections["non_goals"].entries
+    assert [(entry.value, entry.status) for entry in non_goals] == [
+        ("network calls", LedgerStatus.WEAK),
+        ("network calls and package publishing", LedgerStatus.CONFIRMED),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -149,6 +149,25 @@ def test_seed_draft_ledger_ignores_inline_section_label_phrases() -> None:
     assert acceptance_criteria == "stdout includes hello"
 
 
+def test_seed_draft_ledger_hydrates_markdown_bulleted_goal() -> None:
+    ledger = SeedDraftLedger.from_goal(
+        "- Actor is a local developer\n"
+        "- Inputs are no CLI arguments\n"
+        "- Outputs are stable stdout\n"
+        "- Runtime context is local Python 3.11\n"
+        "- Constraints are stdlib only\n"
+        "- Non-goals are network calls\n"
+        "- Acceptance criteria are stdout includes hello\n"
+        "- Verification plan is run pytest\n"
+        "- Failure modes are missing stdout assertion"
+    )
+
+    assert ledger.is_seed_ready()
+    assert "actors" not in ledger.open_gaps()
+    assert ledger.sections["actors"].entries[-1].value == "a local developer"
+    assert ledger.sections["inputs"].entries[-1].value == "no CLI arguments"
+
+
 @pytest.mark.asyncio
 async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -106,6 +106,29 @@ def test_seed_draft_ledger_hydrates_explicit_goal_facts() -> None:
     assert "temporary scratch directory" in ledger.sections["runtime_context"].entries[-1].value
 
 
+def test_seed_draft_ledger_preserves_punctuation_inside_explicit_goal_facts() -> None:
+    ledger = SeedDraftLedger.from_goal(
+        "Actor is a local developer. "
+        "Inputs are config path ./fixtures/hello.txt; use Python 3.11. "
+        "Outputs are write ./out/hello.txt and print hello; goodbye. "
+        "Runtime context is Python 3.11 on linux; cwd is /tmp/demo.v1. "
+        "Constraints are stdlib only. "
+        "Non-goals are network calls. "
+        "Acceptance criteria are hello.txt exists and stdout is hello. "
+        "Verification plan is run python3.11 ./hello.py. "
+        "Failure modes are missing ./out/hello.txt."
+    )
+
+    assert ledger.is_seed_ready()
+    inputs = ledger.sections["inputs"].entries[-1].value
+    outputs = ledger.sections["outputs"].entries[-1].value
+    runtime_context = ledger.sections["runtime_context"].entries[-1].value
+    assert "./fixtures/hello.txt; use Python 3.11" in inputs
+    assert "write ./out/hello.txt and print hello; goodbye" in outputs
+    assert "Python 3.11 on linux; cwd is /tmp/demo.v1" in runtime_context
+    assert "Constraints are" not in runtime_context
+
+
 @pytest.mark.asyncio
 async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -129,6 +129,26 @@ def test_seed_draft_ledger_preserves_punctuation_inside_explicit_goal_facts() ->
     assert "Constraints are" not in runtime_context
 
 
+def test_seed_draft_ledger_ignores_inline_section_label_phrases() -> None:
+    ledger = SeedDraftLedger.from_goal(
+        "Actor is a local developer. "
+        "Inputs are no CLI arguments. "
+        "Outputs are stable stdout. "
+        "Runtime context is local Python 3.11. "
+        "Constraints are the Seed must mention acceptance criteria are important to reviewers. "
+        "Non-goals are network calls. "
+        "Acceptance criteria are stdout includes hello. "
+        "Verification plan is run pytest. "
+        "Failure modes are missing stdout assertion."
+    )
+
+    assert ledger.is_seed_ready()
+    constraints = ledger.sections["constraints"].entries[-1].value
+    acceptance_criteria = ledger.sections["acceptance_criteria"].entries[-1].value
+    assert "acceptance criteria are important" in constraints
+    assert acceptance_criteria == "stdout includes hello"
+
+
 @pytest.mark.asyncio
 async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -168,6 +168,28 @@ def test_seed_draft_ledger_hydrates_markdown_bulleted_goal() -> None:
     assert ledger.sections["inputs"].entries[-1].value == "no CLI arguments"
 
 
+def test_seed_draft_ledger_uses_later_repeated_goal_label_as_correction() -> None:
+    ledger = SeedDraftLedger.from_goal(
+        "Actor is a local developer. "
+        "Inputs are no CLI arguments. "
+        "Outputs are json. "
+        "Outputs are yaml. "
+        "Runtime context is local Python 3.11. "
+        "Constraints are stdlib only. "
+        "Non-goals are network calls. "
+        "Acceptance criteria are stdout includes hello. "
+        "Verification plan is run pytest. "
+        "Failure modes are missing stdout assertion."
+    )
+
+    assert ledger.is_seed_ready()
+    outputs = ledger.sections["outputs"].entries
+    assert [(entry.value, entry.status) for entry in outputs] == [
+        ("json", LedgerStatus.WEAK),
+        ("yaml", LedgerStatus.CONFIRMED),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -78,6 +78,34 @@ def _seed(
     )
 
 
+def _fully_specified_hello_goal() -> str:
+    return (
+        "Produce only an A-grade Seed for a future tiny CLI. "
+        "Actor is a local developer or automated agent. "
+        "Inputs are no CLI arguments and no stdin. "
+        "Outputs are exactly hello followed by one trailing newline on stdout, no stderr, exit code 0. "
+        "Runtime context is a local Unix-like shell in a temporary scratch directory outside real projects. "
+        "Constraints are Seed artifact only, Python 3 standard library only, and no real-project edits. "
+        "Non-goals are implementation in this run, package publishing, external dependencies, network, auth, persistence, and real-project edits. "
+        "Acceptance criteria are Seed artifact only, scratch repo isolation, exact stdout newline behavior, empty stderr, and exit status 0. "
+        "Verification plan is future checks for stdout, stderr, and exit code without executing in this Seed-only run. "
+        "Failure modes are real-project edits, execution during skip-run, missing exact output checks, or out-of-scope dependencies."
+    )
+
+
+def test_seed_draft_ledger_hydrates_explicit_goal_facts() -> None:
+    ledger = SeedDraftLedger.from_goal(_fully_specified_hello_goal())
+
+    assert ledger.is_seed_ready()
+    statuses = ledger.section_statuses()
+    for section in ("actors", "inputs", "outputs", "runtime_context"):
+        assert statuses[section] == LedgerStatus.CONFIRMED
+    assert "local developer" in ledger.sections["actors"].entries[-1].value
+    assert "no CLI arguments" in ledger.sections["inputs"].entries[-1].value
+    assert "hello" in ledger.sections["outputs"].entries[-1].value
+    assert "temporary scratch directory" in ledger.sections["runtime_context"].entries[-1].value
+
+
 @pytest.mark.asyncio
 async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
@@ -299,6 +327,51 @@ async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
     assert result.status == "complete"
     assert result.grade == "A"
     assert result.job_id is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_uses_explicit_goal_facts_before_completed_interview(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_hello", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("fully specified completed interview should not need another answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed(
+            ac=("`python hello.py` prints exactly `hello\\n` to stdout and exits 0",)
+        ).model_copy(update={"goal": state.goal})
+
+    saved: list[str] = []
+
+    def save(seed: Seed) -> str:
+        path = str(tmp_path / f"{seed.metadata.seed_id}.yaml")
+        saved.append(path)
+        return path
+
+    state = AutoPipelineState(goal=_fully_specified_hello_goal(), cwd=str(tmp_path))
+    state.skip_run = True
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        seed_saver=save,
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    assert result.seed_path == saved[0]
+    assert state.phase == AutoPhase.COMPLETE
+    assert state.seed_id is not None
+    assert state.seed_path == saved[0]
+    assert state.last_grade == "A"
+    assert state.job_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/server/test_security.py
+++ b/tests/unit/mcp/server/test_security.py
@@ -217,6 +217,24 @@ class TestInputValidator:
         assert result.is_err
         assert "Potentially dangerous" in str(result.error)
 
+    def test_validate_allows_goal_punctuation_as_freetext(self) -> None:
+        """Natural-language tool goals can contain punctuation like semicolons."""
+        validator = InputValidator()
+        result = validator.validate(
+            "ouroboros_auto",
+            {"goal": "Create a Seed; do not edit real projects", "skip_run": True},
+        )
+
+        assert result.is_ok
+
+    def test_validate_still_rejects_shell_metacharacters_in_non_freetext_fields(self) -> None:
+        """Shell metacharacter checks still protect non-freetext arguments."""
+        validator = InputValidator()
+        result = validator.validate("tool", {"name": "safe; rm -rf /tmp/nope"})
+
+        assert result.is_err
+        assert "Shell metacharacter" in str(result.error)
+
 
 class TestRateLimiter:
     """Test RateLimiter class."""


### PR DESCRIPTION
## Summary
- hydrate the auto Seed draft ledger from explicitly labeled user-goal facts before interview completion gates run
- allow natural-language `goal` text to contain punctuation such as semicolons while keeping dangerous-pattern and non-freetext shell metacharacter checks intact
- add regression coverage for the reproduced Seed-only hello CLI shape so `skip_run` reaches `complete` with a persisted Seed path instead of blocking on empty actors/inputs/outputs/runtime_context

## Why
A live `ooo auto ... --skip-run` run now reaches the `ouroboros_auto` MCP tool, but it can still block after the interview backend completes because the auto ledger does not copy explicit facts already present in the initial goal. In the reproduced run, the Seed was only produced by a separate `ouroboros_generate_seed` call; the auto session itself stayed `blocked` with no `seed_id`, `seed_path`, or `last_grade`.

This PR fixes the narrow failing case: if the goal explicitly says `Actor is ...`, `Inputs are ...`, `Outputs are ...`, `Runtime context is ...`, etc., those facts are confirmed in the ledger before the readiness gate checks required sections.

## Issue links
- Adds concrete follow-up for the #637 umbrella end-to-end auto contract.
- Covers the user-goal grounding slice adjacent to #640 without adding broad repo crawling.

## Tests
- `PYTHONPATH=src pytest -q tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_state.py tests/unit/auto/test_surface.py tests/unit/mcp/server/test_security.py`
- `PYTHONPATH=src ruff check src/ouroboros/auto/ledger.py src/ouroboros/mcp/server/security.py tests/unit/auto/test_interview_pipeline.py tests/unit/mcp/server/test_security.py`
- `PYTHONPATH=src ruff format --check src/ouroboros/auto/ledger.py src/ouroboros/mcp/server/security.py tests/unit/auto/test_interview_pipeline.py tests/unit/mcp/server/test_security.py`
- `uv run mypy src/ouroboros/auto/ledger.py src/ouroboros/mcp/server/security.py`

## Not tested
- Full live MCP server rerun with this branch installed into the active Codex runtime.
