### PR TITLE
feat(auto): add selected-driver answer metadata

### DIFF
--- a/src/ouroboros/auto/__init__.py
+++ b/src/ouroboros/auto/__init__.py
@@ -6,7 +6,7 @@ state plus deterministic quality gates that a higher-level supervisor can use
 before starting execution.
 """
 
-from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
+from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerMetadata, AutoAnswerSource
 from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import AutoInterviewDriver, AutoInterviewResult, InterviewTurn
 from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
@@ -17,6 +17,7 @@ from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoPolicy, AutoS
 
 __all__ = [
     "AutoAnswer",
+    "AutoAnswerMetadata",
     "AutoAnswerSource",
     "AutoAnswerer",
     "AutoInterviewDriver",

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -66,6 +66,15 @@ class AutoBlocker:
 
 
 @dataclass(frozen=True, slots=True)
+class AutoAnswerMetadata:
+    """Structured provenance for auto answers that need audit context."""
+
+    risk: str | None = None
+    confidence: float | None = None
+    provenance: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class AutoAnswer:
     """Answer plus structured ledger updates."""
 
@@ -76,6 +85,7 @@ class AutoAnswer:
     assumptions: list[str] = field(default_factory=list)
     non_goals: list[str] = field(default_factory=list)
     blocker: AutoBlocker | None = None
+    metadata: AutoAnswerMetadata = field(default_factory=AutoAnswerMetadata)
 
     @property
     def prefixed_text(self) -> str:

--- a/src/ouroboros/auto/driver_answerer.py
+++ b/src/ouroboros/auto/driver_answerer.py
@@ -11,6 +11,7 @@ from ouroboros.auto.answerer import (
     AutoAnswer,
     AutoAnswerContext,
     AutoAnswerer,
+    AutoAnswerMetadata,
     AutoAnswerSource,
     AutoBlocker,
 )
@@ -66,7 +67,14 @@ class DriverAutoAnswerer:
                 source=AutoAnswerSource.BLOCKER,
                 confidence=1.0,
                 blocker=AutoBlocker(reason=reason, question=question),
-        )
+                metadata=_answer_metadata(
+                    backend=self.backend or "driver",
+                    brake=self.brake,
+                    risk=risk,
+                    confidence=1.0,
+                    scaffold=scaffold,
+                ),
+            )
 
         if self.adapter is None:
             allowed_tools: list[str] | None = None if self.backend == "hermes" else []
@@ -101,6 +109,13 @@ class DriverAutoAnswerer:
                     reason=f"selected driver {self.backend} failed to answer: {result.error}",
                     question=question,
                 ),
+                metadata=_answer_metadata(
+                    backend=self.backend or "driver",
+                    brake=self.brake,
+                    risk="driver answer unavailable",
+                    confidence=1.0,
+                    scaffold=scaffold,
+                ),
             )
         text = _clean_driver_text(result.value.content)
         if not text:
@@ -111,6 +126,13 @@ class DriverAutoAnswerer:
                 blocker=AutoBlocker(
                     reason=f"selected driver {self.backend} returned an empty answer",
                     question=question,
+                ),
+                metadata=_answer_metadata(
+                    backend=self.backend or "driver",
+                    brake=self.brake,
+                    risk="empty driver answer",
+                    confidence=1.0,
+                    scaffold=scaffold,
                 ),
             )
 
@@ -134,6 +156,13 @@ class DriverAutoAnswerer:
             ),
             assumptions=assumptions,
             non_goals=list(scaffold.non_goals),
+            metadata=_answer_metadata(
+                backend=self.backend or "driver",
+                brake=self.brake,
+                risk=risk,
+                confidence=confidence,
+                scaffold=scaffold,
+            ),
         )
 
     def apply(self, answer: AutoAnswer, ledger: SeedDraftLedger, *, question: str) -> None:
@@ -222,6 +251,26 @@ def _tag_driver_text(text: str, *, backend: str, brake: AutoBrakeMode, risk: str
     if risk:
         tags.append(f"risk={risk}")
     return f"[{' ; '.join(tags)}] {text}"
+
+
+def _answer_metadata(
+    *,
+    backend: str,
+    brake: AutoBrakeMode,
+    risk: str | None,
+    confidence: float,
+    scaffold: AutoAnswer,
+) -> AutoAnswerMetadata:
+    """Build structured selected-driver provenance for downstream audit surfaces."""
+    return AutoAnswerMetadata(
+        risk=risk,
+        confidence=max(0.0, min(1.0, float(confidence))),
+        provenance=(
+            f"driver:{backend}",
+            f"brake:{brake.value}",
+            f"scaffold_source:{scaffold.source.value}",
+        ),
+    )
 
 
 def _ledger_updates_for(

--- a/tests/unit/auto/test_driver_answerer.py
+++ b/tests/unit/auto/test_driver_answerer.py
@@ -49,6 +49,13 @@ async def test_driver_answerer_brake_off_answers_risky_question() -> None:
     assert "driver=codex" in answer.text
     assert "brake=off" in answer.text
     assert "risk=" in answer.text
+    assert answer.metadata.risk == "destructive or financial/production choice"
+    assert answer.metadata.confidence == answer.confidence
+    assert answer.metadata.provenance == (
+        "driver:codex",
+        "brake:off",
+        "scaffold_source:conservative_default",
+    )
     assert adapter.prompts
 
 
@@ -142,4 +149,11 @@ async def test_driver_answerer_brake_on_gates_risky_question() -> None:
 
     assert answer.blocker is not None
     assert "requires approval" in answer.blocker.reason
+    assert answer.metadata.risk == "destructive or financial/production choice"
+    assert answer.metadata.confidence == 1.0
+    assert answer.metadata.provenance == (
+        "driver:codex",
+        "brake:on",
+        "scaffold_source:conservative_default",
+    )
     assert adapter.prompts == []


### PR DESCRIPTION
## Summary
- Add `AutoAnswerMetadata` as structured metadata on auto answers.
- Populate selected-driver answers and selected-driver blockers with risk, confidence, and provenance metadata.
- Preserve existing selected-driver behavior; this slice only adds metadata plumbing for downstream classifier/enforcement work.

## Discussion / implementation notes
- This is the first #675 slice and intentionally uses `Refs #675` instead of closing it.
- The follow-up slice should consume this metadata for post-response classification and brake-specific enforcement.
- Existing text tags and ledger provenance are preserved for compatibility.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_driver_answerer.py -q` → 7 passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/answerer.py src/ouroboros/auto/driver_answerer.py src/ouroboros/auto/__init__.py tests/unit/auto/test_driver_answerer.py` → passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check src/ouroboros/auto/answerer.py src/ouroboros/auto/driver_answerer.py src/ouroboros/auto/__init__.py tests/unit/auto/test_driver_answerer.py` → passed
- `git diff --check` → passed

Refs #675
Depends on #672
