### PR TITLE
Expose Codex auth-plane failures to chat bridges

### DIFF
--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -693,7 +693,11 @@ class CodexCliLLMAdapter:
             return
 
         if item_type == "web_search":
-            query = item.get("query") if isinstance(item.get("query"), str) else self._extract_text(item)
+            query = (
+                item.get("query")
+                if isinstance(item.get("query"), str)
+                else self._extract_text(item)
+            )
             tool_info = self._format_tool_info("WebSearch", {"query": query})
             self._on_message("tool_started" if event_type == "item.started" else "tool", tool_info)
 

--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -62,6 +62,15 @@ _RETRYABLE_ERROR_PATTERNS = (
     "connection reset",
 )
 
+_CODEX_AUTH_FAILURE_PATTERNS = (
+    "missing bearer or basic authentication",
+    "401 unauthorized",
+    "invalid api key",
+    "no api key",
+    "api key",
+)
+_OPENAI_RESPONSES_ENDPOINT = "api.openai.com/v1/responses"
+
 
 class CodexCliLLMAdapter:
     """LLM adapter backed by local Codex CLI execution."""
@@ -491,6 +500,82 @@ class CodexCliLLMAdapter:
                 return candidate.strip()
         return ""
 
+    @staticmethod
+    def _redact_env_presence(value: str | None) -> bool:
+        """Return presence without exposing secret material in error details."""
+        return bool(value and value.strip())
+
+    @staticmethod
+    def _path_exists(value: str | None, child: str | None = None) -> bool:
+        """Return whether an env-backed path exists without raising."""
+        if not value:
+            return False
+        path = Path(value).expanduser()
+        if child:
+            path = path / child
+        return path.exists()
+
+    @classmethod
+    def _codex_auth_context(cls) -> dict[str, object]:
+        """Return non-secret Codex auth-plane diagnostics for nested CLI failures."""
+        codex_home = os.environ.get("CODEX_HOME")
+        home = os.environ.get("HOME")
+        auth_base = codex_home or (str(Path(home).expanduser() / ".codex") if home else None)
+        return {
+            "codex_home": codex_home or "",
+            "home": home or "",
+            "codex_auth_json_exists": cls._path_exists(auth_base, "auth.json"),
+            "codex_config_toml_exists": cls._path_exists(auth_base, "config.toml"),
+            "openai_api_key_present": cls._redact_env_presence(os.environ.get("OPENAI_API_KEY")),
+        }
+
+    @staticmethod
+    def _looks_like_codex_auth_failure(message: str) -> bool:
+        """Identify Codex/OpenAI auth failures that are otherwise opaque 401s."""
+        normalized = message.lower()
+        return any(pattern in normalized for pattern in _CODEX_AUTH_FAILURE_PATTERNS)
+
+    @staticmethod
+    def _uses_openai_responses_endpoint(message: str) -> bool:
+        """Return whether the error mentions the OpenAI Responses API endpoint."""
+        return _OPENAI_RESPONSES_ENDPOINT in message.lower()
+
+    @classmethod
+    def _codex_failure_details(
+        cls,
+        *,
+        returncode: int | None,
+        session_id: str | None,
+        stderr: str,
+        stdout_errors: list[str],
+        message: str,
+    ) -> dict[str, object]:
+        """Build structured, non-secret details for a failed Codex CLI call."""
+        details: dict[str, object] = {
+            "returncode": returncode,
+            "session_id": session_id,
+            "stderr": stderr,
+            "stdout_errors": stdout_errors,
+        }
+        auth_failure = cls._looks_like_codex_auth_failure(message)
+        openai_responses = cls._uses_openai_responses_endpoint(message)
+        if auth_failure or openai_responses:
+            details.update(
+                {
+                    "failure_category": "codex_auth",
+                    "auth_plane": "codex_cli",
+                    "openai_responses_endpoint_seen": openai_responses,
+                    "codex_auth_context": cls._codex_auth_context(),
+                    "remediation": (
+                        "Verify that the nested Codex process inherits CODEX_HOME/HOME and "
+                        "that CODEX_HOME/auth.json contains the intended Codex OAuth login. "
+                        "If llm.backend is codex, this should not require OPENAI_API_KEY unless "
+                        "the selected Codex profile intentionally uses an OpenAI API-key provider."
+                    ),
+                }
+            )
+        return details
+
     def _fallback_content(self, stdout_lines: list[str], stderr: str) -> str:
         """Build a fallback response from JSON events or stderr."""
         for line in reversed(stdout_lines):
