### PR TITLE
feat(auto): feed repo facts into interview answers

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -8,9 +8,16 @@ from dataclasses import dataclass, field
 import re
 from typing import Protocol
 
-from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource, AutoBlocker
+from ouroboros.auto.answerer import (
+    AutoAnswer,
+    AutoAnswerContext,
+    AutoAnswerer,
+    AutoAnswerSource,
+    AutoBlocker,
+)
 from ouroboros.auto.gap_detector import Gap, GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
+from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 
 
@@ -58,6 +65,7 @@ class AutoInterviewDriver:
 
     backend: InterviewBackend
     answerer: AutoAnswerer = field(default_factory=AutoAnswerer)
+    context_provider: Callable[[str], AutoAnswerContext] = repo_auto_answer_context
     gap_detector: GapDetector = field(default_factory=GapDetector)
     store: AutoStore | None = None
     timeout_seconds: float = 60.0
@@ -66,6 +74,7 @@ class AutoInterviewDriver:
     async def run(self, state: AutoPipelineState, ledger: SeedDraftLedger) -> AutoInterviewResult:
         """Run bounded auto interview until Seed-ready or blocked."""
         self._ensure_interview_phase(state)
+        answer_context = self.context_provider(state.cwd)
         interview_tool_name = "interview.start"
         try:
             if state.interview_session_id:
@@ -118,7 +127,7 @@ class AutoInterviewDriver:
             state.mark_progress(f"interview round {round_number}/{self.max_rounds}")
             self._save(state)
 
-            answer = self._answer_with_gap_steering(turn.question, ledger)
+            answer = self._answer_with_gap_steering(turn.question, ledger, answer_context)
             if answer.blocker is not None:
                 self.answerer.apply(answer, ledger, question=turn.question)
                 state.ledger = ledger.to_dict()
@@ -184,8 +193,10 @@ class AutoInterviewDriver:
             "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
         )
 
-    def _answer_with_gap_steering(self, question: str, ledger: SeedDraftLedger) -> AutoAnswer:
-        answer = self.answerer.answer(question, ledger)
+    def _answer_with_gap_steering(
+        self, question: str, ledger: SeedDraftLedger, context: AutoAnswerContext
+    ) -> AutoAnswer:
+        answer = self.answerer.answer(question, ledger, context)
         if answer.blocker is not None:
             return answer
         gaps = self.gap_detector.detect(ledger)
@@ -208,7 +219,7 @@ class AutoInterviewDriver:
                 confidence=1.0,
                 blocker=blocker,
             )
