### PR TITLE
feat(auto): add run handoff reconciliation contract

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -95,6 +95,23 @@ class AutoPipeline:
                 return self._result(state, ledger, blocker=state.last_error)
         self._save(state)
 
+        if state.phase == AutoPhase.COMPLETE and (
+            self.attach_execution_id or self.attach_job_id or self.attach_run_session_id
+        ):
+            attached, attach_transient = self._attach_run_if_requested(state)
+            if attached is not None:
+                self._save(state)
+                if attached is False:
+                    blocker = attach_transient or state.last_error
+                else:
+                    blocker = None
+                status_override = "blocked" if attached is False else None
+                return self._result(
+                    state,
+                    ledger,
+                    blocker=blocker,
+                    status_override=status_override,
+                )
         if self.reconcile_run and state.phase == AutoPhase.COMPLETE:
             reconciled, transient_blocker = self._reconcile_run_if_requested(state)
             if reconciled is not None:
@@ -284,7 +301,7 @@ class AutoPipeline:
                 return self._result(state, ledger, review=review)
 
         if state.phase == AutoPhase.RUN:
-            attached = self._attach_run_if_requested(state)
+            attached, _attach_transient = self._attach_run_if_requested(state)
             if attached is not None:
                 self._save(state)
                 return self._result(state, ledger, review=review)
@@ -450,12 +467,24 @@ class AutoPipeline:
             blocker=blocker or state.last_error,
         )
 
-    def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:
+    def _attach_run_if_requested(self, state: AutoPipelineState) -> tuple[bool | None, str | None]:
+        """Apply an attach request, returning ``(outcome, transient_blocker)``.
+
+        Mirrors :meth:`_reconcile_run_if_requested`:
+
+        - ``outcome`` is ``None`` when no attach was requested, ``True`` for a
+          successful attach, and ``False`` when the request fails validation.
+        - ``transient_blocker`` carries an invocation-only error message that
+          must surface to the caller for the current call only. It is used for
+          the invalid-context-on-complete case where mutating
+          ``state.last_error`` durably would leak the misuse into every later
+          plain ``--resume``/``--status`` response.
+        """
         handle = _first_nonempty(
             self.attach_execution_id, self.attach_job_id, self.attach_run_session_id
         )
         if handle is None:
-            return None
+            return None, None
         if not state.run_start_attempted or state.run_handoff_status not in {
             "unknown_no_handle",
             "unknown_timeout",
@@ -464,8 +493,17 @@ class AutoPipeline:
                 "--attach-execution requires an auto session with unknown run handoff "
                 "status after a prior run start attempt"
             )
+            if state.phase == AutoPhase.COMPLETE:
+                # Keep the terminal phase intact and avoid corrupting durable
+                # state.last_error: future plain --resume/--status calls must
+                # not report this per-invocation misuse as a steady-state
+                # blocker. The message is returned as a transient blocker so
+                # the current call still surfaces it via the result.
+                state.last_tool_name = "run_starter"
+                state.mark_progress(msg, tool_name="run_starter")
+                return False, msg
             state.mark_blocked(msg, tool_name="run_starter")
-            return False
+            return False, None
         state.execution_id = _optional_str(self.attach_execution_id)
         state.job_id = _optional_str(self.attach_job_id)
         state.run_session_id = _optional_str(self.attach_run_session_id)
@@ -484,7 +522,7 @@ class AutoPipeline:
         state.run_reconciliation_source = None
         state.run_reconciled_at = None
         state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
-        return True
+        return True, None
 
     def _reconcile_run_if_requested(
         self, state: AutoPipelineState

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -45,6 +45,9 @@ class AutoPipelineResult:
     attached_run_handle: str | None = None
     attached_run_source: str | None = None
     attached_at: str | None = None
+    run_reconciliation_status: str | None = None
+    run_reconciliation_source: str | None = None
+    run_reconciled_at: str | None = None
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
@@ -68,6 +71,8 @@ class AutoPipeline:
     attach_job_id: str | None = None
     attach_run_session_id: str | None = None
     attach_source: str | None = None
+    reconcile_run: bool = False
+    reconcile_source: str | None = None
     seed_timeout_seconds: float = 120.0
     run_start_timeout_seconds: float = 60.0
 
@@ -90,6 +95,18 @@ class AutoPipeline:
                 return self._result(state, ledger, blocker=state.last_error)
         self._save(state)
 
+        if self.reconcile_run and state.phase == AutoPhase.COMPLETE:
+            reconciled = self._reconcile_run_if_requested(state)
+            if reconciled is not None:
+                self._save(state)
+                blocker = state.last_error if reconciled is False else None
+                status_override = "blocked" if reconciled is False else None
+                return self._result(
+                    state,
+                    ledger,
+                    blocker=blocker,
+                    status_override=status_override,
+                )
         if state.phase == AutoPhase.COMPLETE:
             return self._result(state, ledger, blocker=state.last_error)
         if state.phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
@@ -268,6 +285,10 @@ class AutoPipeline:
             if attached is not None:
                 self._save(state)
                 return self._result(state, ledger, review=review)
+            reconciled = self._reconcile_run_if_requested(state)
+            if reconciled is not None:
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
             if any((state.job_id, state.execution_id, state.run_session_id)):
                 state.run_handoff_status = "started"
                 state.run_handoff_guidance = None
@@ -394,9 +415,10 @@ class AutoPipeline:
         review: SeedReview | None = None,
         blocker: str | None = None,
         run_subagent: dict[str, Any] | None = None,
+        status_override: str | None = None,
     ) -> AutoPipelineResult:
         return AutoPipelineResult(
-            status=state.phase.value,
+            status=status_override or state.phase.value,
             auto_session_id=state.auto_session_id,
             phase=state.phase.value,
             grade=review.grade_result.grade.value if review else state.last_grade,
@@ -416,6 +438,9 @@ class AutoPipeline:
             attached_run_handle=state.attached_run_handle,
             attached_run_source=state.attached_run_source,
             attached_at=state.attached_at,
+            run_reconciliation_status=state.run_reconciliation_status,
+            run_reconciliation_source=state.run_reconciliation_source,
+            run_reconciled_at=state.run_reconciled_at,
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,
@@ -450,6 +475,58 @@ class AutoPipeline:
         )
         state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
         return True
