### PR TITLE
feat(auto): expand bounded repo context

### DIFF
--- a/src/ouroboros/auto/repo_context.py
+++ b/src/ouroboros/auto/repo_context.py
@@ -26,6 +26,15 @@ _JS_LOCKFILES = {
     "yarn.lock": "Yarn",
 }
 
+# Ordered so that conflicting-manager output stays stable; first-listed manager
+# is the one mentioned first in the ambiguity message.
+_JVM_BUILD_FILES = (
+    ("pom.xml", "Maven"),
+    ("build.gradle", "Gradle"),
+    ("build.gradle.kts", "Gradle"),
+    ("settings.gradle", "Gradle"),
+)
+
 _SCRIPT_FACTS = {
     "build": "build_command",
     "dev": "dev_command",
@@ -178,16 +187,30 @@ def _add_go_facts(root: Path, facts: dict[str, str], evidence: dict[str, tuple[s
 
 
 def _add_jvm_facts(root: Path, facts: dict[str, str], evidence: dict[str, tuple[str, ...]]) -> None:
-    for filename, manager in (
-        ("pom.xml", "Maven"),
-        ("build.gradle", "Gradle"),
-        ("build.gradle.kts", "Gradle"),
-        ("settings.gradle", "Gradle"),
-    ):
-        if (root / filename).is_file():
-            _set_fact(facts, evidence, "project_kind", "JVM project", (filename,))
-            _set_fact(facts, evidence, "package_manager", manager, (filename,))
-            return
+    matched = [
+        (filename, manager) for filename, manager in _JVM_BUILD_FILES if (root / filename).is_file()
+    ]
+    if not matched:
+        return
+    filenames = tuple(filename for filename, _manager in matched)
+    managers = {manager for _filename, manager in matched}
+    _set_fact(facts, evidence, "project_kind", "JVM project", filenames)
+    if len(managers) == 1:
+        (manager,) = managers
+        _set_fact(facts, evidence, "package_manager", manager, filenames)
+    else:
+        ordered_managers = ", ".join(
+            sorted(
+                managers, key=lambda name: next(i for i, (_f, m) in enumerate(matched) if m == name)
+            )
+        )
+        _set_fact(
+            facts,
+            evidence,
+            "package_manager",
+            f"ambiguous JVM build manager ({ordered_managers})",
+            filenames,
+        )
 
 
 def _add_docker_task_facts(

--- a/src/ouroboros/auto/repo_context.py
+++ b/src/ouroboros/auto/repo_context.py
@@ -56,30 +56,29 @@ def repo_auto_answer_context(cwd: str | Path) -> AutoAnswerContext:
     pyproject = root / "pyproject.toml"
     if pyproject.is_file():
         pyproject_data = _read_pyproject(pyproject)
-        if pyproject_data is None:
-            return AutoAnswerContext(repo_facts=facts, evidence=evidence)
-        project = _table(pyproject_data.get("project"))
+        if pyproject_data is not None:
+            project = _table(pyproject_data.get("project"))
 
-        requires_python = _clean_str(project.get("requires-python"))
-        if requires_python:
-            runtime_parts.append(f"Python project requiring {requires_python}")
-            strong_runtime_fact = True
-        elif project:
-            facts["project_kind"] = "Python project declared in pyproject.toml"
-            evidence["project_kind"] = ("pyproject.toml",)
+            requires_python = _clean_str(project.get("requires-python"))
+            if requires_python:
+                runtime_parts.append(f"Python project requiring {requires_python}")
+                strong_runtime_fact = True
+            elif project:
+                facts["project_kind"] = "Python project declared in pyproject.toml"
+                evidence["project_kind"] = ("pyproject.toml",)
 
-        package_manager = _python_package_manager(root, pyproject_data)
-        if package_manager:
-            facts["package_manager"] = package_manager
-            evidence["package_manager"] = ("pyproject.toml",)
-            runtime_parts.append(f"managed with {package_manager}")
+            package_manager = _python_package_manager(root, pyproject_data)
+            if package_manager:
+                facts["package_manager"] = package_manager
+                evidence["package_manager"] = ("pyproject.toml",)
+                runtime_parts.append(f"managed with {package_manager}")
 
-        framework = _framework(project)
-        if framework:
-            facts["framework"] = framework
-            evidence["framework"] = ("pyproject.toml",)
-            runtime_parts.append(f"using {framework}")
-            strong_runtime_fact = True
+            framework = _framework(project)
+            if framework:
+                facts["framework"] = framework
+                evidence["framework"] = ("pyproject.toml",)
+                runtime_parts.append(f"using {framework}")
+                strong_runtime_fact = True
 
     _add_javascript_facts(root, facts, evidence)
     _add_rust_facts(root, facts, evidence)
@@ -124,7 +123,10 @@ def _add_javascript_facts(
     scripts = data.get("scripts")
     if not isinstance(scripts, dict):
         return
-    script_runner = manager if not manager.startswith("ambiguous ") else "package"
+    if manager and not manager.startswith("ambiguous "):
+        script_runner = manager
+    else:
+        script_runner = "package"
     for script_name, fact_key in _SCRIPT_FACTS.items():
         value = _clean_str(scripts.get(script_name))
         if value:
@@ -295,7 +297,7 @@ def _javascript_package_manager(root: Path) -> tuple[str, tuple[str, ...]]:
     if matched:
         filename, manager = matched[0]
         return manager, ("package.json", filename)
-    return "npm/package.json", ("package.json",)
+    return "", ()
 
 
 def _framework(project: dict[str, Any]) -> str:

--- a/src/ouroboros/auto/repo_context.py
+++ b/src/ouroboros/auto/repo_context.py
@@ -263,7 +263,7 @@ def _read_toml(path: Path) -> dict[str, Any] | None:
 def _read_json_object(path: Path) -> dict[str, Any] | None:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
     return data if isinstance(data, dict) else None
 
@@ -271,7 +271,7 @@ def _read_json_object(path: Path) -> dict[str, Any] | None:
 def _read_go_module(path: Path) -> str | None:
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     for line in text.splitlines():
         stripped = line.strip()

--- a/src/ouroboros/auto/repo_context.py
+++ b/src/ouroboros/auto/repo_context.py
@@ -165,6 +165,8 @@ def _add_go_facts(root: Path, facts: dict[str, str], evidence: dict[str, tuple[s
     if not go_mod.is_file():
         return
     module_name = _read_go_module(go_mod)
+    if module_name is None:
+        return
     project_kind = "Go module declared in go.mod"
     if module_name:
         project_kind = f"Go module {module_name!r} declared in go.mod"
@@ -243,17 +245,18 @@ def _read_json_object(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _read_go_module(path: Path) -> str:
+def _read_go_module(path: Path) -> str | None:
     try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            stripped = line.strip()
-            if stripped == "module":
-                return ""
-            if stripped.startswith("module "):
-                parts = stripped.split(None, 1)
-                return parts[1].strip() if len(parts) > 1 else ""
+        text = path.read_text(encoding="utf-8")
     except OSError:
-        return ""
+        return None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "module":
+            return ""
+        if stripped.startswith("module "):
+            parts = stripped.split(None, 1)
+            return parts[1].strip() if len(parts) > 1 else ""
     return ""
 
 

--- a/src/ouroboros/auto/repo_context.py
+++ b/src/ouroboros/auto/repo_context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import tomllib
 from typing import Any
@@ -18,45 +19,73 @@ _FRAMEWORK_DEPENDENCIES = {
     "typer": "Typer CLI",
 }
 
+_JS_LOCKFILES = {
+    "bun.lockb": "Bun",
+    "package-lock.json": "npm",
+    "pnpm-lock.yaml": "pnpm",
+    "yarn.lock": "Yarn",
+}
+
+_SCRIPT_FACTS = {
+    "build": "build_command",
+    "dev": "dev_command",
+    "lint": "lint_command",
+    "test": "test_command",
+}
+
+_DOCKER_TASK_FILES = {
+    "Dockerfile": "Dockerfile present",
+    "compose.yaml": "Docker Compose file present",
+    "compose.yml": "Docker Compose file present",
+    "docker-compose.yml": "Docker Compose file present",
+    "Makefile": "Makefile task runner present",
+    "justfile": "just task runner present",
+    "Taskfile.yml": "Taskfile task runner present",
+}
+
 
 def repo_auto_answer_context(cwd: str | Path) -> AutoAnswerContext:
     """Derive minimal local repo facts from fixed, bounded paths under ``cwd``."""
     root = Path(cwd)
-    pyproject = root / "pyproject.toml"
-    if not pyproject.is_file():
-        return AutoAnswerContext()
-
-    pyproject_data = _read_pyproject(pyproject)
-    if not pyproject_data:
-        return AutoAnswerContext()
-
-    project = _table(pyproject_data.get("project"))
     facts: dict[str, str] = {}
     evidence: dict[str, tuple[str, ...]] = {}
     runtime_parts: list[str] = []
     runtime_evidence = ["pyproject.toml"]
     strong_runtime_fact = False
 
-    requires_python = _clean_str(project.get("requires-python"))
-    if requires_python:
-        runtime_parts.append(f"Python project requiring {requires_python}")
-        strong_runtime_fact = True
-    elif project:
-        facts["project_kind"] = "Python project declared in pyproject.toml"
-        evidence["project_kind"] = ("pyproject.toml",)
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        pyproject_data = _read_pyproject(pyproject)
+        if pyproject_data is None:
+            return AutoAnswerContext(repo_facts=facts, evidence=evidence)
+        project = _table(pyproject_data.get("project"))
 
-    package_manager = _package_manager(root, pyproject_data)
-    if package_manager:
-        facts["package_manager"] = package_manager
-        evidence["package_manager"] = ("pyproject.toml",)
-        runtime_parts.append(f"managed with {package_manager}")
+        requires_python = _clean_str(project.get("requires-python"))
+        if requires_python:
+            runtime_parts.append(f"Python project requiring {requires_python}")
+            strong_runtime_fact = True
+        elif project:
+            facts["project_kind"] = "Python project declared in pyproject.toml"
+            evidence["project_kind"] = ("pyproject.toml",)
 
-    framework = _framework(project)
-    if framework:
-        facts["framework"] = framework
-        evidence["framework"] = ("pyproject.toml",)
-        runtime_parts.append(f"using {framework}")
-        strong_runtime_fact = True
+        package_manager = _python_package_manager(root, pyproject_data)
+        if package_manager:
+            facts["package_manager"] = package_manager
+            evidence["package_manager"] = ("pyproject.toml",)
+            runtime_parts.append(f"managed with {package_manager}")
+
+        framework = _framework(project)
+        if framework:
+            facts["framework"] = framework
+            evidence["framework"] = ("pyproject.toml",)
+            runtime_parts.append(f"using {framework}")
+            strong_runtime_fact = True
+
+    _add_javascript_facts(root, facts, evidence)
+    _add_rust_facts(root, facts, evidence)
+    _add_go_facts(root, facts, evidence)
+    _add_jvm_facts(root, facts, evidence)
+    _add_docker_task_facts(root, facts, evidence)
 
     structure = _project_structure(root)
     if structure:
@@ -73,13 +102,157 @@ def repo_auto_answer_context(cwd: str | Path) -> AutoAnswerContext:
     return AutoAnswerContext(repo_facts=facts, evidence=evidence)
 
 
-def _read_pyproject(path: Path) -> dict[str, Any]:
+def _add_javascript_facts(
+    root: Path, facts: dict[str, str], evidence: dict[str, tuple[str, ...]]
+) -> None:
+    package_json = root / "package.json"
+    if not package_json.is_file():
+        return
+    data = _read_json_object(package_json)
+    if data is None:
+        return
+    package_name = _clean_str(data.get("name"))
+    project_kind = "JavaScript/TypeScript project"
+    if package_name:
+        project_kind = f"JavaScript/TypeScript project {package_name!r}"
+    _set_fact(facts, evidence, "project_kind", project_kind, ("package.json",))
+
+    manager, manager_evidence = _javascript_package_manager(root)
+    if manager:
+        _set_fact(facts, evidence, "package_manager", manager, manager_evidence)
+
+    scripts = data.get("scripts")
+    if not isinstance(scripts, dict):
+        return
+    script_runner = manager if not manager.startswith("ambiguous ") else "package"
+    for script_name, fact_key in _SCRIPT_FACTS.items():
+        value = _clean_str(scripts.get(script_name))
+        if value:
+            _set_fact(
+                facts,
+                evidence,
+                fact_key,
+                f"{script_runner} script `{script_name}`: {value}",
+                ("package.json",),
+            )
+
+
+def _add_rust_facts(
+    root: Path, facts: dict[str, str], evidence: dict[str, tuple[str, ...]]
+) -> None:
+    cargo_toml = root / "Cargo.toml"
+    if not cargo_toml.is_file():
+        return
+    cargo_data = _read_toml(cargo_toml)
+    if cargo_data is None:
+        return
+    package = _table(cargo_data.get("package"))
+    package_name = _clean_str(package.get("name"))
+    project_kind = "Rust project declared in Cargo.toml"
+    if package_name:
+        project_kind = f"Rust project {package_name!r} declared in Cargo.toml"
+    _set_fact(facts, evidence, "project_kind", project_kind, ("Cargo.toml",))
+    manager_evidence = ["Cargo.toml"]
+    if (root / "Cargo.lock").is_file():
+        manager_evidence.append("Cargo.lock")
+    _set_fact(facts, evidence, "package_manager", "Cargo", tuple(manager_evidence))
+
+
+def _add_go_facts(root: Path, facts: dict[str, str], evidence: dict[str, tuple[str, ...]]) -> None:
+    go_mod = root / "go.mod"
+    if not go_mod.is_file():
+        return
+    module_name = _read_go_module(go_mod)
+    project_kind = "Go module declared in go.mod"
+    if module_name:
+        project_kind = f"Go module {module_name!r} declared in go.mod"
+    _set_fact(facts, evidence, "project_kind", project_kind, ("go.mod",))
+    manager_evidence = ["go.mod"]
+    if (root / "go.sum").is_file():
+        manager_evidence.append("go.sum")
+    _set_fact(facts, evidence, "package_manager", "Go modules", tuple(manager_evidence))
+
+
+def _add_jvm_facts(root: Path, facts: dict[str, str], evidence: dict[str, tuple[str, ...]]) -> None:
+    for filename, manager in (
+        ("pom.xml", "Maven"),
+        ("build.gradle", "Gradle"),
+        ("build.gradle.kts", "Gradle"),
+        ("settings.gradle", "Gradle"),
+    ):
+        if (root / filename).is_file():
+            _set_fact(facts, evidence, "project_kind", "JVM project", (filename,))
+            _set_fact(facts, evidence, "package_manager", manager, (filename,))
+            return
+
+
+def _add_docker_task_facts(
+    root: Path, facts: dict[str, str], evidence: dict[str, tuple[str, ...]]
+) -> None:
+    hints: list[str] = []
+    hint_evidence: list[str] = []
+    for filename, description in _DOCKER_TASK_FILES.items():
+        if (root / filename).is_file():
+            hints.append(description)
+            hint_evidence.append(filename)
+    if hints:
+        _set_fact(
+            facts,
+            evidence,
+            "execution_hints",
+            "; ".join(hints),
+            tuple(hint_evidence),
+        )
+
+
+def _set_fact(
+    facts: dict[str, str],
+    evidence: dict[str, tuple[str, ...]],
+    key: str,
+    value: str,
+    paths: tuple[str, ...],
+) -> None:
+    if key in facts:
+        facts[key] = f"{facts[key]}; {value}"
+        evidence[key] = tuple(dict.fromkeys((*evidence.get(key, ()), *paths)))
+        return
+    facts[key] = value
+    evidence[key] = paths
+
+
+def _read_pyproject(path: Path) -> dict[str, Any] | None:
+    return _read_toml(path)
+
+
+def _read_toml(path: Path) -> dict[str, Any] | None:
     try:
         with path.open("rb") as stream:
             data = tomllib.load(stream)
     except (OSError, tomllib.TOMLDecodeError):
-        return {}
-    return data if isinstance(data, dict) else {}
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _read_go_module(path: Path) -> str:
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped == "module":
+                return ""
+            if stripped.startswith("module "):
+                parts = stripped.split(None, 1)
+                return parts[1].strip() if len(parts) > 1 else ""
+    except OSError:
+        return ""
+    return ""
 
 
 def _table(value: object) -> dict[str, Any]:
@@ -90,7 +263,7 @@ def _clean_str(value: object) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
-def _package_manager(root: Path, pyproject_data: dict[str, Any]) -> str:
+def _python_package_manager(root: Path, pyproject_data: dict[str, Any]) -> str:
     if (root / "uv.lock").is_file():
         return "uv"
     if (root / "poetry.lock").is_file():
@@ -104,6 +277,25 @@ def _package_manager(root: Path, pyproject_data: dict[str, Any]) -> str:
     if backend:
         return f"{backend}/pyproject"
     return "pyproject.toml"
+
+
+def _javascript_package_manager(root: Path) -> tuple[str, tuple[str, ...]]:
+    matched = [
+        (filename, manager)
+        for filename, manager in _JS_LOCKFILES.items()
+        if (root / filename).is_file()
+    ]
+    if len(matched) > 1:
+        filenames = tuple(filename for filename, _manager in matched)
+        managers = ", ".join(manager for _filename, manager in matched)
+        return (
+            f"ambiguous JavaScript package manager ({managers})",
+            ("package.json", *filenames),
+        )
+    if matched:
+        filename, manager = matched[0]
+        return manager, ("package.json", filename)
+    return "npm/package.json", ("package.json",)
 
 
 def _framework(project: dict[str, Any]) -> str:

--- a/tests/unit/auto/test_repo_context.py
+++ b/tests/unit/auto/test_repo_context.py
@@ -152,13 +152,35 @@ def test_repo_context_recognizes_compose_yml_hint(tmp_path) -> None:
 
 def test_repo_context_ignores_malformed_pyproject_conservatively(tmp_path) -> None:
     (tmp_path / "pyproject.toml").write_text("[project\n", encoding="utf-8")
-    (tmp_path / "src").mkdir()
-    (tmp_path / "tests").mkdir()
 
     context = repo_auto_answer_context(tmp_path)
 
     assert context.repo_facts == {}
     assert context.evidence == {}
+
+
+def test_repo_context_keeps_non_python_facts_when_pyproject_malformed(tmp_path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project\n", encoding="utf-8")
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "demo-web", "scripts": {"test": "vitest run"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n", encoding="utf-8")
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "demo-cli"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "Dockerfile").write_text("FROM alpine\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" not in context.repo_facts
+    assert "JavaScript/TypeScript project 'demo-web'" in context.repo_facts["project_kind"]
+    assert "Rust project 'demo-cli'" in context.repo_facts["project_kind"]
+    assert "pnpm" in context.repo_facts["package_manager"]
+    assert "Cargo" in context.repo_facts["package_manager"]
+    assert context.repo_facts["test_command"] == "pnpm script `test`: vitest run"
+    assert context.repo_facts["execution_hints"] == "Dockerfile present"
+    assert "pyproject.toml" not in context.evidence["project_kind"]
 
 
 def test_repo_context_ignores_malformed_package_json_conservatively(tmp_path) -> None:
@@ -170,3 +192,18 @@ def test_repo_context_ignores_malformed_package_json_conservatively(tmp_path) ->
     assert "project_kind" not in context.repo_facts
     assert "package_manager" not in context.repo_facts
     assert "test_command" not in context.repo_facts
+
+
+def test_repo_context_handles_javascript_without_lockfile(tmp_path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "demo-web", "scripts": {"test": "vitest run"}}),
+        encoding="utf-8",
+    )
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" not in context.repo_facts
+    assert context.repo_facts["project_kind"] == "JavaScript/TypeScript project 'demo-web'"
+    assert "package_manager" not in context.repo_facts
+    assert context.repo_facts["test_command"] == "package script `test`: vitest run"
+    assert context.evidence["test_command"] == ("package.json",)

--- a/tests/unit/auto/test_repo_context.py
+++ b/tests/unit/auto/test_repo_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from ouroboros.auto.repo_context import repo_auto_answer_context
 
@@ -207,3 +208,24 @@ def test_repo_context_handles_javascript_without_lockfile(tmp_path) -> None:
     assert "package_manager" not in context.repo_facts
     assert context.repo_facts["test_command"] == "package script `test`: vitest run"
     assert context.evidence["test_command"] == ("package.json",)
+
+
+def test_repo_context_skips_go_facts_when_go_mod_unreadable(tmp_path, monkeypatch) -> None:
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text("module example.com/demo\n", encoding="utf-8")
+    (tmp_path / "go.sum").write_text("", encoding="utf-8")
+
+    real_read_text = Path.read_text
+
+    def fake_read_text(self, *args, **kwargs):
+        if self == go_mod:
+            raise OSError("permission denied")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "project_kind" not in context.repo_facts
+    assert "package_manager" not in context.repo_facts
+    assert context.evidence == {}

--- a/tests/unit/auto/test_repo_context.py
+++ b/tests/unit/auto/test_repo_context.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+
+from ouroboros.auto.repo_context import repo_auto_answer_context
+
+
+def test_repo_context_extracts_javascript_scripts_without_runtime_context(tmp_path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "demo-web",
+                "scripts": {
+                    "test": "vitest run",
+                    "build": "vite build",
+                    "lint": "eslint .",
+                    "dev": "vite --host 0.0.0.0",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" not in context.repo_facts
+    assert "JavaScript/TypeScript project 'demo-web'" in context.repo_facts["project_kind"]
+    assert context.repo_facts["package_manager"] == "pnpm"
+    assert context.repo_facts["test_command"] == "pnpm script `test`: vitest run"
+    assert context.repo_facts["build_command"] == "pnpm script `build`: vite build"
+    assert context.repo_facts["lint_command"] == "pnpm script `lint`: eslint ."
+    assert context.repo_facts["dev_command"] == "pnpm script `dev`: vite --host 0.0.0.0"
+    assert context.evidence["package_manager"] == ("package.json", "pnpm-lock.yaml")
+    assert context.evidence["test_command"] == ("package.json",)
+
+
+def test_repo_context_extracts_rust_facts_as_partial_hints(tmp_path) -> None:
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "demo-cli"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "Cargo.lock").write_text("# lock\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" not in context.repo_facts
+    assert context.repo_facts["project_kind"] == "Rust project 'demo-cli' declared in Cargo.toml"
+    assert context.repo_facts["package_manager"] == "Cargo"
+    assert context.evidence["project_kind"] == ("Cargo.toml",)
+    assert context.evidence["package_manager"] == ("Cargo.toml", "Cargo.lock")
+
+
+def test_repo_context_extracts_go_module_facts_as_partial_hints(tmp_path) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/demo\n\ngo 1.23\n", encoding="utf-8")
+    (tmp_path / "go.sum").write_text("", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" not in context.repo_facts
+    assert context.repo_facts["project_kind"] == "Go module 'example.com/demo' declared in go.mod"
+    assert context.repo_facts["package_manager"] == "Go modules"
+    assert context.evidence["project_kind"] == ("go.mod",)
+    assert context.evidence["package_manager"] == ("go.mod", "go.sum")
+
+
+def test_repo_context_handles_malformed_go_module_without_crashing(tmp_path) -> None:
+    (tmp_path / "go.mod").write_text("module\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" not in context.repo_facts
+    assert context.repo_facts["project_kind"] == "Go module declared in go.mod"
+    assert context.repo_facts["package_manager"] == "Go modules"
+    assert context.evidence["project_kind"] == ("go.mod",)
+
+
+def test_repo_context_keeps_docker_and_task_runner_hints_out_of_runtime(tmp_path) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12\n", encoding="utf-8")
+    (tmp_path / "compose.yaml").write_text("services: {}\n", encoding="utf-8")
+    (tmp_path / "Makefile").write_text("test:\n\tpytest\n", encoding="utf-8")
+    (tmp_path / "justfile").write_text("test:\n    pytest\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" not in context.repo_facts
+    assert context.repo_facts["execution_hints"] == (
+        "Dockerfile present; Docker Compose file present; Makefile task runner present; "
+        "just task runner present"
+    )
+    assert context.evidence["execution_hints"] == (
+        "Dockerfile",
+        "compose.yaml",
+        "Makefile",
+        "justfile",
+    )
+
+
+def test_repo_context_preserves_python_strong_runtime_behavior(tmp_path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo-cli"',
+                'requires-python = ">=3.12"',
+                'dependencies = ["typer>=0.12"]',
+                "",
+                "[build-system]",
+                'build-backend = "hatchling.build"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "runtime_context" in context.repo_facts
+    assert "Python project requiring >=3.12" in context.repo_facts["runtime_context"]
+    assert "Typer CLI" in context.repo_facts["runtime_context"]
+    assert context.evidence["runtime_context"] == ("pyproject.toml", "src/", "tests/")
+
+
+def test_repo_context_surfaces_ambiguous_javascript_lockfiles(tmp_path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"scripts": {"test": "vitest run"}}), encoding="utf-8"
+    )
+    (tmp_path / "package-lock.json").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert (
+        context.repo_facts["package_manager"] == "ambiguous JavaScript package manager (npm, pnpm)"
+    )
+    assert context.repo_facts["test_command"] == "package script `test`: vitest run"
+    assert context.evidence["package_manager"] == (
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+    )
+
+
+def test_repo_context_recognizes_compose_yml_hint(tmp_path) -> None:
+    (tmp_path / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert context.repo_facts["execution_hints"] == "Docker Compose file present"
+    assert context.evidence["execution_hints"] == ("compose.yml",)
+
+
+def test_repo_context_ignores_malformed_pyproject_conservatively(tmp_path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert context.repo_facts == {}
+    assert context.evidence == {}
+
+
+def test_repo_context_ignores_malformed_package_json_conservatively(tmp_path) -> None:
+    (tmp_path / "package.json").write_text('{"scripts": ', encoding="utf-8")
+    (tmp_path / "package-lock.json").write_text("{}\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "project_kind" not in context.repo_facts
+    assert "package_manager" not in context.repo_facts
+    assert "test_command" not in context.repo_facts

--- a/tests/unit/auto/test_repo_context.py
+++ b/tests/unit/auto/test_repo_context.py
@@ -261,3 +261,25 @@ def test_repo_context_surfaces_ambiguous_jvm_build_managers(tmp_path) -> None:
     assert context.repo_facts["project_kind"] == "JVM project"
     assert context.repo_facts["package_manager"] == "ambiguous JVM build manager (Maven, Gradle)"
     assert context.evidence["package_manager"] == ("pom.xml", "build.gradle")
+
+
+def test_repo_context_skips_javascript_on_invalid_utf8(tmp_path) -> None:
+    (tmp_path / "package.json").write_bytes(b'{"name": "demo-\xff\xfe"}')
+    (tmp_path / "package-lock.json").write_text("{}\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "project_kind" not in context.repo_facts
+    assert "package_manager" not in context.repo_facts
+    assert "test_command" not in context.repo_facts
+
+
+def test_repo_context_skips_go_facts_on_invalid_utf8(tmp_path) -> None:
+    (tmp_path / "go.mod").write_bytes(b"module example.com/\xff\xfe\n")
+    (tmp_path / "go.sum").write_text("", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert "project_kind" not in context.repo_facts
+    assert "package_manager" not in context.repo_facts
+    assert context.evidence == {}

--- a/tests/unit/auto/test_repo_context.py
+++ b/tests/unit/auto/test_repo_context.py
@@ -229,3 +229,35 @@ def test_repo_context_skips_go_facts_when_go_mod_unreadable(tmp_path, monkeypatc
     assert "project_kind" not in context.repo_facts
     assert "package_manager" not in context.repo_facts
     assert context.evidence == {}
+
+
+def test_repo_context_recognizes_maven_jvm_project(tmp_path) -> None:
+    (tmp_path / "pom.xml").write_text("<project></project>\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert context.repo_facts["project_kind"] == "JVM project"
+    assert context.repo_facts["package_manager"] == "Maven"
+    assert context.evidence["package_manager"] == ("pom.xml",)
+
+
+def test_repo_context_recognizes_gradle_jvm_project(tmp_path) -> None:
+    (tmp_path / "build.gradle.kts").write_text("plugins {}\n", encoding="utf-8")
+    (tmp_path / "settings.gradle").write_text("rootProject.name = 'demo'\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert context.repo_facts["project_kind"] == "JVM project"
+    assert context.repo_facts["package_manager"] == "Gradle"
+    assert context.evidence["package_manager"] == ("build.gradle.kts", "settings.gradle")
+
+
+def test_repo_context_surfaces_ambiguous_jvm_build_managers(tmp_path) -> None:
+    (tmp_path / "pom.xml").write_text("<project></project>\n", encoding="utf-8")
+    (tmp_path / "build.gradle").write_text("plugins {}\n", encoding="utf-8")
+
+    context = repo_auto_answer_context(tmp_path)
+
+    assert context.repo_facts["project_kind"] == "JVM project"
+    assert context.repo_facts["package_manager"] == "ambiguous JVM build manager (Maven, Gradle)"
+    assert context.evidence["package_manager"] == ("pom.xml", "build.gradle")


### PR DESCRIPTION
## Summary
- Expand bounded auto repo facts beyond Python/`pyproject.toml`.
- Add root-level detection for JavaScript/TypeScript, Rust, Go, JVM, Docker, and task-runner manifests.
- Keep non-Python and Docker/task-runner findings as partial evidence-backed facts instead of promoting weak hints to `runtime_context`.
- Add focused repo context tests for JS scripts, Rust, Go, Docker/task-runner hints, and existing Python strong-runtime behavior.

## Discussion / implementation notes
This PR preserves the #640 grounding rule: only strong runtime evidence creates `runtime_context`. Non-Python manifests contribute bounded repo facts with evidence paths, but no commands are executed and no unbounded directory scans are added.

## Validation
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_repo_context.py tests/unit/auto/test_interview_pipeline.py::test_repo_context_keeps_partial_project_hints_out_of_confirmed_runtime tests/unit/auto/test_interview_pipeline.py::test_interview_driver_supplies_bounded_repo_facts_to_answerer -q` — 7 passed
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/repo_context.py tests/unit/auto/test_repo_context.py` — passed
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check src/ouroboros/auto/repo_context.py tests/unit/auto/test_repo_context.py` — passed
- [x] `git diff --check` — passed

Closes #676
