### PR TITLE
fix(welcome): preserve prefs across onboarding upgrades

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -157,13 +157,22 @@ def is_mcp_configured() -> bool:
 
 
 def is_first_time() -> bool:
-    """Check if this is the user's first interaction (welcome not yet completed)."""
+    """Check if this is the user's first interaction.
+
+    Older onboarding flows wrote ``welcomeShown`` or other preference keys without
+    ``welcomeCompleted``. Treat any valid existing prefs as a non-first-run state
+    so upgrades do not repeatedly auto-trigger the welcome experience.
+    """
     try:
         prefs_path = Path.home() / ".ouroboros" / "prefs.json"
         if not prefs_path.exists():
             return True
         prefs = json.loads(prefs_path.read_text())
-        return not prefs.get("welcomeCompleted", False)
+        if not isinstance(prefs, dict):
+            return True
+        if prefs.get("welcomeCompleted") or prefs.get("welcomeShown"):
+            return False
+        return not bool(prefs)
     except Exception:
         return True
 

--- a/skills/seed/SKILL.md
+++ b/skills/seed/SKILL.md
@@ -135,11 +135,30 @@ Then check `~/.ouroboros/prefs.json` for `star_asked`. If `star_asked` is not se
 }
 ```
 
-- **Star & Setup**: Run `gh api -X PUT /user/starred/Q00/ouroboros`, save `{"star_asked": true}` to `~/.ouroboros/prefs.json`, then read and execute `skills/setup/SKILL.md`
-- **Just Setup**: Save `{"star_asked": true}` to `~/.ouroboros/prefs.json`, then read and execute `skills/setup/SKILL.md`
-- **Other** (user provides custom text): Save `{"star_asked": true}`, skip setup
+- **Star & Setup**: Run `gh api -X PUT /user/starred/Q00/ouroboros`, merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`, then read and execute `skills/setup/SKILL.md`
+- **Just Setup**: Merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`, then read and execute `skills/setup/SKILL.md`
+- **Other** (user provides custom text): Merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`, skip setup
 
-Create `~/.ouroboros/` directory if it doesn't exist.
+Create `~/.ouroboros/` directory if it doesn't exist. Preserve existing keys such as `welcomeShown`, `welcomeCompleted`, and `welcomeVersion` when updating `star_asked`:
+
+```bash
+python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs['star_asked'] = True
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+```
 
 If `star_asked` is already `true`, skip the question and just announce:
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -85,11 +85,30 @@ Before we begin, check `~/.ouroboros/prefs.json` for `star_asked`. If not `true`
 }
 ```
 
-- **Star on GitHub**: Run `gh api -X PUT /user/starred/Q00/ouroboros`, save `{"star_asked": true}` to `~/.ouroboros/prefs.json`
-- **Skip for now**: Save `{"star_asked": true}` to `~/.ouroboros/prefs.json`
-- **Other**: Save `{"star_asked": true}`
+- **Star on GitHub**: Run `gh api -X PUT /user/starred/Q00/ouroboros`, then merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`
+- **Skip for now**: Merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`
+- **Other**: Merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`
 
-Create `~/.ouroboros/` directory if it doesn't exist.
+Create `~/.ouroboros/` directory if it doesn't exist. Preserve any existing keys such as `welcomeShown`, `welcomeCompleted`, and `welcomeVersion` when updating `star_asked`:
+
+```bash
+python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs['star_asked'] = True
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+```
 
 If `star_asked` is already `true`, skip this step silently.
 

--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -23,14 +23,32 @@ When this skill is invoked, follow this flow:
 
 ### Pre-Check: Already Completed?
 
-First, check `~/.ouroboros/prefs.json` for `welcomeCompleted`:
+First, check `~/.ouroboros/prefs.json` for `welcomeCompleted`. For upgrades from older releases, also treat legacy `welcomeShown: true` as completed so the welcome prompt does not reappear forever:
 
 ```bash
 PREFFILE="$HOME/.ouroboros/prefs.json"
 
 if [ -f "$PREFFILE" ]; then
-  WELCOME_COMPLETED=$(jq -r '.welcomeCompleted // empty' "$PREFFILE" 2>/dev/null)
-  WELCOME_VERSION=$(jq -r '.welcomeVersion // empty' "$PREFFILE" 2>/dev/null)
+  WELCOME_COMPLETED=$(python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+try:
+    prefs = json.load(open(path, encoding='utf-8'))
+except Exception:
+    prefs = {}
+print(prefs.get('welcomeCompleted') or ('legacy-welcomeShown' if prefs.get('welcomeShown') else ''))
+PY
+)
+  WELCOME_VERSION=$(python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+try:
+    prefs = json.load(open(path, encoding='utf-8'))
+except Exception:
+    prefs = {}
+print(prefs.get('welcomeVersion') or '')
+PY
+)
 
   if [ -n "$WELCOME_COMPLETED" ] && [ "$WELCOME_COMPLETED" != "null" ]; then
     ALREADY_COMPLETED="true"
@@ -58,7 +76,30 @@ Use **AskUserQuestion**:
 - **Re-run welcome**: Continue to Step 1 below
 
 **If `--skip` flag present:**
-- Mark `welcomeShown: true` (if not exists)
+- Merge `welcomeShown: true`, `welcomeCompleted: <current timestamp>`, and `welcomeVersion` into `~/.ouroboros/prefs.json` without deleting existing keys:
+  ```bash
+python3 - <<'PY'
+import json, os
+from datetime import UTC, datetime
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs.update({
+    'welcomeShown': True,
+    'welcomeCompleted': datetime.now(UTC).isoformat(),
+    'welcomeVersion': '0.14.0',
+})
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+  ```
 - Show brief message:
   ```
   Ouroboros welcome skipped.

