### PR TITLE
Render started tool events in debug interviews

### DIFF
--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -112,6 +112,10 @@ def _make_message_callback(debug: bool):
             display = first_line[:100] + "..." if len(first_line) > 100 else first_line
             if display:
                 console.print(f"  [dim]💭 {display}[/dim]")
+        elif msg_type == "tool_started":
+            # External chat renderers and debug terminals can show tool/MCP progress
+            # before completion when providers stream start events.
+            console.print(f"  [cyan]▶ {content}[/cyan]")
         elif msg_type == "tool":
             # Tool info now includes details like "Read: /path/to/file"
             console.print(f"  [yellow]🔧 {content}[/yellow]")

--- a/src/ouroboros/cli/commands/pm.py
+++ b/src/ouroboros/cli/commands/pm.py
@@ -385,6 +385,8 @@ def _make_message_callback(debug: bool):
             display = first_line[:100] + "..." if len(first_line) > 100 else first_line
             if display:
                 console.print(f"  [dim]thinking:[/] {display}")
+        elif msg_type == "tool_started":
+            console.print(f"  [cyan]tool started:[/] {content}")
         elif msg_type == "tool":
             console.print(f"  [yellow]tool:[/] {content}")
 

--- a/tests/unit/cli/test_debug_tool_started_callbacks.py
+++ b/tests/unit/cli/test_debug_tool_started_callbacks.py
@@ -1,0 +1,36 @@
+"""Tests for CLI debug rendering of provider tool-start callbacks."""
+
+from __future__ import annotations
+
+from ouroboros.cli.commands import init as init_command
+from ouroboros.cli.commands import pm as pm_command
+
+
+class _FakeConsole:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def print(self, message: str) -> None:
+        self.messages.append(message)
+
+
+def test_init_debug_callback_renders_tool_started(monkeypatch) -> None:
+    console = _FakeConsole()
+    monkeypatch.setattr(init_command, "console", console)
+
+    callback = init_command._make_message_callback(debug=True)
+    assert callback is not None
+    callback("tool_started", "mcp__ouroboros__ouroboros_interview")
+
+    assert console.messages == ["  [cyan]▶ mcp__ouroboros__ouroboros_interview[/cyan]"]
+
+
+def test_pm_debug_callback_renders_tool_started(monkeypatch) -> None:
+    console = _FakeConsole()
+    monkeypatch.setattr(pm_command, "console", console)
+
+    callback = pm_command._make_message_callback(debug=True)
+    assert callback is not None
+    callback("tool_started", "mcp__ouroboros__ouroboros_pm")
+
+    assert console.messages == ["  [cyan]tool started:[/] mcp__ouroboros__ouroboros_pm"]


### PR DESCRIPTION
## Summary

- render `tool_started` provider callbacks in `ouroboros init start --debug`
- render `tool_started` provider callbacks in PM interview debug output
- add focused tests for both debug callback surfaces

## Why

External chat and terminal debug renderers need to show when nested MCP/tool work starts, not only when completed output arrives. This small UI slice prepares the CLI interview surfaces to consume the started-tool events emitted by Codex providers without changing completed-tool rendering.

## Risks

- Low risk: only affects debug output when callbacks emit the new `tool_started` kind.
- Depends on providers emitting `tool_started` for users to see new lines; otherwise behavior is unchanged.

## Validation

- `uv run ruff check src/ouroboros/cli/commands/init.py src/ouroboros/cli/commands/pm.py tests/unit/cli/test_debug_tool_started_callbacks.py`
- `uv run pytest tests/unit/cli/test_debug_tool_started_callbacks.py -q`
