### PR TITLE
feat(auto): attach unknown run handoffs

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -42,6 +42,9 @@ class AutoPipelineResult:
     last_grade: str | None = None
     run_handoff_status: str | None = None
     run_handoff_guidance: str | None = None
+    attached_run_handle: str | None = None
+    attached_run_source: str | None = None
+    attached_at: str | None = None
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
@@ -61,6 +64,10 @@ class AutoPipeline:
     seed_saver: SeedSaver | None = None
     seed_loader: SeedLoader | None = None
     skip_run: bool = False
+    attach_execution_id: str | None = None
+    attach_job_id: str | None = None
+    attach_run_session_id: str | None = None
+    attach_source: str | None = None
     seed_timeout_seconds: float = 120.0
     run_start_timeout_seconds: float = 60.0
 
@@ -257,6 +264,10 @@ class AutoPipeline:
                 return self._result(state, ledger, review=review)
 
         if state.phase == AutoPhase.RUN:
+            attached = self._attach_run_if_requested(state)
+            if attached is not None:
+                self._save(state)
+                return self._result(state, ledger, review=review)
             if any((state.job_id, state.execution_id, state.run_session_id)):
                 state.run_handoff_status = "started"
                 state.run_handoff_guidance = None
@@ -402,10 +413,43 @@ class AutoPipeline:
             last_grade=state.last_grade,
             run_handoff_status=state.run_handoff_status,
             run_handoff_guidance=state.run_handoff_guidance,
+            attached_run_handle=state.attached_run_handle,
+            attached_run_source=state.attached_run_source,
+            attached_at=state.attached_at,
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,
         )
+
+    def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:
+        handle = _first_nonempty(
+            self.attach_execution_id, self.attach_job_id, self.attach_run_session_id
+        )
+        if handle is None:
+            return None
+        if not state.run_start_attempted or state.run_handoff_status not in {
+            "unknown_no_handle",
+            "unknown_timeout",
+        }:
+            msg = (
+                "--attach-execution requires an auto session with unknown run handoff "
+                "status after a prior run start attempt"
+            )
+            state.mark_blocked(msg, tool_name="run_starter")
+            return False
+        state.execution_id = _optional_str(self.attach_execution_id)
+        state.job_id = _optional_str(self.attach_job_id)
+        state.run_session_id = _optional_str(self.attach_run_session_id)
+        state.attached_run_handle = handle
+        state.attached_run_source = _optional_str(self.attach_source) or "manual"
+        state.attached_at = utc_now_iso()
+        state.run_handoff_status = "attached"
+        state.run_handoff_guidance = (
+            "Attached an externally verified execution handle to this auto session; "
+            "resume will use the attached handle and will not start a duplicate run."
+        )
+        state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
+        return True
 
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:
@@ -476,5 +520,13 @@ def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
     return None
 
 
+def _first_nonempty(*values: str | None) -> str | None:
+    for value in values:
+        normalized = _optional_str(value)
+        if normalized is not None:
+            return normalized
+    return None
+
+
 def _optional_str(value: object) -> str | None:
-    return value if isinstance(value, str) and value else None
+    return value.strip() if isinstance(value, str) and value.strip() else None

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -103,6 +103,9 @@ class AutoPipelineState:
     run_start_attempted: bool = False
     run_handoff_status: str | None = None
     run_handoff_guidance: str | None = None
+    attached_run_handle: str | None = None
+    attached_run_source: str | None = None
+    attached_at: str | None = None
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
@@ -194,6 +197,9 @@ class AutoPipelineState:
         payload.setdefault("max_repair_rounds", 5)
         payload.setdefault("run_handoff_status", None)
         payload.setdefault("run_handoff_guidance", None)
+        payload.setdefault("attached_run_handle", None)
+        payload.setdefault("attached_run_source", None)
+        payload.setdefault("attached_at", None)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -296,6 +302,9 @@ class AutoPipelineState:
             "run_session_id",
             "run_handoff_status",
             "run_handoff_guidance",
