### PR TITLE
Teach MCP doctor to verify Codex OAuth readiness

### DIFF
--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -142,6 +142,16 @@ def _get_runtime_backend() -> str:
         return "claude"
 
 
+def _get_llm_backend() -> str:
+    """Return the configured LLM backend, with a safe fallback."""
+    try:
+        from ouroboros.config.loader import get_llm_backend
+
+        return get_llm_backend()
+    except Exception:
+        return "claude_code"
+
+
 def check_claude_agent_sdk_import() -> CheckResult:
     """Check that the ``claude`` extra (claude-agent-sdk) is installed.
 
@@ -202,6 +212,66 @@ def check_litellm_import() -> CheckResult:
             message="litellm not installed (optional)",
             remediation="pip install 'ouroboros-ai[litellm]'  or  uv add 'ouroboros-ai[litellm]'",
         )
+
+
+_CODEX_BACKENDS = frozenset({"codex", "codex_cli"})
+
+
+def _codex_home_from_env() -> Path:
+    """Return the Codex home directory implied by the current environment."""
+    codex_home = os.environ.get("CODEX_HOME", "").strip()
+    if codex_home:
+        return Path(codex_home).expanduser()
+    return Path.home() / ".codex"
+
+
+def _codex_backend_active() -> bool:
+    """Return whether any configured Ouroboros backend relies on Codex auth."""
+    return _get_runtime_backend() in _CODEX_BACKENDS or _get_llm_backend() in _CODEX_BACKENDS
+
+
+def check_codex_oauth_auth() -> CheckResult:
+    """Check Codex OAuth files when Codex is the selected runtime/LLM backend.
+
+    ``ouroboros_interview`` and ``ouroboros_auto`` can launch nested ``codex
+    exec`` calls from MCP server processes.  In Hermes/Discord deployments, an
+    opaque 401 from ``api.openai.com/v1/responses`` often means the nested
+    process did not see the expected Codex OAuth home, not that the user should
+    blindly add an OpenAI API key.
+    """
+    codex_home = _codex_home_from_env()
+    auth_json = codex_home / "auth.json"
+    config_toml = codex_home / "config.toml"
+    openai_key_present = bool(os.environ.get("OPENAI_API_KEY", "").strip())
+    codex_active = _codex_backend_active()
+
+    if auth_json.exists():
+        config_note = "config.toml found" if config_toml.exists() else "config.toml missing"
+        key_note = "OPENAI_API_KEY present" if openai_key_present else "OPENAI_API_KEY not required"
+        return CheckResult(
+            name="codex_oauth_auth",
+            status="pass",
+            message=f"{auth_json} found ({config_note}; {key_note})",
+        )
+
+    if codex_active:
+        return CheckResult(
+            name="codex_oauth_auth",
+            status="fail",
+            message=f"Codex backend active but {auth_json} not found",
+            remediation=(
+                "Run `codex login` for the same user/environment, or set CODEX_HOME/HOME "
+                "so nested MCP/Codex processes can read the existing Codex OAuth auth.json. "
+                "Do not add OPENAI_API_KEY unless you intentionally use an API-key Codex profile."
+            ),
+        )
+
+    return CheckResult(
+        name="codex_oauth_auth",
+        status="warn",
+        message=f"{auth_json} not found (Codex backend not active)",
+        remediation="Required only when runtime_backend or llm.backend is codex.",
+    )
 
 
 def check_event_store() -> CheckResult:
@@ -319,6 +389,7 @@ _ALL_CHECKS = [
     check_mcp_import,
     check_claude_agent_sdk_import,
     check_litellm_import,
+    check_codex_oauth_auth,
     check_event_store,
     check_pid_file,
 ]
@@ -342,7 +413,7 @@ def register_doctor_command(app: typer.Typer) -> None:
         """Run environment diagnostics for the MCP server.
 
         Checks Python version, installed extras (mcp, claude-agent-sdk,
-        litellm), EventStore health, and PID file liveness.  Backend-specific
+        litellm), Codex OAuth readiness, EventStore health, and PID file liveness.  Backend-specific
         extras are validated against the configured runtime so that non-Claude
         setups (codex, opencode) do not produce false failures.  Exit code 1
         if any check fails.
@@ -387,6 +458,7 @@ __all__ = [
     "check_mcp_import",
     "check_claude_agent_sdk_import",
     "check_litellm_import",
+    "check_codex_oauth_auth",
     "check_event_store",
     "check_pid_file",
     "register_doctor_command",

--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -254,6 +254,21 @@ def check_codex_oauth_auth() -> CheckResult:
             message=f"{auth_json} found ({config_note}; {key_note})",
         )
 
