### PR TITLE
fix(install): align uv [all] extras with pyproject contract

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -331,16 +331,34 @@ if [ "$HAS_UV" = true ]; then
   if [ -n "$PRE_FLAG" ]; then
     UV_ARGS+=(--prerelease=allow)
   fi
-  # Map extras to explicit --with flags for uv
+  # Map extras to explicit --with flags for uv.
+  # NOTE: Pin specs MUST mirror [project.optional-dependencies] in
+  # pyproject.toml. tests/unit/scripts/test_install_runtime_selection.py
+  # asserts the `[all]` set covers every declared extra so silent drift
+  # (e.g. forgetting `tui` / `dashboard`) is caught in CI rather than
+  # discovered by a user with a half-installed `[all]` tree.
   case "$EXTRAS" in
     "[mcp,claude]")
-      UV_ARGS+=(--with "mcp>=1.26.0,<2.0.0" --with "claude-agent-sdk>=0.1.0" --with "anthropic>=0.52.0")
+      UV_ARGS+=(
+        --with "mcp>=1.26.0,<2.0.0"
+        --with "claude-agent-sdk>=0.1.0,<1.0.0"
+        --with "anthropic>=0.52.0,<1.0.0"
+      )
       ;;
     "[mcp]")
       UV_ARGS+=(--with "mcp>=1.26.0,<2.0.0")
       ;;
     "[all]")
-      UV_ARGS+=(--with "mcp>=1.26.0,<2.0.0" --with "claude-agent-sdk>=0.1.0" --with "anthropic>=0.52.0" --with "litellm>=1.80.0,<=1.82.6")
+      UV_ARGS+=(
+        --with "mcp>=1.26.0,<2.0.0"
+        --with "claude-agent-sdk>=0.1.0,<1.0.0"
+        --with "anthropic>=0.52.0,<1.0.0"
+        --with "litellm>=1.80.0,<=1.82.6"
+        --with "textual>=1.0.0,<9.0.0"
+        --with "streamlit>=1.40.0,<2.0.0"
+        --with "plotly>=5.24.0,<7.0.0"
+        --with "pandas>=2.2.0,<3.0.0"
+      )
       ;;
   esac
   uv "${UV_ARGS[@]}"

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -105,7 +105,79 @@ def test_explicit_claude_installs_mcp_and_claude_extras(tmp_path: Path) -> None:
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
     assert "Runtime: claude (from --runtime / OUROBOROS_INSTALL_RUNTIME)" in result.stdout
     assert (
-        "uv tool install --upgrade --python >=3.12 . --prerelease=allow --with mcp>=1.26.0,<2.0.0 --with claude-agent-sdk>=0.1.0 --with anthropic>=0.52.0"
+        "uv tool install --upgrade --python >=3.12 . --prerelease=allow --with mcp>=1.26.0,<2.0.0 --with claude-agent-sdk>=0.1.0,<1.0.0 --with anthropic>=0.52.0,<1.0.0"
         in calls
     )
     assert "ouroboros setup --runtime claude --non-interactive" in calls