+
+    def _reconcile_run_if_requested(self, state: AutoPipelineState) -> bool | None:
+        if not self.reconcile_run:
+            return None
+        if state.run_handoff_status == "attached" and state.attached_run_handle:
+            state.run_reconciliation_status = "attached"
+            state.run_reconciliation_source = _optional_str(self.reconcile_source) or "attached_run"
+            state.run_reconciled_at = utc_now_iso()
+            state.run_handoff_guidance = (
+                "Reconciliation confirmed the session already has an attached run handle; "
+                "resume will not start a duplicate run."
+            )
+            if state.phase == AutoPhase.COMPLETE:
+                state.mark_progress(
+                    "reconciled existing attached execution handle",
+                    tool_name="run_starter",
+                )
+            else:
+                state.transition(
+                    AutoPhase.COMPLETE, "reconciled existing attached execution handle"
+                )
+            return True
+        if not state.run_start_attempted or state.run_handoff_status not in {
+            "unknown_no_handle",
+            "unknown_timeout",
+        }:
+            msg = (
+                "--reconcile-run requires an auto session with unknown run handoff "
+                "status after a prior run start attempt"
+            )
+            state.run_reconciliation_status = "invalid_context"
+            state.run_reconciliation_source = _optional_str(self.reconcile_source) or "generic"
+            state.run_reconciled_at = utc_now_iso()
+            state.run_handoff_guidance = msg
+            if state.phase == AutoPhase.COMPLETE:
+                state.last_tool_name = "run_starter"
+                state.last_error = msg
+                state.mark_progress(msg, tool_name="run_starter")
+            else:
+                state.mark_blocked(msg, tool_name="run_starter")
+            return False
+        state.run_reconciliation_status = "unsupported"
+        state.run_reconciliation_source = _optional_str(self.reconcile_source) or "generic"
+        state.run_reconciled_at = utc_now_iso()
+        state.run_handoff_guidance = (
+            "Generic reconciliation has no runtime-specific discovery adapter for this "
+            "unknown handoff. No duplicate run was started. Attach a verified handle with "
+            "--attach-execution/--attach-job/--attach-session, or add a runtime-specific "
+            "reconciler that returns attached, not_found, ambiguous, or unsupported."
+        )
+        state.mark_blocked(state.run_handoff_guidance, tool_name="run_starter")
+        return False
 
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -96,10 +96,13 @@ class AutoPipeline:
         self._save(state)
 
         if self.reconcile_run and state.phase == AutoPhase.COMPLETE:
-            reconciled = self._reconcile_run_if_requested(state)
+            reconciled, transient_blocker = self._reconcile_run_if_requested(state)
             if reconciled is not None:
                 self._save(state)
-                blocker = state.last_error if reconciled is False else None
+                if reconciled is False:
+                    blocker = transient_blocker or state.last_error
+                else:
+                    blocker = None
                 status_override = "blocked" if reconciled is False else None
                 return self._result(
                     state,
@@ -285,10 +288,11 @@ class AutoPipeline:
             if attached is not None:
                 self._save(state)
                 return self._result(state, ledger, review=review)
-            reconciled = self._reconcile_run_if_requested(state)
+            reconciled, transient_blocker = self._reconcile_run_if_requested(state)
             if reconciled is not None:
                 self._save(state)
-                return self._result(state, ledger, review=review, blocker=state.last_error)
+                blocker = transient_blocker or state.last_error
+                return self._result(state, ledger, review=review, blocker=blocker)
             if any((state.job_id, state.execution_id, state.run_session_id)):
                 state.run_handoff_status = "started"
                 state.run_handoff_guidance = None
@@ -473,12 +477,32 @@ class AutoPipeline:
             "Attached an externally verified execution handle to this auto session; "
             "resume will use the attached handle and will not start a duplicate run."
         )
+        # Successful attach supersedes any prior reconciliation outcome on the
+        # same unknown handoff, so clear stale reconciliation metadata to avoid
+        # surfacing contradictory state (attached + previous reconciliation failure).
+        state.run_reconciliation_status = None
+        state.run_reconciliation_source = None
+        state.run_reconciled_at = None
         state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
         return True
 
-    def _reconcile_run_if_requested(self, state: AutoPipelineState) -> bool | None:
+    def _reconcile_run_if_requested(
+        self, state: AutoPipelineState
+    ) -> tuple[bool | None, str | None]:
+        """Run the generic reconciliation contract.
+
+        Returns ``(outcome, transient_blocker)``:
+
+        - ``outcome`` is ``None`` when reconcile was not requested, ``True`` for
+          a successful reconciliation, and ``False`` when the request fails.
+        - ``transient_blocker`` carries an invocation-only error message that
+          must be surfaced to the caller for the current call only. It is used
+          for failure paths (notably invalid-context against a terminal complete
+          session) where mutating ``state.last_error`` durably would leak the
+          error into every later plain ``--resume``/``--status`` response.
+        """
         if not self.reconcile_run:
-            return None
+            return None, None
         if state.run_handoff_status == "attached" and state.attached_run_handle:
             state.run_reconciliation_status = "attached"
             state.run_reconciliation_source = _optional_str(self.reconcile_source) or "attached_run"
@@ -496,7 +520,7 @@ class AutoPipeline:
                 state.transition(
                     AutoPhase.COMPLETE, "reconciled existing attached execution handle"
                 )
