### PR TITLE
feat(auto): persist goal classification on state and ledger (2/6 of #689)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ docs/code-surface-inventory.yaml
 docs/code-surface-lookup.yaml
 docs/cli-inventory.yaml
 
+

--- a/src/ouroboros/auto/goal_classifier.py
+++ b/src/ouroboros/auto/goal_classifier.py
@@ -30,6 +30,19 @@ class SideEffectRisk(StrEnum):
     HIGH = "high"
 
 
+class _AnchorRequirement(StrEnum):
+    """Which anchor type a verb is meaningful against.
+
+    PR mutations (merge, rebase, close, …) are only well defined against
+    a Pull Request URL: an Issue URL describing a related bug is *not*
+    a sufficient anchor for those verbs even though the URL parses.
+    Read-only verbs (review, analyze, summarize) work with either anchor.
+    """
+
+    PR_ONLY = "pr_only"
+    ANY = "any"
+
+
 _RISK_RANK: dict[SideEffectRisk, int] = {
     SideEffectRisk.NONE: 0,
     SideEffectRisk.LOW: 1,
@@ -94,7 +107,10 @@ class GoalClassification:
         """Deserialize from a JSON-compatible dictionary.
 
         Rejects malformed records eagerly so persisted state cannot smuggle
-        unexpected types past the auto pipeline.
+        unexpected types past the auto pipeline.  In particular, the
+        invariant ``interview_required != direct_run_allowed`` is enforced
+        here: contradictory records (both True or both False) are
+        rejected so downstream routing code can safely read either flag.
         """
         if not isinstance(data, dict):
             msg = "goal classification must be an object"
@@ -108,10 +124,7 @@ class GoalClassification:
         }
         missing = sorted(required - data.keys())
         if missing:
-            msg = (
-                "goal classification is missing required fields: "
-                f"{', '.join(missing)}"
-            )
+            msg = "goal classification is missing required fields: " + ", ".join(missing)
             raise ValueError(msg)
         for bool_field in (
             "interview_required",
@@ -139,6 +152,12 @@ class GoalClassification:
             isinstance(item, str) for item in signals_raw
         ):
             msg = "goal classification matched_signals must be a list of strings"
+            raise ValueError(msg)
+        if data["interview_required"] == data["direct_run_allowed"]:
+            msg = (
+                "goal classification interview_required and direct_run_allowed "
+                "must be opposite booleans; refused contradictory record"
+            )
             raise ValueError(msg)
         if data["requires_confirmation"] is False and risk is SideEffectRisk.HIGH:
             msg = (
@@ -176,33 +195,45 @@ _GITHUB_ISSUE_URL = re.compile(
 )
 
 
-# Operational verbs map to a risk tier.  English and Korean variants are
-# both included because ``ooo auto`` is invoked from Korean shells in the
-# observed incident (auto_78c98678de5d).
-_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk], ...] = (
-    # High-risk: destructive or hard-to-reverse mutations.
-    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH),
+# Operational verbs map to a risk tier and an anchor requirement.  PR-only
+# verbs need an unambiguous PR URL; an Issue URL alone is *not* a valid
+# anchor for them.  Read-only verbs (``ANY``) work with either anchor.
+# English and Korean variants are both included because ``ooo auto`` is
+# invoked from Korean shells in the observed incident (auto_78c98678de5d).
+_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk, _AnchorRequirement], ...] = (
+    # High-risk: destructive or hard-to-reverse mutations.  All PR-only.
+    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (
+        re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE),
+        SideEffectRisk.HIGH,
+        _AnchorRequirement.PR_ONLY,
+    ),
+    (
+        re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE),
+        SideEffectRisk.HIGH,
+        _AnchorRequirement.PR_ONLY,
+    ),
+    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
     # Medium-risk: writes to the PR but reversible (closing a PR can be
     # reopened; rebasing rewrites history that has not yet been merged).
-    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    # Low-risk: read-only or comment-only operations.
-    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    # All require a PR anchor; an Issue URL is the wrong target type.
+    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    # Low-risk: read-only or comment-only operations.  Allowed against
+    # either an Issue URL ("review #42 design") or a PR URL.
+    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
 )
 
 
@@ -238,22 +269,28 @@ def classify_goal(goal: str) -> GoalClassification:
         )
 
     signals: list[str] = []
-    pr_match = _GITHUB_PR_URL.search(text)
-    issue_match = _GITHUB_ISSUE_URL.search(text)
+    pr_matches = list(_GITHUB_PR_URL.finditer(text))
+    issue_matches = list(_GITHUB_ISSUE_URL.finditer(text))
     pr_list_match = _GITHUB_PR_LIST_URL.search(text)
-    if pr_match:
-        signals.append(f"pr_url:{pr_match.group(0)}")
-    if issue_match:
-        signals.append(f"issue_url:{issue_match.group(0)}")
-    if pr_list_match and not pr_match:
+    for match in pr_matches:
+        signals.append(f"pr_url:{match.group(0)}")
+    for match in issue_matches:
+        signals.append(f"issue_url:{match.group(0)}")
+    if pr_list_match and not pr_matches:
         signals.append(f"pr_list_url:{pr_list_match.group(0)}")
 
     verb_risk = SideEffectRisk.NONE