-        return self.answerer.answer(_gap_prompt(next_gap), ledger)
+        return self.answerer.answer(_gap_prompt(next_gap), ledger, context)
 
     def _handle_completed_turn(
         self, state: AutoPipelineState, ledger: SeedDraftLedger, turn: InterviewTurn, rounds: int

--- a/src/ouroboros/auto/repo_context.py
+++ b/src/ouroboros/auto/repo_context.py
@@ -1,0 +1,141 @@
+"""Bounded repository context for deterministic auto interview answers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+from typing import Any
+
+from ouroboros.auto.answerer import AutoAnswerContext
+
+_FRAMEWORK_DEPENDENCIES = {
+    "click": "Click CLI",
+    "django": "Django",
+    "fastapi": "FastAPI",
+    "flask": "Flask",
+    "streamlit": "Streamlit",
+    "textual": "Textual TUI",
+    "typer": "Typer CLI",
+}
+
+
+def repo_auto_answer_context(cwd: str | Path) -> AutoAnswerContext:
+    """Derive minimal local repo facts from fixed, bounded paths under ``cwd``."""
+    root = Path(cwd)
+    pyproject = root / "pyproject.toml"
+    if not pyproject.is_file():
+        return AutoAnswerContext()
+
+    pyproject_data = _read_pyproject(pyproject)
+    if not pyproject_data:
+        return AutoAnswerContext()
+
+    project = _table(pyproject_data.get("project"))
+    facts: dict[str, str] = {}
+    evidence: dict[str, tuple[str, ...]] = {}
+    runtime_parts: list[str] = []
+    runtime_evidence = ["pyproject.toml"]
+
+    requires_python = _clean_str(project.get("requires-python"))
+    if requires_python:
+        runtime_parts.append(f"Python project requiring {requires_python}")
+    elif project:
+        runtime_parts.append("Python project declared in pyproject.toml")
+
+    package_manager = _package_manager(root, pyproject_data)
+    if package_manager:
+        facts["package_manager"] = package_manager
+        evidence["package_manager"] = ("pyproject.toml",)
+        runtime_parts.append(f"managed with {package_manager}")
+
+    framework = _framework(project)
+    if framework:
+        facts["framework"] = framework
+        evidence["framework"] = ("pyproject.toml",)
+        runtime_parts.append(f"using {framework}")
+
+    structure = _project_structure(root)
+    if structure:
+        facts["project_structure"] = structure
+        structure_evidence = tuple(_structure_evidence(root))
+        evidence["project_structure"] = structure_evidence
+        runtime_parts.append(structure)
+        runtime_evidence.extend(structure_evidence)
+
+    if runtime_parts:
+        facts["runtime_context"] = "; ".join(runtime_parts) + "."
+        evidence["runtime_context"] = tuple(dict.fromkeys(runtime_evidence))
+
+    return AutoAnswerContext(repo_facts=facts, evidence=evidence)
+
+
+def _read_pyproject(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as stream:
+            data = tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _table(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _clean_str(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _package_manager(root: Path, pyproject_data: dict[str, Any]) -> str:
+    if (root / "uv.lock").is_file():
+        return "uv"
+    if (root / "poetry.lock").is_file():
+        return "Poetry"
+    if (root / "pdm.lock").is_file():
+        return "PDM"
+    build_system = _table(pyproject_data.get("build-system"))
+    backend = _clean_str(build_system.get("build-backend"))
+    if "hatchling" in backend:
+        return "hatchling/pyproject"
+    if backend:
+        return f"{backend}/pyproject"
+    return "pyproject.toml"
+
+
+def _framework(project: dict[str, Any]) -> str:
+    dependencies = project.get("dependencies")
+    if not isinstance(dependencies, list):
+        return ""
+    normalized = {_dependency_name(item) for item in dependencies if isinstance(item, str)}
+    frameworks = [
+        framework for dependency, framework in _FRAMEWORK_DEPENDENCIES.items() if dependency in normalized
+    ]
+    return ", ".join(frameworks)
+
+
+def _dependency_name(requirement: str) -> str:
+    name = requirement.strip().split("[", 1)[0]
+    for separator in ("<", ">", "=", "!", "~", ";", " "):
+        name = name.split(separator, 1)[0]
+    return name.lower().replace("_", "-")
+
+
+def _project_structure(root: Path) -> str:
+    has_src = (root / "src").is_dir()
+    has_tests = (root / "tests").is_dir()
+    if has_src and has_tests:
+        return "src layout with tests directory"
+    if has_src:
+        return "src layout"
+    if has_tests:
+        return "tests directory present"
+    return ""
+
+
+def _structure_evidence(root: Path) -> list[str]:
+    evidence: list[str] = []
+    if (root / "src").is_dir():
+        evidence.append("src/")
+    if (root / "tests").is_dir():
+        evidence.append("tests/")
+    return evidence

--- a/src/ouroboros/auto/repo_context.py
+++ b/src/ouroboros/auto/repo_context.py
@@ -108,7 +108,9 @@ def _framework(project: dict[str, Any]) -> str:
         return ""
     normalized = {_dependency_name(item) for item in dependencies if isinstance(item, str)}
     frameworks = [
-        framework for dependency, framework in _FRAMEWORK_DEPENDENCIES.items() if dependency in normalized
+        framework
+        for dependency, framework in _FRAMEWORK_DEPENDENCIES.items()
+        if dependency in normalized
     ]
     return ", ".join(frameworks)
 

--- a/src/ouroboros/auto/repo_context.py
+++ b/src/ouroboros/auto/repo_context.py
@@ -35,12 +35,15 @@ def repo_auto_answer_context(cwd: str | Path) -> AutoAnswerContext:
     evidence: dict[str, tuple[str, ...]] = {}
     runtime_parts: list[str] = []
     runtime_evidence = ["pyproject.toml"]
+    strong_runtime_fact = False
 
     requires_python = _clean_str(project.get("requires-python"))
     if requires_python:
         runtime_parts.append(f"Python project requiring {requires_python}")
+        strong_runtime_fact = True
     elif project:
-        runtime_parts.append("Python project declared in pyproject.toml")
+        facts["project_kind"] = "Python project declared in pyproject.toml"
+        evidence["project_kind"] = ("pyproject.toml",)
 
     package_manager = _package_manager(root, pyproject_data)
     if package_manager:
@@ -53,6 +56,7 @@ def repo_auto_answer_context(cwd: str | Path) -> AutoAnswerContext:
         facts["framework"] = framework
         evidence["framework"] = ("pyproject.toml",)
         runtime_parts.append(f"using {framework}")
+        strong_runtime_fact = True
 
     structure = _project_structure(root)
     if structure:
@@ -62,7 +66,7 @@ def repo_auto_answer_context(cwd: str | Path) -> AutoAnswerContext:
         runtime_parts.append(structure)
         runtime_evidence.extend(structure_evidence)
 
-    if runtime_parts:
+    if strong_runtime_fact and runtime_parts:
         facts["runtime_context"] = "; ".join(runtime_parts) + "."
         evidence["runtime_context"] = tuple(dict.fromkeys(runtime_evidence))
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -260,6 +260,89 @@ async def test_interview_driver_blocks_on_backend_timeout(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_supplies_bounded_repo_facts_to_answerer(tmp_path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo-cli"',
+                'requires-python = ">=3.12"',
+                'dependencies = ["typer>=0.12"]',
+                "",
+                "[build-system]",
+                'build-backend = "hatchling.build"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("Which runtime and framework should we use?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    ledger.sections["runtime_context"].entries.clear()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert answers and "[repo_fact]" in answers[0]
+    runtime_entries = ledger.sections["runtime_context"].entries
+    repo_entry = next(entry for entry in runtime_entries if entry.key == "runtime.repo_fact")
+    assert repo_entry.source == LedgerSource.REPO_FACT
+    assert repo_entry.status == LedgerStatus.CONFIRMED
+    assert repo_entry.evidence == ["pyproject.toml", "src/", "tests/"]
+    assert "Python project requiring >=3.12" in repo_entry.value
+    assert "Typer CLI" in repo_entry.value
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_keeps_runtime_default_without_repo_facts(tmp_path) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("Which runtime and framework should we use?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    ledger.sections["runtime_context"].entries.clear()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert answers and "[existing_convention]" in answers[0]
+    runtime_entries = ledger.sections["runtime_context"].entries
+    assert runtime_entries[-1].source == LedgerSource.EXISTING_CONVENTION
+    assert runtime_entries[-1].status == LedgerStatus.DEFAULTED
+    assert runtime_entries[-1].evidence == []
+
+
+@pytest.mark.asyncio
 async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What should we verify?", "interview_1")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -12,6 +12,7 @@ from ouroboros.auto.interview_driver import (
 )
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
@@ -308,6 +309,29 @@ async def test_interview_driver_supplies_bounded_repo_facts_to_answerer(tmp_path
     assert repo_entry.evidence == ["pyproject.toml", "src/", "tests/"]
     assert "Python project requiring >=3.12" in repo_entry.value
     assert "Typer CLI" in repo_entry.value
+
+
+def test_repo_context_keeps_partial_project_hints_out_of_confirmed_runtime(tmp_path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "tool-only"',
+                "",
+                "[build-system]",
+                'build-backend = "hatchling.build"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" not in context.repo_facts
+    assert context.repo_facts["package_manager"] == "hatchling/pyproject"
+    assert context.repo_facts["project_structure"] == "src layout with tests directory"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a bounded repository context provider for auto interview answers.
- Wires `AutoInterviewDriver` to pass `AutoAnswerContext` into the deterministic answerer.
- Covers repo-backed runtime answers and no-fact fallback behavior with focused tests.

## Discussion / implementation notes
This is a narrow first slice for #640. The provider only reads fixed local paths under `cwd` (`pyproject.toml`, `src/`, `tests/`, lock files) and performs no unbounded scans or network access. Repo facts are recorded as ledger evidence when available; empty/no-fact directories keep the existing conservative default path.

Out of scope: full brownfield discovery, broad provenance UI, and final Seed formatting changes.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_interview_pipeline.py::test_interview_driver_supplies_bounded_repo_facts_to_answerer tests/unit/auto/test_interview_pipeline.py::test_interview_driver_keeps_runtime_default_without_repo_facts tests/unit/auto/test_ledger_grading_answerer.py::test_auto_answerer_uses_supplied_repo_fact_for_runtime_questions -q` → passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/repo_context.py src/ouroboros/auto/interview_driver.py tests/unit/auto/test_interview_pipeline.py` → passed
- `git diff --check` → passed

Refs #640
