### PR TITLE
feat(auto): add deterministic goal classifier (1/6 of #689)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ docs/code-surface-inventory.yaml
 docs/code-surface-lookup.yaml
 docs/cli-inventory.yaml
 
+

--- a/src/ouroboros/auto/goal_classifier.py
+++ b/src/ouroboros/auto/goal_classifier.py
@@ -30,6 +30,19 @@ class SideEffectRisk(StrEnum):
     HIGH = "high"
 
 
+class _AnchorRequirement(StrEnum):
+    """Which anchor type a verb is meaningful against.
+
+    PR mutations (merge, rebase, close, …) are only well defined against
+    a Pull Request URL: an Issue URL describing a related bug is *not*
+    a sufficient anchor for those verbs even though the URL parses.
+    Read-only verbs (review, analyze, summarize) work with either anchor.
+    """
+
+    PR_ONLY = "pr_only"
+    ANY = "any"
+
+
 _RISK_RANK: dict[SideEffectRisk, int] = {
     SideEffectRisk.NONE: 0,
     SideEffectRisk.LOW: 1,
@@ -94,7 +107,10 @@ class GoalClassification:
         """Deserialize from a JSON-compatible dictionary.
 
         Rejects malformed records eagerly so persisted state cannot smuggle
-        unexpected types past the auto pipeline.
+        unexpected types past the auto pipeline.  In particular, the
+        invariant ``interview_required != direct_run_allowed`` is enforced
+        here: contradictory records (both True or both False) are
+        rejected so downstream routing code can safely read either flag.
         """
         if not isinstance(data, dict):
             msg = "goal classification must be an object"
@@ -108,10 +124,7 @@ class GoalClassification:
         }
         missing = sorted(required - data.keys())
         if missing:
-            msg = (
-                "goal classification is missing required fields: "
-                f"{', '.join(missing)}"
-            )
+            msg = "goal classification is missing required fields: " + ", ".join(missing)
             raise ValueError(msg)
         for bool_field in (
             "interview_required",
@@ -139,6 +152,12 @@ class GoalClassification:
             isinstance(item, str) for item in signals_raw
         ):
             msg = "goal classification matched_signals must be a list of strings"
+            raise ValueError(msg)
+        if data["interview_required"] == data["direct_run_allowed"]:
+            msg = (
+                "goal classification interview_required and direct_run_allowed "
+                "must be opposite booleans; refused contradictory record"
+            )
             raise ValueError(msg)
         if data["requires_confirmation"] is False and risk is SideEffectRisk.HIGH:
             msg = (
@@ -176,33 +195,45 @@ _GITHUB_ISSUE_URL = re.compile(
 )
 
 
-# Operational verbs map to a risk tier.  English and Korean variants are
-# both included because ``ooo auto`` is invoked from Korean shells in the
-# observed incident (auto_78c98678de5d).
-_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk], ...] = (
-    # High-risk: destructive or hard-to-reverse mutations.
-    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH),
+# Operational verbs map to a risk tier and an anchor requirement.  PR-only
+# verbs need an unambiguous PR URL; an Issue URL alone is *not* a valid
+# anchor for them.  Read-only verbs (``ANY``) work with either anchor.
+# English and Korean variants are both included because ``ooo auto`` is
+# invoked from Korean shells in the observed incident (auto_78c98678de5d).
+_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk, _AnchorRequirement], ...] = (
+    # High-risk: destructive or hard-to-reverse mutations.  All PR-only.
+    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (
+        re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE),
+        SideEffectRisk.HIGH,
+        _AnchorRequirement.PR_ONLY,
+    ),
+    (
+        re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE),
+        SideEffectRisk.HIGH,
+        _AnchorRequirement.PR_ONLY,
+    ),
+    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
     # Medium-risk: writes to the PR but reversible (closing a PR can be
     # reopened; rebasing rewrites history that has not yet been merged).
-    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    # Low-risk: read-only or comment-only operations.
-    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    # All require a PR anchor; an Issue URL is the wrong target type.
+    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    # Low-risk: read-only or comment-only operations.  Allowed against
+    # either an Issue URL ("review #42 design") or a PR URL.
+    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
 )
 
 
@@ -238,22 +269,28 @@ def classify_goal(goal: str) -> GoalClassification:
         )
 
     signals: list[str] = []
