### PR TITLE
fix(auto): expose unknown run handoff guidance

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -321,7 +321,7 @@ class AutoPipeline:
             state.job_id = _optional_str(run_meta.get("job_id"))
             state.execution_id = _optional_str(run_meta.get("execution_id"))
         except TimeoutError as exc:
-            _mark_unknown_run_handoff(state)
+            _mark_unknown_run_handoff(state, status="unknown_timeout")
             state.mark_blocked(
                 f"run start timed out after {self.run_start_timeout_seconds:.0f}s",
                 tool_name="run_starter",
@@ -427,8 +427,23 @@ def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:
     state.mark_failed(message, tool_name="auto_pipeline")
 
 
-def _mark_unknown_run_handoff(state: AutoPipelineState) -> None:
-    state.run_handoff_status = "unknown_no_handle"
+def _mark_unknown_run_handoff(
+    state: AutoPipelineState, *, status: str = "unknown_no_handle"
+) -> None:
+    if status == "unknown_no_handle" and state.run_handoff_status in {
+        "unknown_no_handle",
+        "unknown_timeout",
+    }:
+        status = state.run_handoff_status
+    state.run_handoff_status = status
+    if status == "unknown_timeout":
+        state.run_handoff_guidance = (
+            "Run starter timed out before a durable tracking handle was captured. "
+            "The runtime may still have created an execution. Resume will not start "
+            "another run automatically or risk duplicate execution; inspect the "
+            "runtime for an existing execution before rerunning manually."
+        )
+        return
     state.run_handoff_guidance = (
         "Run starter was attempted, but no durable tracking handle was captured. "
         "Resume will not start another run automatically or risk duplicate execution; "

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -40,6 +40,8 @@ class AutoPipelineResult:
     last_progress_message: str | None = None
     last_progress_at: str | None = None
     last_grade: str | None = None
+    run_handoff_status: str | None = None
+    run_handoff_guidance: str | None = None
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
@@ -256,14 +258,18 @@ class AutoPipeline:
 
         if state.phase == AutoPhase.RUN:
             if any((state.job_id, state.execution_id, state.run_session_id)):
+                state.run_handoff_status = "started"
+                state.run_handoff_guidance = None
                 state.transition(
                     AutoPhase.COMPLETE, "execution already started; using persisted run handle"
                 )
                 self._save(state)
                 return self._result(state, ledger, review=review)
             if state.run_start_attempted:
+                _mark_unknown_run_handoff(state)
                 state.mark_blocked(
-                    "Run start status is unknown; refusing to start a duplicate execution",
+                    state.run_handoff_guidance
+                    or "Run start status is unknown; refusing to start a duplicate execution",
                     tool_name="run_starter",
                 )
                 self._save(state)
@@ -296,6 +302,8 @@ class AutoPipeline:
 
         if state.phase != AutoPhase.RUN:
             state.run_start_attempted = False
+            state.run_handoff_status = None
+            state.run_handoff_guidance = None
             state.transition(
                 AutoPhase.RUN,
                 f"starting execution for grade {state.last_grade or state.required_grade} Seed",
@@ -313,6 +321,7 @@ class AutoPipeline:
             state.job_id = _optional_str(run_meta.get("job_id"))
             state.execution_id = _optional_str(run_meta.get("execution_id"))
         except TimeoutError as exc:
+            _mark_unknown_run_handoff(state)
             state.mark_blocked(
                 f"run start timed out after {self.run_start_timeout_seconds:.0f}s",
                 tool_name="run_starter",
@@ -330,10 +339,15 @@ class AutoPipeline:
         )
         state.run_subagent = run_subagent or {}
         if not any((state.job_id, state.execution_id, state.run_session_id)):
-            state.run_start_attempted = False
-            state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
+            _mark_unknown_run_handoff(state)
+            state.mark_blocked(
+                state.run_handoff_guidance or "Run starter returned no tracking handle",
+                tool_name="run_starter",
+            )
             self._save(state)
             return self._result(state, ledger, review=review, blocker=state.last_error)
+        state.run_handoff_status = "started"
+        state.run_handoff_guidance = None
         state.transition(
             AutoPhase.COMPLETE,
             f"execution started for grade {state.last_grade or state.required_grade} Seed",
@@ -386,6 +400,8 @@ class AutoPipeline:
             last_progress_message=state.last_progress_message,
             last_progress_at=state.last_progress_at,
             last_grade=state.last_grade,
+            run_handoff_status=state.run_handoff_status,
+            run_handoff_guidance=state.run_handoff_guidance,
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,
@@ -409,6 +425,15 @@ def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:
         state.last_error = message
         return
     state.mark_failed(message, tool_name="auto_pipeline")
+
+
+def _mark_unknown_run_handoff(state: AutoPipelineState) -> None:
+    state.run_handoff_status = "unknown_no_handle"
+    state.run_handoff_guidance = (
+        "Run starter was attempted, but no durable tracking handle was captured. "
+        "Resume will not start another run automatically or risk duplicate execution; "
+        "inspect the runtime for an existing execution before rerunning manually."
+    )
 
 
 def _grade_meets_required(actual: str | None, required: str) -> bool:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -101,6 +101,8 @@ class AutoPipelineState:
     run_session_id: str | None = None
     run_subagent: dict[str, Any] = field(default_factory=dict)
     run_start_attempted: bool = False
+    run_handoff_status: str | None = None
+    run_handoff_guidance: str | None = None
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
@@ -190,6 +192,8 @@ class AutoPipelineState:
         # persisting them with subsequent saves.
         payload.setdefault("max_interview_rounds", 12)
         payload.setdefault("max_repair_rounds", 5)
+        payload.setdefault("run_handoff_status", None)
+        payload.setdefault("run_handoff_guidance", None)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -290,6 +294,8 @@ class AutoPipelineState:
             "execution_id",
             "job_id",
             "run_session_id",
+            "run_handoff_status",
+            "run_handoff_guidance",
             "last_grade",
             "pending_question",
             "last_tool_name",

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -271,6 +271,10 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"  Job ID: {state.job_id}")
         console.print(f"  Execution ID: {state.execution_id}")
         console.print(f"  Session ID: {state.run_session_id}")
+    if state.run_handoff_status:
+        console.print(f"Run handoff status: [bold]{state.run_handoff_status}[/]")
+    if state.run_handoff_guidance:
+        console.print(f"Run handoff guidance: [yellow]{state.run_handoff_guidance}[/]")
     if state.last_error:
         console.print(f"Blocker: [yellow]{state.last_error}[/]")
     console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")
@@ -296,6 +300,10 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"  Job ID: {result.job_id}")
         console.print(f"  Execution ID: {result.execution_id}")
         console.print(f"  Session ID: {result.run_session_id}")
+    if result.run_handoff_status:
+        console.print(f"Run handoff status: [bold]{result.run_handoff_status}[/]")
+    if result.run_handoff_guidance:
+        console.print(f"Run handoff guidance: [yellow]{result.run_handoff_guidance}[/]")
     if show_ledger:
         if result.assumptions:
             console.print("Assumptions:")

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -201,11 +201,13 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "execution_id": result.execution_id,
         "job_id": result.job_id,
         "run_session_id": result.run_session_id,
-        "run_handoff_status": result.run_handoff_status,
-        "run_handoff_guidance": result.run_handoff_guidance,
     }
     if result.pending_question:
         meta["pending_question"] = result.pending_question
+    if result.run_handoff_status:
+        meta["run_handoff_status"] = result.run_handoff_status
+    if result.run_handoff_guidance:
+        meta["run_handoff_guidance"] = result.run_handoff_guidance
     return meta
 
 

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -201,6 +201,8 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "execution_id": result.execution_id,
         "job_id": result.job_id,
         "run_session_id": result.run_session_id,
+        "run_handoff_status": result.run_handoff_status,
+        "run_handoff_guidance": result.run_handoff_guidance,
     }
     if result.pending_question:
         meta["pending_question"] = result.pending_question
