### PR TITLE
feat(backends): add capability registry

### DIFF
--- a/src/ouroboros/backends/__init__.py
+++ b/src/ouroboros/backends/__init__.py
@@ -1,0 +1,27 @@
+"""Backend capability registry for Ouroboros runtimes and providers."""
+
+from ouroboros.backends.capabilities import (
+    BackendCapability,
+    get_backend_capability,
+    interview_driver_backend_choices,
+    llm_backend_choices,
+    resolve_backend_alias,
+    resolve_interview_driver_backend,
+    resolve_llm_backend_name,
+    resolve_runtime_backend_name,
+    runtime_backend_choices,
+    soft_tool_enforcement_backends,
+)
+
+__all__ = [
+    "BackendCapability",
+    "get_backend_capability",
+    "interview_driver_backend_choices",
+    "llm_backend_choices",
+    "resolve_backend_alias",
+    "resolve_interview_driver_backend",
+    "resolve_llm_backend_name",
+    "resolve_runtime_backend_name",
+    "runtime_backend_choices",
+    "soft_tool_enforcement_backends",
+]

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -1,0 +1,197 @@
+"""Canonical backend capability registry.
+
+The same backend names show up in CLI help, config validation, provider
+factory selection, and runtime construction.  Keep those names and aliases in
+one place so adding a backend does not require updating several independent
+sets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class BackendCapability:
+    """Capabilities and aliases for one canonical backend."""
+
+    name: str
+    aliases: tuple[str, ...] = ()
+    supports_runtime: bool = False
+    supports_llm: bool = False
+    supports_interview_driver: bool = False
+    switchable_runtime: bool = False
+    cli_name: str | None = None
+    cli_config_key: str | None = None
+    soft_tool_enforcement: bool = False
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Canonical name plus accepted aliases."""
+        return (self.name, *self.aliases)
+
+
+_CAPABILITIES: tuple[BackendCapability, ...] = (
+    BackendCapability(
+        name="claude",
+        aliases=("claude_code",),
+        supports_runtime=True,
+        supports_llm=True,
+        supports_interview_driver=True,
+        switchable_runtime=True,
+        cli_name="claude",
+        cli_config_key="cli_path",
+    ),
+    BackendCapability(
+        name="codex",
+        aliases=("codex_cli",),
+        supports_runtime=True,
+        supports_llm=True,
+        supports_interview_driver=True,
+        switchable_runtime=True,
+        cli_name="codex",
+        cli_config_key="codex_cli_path",
+    ),
+    BackendCapability(
+        name="copilot",
+        aliases=("copilot_cli",),
+        supports_runtime=True,
+        supports_llm=True,
+        supports_interview_driver=True,
+        cli_name="copilot",
+        cli_config_key="copilot_cli_path",
+    ),
+    BackendCapability(
+        name="gemini",
+        aliases=("gemini_cli",),
+        supports_runtime=True,
+        supports_llm=True,
+        supports_interview_driver=True,
+        switchable_runtime=True,
+        cli_name="gemini",
+        cli_config_key="gemini_cli_path",
+        soft_tool_enforcement=True,
+    ),
+    BackendCapability(
+        name="hermes",
+        aliases=("hermes_cli",),
+        supports_runtime=True,
+        supports_llm=False,
+        supports_interview_driver=False,
+        switchable_runtime=True,
+        cli_name="hermes",
+        cli_config_key="hermes_cli_path",
+    ),
+    BackendCapability(
+        name="kiro",
+        aliases=("kiro_cli",),
+        supports_runtime=True,
+        supports_llm=True,
+        supports_interview_driver=True,
+        cli_name="kiro",
+        cli_config_key="kiro_cli_path",
+    ),
+    BackendCapability(
+        name="opencode",
+        aliases=("opencode_cli",),
+        supports_runtime=True,
+        supports_llm=True,
+        supports_interview_driver=True,
+        cli_name="opencode",
+        cli_config_key="opencode_cli_path",
+        soft_tool_enforcement=True,
+    ),
+    BackendCapability(
+        name="litellm",
+        aliases=("openai", "openrouter"),
+        supports_llm=True,
+        supports_interview_driver=False,
+    ),
+)
+
+_BY_NAME: dict[str, BackendCapability] = {
+    name: capability for capability in _CAPABILITIES for name in capability.names
+}
+
+
+def get_backend_capability(name: str) -> BackendCapability | None:
+    """Return capability metadata for a canonical backend name or alias."""
+    return _BY_NAME.get(name.strip().lower())
+
+
+def resolve_backend_alias(name: str) -> str:
+    """Resolve a backend alias to its canonical name."""
+    capability = get_backend_capability(name)
+    if capability is None:
+        msg = f"Unsupported backend: {name.strip().lower()}"
+        raise ValueError(msg)
+    return capability.name
+
+
+def _resolve_capable_backend(name: str, *, capability_name: str) -> str:
+    candidate = name.strip().lower()
+    capability = get_backend_capability(candidate)
+    if capability is None or not getattr(capability, capability_name):
+        msg = f"Unsupported backend for {capability_name.removeprefix('supports_')}: {candidate}"
+        raise ValueError(msg)
+    return capability.name
+
+
+def resolve_runtime_backend_name(name: str) -> str:
+    """Resolve and validate a backend that can run agent tasks."""
+    return _resolve_capable_backend(name, capability_name="supports_runtime")
+
+
+def resolve_llm_backend_name(name: str) -> str:
+    """Resolve and validate a backend that can produce LLM completions."""
+    return _resolve_capable_backend(name, capability_name="supports_llm")
+
+
+def resolve_interview_driver_backend(name: str) -> str:
+    """Resolve and validate a backend usable as an auto interview driver."""
+    return _resolve_capable_backend(name, capability_name="supports_interview_driver")
+
+
+def _choices(*, capability_name: str, include_aliases: bool = False) -> tuple[str, ...]:
+    values: list[str] = []
+    for capability in _CAPABILITIES:
+        if getattr(capability, capability_name):
+            values.extend(capability.names if include_aliases else (capability.name,))
+    return tuple(values)
+
+
+def runtime_backend_choices(*, include_aliases: bool = False) -> tuple[str, ...]:
+    """Backend names that support orchestrator runtime execution."""
+    return _choices(capability_name="supports_runtime", include_aliases=include_aliases)
+
+
+def llm_backend_choices(*, include_aliases: bool = False) -> tuple[str, ...]:
+    """Backend names that support LLM completion."""
+    return _choices(capability_name="supports_llm", include_aliases=include_aliases)
+
+
+def interview_driver_backend_choices(*, include_aliases: bool = False) -> tuple[str, ...]:
+    """Backend names that can answer auto interview questions."""
+    return _choices(
+        capability_name="supports_interview_driver",
+        include_aliases=include_aliases,
+    )
+
+
+def soft_tool_enforcement_backends() -> frozenset[str]:
+    """Canonical backends whose tool envelope is cooperatively enforced."""
+    return frozenset(c.name for c in _CAPABILITIES if c.soft_tool_enforcement)
+
+
+__all__ = [
+    "BackendCapability",
+    "get_backend_capability",
+    "interview_driver_backend_choices",
+    "llm_backend_choices",
+    "resolve_backend_alias",
+    "resolve_interview_driver_backend",
+    "resolve_llm_backend_name",
+    "resolve_runtime_backend_name",
+    "runtime_backend_choices",
+    "soft_tool_enforcement_backends",
+]

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -14,6 +14,7 @@ import yaml
 
 from ouroboros.backends import (
     get_backend_capability,
+    resolve_runtime_backend_name,
     runtime_backend_choices,
 )
 from ouroboros.cli.formatters import console
