### PR TITLE
test(auto): lock packaged driver/brake forwarding at MCP payload

### DIFF
--- a/tests/unit/router/test_packaged_auto_dispatch.py
+++ b/tests/unit/router/test_packaged_auto_dispatch.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.command_dispatcher import create_codex_command_dispatcher
 from ouroboros.router import Resolved, resolve_skill_dispatch
 
 
@@ -49,3 +55,72 @@ def test_packaged_auto_skill_dispatches_driver_and_brake_to_ouroboros_auto(
         "brake": "off",
     }
     assert result.first_argument == "Audit the open PRs --driver hermes --brake off"
+
+
+def _fake_ouroboros_server() -> AsyncMock:
+    server = AsyncMock()
+    server.call_tool = AsyncMock(
+        return_value=Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                meta={"auto_session_id": "auto_test"},
+            )
+        )
+    )
+    return server
+
+
+@pytest.mark.asyncio
+async def test_packaged_auto_skill_dispatch_forwards_driver_and_brake_to_mcp_payload(
+    tmp_path: Path,
+) -> None:
+    """Lock packaged ``ooo auto`` driver/brake forwarding into the actual MCP call."""
+    prompt = 'ooo auto "Audit the open PRs" --driver hermes --brake off --skip-run'
+    result = resolve_skill_dispatch(prompt, cwd=tmp_path)
+    assert isinstance(result, Resolved)
+
+    fake_server = _fake_ouroboros_server()
+    dispatch = create_codex_command_dispatcher(cwd=tmp_path)
+
+    with patch(
+        "ouroboros.mcp.server.adapter.create_ouroboros_server",
+        return_value=fake_server,
+    ):
+        messages = await dispatch(result, None)
+
+    fake_server.call_tool.assert_awaited_once()
+    tool_name, payload = fake_server.call_tool.await_args.args
+    assert tool_name == "ouroboros_auto"
+    assert payload["goal"] == "Audit the open PRs"
+    assert payload["driver"] == "hermes"
+    assert payload["brake"] == "off"
+    assert payload["skip_run"] is True
+    assert messages is not None
+    assert messages[0].data["tool_input"] == payload
+
+
+@pytest.mark.asyncio
+async def test_packaged_auto_skill_dispatch_does_not_leak_placeholder_strings_for_unset_driver_brake(
+    tmp_path: Path,
+) -> None:
+    """Plain ``ooo auto`` must not leak ``$driver``/``$brake`` placeholder literals into MCP."""
+    result = resolve_skill_dispatch('ouroboros:auto "Audit the open PRs"', cwd=tmp_path)
+    if not isinstance(result, Resolved):
+        result = resolve_skill_dispatch('ooo auto "Audit the open PRs"', cwd=tmp_path)
+    assert isinstance(result, Resolved)
+
+    fake_server = _fake_ouroboros_server()
+    dispatch = create_codex_command_dispatcher(cwd=tmp_path)
+
+    with patch(
+        "ouroboros.mcp.server.adapter.create_ouroboros_server",
+        return_value=fake_server,
+    ):
+        await dispatch(result, None)
+
+    payload = fake_server.call_tool.await_args.args[1]
+    assert payload["goal"] == "Audit the open PRs"
+    assert payload.get("driver", "") != "$driver"
+    assert payload.get("brake", "") != "$brake"
+    assert payload.get("driver", "") in ("", None)
+    assert payload.get("brake", "") in ("", None)


### PR DESCRIPTION
## Summary
Add a single MCP-payload-level regression test that locks packaged `ooo auto` driver/brake forwarding into the actual `ouroboros_auto` `call_tool` payload — the layer that #673 step 4 explicitly asks for ("the MCP input includes exactly those values").

This PR was originally a broader dispatch-layer change. After `stack/auto-capabilities/3-auto-driver-brake` advanced (commit `3f91e39`) and adopted empty-string-on-unset semantics for `driver`/`brake` template placeholders, the dispatch-layer changes here became redundant or design-conflicting. The PR has been rebased and reduced to the single piece of coverage that the upstream stack does not provide.

## What this PR adds
`tests/unit/router/test_packaged_auto_dispatch.py` (+75 lines, 0 production changes):

1. `test_packaged_auto_skill_dispatch_forwards_driver_and_brake_to_mcp_payload` — patches `create_ouroboros_server`, dispatches `ooo auto "..." --driver hermes --brake off --skip-run`, asserts the `ouroboros_auto` `call_tool` payload contains `driver="hermes"`, `brake="off"`, `skip_run=True`, and that `messages[0].data["tool_input"]` matches the same payload.
2. `test_packaged_auto_skill_dispatch_does_not_leak_placeholder_strings_for_unset_driver_brake` — plain `ooo auto "..."`; asserts the payload's `driver`/`brake` are not the literal `$driver`/`$brake` placeholder strings (empty or None is acceptable).

A shared `_fake_ouroboros_server()` helper builds the `AsyncMock` for both tests.

## Acceptance criteria mapping (#673)
| Criterion | Where it is locked |
|---|---|
| Forwards `driver` to `ouroboros_auto` when provided | `test_*_forwards_driver_and_brake_to_mcp_payload` (this PR) + stack/3 dispatch test |
| Forwards `brake` to `ouroboros_auto` when provided | same as above |
| Existing args (`goal`, `resume`, `cwd`, `max_interview_rounds`, `max_repair_rounds`, `skip_run`) continue to forward unchanged | stack/3 `test_packaged_auto_skill_dispatches_to_ouroboros_auto` |
| Plain `ooo auto "goal"` does not implicitly select a driver | `test_*_does_not_leak_placeholder_strings_for_unset_driver_brake` (this PR) + stack/3 dispatch test |
| Unset values do not appear as literal placeholders such as `$driver` or `$brake` | `test_*_does_not_leak_placeholder_strings_for_unset_driver_brake` (this PR) |

## Out of scope (intentionally dropped from earlier revisions)
- `_VALUE_OPTION_NAMES` augmentation for `driver`/`brake` — superseded by upstream stack/3's template-resolution path.
- `_OMIT_UNSET_OPTION_NAMES` omission logic — upstream chose empty-string-on-unset semantics; both satisfy "no literal placeholder leak".
- `skills/auto/SKILL.md` frontmatter additions — already merged into stack/3.
- Bare-flag (`--driver` with no value) fail-fast rejection — not in #673 acceptance criteria.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/router/test_packaged_auto_dispatch.py tests/unit/router/test_valid_dispatch_normalization.py -q` — passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/integration/test_codex_cli_passthrough_smoke.py::test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fallback -q` — passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/router/dispatch.py tests/unit/router/test_packaged_auto_dispatch.py` — passed

## Stack
Stacks on `stack/auto-capabilities/3-auto-driver-brake` (#672). The #637 fail-closed behavior is preserved — no production code is touched in this PR.

Closes #673