### PR TITLE
feat(auto): expose MCP progress metadata

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -35,6 +35,11 @@ class AutoPipelineResult:
     job_id: str | None = None
     run_session_id: str | None = None
     run_subagent: dict[str, Any] | None = None
+    current_round: int = 0
+    pending_question: str | None = None
+    last_progress_message: str | None = None
+    last_progress_at: str | None = None
+    last_grade: str | None = None
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
@@ -376,6 +381,11 @@ class AutoPipeline:
             job_id=state.job_id,
             run_session_id=state.run_session_id,
             run_subagent=run_subagent or state.run_subagent or None,
+            current_round=state.current_round,
+            pending_question=state.pending_question,
+            last_progress_message=state.last_progress_message,
+            last_progress_at=state.last_progress_at,
+            last_grade=state.last_grade,
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -96,19 +96,7 @@ class AutoHandler:
             return Result.err(
                 MCPToolError(f"Auto pipeline failed: {exc}", tool_name="ouroboros_auto")
             )
-        meta: dict[str, Any] = {
-            "status": result.status,
-            "auto_session_id": result.auto_session_id,
-            "phase": result.phase,
-            "grade": result.grade,
-            "seed_path": result.seed_path,
-            "interview_session_id": result.interview_session_id,
-            "execution_id": result.execution_id,
-            "job_id": result.job_id,
-            "run_session_id": result.run_session_id,
-            "resume_command": f"ooo auto --resume {result.auto_session_id}",
-            "blocker": result.blocker,
-        }
+        meta = _result_meta(result)
         text = _format_result(result)
         if result.run_subagent is not None:
             meta["_subagent"] = result.run_subagent
@@ -193,6 +181,30 @@ class AutoHandler:
             skip_run=skip_run,
         )
         return await pipeline.run(state)
+
+
+def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
+    """Build MCP metadata for clients that render auto progress outside CLI text."""
+    meta: dict[str, Any] = {
+        "status": result.status,
+        "auto_session_id": result.auto_session_id,
+        "phase": result.phase,
+        "current_round": result.current_round,
+        "last_progress_message": result.last_progress_message,
+        "last_progress_at": result.last_progress_at,
+        "resume_command": f"ooo auto --resume {result.auto_session_id}",
+        "blocker": result.blocker,
+        "seed_path": result.seed_path,
+        "grade": result.grade,
+        "last_grade": result.last_grade,
+        "interview_session_id": result.interview_session_id,
+        "execution_id": result.execution_id,
+        "job_id": result.job_id,
+        "run_session_id": result.run_session_id,
+    }
+    if result.pending_question:
+        meta["pending_question"] = result.pending_question
+    return meta
 
 
 def _resolved_opencode_mode(runtime_backend: str | None, opencode_mode: str | None) -> str | None:

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -401,6 +401,115 @@ async def test_auto_handler_forwards_run_subagent_envelope(monkeypatch) -> None:
     assert '"_subagent"' in result.value.content[0].text
 
 