@@ -440,8 +441,11 @@ def validate() -> None:
     backend_val = data.get("orchestrator", {}).get("runtime_backend")
     if not backend_val:
         issues.append("orchestrator.runtime_backend is not set")
-    elif backend_val not in _VALID_BACKENDS:
-        issues.append(f"orchestrator.runtime_backend '{backend_val}' is not supported")
+    else:
+        try:
+            resolve_runtime_backend_name(str(backend_val))
+        except ValueError:
+            issues.append(f"orchestrator.runtime_backend '{backend_val}' is not supported")
 
     # Check CLI path exists
     capability = get_backend_capability(str(backend_val or ""))

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -12,6 +12,10 @@ from typing import Annotated
 import typer
 import yaml
 
+from ouroboros.backends import (
+    get_backend_capability,
+    runtime_backend_choices,
+)
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
 from ouroboros.cli.formatters.tables import create_key_value_table, print_table
@@ -22,8 +26,12 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-_VALID_BACKENDS = ("claude", "codex", "opencode", "hermes", "gemini")
-_SWITCHABLE_BACKENDS = ("claude", "codex", "hermes", "gemini")
+_VALID_BACKENDS = runtime_backend_choices()
+_SWITCHABLE_BACKENDS = tuple(
+    backend
+    for backend in _VALID_BACKENDS
+    if (capability := get_backend_capability(backend)) is not None and capability.switchable_runtime
+)
 
 
 def _load_config() -> tuple[dict, Path]:
@@ -84,15 +92,10 @@ def _save_config(data: dict, path: Path) -> None:
 def _resolve_cli_path(data: dict) -> str | None:
     """Return the active CLI path based on the current runtime backend."""
     backend = data.get("orchestrator", {}).get("runtime_backend", "claude")
-    if backend == "codex":
-        return data.get("orchestrator", {}).get("codex_cli_path")
-    if backend == "opencode":
-        return data.get("orchestrator", {}).get("opencode_cli_path")
-    if backend == "hermes":
-        return data.get("orchestrator", {}).get("hermes_cli_path")
-    if backend == "gemini":
-        return data.get("orchestrator", {}).get("gemini_cli_path")
-    return data.get("orchestrator", {}).get("cli_path")
+    capability = get_backend_capability(str(backend))
+    if capability is not None and capability.cli_config_key:
+        return data.get("orchestrator", {}).get(capability.cli_config_key)
+    return None
 
 
 def _resolve_db_path(data: dict, config_path: Path) -> str:
@@ -200,12 +203,8 @@ def backend(
     # Detect CLI path. For backends that expose an env-var or persisted
     # config path (gemini), honor those before falling back to PATH so users
     # with explicit-path installs can still switch via the CLI.
-    cli_name = {
-        "claude": "claude",
-        "codex": "codex",
-        "hermes": "hermes",
-        "gemini": "gemini",
-    }[new_backend]
+    capability = get_backend_capability(new_backend)
+    cli_name = capability.cli_name if capability and capability.cli_name else new_backend
     cli_path = None
     if new_backend == "gemini":
         from ouroboros.config import get_gemini_cli_path
@@ -445,26 +444,11 @@ def validate() -> None:
         issues.append(f"orchestrator.runtime_backend '{backend_val}' is not supported")
 
     # Check CLI path exists
-    if backend_val == "claude":
-        cli = data.get("orchestrator", {}).get("cli_path")
+    capability = get_backend_capability(str(backend_val or ""))
+    if capability is not None and capability.cli_config_key:
+        cli = data.get("orchestrator", {}).get(capability.cli_config_key)
         if cli and not Path(cli).exists():
-            issues.append(f"Claude CLI path does not exist: {cli}")
-    elif backend_val == "codex":
-        cli = data.get("orchestrator", {}).get("codex_cli_path")
-        if cli and not Path(cli).exists():
-            issues.append(f"Codex CLI path does not exist: {cli}")
-    elif backend_val == "opencode":
-        cli = data.get("orchestrator", {}).get("opencode_cli_path")
-        if cli and not Path(cli).exists():
-            issues.append(f"OpenCode CLI path does not exist: {cli}")
-    elif backend_val == "hermes":
-        cli = data.get("orchestrator", {}).get("hermes_cli_path")
-        if cli and not Path(cli).exists():
-            issues.append(f"Hermes CLI path does not exist: {cli}")
-    elif backend_val == "gemini":
-        cli = data.get("orchestrator", {}).get("gemini_cli_path")
-        if cli and not Path(cli).exists():
-            issues.append(f"Gemini CLI path does not exist: {cli}")
+            issues.append(f"{capability.name} CLI path does not exist: {cli}")
 
     # Try loading config through the validated schema
     try:

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -46,6 +46,7 @@ from typing import Any
 from pydantic import ValidationError as PydanticValidationError
 import yaml
 
+from ouroboros.backends import get_backend_capability
 from ouroboros.config.models import (  # noqa: E402
     CredentialsConfig,
     OuroborosConfig,
@@ -1057,19 +1058,11 @@ def get_llm_backend() -> str:
         return env_backend
 
     env_runtime = os.environ.get("OUROBOROS_RUNTIME", "").strip().lower()
-    llm_capable_runtime_aliases = {
-        "claude": "claude",
-        "claude_code": "claude_code",
-        "codex": "codex",
-        "copilot": "copilot",
-        "copilot_cli": "copilot",
-        "gemini": "gemini",
-        "kiro": "kiro",
-        "kiro_cli": "kiro",
-        "opencode": "opencode",
-    }
-    if env_runtime in llm_capable_runtime_aliases:
-        return llm_capable_runtime_aliases[env_runtime]
+    env_runtime_capability = get_backend_capability(env_runtime)
+    if env_runtime_capability is not None and env_runtime_capability.supports_llm:
+        if env_runtime in {"claude_code"}:
+            return "claude_code"
+        return env_runtime_capability.name
 
     try:
         config = load_config()

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ouroboros.backends import resolve_runtime_backend_name, runtime_backend_choices
 from ouroboros.config import (
     get_agent_permission_mode,
     get_agent_runtime_backend,
@@ -20,40 +21,20 @@ from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.command_dispatcher import create_codex_command_dispatcher
 from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 
-_CLAUDE_BACKENDS = {"claude", "claude_code"}
-_CODEX_BACKENDS = {"codex", "codex_cli"}
-_KIRO_BACKENDS = {"kiro", "kiro_cli"}
-_OPENCODE_BACKENDS = {"opencode", "opencode_cli"}
-_HERMES_BACKENDS = {"hermes", "hermes_cli"}
-_GEMINI_BACKENDS = {"gemini", "gemini_cli"}
-_COPILOT_BACKENDS = {"copilot", "copilot_cli"}
-
-_SUPPORTED_BACKENDS = ("claude", "codex", "opencode", "hermes", "gemini", "kiro", "copilot")
+_SUPPORTED_BACKENDS = runtime_backend_choices()
 
 
 def resolve_agent_runtime_backend(backend: str | None = None) -> str:
     """Resolve and validate the orchestrator runtime backend name."""
     candidate = (backend or get_agent_runtime_backend()).strip().lower()
-    if candidate in _CLAUDE_BACKENDS:
-        return "claude"
-    if candidate in _CODEX_BACKENDS:
-        return "codex"
-    if candidate in _KIRO_BACKENDS:
-        return "kiro"
-    if candidate in _OPENCODE_BACKENDS:
-        return "opencode"
-    if candidate in _HERMES_BACKENDS:
-        return "hermes"
-    if candidate in _GEMINI_BACKENDS:
-        return "gemini"
-    if candidate in _COPILOT_BACKENDS:
-        return "copilot"
-
-    msg = (
-        f"Unsupported orchestrator runtime backend: {candidate}. "
-        f"Supported backends: {', '.join(_SUPPORTED_BACKENDS)}"
-    )
-    raise ValueError(msg)
+    try:
+        return resolve_runtime_backend_name(candidate)
+    except ValueError as exc:
+        msg = (
+            f"Unsupported orchestrator runtime backend: {candidate}. "
+            f"Supported backends: {', '.join(_SUPPORTED_BACKENDS)}"
+        )
+        raise ValueError(msg) from exc
 
 
 def create_agent_runtime(

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal
 
 import structlog
 
+from ouroboros.backends import resolve_llm_backend_name, soft_tool_enforcement_backends
 from ouroboros.config import (
     get_codex_cli_path,
     get_gemini_cli_path,
@@ -27,13 +28,6 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger(__name__)
 
-_CLAUDE_CODE_BACKENDS = {"claude", "claude_code"}
-_CODEX_BACKENDS = {"codex", "codex_cli"}
-_COPILOT_BACKENDS = {"copilot", "copilot_cli"}
-_GEMINI_BACKENDS = {"gemini", "gemini_cli"}
-_KIRO_BACKENDS = {"kiro", "kiro_cli"}
-_OPENCODE_BACKENDS = {"opencode", "opencode_cli"}
-_LITELLM_BACKENDS = {"litellm", "openai", "openrouter"}
 _LLM_USE_CASES = frozenset({"default", "interview"})
 
 # Resolved backend names whose adapter enforces the ``allowed_tools``
@@ -65,29 +59,20 @@ _LLM_USE_CASES = frozenset({"default", "interview"})
 # completion-only API that never executes tools from the adapter, so an
 # envelope has nothing to restrict on that path (enforcement is
 # vacuously satisfied).
-_BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT: frozenset[str] = frozenset({"gemini", "opencode"})
+_BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT: frozenset[str] = soft_tool_enforcement_backends()
 
 
 def resolve_llm_backend(backend: str | None = None) -> str:
     """Resolve and validate the LLM adapter backend name."""
     candidate = (backend or get_llm_backend()).strip().lower()
-    if candidate in _CLAUDE_CODE_BACKENDS:
+    try:
+        resolved = resolve_llm_backend_name(candidate)
+    except ValueError as exc:
+        msg = f"Unsupported LLM backend: {candidate}"
+        raise ValueError(msg) from exc
+    if resolved == "claude":
         return "claude_code"
-    if candidate in _CODEX_BACKENDS:
-        return "codex"
-    if candidate in _COPILOT_BACKENDS:
-        return "copilot"
-    if candidate in _GEMINI_BACKENDS:
-        return "gemini"
-    if candidate in _KIRO_BACKENDS:
-        return "kiro"
-    if candidate in _OPENCODE_BACKENDS:
-        return "opencode"
-    if candidate in _LITELLM_BACKENDS:
-        return "litellm"
-
-    msg = f"Unsupported LLM backend: {candidate}"
-    raise ValueError(msg)
+    return resolved
 
 
 def resolve_llm_permission_mode(

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -1,0 +1,56 @@
+"""Tests for the shared backend capability registry."""
+
+import pytest
+
+from ouroboros.backends import (
+    get_backend_capability,
+    interview_driver_backend_choices,
+    llm_backend_choices,
+    resolve_backend_alias,
+    resolve_llm_backend_name,
+    resolve_runtime_backend_name,
+    runtime_backend_choices,
+    soft_tool_enforcement_backends,
+)
+
+
+def test_resolves_aliases_to_canonical_names() -> None:
+    assert resolve_backend_alias("codex_cli") == "codex"
+    assert resolve_backend_alias("claude_code") == "claude"
+    assert resolve_backend_alias("openrouter") == "litellm"
+
+
+def test_runtime_choices_include_runtime_only_backends() -> None:
+    choices = runtime_backend_choices()
+    assert "hermes" in choices
+    assert "litellm" not in choices
+
+
+def test_llm_choices_exclude_runtime_without_adapter() -> None:
+    choices = llm_backend_choices()
+    assert "codex" in choices
+    assert "hermes" not in choices
+
+
+def test_capability_specific_resolution_rejects_wrong_surface() -> None:
+    with pytest.raises(ValueError):
+        resolve_runtime_backend_name("litellm")
+    with pytest.raises(ValueError):
+        resolve_llm_backend_name("hermes")
+
+
+def test_interview_driver_choices_follow_llm_capability() -> None:
+    assert "codex" in interview_driver_backend_choices()
+    assert "hermes" not in interview_driver_backend_choices()
+
+
+def test_soft_tool_enforcement_is_registry_owned() -> None:
+    assert soft_tool_enforcement_backends() == frozenset({"gemini", "opencode"})
+
+
+def test_switchable_runtime_metadata_is_registry_owned() -> None:
+    capability = get_backend_capability("gemini_cli")
+    assert capability is not None
+    assert capability.name == "gemini"
+    assert capability.switchable_runtime is True
+    assert capability.cli_config_key == "gemini_cli_path"

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -284,6 +284,22 @@ class TestConfigValidate:
             result = runner.invoke(app, ["validate"])
         assert result.exit_code == 0
 
+    @pytest.mark.parametrize(
+        "alias",
+        ["claude_code", "codex_cli", "opencode_cli", "gemini_cli", "hermes_cli"],
+    )
+    def test_runtime_backend_alias_is_valid(self, tmp_path: Path, alias: str) -> None:
+        """validate should accept runtime_backend aliases that the schema permits."""
+        config = {"orchestrator": {"runtime_backend": alias}, "llm": {"backend": "claude"}}
+        (tmp_path / "config.yaml").write_text(yaml.dump(config))
+
+        with (
+            patch("ouroboros.config.models.get_config_dir", return_value=tmp_path),
+            patch("ouroboros.config.loader.load_config"),
+        ):
+            result = runner.invoke(app, ["validate"])
+        assert result.exit_code == 0
+
     def test_missing_cli_path_exits_nonzero(self, tmp_path: Path) -> None:
         """validate should exit 1 when CLI path doesn't exist."""
         config = {


### PR DESCRIPTION
## Stack

1/3 Capability registry for backend aliases and surfaces.

Next PRs:
- 2/3 Hermes LLM/interview driver support
- 3/3 Auto driver/brake CLI wiring

## Changes
- Adds `ouroboros.backends` capability registry.
- Refactors runtime/provider/config validation to use the registry as source of truth.
- Keeps Hermes runtime-only in this layer.

## Validation
- `uv run pytest tests/unit/backends/test_capabilities.py tests/unit/providers/test_factory.py tests/unit/config/test_loader.py tests/unit/cli/test_config.py tests/unit/orchestrator/test_runtime_factory.py -q`
- `uv run ruff check src/ouroboros/backends src/ouroboros/providers/factory.py src/ouroboros/orchestrator/runtime_factory.py src/ouroboros/config/loader.py src/ouroboros/cli/commands/config.py tests/unit/backends/test_capabilities.py`