-            return True
+            return True, None
         if not state.run_start_attempted or state.run_handoff_status not in {
             "unknown_no_handle",
             "unknown_timeout",
@@ -510,12 +534,16 @@ class AutoPipeline:
             state.run_reconciled_at = utc_now_iso()
             state.run_handoff_guidance = msg
             if state.phase == AutoPhase.COMPLETE:
+                # Keep the terminal phase intact and avoid corrupting durable
+                # state.last_error: future plain --resume/--status calls must
+                # not report this per-invocation misuse as a steady-state
+                # blocker. The message is returned as a transient blocker so
+                # the current call still surfaces it via the result.
                 state.last_tool_name = "run_starter"
-                state.last_error = msg
                 state.mark_progress(msg, tool_name="run_starter")
-            else:
-                state.mark_blocked(msg, tool_name="run_starter")
-            return False
+                return False, msg
+            state.mark_blocked(msg, tool_name="run_starter")
+            return False, None
         state.run_reconciliation_status = "unsupported"
         state.run_reconciliation_source = _optional_str(self.reconcile_source) or "generic"
         state.run_reconciled_at = utc_now_iso()
@@ -526,7 +554,7 @@ class AutoPipeline:
             "reconciler that returns attached, not_found, ambiguous, or unsupported."
         )
         state.mark_blocked(state.run_handoff_guidance, tool_name="run_starter")
-        return False
+        return False, None
 
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -521,7 +521,17 @@ class AutoPipeline:
         state.run_reconciliation_status = None
         state.run_reconciliation_source = None
         state.run_reconciled_at = None
-        state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
+        if state.phase == AutoPhase.COMPLETE:
+            # Operator recovery for an already-terminal complete-but-unknown
+            # handoff: keep the durable terminal phase and just record progress.
+            # COMPLETE -> COMPLETE is not a legal transition, and the session
+            # is already in the right place; just acknowledge the attach.
+            state.mark_progress(
+                "attached existing execution handle to terminal complete session",
+                tool_name="run_starter",
+            )
+        else:
+            state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
         return True, None
 
     def _reconcile_run_if_requested(
@@ -591,6 +601,15 @@ class AutoPipeline:
             "--attach-execution/--attach-job/--attach-session, or add a runtime-specific "
             "reconciler that returns attached, not_found, ambiguous, or unsupported."
         )
+        if state.phase == AutoPhase.COMPLETE:
+            # The session has already reached terminal complete with an unknown
+            # handoff (the documented supported scenario). Preserve the durable
+            # terminal phase and surface the unsupported result as a transient
+            # blocked status override at the caller; do not attempt the illegal
+            # COMPLETE -> BLOCKED transition that mark_blocked would force.
+            state.last_tool_name = "run_starter"
+            state.mark_progress(state.run_handoff_guidance, tool_name="run_starter")
+            return False, state.run_handoff_guidance
         state.mark_blocked(state.run_handoff_guidance, tool_name="run_starter")
         return False, None
 

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -42,6 +42,9 @@ class AutoPipelineResult:
     last_grade: str | None = None
     run_handoff_status: str | None = None
     run_handoff_guidance: str | None = None
+    attached_run_handle: str | None = None
+    attached_run_source: str | None = None
+    attached_at: str | None = None
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
@@ -61,6 +64,10 @@ class AutoPipeline:
     seed_saver: SeedSaver | None = None
     seed_loader: SeedLoader | None = None
     skip_run: bool = False
+    attach_execution_id: str | None = None
+    attach_job_id: str | None = None
+    attach_run_session_id: str | None = None
+    attach_source: str | None = None
     seed_timeout_seconds: float = 120.0
     run_start_timeout_seconds: float = 60.0
 
@@ -257,6 +264,10 @@ class AutoPipeline:
                 return self._result(state, ledger, review=review)
 
         if state.phase == AutoPhase.RUN:
+            attached = self._attach_run_if_requested(state)
+            if attached is not None:
+                self._save(state)
+                return self._result(state, ledger, review=review)
             if any((state.job_id, state.execution_id, state.run_session_id)):
                 state.run_handoff_status = "started"
                 state.run_handoff_guidance = None
@@ -402,10 +413,43 @@ class AutoPipeline:
             last_grade=state.last_grade,
             run_handoff_status=state.run_handoff_status,
             run_handoff_guidance=state.run_handoff_guidance,
+            attached_run_handle=state.attached_run_handle,
+            attached_run_source=state.attached_run_source,
+            attached_at=state.attached_at,
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,
         )
+
+    def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:
+        handle = _first_nonempty(
+            self.attach_execution_id, self.attach_job_id, self.attach_run_session_id
+        )
+        if handle is None:
+            return None
+        if not state.run_start_attempted or state.run_handoff_status not in {
+            "unknown_no_handle",
+            "unknown_timeout",
+        }:
+            msg = (
+                "--attach-execution requires an auto session with unknown run handoff "
+                "status after a prior run start attempt"
+            )
+            state.mark_blocked(msg, tool_name="run_starter")
+            return False
+        state.execution_id = _optional_str(self.attach_execution_id)
+        state.job_id = _optional_str(self.attach_job_id)
+        state.run_session_id = _optional_str(self.attach_run_session_id)
+        state.attached_run_handle = handle
+        state.attached_run_source = _optional_str(self.attach_source) or "manual"
+        state.attached_at = utc_now_iso()
+        state.run_handoff_status = "attached"
+        state.run_handoff_guidance = (
+            "Attached an externally verified execution handle to this auto session; "
+            "resume will use the attached handle and will not start a duplicate run."
+        )
+        state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
+        return True
 
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:
@@ -476,5 +520,13 @@ def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
     return None
 
 
+def _first_nonempty(*values: str | None) -> str | None:
+    for value in values:
+        normalized = _optional_str(value)
+        if normalized is not None:
+            return normalized
+    return None
+
+
 def _optional_str(value: object) -> str | None:
-    return value if isinstance(value, str) and value else None
+    return value.strip() if isinstance(value, str) and value.strip() else None

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -103,6 +103,9 @@ class AutoPipelineState:
     run_start_attempted: bool = False
     run_handoff_status: str | None = None
     run_handoff_guidance: str | None = None
+    attached_run_handle: str | None = None
+    attached_run_source: str | None = None
+    attached_at: str | None = None
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
@@ -194,6 +197,9 @@ class AutoPipelineState:
         payload.setdefault("max_repair_rounds", 5)
         payload.setdefault("run_handoff_status", None)
         payload.setdefault("run_handoff_guidance", None)
+        payload.setdefault("attached_run_handle", None)
+        payload.setdefault("attached_run_source", None)
+        payload.setdefault("attached_at", None)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -296,6 +302,9 @@ class AutoPipelineState:
             "run_session_id",
             "run_handoff_status",
             "run_handoff_guidance",