-    pr_match = _GITHUB_PR_URL.search(text)
-    issue_match = _GITHUB_ISSUE_URL.search(text)
+    pr_matches = list(_GITHUB_PR_URL.finditer(text))
+    issue_matches = list(_GITHUB_ISSUE_URL.finditer(text))
     pr_list_match = _GITHUB_PR_LIST_URL.search(text)
-    if pr_match:
-        signals.append(f"pr_url:{pr_match.group(0)}")
-    if issue_match:
-        signals.append(f"issue_url:{issue_match.group(0)}")
-    if pr_list_match and not pr_match:
+    for match in pr_matches:
+        signals.append(f"pr_url:{match.group(0)}")
+    for match in issue_matches:
+        signals.append(f"issue_url:{match.group(0)}")
+    if pr_list_match and not pr_matches:
         signals.append(f"pr_list_url:{pr_list_match.group(0)}")
 
     verb_risk = SideEffectRisk.NONE
-    for pattern, risk in _OPERATIONAL_VERBS:
+    requires_pr_anchor = False
+    has_read_only_verb = False
+    for pattern, risk, anchor_req in _OPERATIONAL_VERBS:
         match = pattern.search(text)
         if match:
             signals.append(f"verb:{match.group(0).lower()}={risk.value}")
             verb_risk = _max_risk(verb_risk, risk)
+            if anchor_req is _AnchorRequirement.PR_ONLY:
+                requires_pr_anchor = True
+            else:
+                has_read_only_verb = True
 
     ambiguous_signals: list[str] = []
     for pattern in _AMBIGUOUS_INTENT:
@@ -261,7 +298,9 @@ def classify_goal(goal: str) -> GoalClassification:
         if match:
             ambiguous_signals.append(f"ambiguous:{match.group(0).lower()}")
 
-    has_concrete_anchor = bool(pr_match or issue_match)
+    has_pr_anchor = bool(pr_matches)
+    has_issue_anchor = bool(issue_matches)
+    has_concrete_anchor = has_pr_anchor or has_issue_anchor
     has_operational_verb = verb_risk is not SideEffectRisk.NONE
 
     if ambiguous_signals:
@@ -277,16 +316,43 @@ def classify_goal(goal: str) -> GoalClassification:
             matched_signals=tuple(signals),
         )
 
+    # Multiple PR or issue URLs make the mutation target ambiguous even
+    # when one verb is present.  "compare PR/1 and PR/2 then merge the
+    # better one" must not silently route to the wrong PR.
+    if len(pr_matches) > 1 or len(issue_matches) > 1:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="goal references multiple PR/issue URLs; mutation target is ambiguous",
+            matched_signals=tuple(signals),
+        )
+
+    # PR-only verbs paired with only an Issue URL would target the wrong
+    # artifact type ("merge issue #42").  Force interview.
+    if requires_pr_anchor and not has_pr_anchor:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason=(
+                "operational verb requires a PR URL anchor; goal has only an issue URL "
+                "or no PR anchor"
+            ),
+            matched_signals=tuple(signals),
+        )
+
     if has_concrete_anchor and has_operational_verb:
+        # Single PR or single issue URL paired with a verb whose anchor
+        # requirement is satisfied above.
         return GoalClassification(
             interview_required=False,
             direct_run_allowed=True,
             side_effect_risk=verb_risk,
             requires_confirmation=verb_risk is SideEffectRisk.HIGH,
-            reason=(
-                "concrete PR/issue URL paired with operational verb "
-                f"({verb_risk.value} risk)"
-            ),
+            reason=(f"concrete PR/issue URL paired with operational verb ({verb_risk.value} risk)"),
             matched_signals=tuple(signals),
         )
 
@@ -294,7 +360,7 @@ def classify_goal(goal: str) -> GoalClassification:
         # ``/pulls`` is a list page, not a single PR.  Allow direct path
         # only if the verb is read-only (review, analyze).  Anything that
         # mutates needs the interview to narrow the target.