@@ -376,6 +378,10 @@ def _format_result(result: AutoPipelineResult) -> str:
                 f"  session_id: {result.run_session_id}",
             ]
         )
+    if result.run_handoff_status:
+        lines.append(f"Run handoff status: {result.run_handoff_status}")
+    if result.run_handoff_guidance:
+        lines.append(f"Run handoff guidance: {result.run_handoff_guidance}")
     if result.assumptions:
         lines.append("Assumptions:")
         lines.extend(f"- {item}" for item in result.assumptions)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1235,8 +1235,11 @@ async def test_pipeline_blocks_duplicate_run_after_start_timeout(tmp_path) -> No
     second = await pipeline.run(state)
 
     assert first.status == "blocked"
+    assert first.run_handoff_status == "unknown_timeout"
+    assert "may still have created an execution" in (first.run_handoff_guidance or "")
     assert state.run_start_attempted is True
     assert second.status == "blocked"
+    assert second.run_handoff_status == "unknown_timeout"
     assert "duplicate execution" in (second.blocker or "")
     assert calls == 1
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -877,7 +877,10 @@ async def test_pipeline_refuses_duplicate_unknown_run_resume(tmp_path) -> None:
     result = await pipeline.run(state)
 
     assert result.status == "blocked"
+    assert result.run_handoff_status == "unknown_no_handle"
     assert "duplicate execution" in (result.blocker or "")
