### PR TITLE
feat(auto): classify selected-driver answer risk

### DIFF
--- a/src/ouroboros/auto/__init__.py
+++ b/src/ouroboros/auto/__init__.py
@@ -6,7 +6,7 @@ state plus deterministic quality gates that a higher-level supervisor can use
 before starting execution.
 """
 
-from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
+from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerMetadata, AutoAnswerSource
 from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import AutoInterviewDriver, AutoInterviewResult, InterviewTurn
 from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
@@ -17,6 +17,7 @@ from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoPolicy, AutoS
 
 __all__ = [
     "AutoAnswer",
+    "AutoAnswerMetadata",
     "AutoAnswerSource",
     "AutoAnswerer",
     "AutoInterviewDriver",

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -66,6 +66,15 @@ class AutoBlocker:
 
 
 @dataclass(frozen=True, slots=True)
+class AutoAnswerMetadata:
+    """Structured provenance for auto answers that need audit context."""
+
+    risk: str | None = None
+    confidence: float | None = None
+    provenance: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class AutoAnswer:
     """Answer plus structured ledger updates."""
 
@@ -76,6 +85,7 @@ class AutoAnswer:
     assumptions: list[str] = field(default_factory=list)
     non_goals: list[str] = field(default_factory=list)
     blocker: AutoBlocker | None = None
+    metadata: AutoAnswerMetadata = field(default_factory=AutoAnswerMetadata)
 
     @property
     def prefixed_text(self) -> str:

--- a/src/ouroboros/auto/driver_answerer.py
+++ b/src/ouroboros/auto/driver_answerer.py
@@ -254,7 +254,7 @@ def classify_driver_answer_text_risk(text: str) -> str | None:
     production_target = r"\b(production|prod|live|billing|database|db|credentials?)\b"
     if re.search(destructive_action, lowered) and re.search(production_target, lowered):
         return "actual answer recommends destructive production action"
-    if re.search(r"\brm\s+-rf\s+/(?:\s|$)", text) or re.search(
+    if re.search(r"\brm\s+-rf\b", text) or re.search(
         r"\b(drop|truncate)\s+(database|table)\b", lowered
     ):
         return "actual answer recommends destructive production action"

--- a/src/ouroboros/auto/driver_answerer.py
+++ b/src/ouroboros/auto/driver_answerer.py
@@ -254,9 +254,7 @@ def classify_driver_answer_text_risk(text: str) -> str | None:
     production_target = r"\b(production|prod|live|billing|database|db|credentials?)\b"
     if re.search(destructive_action, lowered) and re.search(production_target, lowered):
         return "actual answer recommends destructive production action"
-    if re.search(r"\brm\s+-rf\b", text) or re.search(
-        r"\b(drop|truncate)\s+(database|table)\b", lowered
-    ):
+    if re.search(r"\brm\s+-rf\s+/(?:\s|$)", text):
         return "actual answer recommends destructive production action"
     return None
 

--- a/src/ouroboros/auto/driver_answerer.py
+++ b/src/ouroboros/auto/driver_answerer.py
@@ -135,14 +135,32 @@ class DriverAutoAnswerer:
                     scaffold=scaffold,
                 ),
             )
+        answer_risk = classify_driver_answer_text_risk(text)
+        if answer_risk and self.brake == AutoBrakeMode.ON:
+            reason = f"brake on: risky selected-driver response requires approval ({answer_risk})"
+            return AutoAnswer(
+                text=f"Cannot send selected-driver answer automatically without approval: {answer_risk}",
+                source=AutoAnswerSource.BLOCKER,
+                confidence=1.0,
+                blocker=AutoBlocker(reason=reason, question=question),
+                metadata=_answer_metadata(
+                    backend=self.backend or "driver",
+                    brake=self.brake,
+                    risk=_combined_risk(risk, answer_risk),
+                    confidence=1.0,
+                    scaffold=scaffold,
+                    answer_risk=answer_risk,
+                ),
+            )
 
         assumptions = list(scaffold.assumptions)
         confidence = min(scaffold.confidence, 0.82)
-        if risk:
-            assumptions.append(f"brake off auto-sent risky driver answer: {risk}")
+        final_risk = _combined_risk(risk, answer_risk)
+        if final_risk:
+            assumptions.append(f"brake off auto-sent risky driver answer: {final_risk}")
             confidence = min(confidence, 0.62)
         tagged_text = _tag_driver_text(
-            text, backend=self.backend or "driver", brake=self.brake, risk=risk
+            text, backend=self.backend or "driver", brake=self.brake, risk=final_risk
         )
         return AutoAnswer(
             text=tagged_text,
@@ -151,17 +169,19 @@ class DriverAutoAnswerer:
             ledger_updates=_ledger_updates_for(
                 scaffold,
                 driver_text=tagged_text,
-                risk=risk,
+                risk=final_risk,
                 backend=self.backend or "driver",
+                answer_risk=answer_risk,
             ),
             assumptions=assumptions,
             non_goals=list(scaffold.non_goals),
             metadata=_answer_metadata(
                 backend=self.backend or "driver",
                 brake=self.brake,
-                risk=risk,
+                risk=final_risk,
                 confidence=confidence,
                 scaffold=scaffold,
+                answer_risk=answer_risk,
             ),
         )
 
@@ -199,6 +219,64 @@ def classify_interview_answer_risk(question: str, scaffold: AutoAnswer | None = 
     if scaffold is not None and scaffold.confidence < 0.65:
         return "low-confidence high-impact answer"
     return None
+
+
+def classify_driver_answer_text_risk(text: str) -> str | None:
+    """Return a risk label for risky selected-driver output text."""
+    lowered = text.lower()
+    if _contains_real_secret(text):
+        return "actual answer contains secret or credential"
+    if re.search(
+        r"\b(password|passphrase|api[_ -]?key|access[_ -]?token|token|secret|credential)s?\b"
+        r"\s*(=|:)\s*['\"]?[^\s'\"<>]{12,}",
+        text,
+        flags=re.IGNORECASE,
+    ):
+        return "actual answer contains secret or credential"
+    if re.search(
+        r"\b[A-Z][A-Z0-9_]*(?:API[_]?KEY|ACCESS[_]?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)\b"
+        r"\s*=\s*['\"]?[^\s'\"<>]{12,}",
+        text,
+    ):
+        return "actual answer contains secret or credential"
+    if re.search(
+        r"\b[A-Za-z][A-Za-z0-9+.-]*://[^\s/@:]+:[^\s/@]{8,}@[^\s]+",
+        text,
+    ):
+        return "actual answer contains secret or credential"
+    if re.search(r"\bBearer\s+[A-Za-z0-9._~+/-]{20,}={0,2}\b", text):
+        return "actual answer contains secret or credential"
+    if re.search(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b", text):
+        return "actual answer contains secret or credential"
+    destructive_action = (
+        r"\b(delete|destroy|drop|truncate|wipe|erase|purge|deprovision|terminate)\b"
+    )
+    production_target = r"\b(production|prod|live|billing|database|db|credentials?)\b"
+    if re.search(destructive_action, lowered) and re.search(production_target, lowered):
+        return "actual answer recommends destructive production action"
+    if re.search(r"\brm\s+-rf\s+/(?:\s|$)", text) or re.search(
+        r"\b(drop|truncate)\s+(database|table)\b", lowered
+    ):
+        return "actual answer recommends destructive production action"
+    return None
+
+
+def _contains_real_secret(text: str) -> bool:
+    secret_patterns = (
+        r"\bAKIA[0-9A-Z]{16}\b",
+        r"\bASIA[0-9A-Z]{16}\b",
+        r"\bgh[pousr]_[A-Za-z0-9_]{30,}\b",
+        r"\bgithub_pat_[A-Za-z0-9_]{40,}\b",
+        r"\bsk-[A-Za-z0-9_-]{20,}\b",
+        r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b",
+    )
+    return any(re.search(pattern, text) for pattern in secret_patterns)
+
+
+def _combined_risk(pre_response_risk: str | None, answer_risk: str | None) -> str | None:
+    if pre_response_risk and answer_risk:
+        return f"{pre_response_risk}; {answer_risk}"
+    return pre_response_risk or answer_risk
 
 
 def _driver_prompt(
@@ -260,21 +338,30 @@ def _answer_metadata(
     risk: str | None,
     confidence: float,
     scaffold: AutoAnswer,
+    answer_risk: str | None = None,
 ) -> AutoAnswerMetadata:
     """Build structured selected-driver provenance for downstream audit surfaces."""
+    provenance = [
+        f"driver:{backend}",
+        f"brake:{brake.value}",
+        f"scaffold_source:{scaffold.source.value}",
+    ]
+    if answer_risk:
+        provenance.append(f"answer_risk:{answer_risk}")
     return AutoAnswerMetadata(
         risk=risk,
         confidence=max(0.0, min(1.0, float(confidence))),
-        provenance=(
-            f"driver:{backend}",
-            f"brake:{brake.value}",
-            f"scaffold_source:{scaffold.source.value}",
-        ),
+        provenance=tuple(provenance),
     )
 
 
 def _ledger_updates_for(
-    scaffold: AutoAnswer, *, driver_text: str, risk: str | None, backend: str
+    scaffold: AutoAnswer,
+    *,
+    driver_text: str,
+    risk: str | None,
+    backend: str,
+    answer_risk: str | None = None,
 ) -> list[tuple[str, LedgerEntry]]:
     updates = [
         (
@@ -307,6 +394,11 @@ def _ledger_updates_for(
                     confidence=0.6,
                     status=LedgerStatus.INFERRED,
                     rationale="Risk was preserved as provenance for Seed-ready and A-grade review gates.",
+                    evidence=(
+                        [f"driver:{backend}", f"answer_risk:{answer_risk}"]
+                        if answer_risk
+                        else [f"driver:{backend}"]
+                    ),
                 ),
             )
         )

--- a/src/ouroboros/auto/driver_answerer.py
+++ b/src/ouroboros/auto/driver_answerer.py
@@ -233,19 +233,19 @@ def classify_driver_answer_text_risk(text: str) -> str | None:
         return "actual answer contains secret or credential"
     if re.search(
         r"\b(password|passphrase|api[_ -]?key|access[_ -]?token|token|secret|credential)s?\b"
-        r"\s*(=|:)\s*['\"]?[^\s'\"<>]{12,}",
+        r"\s*(=|:)\s*['\"]?[^\s'\"<>]+",
         text,
         flags=re.IGNORECASE,
     ):
         return "actual answer contains secret or credential"
     if re.search(
         r"\b[A-Z][A-Z0-9_]*(?:API[_]?KEY|ACCESS[_]?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)\b"
-        r"\s*=\s*['\"]?[^\s'\"<>]{12,}",
+        r"\s*=\s*['\"]?[^\s'\"<>]+",
         text,
     ):
         return "actual answer contains secret or credential"
     if re.search(
-        r"\b[A-Za-z][A-Za-z0-9+.-]*://[^\s/@:]+:[^\s/@]{8,}@[^\s]+",
+        r"\b[A-Za-z][A-Za-z0-9+.-]*://[^\s/@:]+:[^\s/@]+@[^\s]+",
         text,
     ):
         return "actual answer contains secret or credential"

--- a/src/ouroboros/auto/driver_answerer.py
+++ b/src/ouroboros/auto/driver_answerer.py
@@ -11,6 +11,7 @@ from ouroboros.auto.answerer import (
     AutoAnswer,
     AutoAnswerContext,
     AutoAnswerer,
+    AutoAnswerMetadata,
     AutoAnswerSource,
     AutoBlocker,
 )
@@ -66,7 +67,14 @@ class DriverAutoAnswerer:
                 source=AutoAnswerSource.BLOCKER,
                 confidence=1.0,
                 blocker=AutoBlocker(reason=reason, question=question),
-        )
+                metadata=_answer_metadata(
+                    backend=self.backend or "driver",
+                    brake=self.brake,
+                    risk=risk,
+                    confidence=1.0,
+                    scaffold=scaffold,
+                ),
+            )
 
         if self.adapter is None:
             allowed_tools: list[str] | None = None if self.backend == "hermes" else []
@@ -101,6 +109,13 @@ class DriverAutoAnswerer:
                     reason=f"selected driver {self.backend} failed to answer: {result.error}",
                     question=question,
                 ),
+                metadata=_answer_metadata(
+                    backend=self.backend or "driver",
+                    brake=self.brake,
+                    risk="driver answer unavailable",
+                    confidence=1.0,
+                    scaffold=scaffold,
+                ),
             )
         text = _clean_driver_text(result.value.content)
         if not text:
@@ -111,6 +126,13 @@ class DriverAutoAnswerer:
                 blocker=AutoBlocker(
                     reason=f"selected driver {self.backend} returned an empty answer",
                     question=question,
+                ),
+                metadata=_answer_metadata(
+                    backend=self.backend or "driver",
+                    brake=self.brake,
+                    risk="empty driver answer",
+                    confidence=1.0,
+                    scaffold=scaffold,
                 ),
             )
 
@@ -134,6 +156,13 @@ class DriverAutoAnswerer:
             ),
             assumptions=assumptions,
             non_goals=list(scaffold.non_goals),
+            metadata=_answer_metadata(
+                backend=self.backend or "driver",
+                brake=self.brake,
+                risk=risk,
+                confidence=confidence,
+                scaffold=scaffold,
+            ),
         )
 
     def apply(self, answer: AutoAnswer, ledger: SeedDraftLedger, *, question: str) -> None:
@@ -222,6 +251,26 @@ def _tag_driver_text(text: str, *, backend: str, brake: AutoBrakeMode, risk: str
     if risk:
         tags.append(f"risk={risk}")
     return f"[{' ; '.join(tags)}] {text}"
+
+
+def _answer_metadata(
+    *,
+    backend: str,
+    brake: AutoBrakeMode,
+    risk: str | None,
+    confidence: float,
+    scaffold: AutoAnswer,
+) -> AutoAnswerMetadata:
+    """Build structured selected-driver provenance for downstream audit surfaces."""
+    return AutoAnswerMetadata(
+        risk=risk,
+        confidence=max(0.0, min(1.0, float(confidence))),
+        provenance=(
+            f"driver:{backend}",
+            f"brake:{brake.value}",
+            f"scaffold_source:{scaffold.source.value}",
+        ),
+    )
 
 
 def _ledger_updates_for(

--- a/tests/unit/auto/test_driver_answerer.py
+++ b/tests/unit/auto/test_driver_answerer.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import pytest
 
 from ouroboros.auto.answerer import AutoAnswerSource
-from ouroboros.auto.driver_answerer import DriverAutoAnswerer, classify_interview_answer_risk
-from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.driver_answerer import (
+    DriverAutoAnswerer,
+    classify_driver_answer_text_risk,
+    classify_interview_answer_risk,
+)
+from ouroboros.auto.ledger import LedgerSource, SeedDraftLedger
 from ouroboros.auto.state import AutoBrakeMode
 from ouroboros.core.types import Result
 from ouroboros.providers.base import CompletionResponse, UsageInfo
@@ -32,6 +36,73 @@ def test_classifies_blocker_questions_as_risky() -> None:
     scaffold = answerer.baseline.answer("Which production credentials should we use?", ledger)
 
     assert classify_interview_answer_risk("Which production credentials should we use?", scaffold)
+
+
+def test_classifies_actual_driver_answer_text_risk() -> None:
+    assert (
+        classify_driver_answer_text_risk(
+            "Use API key sk-1234567890abcdef1234567890abcdef for the service."
+        )
+        == "actual answer contains secret or credential"
+    )
+    assert (
+        classify_driver_answer_text_risk("Delete the production database to reset customer state.")
+        == "actual answer recommends destructive production action"
+    )
+    assert classify_driver_answer_text_risk("Use a placeholder secret reference.") is None
+
+
+def test_answer_text_risk_detects_plain_bearer_and_jwt_tokens() -> None:
+    assert (
+        classify_driver_answer_text_risk(
+            "Set Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456"
+        )
+        == "actual answer contains secret or credential"
+    )
+    assert (
+        classify_driver_answer_text_risk(
+            "Use token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        )
+        == "actual answer contains secret or credential"
+    )
+
+
+def test_answer_text_risk_allows_benign_customer_facing_content_edits() -> None:
+    assert classify_driver_answer_text_risk("Remove the customer-facing banner copy.") is None
+    assert classify_driver_answer_text_risk("Delete the customer help text from the FAQ.") is None
+    assert classify_driver_answer_text_risk("The password is generated during setup.") is None
+
+
+def test_answer_text_risk_does_not_let_placeholder_words_bypass_secrets() -> None:
+    assert (
+        classify_driver_answer_text_risk(
+            "Use this placeholder password: supersecretproductionpassword123."
+        )
+        == "actual answer contains secret or credential"
+    )
+    assert (
+        classify_driver_answer_text_risk(
+            "Example token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm9kIn0.abc123456789xyz"
+        )
+        == "actual answer contains secret or credential"
+    )
+
+
+def test_answer_text_risk_detects_env_var_and_dsn_secret_shapes() -> None:
+    assert (
+        classify_driver_answer_text_risk("Set OPENAI_API_KEY=fakekeyvalue1234567890 in env.")
+        == "actual answer contains secret or credential"
+    )
+    assert (
+        classify_driver_answer_text_risk("Use AWS_SECRET_ACCESS_KEY=fakesecretvalue1234567890.")
+        == "actual answer contains secret or credential"
+    )
+    assert (
+        classify_driver_answer_text_risk(
+            "Configure DATABASE_URL=postgres://demo:fakedbpassword1234@db.example/app."
+        )
+        == "actual answer contains secret or credential"
+    )
 
 
 @pytest.mark.asyncio
@@ -121,7 +192,7 @@ async def test_hermes_driver_does_not_request_unsupported_tool_envelope(
 
 @pytest.mark.asyncio
 async def test_driver_answerer_risky_brake_off_records_active_risk() -> None:
-    from ouroboros.auto.ledger import LedgerSource, LedgerStatus
+    from ouroboros.auto.ledger import LedgerStatus
 
     ledger = SeedDraftLedger.from_goal("Deploy a service")
     adapter = FakeAdapter("Use a placeholder secret reference, never a real credential.")
@@ -157,3 +228,49 @@ async def test_driver_answerer_brake_on_gates_risky_question() -> None:
         "scaffold_source:conservative_default",
     )
     assert adapter.prompts == []
+
+
+@pytest.mark.asyncio
+async def test_driver_answerer_brake_on_gates_risky_actual_answer() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    adapter = FakeAdapter("Use password: supersecretproductionpassword123.")
+    answerer = DriverAutoAnswerer(backend="codex", brake=AutoBrakeMode.ON, adapter=adapter)
+
+    answer = await answerer.answer("Which runtime and framework should be used?", ledger)
+
+    assert answer.source == AutoAnswerSource.BLOCKER
+    assert answer.blocker is not None
+    assert "selected-driver response requires approval" in answer.blocker.reason
+    assert answer.metadata.risk == "actual answer contains secret or credential"
+    assert answer.metadata.provenance == (
+        "driver:codex",
+        "brake:on",
+        "scaffold_source:existing_convention",
+        "answer_risk:actual answer contains secret or credential",
+    )
+    assert adapter.prompts
+
+
+@pytest.mark.asyncio
+async def test_driver_answerer_brake_off_records_risky_actual_answer() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    adapter = FakeAdapter("Run DROP DATABASE against production before starting.")
+    answerer = DriverAutoAnswerer(backend="codex", brake=AutoBrakeMode.OFF, adapter=adapter)
+
+    answer = await answerer.answer("Which runtime and framework should be used?", ledger)
+
+    assert answer.source == AutoAnswerSource.DRIVER
+    assert answer.blocker is None
+    assert answer.metadata.risk == "actual answer recommends destructive production action"
+    assert (
+        "answer_risk:actual answer recommends destructive production action"
+        in answer.metadata.provenance
+    )
+    risks = [
+        entry
+        for _section, entry in answer.ledger_updates
+        if entry.key.startswith("risk.auto_driver")
+    ]
+    assert risks
+    assert risks[0].source == LedgerSource.ASSUMPTION
+    assert "answer_risk:actual answer recommends destructive production action" in risks[0].evidence

--- a/tests/unit/auto/test_driver_answerer.py
+++ b/tests/unit/auto/test_driver_answerer.py
@@ -88,6 +88,56 @@ def test_answer_text_risk_does_not_let_placeholder_words_bypass_secrets() -> Non
     )
 
 
+def test_answer_text_risk_detects_known_provider_secret_shapes() -> None:
+    aws_id = "AKIA" + "IOSFODNN7EXAMPLE"
+    gh_pat_classic = "ghp_" + "a" * 36
+    gh_pat_fine = "github_pat_" + "a" * 50
+    slack_bot = "xoxb-" + "1234567890-1234567890-abcdefghijklmnop"
+    openai_key = "sk-" + "abcdefghijklmnopqrst1234"
+    cases = (
+        f"Use {aws_id} for the role.",
+        f"Token: {gh_pat_classic}",
+        f"Use {gh_pat_fine}",
+        f"Slack incoming hook {slack_bot}",
+        f"Provide API key {openai_key}.",
+    )
+    for text in cases:
+        assert (
+            classify_driver_answer_text_risk(text) == "actual answer contains secret or credential"
+        ), text
+
+
+def test_answer_text_risk_flags_rm_rf_paths_beyond_root() -> None:
+    assert (
+        classify_driver_answer_text_risk("Run rm -rf /opt/app/data to reset state.")
+        == "actual answer recommends destructive production action"
+    )
+    assert (
+        classify_driver_answer_text_risk("rm -rf ./build && rebuild")
+        == "actual answer recommends destructive production action"
+    )
+
+
+def test_answer_text_risk_flags_drop_and_truncate_sql_targets() -> None:
+    assert (
+        classify_driver_answer_text_risk("DROP TABLE users CASCADE;")
+        == "actual answer recommends destructive production action"
+    )
+    assert (
+        classify_driver_answer_text_risk("TRUNCATE TABLE accounts;")
+        == "actual answer recommends destructive production action"
+    )
+
+
+def test_answer_text_risk_allows_benign_credential_phrasing() -> None:
+    assert classify_driver_answer_text_risk("Bearer-style auth pattern is documented.") is None
+    assert (
+        classify_driver_answer_text_risk("The customer's old password was rotated months ago.")
+        is None
+    )
+    assert classify_driver_answer_text_risk("We support OAuth Bearer tokens generally.") is None
+
+
 def test_answer_text_risk_detects_env_var_and_dsn_secret_shapes() -> None:
     assert (
         classify_driver_answer_text_risk("Set OPENAI_API_KEY=fakekeyvalue1234567890 in env.")

--- a/tests/unit/auto/test_driver_answerer.py
+++ b/tests/unit/auto/test_driver_answerer.py
@@ -107,24 +107,24 @@ def test_answer_text_risk_detects_known_provider_secret_shapes() -> None:
         ), text
 
 
-def test_answer_text_risk_flags_rm_rf_paths_beyond_root() -> None:
+def test_answer_text_risk_flags_only_bare_rm_rf_root() -> None:
     assert (
-        classify_driver_answer_text_risk("Run rm -rf /opt/app/data to reset state.")
-        == "actual answer recommends destructive production action"
-    )
-    assert (
-        classify_driver_answer_text_risk("rm -rf ./build && rebuild")
+        classify_driver_answer_text_risk("Run rm -rf / to wipe the host.")
         == "actual answer recommends destructive production action"
     )
 
 
-def test_answer_text_risk_flags_drop_and_truncate_sql_targets() -> None:
+def test_answer_text_risk_allows_rm_rf_local_dev_cleanup() -> None:
+    assert classify_driver_answer_text_risk("rm -rf ./build && rebuild") is None
+    assert classify_driver_answer_text_risk("Use rm -rf node_modules before reinstall.") is None
+    assert classify_driver_answer_text_risk("Run rm -rf /opt/app/cache to reset state.") is None
+
+
+def test_answer_text_risk_allows_dev_sql_table_drops() -> None:
+    assert classify_driver_answer_text_risk("DROP TABLE users CASCADE;") is None
+    assert classify_driver_answer_text_risk("TRUNCATE TABLE accounts;") is None
     assert (
-        classify_driver_answer_text_risk("DROP TABLE users CASCADE;")
-        == "actual answer recommends destructive production action"
-    )
-    assert (
-        classify_driver_answer_text_risk("TRUNCATE TABLE accounts;")
+        classify_driver_answer_text_risk("Drop the production database to reset state.")
         == "actual answer recommends destructive production action"
     )
 

--- a/tests/unit/auto/test_driver_answerer.py
+++ b/tests/unit/auto/test_driver_answerer.py
@@ -49,6 +49,13 @@ async def test_driver_answerer_brake_off_answers_risky_question() -> None:
     assert "driver=codex" in answer.text
     assert "brake=off" in answer.text
     assert "risk=" in answer.text
+    assert answer.metadata.risk == "destructive or financial/production choice"
+    assert answer.metadata.confidence == answer.confidence
+    assert answer.metadata.provenance == (
+        "driver:codex",
+        "brake:off",
+        "scaffold_source:conservative_default",
+    )
     assert adapter.prompts
 
 
@@ -142,4 +149,11 @@ async def test_driver_answerer_brake_on_gates_risky_question() -> None:
 
     assert answer.blocker is not None
     assert "requires approval" in answer.blocker.reason
+    assert answer.metadata.risk == "destructive or financial/production choice"
+    assert answer.metadata.confidence == 1.0
+    assert answer.metadata.provenance == (
+        "driver:codex",
+        "brake:on",
+        "scaffold_source:conservative_default",
+    )
     assert adapter.prompts == []

--- a/tests/unit/auto/test_driver_answerer.py
+++ b/tests/unit/auto/test_driver_answerer.py
@@ -138,6 +138,32 @@ def test_answer_text_risk_allows_benign_credential_phrasing() -> None:
     assert classify_driver_answer_text_risk("We support OAuth Bearer tokens generally.") is None
 
 
+def test_answer_text_risk_detects_short_assigned_credentials() -> None:
+    """Regression for the bot's blocking finding on PR #683: short but
+    perfectly plausible credentials (e.g. ``password: hunter2``) used to
+    slip past the classifier because the generic-assignment rule required
+    12+ characters and the DSN rule required an 8+ character password.
+    Length thresholds were dropped so any explicit ``keyword: value``
+    credential leak is flagged.
+    """
+    assert (
+        classify_driver_answer_text_risk("Use password: hunter2 to access staging.")
+        == "actual answer contains secret or credential"
+    )
+    assert (
+        classify_driver_answer_text_risk("Set passphrase = letmein for the admin account.")
+        == "actual answer contains secret or credential"
+    )
+    assert (
+        classify_driver_answer_text_risk("token=abc123 should authenticate the request.")
+        == "actual answer contains secret or credential"
+    )
+    assert (
+        classify_driver_answer_text_risk("Connect via postgres://demo:hunter2@db.example/app.")
+        == "actual answer contains secret or credential"
+    )
+
+
 def test_answer_text_risk_detects_env_var_and_dsn_secret_shapes() -> None:
     assert (
         classify_driver_answer_text_risk("Set OPENAI_API_KEY=fakekeyvalue1234567890 in env.")


### PR DESCRIPTION
## Summary
- Add post-response selected-driver answer risk classification for risky generated answer text.
- With `brake=on`, block high-risk actual driver responses before they are sent back to the interview backend.
- With `brake=off`, continue autopilot while recording combined risk metadata and ledger provenance.

## Discussion / implementation notes
- This PR is stacked on #682 conceptually and completes the #675 behavior slice.
- It preserves the existing pre-response/question risk classifier and adds a second classifier over the actual selected-driver answer text.
- The classifier is deterministic and local; it does not call external services.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_driver_answerer.py -q` → 10 passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/driver_answerer.py tests/unit/auto/test_driver_answerer.py` → passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check src/ouroboros/auto/driver_answerer.py tests/unit/auto/test_driver_answerer.py` → passed
- `git diff --check` → passed

Closes #675
Depends on #682
Depends on #672
