### PR TITLE
fix(config): skip .env path when it's a directory

### DIFF
--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -115,7 +115,7 @@ def _is_placeholder_api_key(value: str) -> bool:
 
 
 def _load_env_file(path: Path) -> None:
-    if not path.exists():
+    if not path.is_file():
         return
 
     for raw_line in path.read_text().splitlines():

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -36,6 +36,13 @@ def test_load_env_file_does_not_override_existing_values(
     assert os.environ["FIRST"] == "existing"
 
 
+def test_load_env_file_ignores_directory_path(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.mkdir()
+
+    _load_env_file(env_path)
+
+
 def test_load_env_file_skips_template_placeholders(tmp_path: Path, monkeypatch) -> None:
     """Template placeholders should not block later env values from loading."""
     repo_env = tmp_path / "repo.env"


### PR DESCRIPTION
  ## Summary
  `ouroboros.config.loader._load_env_file` only guarded with `path.exists()`, so a `.env`
  path resolving to a directory fell through to `path.read_text()` and crashed with
  `IsADirectoryError`. Tighten the guard to `path.is_file()` so non-file `.env` paths are
  treated as absent.

  ## Impact
  - All Ouroboros CLI/MCP entrypoints become unusable in any working directory where
    `.env` is a directory; module import dies before any actionable error reaches the
    user.
  - For Claude Code users wiring `ouroboros mcp serve` via `~/.claude/mcp.json`, the
    effect is silent: the MCP host shows only "MCP connection failed" because the
    process dies before the stdio handshake.

  ## Steps to Reproduce
  1. In an empty workspace, create a `.env` directory:
     ```bash
     mkdir repro && cd repro && mkdir .env
  2. Run any Ouroboros command, e.g.:
  uvx --from 'ouroboros-ai[claude]' ouroboros mcp serve --help
  3. Observe the traceback (see Logs).

  Expected Behavior

  _load_env_file treats a non-file .env path the same as a missing path and silently
  returns, so module import succeeds and the command runs normally.

  Actual Behavior

  Path(".env").exists() returns True for the directory, the function continues to
  path.read_text(), and import dies with IsADirectoryError: [Errno 21] Is a directory: '.env'.

  Fix

  - src/ouroboros/config/loader.py — change the guard in _load_env_file from
  path.exists() to path.is_file(). Behaviour for missing files, regular .env
  files, and placeholder values is unchanged.
  - tests/unit/config/test_loader_env.py — add test_load_env_file_ignores_directory_path
  as a regression test.

  Acceptance Criteria for Fix

  - _load_env_file returns silently when path exists but is not a regular file.
  - Regression test fails with IsADirectoryError against the unfixed code and
  passes after the fix (verified locally).
  - Existing _load_env_file behaviour for missing files, real .env files, and
  placeholder values is unchanged (3 pre-existing tests still pass).

  Verification

  - uv run pytest tests/unit/config/test_loader_env.py -v → 4 passed (3 existing + 1 new)
  - uv run ruff check src/ouroboros/config/loader.py tests/unit/config/test_loader_env.py → clean
  - uv run ruff format --check ... → already formatted
  - uv run mypy src/ouroboros/config/loader.py → Success: no issues found

  Docs

  No documentation update required: this PR doesn't change config search paths,
  environment variable names, or YAML loading logic — the surfaces called out in
  CONTRIBUTING.md's "Configuration → Doc Mapping" rule for config/loader.py
  (lines 588-593). It only narrows the dotenv guard from "exists" to "is a regular file".

  Environment

  - Python: 3.14.3 (also reproducible on 3.12+; bug is in stdlib-only code)
  - Ouroboros: v0.34.0 (main) — same code present since at least v0.29.2
  - OS: macOS (Darwin 25.4.0)

  Logs

  File ".../ouroboros/config/loader.py", line 126, in <module>
      _load_env_file(env_path)
  File ".../ouroboros/config/loader.py", line 102, in _load_env_file
      for raw_line in path.read_text().splitlines():
                      ~~~~~~~~~~~~~~^^
  File ".../python3.14/pathlib/__init__.py", line 787, in read_text
      with self.open(mode='r', ...) as f:
  File ".../python3.14/pathlib/__init__.py", line 771, in open
      return io.open(self, mode, buffering, encoding, errors, newline)
  IsADirectoryError: [Errno 21] Is a directory: '.env'