### PR TITLE
test(install): enforce version-pin parity between install.sh and pyproject

### DIFF
--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -181,3 +181,41 @@ def test_install_all_extras_match_pyproject(tmp_path: Path) -> None:
         "Update the case statement in scripts/install.sh to mirror the "
         "pyproject extras."
     )
+
+
+def test_install_all_extras_match_pyproject_pins(tmp_path: Path) -> None:
+    """`[all]` under uv must mirror pyproject's full version specifiers, not
+    just the package names.
+
+    Bot follow-up on PR #660: the package-name check was insufficient — a
+    silent change to a pin range (e.g. relaxing ``<1.0.0`` to ``<2.0.0`` in
+    pyproject without updating install.sh, or vice versa) would have slipped
+    past the existing test. Each pyproject pin string is checked verbatim
+    against the captured ``--with`` arguments so any drift fails here.
+    """
+    extras = _read_pyproject_extras()
+
+    # Collect every dependency string declared by an extra we install via uv
+    # --with (the ``copilot`` extra has no Python deps, so nothing to pin).
+    expected_pins: list[str] = []
+    for extra_name in _EXTRA_TO_PACKAGES:
+        for dep in extras.get(extra_name, []):
+            stripped = dep.strip()
+            if stripped:
+                expected_pins.append(stripped)
+
+    # Sanity: pyproject must declare at least one pin we expect to enforce.
+    # If this fails the parsing is broken or the extras went empty.
+    assert expected_pins, "no pyproject pins discovered — parity check inert"
+
+    result = _run_installer(tmp_path, env={"OUROBOROS_INSTALL_RUNTIME": "all"})
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
+
+    drifted = sorted(pin for pin in expected_pins if f"--with {pin}" not in calls)
+    assert not drifted, (
+        "install.sh `[all]` --with list has drifted from pyproject pins.\n"
+        f"Missing or mismatched: {drifted}\n"
+        "Update the case statement in scripts/install.sh so each "
+        "`--with <spec>` string matches pyproject [project.optional-dependencies]."
+    )


### PR DESCRIPTION
## Summary
Follow-up to PR #660. ouroboros-agent's review left a non-blocking finding: the new parity test only verified that each extra's **package name** appeared in the `uv ... --with` call, not that the **version specifier** matched pyproject. A silent change to a pin range on either side would slip past.

This PR adds `test_install_all_extras_match_pyproject_pins` that pulls every declared dependency string verbatim from `[project.optional-dependencies]` and asserts each `pkg>=A,<B` spec appears as `--with pkg>=A,<B` in the captured installer calls.

## Branch base
Stacked on top of `fix/install-all-extras-contract` (PR #660). Targets `main` so it auto-rebases cleanly once #660 merges.

## Verification of the test itself
Temporarily relaxed install.sh's `textual>=1.0.0,<9.0.0` to `textual>=1.0.0` and ran the new test:

```
AssertionError: install.sh `[all]` --with list has drifted from pyproject pins.
Missing or mismatched: ['textual>=1.0.0,<9.0.0']
```

The assertion fires with a clear, actionable message — exactly the drift the bot flagged.

## Test plan
- [x] `uv run pytest tests/unit/scripts/test_install_runtime_selection.py` — 5 passed (4 existing + 1 new)
- [x] `uv run ruff check / format --check / mypy` — clean
- [x] Manual drift simulation (above) — test fails as designed

## Reference
- Bot review on #660: https://github.com/Q00/ouroboros/pull/660#pullrequestreview-4235688213

🤖 Generated with [Claude Code](https://claude.com/claude-code)