-    for pattern, risk in _OPERATIONAL_VERBS:
+    requires_pr_anchor = False
+    has_read_only_verb = False
+    for pattern, risk, anchor_req in _OPERATIONAL_VERBS:
         match = pattern.search(text)
         if match:
             signals.append(f"verb:{match.group(0).lower()}={risk.value}")
             verb_risk = _max_risk(verb_risk, risk)
+            if anchor_req is _AnchorRequirement.PR_ONLY:
+                requires_pr_anchor = True
+            else:
+                has_read_only_verb = True
 
     ambiguous_signals: list[str] = []
     for pattern in _AMBIGUOUS_INTENT:
@@ -261,7 +298,9 @@ def classify_goal(goal: str) -> GoalClassification:
         if match:
             ambiguous_signals.append(f"ambiguous:{match.group(0).lower()}")
 
-    has_concrete_anchor = bool(pr_match or issue_match)
+    has_pr_anchor = bool(pr_matches)
+    has_issue_anchor = bool(issue_matches)
+    has_concrete_anchor = has_pr_anchor or has_issue_anchor
     has_operational_verb = verb_risk is not SideEffectRisk.NONE
 
     if ambiguous_signals:
@@ -277,16 +316,43 @@ def classify_goal(goal: str) -> GoalClassification:
             matched_signals=tuple(signals),
         )
 
+    # Multiple PR or issue URLs make the mutation target ambiguous even
+    # when one verb is present.  "compare PR/1 and PR/2 then merge the
+    # better one" must not silently route to the wrong PR.
+    if len(pr_matches) > 1 or len(issue_matches) > 1:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="goal references multiple PR/issue URLs; mutation target is ambiguous",
+            matched_signals=tuple(signals),
+        )
+
+    # PR-only verbs paired with only an Issue URL would target the wrong
+    # artifact type ("merge issue #42").  Force interview.
+    if requires_pr_anchor and not has_pr_anchor:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason=(
+                "operational verb requires a PR URL anchor; goal has only an issue URL "
+                "or no PR anchor"
+            ),
+            matched_signals=tuple(signals),
+        )
+
     if has_concrete_anchor and has_operational_verb:
+        # Single PR or single issue URL paired with a verb whose anchor
+        # requirement is satisfied above.
         return GoalClassification(
             interview_required=False,
             direct_run_allowed=True,
             side_effect_risk=verb_risk,
             requires_confirmation=verb_risk is SideEffectRisk.HIGH,
-            reason=(
-                "concrete PR/issue URL paired with operational verb "
-                f"({verb_risk.value} risk)"
-            ),
+            reason=(f"concrete PR/issue URL paired with operational verb ({verb_risk.value} risk)"),
             matched_signals=tuple(signals),
         )
 
@@ -294,7 +360,7 @@ def classify_goal(goal: str) -> GoalClassification:
         # ``/pulls`` is a list page, not a single PR.  Allow direct path
         # only if the verb is read-only (review, analyze).  Anything that
         # mutates needs the interview to narrow the target.