+            "attached_run_handle",
+            "attached_run_source",
+            "attached_at",
             "last_grade",
             "pending_question",
             "last_tool_name",

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -106,6 +106,9 @@ class AutoPipelineState:
     attached_run_handle: str | None = None
     attached_run_source: str | None = None
     attached_at: str | None = None
+    run_reconciliation_status: str | None = None
+    run_reconciliation_source: str | None = None
+    run_reconciled_at: str | None = None
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
@@ -200,6 +203,9 @@ class AutoPipelineState:
         payload.setdefault("attached_run_handle", None)
         payload.setdefault("attached_run_source", None)
         payload.setdefault("attached_at", None)
+        payload.setdefault("run_reconciliation_status", None)
+        payload.setdefault("run_reconciliation_source", None)
+        payload.setdefault("run_reconciled_at", None)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -305,6 +311,9 @@ class AutoPipelineState:
             "attached_run_handle",
             "attached_run_source",
             "attached_at",
+            "run_reconciliation_status",
+            "run_reconciliation_source",
+            "run_reconciled_at",
             "last_grade",
             "pending_question",
             "last_tool_name",

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -89,6 +89,25 @@ def auto_command(
     status: Annotated[
         bool, typer.Option("--status", help="Print persisted auto session status without running.")
     ] = False,
+    attach_execution: Annotated[
+        str | None,
+        typer.Option(
+            "--attach-execution",
+            help="Attach an externally verified execution id to an unknown run handoff.",
+        ),
+    ] = None,
+    attach_job: Annotated[
+        str | None,
+        typer.Option("--attach-job", help="Attach an externally verified job id."),
+    ] = None,
+    attach_session: Annotated[
+        str | None,
+        typer.Option("--attach-session", help="Attach an externally verified run session id."),
+    ] = None,
+    attach_source: Annotated[
+        str | None,
+        typer.Option("--attach-source", help="Source label for an attached run handle."),
+    ] = None,
 ) -> None:
     """Run an A-grade-gated auto pipeline.
 
@@ -118,6 +137,10 @@ def auto_command(
                 max_interview_rounds=max_interview_rounds,
                 max_repair_rounds=max_repair_rounds,
                 skip_run=skip_run,
+                attach_execution=attach_execution,
+                attach_job=attach_job,
+                attach_session=attach_session,
+                attach_source=attach_source,
             )
         )
     except Exception as exc:
@@ -152,8 +175,18 @@ async def _run_auto(
     max_interview_rounds: int | None,
     max_repair_rounds: int | None,
     skip_run: bool,
+    attach_execution: str | None = None,
+    attach_job: str | None = None,
+    attach_session: str | None = None,
+    attach_source: str | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
+    attach_requested = any(
+        isinstance(item, str) and item.strip()
+        for item in (attach_execution, attach_job, attach_session)
+    )
+    if attach_requested and not resume:
+        raise ValueError("--attach-execution/--attach-job/--attach-session require --resume")
     if resume:
         state = store.load(resume)
         persisted_runtime = state.runtime_backend
@@ -242,6 +275,10 @@ async def _run_auto(
         seed_saver=save_seed,
         seed_loader=load_seed,
         skip_run=skip_run,
+        attach_execution_id=attach_execution,
+        attach_job_id=attach_job,
+        attach_run_session_id=attach_session,
+        attach_source=attach_source,
     )
     result = await pipeline.run(state)
     return result
@@ -275,6 +312,10 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Run handoff status: [bold]{state.run_handoff_status}[/]")
     if state.run_handoff_guidance:
         console.print(f"Run handoff guidance: [yellow]{state.run_handoff_guidance}[/]")
+    if state.attached_run_handle:
+        console.print(f"Attached run handle: {state.attached_run_handle}")
+        console.print(f"Attached run source: {state.attached_run_source}")
+        console.print(f"Attached at: {state.attached_at}")
     if state.last_error:
         console.print(f"Blocker: [yellow]{state.last_error}[/]")
     console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")
@@ -304,6 +345,10 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"Run handoff status: [bold]{result.run_handoff_status}[/]")
     if result.run_handoff_guidance:
         console.print(f"Run handoff guidance: [yellow]{result.run_handoff_guidance}[/]")
+    if result.attached_run_handle:
+        console.print(f"Attached run handle: {result.attached_run_handle}")
+        console.print(f"Attached run source: {result.attached_run_source}")
+        console.print(f"Attached at: {result.attached_at}")
     if show_ledger:
         if result.assumptions:
             console.print("Assumptions:")

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -108,6 +108,17 @@ def auto_command(
         str | None,
         typer.Option("--attach-source", help="Source label for an attached run handle."),
     ] = None,
+    reconcile_run: Annotated[
+        bool,
+        typer.Option(
+            "--reconcile-run",
+            help="Try to reconcile an unknown run handoff without starting a duplicate run.",
+        ),
+    ] = False,
+    reconcile_source: Annotated[
+        str | None,
+        typer.Option("--reconcile-source", help="Source label for run handoff reconciliation."),
+    ] = None,
 ) -> None:
     """Run an A-grade-gated auto pipeline.
 
@@ -141,6 +152,8 @@ def auto_command(
                 attach_job=attach_job,
                 attach_session=attach_session,
                 attach_source=attach_source,
+                reconcile_run=reconcile_run,
+                reconcile_source=reconcile_source,
             )
         )
     except Exception as exc:
@@ -179,6 +192,8 @@ async def _run_auto(
     attach_job: str | None = None,
     attach_session: str | None = None,
     attach_source: str | None = None,
+    reconcile_run: bool = False,
+    reconcile_source: str | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
     attach_requested = any(
@@ -187,6 +202,8 @@ async def _run_auto(
     )
     if attach_requested and not resume:
         raise ValueError("--attach-execution/--attach-job/--attach-session require --resume")
+    if reconcile_run and not resume:
+        raise ValueError("--reconcile-run requires --resume")
     if resume:
         state = store.load(resume)
         persisted_runtime = state.runtime_backend
@@ -279,6 +296,8 @@ async def _run_auto(
         attach_job_id=attach_job,
         attach_run_session_id=attach_session,
         attach_source=attach_source,
+        reconcile_run=reconcile_run,
+        reconcile_source=reconcile_source,
     )
     result = await pipeline.run(state)
     return result
@@ -316,6 +335,10 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Attached run handle: {state.attached_run_handle}")
         console.print(f"Attached run source: {state.attached_run_source}")
         console.print(f"Attached at: {state.attached_at}")
+    if state.run_reconciliation_status:
+        console.print(f"Run reconciliation status: {state.run_reconciliation_status}")
+        console.print(f"Run reconciliation source: {state.run_reconciliation_source}")
+        console.print(f"Run reconciled at: {state.run_reconciled_at}")
     if state.last_error:
         console.print(f"Blocker: [yellow]{state.last_error}[/]")
     console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")
@@ -349,6 +372,10 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"Attached run handle: {result.attached_run_handle}")
         console.print(f"Attached run source: {result.attached_run_source}")
         console.print(f"Attached at: {result.attached_at}")
+    if result.run_reconciliation_status:
+        console.print(f"Run reconciliation status: {result.run_reconciliation_status}")
+        console.print(f"Run reconciliation source: {result.run_reconciliation_source}")
+        console.print(f"Run reconciled at: {result.run_reconciled_at}")
     if show_ledger:
         if result.assumptions:
             console.print("Assumptions:")

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -110,6 +110,19 @@ class AutoHandler:
                     "Source label for an attached run handle",
                     required=False,
                 ),
+                MCPToolParameter(
+                    "reconcile_run",
+                    ToolInputType.BOOLEAN,
+                    "Try to reconcile an unknown run handoff without starting a duplicate run",
+                    required=False,
+                    default=False,
+                ),
+                MCPToolParameter(
+                    "reconcile_source",
+                    ToolInputType.STRING,
+                    "Source label for run handoff reconciliation",
+                    required=False,
+                ),
             ),
         )
 
@@ -141,9 +154,13 @@ class AutoHandler:
         attach_job = _optional_text_arg(arguments, "attach_job")
         attach_session = _optional_text_arg(arguments, "attach_session")
         attach_source = _optional_text_arg(arguments, "attach_source")
+        reconcile_run = bool(arguments.get("reconcile_run", False))
+        reconcile_source = _optional_text_arg(arguments, "reconcile_source")
         attach_requested = any((attach_execution, attach_job, attach_session))
         if attach_requested and not (isinstance(resume, str) and resume):
             raise ValueError("attach_* arguments require resume")
+        if reconcile_run and not (isinstance(resume, str) and resume):
+            raise ValueError("reconcile_run requires resume")
         if isinstance(resume, str) and resume:
             state = store.load(resume)
             cwd = state.cwd
@@ -214,6 +231,8 @@ class AutoHandler:
             attach_job_id=attach_job,
             attach_run_session_id=attach_session,
             attach_source=attach_source,
+            reconcile_run=reconcile_run,
+            reconcile_source=reconcile_source,
         )
         return await pipeline.run(state)
 
@@ -247,6 +266,10 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["attached_run_handle"] = result.attached_run_handle
         meta["attached_run_source"] = result.attached_run_source
         meta["attached_at"] = result.attached_at
+    if result.run_reconciliation_status:
+        meta["run_reconciliation_status"] = result.run_reconciliation_status
+        meta["run_reconciliation_source"] = result.run_reconciliation_source
+        meta["run_reconciled_at"] = result.run_reconciled_at
     return meta
 
 
@@ -437,6 +460,10 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.append(f"Attached run handle: {result.attached_run_handle}")
         lines.append(f"Attached run source: {result.attached_run_source}")
         lines.append(f"Attached at: {result.attached_at}")
+    if result.run_reconciliation_status:
+        lines.append(f"Run reconciliation status: {result.run_reconciliation_status}")
+        lines.append(f"Run reconciliation source: {result.run_reconciliation_source}")
+        lines.append(f"Run reconciled at: {result.run_reconciled_at}")
     if result.assumptions:
         lines.append("Assumptions:")
         lines.extend(f"- {item}" for item in result.assumptions)

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -86,6 +86,30 @@ class AutoHandler:
                     required=False,
                     default=False,
                 ),
+                MCPToolParameter(
+                    "attach_execution",
+                    ToolInputType.STRING,
+                    "Attach an externally verified execution id to an unknown run handoff",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    "attach_job",
+                    ToolInputType.STRING,
+                    "Attach an externally verified job id to an unknown run handoff",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    "attach_session",
+                    ToolInputType.STRING,
+                    "Attach an externally verified run session id to an unknown run handoff",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    "attach_source",
+                    ToolInputType.STRING,
+                    "Source label for an attached run handle",
+                    required=False,
+                ),
             ),
         )
 
@@ -113,6 +137,13 @@ class AutoHandler:
         store = self.store or AutoStore()
         resume = arguments.get("resume")
         requested_skip_run = bool(arguments.get("skip_run", False))
+        attach_execution = _optional_text_arg(arguments, "attach_execution")
+        attach_job = _optional_text_arg(arguments, "attach_job")
+        attach_session = _optional_text_arg(arguments, "attach_session")
+        attach_source = _optional_text_arg(arguments, "attach_source")
+        attach_requested = any((attach_execution, attach_job, attach_session))
+        if attach_requested and not (isinstance(resume, str) and resume):
+            raise ValueError("attach_* arguments require resume")
         if isinstance(resume, str) and resume:
             state = store.load(resume)
             cwd = state.cwd
@@ -179,6 +210,10 @@ class AutoHandler:
             seed_saver=save_seed,
             seed_loader=load_seed,
             skip_run=skip_run,
+            attach_execution_id=attach_execution,
+            attach_job_id=attach_job,
+            attach_run_session_id=attach_session,
+            attach_source=attach_source,
         )
         return await pipeline.run(state)
 
@@ -208,6 +243,10 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["run_handoff_status"] = result.run_handoff_status
     if result.run_handoff_guidance:
         meta["run_handoff_guidance"] = result.run_handoff_guidance