@@ -558,11 +643,18 @@ class CodexCliLLMAdapter:
         return tool_name
 
     def _emit_callback_for_event(self, event: dict[str, Any]) -> None:
-        """Emit best-effort debug callbacks from Codex JSON events."""
+        """Emit best-effort debug callbacks from Codex JSON events.
+
+        External chat hosts such as Hermes/Discord need to distinguish tool
+        start from tool completion when they render nested Codex progress.
+        Keep the historical ``tool`` callback for completed items and add a
+        non-breaking ``tool_started`` callback for started tool events.
+        """
         if self._on_message is None:
             return
 
-        if event.get("type") != "item.completed":
+        event_type = event.get("type")
+        if event_type not in {"item.started", "item.completed"}:
             return
 
         item = event.get("item")
@@ -574,6 +666,8 @@ class CodexCliLLMAdapter:
             return
 
         if item_type in {"agent_message", "reasoning", "todo_list"}:
+            if event_type == "item.started":
+                return
             content = self._extract_text(item)
             if content:
                 self._on_message("thinking", content)
@@ -582,13 +676,13 @@ class CodexCliLLMAdapter:
         if item_type == "command_execution":
             command = self._extract_text({"command": item.get("command")}) or ""
             tool_info = self._format_tool_info("Bash", {"command": command})
-            self._on_message("tool", tool_info)
+            self._on_message("tool_started" if event_type == "item.started" else "tool", tool_info)
             return
 
         if item_type == "mcp_tool_call":
             tool_name = item.get("name") if isinstance(item.get("name"), str) else "mcp_tool"
             tool_info = self._format_tool_info(tool_name, self._extract_tool_input(item))
-            self._on_message("tool", tool_info)
+            self._on_message("tool_started" if event_type == "item.started" else "tool", tool_info)
             return
 
         if item_type == "file_change":
@@ -799,12 +893,15 @@ class CodexCliLLMAdapter:
                         or content
                         or f"{self._display_name} exited with code {process.returncode}",
                         provider=self._provider_name,
-                        details={
-                            "returncode": process.returncode,
-                            "session_id": session_id,
-                            "stderr": "\n".join(stderr_lines).strip(),
-                            "stdout_errors": stdout_errors,
-                        },
+                        details=self._codex_failure_details(
+                            returncode=process.returncode,
+                            session_id=session_id,
+                            stderr="\n".join(stderr_lines).strip(),
+                            stdout_errors=stdout_errors,
+                            message=(stdout_errors[-1] if stdout_errors else None)
+                            or content
+                            or f"{self._display_name} exited with code {process.returncode}",
+                        ),
                     )
                 )
 
@@ -963,12 +1060,15 @@ class CodexCliLLMAdapter:
                     or content
                     or f"{self._display_name} exited with code {process.returncode}",
                     provider=self._provider_name,
-                    details={
-                        "returncode": process.returncode,
-                        "session_id": session_id,
-                        "stderr": "\n".join(stderr_lines).strip(),
-                        "stdout_errors": stdout_errors,
-                    },
+                    details=self._codex_failure_details(
+                        returncode=process.returncode,
+                        session_id=session_id,
+                        stderr="\n".join(stderr_lines).strip(),
+                        stdout_errors=stdout_errors,
+                        message=(stdout_errors[-1] if stdout_errors else None)
+                        or content
+                        or f"{self._display_name} exited with code {process.returncode}",
+                    ),
                 )
             )
 

--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -65,9 +65,11 @@ _RETRYABLE_ERROR_PATTERNS = (
 _CODEX_AUTH_FAILURE_PATTERNS = (
     "missing bearer or basic authentication",
     "401 unauthorized",
+    "unauthorized",
     "invalid api key",
     "no api key",
-    "api key",
+    "missing api key",
+    "invalid bearer token",
 )
 _OPENAI_RESPONSES_ENDPOINT = "api.openai.com/v1/responses"
 
@@ -559,7 +561,7 @@ class CodexCliLLMAdapter:
         }
         auth_failure = cls._looks_like_codex_auth_failure(message)
         openai_responses = cls._uses_openai_responses_endpoint(message)