+    if codex_active and openai_key_present:
+        return CheckResult(
+            name="codex_oauth_auth",
+            status="pass",
+            message=(
+                f"{auth_json} not found, but OPENAI_API_KEY is present for an "
+                "API-key-backed Codex profile"
+            ),
+            remediation=(
+                "If this deployment is intended to use Codex OAuth instead, run `codex login` "
+                "for the same user/environment or set CODEX_HOME/HOME so nested MCP/Codex "
+                "processes can read the existing auth.json."
+            ),
+        )
+
     if codex_active:
         return CheckResult(
             name="codex_oauth_auth",

--- a/tests/unit/cli/test_mcp_doctor.py
+++ b/tests/unit/cli/test_mcp_doctor.py
@@ -280,9 +280,7 @@ class TestCheckLitellmImport:
 
 
 class TestCheckCodexOauthAuth:
-    def test_passes_when_codex_auth_json_exists_without_openai_key(
-        self, tmp_path, monkeypatch
-    ):
+    def test_passes_when_codex_auth_json_exists_without_openai_key(self, tmp_path, monkeypatch):
         codex_home = tmp_path / "codex-home"
         codex_home.mkdir()
         (codex_home / "auth.json").write_text("{}", encoding="utf-8")

--- a/tests/unit/cli/test_mcp_doctor.py
+++ b/tests/unit/cli/test_mcp_doctor.py
@@ -301,6 +301,7 @@ class TestCheckCodexOauthAuth:
     def test_fails_when_codex_backend_active_without_auth_json(self, tmp_path, monkeypatch):
         codex_home = tmp_path / "codex-home"
         monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
         with (
             patch("ouroboros.cli.commands.mcp_doctor._get_runtime_backend", return_value="hermes"),
@@ -312,6 +313,24 @@ class TestCheckCodexOauthAuth:
         assert "Codex backend active" in result.message
         assert "CODEX_HOME/HOME" in result.remediation
         assert "OPENAI_API_KEY" in result.remediation
+
+    def test_passes_when_codex_backend_uses_openai_api_key_without_auth_json(
+        self, tmp_path, monkeypatch
+    ):
+        codex_home = tmp_path / "codex-home"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        with (
+            patch("ouroboros.cli.commands.mcp_doctor._get_runtime_backend", return_value="hermes"),
+            patch("ouroboros.cli.commands.mcp_doctor._get_llm_backend", return_value="codex"),
+        ):
+            result = check_codex_oauth_auth()
+
+        assert result.status == "pass"
+        assert "OPENAI_API_KEY is present" in result.message
+        assert "API-key-backed Codex profile" in result.message
+        assert "codex login" in result.remediation
 
     def test_warns_when_codex_backend_inactive_without_auth_json(self, tmp_path, monkeypatch):
         codex_home = tmp_path / "codex-home"

--- a/tests/unit/cli/test_mcp_doctor.py
+++ b/tests/unit/cli/test_mcp_doctor.py
@@ -19,6 +19,7 @@ from typer.testing import CliRunner
 from ouroboros.cli.commands.mcp_doctor import (
     CheckResult,
     check_claude_agent_sdk_import,
+    check_codex_oauth_auth,
     check_event_store,
     check_litellm_import,
     check_mcp_import,
@@ -271,6 +272,61 @@ class TestCheckLitellmImport:
         with patch("builtins.__import__", side_effect=_import_error_for("litellm")):
             result = check_litellm_import()
         assert result.status != "fail"
+
+
+# ---------------------------------------------------------------------------
+# check_codex_oauth_auth
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCodexOauthAuth:
+    def test_passes_when_codex_auth_json_exists_without_openai_key(
+        self, tmp_path, monkeypatch
+    ):
+        codex_home = tmp_path / "codex-home"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+        (codex_home / "config.toml").write_text('model = "gpt-5.5"\n', encoding="utf-8")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with (
+            patch("ouroboros.cli.commands.mcp_doctor._get_runtime_backend", return_value="codex"),
+            patch("ouroboros.cli.commands.mcp_doctor._get_llm_backend", return_value="codex"),
+        ):
+            result = check_codex_oauth_auth()
+
+        assert result.status == "pass"
+        assert "auth.json" in result.message
+        assert "OPENAI_API_KEY not required" in result.message
+
+    def test_fails_when_codex_backend_active_without_auth_json(self, tmp_path, monkeypatch):
+        codex_home = tmp_path / "codex-home"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+        with (
+            patch("ouroboros.cli.commands.mcp_doctor._get_runtime_backend", return_value="hermes"),
+            patch("ouroboros.cli.commands.mcp_doctor._get_llm_backend", return_value="codex"),
+        ):
+            result = check_codex_oauth_auth()
+
+        assert result.status == "fail"
+        assert "Codex backend active" in result.message
+        assert "CODEX_HOME/HOME" in result.remediation
+        assert "OPENAI_API_KEY" in result.remediation
+
+    def test_warns_when_codex_backend_inactive_without_auth_json(self, tmp_path, monkeypatch):
+        codex_home = tmp_path / "codex-home"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+        with (
+            patch("ouroboros.cli.commands.mcp_doctor._get_runtime_backend", return_value="claude"),
+            patch("ouroboros.cli.commands.mcp_doctor._get_llm_backend", return_value="claude_code"),
+        ):
+            result = check_codex_oauth_auth()
+
+        assert result.status == "warn"
+        assert "Codex backend not active" in result.message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a backend-aware `codex_oauth_auth` check to `ouroboros mcp doctor`
- pass when Codex OAuth `auth.json` is visible, even without `OPENAI_API_KEY`
- fail when Codex runtime/LLM backend is active but the MCP process cannot see Codex OAuth auth
- warn when Codex is inactive and auth is absent

## Why

Hermes-hosted Ouroboros can run with `runtime_backend=hermes` while keeping `llm.backend=codex` for interview/question generation. In that setup the MCP server may launch nested `codex exec` processes, so `ouroboros mcp doctor` needs to verify Codex OAuth visibility directly instead of treating `OPENAI_API_KEY` as the primary signal.

## Risks

- Low risk: doctor-only diagnostic behavior.
- Environments using a deliberate API-key Codex profile may see stronger guidance to verify OAuth when `llm.backend=codex`; the remediation explicitly notes that API-key profiles are intentional exceptions.
- The check is file-presence based; it does not perform a live Codex request.

## Validation

- `uv run ruff check src/ouroboros/cli/commands/mcp_doctor.py tests/unit/cli/test_mcp_doctor.py`
- `uv run pytest tests/unit/cli/test_mcp_doctor.py -q`
