### PR TITLE
feat(auto): allowlisted gateway provenance on AutoPipelineState (#691) [1/3]

### DIFF
--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -40,6 +40,93 @@ DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
     AutoPhase.RUN.value: 60,
 }
 
+# Allowed keys for the optional gateway-provenance metadata recorded on auto state.
+# Strict allowlist: anything not listed here is dropped during redaction so that
+# tokens, credentials, or raw user utterances cannot be persisted by accident.
+PROVENANCE_ALLOWED_KEYS: frozenset[str] = frozenset(
+    {
+        "source",
+        "rewrite",
+        "original_utterance_hash",
+        "channel_id_hash",
+        "user_id_hash",
+        "platform_message_id",
+        "gateway_version",
+    }
+)
+
+# Per-key validators. Each returns the cleaned value or raises ValueError.
+_PROVENANCE_HEX_KEYS = {
+    "original_utterance_hash",
+    "channel_id_hash",
+    "user_id_hash",
+}
+_PROVENANCE_MAX_LENGTHS = {
+    "source": 32,
+    "platform_message_id": 64,
+    "gateway_version": 32,
+    "original_utterance_hash": 128,
+    "channel_id_hash": 128,
+    "user_id_hash": 128,
+}
+# Surface a clear ImportError instead of a runtime KeyError when the allowlist
+# grows but a length cap is not added alongside it.
+assert (PROVENANCE_ALLOWED_KEYS - {"rewrite"}).issubset(  # noqa: S101
+    _PROVENANCE_MAX_LENGTHS.keys()
+), "every non-rewrite provenance key needs an entry in _PROVENANCE_MAX_LENGTHS"
+
+
+def _clean_provenance_value(key: str, value: Any) -> Any:
+    if key == "rewrite":
+        if not isinstance(value, bool):
+            msg = "provenance.rewrite must be a boolean"
+            raise ValueError(msg)
+        return value
+    if not isinstance(value, str):
+        msg = f"provenance.{key} must be a string"
+        raise ValueError(msg)
+    cleaned = value.strip()
+    if not cleaned:
+        msg = f"provenance.{key} must be a non-empty string"
+        raise ValueError(msg)
+    limit = _PROVENANCE_MAX_LENGTHS[key]
+    if len(cleaned) > limit:
+        msg = f"provenance.{key} exceeds {limit}-character limit"
+        raise ValueError(msg)
+    if key in _PROVENANCE_HEX_KEYS:
+        lowered = cleaned.lower()
+        if not all(c in "0123456789abcdef" for c in lowered):
+            msg = f"provenance.{key} must be a lowercase hex digest"
+            raise ValueError(msg)
+        return lowered
+    if any(c.isspace() or not c.isprintable() for c in cleaned):
+        msg = f"provenance.{key} must be printable without whitespace"
+        raise ValueError(msg)
+    return cleaned
+
+
+def redact_provenance(raw: Any) -> dict[str, Any] | None:
+    """Return an allowlisted, type-checked provenance dict (or None).
+
+    Unknown keys are silently dropped so that callers cannot smuggle private
+    data via ad-hoc fields. Validation errors on allowed keys raise instead of
+    being swallowed so that bad gateway integrations surface early.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        msg = "provenance must be an object or null"
+        raise ValueError(msg)
+    cleaned: dict[str, Any] = {}
+    for key, value in raw.items():
+        if key not in PROVENANCE_ALLOWED_KEYS:
+            continue
+        cleaned[key] = _clean_provenance_value(key, value)
+    if not cleaned:
+        return None
+    return cleaned
+
+
 TERMINAL_PHASES = {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}
 _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
     AutoPhase.CREATED: {AutoPhase.INTERVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
@@ -133,6 +220,10 @@ class AutoPipelineState:
     timeout_seconds_by_phase: dict[str, int] = field(
         default_factory=lambda: dict(DEFAULT_TIMEOUT_SECONDS_BY_PHASE)
     )
+    # Optional provenance metadata supplied by an external gateway when it
+    # rewrote a natural-language request into ``ooo auto`` shell command. None
+    # for direct CLI invocations so legacy state files load unchanged.
+    provenance: dict[str, Any] | None = None
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.
@@ -221,6 +312,7 @@ class AutoPipelineState:
         payload.setdefault("run_reconciliation_status", None)
         payload.setdefault("run_reconciliation_source", None)
         payload.setdefault("run_reconciled_at", None)
+        payload.setdefault("provenance", None)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -304,6 +396,14 @@ class AutoPipelineState:
         if not isinstance(self.run_subagent, dict):
             msg = "run_subagent must be an object"
             raise ValueError(msg)
+        if self.provenance is not None:
+            if not isinstance(self.provenance, dict):
+                msg = "provenance must be an object or null"
+                raise ValueError(msg)
+            cleaned = redact_provenance(self.provenance)
+            if cleaned != self.provenance:
+                msg = "provenance contains unallowed keys; pass through redact_provenance() before persisting"
+                raise ValueError(msg)
         if self.ledger:
             try:
                 from ouroboros.auto.ledger import SeedDraftLedger

--- a/tests/unit/auto/test_state_provenance.py
+++ b/tests/unit/auto/test_state_provenance.py
@@ -1,0 +1,118 @@
+"""Tests for the optional gateway-provenance metadata on auto state."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.auto.state import (
+    PROVENANCE_ALLOWED_KEYS,
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+    redact_provenance,
+)
+
+
+def _state(**overrides) -> AutoPipelineState:
+    base = {"goal": "Build a CLI", "cwd": "/tmp/project"}
+    base.update(overrides)
+    return AutoPipelineState(**base)
+
+
+def test_default_state_has_no_provenance() -> None:
+    state = _state()
+    assert state.provenance is None
+    payload = state.to_dict()
+    assert payload["provenance"] is None
+
+
+def test_redact_provenance_drops_unknown_keys() -> None:
+    raw = {
+        "source": "discord",
+        "rewrite": True,
+        "user_token": "xoxb-supersecret",
+        "raw_message": "delete prod database now",
+        "channel_id_hash": "ab12cd",
+    }
+    cleaned = redact_provenance(raw)
+    assert cleaned == {
+        "source": "discord",
+        "rewrite": True,
+        "channel_id_hash": "ab12cd",
+    }
+    # The allowlist must not silently grow without intent.
+    assert "user_token" not in PROVENANCE_ALLOWED_KEYS
+    assert "raw_message" not in PROVENANCE_ALLOWED_KEYS
+
+
+def test_redact_provenance_returns_none_for_empty() -> None:
+    assert redact_provenance(None) is None
+    assert redact_provenance({}) is None
+    assert redact_provenance({"unrelated": "x"}) is None
+
+
+def test_redact_provenance_rejects_wrong_types() -> None:
+    with pytest.raises(ValueError, match="must be an object"):
+        redact_provenance("discord")
+    with pytest.raises(ValueError, match="rewrite must be a boolean"):
+        redact_provenance({"rewrite": "yes"})
+    with pytest.raises(ValueError, match="source must be a string"):
+        redact_provenance({"source": 7})
+    with pytest.raises(ValueError, match="exceeds 32"):
+        redact_provenance({"source": "x" * 33})
+    with pytest.raises(ValueError, match="hex digest"):
+        redact_provenance({"channel_id_hash": "not-hex!"})
+    with pytest.raises(ValueError, match="printable without whitespace"):
+        redact_provenance({"platform_message_id": "id with space"})
+
+
+def test_state_persists_only_allowlisted_provenance(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _state()
+    state.provenance = redact_provenance(
+        {
+            "source": "discord",
+            "rewrite": True,
+            "channel_id_hash": "deadbeef",
+            "secret": "leak",
+        }
+    )
+    state.transition(AutoPhase.INTERVIEW, "starting")
+    path = store.save(state)
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["provenance"] == {
+        "source": "discord",
+        "rewrite": True,
+        "channel_id_hash": "deadbeef",
+    }
+    assert "secret" not in raw["provenance"]
+
+    loaded = store.load(state.auto_session_id)
+    assert loaded.provenance == state.provenance
+
+
+def test_state_save_rejects_unredacted_provenance(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _state()
+    state.provenance = {"source": "discord", "raw_message": "leak"}
+
+    with pytest.raises(ValueError, match="redact_provenance"):
+        store.save(state)
+
+
+def test_legacy_state_without_provenance_field_loads(tmp_path) -> None:
+    """State files written before this field exists must still load."""
+    store = AutoStore(tmp_path)
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "starting")
+    path = store.save(state)
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw.pop("provenance", None)
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    loaded = store.load(state.auto_session_id)
+    assert loaded.provenance is None


### PR DESCRIPTION
## Summary

PR 1/3 of the gateway-provenance stack for #691. Adds an optional, allowlisted ``provenance`` dict on ``AutoPipelineState`` so the durable auto-session JSON can record why a particular ``ooo auto`` run exists when an external gateway (Discord/Hermes deterministic command rewrite) translated a natural-language request into a shell invocation.

- New ``PROVENANCE_ALLOWED_KEYS`` + ``redact_provenance()`` helper in ``src/ouroboros/auto/state.py``
- New ``provenance: dict | None`` field on ``AutoPipelineState`` (default ``None`` so direct CLI runs are untouched)
- ``_validate_loaded`` refuses unredacted payloads on save
- ``from_dict`` backfills ``None`` so legacy auto-session JSON files load unchanged
- 7 new tests in ``tests/unit/auto/test_state_provenance.py``

Refs #691, epic #692. Stack: **PR-A (this)** → PR-B (CLI/env wiring) → PR-C (reporting). Subsequent PRs are stacked on this branch and link back here for context.

## Test plan

- [x] ``pytest tests/unit/auto/test_state_provenance.py tests/unit/auto/test_state.py``
- [x] ``ruff check`` clean on touched files
- [x] Legacy state JSON without ``provenance`` field still loads via ``AutoStore.load``
- [ ] Reviewer confirms allowlist keys cover the gateway-integration shape called out in #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)