### PR TITLE
feat(auto): tag seed_origin in persisted auto state

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -579,6 +579,11 @@ class AutoPipeline:
 
 def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:
     state.seed_artifact = {}
+    # Keep seed_origin consistent with the now-empty seed_artifact: the
+    # session no longer has a persisted Seed of any provenance, so the
+    # publicly surfaced "auto_pipeline" / "external_authoring" claim
+    # would otherwise become a misleading orphan attribution.
+    state.seed_origin = SeedOrigin.NONE
     if state.phase in {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}:
         now = utc_now_iso()
         state.phase = AutoPhase.FAILED

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -12,7 +12,13 @@ from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
-from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore, utc_now_iso
+from ouroboros.auto.state import (
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+    SeedOrigin,
+    utc_now_iso,
+)
 from ouroboros.core.seed import Seed
 
 SeedGenerator = Callable[[str], Awaitable[Seed]]
@@ -30,6 +36,7 @@ class AutoPipelineResult:
     phase: str
     grade: str | None = None
     seed_path: str | None = None
+    seed_origin: str = SeedOrigin.NONE.value
     interview_session_id: str | None = None
     execution_id: str | None = None
     job_id: str | None = None
@@ -194,6 +201,7 @@ class AutoPipeline:
                         raise TypeError(msg)
                     state.seed_id = seed.metadata.seed_id
                     state.seed_artifact = seed.to_dict()
+                    state.seed_origin = SeedOrigin.AUTO_PIPELINE
                 except TimeoutError as exc:
                     state.mark_blocked(
                         f"seed generation timed out after {self.seed_timeout_seconds:.0f}s",
@@ -427,6 +435,7 @@ class AutoPipeline:
             phase=state.phase.value,
             grade=review.grade_result.grade.value if review else state.last_grade,
             seed_path=state.seed_path,
+            seed_origin=state.seed_origin.value,
             interview_session_id=state.interview_session_id,
             execution_id=state.execution_id,
             job_id=state.job_id,

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -424,6 +424,15 @@ class AutoPipeline:
             )
             self._save(state)
             return None