+    if result.attached_run_handle:
+        meta["attached_run_handle"] = result.attached_run_handle
+        meta["attached_run_source"] = result.attached_run_source
+        meta["attached_at"] = result.attached_at
     return meta
 
 
@@ -215,6 +254,16 @@ def _resolved_opencode_mode(runtime_backend: str | None, opencode_mode: str | No
     if runtime_backend != "opencode":
         return None
     return opencode_mode or get_opencode_mode()
+
+
+def _optional_text_arg(arguments: dict[str, Any], name: str) -> str | None:
+    value = arguments.get(name)
+    if value in {None, ""}:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        msg = f"{name} must be a non-empty string"
+        raise ValueError(msg)
+    return value.strip()
 
 
 def _positive_int_arg(arguments: dict[str, Any], name: str, default: int) -> int:
@@ -384,6 +433,10 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.append(f"Run handoff status: {result.run_handoff_status}")
     if result.run_handoff_guidance:
         lines.append(f"Run handoff guidance: {result.run_handoff_guidance}")
+    if result.attached_run_handle:
+        lines.append(f"Attached run handle: {result.attached_run_handle}")
+        lines.append(f"Attached run source: {result.attached_run_source}")
+        lines.append(f"Attached at: {result.attached_at}")
     if result.assumptions:
         lines.append("Assumptions:")
         lines.extend(f"- {item}" for item in result.assumptions)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2155,3 +2155,91 @@ async def test_resume_after_interview_max_rounds_can_continue_when_bound_raised(
     assert result.status == "complete", f"resume blocked: {result.blocker!r}"
     assert state.phase == AutoPhase.COMPLETE
     assert answer_calls, "interview backend must be re-engaged on resume"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_attaches_run_handle_after_unknown_handoff_without_restart(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("attach-only resume must not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.run_start_attempted = True
+    state.run_handoff_status = "unknown_no_handle"
+    state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        attach_execution_id="exec_existing",
+        attach_source="operator",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "attached"
+    assert result.execution_id == "exec_existing"
+    assert result.attached_run_handle == "exec_existing"
+    assert result.attached_run_source == "operator"
+    assert result.attached_at is not None
+    assert state.run_start_attempted is True
+    assert state.execution_id == "exec_existing"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_rejects_attach_without_unknown_handoff(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+        attach_execution_id="exec_existing",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "unknown run handoff" in (result.blocker or "")
+    assert state.execution_id is None

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2302,6 +2302,129 @@ async def test_pipeline_rejects_attach_against_complete_session_without_unknown_
 
 
 @pytest.mark.asyncio
+async def test_pipeline_attaches_handle_to_terminal_complete_unknown_handoff(tmp_path) -> None:
+    """Successful attach against an already-terminal complete-but-unknown
+    handoff must not crash on an illegal ``COMPLETE -> COMPLETE`` transition.
+
+    Regression for the bot's blocking finding on PR #685: legitimate operator
+    recovery for a terminal complete session with
+    ``run_handoff_status="unknown_no_handle"`` used to raise ``ValueError``
+    from ``state.transition`` because the pipeline always called
+    ``state.transition(AutoPhase.COMPLETE, ...)`` on the success branch.
+    """
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("attach against complete must not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "complete")
+    state.run_start_attempted = True
+    state.run_handoff_status = "unknown_no_handle"
+    AutoStore(tmp_path).save(state)
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        attach_execution_id="exec_recovered",
+        attach_source="operator",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.phase == "complete"
+    assert result.run_handoff_status == "attached"
+    assert result.execution_id == "exec_recovered"
+    assert result.attached_run_handle == "exec_recovered"
+    assert state.phase == AutoPhase.COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_pipeline_records_unsupported_reconciliation_on_terminal_complete(
+    tmp_path,
+) -> None:
+    """Unsupported generic reconcile against a terminal complete-but-unknown
+    handoff must not crash on an illegal ``COMPLETE -> BLOCKED`` transition.
+
+    Regression for the bot's blocking finding on PR #685: the public contract
+    documents complete-but-unknown handoffs as a supported blocked-result
+    scenario, but the unsupported branch used to call ``state.mark_blocked``
+    (forcing ``COMPLETE -> BLOCKED``) and raise ``ValueError`` instead of
+    surfacing the unsupported result with a transient blocked status.
+    """
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("reconcile against complete must not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "complete")
+    state.run_start_attempted = True
+    state.run_handoff_status = "unknown_timeout"
+    AutoStore(tmp_path).save(state)
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        reconcile_run=True,
+        reconcile_source="generic",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert result.phase == "complete"
+    assert result.run_reconciliation_status == "unsupported"
+    assert "No duplicate run was started" in (result.run_handoff_guidance or "")
+    # Durable phase stays terminal complete; no illegal COMPLETE -> BLOCKED
+    # transition was attempted, and state.last_error stays clean for later
+    # plain --resume/--status calls.
+    assert state.phase == AutoPhase.COMPLETE
+    assert state.last_error is None
+
+
+@pytest.mark.asyncio
 async def test_pipeline_records_unsupported_reconciliation_without_restart(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("resume should not restart interview")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2246,6 +2246,62 @@ async def test_pipeline_rejects_attach_without_unknown_handoff(tmp_path) -> None
 
 
 @pytest.mark.asyncio
+async def test_pipeline_rejects_attach_against_complete_session_without_unknown_handoff(
+    tmp_path,
+) -> None:
+    """Attach must not silently succeed against an already-complete session.
+
+    Regression for the bot's blocking finding on PR #685: ``--attach-execution``
+    used to be parsed only after the early ``COMPLETE`` return, so misuse
+    against a skip-run or already-complete session exited with status
+    ``complete`` and exit code 0 with no state change. The pipeline now hoists
+    attach validation before the ``COMPLETE`` early return and returns a
+    transient blocker without mutating durable ``state.last_error``.
+    """
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.COMPLETE, "complete")
+    AutoStore(tmp_path).save(state)
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+        attach_execution_id="exec_misuse",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "unknown run handoff" in (result.blocker or "")
+    assert result.phase == "complete"
+    # Per-invocation misuse must not leak into durable state.last_error,
+    # so a later plain --resume of the same session must show no blocker.
+    assert state.last_error is None
+    assert state.execution_id is None
+    assert state.attached_run_handle is None
+
+
+@pytest.mark.asyncio
 async def test_pipeline_records_unsupported_reconciliation_without_restart(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("resume should not restart interview")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2243,3 +2243,177 @@ async def test_pipeline_rejects_attach_without_unknown_handoff(tmp_path) -> None
     assert result.status == "blocked"
     assert "unknown run handoff" in (result.blocker or "")
     assert state.execution_id is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_records_unsupported_reconciliation_without_restart(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("reconcile-only resume must not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.run_start_attempted = True
+    state.run_handoff_status = "unknown_timeout"
+    state.mark_blocked("run start timed out", tool_name="run_starter")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        reconcile_run=True,
+        reconcile_source="generic",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert result.run_handoff_status == "unknown_timeout"
+    assert result.run_reconciliation_status == "unsupported"
+    assert result.run_reconciliation_source == "generic"
+    assert result.run_reconciled_at is not None
+    assert "No duplicate run was started" in (result.run_handoff_guidance or "")
+    assert state.execution_id is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_reports_attached_reconciliation_without_restart(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.run_start_attempted = True
+    state.run_handoff_status = "attached"
+    state.execution_id = "exec_existing"
+    state.attached_run_handle = "exec_existing"
+    state.attached_run_source = "operator"
+    state.attached_at = "2026-05-07T00:00:00+00:00"
+    state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver, generate_seed, run_starter=None, store=AutoStore(tmp_path), reconcile_run=True
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_reconciliation_status == "attached"
+    assert result.run_reconciliation_source == "attached_run"
+    assert result.run_reconciled_at is not None
+    assert result.execution_id == "exec_existing"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_marks_reconcile_invalid_context_separately(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+        reconcile_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert result.run_reconciliation_status == "invalid_context"
+    assert result.run_reconciliation_source == "generic"
+    assert result.run_reconciled_at is not None
+    assert "unknown run handoff" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_complete_session_invalid_reconcile_reports_blocked_result(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "already complete without run handoff")
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+        reconcile_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert state.phase == AutoPhase.COMPLETE
+    assert result.phase == "complete"
+    assert result.status == "blocked"
+    assert result.run_reconciliation_status == "invalid_context"
+    assert result.run_reconciliation_source == "generic"
+    assert "unknown run handoff" in (result.blocker or "")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2417,3 +2417,117 @@ async def test_complete_session_invalid_reconcile_reports_blocked_result(tmp_pat
     assert result.run_reconciliation_status == "invalid_context"
     assert result.run_reconciliation_source == "generic"
     assert "unknown run handoff" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_attach_clears_stale_reconciliation_metadata(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("attach must not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.run_start_attempted = True
+    state.run_handoff_status = "unknown_no_handle"
+    state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
+    # Prior --reconcile-run on the same unknown handoff recorded an unsupported
+    # reconciliation outcome. A subsequent successful attach must clear those
+    # fields so callers do not see contradictory state.
+    state.run_reconciliation_status = "unsupported"
+    state.run_reconciliation_source = "generic"
+    state.run_reconciled_at = "2026-05-07T00:00:00+00:00"
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        attach_execution_id="exec_existing",
+        attach_source="operator",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "attached"
+    assert result.attached_run_handle == "exec_existing"
+    assert result.run_reconciliation_status is None
+    assert result.run_reconciliation_source is None
+    assert result.run_reconciled_at is None
+    assert state.run_reconciliation_status is None
+    assert state.run_reconciliation_source is None
+    assert state.run_reconciled_at is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_reconcile_on_complete_does_not_poison_future_resume(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "already complete without run handoff")
+    assert state.last_error is None
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    invalid_pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+        reconcile_run=True,
+    )
+    invalid_result = await invalid_pipeline.run(state)
+
+    assert invalid_result.status == "blocked"
+    assert invalid_result.run_reconciliation_status == "invalid_context"
+    assert "unknown run handoff" in (invalid_result.blocker or "")
+    # Per-invocation misuse must not corrupt the durable terminal-complete state:
+    # last_error stays clean so subsequent plain --resume/--status do not
+    # report a steady-state blocker.
+    assert state.phase == AutoPhase.COMPLETE
+    assert state.last_error is None
+
+    plain_pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+    )
+    plain_result = await plain_pipeline.run(state)
+
+    assert plain_result.status == "complete"
+    assert plain_result.blocker is None
+    assert state.last_error is None

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1225,3 +1225,47 @@ async def test_auto_handler_rejects_zero_loop_bounds() -> None:
         assert result.is_err
         assert field_name in str(result.error)
         assert ">= 1" in str(result.error)
+
+
+def test_auto_state_loads_legacy_sessions_without_attached_run_fields() -> None:
+    from ouroboros.auto.state import AutoPipelineState
+
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/repo").to_dict()
+    payload.pop("attached_run_handle")
+    payload.pop("attached_run_source")
+    payload.pop("attached_at")
+
+    restored = AutoPipelineState.from_dict(payload)
+
+    assert restored.attached_run_handle is None
+    assert restored.attached_run_source is None
+    assert restored.attached_at is None
+
+
+def test_auto_handler_definition_exposes_attach_arguments() -> None:
+    names = {param.name for param in AutoHandler().definition.parameters}
+
+    assert {"attach_execution", "attach_job", "attach_session", "attach_source"} <= names
+
+
+def test_auto_handler_meta_exposes_attached_run_fields() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _result_meta
+
+    meta = _result_meta(
+        AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+            execution_id="exec_existing",
+            run_handoff_status="attached",
+            attached_run_handle="exec_existing",
+            attached_run_source="operator",
+            attached_at="2026-05-07T00:00:00+00:00",
+        )
+    )
+
+    assert meta["run_handoff_status"] == "attached"
+    assert meta["attached_run_handle"] == "exec_existing"
+    assert meta["attached_run_source"] == "operator"
+    assert meta["attached_at"] == "2026-05-07T00:00:00+00:00"

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1303,3 +1303,74 @@ def test_auto_handler_meta_exposes_run_reconciliation_fields() -> None:
     assert meta["run_reconciliation_status"] == "unsupported"
     assert meta["run_reconciliation_source"] == "generic"
     assert meta["run_reconciled_at"] == "2026-05-07T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_reports_is_error_for_complete_phase_blocked_status(
+    monkeypatch,
+) -> None:
+    """A complete-phase result with a blocked status_override must surface as is_error.
+
+    Regression guard for the public `status` override introduced for the run
+    handoff reconciliation contract: a session may finish its lifecycle
+    (`phase="complete"`) yet still need to be reported as blocked (e.g. an
+    invalid reconcile against a terminal session, or a complete-but-unknown
+    handoff). The MCP surface must propagate that as an error to callers,
+    matching the CLI exit-code contract.
+    """
+
+    async def fake_run(self, arguments):  # noqa: ARG001
+        from ouroboros.auto.pipeline import AutoPipelineResult
+
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id="auto_complete_blocked",
+            phase="complete",
+            grade="A",
+            blocker="invalid reconcile against complete session",
+        )
+
+    monkeypatch.setattr(AutoHandler, "_run", fake_run)
+
+    result = await AutoHandler().handle({"goal": "Build a CLI"})
+
+    assert result.is_ok
+    assert result.value.is_error is True
+    assert result.value.meta["status"] == "blocked"
+    assert result.value.meta["phase"] == "complete"
+
+
+def test_cli_auto_exits_non_zero_when_complete_phase_status_is_blocked(
+    monkeypatch, tmp_path
+) -> None:
+    """CLI must exit non-zero when an A-grade complete session is overridden to blocked."""
+    from unittest.mock import patch
+
+    from ouroboros.auto.pipeline import AutoPipelineResult
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.auto_session_id = "auto_complete_blocked"
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    async def fake_pipeline_run(self, state):  # noqa: ARG001
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id="auto_complete_blocked",
+            phase="complete",
+            grade="A",
+            blocker="invalid reconcile against complete session",
+        )
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run),
+    ):
+        store_cls.return_value = store
+        result = CliRunner().invoke(
+            app,
+            ["auto", "--resume", "auto_complete_blocked"],
+        )
+
+    assert result.exit_code == 1
+    assert "blocked" in result.output

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1234,18 +1234,31 @@ def test_auto_state_loads_legacy_sessions_without_attached_run_fields() -> None:
     payload.pop("attached_run_handle")
     payload.pop("attached_run_source")
     payload.pop("attached_at")
+    payload.pop("run_reconciliation_status")
+    payload.pop("run_reconciliation_source")
+    payload.pop("run_reconciled_at")
 
     restored = AutoPipelineState.from_dict(payload)
 
     assert restored.attached_run_handle is None
     assert restored.attached_run_source is None
     assert restored.attached_at is None
+    assert restored.run_reconciliation_status is None
+    assert restored.run_reconciliation_source is None
+    assert restored.run_reconciled_at is None
 
 
 def test_auto_handler_definition_exposes_attach_arguments() -> None:
     names = {param.name for param in AutoHandler().definition.parameters}
 
-    assert {"attach_execution", "attach_job", "attach_session", "attach_source"} <= names
+    assert {
+        "attach_execution",
+        "attach_job",
+        "attach_session",
+        "attach_source",
+        "reconcile_run",
+        "reconcile_source",
+    } <= names
 
 
 def test_auto_handler_meta_exposes_attached_run_fields() -> None:
@@ -1269,3 +1282,24 @@ def test_auto_handler_meta_exposes_attached_run_fields() -> None:
     assert meta["attached_run_handle"] == "exec_existing"
     assert meta["attached_run_source"] == "operator"
     assert meta["attached_at"] == "2026-05-07T00:00:00+00:00"
+
+
+def test_auto_handler_meta_exposes_run_reconciliation_fields() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _result_meta
+
+    meta = _result_meta(
+        AutoPipelineResult(
+            status="blocked",
+            auto_session_id="auto_test",
+            phase="blocked",
+            run_handoff_status="unknown_no_handle",
+            run_reconciliation_status="unsupported",
+            run_reconciliation_source="generic",
+            run_reconciled_at="2026-05-07T00:00:00+00:00",
+        )
+    )
+
+    assert meta["run_reconciliation_status"] == "unsupported"
+    assert meta["run_reconciliation_source"] == "generic"
+    assert meta["run_reconciled_at"] == "2026-05-07T00:00:00+00:00"


### PR DESCRIPTION
## Summary
- Add a generic run-handoff reconciliation contract for auto sessions.
- Persist reconciliation result metadata (`attached`, `not_found`, `ambiguous`, `unsupported` contract; this generic slice currently records `attached` or `unsupported`).
- Add CLI/MCP `reconcile_run` inputs that never start a duplicate run.
- Surface reconciliation status/source/timestamp in CLI and MCP outputs.

## Discussion / implementation notes
- This PR is stacked conceptually on #684 and completes the #677 recovery contract.
- Generic reconciliation has no provider-specific discovery adapter yet, so unknown handoffs return `unsupported` with guidance to attach a verified handle or add a runtime-specific reconciler.
- Existing attached handles reconcile as `attached`; unknown handoffs remain fail-closed and blocked rather than starting a second execution.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_surface.py -q` → 52 passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_interview_pipeline.py::test_pipeline_blocks_duplicate_run_after_start_timeout tests/unit/auto/test_interview_pipeline.py::test_pipeline_refuses_retry_after_malformed_run_starter_metadata tests/unit/auto/test_interview_pipeline.py::test_pipeline_attaches_run_handle_after_unknown_handoff_without_restart tests/unit/auto/test_interview_pipeline.py::test_pipeline_rejects_attach_without_unknown_handoff tests/unit/auto/test_interview_pipeline.py::test_pipeline_records_unsupported_reconciliation_without_restart tests/unit/auto/test_interview_pipeline.py::test_pipeline_reports_attached_reconciliation_without_restart -q` → 6 passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/state.py src/ouroboros/auto/pipeline.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_surface.py` → passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check src/ouroboros/auto/state.py src/ouroboros/auto/pipeline.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_surface.py` → passed
- `git diff --check` → passed

Closes #677
Depends on #684