+            "attached_run_handle",
+            "attached_run_source",
+            "attached_at",
             "last_grade",
             "pending_question",
             "last_tool_name",

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -89,6 +89,25 @@ def auto_command(
     status: Annotated[
         bool, typer.Option("--status", help="Print persisted auto session status without running.")
     ] = False,
+    attach_execution: Annotated[
+        str | None,
+        typer.Option(
+            "--attach-execution",
+            help="Attach an externally verified execution id to an unknown run handoff.",
+        ),
+    ] = None,
+    attach_job: Annotated[
+        str | None,
+        typer.Option("--attach-job", help="Attach an externally verified job id."),
+    ] = None,
+    attach_session: Annotated[
+        str | None,
+        typer.Option("--attach-session", help="Attach an externally verified run session id."),
+    ] = None,
+    attach_source: Annotated[
+        str | None,
+        typer.Option("--attach-source", help="Source label for an attached run handle."),
+    ] = None,
 ) -> None:
     """Run an A-grade-gated auto pipeline.
 
@@ -118,6 +137,10 @@ def auto_command(
                 max_interview_rounds=max_interview_rounds,
                 max_repair_rounds=max_repair_rounds,
                 skip_run=skip_run,
+                attach_execution=attach_execution,
+                attach_job=attach_job,
+                attach_session=attach_session,
+                attach_source=attach_source,
             )
         )
     except Exception as exc:
@@ -152,8 +175,18 @@ async def _run_auto(
     max_interview_rounds: int | None,
     max_repair_rounds: int | None,
     skip_run: bool,
+    attach_execution: str | None = None,
+    attach_job: str | None = None,
+    attach_session: str | None = None,
+    attach_source: str | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
+    attach_requested = any(
+        isinstance(item, str) and item.strip()
+        for item in (attach_execution, attach_job, attach_session)
+    )
+    if attach_requested and not resume:
+        raise ValueError("--attach-execution/--attach-job/--attach-session require --resume")
     if resume:
         state = store.load(resume)
         persisted_runtime = state.runtime_backend
@@ -242,6 +275,10 @@ async def _run_auto(
         seed_saver=save_seed,
         seed_loader=load_seed,
         skip_run=skip_run,
+        attach_execution_id=attach_execution,
+        attach_job_id=attach_job,
+        attach_run_session_id=attach_session,
+        attach_source=attach_source,
     )
     result = await pipeline.run(state)
     return result
@@ -275,6 +312,10 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Run handoff status: [bold]{state.run_handoff_status}[/]")
     if state.run_handoff_guidance:
         console.print(f"Run handoff guidance: [yellow]{state.run_handoff_guidance}[/]")
+    if state.attached_run_handle:
+        console.print(f"Attached run handle: {state.attached_run_handle}")
+        console.print(f"Attached run source: {state.attached_run_source}")
+        console.print(f"Attached at: {state.attached_at}")
     if state.last_error:
         console.print(f"Blocker: [yellow]{state.last_error}[/]")
     console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")
@@ -304,6 +345,10 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"Run handoff status: [bold]{result.run_handoff_status}[/]")
     if result.run_handoff_guidance:
         console.print(f"Run handoff guidance: [yellow]{result.run_handoff_guidance}[/]")
+    if result.attached_run_handle:
+        console.print(f"Attached run handle: {result.attached_run_handle}")
+        console.print(f"Attached run source: {result.attached_run_source}")
+        console.print(f"Attached at: {result.attached_at}")
     if show_ledger:
         if result.assumptions:
             console.print("Assumptions:")

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -86,6 +86,30 @@ class AutoHandler:
                     required=False,
                     default=False,
                 ),
+                MCPToolParameter(
+                    "attach_execution",
+                    ToolInputType.STRING,
+                    "Attach an externally verified execution id to an unknown run handoff",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    "attach_job",
+                    ToolInputType.STRING,
+                    "Attach an externally verified job id to an unknown run handoff",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    "attach_session",
+                    ToolInputType.STRING,
+                    "Attach an externally verified run session id to an unknown run handoff",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    "attach_source",
+                    ToolInputType.STRING,
+                    "Source label for an attached run handle",
+                    required=False,
+                ),
             ),
         )
 
@@ -113,6 +137,13 @@ class AutoHandler:
         store = self.store or AutoStore()
         resume = arguments.get("resume")
         requested_skip_run = bool(arguments.get("skip_run", False))
+        attach_execution = _optional_text_arg(arguments, "attach_execution")
+        attach_job = _optional_text_arg(arguments, "attach_job")
+        attach_session = _optional_text_arg(arguments, "attach_session")
+        attach_source = _optional_text_arg(arguments, "attach_source")
+        attach_requested = any((attach_execution, attach_job, attach_session))
+        if attach_requested and not (isinstance(resume, str) and resume):
+            raise ValueError("attach_* arguments require resume")
         if isinstance(resume, str) and resume:
             state = store.load(resume)
             cwd = state.cwd
@@ -179,6 +210,10 @@ class AutoHandler:
             seed_saver=save_seed,
             seed_loader=load_seed,
             skip_run=skip_run,
+            attach_execution_id=attach_execution,
+            attach_job_id=attach_job,
+            attach_run_session_id=attach_session,
+            attach_source=attach_source,
         )
         return await pipeline.run(state)
 
@@ -208,6 +243,10 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["run_handoff_status"] = result.run_handoff_status
     if result.run_handoff_guidance:
         meta["run_handoff_guidance"] = result.run_handoff_guidance
+    if result.attached_run_handle:
+        meta["attached_run_handle"] = result.attached_run_handle
+        meta["attached_run_source"] = result.attached_run_source
+        meta["attached_at"] = result.attached_at
     return meta
 
 
@@ -215,6 +254,16 @@ def _resolved_opencode_mode(runtime_backend: str | None, opencode_mode: str | No
     if runtime_backend != "opencode":
         return None
     return opencode_mode or get_opencode_mode()
+
+
+def _optional_text_arg(arguments: dict[str, Any], name: str) -> str | None:
+    value = arguments.get(name)
+    if value in {None, ""}:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        msg = f"{name} must be a non-empty string"
+        raise ValueError(msg)
+    return value.strip()
 
 
 def _positive_int_arg(arguments: dict[str, Any], name: str, default: int) -> int:
@@ -384,6 +433,10 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.append(f"Run handoff status: {result.run_handoff_status}")
     if result.run_handoff_guidance:
         lines.append(f"Run handoff guidance: {result.run_handoff_guidance}")
+    if result.attached_run_handle:
+        lines.append(f"Attached run handle: {result.attached_run_handle}")
+        lines.append(f"Attached run source: {result.attached_run_source}")
+        lines.append(f"Attached at: {result.attached_at}")
     if result.assumptions:
         lines.append("Assumptions:")
         lines.extend(f"- {item}" for item in result.assumptions)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2155,3 +2155,91 @@ async def test_resume_after_interview_max_rounds_can_continue_when_bound_raised(
     assert result.status == "complete", f"resume blocked: {result.blocker!r}"
     assert state.phase == AutoPhase.COMPLETE
     assert answer_calls, "interview backend must be re-engaged on resume"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_attaches_run_handle_after_unknown_handoff_without_restart(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("attach-only resume must not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.run_start_attempted = True
+    state.run_handoff_status = "unknown_no_handle"
+    state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        attach_execution_id="exec_existing",
+        attach_source="operator",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "attached"
+    assert result.execution_id == "exec_existing"
+    assert result.attached_run_handle == "exec_existing"
+    assert result.attached_run_source == "operator"
+    assert result.attached_at is not None
+    assert state.run_start_attempted is True
+    assert state.execution_id == "exec_existing"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_rejects_attach_without_unknown_handoff(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+        attach_execution_id="exec_existing",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "unknown run handoff" in (result.blocker or "")
+    assert state.execution_id is None

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1225,3 +1225,47 @@ async def test_auto_handler_rejects_zero_loop_bounds() -> None:
         assert result.is_err
         assert field_name in str(result.error)
         assert ">= 1" in str(result.error)
+
+
+def test_auto_state_loads_legacy_sessions_without_attached_run_fields() -> None:
+    from ouroboros.auto.state import AutoPipelineState
+
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/repo").to_dict()
+    payload.pop("attached_run_handle")
+    payload.pop("attached_run_source")
+    payload.pop("attached_at")
+
+    restored = AutoPipelineState.from_dict(payload)
+
+    assert restored.attached_run_handle is None
+    assert restored.attached_run_source is None
+    assert restored.attached_at is None
+
+
+def test_auto_handler_definition_exposes_attach_arguments() -> None:
+    names = {param.name for param in AutoHandler().definition.parameters}
+
+    assert {"attach_execution", "attach_job", "attach_session", "attach_source"} <= names
+
+
+def test_auto_handler_meta_exposes_attached_run_fields() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _result_meta
+
+    meta = _result_meta(
+        AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+            execution_id="exec_existing",
+            run_handoff_status="attached",
+            attached_run_handle="exec_existing",
+            attached_run_source="operator",
+            attached_at="2026-05-07T00:00:00+00:00",
+        )
+    )
+
+    assert meta["run_handoff_status"] == "attached"
+    assert meta["attached_run_handle"] == "exec_existing"
+    assert meta["attached_run_source"] == "operator"
+    assert meta["attached_at"] == "2026-05-07T00:00:00+00:00"


### PR DESCRIPTION
## Summary
- Add durable attached-run fields to auto session state for recovering unknown run handoffs.
- Add attach-only CLI/MCP inputs for externally verified execution/job/session handles.
- Mark eligible `unknown_no_handle` / `unknown_timeout` handoffs as `attached` without starting or reconciling another runtime execution.
- Surface attached-run metadata in CLI output and MCP result metadata.

## Discussion / implementation notes
- This is the attach-only slice for #677; it intentionally does not implement runtime discovery/reconciliation.
- Attach is accepted only after a prior run start attempt left the auto session in an unknown handoff status, preserving duplicate-run fail-closed behavior.
- Legacy auto state files backfill attached-run fields as `null`.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_surface.py -q` → 51 passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_interview_pipeline.py::test_pipeline_blocks_duplicate_run_after_start_timeout tests/unit/auto/test_interview_pipeline.py::test_pipeline_refuses_retry_after_malformed_run_starter_metadata tests/unit/auto/test_interview_pipeline.py::test_pipeline_attaches_run_handle_after_unknown_handoff_without_restart tests/unit/auto/test_interview_pipeline.py::test_pipeline_rejects_attach_without_unknown_handoff -q` → 4 passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/state.py src/ouroboros/auto/pipeline.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_surface.py` → passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check src/ouroboros/auto/state.py src/ouroboros/auto/pipeline.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_surface.py` → passed
- `git diff --check` → passed

Refs #677