+        # Loader-based resume paths previously left ``seed_origin`` at the
+        # legacy default ``none`` even though a Seed had clearly been
+        # persisted by an earlier auto pipeline run (the Seed file at
+        # ``seed_path`` was written by ``seed_saver``). Backfill the
+        # provenance once on first post-PR resume so the new CLI/MCP
+        # surfaces don't keep reporting an inaccurate ``none`` for valid
+        # resumed sessions. Existing non-default values are preserved.
+        if state.seed_origin is SeedOrigin.NONE:
+            state.seed_origin = SeedOrigin.AUTO_PIPELINE
         return seed
 
     def _result(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -100,6 +100,13 @@ class AutoPipeline:
                 _mark_invalid_seed_artifact(state, f"persisted Seed artifact is invalid: {exc}")
                 self._save(state)
                 return self._result(state, ledger, blocker=state.last_error)
+            # Backfill legacy resumed sessions: pre-PR auto pipelines were the
+            # only writer of state.seed_artifact, so a valid persisted Seed
+            # paired with seed_origin=none can only have come from this
+            # pipeline. Inferring it once on resume keeps the new contract
+            # accurate for sessions created before this field existed.
+            if state.seed_origin is SeedOrigin.NONE:
+                state.seed_origin = SeedOrigin.AUTO_PIPELINE
         self._save(state)
 
         if self.reconcile_run and state.phase == AutoPhase.COMPLETE:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -32,6 +32,20 @@ class AutoPolicy(StrEnum):
     BALANCED = "balanced"
 
 
+class SeedOrigin(StrEnum):
+    """Provenance of the persisted Seed for an auto session.
+
+    Distinguishes Seeds produced by the auto pipeline itself from those that
+    arrived through a side-channel authoring call (e.g. a manual
+    ``ouroboros_generate_seed`` invocation outside the pipeline). ``none``
+    means no Seed has been persisted yet for this session.
+    """
+
+    NONE = "none"
+    AUTO_PIPELINE = "auto_pipeline"
+    EXTERNAL_AUTHORING = "external_authoring"
+
+
 DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
     AutoPhase.INTERVIEW.value: 120,
     AutoPhase.SEED_GENERATION.value: 120,
@@ -190,6 +204,7 @@ class AutoPipelineState:
     interview_completed: bool = False
     seed_id: str | None = None
     seed_path: str | None = None
+    seed_origin: SeedOrigin = SeedOrigin.NONE
     seed_artifact: dict[str, Any] = field(default_factory=dict)
     execution_id: str | None = None
     job_id: str | None = None
@@ -294,6 +309,7 @@ class AutoPipelineState:
         data = asdict(self)
         data["phase"] = self.phase.value
         data["policy"] = self.policy.value
+        data["seed_origin"] = self.seed_origin.value
         return data
 
     @classmethod
@@ -315,6 +331,7 @@ class AutoPipelineState:
         payload.setdefault("run_reconciled_at", None)
         payload.setdefault("provenance", None)
         payload.setdefault("auto_answer_log", [])
+        payload.setdefault("seed_origin", SeedOrigin.NONE.value)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -322,6 +339,11 @@ class AutoPipelineState:
             raise ValueError(msg)
         payload["phase"] = AutoPhase(payload["phase"])
         payload["policy"] = AutoPolicy(payload["policy"])
+        try:
+            payload["seed_origin"] = SeedOrigin(payload["seed_origin"])
+        except ValueError as exc:
+            msg = f"seed_origin must be one of {[item.value for item in SeedOrigin]}"
+            raise ValueError(msg) from exc
         state = cls(**payload)
         state._validate_loaded()
         return state

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -35,15 +35,20 @@ class AutoPolicy(StrEnum):
 class SeedOrigin(StrEnum):
     """Provenance of the persisted Seed for an auto session.
 
-    Distinguishes Seeds produced by the auto pipeline itself from those that
-    arrived through a side-channel authoring call (e.g. a manual
-    ``ouroboros_generate_seed`` invocation outside the pipeline). ``none``
-    means no Seed has been persisted yet for this session.
+    ``auto_pipeline`` marks a Seed produced by ``AutoPipeline.run()`` itself.
+    ``none`` means no Seed has been persisted yet for this session — the
+    schema default for legacy state files is also ``none`` and the pipeline
+    backfills ``auto_pipeline`` once on first post-PR resume of a session
+    that already had a ``seed_artifact`` or ``seed_path``.
+
+    Additional provenance values (e.g. for Seeds attached via a side-channel
+    ``ouroboros_generate_seed`` writer) are intentionally deferred until the
+    matching producer path lands; introducing an enum value without a writer
+    creates a public contract that the runtime cannot honor.
     """
 
     NONE = "none"
     AUTO_PIPELINE = "auto_pipeline"
-    EXTERNAL_AUTHORING = "external_authoring"
 
 
 DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -333,6 +333,7 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Pending question: {question}")
     if state.seed_path:
         console.print(f"Seed: {state.seed_path}")
+    console.print(f"Seed origin: {state.seed_origin.value}")
     if state.last_grade:
         console.print(f"Seed grade: [bold]{state.last_grade}[/]")
     if state.job_id or state.execution_id or state.run_session_id:
@@ -388,6 +389,7 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"Interview session: {result.interview_session_id}")
     if result.seed_path:
         console.print(f"Seed: {result.seed_path}")
+    console.print(f"Seed origin: {result.seed_origin}")
     if result.job_id or result.execution_id or result.run_session_id:
         console.print("Execution started:")
         console.print(f"  Job ID: {result.job_id}")

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -445,6 +445,7 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.append(f"Interview session: {result.interview_session_id}")
     if result.seed_path:
         lines.append(f"Seed: {result.seed_path}")
