### PR TITLE
test(codex): guard packaged auto MCP dispatch

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -543,10 +543,12 @@ class CodexCliRuntime:
     def _is_auto_recoverable_dispatch_unavailable(recoverable_error: AgentMessage) -> bool:
         """Return whether a recoverable auto dispatch error means the tool is unavailable."""
         error_type = recoverable_error.data.get("error_type")
+        error_text = recoverable_error.content.lower()
         if error_type == "MCPResourceNotFoundError":
             return True
+        if error_type == "LookupError":
+            return "no local handler registered" in error_text
 
-        error_text = recoverable_error.content.lower()
         if error_type == "MCPClientError":
             return any(
                 marker in error_text

--- a/tests/integration/test_codex_cli_passthrough_smoke.py
+++ b/tests/integration/test_codex_cli_passthrough_smoke.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -127,3 +127,46 @@ async def test_unhandled_ooo_commands_pass_through_to_codex_unchanged(
         mock_warning.assert_called_once()
         assert mock_warning.call_args[0][0] == expected_warning
         assert mock_warning.call_args.kwargs["error"] == expected_error
+
+
+@pytest.mark.asyncio
+async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fallback(
+    tmp_path: Path,
+) -> None:
+    """Packaged `ooo auto` must not fall through to Codex when the MCP tool is absent."""
+    runtime = create_agent_runtime(
+        backend="codex",
+        cli_path="/tmp/codex",
+        permission_mode="acceptEdits",
+        cwd=tmp_path,
+    )
+
+    assert isinstance(runtime, CodexCliRuntime)
+    assert runtime._skill_dispatcher is not None
+    with resolve_packaged_codex_skill_path("auto", skills_dir=runtime._skills_dir) as skill_md_path:
+        content = skill_md_path.read_text(encoding="utf-8")
+    assert "mcp_tool: ouroboros_auto" in content
+
+    fake_server = AsyncMock()
+    fake_server.call_tool = AsyncMock(
+        side_effect=LookupError("No local handler registered for tool: ouroboros_auto")
+    )
+
+    with (
+        patch("ouroboros.mcp.server.adapter.create_ouroboros_server", return_value=fake_server),
+        patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
+        patch("ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec") as mock_exec,
+    ):
+        messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
+
+    fake_server.call_tool.assert_awaited_once()
+    assert fake_server.call_tool.await_args.args[0] == "ouroboros_auto"
+    mock_exec.assert_not_called()
+    mock_warning.assert_called_once()
+    assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
+    assert len(messages) == 1
+    assert messages[0].is_error is True
+    assert messages[0].content.startswith("Cannot run ooo auto")
+    assert "`ouroboros_auto` is unavailable" in messages[0].content
+    assert messages[0].data["error_type"] == "SkillDispatchUnavailable"
+    assert messages[0].data["tool_name"] == "ouroboros_auto"

--- a/tests/integration/test_codex_cli_passthrough_smoke.py
+++ b/tests/integration/test_codex_cli_passthrough_smoke.py
@@ -155,7 +155,9 @@ async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fal
     with (
         patch("ouroboros.mcp.server.adapter.create_ouroboros_server", return_value=fake_server),
         patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
-        patch("ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec") as mock_exec,
+        patch(
+            "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec"
+        ) as mock_exec,
     ):
         messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
 


### PR DESCRIPTION
## Summary
- Adds a packaged `ooo auto` regression guard that resolves the packaged auto skill and attempts the real `ouroboros_auto` dispatch path.
- Verifies missing local MCP handler failures stop before Codex subprocess fallback.
- Treats recoverable `LookupError` "No local handler registered" dispatch results as auto tool-unavailable so the runtime fails closed instead of silently emulating auto.

## Discussion / implementation notes
This is the narrow #637 boundary: a dispatch guard and fail-closed missing-tool handling. It does not close the full umbrella contract by itself, and it intentionally avoids progress UI, provenance, or broader Agent OS changes.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/integration/test_codex_cli_passthrough_smoke.py::test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fallback tests/unit/orchestrator/test_codex_cli_runtime.py::TestCodexCliRuntime::test_execute_task_auto_dispatch_failure_does_not_fall_back tests/unit/orchestrator/test_codex_cli_runtime.py::TestCodexCliRuntime::test_execute_task_auto_key_error_falls_back_with_real_cause -q` → passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check tests/integration/test_codex_cli_passthrough_smoke.py src/ouroboros/orchestrator/codex_cli_runtime.py` → passed
- `git diff --check` → passed

Refs #637
