### PR TITLE
feat(providers): support hermes interview driver

### DIFF
--- a/src/ouroboros/backends/__init__.py
+++ b/src/ouroboros/backends/__init__.py
@@ -2,6 +2,7 @@
 
 from ouroboros.backends.capabilities import (
     BackendCapability,
+    backend_supports_tool_envelope,
     get_backend_capability,
     interview_driver_backend_choices,
     llm_backend_choices,
@@ -15,6 +16,7 @@ from ouroboros.backends.capabilities import (
 
 __all__ = [
     "BackendCapability",
+    "backend_supports_tool_envelope",
     "get_backend_capability",
     "interview_driver_backend_choices",
     "llm_backend_choices",

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -24,6 +24,7 @@ class BackendCapability:
     cli_name: str | None = None
     cli_config_key: str | None = None
     soft_tool_enforcement: bool = False
+    supports_tool_envelope: bool = True
 
     @property
     def names(self) -> tuple[str, ...]:
@@ -76,11 +77,12 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         name="hermes",
         aliases=("hermes_cli",),
         supports_runtime=True,
-        supports_llm=False,
-        supports_interview_driver=False,
+        supports_llm=True,
+        supports_interview_driver=True,
         switchable_runtime=True,
         cli_name="hermes",
         cli_config_key="hermes_cli_path",
+        supports_tool_envelope=False,
     ),
     BackendCapability(
         name="kiro",
@@ -183,8 +185,17 @@ def soft_tool_enforcement_backends() -> frozenset[str]:
     return frozenset(c.name for c in _CAPABILITIES if c.soft_tool_enforcement)
 
 
+def backend_supports_tool_envelope(name: str | None) -> bool:
+    """Return whether a backend accepts an engine-owned tool envelope."""
+    if name is None:
+        return True
+    capability = get_backend_capability(name)
+    return True if capability is None else capability.supports_tool_envelope
+
+
 __all__ = [
     "BackendCapability",
+    "backend_supports_tool_envelope",
     "get_backend_capability",
     "interview_driver_backend_choices",
     "llm_backend_choices",

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -60,10 +60,12 @@ from ouroboros.core.errors import ConfigError  # noqa: E402
 _CODEX_LLM_BACKENDS = frozenset({"codex", "codex_cli", "opencode", "opencode_cli"})
 _KIRO_LLM_BACKENDS = frozenset({"kiro", "kiro_cli"})
 _COPILOT_LLM_BACKENDS = frozenset({"copilot", "copilot_cli"})
+_HERMES_LLM_BACKENDS = frozenset({"hermes", "hermes_cli"})
 _OPENCODE_BACKENDS = frozenset({"opencode", "opencode_cli"})
 _CODEX_DEFAULT_MODEL = "default"
 _KIRO_DEFAULT_MODEL = "default"
 _COPILOT_DEFAULT_MODEL = "default"
+_HERMES_DEFAULT_MODEL = "default"
 _PLACEHOLDER_API_KEY_PREFIX = "YOUR_"
 _PLACEHOLDER_API_KEY_SUFFIX = "_API_KEY"
 _DEFAULT_MAX_PARALLEL_WORKERS = 3
@@ -1117,6 +1119,8 @@ def _default_model_for_backend(
         return _KIRO_DEFAULT_MODEL
     if resolved in _COPILOT_LLM_BACKENDS:
         return _COPILOT_DEFAULT_MODEL
+    if resolved in _HERMES_LLM_BACKENDS:
+        return _HERMES_DEFAULT_MODEL
     return default_model
 
 
@@ -1147,6 +1151,8 @@ def _normalize_configured_model_for_backend(
         return _KIRO_DEFAULT_MODEL
     if resolved in _COPILOT_LLM_BACKENDS and candidate == default_model:
         return _COPILOT_DEFAULT_MODEL
+    if resolved in _HERMES_LLM_BACKENDS and candidate == default_model:
+        return _HERMES_DEFAULT_MODEL
 
     return candidate
 
@@ -1163,7 +1169,8 @@ def _normalize_configured_models_for_backend(
         return _default_models_for_backend(default_models, backend=backend)
 
     if (
-        _resolve_llm_backend_for_models(backend) in (_CODEX_LLM_BACKENDS | _COPILOT_LLM_BACKENDS)
+        _resolve_llm_backend_for_models(backend)
+        in (_CODEX_LLM_BACKENDS | _COPILOT_LLM_BACKENDS | _HERMES_LLM_BACKENDS)
         and normalized == default_models
     ):
         return _default_models_for_backend(default_models, backend=backend)

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -126,6 +126,7 @@ class LLMConfig(BaseModel, frozen=True):
         "gemini",
         "opencode",
         "kiro",
+        "hermes",
     ] = "claude_code"
     permission_mode: Literal["default", "acceptEdits", "bypassPermissions"] = "default"
     opencode_permission_mode: Literal["default", "acceptEdits", "bypassPermissions"] = "acceptEdits"

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError as PydanticValidationError
 import structlog
 import yaml
 
+from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.bigbang.ambiguity import (
     AMBIGUITY_THRESHOLD,
     AUTO_COMPLETE_STREAK_REQUIRED,
@@ -60,7 +61,7 @@ from ouroboros.orchestrator.policy import (
     allowed_runtime_builtin_tool_names,
 )
 from ouroboros.persistence.event_store import EventStore
-from ouroboros.providers import create_llm_adapter
+from ouroboros.providers import create_llm_adapter, resolve_llm_backend
 from ouroboros.providers.base import LLMAdapter
 
 log = structlog.get_logger(__name__)
@@ -102,11 +103,14 @@ _INTERVIEW_COMPLETION_PHRASES = (
 )
 
 
-def _interview_allowed_tools(runtime_backend: str | None) -> list[str]:
+def _interview_allowed_tools(runtime_backend: str | None) -> list[str] | None:
     """Return the policy-derived read-only tool envelope for interviews."""
+    effective_backend = resolve_llm_backend(runtime_backend)
+    if not backend_supports_tool_envelope(effective_backend):
+        return None
     return allowed_runtime_builtin_tool_names(
         PolicyContext(
-            runtime_backend=runtime_backend,
+            runtime_backend=effective_backend,
             session_role=PolicySessionRole.INTERVIEW,
             execution_phase=PolicyExecutionPhase.INTERVIEW,
         )

--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import structlog
 
+from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.bigbang.interview import (
     InterviewRound,
     InterviewState,
@@ -57,7 +58,7 @@ from ouroboros.mcp.types import (
 from ouroboros.persistence.brownfield import BrownfieldRepo, BrownfieldStore
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.pm.handoff import build_pm_dev_handoff_next_step
-from ouroboros.providers import create_llm_adapter
+from ouroboros.providers import create_llm_adapter, resolve_llm_backend
 
 log = structlog.get_logger()
 
@@ -368,7 +369,9 @@ class PMInterviewHandler:
             backend=self.llm_backend,
             max_turns=1,
             use_case="interview",
-            allowed_tools=[],
+            allowed_tools=[]
+            if backend_supports_tool_envelope(resolve_llm_backend(self.llm_backend))
+            else None,
         )
         model = get_clarification_model(self.llm_backend)
         return PMInterviewEngine.create(

--- a/src/ouroboros/providers/__init__.py
+++ b/src/ouroboros/providers/__init__.py
@@ -39,6 +39,10 @@ def __getattr__(name: str) -> object:
         from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
 
         return OpenCodeLLMAdapter
+    if name == "HermesCliLLMAdapter":
+        from ouroboros.providers.hermes_cli_adapter import HermesCliLLMAdapter
+
+        return HermesCliLLMAdapter
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -56,6 +60,7 @@ __all__ = [
     "CodexCliLLMAdapter",
     "CopilotCliLLMAdapter",
     "OpenCodeLLMAdapter",
+    "HermesCliLLMAdapter",
     "LiteLLMAdapter",
     # Factory helpers
     "create_llm_adapter",

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -12,6 +12,7 @@ from ouroboros.backends import resolve_llm_backend_name, soft_tool_enforcement_b
 from ouroboros.config import (
     get_codex_cli_path,
     get_gemini_cli_path,
+    get_hermes_cli_path,
     get_llm_backend,
     get_llm_permission_mode,
     get_runtime_profile,
@@ -95,6 +96,7 @@ def resolve_llm_permission_mode(
         "codex",
         "copilot",
         "gemini",
+        "hermes",
         "opencode",
     ):
         # Interview uses LLM to generate questions — no file writes, but
@@ -202,6 +204,18 @@ def create_llm_adapter(
             cli_path=cli_path,
             cwd=cwd,
             permission_mode=resolved_permission_mode,
+            allowed_tools=allowed_tools,
+            max_turns=max_turns,
+            on_message=on_message,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+    if resolved_backend == "hermes":
+        from ouroboros.providers.hermes_cli_adapter import HermesCliLLMAdapter
+
+        return HermesCliLLMAdapter(
+            cli_path=cli_path or get_hermes_cli_path(),
+            cwd=cwd,
             allowed_tools=allowed_tools,
             max_turns=max_turns,
             on_message=on_message,

--- a/src/ouroboros/providers/hermes_cli_adapter.py
+++ b/src/ouroboros/providers/hermes_cli_adapter.py
@@ -1,0 +1,325 @@
+"""Hermes CLI adapter for LLM completion using local Hermes authentication."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+import os
+from pathlib import Path
+import re
+import shutil
+
+import structlog
+
+from ouroboros.config import get_hermes_cli_path
+from ouroboros.core.errors import ProviderError
+from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH, InputValidator
+from ouroboros.core.types import Result
+from ouroboros.orchestrator.hermes_runtime import _parse_quiet_output
+from ouroboros.providers.base import (
+    CompletionConfig,
+    CompletionResponse,
+    Message,
+    MessageRole,
+    UsageInfo,
+)
+from ouroboros.providers.codex_cli_stream import terminate_process
+from ouroboros.providers.profiles import resolve_completion_profile_result
+
+log = structlog.get_logger()
+
+_DEFAULT_MODEL = "default"
+_MAX_OUROBOROS_DEPTH = 5
+_SAFE_MODEL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_./:@-]+$")
+
+
+class HermesCliLLMAdapter:
+    """LLM completion adapter backed by ``hermes chat -Q``."""
+
+    _provider_name = "hermes_cli"
+    _display_name = "Hermes CLI"
+    _default_cli_name = "hermes"
+    _process_shutdown_timeout_seconds = 5.0
+
+    def __init__(
+        self,
+        *,
+        cli_path: str | Path | None = None,
+        model: str | None = None,
+        cwd: str | Path | None = None,
+        max_turns: int = 1,
+        timeout: float | None = 120.0,
+        max_retries: int = 3,
+        on_message: Callable[[str, str], None] | None = None,
+        allowed_tools: list[str] | None = None,
+    ) -> None:
+        self._cli_path = self._resolve_cli_path(cli_path)
+        self._model = model or _DEFAULT_MODEL
+        self._cwd = Path(cwd).resolve() if cwd else None
+        self._max_turns = max_turns
+        self._timeout = timeout
+        self._max_retries = max_retries
+        self._on_message = on_message
+        self._allowed_tools = tuple(allowed_tools) if allowed_tools is not None else None
+
+        log.info(
+            "hermes_cli_adapter.initialized",
+            cli_path=str(self._cli_path),
+            model=self._model,
+        )
+        if self._allowed_tools is not None:
+            log.warning(
+                "hermes_cli_adapter.tool_envelope_unsupported",
+                allowed_tools=list(self._allowed_tools),
+                reason=(
+                    "Hermes CLI quiet output does not expose tool-use events "
+                    "for post-hoc envelope auditing. Pass allowed_tools=None "
+                    "for Hermes sessions."
+                ),
+            )
+
+    async def complete(
+        self,
+        messages: list[Message],
+        config: CompletionConfig,
+    ) -> Result[CompletionResponse, ProviderError]:
+        """Make a single-turn completion request through Hermes CLI."""
+        if self._allowed_tools is not None:
+            return Result.err(
+                ProviderError(
+                    message=(
+                        "Hermes CLI adapter does not support allowed_tools envelopes; "
+                        "quiet mode cannot audit tool-use violations"
+                    ),
+                    provider=self._provider_name,
+                    details={"allowed_tools": list(self._allowed_tools)},
+                )
+            )
+
+        profile_result = resolve_completion_profile_result(config, backend="hermes")
+        if profile_result.is_err:
+            return Result.err(profile_result.error)
+        config = profile_result.value.config
+
+        prompt = self._build_prompt(messages)
+        model = self._resolve_model(config.model)
+        last_error: ProviderError | None = None
+
+        for attempt in range(max(1, self._max_retries)):
+            max_turns = config.max_turns or self._max_turns
+            result = await self._execute_request(prompt, model, max_turns=max_turns)
+            if result.is_ok:
+                return result
+
+            last_error = result.error
+            if attempt < self._max_retries - 1:
+                await asyncio.sleep(2**attempt)
+
+        return Result.err(last_error or ProviderError(message="Max retries exceeded"))
+
+    async def _execute_request(
+        self,
+        prompt: str,
+        model: str,
+        *,
+        max_turns: int,
+    ) -> Result[CompletionResponse, ProviderError]:
+        cmd = self._build_command(prompt, model, max_turns=max_turns)
+        log.debug("hermes_cli_adapter.spawning", cmd=cmd)
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(self._cwd) if self._cwd else None,
+                env=self._build_env(),
+            )
+        except FileNotFoundError:
+            return Result.err(
+                ProviderError(
+                    message=f"Hermes CLI not found at '{self._cli_path}'",
+                    provider=self._provider_name,
+                )
+            )
+        except Exception as exc:
+            return Result.err(
+                ProviderError(
+                    message=f"Failed to spawn Hermes CLI: {exc}",
+                    provider=self._provider_name,
+                )
+            )
+
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self._timeout)
+        except TimeoutError:
+            await terminate_process(
+                process,
+                shutdown_timeout=self._process_shutdown_timeout_seconds,
+            )
+            return Result.err(
+                ProviderError(
+                    message=f"Hermes CLI timed out after {self._timeout}s",
+                    provider=self._provider_name,
+                    details={"timeout_seconds": self._timeout},
+                )
+            )
+
+        stdout_text = self._decode(stdout)
+        stderr_text = self._decode(stderr)
+        returncode = getattr(process, "returncode", None)
+        if returncode not in (0, None):
+            return Result.err(
+                ProviderError(
+                    message=(
+                        f"Hermes CLI exited with code {returncode}"
+                        + (f": {stderr_text.strip()}" if stderr_text.strip() else "")
+                    ),
+                    provider=self._provider_name,
+                    details={"returncode": returncode, "stderr": stderr_text},
+                )
+            )
+
+        content, session_id = _parse_quiet_output(stdout_text)
+        if not content:
+            return Result.err(
+                ProviderError(
+                    message="Hermes CLI produced an empty response",
+                    provider=self._provider_name,
+                    details={"session_id": session_id, "stderr": stderr_text},
+                )
+            )
+
+        is_valid, _ = InputValidator.validate_llm_response(content)
+        if not is_valid:
+            log.warning(
+                "llm.response.truncated",
+                model=model,
+                original_length=len(content),
+                max_length=MAX_LLM_RESPONSE_LENGTH,
+            )
+            content = content[:MAX_LLM_RESPONSE_LENGTH]
+
+        if self._on_message and content.strip():
+            self._on_message("thinking", content.strip())
+
+        return Result.ok(
+            CompletionResponse(
+                content=content,
+                model=model,
+                usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+                finish_reason="stop",
+                raw_response={"session_id": session_id},
+            )
+        )
+
+    def _build_command(self, prompt: str, model: str, *, max_turns: int) -> list[str]:
+        cmd = [
+            str(self._cli_path),
+            "chat",
+            "-Q",
+            "--source",
+            "tool",
+            "--max-turns",
+            str(max(1, max_turns)),
+            "-q",
+            prompt,
+        ]
+        if model and model != "default":
+            cmd.extend(["--model", model])
+        return cmd
+
+    def _build_prompt(self, messages: list[Message]) -> str:
+        parts: list[str] = []
+        system_msgs = [m for m in messages if m.role == MessageRole.SYSTEM]
+        non_system = [m for m in messages if m.role != MessageRole.SYSTEM]
+
+        system_parts: list[str] = []
+        envelope_block = self._render_tool_envelope_block()
+        if envelope_block:
+            system_parts.append(envelope_block)
+        system_parts.extend(m.content for m in system_msgs)
+        if system_parts:
+            parts.append("<system>\n" + "\n\n".join(system_parts) + "\n</system>")
+
+        for msg in non_system:
+            if msg.role == MessageRole.USER:
+                parts.append(f"User: {msg.content}")
+            elif msg.role == MessageRole.ASSISTANT:
+                parts.append(f"Assistant: {msg.content}")
+        return "\n\n".join(parts)
+
+    def _render_tool_envelope_block(self) -> str | None:
+        if self._allowed_tools is None:
+            return None
+        if not self._allowed_tools:
+            return (
+                "<tool_envelope>\n"
+                "You are not permitted to invoke any tools in this session. "
+                "Respond using only text.\n"
+                "</tool_envelope>"
+            )
+        allowed_list = ", ".join(self._allowed_tools)
+        return (
+            "<tool_envelope>\n"
+            f"You may ONLY invoke the following tools in this session: {allowed_list}. "
+            "Do not invoke any other tool under any circumstances.\n"
+            "</tool_envelope>"
+        )
+
+    def _build_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
+            env.pop(key, None)
+        try:
+            depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
+        except (ValueError, TypeError):
+            depth = 1
+        if depth > _MAX_OUROBOROS_DEPTH:
+            raise ProviderError(
+                message=f"Maximum Ouroboros nesting depth ({_MAX_OUROBOROS_DEPTH}) exceeded",
+                provider=self._provider_name,
+                details={"depth": depth},
+            )
+        env["_OUROBOROS_DEPTH"] = str(depth)
+        return env
+
+    def _resolve_model(self, config_model: str) -> str:
+        if not config_model or config_model == "default":
+            return self._model
+        if not _SAFE_MODEL_NAME_PATTERN.match(config_model):
+            log.warning(
+                "hermes_cli_adapter.unsafe_model_name",
+                model=config_model,
+                fallback=self._model,
+            )
+            return self._model
+        return config_model
+
+    def _resolve_cli_path(self, cli_path: str | Path | None) -> Path:
+        if cli_path:
+            candidate = Path(cli_path).expanduser()
+            if candidate.parent == Path("."):
+                return candidate
+            return candidate.resolve()
+        configured = get_hermes_cli_path()
+        if configured:
+            candidate = Path(configured).expanduser()
+            if candidate.parent == Path("."):
+                return candidate
+            return candidate.resolve()
+        found = shutil.which(self._default_cli_name)
+        if found:
+            return Path(found)
+        return Path(self._default_cli_name)
+
+    @staticmethod
+    def _decode(value: bytes | str | None) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        return value.decode("utf-8", errors="replace")
+
+
+__all__ = ["HermesCliLLMAdapter"]

--- a/src/ouroboros/providers/profiles.py
+++ b/src/ouroboros/providers/profiles.py
@@ -21,6 +21,8 @@ _BACKEND_ALIASES = {
     "copilot_cli": "copilot",
     "gemini": "gemini",
     "gemini_cli": "gemini",
+    "hermes": "hermes",
+    "hermes_cli": "hermes",
     "opencode": "opencode",
     "opencode_cli": "opencode",
     "litellm": "litellm",

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -10,7 +10,11 @@ from ouroboros.auto.adapters import HandlerInterviewBackend
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.cli.main import app
 from ouroboros.core.types import Result
-from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
+from ouroboros.mcp.tools.authoring_handlers import (
+    GenerateSeedHandler,
+    InterviewHandler,
+    _interview_allowed_tools,
+)
 from ouroboros.mcp.tools.auto_handler import (
     AutoHandler,
     _authoring_interview_handler,
@@ -35,6 +39,17 @@ def test_cli_auto_runtime_enum_matches_supported_backends() -> None:
         "copilot",
         "kiro",
     }
+
+
+def test_interview_allowed_tools_omits_unsupported_hermes_envelope(monkeypatch) -> None:
+    assert _interview_allowed_tools("hermes") is None
+    assert _interview_allowed_tools("codex")
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+        lambda *_args, **_kwargs: "hermes",
+    )
+    assert _interview_allowed_tools(None) is None
 
 
 def test_cli_auto_help_is_registered() -> None:

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -3,6 +3,7 @@
 import pytest
 
 from ouroboros.backends import (
+    backend_supports_tool_envelope,
     get_backend_capability,
     interview_driver_backend_choices,
     llm_backend_choices,
@@ -26,26 +27,31 @@ def test_runtime_choices_include_runtime_only_backends() -> None:
     assert "litellm" not in choices
 
 
-def test_llm_choices_exclude_runtime_without_adapter() -> None:
+def test_llm_choices_include_hermes_adapter() -> None:
     choices = llm_backend_choices()
     assert "codex" in choices
-    assert "hermes" not in choices
+    assert "hermes" in choices
 
 
 def test_capability_specific_resolution_rejects_wrong_surface() -> None:
     with pytest.raises(ValueError):
         resolve_runtime_backend_name("litellm")
-    with pytest.raises(ValueError):
-        resolve_llm_backend_name("hermes")
+    assert resolve_llm_backend_name("hermes_cli") == "hermes"
 
 
 def test_interview_driver_choices_follow_llm_capability() -> None:
     assert "codex" in interview_driver_backend_choices()
-    assert "hermes" not in interview_driver_backend_choices()
+    assert "hermes" in interview_driver_backend_choices()
 
 
 def test_soft_tool_enforcement_is_registry_owned() -> None:
     assert soft_tool_enforcement_backends() == frozenset({"gemini", "opencode"})
+
+
+def test_tool_envelope_support_is_registry_owned() -> None:
+    assert backend_supports_tool_envelope("codex")
+    assert backend_supports_tool_envelope("gemini_cli")
+    assert not backend_supports_tool_envelope("hermes")
 
 
 def test_switchable_runtime_metadata_is_registry_owned() -> None:

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -1089,8 +1089,8 @@ class TestLLMHelperLookups:
         monkeypatch.setenv("OUROBOROS_RUNTIME", "kiro_cli")
         assert get_llm_backend() == "kiro"
 
-    def test_get_llm_backend_ignores_runtime_without_llm_adapter(self) -> None:
-        """Hermes runtime should keep using the configured LLM backend."""
+    def test_get_llm_backend_accepts_hermes_runtime_shortcut(self) -> None:
+        """Hermes runtime can also serve LLM completion defaults."""
         with (
             patch.dict(os.environ, {"OUROBOROS_RUNTIME": "hermes"}, clear=True),
             patch(
@@ -1101,7 +1101,7 @@ class TestLLMHelperLookups:
                 ),
             ),
         ):
-            assert get_llm_backend() == "claude_code"
+            assert get_llm_backend() == "hermes"
 
     def test_get_llm_permission_mode_prefers_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Environment variable overrides config for llm permission mode."""
@@ -1243,6 +1243,22 @@ class TestLLMHelperLookups:
             assert get_reflect_model(backend="copilot") == "default"
             assert get_semantic_model(backend="copilot") == "default"
             assert get_assertion_extraction_model(backend="copilot") == "default"
+
+    def test_hermes_backend_normalizes_config_default_models_to_default_sentinel(self) -> None:
+        """Existing default configs should remain usable after switching to Hermes."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "ouroboros.config.loader.load_config",
+                return_value=OuroborosConfig(),
+            ),
+        ):
+            assert get_clarification_model(backend="hermes") == "default"
+            assert get_qa_model(backend="hermes") == "default"
+            assert get_wonder_model(backend="hermes") == "default"
+            assert get_reflect_model(backend="hermes") == "default"
+            assert get_semantic_model(backend="hermes") == "default"
+            assert get_assertion_extraction_model(backend="hermes") == "default"
 
     def test_codex_backend_preserves_explicit_non_default_models_from_config(self) -> None:
         """Explicit config overrides should survive backend normalization."""

--- a/tests/unit/mcp/tools/test_pm_handler.py
+++ b/tests/unit/mcp/tools/test_pm_handler.py
@@ -571,6 +571,49 @@ class TestGetEngine:
             assert call_kwargs.kwargs["llm_adapter"] is mock_adapter
             assert call_kwargs.kwargs["model"] == "claude-opus-4-6"
 
+    def test_omits_tool_envelope_for_hermes_backend(self) -> None:
+        """Hermes is interview-capable but does not expose auditable tool envelopes."""
+        with (
+            patch("ouroboros.mcp.tools.pm_handler.create_llm_adapter") as mock_create,
+            patch("ouroboros.mcp.tools.pm_handler.get_clarification_model") as mock_model,
+            patch("ouroboros.mcp.tools.pm_handler.PMInterviewEngine") as mock_engine_cls,
+        ):
+            mock_create.return_value = MagicMock()
+            mock_model.return_value = "default"
+            mock_engine_cls.create.return_value = MagicMock()
+
+            handler = PMInterviewHandler(llm_backend="hermes")
+            handler._get_engine()
+
+            mock_create.assert_called_once_with(
+                backend="hermes",
+                max_turns=1,
+                use_case="interview",
+                allowed_tools=None,
+            )
+
+    def test_omits_tool_envelope_for_configured_hermes_backend(self) -> None:
+        """Default-configured Hermes also omits unsupported interview envelopes."""
+        with (
+            patch("ouroboros.mcp.tools.pm_handler.create_llm_adapter") as mock_create,
+            patch("ouroboros.mcp.tools.pm_handler.get_clarification_model") as mock_model,
+            patch("ouroboros.mcp.tools.pm_handler.PMInterviewEngine") as mock_engine_cls,
+            patch("ouroboros.mcp.tools.pm_handler.resolve_llm_backend", return_value="hermes"),
+        ):
+            mock_create.return_value = MagicMock()
+            mock_model.return_value = "default"
+            mock_engine_cls.create.return_value = MagicMock()
+
+            handler = PMInterviewHandler()
+            handler._get_engine()
+
+            mock_create.assert_called_once_with(
+                backend=None,
+                max_turns=1,
+                use_case="interview",
+                allowed_tools=None,
+            )
+
     def test_uses_custom_data_dir(self, tmp_path: Path) -> None:
         """When data_dir is set, passes it to PMInterviewEngine.create."""
         with (

--- a/tests/unit/providers/test_factory.py
+++ b/tests/unit/providers/test_factory.py
@@ -15,6 +15,7 @@ from ouroboros.providers.factory import (
     resolve_llm_backend,
     resolve_llm_permission_mode,
 )
+from ouroboros.providers.hermes_cli_adapter import HermesCliLLMAdapter
 from ouroboros.providers.litellm_adapter import LiteLLMAdapter
 from ouroboros.providers.opencode_adapter import OpenCodeLLMAdapter
 
@@ -63,10 +64,10 @@ class TestResolveLLMBackend:
         with pytest.raises(ValueError, match="Unsupported LLM backend"):
             resolve_llm_backend("invalid")
 
-    def test_rejects_hermes_backend(self) -> None:
-        """Hermes is runtime-only until an LLM adapter exists."""
-        with pytest.raises(ValueError, match="Unsupported LLM backend"):
-            resolve_llm_backend("hermes")
+    def test_resolves_hermes_aliases(self) -> None:
+        """Hermes aliases normalize to hermes."""
+        assert resolve_llm_backend("hermes") == "hermes"
+        assert resolve_llm_backend("hermes_cli") == "hermes"
 
 
 class TestCreateLLMAdapter:
@@ -185,6 +186,20 @@ class TestCreateLLMAdapter:
         adapter = create_llm_adapter(backend="opencode", cwd="/tmp/project")
         assert isinstance(adapter, OpenCodeLLMAdapter)
         assert adapter._cwd == "/tmp/project"
+
+    def test_creates_hermes_adapter(self) -> None:
+        """Hermes backend returns HermesCliLLMAdapter."""
+        adapter = create_llm_adapter(backend="hermes", cwd="/tmp/project")
+        assert isinstance(adapter, HermesCliLLMAdapter)
+        assert adapter._cwd is not None
+        assert adapter._cwd.name == "project"
+
+    def test_hermes_adapter_preserves_unsupported_tool_envelope(self) -> None:
+        """Factory preserves unsupported envelopes so Hermes can fail explicitly."""
+        adapter = create_llm_adapter(backend="hermes", allowed_tools=[], cwd="/tmp/project")
+
+        assert isinstance(adapter, HermesCliLLMAdapter)
+        assert adapter._allowed_tools == ()
 
     def test_creates_opencode_adapter_uses_configured_cli_path(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/providers/test_hermes_cli_adapter.py
+++ b/tests/unit/providers/test_hermes_cli_adapter.py
@@ -1,0 +1,163 @@
+"""Unit tests for the Hermes CLI-backed LLM adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ouroboros.providers.base import CompletionConfig, Message, MessageRole
+from ouroboros.providers.hermes_cli_adapter import HermesCliLLMAdapter
+
+
+class _FakeProcess:
+    """Minimal asyncio subprocess substitute for communicate-based adapters."""
+
+    def __init__(
+        self,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+    ) -> None:
+        self._stdout = stdout.encode()
+        self._stderr = stderr.encode()
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+@pytest.mark.asyncio
+async def test_complete_invokes_hermes_quiet_chat_and_parses_session() -> None:
+    commands: list[tuple[str, ...]] = []
+    process = _FakeProcess(stdout="Hello from Hermes\nsession_id: 20260507_120000_abcdef\n")
+
+    async def _fake_exec(*cmd: str, **kwargs: object) -> _FakeProcess:
+        commands.append(cmd)
+        return process
+
+    adapter = HermesCliLLMAdapter(cli_path="/usr/bin/hermes", cwd="/tmp/project")
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = await adapter.complete(
+            [Message(role=MessageRole.USER, content="Answer this")],
+            CompletionConfig(model="default"),
+        )
+
+    assert result.is_ok
+    assert result.value.content == "Hello from Hermes"
+    assert result.value.raw_response["session_id"] == "20260507_120000_abcdef"
+    assert commands
+    assert commands[0][:7] == (
+        "/usr/bin/hermes",
+        "chat",
+        "-Q",
+        "--source",
+        "tool",
+        "--max-turns",
+        "1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_complete_returns_provider_error_on_nonzero_exit() -> None:
+    process = _FakeProcess(stderr="auth failed", returncode=2)
+
+    async def _fake_exec(*cmd: str, **kwargs: object) -> _FakeProcess:
+        return process
+
+    adapter = HermesCliLLMAdapter(cli_path="/usr/bin/hermes", max_retries=1)
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = await adapter.complete(
+            [Message(role=MessageRole.USER, content="Answer this")],
+            CompletionConfig(model="default"),
+        )
+
+    assert result.is_err
+    assert result.error.provider == "hermes_cli"
+    assert "exited with code 2" in result.error.message
+
+
+def test_build_prompt_includes_tool_envelope() -> None:
+    adapter = HermesCliLLMAdapter(
+        cli_path=Path("/usr/bin/hermes"),
+        allowed_tools=["Read", "Grep"],
+    )
+
+    prompt = adapter._build_prompt(
+        [
+            Message(role=MessageRole.SYSTEM, content="Be concise."),
+            Message(role=MessageRole.USER, content="Question?"),
+        ]
+    )
+
+    assert "<tool_envelope>" in prompt
+    assert "Read, Grep" in prompt
+    assert "Be concise." in prompt
+
+
+@pytest.mark.asyncio
+async def test_allowed_tools_returns_error_without_spawning() -> None:
+    adapter = HermesCliLLMAdapter(cli_path="/usr/bin/hermes", allowed_tools=[])
+
+    with patch("asyncio.create_subprocess_exec") as create_process:
+        result = await adapter.complete(
+            [Message(role=MessageRole.USER, content="Answer this")],
+            CompletionConfig(model="default"),
+        )
+
+    assert result.is_err
+    assert "does not support allowed_tools envelopes" in result.error.message
+    create_process.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_complete_forwards_configured_max_turns() -> None:
+    commands: list[tuple[str, ...]] = []
+    process = _FakeProcess(stdout="Done\n")
+
+    async def _fake_exec(*cmd: str, **kwargs: object) -> _FakeProcess:
+        commands.append(cmd)
+        return process
+
+    adapter = HermesCliLLMAdapter(cli_path="/usr/bin/hermes", max_turns=5)
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = await adapter.complete(
+            [Message(role=MessageRole.USER, content="Answer this")],
+            CompletionConfig(model="default", max_turns=2),
+        )
+
+    assert result.is_ok
+    assert "--max-turns" in commands[0]
+    assert commands[0][commands[0].index("--max-turns") + 1] == "2"
+
+
+def test_bare_cli_path_preserves_path_lookup() -> None:
+    adapter = HermesCliLLMAdapter(cli_path="hermes")
+
+    assert adapter._cli_path == Path("hermes")
+
+
+def test_configured_bare_cli_path_preserves_path_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ouroboros.providers.hermes_cli_adapter.get_hermes_cli_path",
+        lambda: "hermes",
+    )
+
+    adapter = HermesCliLLMAdapter()
+
+    assert adapter._cli_path == Path("hermes")


### PR DESCRIPTION
## Stack

2/3 Hermes LLM/interview driver support. Review after #670.

Previous PR:
- #670 Capability registry

Next PR:
- 3/3 Auto driver/brake CLI wiring

## Changes
- Adds `HermesCliLLMAdapter` backed by `hermes chat -Q`.
- Marks Hermes as LLM and interview-driver capable in the registry.
- Allows `llm.backend: hermes` and `OUROBOROS_RUNTIME=hermes` to route completion through Hermes.

## Validation
- `uv run pytest tests/unit/backends/test_capabilities.py tests/unit/providers/test_factory.py tests/unit/providers/test_hermes_cli_adapter.py tests/unit/config/test_loader.py tests/unit/config/test_models.py -q`
- `uv run ruff check src/ouroboros/backends src/ouroboros/providers/hermes_cli_adapter.py src/ouroboros/providers/factory.py tests/unit/backends/test_capabilities.py tests/unit/providers/test_hermes_cli_adapter.py tests/unit/providers/test_factory.py`