+    assert "will not start another run automatically" in (result.run_handoff_guidance or "")
+    assert state.run_handoff_status == "unknown_no_handle"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1242,7 +1242,7 @@ async def test_pipeline_blocks_duplicate_run_after_start_timeout(tmp_path) -> No
 
 
 @pytest.mark.asyncio
-async def test_pipeline_retries_after_malformed_run_starter_metadata(tmp_path) -> None:
+async def test_pipeline_refuses_retry_after_malformed_run_starter_metadata(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("resume should not restart interview")
 
@@ -1278,10 +1278,13 @@ async def test_pipeline_retries_after_malformed_run_starter_metadata(tmp_path) -
     second = await pipeline.run(state)
 
     assert first.status == "blocked"
+    assert first.run_handoff_status == "unknown_no_handle"
+    assert "will not start another run automatically" in (first.run_handoff_guidance or "")
     assert state.run_start_attempted is True
-    assert second.status == "complete"
-    assert second.job_id == "job_after_retry"
-    assert calls == 2
+    assert second.status == "blocked"
+    assert second.run_handoff_status == "unknown_no_handle"
+    assert second.job_id is None
+    assert calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Persists explicit `run_handoff_status` and `run_handoff_guidance` on auto pipeline state/results.
- Marks the ambiguous "run starter attempted but no durable handle captured" case as `unknown_no_handle`.
- Surfaces the guidance in CLI and MCP output so resume paths explain that auto will not start another run automatically.

## Discussion / implementation notes
This is a narrow #579 slice. It does not introduce a new Agent OS control framework; it makes the existing `run_start_attempted` duplicate guard user-visible and machine-readable. When the run starter returns no `job_id`, `execution_id`, or `run_session_id`, the session blocks with explicit guidance to inspect the runtime before manually rerunning.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_interview_pipeline.py::test_pipeline_refuses_duplicate_unknown_run_resume tests/unit/auto/test_interview_pipeline.py::test_pipeline_blocks_run_start_without_tracking_handle tests/unit/auto/test_interview_pipeline.py::test_pipeline_resumes_run_with_persisted_handle_without_restarting -q` → passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/pipeline.py src/ouroboros/auto/state.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_interview_pipeline.py` → passed
- `git diff --check` → passed

Refs #579
