### PR TITLE
test(watchdog): make parent cancellation assertion deterministic

### DIFF
--- a/src/ouroboros/evolution/watchdog.py
+++ b/src/ouroboros/evolution/watchdog.py
@@ -105,9 +105,9 @@ class GenerationProgressWatchdog:
 
     async def watch[T](self, awaitable: Awaitable[T]) -> T:
         """Run *awaitable* until it finishes or watchdog policy cancels it."""
-        await self.initialize_baseline()
         task: asyncio.Task[T] = asyncio.create_task(awaitable)
         try:
+            await self.initialize_baseline()
             while True:
                 done, _ = await asyncio.wait(
                     {task},

--- a/src/ouroboros/evolution/watchdog.py
+++ b/src/ouroboros/evolution/watchdog.py
@@ -105,9 +105,9 @@ class GenerationProgressWatchdog:
 
     async def watch[T](self, awaitable: Awaitable[T]) -> T:
         """Run *awaitable* until it finishes or watchdog policy cancels it."""
+        await self.initialize_baseline()
         task: asyncio.Task[T] = asyncio.create_task(awaitable)
         try:
-            await self.initialize_baseline()
             while True:
                 done, _ = await asyncio.wait(
                     {task},

--- a/tests/unit/evolution/test_generation_watchdog.py
+++ b/tests/unit/evolution/test_generation_watchdog.py
@@ -461,8 +461,14 @@ async def test_parent_cancellation_cancels_watched_generation() -> None:
             child_cancelled.set()
             raise
 
-    parent = asyncio.create_task(watchdog.watch(long_work()))
-    await asyncio.sleep(0.05)
+    child_started = asyncio.Event()
+
+    async def tracked_long_work() -> str:
+        child_started.set()
+        return await long_work()
+
+    parent = asyncio.create_task(watchdog.watch(tracked_long_work()))
+    await asyncio.wait_for(child_started.wait(), timeout=1)
     parent.cancel()
 
     with pytest.raises(asyncio.CancelledError):


### PR DESCRIPTION
## Summary
- Preserve the watchdog invariant that the EventStore baseline is initialized before the watched generation starts.
- Replace the sleep-based parent-cancellation test with an explicit child-start synchronization point so cancellation is asserted only after the generation task exists.

## Review response
- Addresses the bot review on commit edbaf7b: the production change that created the watched task before baseline initialization has been reverted, avoiding the startup cursor race that could hide first progress events.

## Validation
- uv run pytest tests/unit/evolution/test_generation_watchdog.py -q
- uv run pytest tests/unit/evolution/test_generation_watchdog.py tests/unit/scripts/test_keyword_detector.py -q
- uv run ruff check src/ouroboros/evolution/watchdog.py tests/unit/evolution/test_generation_watchdog.py scripts/keyword-detector.py tests/unit/scripts/test_keyword_detector.py

Refs #578