-        if verb_risk in {SideEffectRisk.LOW, SideEffectRisk.NONE}:
+        if not requires_pr_anchor and has_read_only_verb:
             return GoalClassification(
                 interview_required=False,
                 direct_run_allowed=True,

--- a/src/ouroboros/auto/goal_classifier.py
+++ b/src/ouroboros/auto/goal_classifier.py
@@ -1,0 +1,345 @@
+"""Deterministic classifier for auto-mode goal strings.
+
+Most ``ooo auto`` goals are exploratory ideas that benefit from a Socratic
+interview before Seed generation.  A growing class of goals, however, are
+*operational*: they target an existing artifact (a PR or issue URL) and ask
+for a concrete action (merge, review, fix, close, rebase).  For those goals
+the interview adds only latency and surface area for ``interview.start``
+timeouts (#686, #689).
+
+This module is a pure function that turns a free-form goal string into a
+``GoalClassification``.  It performs no IO, network calls, or model
+invocations and therefore cannot itself stall the auto pipeline.  Callers
+decide whether to act on the classification (PR-C wires routing); landing
+this module changes no observable behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import re
+
+
+class SideEffectRisk(StrEnum):
+    """Coarse risk tier for the action implied by an operational goal."""
+
+    NONE = "none"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+_RISK_RANK: dict[SideEffectRisk, int] = {
+    SideEffectRisk.NONE: 0,
+    SideEffectRisk.LOW: 1,
+    SideEffectRisk.MEDIUM: 2,
+    SideEffectRisk.HIGH: 3,
+}
+
+
+def _max_risk(*risks: SideEffectRisk) -> SideEffectRisk:
+    return max(risks, key=lambda r: _RISK_RANK[r])
+
+
+@dataclass(frozen=True, slots=True)
+class GoalClassification:
+    """Structured summary of a free-form auto goal string.
+
+    Attributes:
+        interview_required: True when the goal lacks enough concrete anchor
+            (a PR/issue URL plus an operational verb) to skip the Socratic
+            interview safely.
+        direct_run_allowed: True when the auto pipeline may bypass the
+            interview phase and hand off directly to a bounded operational
+            run.  Mutually opposite of ``interview_required`` in the
+            current schema, but kept as a separate field so future
+            classifiers can add states (for example "interview optional")
+            without breaking serialized records.
+        side_effect_risk: Coarse risk tier of the implied action.  ``high``
+            covers destructive or hard-to-reverse operations (merge, push
+            --force, branch deletion).  Always pessimistic: only lowered
+            when no risky verb is present.
+        requires_confirmation: True when the implied action is irreversible
+            enough that the auto pipeline must obtain explicit confirmation
+            (policy gate, CI status, reviewer approval) before performing
+            it.  Always True when ``side_effect_risk`` is ``high``.
+        reason: Short human-readable string explaining the verdict.  Stored
+            in the ledger and surfaced in CLI output.
+        matched_signals: Snippets that influenced the verdict, in
+            discovery order.  Used both for debug output and for tests
+            asserting that a particular pattern triggered.
+    """
+
+    interview_required: bool
+    direct_run_allowed: bool
+    side_effect_risk: SideEffectRisk
+    requires_confirmation: bool
+    reason: str
+    matched_signals: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "interview_required": self.interview_required,
+            "direct_run_allowed": self.direct_run_allowed,
+            "side_effect_risk": self.side_effect_risk.value,
+            "requires_confirmation": self.requires_confirmation,
+            "reason": self.reason,
+            "matched_signals": list(self.matched_signals),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> GoalClassification:
+        """Deserialize from a JSON-compatible dictionary.
+
+        Rejects malformed records eagerly so persisted state cannot smuggle
+        unexpected types past the auto pipeline.
+        """
+        if not isinstance(data, dict):
+            msg = "goal classification must be an object"
+            raise ValueError(msg)
+        required = {
+            "interview_required",
+            "direct_run_allowed",
+            "side_effect_risk",
+            "requires_confirmation",
+            "reason",
+        }
+        missing = sorted(required - data.keys())
+        if missing:
+            msg = (
+                "goal classification is missing required fields: "
+                f"{', '.join(missing)}"
+            )
+            raise ValueError(msg)
+        for bool_field in (
+            "interview_required",
+            "direct_run_allowed",
+            "requires_confirmation",
+        ):
+            if not isinstance(data[bool_field], bool):
+                msg = f"goal classification {bool_field} must be a boolean"
+                raise ValueError(msg)
+        risk_raw = data["side_effect_risk"]
+        if not isinstance(risk_raw, str):
+            msg = "goal classification side_effect_risk must be a string"
+            raise ValueError(msg)
+        try:
+            risk = SideEffectRisk(risk_raw)
+        except ValueError as exc:
+            msg = f"goal classification side_effect_risk is unknown: {risk_raw}"
+            raise ValueError(msg) from exc
+        reason = data["reason"]
+        if not isinstance(reason, str) or not reason.strip():
+            msg = "goal classification reason must be a non-empty string"
+            raise ValueError(msg)
+        signals_raw = data.get("matched_signals", [])
+        if not isinstance(signals_raw, list) or not all(
+            isinstance(item, str) for item in signals_raw
+        ):
+            msg = "goal classification matched_signals must be a list of strings"
+            raise ValueError(msg)
+        if data["requires_confirmation"] is False and risk is SideEffectRisk.HIGH:
+            msg = (
+                "goal classification requires_confirmation must be True when "
+                "side_effect_risk is high"
+            )
+            raise ValueError(msg)
+        return cls(
+            interview_required=data["interview_required"],
+            direct_run_allowed=data["direct_run_allowed"],
+            side_effect_risk=risk,
+            requires_confirmation=data["requires_confirmation"],
+            reason=reason,
+            matched_signals=tuple(signals_raw),
+        )
+
+
+# A GitHub PR URL can take either of two shapes:
+#   https://github.com/<owner>/<repo>/pull/<number>
+#   https://github.com/<owner>/<repo>/pulls            (list page)
+# Both are sufficient anchors for an operational goal, but ``/pulls`` is
+# always treated as ambiguous merge target — the user must still narrow
+# the action through interview unless paired with an explicit verb.
+_GITHUB_PR_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pull/(?P<number>\d+)\b",
+    re.IGNORECASE,
+)
+_GITHUB_PR_LIST_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pulls\b",
+    re.IGNORECASE,
+)
+_GITHUB_ISSUE_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/issues/(?P<number>\d+)\b",
+    re.IGNORECASE,
+)
+
+
+# Operational verbs map to a risk tier.  English and Korean variants are
+# both included because ``ooo auto`` is invoked from Korean shells in the
+# observed incident (auto_78c98678de5d).
+_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk], ...] = (
+    # High-risk: destructive or hard-to-reverse mutations.
+    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH),
+    # Medium-risk: writes to the PR but reversible (closing a PR can be
+    # reopened; rebasing rewrites history that has not yet been merged).
+    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    # Low-risk: read-only or comment-only operations.
+    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM),
+)
+
+
+# Verbs/patterns that indicate the goal is *not* yet operational and an
+# interview should still run, even if a URL was mentioned for context.
+_AMBIGUOUS_INTENT = (
+    re.compile(r"\b(plan|design|brainstorm|investigate|explore)\b", re.IGNORECASE),
+    re.compile(r"\b(어떻게|어떨까|고민)\b", re.IGNORECASE),
+)
+
+
+def classify_goal(goal: str) -> GoalClassification:
+    """Classify a free-form ``ooo auto`` goal string.
+
+    The classifier is deterministic: same input → same verdict.  It does
+    not consult external state, environment, repository facts, or
+    backends.  Callers needing repository state (CI status, mergeability)
+    should fetch it separately and feed the policy gate (PR-D), keeping
+    classification cheap and side-effect free.
+    """
+    if not isinstance(goal, str):
+        msg = f"goal must be a string, got {type(goal).__name__}"
+        raise TypeError(msg)
+    text = goal.strip()
+    if not text:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=SideEffectRisk.NONE,
+            requires_confirmation=False,
+            reason="empty goal",
+            matched_signals=(),
+        )
+
+    signals: list[str] = []
+    pr_match = _GITHUB_PR_URL.search(text)
+    issue_match = _GITHUB_ISSUE_URL.search(text)
+    pr_list_match = _GITHUB_PR_LIST_URL.search(text)
+    if pr_match:
+        signals.append(f"pr_url:{pr_match.group(0)}")
+    if issue_match:
+        signals.append(f"issue_url:{issue_match.group(0)}")
+    if pr_list_match and not pr_match:
+        signals.append(f"pr_list_url:{pr_list_match.group(0)}")
+
+    verb_risk = SideEffectRisk.NONE
+    for pattern, risk in _OPERATIONAL_VERBS:
+        match = pattern.search(text)
+        if match:
+            signals.append(f"verb:{match.group(0).lower()}={risk.value}")
+            verb_risk = _max_risk(verb_risk, risk)
+
+    ambiguous_signals: list[str] = []
+    for pattern in _AMBIGUOUS_INTENT:
+        match = pattern.search(text)
+        if match:
+            ambiguous_signals.append(f"ambiguous:{match.group(0).lower()}")
+
+    has_concrete_anchor = bool(pr_match or issue_match)
+    has_operational_verb = verb_risk is not SideEffectRisk.NONE
+
+    if ambiguous_signals:
+        # Even if an operational verb is present, an ambiguous intent
+        # ("plan how we should fix this") needs interview clarity.
+        signals.extend(ambiguous_signals)
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="goal mixes operational verb with ambiguous planning intent",
+            matched_signals=tuple(signals),
+        )
+
+    if has_concrete_anchor and has_operational_verb:
+        return GoalClassification(
+            interview_required=False,
+            direct_run_allowed=True,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason=(
+                "concrete PR/issue URL paired with operational verb "
+                f"({verb_risk.value} risk)"
+            ),
+            matched_signals=tuple(signals),
+        )
+
+    if pr_list_match and has_operational_verb:
+        # ``/pulls`` is a list page, not a single PR.  Allow direct path
+        # only if the verb is read-only (review, analyze).  Anything that
+        # mutates needs the interview to narrow the target.
+        if verb_risk in {SideEffectRisk.LOW, SideEffectRisk.NONE}:
+            return GoalClassification(
+                interview_required=False,
+                direct_run_allowed=True,
+                side_effect_risk=verb_risk,
+                requires_confirmation=False,
+                reason="PR list URL with read-only verb permits direct review",
+                matched_signals=tuple(signals),
+            )
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="PR list URL needs interview to narrow target before mutating",
+            matched_signals=tuple(signals),
+        )
+
+    if has_concrete_anchor:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=SideEffectRisk.NONE,
+            requires_confirmation=False,
+            reason="PR/issue URL present but no operational verb",
+            matched_signals=tuple(signals),
+        )
+
+    if has_operational_verb:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="operational verb present but no concrete PR/issue anchor",
+            matched_signals=tuple(signals),
+        )
+
+    return GoalClassification(
+        interview_required=True,
+        direct_run_allowed=False,
+        side_effect_risk=SideEffectRisk.NONE,
+        requires_confirmation=False,
+        reason="no operational signals detected",
+        matched_signals=tuple(signals),
+    )
+
+
+__all__ = ["GoalClassification", "SideEffectRisk", "classify_goal"]

--- a/tests/unit/auto/test_goal_classifier.py
+++ b/tests/unit/auto/test_goal_classifier.py
@@ -51,8 +51,49 @@ def test_pr_url_with_review_verb_is_low_risk_direct_path() -> None:
     assert result.requires_confirmation is False
 
 
-def test_issue_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+def test_issue_url_with_pr_only_verb_routes_to_interview() -> None:
+    """``fix`` mutates a PR; an issue URL alone is the wrong anchor type."""
     goal = "fix https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+    assert "requires a PR URL anchor" in result.reason
+
+
+def test_issue_url_with_merge_verb_routes_to_interview() -> None:
+    """Issues cannot be merged; classifier must not authorize the wrong target."""
+    goal = "merge https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_issue_url_with_rebase_verb_routes_to_interview() -> None:
+    goal = "rebase https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+
+
+def test_issue_url_with_read_only_verb_allows_direct_path() -> None:
+    """Read-only verbs (review/analyze) are well-defined for issues too."""
+    goal = "analyze https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+
+
+def test_pr_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+    goal = "fix https://github.com/Q00/ouroboros/pull/689"
     result = classify_goal(goal)
 
     assert result.interview_required is False
@@ -106,10 +147,7 @@ def test_verb_without_url_routes_to_interview() -> None:
 
 
 def test_planning_verb_with_url_keeps_interview_even_with_operational_verb() -> None:
-    goal = (
-        "plan how we should fix https://github.com/Q00/ouroboros/issues/692 "
-        "before any merge"
-    )
+    goal = "plan how we should fix https://github.com/Q00/ouroboros/issues/692 before any merge"
     result = classify_goal(goal)
 
     assert result.interview_required is True
@@ -146,9 +184,7 @@ def test_korean_merge_signal_classified_as_high() -> None:
 
 
 def test_classification_round_trips_through_dict() -> None:
-    original = classify_goal(
-        "https://github.com/Q00/ouroboros/pull/689 merge once CI is green"
-    )
+    original = classify_goal("https://github.com/Q00/ouroboros/pull/689 merge once CI is green")
     restored = GoalClassification.from_dict(original.to_dict())
     assert restored == original
 
@@ -182,6 +218,75 @@ def test_classification_from_dict_rejects_unknown_risk_tier() -> None:
 def test_classify_goal_rejects_non_string_input() -> None:
     with pytest.raises(TypeError):
         classify_goal(None)  # type: ignore[arg-type]
+
+
+def test_multiple_pr_urls_force_interview() -> None:
+    """Two PR URLs paired with a destructive verb is an ambiguous target."""
+    goal = (
+        "compare https://github.com/Q00/ouroboros/pull/694 and "
+        "https://github.com/Q00/ouroboros/pull/697, then merge the better one"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert "multiple PR/issue URLs" in result.reason
+
+
+def test_multiple_issue_urls_force_interview_for_review() -> None:
+    """Multiple issue URLs are still ambiguous even for read-only verbs."""
+    goal = (
+        "review https://github.com/Q00/ouroboros/issues/689 "
+        "and https://github.com/Q00/ouroboros/issues/692"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_one_pr_url_and_one_issue_url_with_pr_verb_is_direct() -> None:
+    """A single PR URL + a single referenced issue URL still pinpoints the target."""
+    goal = (
+        "merge https://github.com/Q00/ouroboros/pull/694 "
+        "(closes https://github.com/Q00/ouroboros/issues/689)"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_classification_from_dict_rejects_contradictory_invariant() -> None:
+    """Both flags True is not a meaningful classification."""
+    payload = {
+        "interview_required": True,
+        "direct_run_allowed": True,
+        "side_effect_risk": "low",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="opposite booleans"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classification_from_dict_rejects_both_false_invariant() -> None:
+    """Both flags False is also rejected: routing flags must be opposites."""
+    payload = {
+        "interview_required": False,
+        "direct_run_allowed": False,
+        "side_effect_risk": "low",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="opposite booleans"):
+        GoalClassification.from_dict(payload)
 
 
 def test_observed_incident_goal_keeps_interview_path() -> None:

--- a/tests/unit/auto/test_goal_classifier.py
+++ b/tests/unit/auto/test_goal_classifier.py
@@ -1,0 +1,197 @@
+"""Unit tests for the auto-mode goal classifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.goal_classifier import (
+    GoalClassification,
+    SideEffectRisk,
+    classify_goal,
+)
+
+
+def test_empty_goal_requires_interview() -> None:
+    result = classify_goal("")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+    assert result.requires_confirmation is False
+    assert "empty" in result.reason
+
+
+def test_whitespace_goal_requires_interview() -> None:
+    result = classify_goal("   \n\t  ")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_single_pr_url_with_merge_verb_allows_direct_path_with_high_risk() -> None:
+    goal = (
+        "https://github.com/shaun0927/opensafari/pull/42 의 PR을 면밀히 해석해 "
+        "merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert any(signal.startswith("pr_url:") for signal in result.matched_signals)
+    assert any("merge" in signal for signal in result.matched_signals)
+
+
+def test_pr_url_with_review_verb_is_low_risk_direct_path() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 review and summarize"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+    assert result.requires_confirmation is False
+
+
+def test_issue_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+    goal = "fix https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+    assert result.requires_confirmation is False
+
+
+def test_pulls_list_url_with_merge_verb_still_routes_to_interview() -> None:
+    """List URL must not authorize a destructive verb without narrowing."""
+    goal = (
+        "https://github.com/shaun0927/opensafari/pulls 의 열린 pr을 면밀히 해석해 "
+        "merge 가능한 수준까지 반복 개선해줘. merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert any(signal.startswith("pr_list_url:") for signal in result.matched_signals)
+
+
+def test_pulls_list_url_with_only_review_verb_permits_direct_path() -> None:
+    goal = "review https://github.com/Q00/ouroboros/pulls"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+    assert result.requires_confirmation is False
+
+
+def test_url_without_verb_routes_to_interview() -> None:
+    goal = "look at https://github.com/Q00/ouroboros/pull/489"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+
+
+def test_verb_without_url_routes_to_interview() -> None:
+    goal = "merge the bug-fix PR for me"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_planning_verb_with_url_keeps_interview_even_with_operational_verb() -> None:
+    goal = (
+        "plan how we should fix https://github.com/Q00/ouroboros/issues/692 "
+        "before any merge"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    # Highest verb in goal is "merge" (high), classifier keeps risk
+    # pessimistic for downstream policy gates.
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_idea_goal_routes_to_interview() -> None:
+    result = classify_goal("Build me a CLI tool that tracks daily habits")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+    assert result.matched_signals == ()
+
+
+def test_korean_review_signal_detected() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 리뷰 부탁드립니다"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+
+
+def test_korean_merge_signal_classified_as_high() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 머지 가능하면 진행해줘"
+    result = classify_goal(goal)
+
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_classification_round_trips_through_dict() -> None:
+    original = classify_goal(
+        "https://github.com/Q00/ouroboros/pull/689 merge once CI is green"
+    )
+    restored = GoalClassification.from_dict(original.to_dict())
+    assert restored == original
+
+
+def test_classification_from_dict_rejects_inconsistent_high_risk_record() -> None:
+    payload = {
+        "interview_required": False,
+        "direct_run_allowed": True,
+        "side_effect_risk": "high",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="requires_confirmation"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classification_from_dict_rejects_unknown_risk_tier() -> None:
+    payload = {
+        "interview_required": True,
+        "direct_run_allowed": False,
+        "side_effect_risk": "catastrophic",
+        "requires_confirmation": True,
+        "reason": "bad",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="side_effect_risk"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classify_goal_rejects_non_string_input() -> None:
+    with pytest.raises(TypeError):
+        classify_goal(None)  # type: ignore[arg-type]
+
+
+def test_observed_incident_goal_keeps_interview_path() -> None:
+    """Regression: the auto_78c98678de5d goal must NOT silently merge."""
+    goal = (
+        "https://github.com/shaun0927/opensafari/pulls의 열린 pr을 면밀히 해석해 "
+        "merge 가능한 수준까지 반복 개선해줘. merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+    # With only a /pulls list URL and a high-risk verb, the safe default
+    # is to keep interview-first so the user clarifies which PR to merge.
+    assert result.direct_run_allowed is False
+    assert result.requires_confirmation is True


### PR DESCRIPTION
## Summary
- Adds `src/ouroboros/auto/goal_classifier.py`: pure-function classifier returning a `GoalClassification` (`interview_required`, `direct_run_allowed`, `side_effect_risk`, `requires_confirmation`, `reason`, `matched_signals`).
- Detects GitHub PR/issue URLs (`/pull/<n>`, `/issues/<n>`, `/pulls`) and English/Korean operational verbs (merge, review, fix, close, rebase, 머지, 리뷰, 수정, 분석…).
- Performs no IO, network calls, or backend invocations — cannot stall the auto pipeline (the #686 root cause).
- Pessimistic by default: `/pulls` list URLs paired with destructive verbs still route to interview; ambiguous planning verbs keep interview-first even with an operational verb present.

## Why this PR is small
This is part 1 of a 6-PR stack for #689 (see issue body for the full scope split). Landing the module on its own changes **no observable behavior** — pipeline routing, ledger persistence, and policy gates land in subsequent PRs:

- **PR-A (this) — classifier module**
- PR-B — state/ledger fields
- PR-C — pipeline routing + CLI flag
- PR-D — merge policy gate contract
- PR-E — gh-CLI provider adapter
- PR-F — docs + e2e integration

## Test plan
- [x] `pytest tests/unit/auto/test_goal_classifier.py` — 18 cases, all green
- [ ] Reviewer: confirm regex set covers the observed incident goal (auto_78c98678de5d) without authorizing destructive merges
- [ ] Reviewer: confirm `from_dict` rejects malformed persisted records (high-risk without confirmation, unknown risk tier)

Closes part of #689. Tracker: #692.