-        if verb_risk in {SideEffectRisk.LOW, SideEffectRisk.NONE}:
+        if not requires_pr_anchor and has_read_only_verb:
             return GoalClassification(
                 interview_required=False,
                 direct_run_allowed=True,

--- a/src/ouroboros/auto/goal_classifier.py
+++ b/src/ouroboros/auto/goal_classifier.py
@@ -1,0 +1,345 @@
+"""Deterministic classifier for auto-mode goal strings.
+
+Most ``ooo auto`` goals are exploratory ideas that benefit from a Socratic
+interview before Seed generation.  A growing class of goals, however, are
+*operational*: they target an existing artifact (a PR or issue URL) and ask
+for a concrete action (merge, review, fix, close, rebase).  For those goals
+the interview adds only latency and surface area for ``interview.start``
+timeouts (#686, #689).
+
+This module is a pure function that turns a free-form goal string into a
+``GoalClassification``.  It performs no IO, network calls, or model
+invocations and therefore cannot itself stall the auto pipeline.  Callers
+decide whether to act on the classification (PR-C wires routing); landing
+this module changes no observable behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import re
+
+
+class SideEffectRisk(StrEnum):
+    """Coarse risk tier for the action implied by an operational goal."""
+
+    NONE = "none"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+_RISK_RANK: dict[SideEffectRisk, int] = {
+    SideEffectRisk.NONE: 0,
+    SideEffectRisk.LOW: 1,
+    SideEffectRisk.MEDIUM: 2,
+    SideEffectRisk.HIGH: 3,
+}
+
+
+def _max_risk(*risks: SideEffectRisk) -> SideEffectRisk:
+    return max(risks, key=lambda r: _RISK_RANK[r])
+
+
+@dataclass(frozen=True, slots=True)
+class GoalClassification:
+    """Structured summary of a free-form auto goal string.
+
+    Attributes:
+        interview_required: True when the goal lacks enough concrete anchor
+            (a PR/issue URL plus an operational verb) to skip the Socratic
+            interview safely.
+        direct_run_allowed: True when the auto pipeline may bypass the
+            interview phase and hand off directly to a bounded operational
+            run.  Mutually opposite of ``interview_required`` in the
+            current schema, but kept as a separate field so future
+            classifiers can add states (for example "interview optional")
+            without breaking serialized records.
+        side_effect_risk: Coarse risk tier of the implied action.  ``high``
+            covers destructive or hard-to-reverse operations (merge, push
+            --force, branch deletion).  Always pessimistic: only lowered
+            when no risky verb is present.
+        requires_confirmation: True when the implied action is irreversible
+            enough that the auto pipeline must obtain explicit confirmation
+            (policy gate, CI status, reviewer approval) before performing
+            it.  Always True when ``side_effect_risk`` is ``high``.
+        reason: Short human-readable string explaining the verdict.  Stored
+            in the ledger and surfaced in CLI output.
+        matched_signals: Snippets that influenced the verdict, in
+            discovery order.  Used both for debug output and for tests
+            asserting that a particular pattern triggered.
+    """
+
+    interview_required: bool
+    direct_run_allowed: bool
+    side_effect_risk: SideEffectRisk
+    requires_confirmation: bool
+    reason: str
+    matched_signals: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "interview_required": self.interview_required,
+            "direct_run_allowed": self.direct_run_allowed,
+            "side_effect_risk": self.side_effect_risk.value,
+            "requires_confirmation": self.requires_confirmation,
+            "reason": self.reason,
+            "matched_signals": list(self.matched_signals),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> GoalClassification:
+        """Deserialize from a JSON-compatible dictionary.
+
+        Rejects malformed records eagerly so persisted state cannot smuggle
+        unexpected types past the auto pipeline.
+        """
+        if not isinstance(data, dict):
+            msg = "goal classification must be an object"
+            raise ValueError(msg)
+        required = {
+            "interview_required",
+            "direct_run_allowed",
+            "side_effect_risk",
+            "requires_confirmation",
+            "reason",
+        }
+        missing = sorted(required - data.keys())
+        if missing:
+            msg = (
+                "goal classification is missing required fields: "
+                f"{', '.join(missing)}"
+            )
+            raise ValueError(msg)
+        for bool_field in (
+            "interview_required",
+            "direct_run_allowed",
+            "requires_confirmation",
+        ):
+            if not isinstance(data[bool_field], bool):
+                msg = f"goal classification {bool_field} must be a boolean"
+                raise ValueError(msg)
+        risk_raw = data["side_effect_risk"]
+        if not isinstance(risk_raw, str):
+            msg = "goal classification side_effect_risk must be a string"
+            raise ValueError(msg)
+        try:
+            risk = SideEffectRisk(risk_raw)
+        except ValueError as exc:
+            msg = f"goal classification side_effect_risk is unknown: {risk_raw}"
+            raise ValueError(msg) from exc
+        reason = data["reason"]
+        if not isinstance(reason, str) or not reason.strip():
+            msg = "goal classification reason must be a non-empty string"
+            raise ValueError(msg)
+        signals_raw = data.get("matched_signals", [])
+        if not isinstance(signals_raw, list) or not all(
+            isinstance(item, str) for item in signals_raw
+        ):
+            msg = "goal classification matched_signals must be a list of strings"
+            raise ValueError(msg)
+        if data["requires_confirmation"] is False and risk is SideEffectRisk.HIGH:
+            msg = (
+                "goal classification requires_confirmation must be True when "
+                "side_effect_risk is high"
+            )
+            raise ValueError(msg)
+        return cls(
+            interview_required=data["interview_required"],
+            direct_run_allowed=data["direct_run_allowed"],
+            side_effect_risk=risk,
+            requires_confirmation=data["requires_confirmation"],
+            reason=reason,
+            matched_signals=tuple(signals_raw),
+        )
+
+
+# A GitHub PR URL can take either of two shapes:
+#   https://github.com/<owner>/<repo>/pull/<number>
+#   https://github.com/<owner>/<repo>/pulls            (list page)
+# Both are sufficient anchors for an operational goal, but ``/pulls`` is
+# always treated as ambiguous merge target — the user must still narrow
+# the action through interview unless paired with an explicit verb.
+_GITHUB_PR_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pull/(?P<number>\d+)\b",
+    re.IGNORECASE,
+)
+_GITHUB_PR_LIST_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pulls\b",
+    re.IGNORECASE,
+)
+_GITHUB_ISSUE_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/issues/(?P<number>\d+)\b",
+    re.IGNORECASE,
+)
+
+
+# Operational verbs map to a risk tier.  English and Korean variants are
+# both included because ``ooo auto`` is invoked from Korean shells in the
+# observed incident (auto_78c98678de5d).
+_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk], ...] = (
+    # High-risk: destructive or hard-to-reverse mutations.
+    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH),
+    # Medium-risk: writes to the PR but reversible (closing a PR can be
+    # reopened; rebasing rewrites history that has not yet been merged).
+    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    # Low-risk: read-only or comment-only operations.
+    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM),
+)
+
+
+# Verbs/patterns that indicate the goal is *not* yet operational and an
+# interview should still run, even if a URL was mentioned for context.
+_AMBIGUOUS_INTENT = (
+    re.compile(r"\b(plan|design|brainstorm|investigate|explore)\b", re.IGNORECASE),
+    re.compile(r"\b(어떻게|어떨까|고민)\b", re.IGNORECASE),
+)
+
+
+def classify_goal(goal: str) -> GoalClassification:
+    """Classify a free-form ``ooo auto`` goal string.
+
+    The classifier is deterministic: same input → same verdict.  It does
+    not consult external state, environment, repository facts, or
+    backends.  Callers needing repository state (CI status, mergeability)
+    should fetch it separately and feed the policy gate (PR-D), keeping
+    classification cheap and side-effect free.
+    """
+    if not isinstance(goal, str):
+        msg = f"goal must be a string, got {type(goal).__name__}"
+        raise TypeError(msg)
+    text = goal.strip()
+    if not text:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=SideEffectRisk.NONE,
+            requires_confirmation=False,
+            reason="empty goal",
+            matched_signals=(),
+        )
+
+    signals: list[str] = []
+    pr_match = _GITHUB_PR_URL.search(text)
+    issue_match = _GITHUB_ISSUE_URL.search(text)
+    pr_list_match = _GITHUB_PR_LIST_URL.search(text)
+    if pr_match:
+        signals.append(f"pr_url:{pr_match.group(0)}")
+    if issue_match:
+        signals.append(f"issue_url:{issue_match.group(0)}")
+    if pr_list_match and not pr_match:
+        signals.append(f"pr_list_url:{pr_list_match.group(0)}")
+
+    verb_risk = SideEffectRisk.NONE
+    for pattern, risk in _OPERATIONAL_VERBS:
+        match = pattern.search(text)
+        if match:
+            signals.append(f"verb:{match.group(0).lower()}={risk.value}")
+            verb_risk = _max_risk(verb_risk, risk)
+
+    ambiguous_signals: list[str] = []
+    for pattern in _AMBIGUOUS_INTENT:
+        match = pattern.search(text)
+        if match:
+            ambiguous_signals.append(f"ambiguous:{match.group(0).lower()}")
+
+    has_concrete_anchor = bool(pr_match or issue_match)
+    has_operational_verb = verb_risk is not SideEffectRisk.NONE
+
+    if ambiguous_signals:
+        # Even if an operational verb is present, an ambiguous intent
+        # ("plan how we should fix this") needs interview clarity.
+        signals.extend(ambiguous_signals)
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="goal mixes operational verb with ambiguous planning intent",
+            matched_signals=tuple(signals),
+        )
+
+    if has_concrete_anchor and has_operational_verb:
+        return GoalClassification(
+            interview_required=False,
+            direct_run_allowed=True,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason=(
+                "concrete PR/issue URL paired with operational verb "
+                f"({verb_risk.value} risk)"
+            ),
+            matched_signals=tuple(signals),
+        )
+
+    if pr_list_match and has_operational_verb:
+        # ``/pulls`` is a list page, not a single PR.  Allow direct path
+        # only if the verb is read-only (review, analyze).  Anything that
+        # mutates needs the interview to narrow the target.
+        if verb_risk in {SideEffectRisk.LOW, SideEffectRisk.NONE}:
+            return GoalClassification(
+                interview_required=False,
+                direct_run_allowed=True,
+                side_effect_risk=verb_risk,
+                requires_confirmation=False,
+                reason="PR list URL with read-only verb permits direct review",
+                matched_signals=tuple(signals),
+            )
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="PR list URL needs interview to narrow target before mutating",
+            matched_signals=tuple(signals),
+        )
+
+    if has_concrete_anchor:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=SideEffectRisk.NONE,
+            requires_confirmation=False,
+            reason="PR/issue URL present but no operational verb",
+            matched_signals=tuple(signals),
+        )
+
+    if has_operational_verb:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="operational verb present but no concrete PR/issue anchor",
+            matched_signals=tuple(signals),
+        )
+
+    return GoalClassification(
+        interview_required=True,
+        direct_run_allowed=False,
+        side_effect_risk=SideEffectRisk.NONE,
+        requires_confirmation=False,
+        reason="no operational signals detected",
+        matched_signals=tuple(signals),
+    )
+
+
+__all__ = ["GoalClassification", "SideEffectRisk", "classify_goal"]

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -165,6 +165,25 @@ class SeedDraftLedger:
 
     sections: dict[str, LedgerSection] = field(default_factory=dict)
     question_history: list[dict[str, str]] = field(default_factory=list)
+    # Recorded reason whenever the auto pipeline takes the direct
+    # operational path instead of running an interview (#689 PR-B).
+    # ``None`` for legacy ledgers and for sessions that took the
+    # interview-first route.
+    direct_path_reason: str | None = None
+
+    def record_direct_path_reason(self, reason: str) -> None:
+        """Persist why the auto pipeline skipped interview for this session.
+
+        The reason is the human-readable string from
+        ``GoalClassification.reason``; storing it on the ledger keeps the
+        explanation alongside the other Seed draft facts and survives
+        resume.  Pure assignment with empty-string guard — no IO.
+        """
+        cleaned = reason.strip() if isinstance(reason, str) else ""
+        if not cleaned:
+            msg = "direct_path_reason must be a non-empty string"
+            raise ValueError(msg)
+        self.direct_path_reason = cleaned
 
     @classmethod
     def from_goal(cls, goal: str) -> SeedDraftLedger:
@@ -320,6 +339,7 @@ class SeedDraftLedger:
         return {
             "sections": {name: section.to_dict() for name, section in self.sections.items()},
             "question_history": list(self.question_history),
+            "direct_path_reason": self.direct_path_reason,
         }
 
     @classmethod
@@ -358,7 +378,17 @@ class SeedDraftLedger:
                 msg = "ledger question_history question and answer must be strings"
                 raise ValueError(msg)
 
-        ledger = cls(sections=sections, question_history=[dict(item) for item in question_history])
+        direct_path_reason = data.get("direct_path_reason")
+        if direct_path_reason is not None:
+            if not isinstance(direct_path_reason, str) or not direct_path_reason.strip():
+                msg = "ledger direct_path_reason must be a non-empty string or null"
+                raise ValueError(msg)
+
+        ledger = cls(
+            sections=sections,
+            question_history=[dict(item) for item in question_history],
+            direct_path_reason=direct_path_reason,
+        )
         for required in REQUIRED_SECTIONS:
             ledger.sections.setdefault(required, LedgerSection(required))
         return ledger

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -93,6 +93,12 @@ class AutoPipelineState:
     max_repair_rounds: int = 5
     interview_session_id: str | None = None
     interview_completed: bool = False
+    # Goal classification (#689) -- populated when the classifier has been
+    # consulted for this session.  ``None`` for legacy records and for any
+    # pipeline that has not yet wired classification.  Persistence-only in
+    # PR-B; PR-C reads this field to route around interview.
+    classification: dict[str, Any] | None = None
+    direct_path_reason: str | None = None
     seed_id: str | None = None
     seed_path: str | None = None
     seed_artifact: dict[str, Any] = field(default_factory=dict)
@@ -138,6 +144,27 @@ class AutoPipelineState:
         self.updated_at = now
         self.last_progress_message = message
         self.last_error = error
+
+    def record_classification(self, classification: object) -> None:
+        """Persist a ``GoalClassification`` on the state record (#689 PR-B).
+
+        Accepts a ``GoalClassification`` instance directly to avoid forcing
+        callers to import the dataclass when they only care about
+        recording the verdict.  The classification is normalized to its
+        dict form so the state remains JSON-serializable for resume.
+        """
+        from ouroboros.auto.goal_classifier import GoalClassification
+
+        if not isinstance(classification, GoalClassification):
+            msg = (
+                "record_classification expects a GoalClassification, got "
+                f"{type(classification).__name__}"
+            )
+            raise TypeError(msg)
+        self.classification = classification.to_dict()
+        self.direct_path_reason = (
+            classification.reason if classification.direct_run_allowed else None
+        )
 
     def mark_progress(self, message: str, *, tool_name: str | None = None) -> None:
         """Record non-terminal progress within the current phase."""
@@ -194,6 +221,8 @@ class AutoPipelineState:
         payload.setdefault("max_repair_rounds", 5)
         payload.setdefault("run_handoff_status", None)
         payload.setdefault("run_handoff_guidance", None)
+        payload.setdefault("classification", None)
+        payload.setdefault("direct_path_reason", None)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -285,6 +314,17 @@ class AutoPipelineState:
             except Exception as exc:
                 msg = "ledger must be a valid Seed Draft Ledger"
                 raise ValueError(msg) from exc
+        if self.classification is not None:
+            if not isinstance(self.classification, dict):
+                msg = "classification must be an object or null"
+                raise ValueError(msg)
+            try:
+                from ouroboros.auto.goal_classifier import GoalClassification
+
+                GoalClassification.from_dict(self.classification)
+            except Exception as exc:
+                msg = "classification must be a valid GoalClassification record"
+                raise ValueError(msg) from exc
         optional_string_fields = (
             "runtime_backend",
             "opencode_mode",
@@ -300,6 +340,7 @@ class AutoPipelineState:
             "pending_question",
             "last_tool_name",
             "last_error",
+            "direct_path_reason",
         )
         for field_name in optional_string_fields:
             value = getattr(self, field_name)

--- a/tests/unit/auto/test_goal_classifier.py
+++ b/tests/unit/auto/test_goal_classifier.py
@@ -51,8 +51,49 @@ def test_pr_url_with_review_verb_is_low_risk_direct_path() -> None:
     assert result.requires_confirmation is False
 
 
-def test_issue_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+def test_issue_url_with_pr_only_verb_routes_to_interview() -> None:
+    """``fix`` mutates a PR; an issue URL alone is the wrong anchor type."""
     goal = "fix https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+    assert "requires a PR URL anchor" in result.reason
+
+
+def test_issue_url_with_merge_verb_routes_to_interview() -> None:
+    """Issues cannot be merged; classifier must not authorize the wrong target."""
+    goal = "merge https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_issue_url_with_rebase_verb_routes_to_interview() -> None:
+    goal = "rebase https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+
+
+def test_issue_url_with_read_only_verb_allows_direct_path() -> None:
+    """Read-only verbs (review/analyze) are well-defined for issues too."""
+    goal = "analyze https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+
+
+def test_pr_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+    goal = "fix https://github.com/Q00/ouroboros/pull/689"
     result = classify_goal(goal)
 
     assert result.interview_required is False
@@ -106,10 +147,7 @@ def test_verb_without_url_routes_to_interview() -> None:
 
 
 def test_planning_verb_with_url_keeps_interview_even_with_operational_verb() -> None:
-    goal = (
-        "plan how we should fix https://github.com/Q00/ouroboros/issues/692 "
-        "before any merge"
-    )
+    goal = "plan how we should fix https://github.com/Q00/ouroboros/issues/692 before any merge"
     result = classify_goal(goal)
 
     assert result.interview_required is True
@@ -146,9 +184,7 @@ def test_korean_merge_signal_classified_as_high() -> None:
 
 
 def test_classification_round_trips_through_dict() -> None:
-    original = classify_goal(
-        "https://github.com/Q00/ouroboros/pull/689 merge once CI is green"
-    )
+    original = classify_goal("https://github.com/Q00/ouroboros/pull/689 merge once CI is green")
     restored = GoalClassification.from_dict(original.to_dict())
     assert restored == original
 
@@ -182,6 +218,75 @@ def test_classification_from_dict_rejects_unknown_risk_tier() -> None:
 def test_classify_goal_rejects_non_string_input() -> None:
     with pytest.raises(TypeError):
         classify_goal(None)  # type: ignore[arg-type]
+
+
+def test_multiple_pr_urls_force_interview() -> None:
+    """Two PR URLs paired with a destructive verb is an ambiguous target."""
+    goal = (
+        "compare https://github.com/Q00/ouroboros/pull/694 and "
+        "https://github.com/Q00/ouroboros/pull/697, then merge the better one"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert "multiple PR/issue URLs" in result.reason
+
+
+def test_multiple_issue_urls_force_interview_for_review() -> None:
+    """Multiple issue URLs are still ambiguous even for read-only verbs."""
+    goal = (
+        "review https://github.com/Q00/ouroboros/issues/689 "
+        "and https://github.com/Q00/ouroboros/issues/692"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_one_pr_url_and_one_issue_url_with_pr_verb_is_direct() -> None:
+    """A single PR URL + a single referenced issue URL still pinpoints the target."""
+    goal = (
+        "merge https://github.com/Q00/ouroboros/pull/694 "
+        "(closes https://github.com/Q00/ouroboros/issues/689)"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_classification_from_dict_rejects_contradictory_invariant() -> None:
+    """Both flags True is not a meaningful classification."""
+    payload = {
+        "interview_required": True,
+        "direct_run_allowed": True,
+        "side_effect_risk": "low",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="opposite booleans"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classification_from_dict_rejects_both_false_invariant() -> None:
+    """Both flags False is also rejected: routing flags must be opposites."""
+    payload = {
+        "interview_required": False,
+        "direct_run_allowed": False,
+        "side_effect_risk": "low",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="opposite booleans"):
+        GoalClassification.from_dict(payload)
 
 
 def test_observed_incident_goal_keeps_interview_path() -> None:

--- a/tests/unit/auto/test_goal_classifier.py
+++ b/tests/unit/auto/test_goal_classifier.py
@@ -1,0 +1,197 @@
+"""Unit tests for the auto-mode goal classifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.goal_classifier import (
+    GoalClassification,
+    SideEffectRisk,
+    classify_goal,
+)
+
+
+def test_empty_goal_requires_interview() -> None:
+    result = classify_goal("")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+    assert result.requires_confirmation is False
+    assert "empty" in result.reason
+
+
+def test_whitespace_goal_requires_interview() -> None:
+    result = classify_goal("   \n\t  ")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_single_pr_url_with_merge_verb_allows_direct_path_with_high_risk() -> None:
+    goal = (
+        "https://github.com/shaun0927/opensafari/pull/42 의 PR을 면밀히 해석해 "
+        "merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert any(signal.startswith("pr_url:") for signal in result.matched_signals)
+    assert any("merge" in signal for signal in result.matched_signals)
+
+
+def test_pr_url_with_review_verb_is_low_risk_direct_path() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 review and summarize"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+    assert result.requires_confirmation is False
+
+
+def test_issue_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+    goal = "fix https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+    assert result.requires_confirmation is False
+
+
+def test_pulls_list_url_with_merge_verb_still_routes_to_interview() -> None:
+    """List URL must not authorize a destructive verb without narrowing."""
+    goal = (
+        "https://github.com/shaun0927/opensafari/pulls 의 열린 pr을 면밀히 해석해 "
+        "merge 가능한 수준까지 반복 개선해줘. merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert any(signal.startswith("pr_list_url:") for signal in result.matched_signals)
+
+
+def test_pulls_list_url_with_only_review_verb_permits_direct_path() -> None:
+    goal = "review https://github.com/Q00/ouroboros/pulls"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+    assert result.requires_confirmation is False
+
+
+def test_url_without_verb_routes_to_interview() -> None:
+    goal = "look at https://github.com/Q00/ouroboros/pull/489"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+
+
+def test_verb_without_url_routes_to_interview() -> None:
+    goal = "merge the bug-fix PR for me"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_planning_verb_with_url_keeps_interview_even_with_operational_verb() -> None:
+    goal = (
+        "plan how we should fix https://github.com/Q00/ouroboros/issues/692 "
+        "before any merge"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    # Highest verb in goal is "merge" (high), classifier keeps risk
+    # pessimistic for downstream policy gates.
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_idea_goal_routes_to_interview() -> None:
+    result = classify_goal("Build me a CLI tool that tracks daily habits")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+    assert result.matched_signals == ()
+
+
+def test_korean_review_signal_detected() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 리뷰 부탁드립니다"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+
+
+def test_korean_merge_signal_classified_as_high() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 머지 가능하면 진행해줘"
+    result = classify_goal(goal)
+
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_classification_round_trips_through_dict() -> None:
+    original = classify_goal(
+        "https://github.com/Q00/ouroboros/pull/689 merge once CI is green"
+    )
+    restored = GoalClassification.from_dict(original.to_dict())
+    assert restored == original
+
+
+def test_classification_from_dict_rejects_inconsistent_high_risk_record() -> None:
+    payload = {
+        "interview_required": False,
+        "direct_run_allowed": True,
+        "side_effect_risk": "high",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="requires_confirmation"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classification_from_dict_rejects_unknown_risk_tier() -> None:
+    payload = {
+        "interview_required": True,
+        "direct_run_allowed": False,
+        "side_effect_risk": "catastrophic",
+        "requires_confirmation": True,
+        "reason": "bad",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="side_effect_risk"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classify_goal_rejects_non_string_input() -> None:
+    with pytest.raises(TypeError):
+        classify_goal(None)  # type: ignore[arg-type]
+
+
+def test_observed_incident_goal_keeps_interview_path() -> None:
+    """Regression: the auto_78c98678de5d goal must NOT silently merge."""
+    goal = (
+        "https://github.com/shaun0927/opensafari/pulls의 열린 pr을 면밀히 해석해 "
+        "merge 가능한 수준까지 반복 개선해줘. merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+    # With only a /pulls list URL and a high-risk verb, the safe default
+    # is to keep interview-first so the user clarifies which PR to merge.
+    assert result.direct_run_allowed is False
+    assert result.requires_confirmation is True

--- a/tests/unit/auto/test_state_classification.py
+++ b/tests/unit/auto/test_state_classification.py
@@ -23,9 +23,7 @@ def test_state_default_classification_is_none() -> None:
 
 def test_record_classification_persists_dict_and_reason() -> None:
     state = _make_state()
-    classification = classify_goal(
-        "https://github.com/Q00/ouroboros/pull/689 review please"
-    )
+    classification = classify_goal("https://github.com/Q00/ouroboros/pull/689 review please")
 
     state.record_classification(classification)
 

--- a/tests/unit/auto/test_state_classification.py
+++ b/tests/unit/auto/test_state_classification.py
@@ -1,0 +1,150 @@
+"""Persistence tests for the goal-classification state extension (#689 PR-B)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.auto.goal_classifier import classify_goal
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+
+def _make_state() -> AutoPipelineState:
+    return AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+
+
+def test_state_default_classification_is_none() -> None:
+    state = _make_state()
+    assert state.classification is None
+    assert state.direct_path_reason is None
+
+
+def test_record_classification_persists_dict_and_reason() -> None:
+    state = _make_state()
+    classification = classify_goal(
+        "https://github.com/Q00/ouroboros/pull/689 review please"
+    )
+
+    state.record_classification(classification)
+
+    assert state.classification == classification.to_dict()
+    assert state.direct_path_reason == classification.reason
+
+
+def test_record_classification_clears_reason_when_interview_required() -> None:
+    state = _make_state()
+    classification = classify_goal("just plan the migration please")
+    state.record_classification(classification)
+
+    # Goal routed to interview, so direct_path_reason must remain None to
+    # avoid confusing CLI output that suggests a direct path was taken.
+    assert classification.direct_run_allowed is False
+    assert state.classification == classification.to_dict()
+    assert state.direct_path_reason is None
+
+
+def test_record_classification_rejects_non_classification() -> None:
+    state = _make_state()
+    with pytest.raises(TypeError):
+        state.record_classification({"reason": "not a classification"})  # type: ignore[arg-type]
+
+
+def test_state_round_trips_classification_through_store(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _make_state()
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+    classification = classify_goal(
+        "merge https://github.com/Q00/ouroboros/pull/689 once CI is green"
+    )
+    state.record_classification(classification)
+
+    path = store.save(state)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["classification"] == classification.to_dict()
+    assert raw["direct_path_reason"] == classification.reason
+
+    loaded = store.load(state.auto_session_id)
+    assert loaded.classification == classification.to_dict()
+    assert loaded.direct_path_reason == classification.reason
+
+
+def test_state_loads_legacy_record_without_classification(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _make_state()
+    path = store.save(state)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw.pop("classification", None)
+    raw.pop("direct_path_reason", None)
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    loaded = store.load(state.auto_session_id)
+    assert loaded.classification is None
+    assert loaded.direct_path_reason is None
+
+
+def test_state_rejects_invalid_classification_payload(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _make_state()
+    path = store.save(state)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["classification"] = {"interview_required": True}  # missing fields
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="classification"):
+        store.load(state.auto_session_id)
+
+
+def test_state_rejects_blank_direct_path_reason(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _make_state()
+    path = store.save(state)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["direct_path_reason"] = "   "
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="direct_path_reason"):
+        store.load(state.auto_session_id)
+
+
+def test_ledger_default_direct_path_reason_is_none() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    assert ledger.direct_path_reason is None
+
+
+def test_ledger_record_direct_path_reason_persists_through_round_trip() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    ledger.record_direct_path_reason(
+        "concrete PR/issue URL paired with operational verb (low risk)"
+    )
+    serialized = ledger.to_dict()
+    assert (
+        serialized["direct_path_reason"]
+        == "concrete PR/issue URL paired with operational verb (low risk)"
+    )
+
+    restored = SeedDraftLedger.from_dict(serialized)
+    assert restored.direct_path_reason == ledger.direct_path_reason
+
+
+def test_ledger_legacy_dict_without_direct_path_reason_loads_clean() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    payload = ledger.to_dict()
+    payload.pop("direct_path_reason", None)
+    restored = SeedDraftLedger.from_dict(payload)
+    assert restored.direct_path_reason is None
+
+
+def test_ledger_rejects_blank_direct_path_reason() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    with pytest.raises(ValueError, match="direct_path_reason"):
+        ledger.record_direct_path_reason("   ")
+
+
+def test_ledger_from_dict_rejects_blank_direct_path_reason() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    payload = ledger.to_dict()
+    payload["direct_path_reason"] = "   "
+    with pytest.raises(ValueError, match="direct_path_reason"):
+        SeedDraftLedger.from_dict(payload)


### PR DESCRIPTION
## Summary
- Adds optional `classification` (dict from `GoalClassification.to_dict()`) and `direct_path_reason` to `AutoPipelineState`, plus a `record_classification(...)` helper that normalizes the verdict and only sets `direct_path_reason` when the classifier authorized a direct run.
- Adds optional `direct_path_reason` metadata + `record_direct_path_reason(...)` to `SeedDraftLedger` so the explanation survives resume alongside Seed draft facts.
- Both fields are additive and **backward compatible**: legacy persisted records without the keys load unchanged via setdefaults in `from_dict`.
- Validation rejects malformed payloads (missing classification fields, blank reason, unknown risk tier).

## Why this PR is small
This is part 2 of the #689 stack. Persistence is intentionally separated from routing so a corrupt-record bug here cannot silently change pipeline behavior — the classifier is **not yet consulted by `pipeline.run()`** (that lands in PR-C).

Stack order:
- PR-A — classifier module ([#694](https://github.com/Q00/ouroboros/pull/694))
- **PR-B (this) — state/ledger persistence**
- PR-C — pipeline routing + CLI flag
- PR-D — merge policy gate contract
- PR-E — gh-CLI provider adapter
- PR-F — docs + e2e integration

> Stacked on top of #694. Diff currently includes #694's commits; review after #694 lands.

## Test plan
- [x] `pytest tests/unit/auto/test_state_classification.py` — 13 cases (state + ledger persistence, legacy compat, malformed-payload rejection)
- [x] `pytest tests/unit/auto/test_state.py tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_goal_classifier.py` — no regression in existing state/ledger/classifier tests
- [ ] Reviewer: confirm `record_classification` clears `direct_path_reason` whenever `direct_run_allowed=False` (avoids stale reason after a re-classification)

Closes part of #689. Tracker: #692.