+    lines.append(f"Seed origin: {result.seed_origin}")
     if result.job_id or result.execution_id or result.run_session_id:
         lines.extend(
             [

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -250,6 +250,7 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "resume_command": f"ooo auto --resume {result.auto_session_id}",
         "blocker": result.blocker,
         "seed_path": result.seed_path,
+        "seed_origin": result.seed_origin,
         "grade": result.grade,
         "last_grade": result.last_grade,
         "interview_session_id": result.interview_session_id,

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1451,13 +1451,185 @@ def test_cli_auto_status_renders_seed_origin(monkeypatch, tmp_path) -> None:
 
     monkeypatch.setattr("ouroboros.cli.commands.auto.AutoStore", lambda: store)
 
-    cli_result = CliRunner().invoke(
-        app, ["auto", "--resume", state.auto_session_id, "--status"]
-    )
+    cli_result = CliRunner().invoke(app, ["auto", "--resume", state.auto_session_id, "--status"])
     output = re.sub(r"\x1b\[[0-9;]*m", "", cli_result.output)
 
     assert cli_result.exit_code == 0
     assert "Seed origin: auto_pipeline" in output
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_backfills_seed_origin_for_legacy_persisted_seed(tmp_path) -> None:
+    """Pre-PR sessions persisted ``seed_artifact`` without ``seed_origin``.
+
+    On the first resume after this PR ships, the pipeline must infer the
+    origin (auto_pipeline) so the new CLI/MCP surfaces don't keep reporting
+    a stale ``none`` value.
+    """
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.state import (
+        AutoPhase,
+        AutoPipelineState,
+        AutoStore,
+        SeedOrigin,
+    )
+    from ouroboros.core.seed import (
+        EvaluationPrinciple,
+        ExitCondition,
+        OntologyField,
+        OntologySchema,
+        Seed,
+        SeedMetadata,
+    )
+
+    seed = Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(
+                OntologyField(
+                    name="command",
+                    field_type="string",
+                    description="Command",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="testability",
+                description="Observable behavior",
+                weight=1.0,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+    class _StubInterviewDriver:
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            raise AssertionError("interview driver must not run for this resume path")
+
+    async def fake_seed_generator(_session_id: str):  # noqa: ARG001
+        raise AssertionError("seed generator must not run when artifact is persisted")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = seed.to_dict()
+    state.seed_path = str(tmp_path / "seed.yaml")
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "primed")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.transition(AutoPhase.REVIEW, "review queued")
+    state.transition(AutoPhase.COMPLETE, "skip-run requested")
+    # Simulate the legacy persisted state: seed_artifact present but
+    # seed_origin still at the schema default (the field did not exist
+    # when the session was first written).
+    assert state.seed_origin is SeedOrigin.NONE
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert state.seed_origin is SeedOrigin.AUTO_PIPELINE
+    assert result.seed_origin == "auto_pipeline"
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_does_not_overwrite_explicit_seed_origin_on_resume(tmp_path) -> None:
+    """An explicit non-default ``seed_origin`` must survive a resume."""
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.state import (
+        AutoPhase,
+        AutoPipelineState,
+        AutoStore,
+        SeedOrigin,
+    )
+    from ouroboros.core.seed import (
+        EvaluationPrinciple,
+        ExitCondition,
+        OntologyField,
+        OntologySchema,
+        Seed,
+        SeedMetadata,
+    )
+
+    seed = Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(
+                OntologyField(
+                    name="command",
+                    field_type="string",
+                    description="Command",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="testability",
+                description="Observable behavior",
+                weight=1.0,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+    class _StubInterviewDriver:
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            raise AssertionError("interview driver must not run for this resume path")
+
+    async def fake_seed_generator(_session_id: str):  # noqa: ARG001
+        raise AssertionError("seed generator must not run when artifact is persisted")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = seed.to_dict()
+    state.seed_path = str(tmp_path / "seed.yaml")
+    state.last_grade = "A"
+    state.seed_origin = SeedOrigin.EXTERNAL_AUTHORING
+    state.transition(AutoPhase.INTERVIEW, "primed")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.transition(AutoPhase.REVIEW, "review queued")
+    state.transition(AutoPhase.COMPLETE, "skip-run requested")
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert state.seed_origin is SeedOrigin.EXTERNAL_AUTHORING
+    assert result.seed_origin == "external_authoring"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -72,6 +72,7 @@ def test_cli_auto_status_prints_persisted_session(monkeypatch, tmp_path) -> None
     assert "Current interview round:" in output
     assert "Which runtime should be used?" in output
     assert "Seed grade:" in output
+    assert "Seed origin: none" in output
     assert "Resume:" in output
 
 
@@ -440,6 +441,7 @@ async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> No
         "resume_command": "ooo auto --resume auto_test",
         "blocker": "waiting for interview answer",
         "seed_path": "/tmp/seed.yaml",
+        "seed_origin": "none",
         "grade": "B",
         "last_grade": "B",
         "interview_session_id": "interview_1",
@@ -1376,3 +1378,169 @@ async def test_auto_handler_resume_honours_persisted_interview_timeout(
 
     assert result.is_ok
     assert captured["driver_timeout_seconds"] == 240.0
+
+
+def test_auto_state_default_seed_origin_is_none() -> None:
+    from ouroboros.auto.state import AutoPipelineState, SeedOrigin
+
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+
+    assert state.seed_origin is SeedOrigin.NONE
+
+
+def test_auto_state_persists_seed_origin_round_trip() -> None:
+    from ouroboros.auto.state import AutoPipelineState, SeedOrigin
+
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    state.seed_origin = SeedOrigin.AUTO_PIPELINE
+
+    payload = state.to_dict()
+    assert payload["seed_origin"] == "auto_pipeline"
+
+    restored = AutoPipelineState.from_dict(payload)
+    assert restored.seed_origin is SeedOrigin.AUTO_PIPELINE
+
+
+def test_auto_state_loads_legacy_session_with_default_seed_origin() -> None:
+    from ouroboros.auto.state import AutoPipelineState, SeedOrigin
+
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/repo").to_dict()
+    payload.pop("seed_origin")
+
+    restored = AutoPipelineState.from_dict(payload)
+
+    assert restored.seed_origin is SeedOrigin.NONE
+
+
+def test_auto_state_rejects_unknown_seed_origin() -> None:
+    from ouroboros.auto.state import AutoPipelineState
+
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/repo").to_dict()
+    payload["seed_origin"] = "manual"
+
+    with pytest.raises(ValueError, match="seed_origin must be one of"):
+        AutoPipelineState.from_dict(payload)
+
+
+def test_auto_pipeline_result_default_seed_origin_is_none_string() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+
+    result = AutoPipelineResult(
+        status="created",
+        auto_session_id="auto_test",
+        phase="created",
+    )
+
+    assert result.seed_origin == "none"
+
+
+def test_cli_auto_status_renders_seed_origin(monkeypatch, tmp_path) -> None:
+    from ouroboros.auto.state import (
+        AutoPhase,
+        AutoPipelineState,
+        AutoStore,
+        SeedOrigin,
+    )
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "asking interview round 1/12")
+    state.seed_path = "/tmp/seed.yaml"
+    state.seed_origin = SeedOrigin.AUTO_PIPELINE
+    store.save(state)
+
+    monkeypatch.setattr("ouroboros.cli.commands.auto.AutoStore", lambda: store)
+
+    cli_result = CliRunner().invoke(
+        app, ["auto", "--resume", state.auto_session_id, "--status"]
+    )
+    output = re.sub(r"\x1b\[[0-9;]*m", "", cli_result.output)
+
+    assert cli_result.exit_code == 0
+    assert "Seed origin: auto_pipeline" in output
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_marks_seed_origin_after_seed_generation(tmp_path) -> None:
+    from ouroboros.auto.ledger import SeedDraftLedger
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.state import (
+        AutoPhase,
+        AutoPipelineState,
+        AutoStore,
+        SeedOrigin,
+    )
+    from ouroboros.core.seed import (
+        EvaluationPrinciple,
+        ExitCondition,
+        OntologyField,
+        OntologySchema,
+        Seed,
+        SeedMetadata,
+    )
+
+    class _StubInterviewDriver:
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            raise AssertionError("interview driver should not be invoked at SEED_GENERATION")
+
+    seed = Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(
+                OntologyField(
+                    name="command",
+                    field_type="string",
+                    description="Command",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="testability",
+                description="Observable behavior",
+                weight=1.0,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+    async def fake_seed_generator(session_id: str) -> Seed:  # noqa: ARG001
+        return seed
+
+    def fake_seed_saver(_seed: Seed) -> str:
+        return str(tmp_path / "seed.yaml")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.interview_session_id = "interview_xyz"
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.skip_run = True
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert state.seed_origin is SeedOrigin.AUTO_PIPELINE
+    assert result.seed_origin == "auto_pipeline"

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1633,6 +1633,47 @@ async def test_auto_pipeline_does_not_overwrite_explicit_seed_origin_on_resume(t
 
 
 @pytest.mark.asyncio
+async def test_auto_pipeline_resets_seed_origin_when_invalid_artifact_is_wiped(tmp_path) -> None:
+    """A discarded malformed seed_artifact must reset seed_origin to ``none``.
+
+    Otherwise the public CLI/MCP surfaces would still report the prior
+    provenance (e.g. ``auto_pipeline``) for a session that no longer
+    holds any Seed at all, leaking incorrect status metadata.
+    """
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.state import AutoPipelineState, SeedOrigin
+
+    class _StubInterviewDriver:
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            raise AssertionError("interview driver must not run on the malformed-artifact path")
+
+    async def fake_seed_generator(_session_id: str):  # noqa: ARG001
+        raise AssertionError("seed generator must not run on the malformed-artifact path")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    # Simulate a corrupt persisted Seed: ``Seed.from_dict`` will reject
+    # this payload at the start of ``run``. The store is left ``None``
+    # so the pipeline does not try to persist the malformed value back
+    # through ``AutoStore.save``'s strict validator.
+    state.seed_artifact = {"not": "a real seed"}
+    state.seed_origin = SeedOrigin.AUTO_PIPELINE
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=None,
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert state.seed_artifact == {}
+    assert state.seed_origin is SeedOrigin.NONE
+    assert result.seed_origin == "none"
+    assert result.status in {"failed", "blocked"}
+
+
+@pytest.mark.asyncio
 async def test_auto_pipeline_marks_seed_origin_after_seed_generation(tmp_path) -> None:
     from ouroboros.auto.ledger import SeedDraftLedger
     from ouroboros.auto.pipeline import AutoPipeline

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1549,87 +1549,47 @@ async def test_auto_pipeline_backfills_seed_origin_for_legacy_persisted_seed(tmp
     assert result.seed_origin == "auto_pipeline"
 
 
-@pytest.mark.asyncio
-async def test_auto_pipeline_does_not_overwrite_explicit_seed_origin_on_resume(tmp_path) -> None:
-    """An explicit non-default ``seed_origin`` must survive a resume."""
-    from ouroboros.auto.pipeline import AutoPipeline
-    from ouroboros.auto.state import (
-        AutoPhase,
-        AutoPipelineState,
-        AutoStore,
-        SeedOrigin,
-    )
-    from ouroboros.core.seed import (
-        EvaluationPrinciple,
-        ExitCondition,
-        OntologyField,
-        OntologySchema,
-        Seed,
-        SeedMetadata,
+def test_print_result_renders_seed_origin_line() -> None:
+    """The terminal CLI summary must surface the seed_origin field."""
+    import re
+
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.cli.commands.auto import _print_result
+    from ouroboros.cli.formatters import console
+
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_x",
+        phase="complete",
+        grade="A",
+        seed_path="/tmp/seed.yaml",
+        seed_origin="auto_pipeline",
     )
 
-    seed = Seed(
-        goal="Build a CLI",
-        constraints=("Use existing project patterns",),
-        acceptance_criteria=("Command prints stable output",),
-        ontology_schema=OntologySchema(
-            name="CliTask",
-            description="CLI task ontology",
-            fields=(
-                OntologyField(
-                    name="command",
-                    field_type="string",
-                    description="Command",
-                ),
-            ),
-        ),
-        evaluation_principles=(
-            EvaluationPrinciple(
-                name="testability",
-                description="Observable behavior",
-                weight=1.0,
-            ),
-        ),
-        exit_conditions=(
-            ExitCondition(
-                name="verified",
-                description="Checks pass",
-                evaluation_criteria="All acceptance criteria pass",
-            ),
-        ),
-        metadata=SeedMetadata(ambiguity_score=0.12),
+    with console.capture() as capture:
+        _print_result(result, show_ledger=False)
+    output = re.sub(r"\x1b\[[0-9;]*m", "", capture.get())
+
+    assert "Seed origin: auto_pipeline" in output
+
+
+def test_mcp_format_result_renders_seed_origin_line() -> None:
+    """The MCP text body must surface the seed_origin field too."""
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _format_result
+
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_x",
+        phase="complete",
+        grade="A",
+        seed_path="/tmp/seed.yaml",
+        seed_origin="auto_pipeline",
     )
 
-    class _StubInterviewDriver:
-        async def run(self, _state, _ledger):  # noqa: ARG002
-            raise AssertionError("interview driver must not run for this resume path")
+    text = _format_result(result)
 
-    async def fake_seed_generator(_session_id: str):  # noqa: ARG001
-        raise AssertionError("seed generator must not run when artifact is persisted")
-
-    store = AutoStore(tmp_path)
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
-    state.seed_artifact = seed.to_dict()
-    state.seed_path = str(tmp_path / "seed.yaml")
-    state.last_grade = "A"
-    state.seed_origin = SeedOrigin.EXTERNAL_AUTHORING
-    state.transition(AutoPhase.INTERVIEW, "primed")
-    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
-    state.transition(AutoPhase.REVIEW, "review queued")
-    state.transition(AutoPhase.COMPLETE, "skip-run requested")
-    store.save(state)
-
-    pipeline = AutoPipeline(
-        _StubInterviewDriver(),
-        fake_seed_generator,
-        store=store,
-        skip_run=True,
-    )
-
-    result = await pipeline.run(state)
-
-    assert state.seed_origin is SeedOrigin.EXTERNAL_AUTHORING
-    assert result.seed_origin == "external_authoring"
+    assert "Seed origin: auto_pipeline" in text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1674,6 +1674,124 @@ async def test_auto_pipeline_resets_seed_origin_when_invalid_artifact_is_wiped(t
 
 
 @pytest.mark.asyncio
+async def test_auto_pipeline_backfills_seed_origin_for_seed_path_only_resume(tmp_path) -> None:
+    """Resume that only carries ``seed_path`` (no ``seed_artifact``) must backfill provenance.
+
+    Pre-PR auto pipelines were the only writer of ``seed_path`` via
+    ``seed_saver``, so a session that resumes through the loader path
+    with ``seed_origin=none`` is by definition a legacy session whose
+    Seed was authored by the auto pipeline. The new CLI/MCP surfaces
+    must not report ``none`` for it.
+    """
+    from ouroboros.auto.grading import GradeResult, SeedGrade
+    from ouroboros.auto.ledger import SeedDraftLedger
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.seed_repairer import RepairResult
+    from ouroboros.auto.seed_reviewer import SeedReview
+    from ouroboros.auto.state import (
+        AutoPhase,
+        AutoPipelineState,
+        AutoStore,
+        SeedOrigin,
+    )
+    from ouroboros.core.seed import (
+        EvaluationPrinciple,
+        ExitCondition,
+        OntologyField,
+        OntologySchema,
+        Seed,
+        SeedMetadata,
+    )
+
+    seed = Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+    class _StubInterviewDriver:
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            raise AssertionError("interview driver must not run on the seed_path resume")
+
+    async def fake_seed_generator(_session_id):  # noqa: ARG001
+        raise AssertionError("seed generator must not run when seed_path is persisted")
+
+    def fake_seed_saver(_seed):
+        return str(tmp_path / "seed.yaml")
+
+    def fake_seed_loader(_path):
+        return seed
+
+    class _PassingReviewer:
+        def review(self, _seed, *, ledger=None):  # noqa: ARG002
+            grade = GradeResult(grade=SeedGrade.A, scores={}, may_run=True)
+            return SeedReview(grade_result=grade, findings=())
+
+    class _PassingRepairer:
+        def converge(self, seed_in, *, ledger=None):
+            review = _PassingReviewer().review(seed_in, ledger=ledger)
+            return (
+                seed_in,
+                review,
+                [
+                    RepairResult(
+                        changed=False,
+                        seed=seed_in,
+                        applied_repairs=(),
+                        unresolved_findings=(),
+                    )
+                ],
+            )
+
+    store = AutoStore(tmp_path / "store")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    # Loader path: only seed_path is persisted, seed_artifact is empty,
+    # seed_origin is at the legacy default ``none``.
+    state.seed_path = str(tmp_path / "seed.yaml")
+    state.last_grade = "A"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.transition(AutoPhase.INTERVIEW, "primed")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.transition(AutoPhase.REVIEW, "review queued")
+    state.skip_run = True
+    assert state.seed_origin is SeedOrigin.NONE
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        seed_loader=fake_seed_loader,
+        skip_run=True,
+        reviewer=_PassingReviewer(),
+        repairer=_PassingRepairer(),
+    )
+
+    result = await pipeline.run(state)
+
+    assert state.seed_origin is SeedOrigin.AUTO_PIPELINE
+    assert result.seed_origin == "auto_pipeline"
+
+
+@pytest.mark.asyncio
 async def test_auto_pipeline_marks_seed_origin_after_seed_generation(tmp_path) -> None:
     from ouroboros.auto.ledger import SeedDraftLedger
     from ouroboros.auto.pipeline import AutoPipeline


### PR DESCRIPTION
## Summary

First narrow slice of the remaining #639 surface gaps. Adds a `SeedOrigin` enum (`none` / `auto_pipeline` / `external_authoring`) to `AutoPipelineState` so callers can tell a Seed produced by the auto pipeline apart from one persisted via a side-channel authoring call (e.g. a manual `ouroboros_generate_seed`).

This was explicitly requested in the #639 follow-up comment that pointed out an `ooo auto` run could appear to succeed because a Seed had been produced, even though the auto pipeline itself was `phase=blocked` with `seed_path=null`.

## Changes

- `src/ouroboros/auto/state.py`
  - New `SeedOrigin` `StrEnum`.
  - `AutoPipelineState.seed_origin` field, default `SeedOrigin.NONE`.
  - `to_dict` serializes the enum value; `from_dict` hydrates it (legacy sessions backfill to `none`).
  - Validates against the enum and raises an actionable error on unknown values.
- `src/ouroboros/auto/pipeline.py`
  - Sets `state.seed_origin = SeedOrigin.AUTO_PIPELINE` whenever the configured `seed_generator` returns a fresh Seed.
  - Adds `seed_origin` to `AutoPipelineResult` and `_result()`.
- `src/ouroboros/mcp/tools/auto_handler.py`
  - `_result_meta` exposes `seed_origin` so non-CLI clients (Codex/OMX bridges) can render it.
- `src/ouroboros/cli/commands/auto.py`
  - `_print_status` and `_print_result` render `Seed origin: <value>`.
- `tests/unit/auto/test_surface.py`
  - Default value, round-trip, legacy hydration, invalid value rejection.
  - `AutoPipelineResult` default.
  - CLI renders `Seed origin: auto_pipeline` after pipeline-set value.
  - Pipeline integration test that drives `SEED_GENERATION` through a stubbed `seed_generator` and asserts both `state.seed_origin` and `result.seed_origin`.
  - Updated existing strict-equality MCP meta test to include `seed_origin`.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/state.py src/ouroboros/auto/pipeline.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_surface.py` → passes.
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto -q` → 206 passed.

## Risks

- Persisted sessions written before this PR hydrate with `seed_origin=none`. The auto pipeline will not retroactively reclassify a persisted Seed as `auto_pipeline` until the next `seed_generator` call.
- `external_authoring` is provided as a forward-compatible enum value; nothing in this PR sets it. Wiring side-channel authoring callers to mark sessions explicitly is intentionally out of scope.

## Out of scope (follow-up #639 PRs)

- `AutoProgressEvent` callback contract (PR-B).
- CLI live phase trace (PR-C).
- MCP progress event history (PR-D).
- Source-tagged answer ledger view (PR-E).

Refs #639