### PR TITLE
fix(auto): align MCP resume bounds

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -42,6 +42,8 @@ class AutoPipelineResult:
     last_grade: str | None = None
     run_handoff_status: str | None = None
     run_handoff_guidance: str | None = None
+    max_interview_rounds: int | None = None
+    max_repair_rounds: int | None = None
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
@@ -402,6 +404,8 @@ class AutoPipeline:
             last_grade=state.last_grade,
             run_handoff_status=state.run_handoff_status,
             run_handoff_guidance=state.run_handoff_guidance,
+            max_interview_rounds=state.max_interview_rounds,
+            max_repair_rounds=state.max_repair_rounds,
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -72,16 +72,14 @@ class AutoHandler:
                 MCPToolParameter(
                     "max_interview_rounds",
                     ToolInputType.INTEGER,
-                    "Max interview rounds",
+                    "Max interview rounds; omit on resume to keep the persisted bound",
                     required=False,
-                    default=12,
                 ),
                 MCPToolParameter(
                     "max_repair_rounds",
                     ToolInputType.INTEGER,
-                    "Max repair rounds",
+                    "Max repair rounds; omit on resume to keep the persisted bound",
                     required=False,
-                    default=5,
                 ),
                 MCPToolParameter(
                     "skip_run",
@@ -153,12 +151,24 @@ class AutoHandler:
             opencode_mode = _resolved_opencode_mode(
                 runtime_backend, state.opencode_mode or self.opencode_mode
             )
-            max_interview_rounds = state.max_interview_rounds
-            max_repair_rounds = state.max_repair_rounds
-            skip_run = requested_skip_run or state.skip_run
-            persisted_driver = _normalize_persisted_driver_backend(
-                state.interview_driver_backend
+            requested_max_interview_rounds = _optional_positive_int_arg(
+                arguments, "max_interview_rounds"
             )
+            requested_max_repair_rounds = _optional_positive_int_arg(arguments, "max_repair_rounds")
+            max_interview_rounds = _effective_resume_bound(
+                "max_interview_rounds",
+                requested_max_interview_rounds,
+                state.max_interview_rounds,
+            )
+            max_repair_rounds = _effective_resume_bound(
+                "max_repair_rounds",
+                requested_max_repair_rounds,
+                state.max_repair_rounds,
+            )
+            state.max_interview_rounds = max_interview_rounds
+            state.max_repair_rounds = max_repair_rounds
+            skip_run = requested_skip_run or state.skip_run
+            persisted_driver = _normalize_persisted_driver_backend(state.interview_driver_backend)
             if requested_driver is not None and persisted_driver not in {
                 None,
                 requested_driver,
@@ -267,6 +277,10 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["run_handoff_status"] = result.run_handoff_status
     if result.run_handoff_guidance:
         meta["run_handoff_guidance"] = result.run_handoff_guidance
+    if result.max_interview_rounds is not None:
+        meta["max_interview_rounds"] = result.max_interview_rounds
+    if result.max_repair_rounds is not None:
+        meta["max_repair_rounds"] = result.max_repair_rounds
     return meta
 
 
@@ -287,6 +301,33 @@ def _positive_int_arg(arguments: dict[str, Any], name: str, default: int) -> int
         msg = f"{name} must be >= 1"
         raise ValueError(msg)
     return value
+
+
+def _optional_positive_int_arg(arguments: dict[str, Any], name: str) -> int | None:
+    if name not in arguments:
+        return None
+    value = arguments.get(name)
+    if value in {None, ""}:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f"{name} must be a positive integer"
+        raise ValueError(msg)
+    if value <= 0:
+        msg = f"{name} must be >= 1"
+        raise ValueError(msg)
+    return value
+
+
+def _effective_resume_bound(name: str, requested: int | None, persisted: int) -> int:
+    if requested is None:
+        return persisted
+    if requested < persisted:
+        msg = (
+            f"{name} {requested} is lower than the persisted bound ({persisted}); "
+            "refuse to tighten a bound on resume"
+        )
+        raise ValueError(msg)
+    return requested
 
 
 def _safe_default_cwd() -> Path:

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -126,6 +126,10 @@ def test_auto_handler_schema_contains_hang_safe_options() -> None:
         "brake",
     } <= names
     params = {param.name: param for param in definition.parameters}
+    assert params["max_interview_rounds"].default is None
+    assert params["max_repair_rounds"].default is None
+    assert "persisted bound" in params["max_interview_rounds"].description
+    assert "persisted bound" in params["max_repair_rounds"].description
     assert params["brake"].default is None
 
 
@@ -1204,6 +1208,98 @@ async def test_auto_handler_resume_uses_persisted_cwd_without_revalidating_serve
     assert captured["cwd"] == str(tmp_path / "project")
     assert captured["driver_rounds"] == 2
     assert captured["repair_rounds"] == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("arguments", "expected_interview_rounds", "expected_repair_rounds"),
+    [
+        ({}, 4, 6),
+        ({"max_interview_rounds": 4, "max_repair_rounds": 6}, 4, 6),
+        ({"max_interview_rounds": 7, "max_repair_rounds": 8}, 7, 8),
+        ({"max_interview_rounds": 7}, 7, 6),
+        ({"max_repair_rounds": 8}, 4, 8),
+    ],
+)
+async def test_auto_handler_resume_resolves_effective_loop_bounds(
+    monkeypatch,
+    tmp_path,
+    arguments,
+    expected_interview_rounds,
+    expected_repair_rounds,
+) -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.auto.state import AutoPipelineState, AutoStore
+    from ouroboros.mcp.tools import auto_handler as auto_module
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path / "project"))
+    state.runtime_backend = "codex"
+    state.max_interview_rounds = 4
+    state.max_repair_rounds = 6
+    store.save(state)
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            captured["driver_rounds"] = args[0].max_rounds
+            captured["repair_rounds"] = kwargs["repairer"].max_repair_rounds
+
+        async def run(self, run_state):  # noqa: ANN001
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+                max_interview_rounds=run_state.max_interview_rounds,
+                max_repair_rounds=run_state.max_repair_rounds,
+            )
+
+    class FakeHandler:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            pass
+
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(auto_module, "InterviewHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "GenerateSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "ExecuteSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "StartExecuteSeedHandler", FakeHandler)
+
+    result = await AutoHandler(store=store).handle({"resume": state.auto_session_id, **arguments})
+
+    assert result.is_ok
+    assert captured["driver_rounds"] == expected_interview_rounds
+    assert captured["repair_rounds"] == expected_repair_rounds
+    assert result.value.meta["max_interview_rounds"] == expected_interview_rounds
+    assert result.value.meta["max_repair_rounds"] == expected_repair_rounds
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field_name", "lower_value"),
+    [("max_interview_rounds", 3), ("max_repair_rounds", 5)],
+)
+async def test_auto_handler_resume_rejects_lower_loop_bounds_without_persisting(
+    tmp_path, field_name, lower_value
+) -> None:
+    from ouroboros.auto.state import AutoPipelineState, AutoStore
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path / "project"))
+    state.runtime_backend = "codex"
+    state.max_interview_rounds = 4
+    state.max_repair_rounds = 6
+    store.save(state)
+
+    result = await AutoHandler(store=store).handle(
+        {"resume": state.auto_session_id, field_name: lower_value}
+    )
+
+    restored = store.load(state.auto_session_id)
+    assert result.is_err
+    assert field_name in str(result.error)
+    assert "lower than the persisted bound" in str(result.error)
+    assert restored.max_interview_rounds == 4
+    assert restored.max_repair_rounds == 6
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Align MCP `ouroboros_auto` resume bound overrides with CLI resume semantics.
- Allow equal or increased `max_interview_rounds` / `max_repair_rounds` on resume, reject lowered bounds, and preserve omitted persisted bounds.
- Surface effective loop bounds in MCP result metadata.
- Add MCP handler coverage for omitted, equal, increased, and lowered resume bounds.

## Discussion / implementation notes
This PR is stacked on #672 because it touches the MCP auto handler after the selected-driver/brake surface. It does not change new-session defaults, driver/brake semantics, or create unbounded loops.

## Validation
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_surface.py -q` — 61 passed
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/cli/test_auto_command.py -q` — 13 passed
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/mcp/tools/auto_handler.py src/ouroboros/auto/pipeline.py tests/unit/auto/test_surface.py` — passed
- [x] `git diff --check` — passed

Depends on #672
Closes #674