+
+
+# ---------------------------------------------------------------------------
+# pyproject ↔ install.sh `[all]` extras parity
+# ---------------------------------------------------------------------------
+#
+# Maps every [project.optional-dependencies] extra to the package names that
+# the installer's `[all]` --with list MUST cover under uv. Update both this
+# table and install.sh whenever pyproject extras change. The mapping is
+# explicit (rather than parsed from pyproject) so a wrong rename or removal
+# fails loudly here instead of silently desyncing.
+_EXTRA_TO_PACKAGES: dict[str, tuple[str, ...]] = {
+    "claude": ("claude-agent-sdk", "anthropic"),
+    "copilot": (),  # pyproject declares copilot extras as []; nothing to install
+    "litellm": ("litellm",),
+    "dashboard": ("streamlit", "plotly", "pandas"),
+    "mcp": ("mcp",),
+    "tui": ("textual",),
+}
+
+
+def _read_pyproject_extras() -> dict[str, list[str]]:
+    """Parse [project.optional-dependencies] from pyproject.toml."""
+    try:
+        import tomllib  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # pragma: no cover — Python <3.11 fallback
+        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+    pyproject = REPO_ROOT / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    return data["project"]["optional-dependencies"]
+
+
+def test_install_all_extras_match_pyproject(tmp_path: Path) -> None:
+    """`[all]` under uv must install every extra that pyproject declares.
+
+    Catches the contract drift flagged by ouroboros-agent on PR #654:
+    install.sh's hand-maintained --with list silently dropped tui and
+    dashboard packages, so users picking 'All' got an incomplete tree.
+    """
+    extras = _read_pyproject_extras()
+    # `all` is a single self-referential entry, e.g.
+    # ``["ouroboros-ai[claude,copilot,litellm,mcp,tui,dashboard]"]``. Pull the
+    # bracketed names back out so we can compare against our mapping.
+    import re
+
+    declared_in_all: set[str] = set()
+    for entry in extras.get("all", []):
+        match = re.search(r"\[([^\]]+)\]", entry)
+        if match:
+            declared_in_all.update(name.strip() for name in match.group(1).split(","))
+
+    expected_extras = set(_EXTRA_TO_PACKAGES.keys())
+
+    # Sanity: pyproject's `all` aggregates every extra we know about.
+    assert declared_in_all == expected_extras, (
+        "pyproject [all] no longer matches the test mapping — update "
+        "_EXTRA_TO_PACKAGES and install.sh together."
+    )
+
+    result = _run_installer(tmp_path, env={"OUROBOROS_INSTALL_RUNTIME": "all"})
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
+
+    expected_packages = {pkg for pkgs in _EXTRA_TO_PACKAGES.values() for pkg in pkgs}
+    missing = sorted(pkg for pkg in expected_packages if f"--with {pkg}" not in calls)
+    assert not missing, (
+        f"install.sh `[all]` is missing --with entries for: {missing}.\n"
+        "Update the case statement in scripts/install.sh to mirror the "
+        "pyproject extras."
+    )


### PR DESCRIPTION
## Summary
Follow-up to #654. ouroboros-agent flagged a non-blocking finding: install.sh's hand-maintained `uv --with` list for `[all]` silently dropped `tui` (textual) and `dashboard` (streamlit / plotly / pandas) extras that `pyproject.toml` aggregates under `all`. Users selecting "All" under `uv` got an incomplete tree — TUI and dashboard surfaces would fail at import.

## What changed

**`scripts/install.sh`**
- Added `tui` and `dashboard` packages to the `[all]` `--with` block.
- Tightened `claude-agent-sdk` and `anthropic` upper bounds to `<1.0.0` to match pyproject pins.
- Added a comment over the case statement pointing at the new regression test.

**`tests/unit/scripts/test_install_runtime_selection.py`**
- Added `test_install_all_extras_match_pyproject`: parses pyproject's `project.optional-dependencies`, expands the self-referential `all = ["ouroboros-ai[…]"]` entry, runs install.sh with `OUROBOROS_INSTALL_RUNTIME=all`, and asserts every declared extra's package appears in the captured `--with` list. Also asserts the test's `_EXTRA_TO_PACKAGES` mapping matches pyproject so future renames/additions fail loudly here instead of silently drifting.

## Why this matters
Two-source-of-truth between `install.sh` and `pyproject.toml` was the root cause. The new test pins them together — drift becomes a CI failure rather than a silent half-install discovered by users.

## Test plan
- [x] `uv run pytest tests/unit/scripts/test_install_runtime_selection.py` — 4 passed (was 3, +1 new)
- [x] `uv run pytest tests/unit/cli` — 667 passed
- [x] `bash -n scripts/install.sh` — syntax OK
- [x] `uv run ruff check / format --check / mypy` on the touched Python file — clean

## Reference
- ouroboros-agent review on #654: https://github.com/Q00/ouroboros/pull/654#pullrequestreview (warning at `scripts/install.sh:342`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)