--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -36,6 +36,8 @@ try:
     prefs = json.load(open(path, encoding='utf-8'))
 except Exception:
     prefs = {}
+if not isinstance(prefs, dict):
+    prefs = {}
 print(prefs.get('welcomeCompleted') or ('legacy-welcomeShown' if prefs.get('welcomeShown') else ''))
 PY
 )
@@ -45,6 +47,8 @@ path = os.path.expanduser('~/.ouroboros/prefs.json')
 try:
     prefs = json.load(open(path, encoding='utf-8'))
 except Exception:
+    prefs = {}
+if not isinstance(prefs, dict):
     prefs = {}
 print(prefs.get('welcomeVersion') or '')
 PY
@@ -254,10 +258,57 @@ gh auth status &>/dev/null && echo "GH_OK" || echo "GH_MISSING"
 ```
 
 - **Star on GitHub**: `gh api -X PUT /user/starred/Q00/ouroboros`
-- Both: Save `{"star_asked": true, "welcomeShown": true, "welcomeCompleted": "$(date -Iseconds)", "welcomeVersion": "0.14.0"}` to `~/.ouroboros/prefs.json`
+- Both choices: merge the welcome completion fields into `~/.ouroboros/prefs.json` without deleting existing keys. Set `star_asked: true` after either star prompt choice so the star prompt is not repeated:
+  ```bash
+python3 - <<'PY'
+import json, os
+from datetime import UTC, datetime
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs.update({
+    'star_asked': True,
+    'welcomeShown': True,
+    'welcomeCompleted': datetime.now(UTC).isoformat(),
+    'welcomeVersion': '0.14.0',
+})
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+  ```
 
 **If `GH_MISSING` or `star_asked` is true:**
-Just save `{"welcomeShown": true, "welcomeCompleted": "$(date -Iseconds)", "welcomeVersion": "0.14.0"}`
+Merge the welcome completion fields into `~/.ouroboros/prefs.json` without deleting existing keys:
+  ```bash
+python3 - <<'PY'
+import json, os
+from datetime import UTC, datetime
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs.update({
+    'welcomeShown': True,
+    'welcomeCompleted': datetime.now(UTC).isoformat(),
+    'welcomeVersion': '0.14.0',
+})
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+  ```
 
 ---
 

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -13,6 +13,38 @@ _spec.loader.exec_module(_mod)
 detect_keywords = _mod.detect_keywords
 SETUP_BYPASS_SKILLS = _mod.SETUP_BYPASS_SKILLS
 main = _mod.main
+is_first_time = _mod.is_first_time
+
+
+class TestFirstTimePrefs:
+    def test_missing_prefs_file_is_first_time(self, tmp_path):
+        home = tmp_path
+        with patch.object(_mod.Path, "home", return_value=home):
+            assert is_first_time() is True
+
+    def test_welcome_completed_marks_not_first_time(self, tmp_path):
+        prefs_dir = tmp_path / ".ouroboros"
+        prefs_dir.mkdir()
+        (prefs_dir / "prefs.json").write_text('{"welcomeCompleted": "2026-05-06T00:00:00Z"}')
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_first_time() is False
+
+    def test_legacy_welcome_shown_marks_not_first_time(self, tmp_path):
+        prefs_dir = tmp_path / ".ouroboros"
+        prefs_dir.mkdir()
+        (prefs_dir / "prefs.json").write_text('{"welcomeShown": true}')
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_first_time() is False
+
+    def test_existing_star_prompt_pref_marks_not_first_time(self, tmp_path):
+        prefs_dir = tmp_path / ".ouroboros"
+        prefs_dir.mkdir()
+        (prefs_dir / "prefs.json").write_text('{"star_asked": true}')
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_first_time() is False
 
 
 class TestDetectKeywords:


### PR DESCRIPTION
## Summary
- Treat legacy `welcomeShown` and any existing valid prefs as non-first-run state so upgraded users do not get the welcome prompt repeatedly.
- Add regression coverage for missing, completed, legacy, and existing `star_asked` prefs.
- Update welcome/setup/seed skill instructions to merge preference updates instead of overwriting `~/.ouroboros/prefs.json`.

## Discussion / implementation notes
This is a narrow fix for #659. The runtime hook now preserves the first-run experience for users with no prefs file or an empty prefs object, while avoiding repeated welcome prompts for users who already have preferences written by older onboarding/star flows.

## Validation
- `uv run pytest tests/unit/scripts/test_keyword_detector.py -q` → 18 passed
- `uv run ruff check scripts/keyword-detector.py tests/unit/scripts/test_keyword_detector.py` → passed
- `uv run ruff format --check scripts/keyword-detector.py tests/unit/scripts/test_keyword_detector.py` → passed
- checked welcome/setup/seed skill docs for legacy destructive prefs instructions

Closes #659