-        if auth_failure or openai_responses:
+        if auth_failure:
             details.update(
                 {
                     "failure_category": "codex_auth",
@@ -687,12 +689,13 @@ class CodexCliLLMAdapter:
 
         if item_type == "file_change":
             tool_info = self._format_tool_info("Edit", {"file_path": self._extract_path(item)})
-            self._on_message("tool", tool_info)
+            self._on_message("tool_started" if event_type == "item.started" else "tool", tool_info)
             return
 
         if item_type == "web_search":
-            tool_info = self._format_tool_info("WebSearch", {"query": self._extract_text(item)})
-            self._on_message("tool", tool_info)
+            query = item.get("query") if isinstance(item.get("query"), str) else self._extract_text(item)
+            tool_info = self._format_tool_info("WebSearch", {"query": query})
+            self._on_message("tool_started" if event_type == "item.started" else "tool", tool_info)
 
     async def _iter_stream_lines(
         self,

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -900,6 +900,21 @@ class TestCodexCliLLMAdapter:
         assert context["openai_api_key_present"] is False
         assert "CODEX_HOME/auth.json" in result.error.details["remediation"]
 
+    def test_codex_failure_details_does_not_classify_endpoint_only_errors_as_auth(
+        self,
+    ) -> None:
+        details = CodexCliLLMAdapter._codex_failure_details(
+            returncode=1,
+            session_id="thread_1",
+            stderr="Reading prompt from stdin...",
+            stdout_errors=["429 from https://api.openai.com/v1/responses"],
+            message="429 from https://api.openai.com/v1/responses",
+        )
+
+        assert details["returncode"] == 1
+        assert "failure_category" not in details
+        assert "remediation" not in details
+
     @pytest.mark.asyncio
     async def test_complete_emits_tool_started_callbacks_from_json_events(self) -> None:
         """Chat renderers can show nested tool/MCP progress before completion."""
@@ -955,6 +970,47 @@ class TestCodexCliLLMAdapter:
         assert callback_events == [
             ("tool_started", "mcp__ouroboros__ouroboros_interview: Build a tool"),
             ("tool", "mcp__ouroboros__ouroboros_interview: Build a tool"),
+        ]
+
+    def test_emit_callback_splits_started_file_change_and_web_search_events(self) -> None:
+        callback_events: list[tuple[str, str]] = []
+        adapter = CodexCliLLMAdapter(
+            cli_path="codex",
+            on_message=lambda message_type, content: callback_events.append(
+                (message_type, content)
+            ),
+        )
+
+        adapter._emit_callback_for_event(
+            {
+                "type": "item.started",
+                "item": {"type": "file_change", "path": "src/demo.py"},
+            }
+        )
+        adapter._emit_callback_for_event(
+            {
+                "type": "item.completed",
+                "item": {"type": "file_change", "path": "src/demo.py"},
+            }
+        )
+        adapter._emit_callback_for_event(
+            {
+                "type": "item.started",
+                "item": {"type": "web_search", "query": "codex oauth"},
+            }
+        )
+        adapter._emit_callback_for_event(
+            {
+                "type": "item.completed",
+                "item": {"type": "web_search", "query": "codex oauth"},
+            }
+        )
+
+        assert callback_events == [
+            ("tool_started", "Edit: src/demo.py"),
+            ("tool", "Edit: src/demo.py"),
+            ("tool_started", "WebSearch: codex oauth"),
+            ("tool", "WebSearch: codex oauth"),
         ]
 
     def test_extract_stdout_errors_returns_messages_in_arrival_order(self) -> None:

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -852,7 +852,6 @@ class TestCodexCliLLMAdapter:
         assert result.error.details["stderr"] == "Reading prompt from stdin..."
         assert process_holder["process"].communicate_calls == 1
 
-
     @pytest.mark.asyncio
     async def test_complete_classifies_openai_responses_auth_failures(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/providers/test_codex_cli_adapter.py
+++ b/tests/unit/providers/test_codex_cli_adapter.py
@@ -852,6 +852,112 @@ class TestCodexCliLLMAdapter:
         assert result.error.details["stderr"] == "Reading prompt from stdin..."
         assert process_holder["process"].communicate_calls == 1
 
+
+    @pytest.mark.asyncio
+    async def test_complete_classifies_openai_responses_auth_failures(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nested Codex auth-plane failures should carry actionable diagnostics."""
+        codex_home = tmp_path / "codex-home"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+        (codex_home / "config.toml").write_text('model = "gpt-5.5"\n', encoding="utf-8")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        adapter = CodexCliLLMAdapter(cli_path="codex")
+        auth_error = (
+            "HTTP 400: 401 Unauthorized: Missing bearer or basic authentication "
+            "in header from https://api.openai.com/v1/responses"
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("", encoding="utf-8")
+            return _FakeProcess(
+                stdout=json.dumps({"type": "turn.failed", "error": {"message": auth_error}}),
+                stderr="Reading prompt from stdin...",
+                returncode=1,
+            )
+
+        with patch(
+            "ouroboros.providers.codex_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Ask the next question.")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert result.error.details["failure_category"] == "codex_auth"
+        assert result.error.details["auth_plane"] == "codex_cli"
+        assert result.error.details["openai_responses_endpoint_seen"] is True
+        context = result.error.details["codex_auth_context"]
+        assert context["codex_home"] == str(codex_home)
+        assert context["codex_auth_json_exists"] is True
+        assert context["codex_config_toml_exists"] is True
+        assert context["openai_api_key_present"] is False
+        assert "CODEX_HOME/auth.json" in result.error.details["remediation"]
+
+    @pytest.mark.asyncio
+    async def test_complete_emits_tool_started_callbacks_from_json_events(self) -> None:
+        """Chat renderers can show nested tool/MCP progress before completion."""
+        callback_events: list[tuple[str, str]] = []
+        adapter = CodexCliLLMAdapter(
+            cli_path="codex",
+            on_message=lambda message_type, content: callback_events.append(
+                (message_type, content)
+            ),
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            output_index = command.index("--output-last-message") + 1
+            Path(command[output_index]).write_text("Final answer", encoding="utf-8")
+            return _FakeProcess(
+                stdout="\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "type": "item.started",
+                                "item": {
+                                    "type": "mcp_tool_call",
+                                    "name": "mcp__ouroboros__ouroboros_interview",
+                                    "input": {"initial_context": "Build a tool"},
+                                },
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "type": "item.completed",
+                                "item": {
+                                    "type": "mcp_tool_call",
+                                    "name": "mcp__ouroboros__ouroboros_interview",
+                                    "input": {"initial_context": "Build a tool"},
+                                },
+                            }
+                        ),
+                    ]
+                ),
+                returncode=0,
+            )
+
+        with patch(
+            "ouroboros.providers.codex_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Run interview MCP.")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_ok
+        assert callback_events == [
+            ("tool_started", "mcp__ouroboros__ouroboros_interview: Build a tool"),
+            ("tool", "mcp__ouroboros__ouroboros_interview: Build a tool"),
+        ]
+
     def test_extract_stdout_errors_returns_messages_in_arrival_order(self) -> None:
         """Helper extracts only error/turn.failed events and preserves order."""
         adapter = CodexCliLLMAdapter(cli_path="codex")


### PR DESCRIPTION
## Summary

- classify nested Codex CLI auth failures as `codex_auth` with non-secret auth-plane diagnostics
- include whether the OpenAI Responses endpoint appeared in the failure, whether `CODEX_HOME/auth.json` / `config.toml` exist, and whether `OPENAI_API_KEY` is merely present
- emit a new non-breaking `tool_started` callback for Codex `item.started` tool/MCP events so external chat renderers can show in-flight nested MCP work before completion

## Why

Hermes/Discord deployments can route `ooo interview` correctly into `mcp__ouroboros__ouroboros_interview`, then fail deeper inside the nested Codex LLM call with an opaque `401 Unauthorized: Missing bearer or basic authentication` from `api.openai.com/v1/responses`. That looks like an MCP routing failure to users, but it is really an auth-plane/profile mismatch in the nested Codex process. This PR makes that distinction observable without requiring or exposing an OpenAI API key.

## Risks

- Low runtime risk: only changes failure details and callback emission for started tool events.
- Callback consumers that assume only `thinking`/`tool` kinds should ignore unknown `tool_started`; existing completed `tool` events are preserved.
- This does not itself repair a broken Codex OAuth environment; it makes the failure diagnosable and renderable.

## Validation

- `uv run ruff check src/ouroboros/providers/codex_cli_adapter.py tests/unit/providers/test_codex_cli_adapter.py`
- `uv run pytest tests/unit/providers/test_codex_cli_adapter.py -q`