+@pytest.mark.asyncio
+async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> None:
+    async def fake_run(self, arguments):  # noqa: ARG001
+        from ouroboros.auto.pipeline import AutoPipelineResult
+
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id="auto_test",
+            phase="interview",
+            grade="B",
+            seed_path="/tmp/seed.yaml",
+            interview_session_id="interview_1",
+            execution_id="execution_1",
+            job_id="job_1",
+            run_session_id="session_1",
+            current_round=2,
+            pending_question="Which runtime should be used?",
+            last_progress_message="asking interview round 2/12",
+            last_progress_at="2026-05-01T12:00:00+00:00",
+            last_grade="B",
+            blocker="waiting for interview answer",
+        )
+
+    monkeypatch.setattr(AutoHandler, "_run", fake_run)
+
+    result = await AutoHandler().handle({"goal": "Build a CLI"})
+
+    assert result.is_ok
+    assert result.value.is_error is True
+    assert result.value.meta == {
+        "status": "blocked",
+        "auto_session_id": "auto_test",
+        "phase": "interview",
+        "current_round": 2,
+        "last_progress_message": "asking interview round 2/12",
+        "last_progress_at": "2026-05-01T12:00:00+00:00",
+        "resume_command": "ooo auto --resume auto_test",
+        "blocker": "waiting for interview answer",
+        "seed_path": "/tmp/seed.yaml",
+        "grade": "B",
+        "last_grade": "B",
+        "interview_session_id": "interview_1",
+        "execution_id": "execution_1",
+        "job_id": "job_1",
+        "run_session_id": "session_1",
+        "pending_question": "Which runtime should be used?",
+    }
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_meta_uses_pipeline_state_progress(monkeypatch, tmp_path) -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.auto.state import AutoStore
+    from ouroboros.mcp.tools import auto_handler as auto_module
+
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            pass
+
+        async def run(self, run_state):  # noqa: ANN001
+            run_state.transition(AutoPhase.INTERVIEW, "asking interview round 3/12")
+            run_state.current_round = 3
+            run_state.pending_question = "What should the command output?"
+            run_state.last_progress_message = "asking interview round 3/12"
+            run_state.last_progress_at = "2026-05-01T12:30:00+00:00"
+            run_state.seed_path = "/tmp/seed.yaml"
+            run_state.last_grade = "A"
+            captured["auto_session_id"] = run_state.auto_session_id
+            return AutoPipelineResult(
+                status=run_state.phase.value,
+                auto_session_id=run_state.auto_session_id,
+                phase=run_state.phase.value,
+                seed_path=run_state.seed_path,
+                current_round=run_state.current_round,
+                pending_question=run_state.pending_question,
+                last_progress_message=run_state.last_progress_message,
+                last_progress_at=run_state.last_progress_at,
+                last_grade=run_state.last_grade,
+            )
+
+    class FakeHandler:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            pass
+
+    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(auto_module, "InterviewHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "GenerateSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "ExecuteSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "StartExecuteSeedHandler", FakeHandler)
+
+    result = await AutoHandler().handle({"goal": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert result.is_ok
+    assert result.value.meta["auto_session_id"] == captured["auto_session_id"]
+    assert result.value.meta["phase"] == "interview"
+    assert result.value.meta["current_round"] == 3
+    assert result.value.meta["pending_question"] == "What should the command output?"
+    assert result.value.meta["last_progress_message"] == "asking interview round 3/12"
+    assert result.value.meta["last_progress_at"] == "2026-05-01T12:30:00+00:00"
+    assert result.value.meta["seed_path"] == "/tmp/seed.yaml"
+    assert result.value.meta["last_grade"] == "A"
+    assert result.value.meta["resume_command"] == (
+        f"ooo auto --resume {captured['auto_session_id']}"
+    )
+
+
 def test_cli_opencode_plugin_uses_subprocess_for_plain_cli(monkeypatch) -> None:
     from ouroboros.cli.commands import auto as auto_command
 


### PR DESCRIPTION
## Summary
- Extends `AutoPipelineResult` with persisted auto progress fields from `AutoPipelineState`.
- Centralizes `ouroboros_auto` MCP metadata construction in `_result_meta`.
- Exposes phase, current round, pending question, progress timestamps, resume command, seed/grade, and execution handles through MCP result metadata.

## Discussion / implementation notes
This is a narrow #639 slice focused on machine-readable MCP metadata for bridge clients. It does not rewrite CLI status output and does not introduce streaming. The CLI already prints status; this PR lets non-CLI clients render the same progress state from `result.meta`.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_surface.py::test_auto_handler_meta_exposes_auto_progress_fields tests/unit/auto/test_surface.py::test_auto_handler_meta_uses_pipeline_state_progress -q` → passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/pipeline.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_surface.py` → passed
- `git diff --check` → passed

Refs #639
