### PR TITLE
feat(auto): surface invoked_by in pipeline result and CLI summary (#691) [3/3]

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -61,6 +61,8 @@ class AutoPipelineResult:
     blocker: str | None = None
     runtime_backend: str | None = None
     opencode_mode: str | None = None
+    invoked_by: str = "direct"
+    provenance: dict[str, Any] | None = None
 
 
 @dataclass(slots=True)
@@ -488,6 +490,8 @@ class AutoPipeline:
             blocker=blocker or state.last_error,
             runtime_backend=state.runtime_backend,
             opencode_mode=state.opencode_mode,
+            invoked_by=state.invoked_by(),
+            provenance=dict(state.provenance) if state.provenance else None,
         )
 
     def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:

--- a/src/ouroboros/auto/provenance.py
+++ b/src/ouroboros/auto/provenance.py
@@ -1,0 +1,72 @@
+"""Resolve optional gateway-provenance metadata for ``ooo auto``.
+
+External gateways (Discord/Hermes deterministic command rewrite, etc.) attach
+context describing how a natural-language request became an ``ooo auto``
+invocation. The contract is intentionally gateway-internal: the gateway sets
+``OUROBOROS_AUTO_PROVENANCE_JSON`` in the child environment before exec'ing
+``ooo auto``. There is no user-facing CLI flag — this metadata is not part of
+the direct CLI UX and we do not want to surface it as such.
+
+Direct CLI invocations leave the env var unset and observe the historical
+behaviour: no provenance is recorded and downstream code paths are unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import os
+from typing import Any
+
+from ouroboros.auto.state import redact_provenance
+
+PROVENANCE_ENV_VAR = "OUROBOROS_AUTO_PROVENANCE_JSON"
+# Allowlisted provenance is hash- and label-sized; 4 KiB is generous for the
+# entire JSON envelope and bounds memory if a misconfigured gateway sets a
+# pathological env value.
+_MAX_PROVENANCE_BYTES = 4096
+
+
+def _decode(payload: str) -> dict[str, Any]:
+    text = payload.strip()
+    if not text:
+        msg = f"{PROVENANCE_ENV_VAR} provenance payload is empty"
+        raise ValueError(msg)
+    try:
+        loaded = json.loads(text)
+    except json.JSONDecodeError as exc:
+        msg = f"{PROVENANCE_ENV_VAR} provenance payload is not valid JSON: {exc.msg}"
+        raise ValueError(msg) from exc
+    if not isinstance(loaded, dict):
+        msg = f"{PROVENANCE_ENV_VAR} provenance payload must be a JSON object"
+        raise ValueError(msg)
+    return loaded
+
+
+def resolve_provenance(
+    *,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any] | None:
+    """Return a redacted provenance dict from the gateway env var, or None.
+
+    ``env`` defaults to ``os.environ`` so the standard call site (the auto
+    CLI) picks up gateway-supplied configuration without ceremony; pass an
+    explicit mapping (including ``{}``) to suppress that lookup in tests.
+    Returning ``None`` covers both "no input provided" and "input only had
+    keys that were dropped by redaction" — callers must treat the two
+    identically.
+    """
+    env_map: Mapping[str, str] = env if env is not None else os.environ
+    env_value = env_map.get(PROVENANCE_ENV_VAR)
+    if env_value is None or not env_value.strip():
+        return None
+    if len(env_value) > _MAX_PROVENANCE_BYTES:
+        msg = (
+            f"{PROVENANCE_ENV_VAR} exceeds {_MAX_PROVENANCE_BYTES}-byte cap (got {len(env_value)})"
+        )
+        raise ValueError(msg)
+    raw = _decode(env_value)
+    return redact_provenance(raw)
+
+
+__all__ = ["PROVENANCE_ENV_VAR", "resolve_provenance"]

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -298,6 +298,23 @@ class AutoPipelineState:
         """Return True when the state cannot continue automatically."""
         return self.phase in TERMINAL_PHASES
 
+    def invoked_by(self) -> str:
+        """Return the high-level invocation source for blocker/summary output.
+
+        ``direct`` covers all CLI-originated runs (no provenance, or
+        ``source == "cli"``). Anything else with a recognized non-cli source
+        is ``gateway``. Provenance present but missing a usable ``source``
+        becomes ``unknown`` so misconfigured integrations are visible.
+        """
+        if not self.provenance:
+            return "direct"
+        source = self.provenance.get("source")
+        if source == "cli":
+            return "direct"
+        if isinstance(source, str) and source.strip():
+            return "gateway"
+        return "unknown"
+
     def is_stale(self, now: datetime | None = None) -> bool:
         """Return True when current phase has exceeded its configured timeout."""
         if self.is_terminal():

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -20,6 +20,7 @@ from ouroboros.auto.adapters import (
 )
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.provenance import resolve_provenance
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.cli.formatters import console
@@ -208,6 +209,7 @@ async def _run_auto(
     reconcile_source: str | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
+    incoming_provenance = resolve_provenance()
     attach_requested = any(
         isinstance(item, str) and item.strip()
         for item in (attach_execution, attach_job, attach_session)
@@ -278,6 +280,20 @@ async def _run_auto(
     state.runtime_backend = runtime
     state.opencode_mode = opencode_mode
     state.skip_run = skip_run
+    if incoming_provenance is not None:
+        if resume and state.provenance is None:
+            msg = (
+                "cannot attach provenance on resume of a session originally "
+                "invoked without provenance; re-attribution would mislead audit"
+            )
+            raise ValueError(msg)
+        if state.provenance is not None and state.provenance != incoming_provenance:
+            msg = (
+                "provenance conflict on resume: persisted state recorded "
+                f"{state.provenance} but caller supplied {incoming_provenance}"
+            )
+            raise ValueError(msg)
+        state.provenance = incoming_provenance
 
     authoring_opencode_mode = "subprocess" if opencode_mode == "plugin" else opencode_mode
     interview = InterviewHandler(

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -379,6 +379,10 @@ def _print_status(state: AutoPipelineState) -> None:
     authoring, run_label = _format_runtime_labels(state.runtime_backend, state.opencode_mode)
     console.print(f"Authoring backend: [bold]{authoring}[/]")
     console.print(f"Run backend: [bold]{run_label}[/]")
+    invoked_by = state.invoked_by()
+    if invoked_by != "direct":
+        source = (state.provenance or {}).get("source", "unknown")
+        console.print(f"Invoked by: [bold]{invoked_by}[/] (source={_rich_escape(source)})")
     console.print(f"Last progress: {state.last_progress_message}")
     console.print(f"Last progress at: {state.last_progress_at}")
     if state.interview_session_id:
@@ -444,6 +448,9 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
     authoring, run_label = _format_runtime_labels(result.runtime_backend, result.opencode_mode)
     console.print(f"Authoring backend: [bold]{authoring}[/]")
     console.print(f"Run backend: [bold]{run_label}[/]")
+    if result.invoked_by != "direct":
+        source = (result.provenance or {}).get("source", "unknown")
+        console.print(f"Invoked by: [bold]{result.invoked_by}[/] (source={_rich_escape(source)})")
     if result.grade:
         console.print(f"Seed grade: [bold]{result.grade}[/]")
     if result.interview_session_id:

--- a/tests/unit/auto/test_pipeline_provenance.py
+++ b/tests/unit/auto/test_pipeline_provenance.py
@@ -1,0 +1,166 @@
+"""Provenance reporting on AutoPipelineResult and CLI rendering."""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.provenance import PROVENANCE_ENV_VAR
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore, redact_provenance
+from ouroboros.cli.main import app
+
+runner = CliRunner()
+
+
+def _plain(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _state_with_provenance(provenance: dict | None) -> AutoPipelineState:
+    state = AutoPipelineState(goal="ship a feature", cwd="/tmp/proj")
+    if provenance is not None:
+        state.provenance = redact_provenance(provenance)
+    return state
+
+
+@pytest.mark.parametrize(
+    "provenance, expected",
+    [
+        (None, "direct"),
+        ({"source": "cli"}, "direct"),
+        ({"source": "discord", "rewrite": True}, "gateway"),
+        ({"source": "hermes"}, "gateway"),
+        ({"rewrite": True}, "unknown"),  # source missing
+    ],
+)
+def test_invoked_by_classification(provenance, expected) -> None:
+    state = _state_with_provenance(provenance)
+    assert state.invoked_by() == expected
+
+
+def test_pipeline_result_carries_provenance_and_redacts_unknown() -> None:
+    pipeline = AutoPipeline(
+        interview_driver=None,  # type: ignore[arg-type]
+        seed_generator=lambda _goal: None,  # type: ignore[arg-type]
+    )
+    state = _state_with_provenance({"source": "discord", "rewrite": True, "user_token": "leak-me"})
+    ledger = SeedDraftLedger.from_goal(state.goal)
+
+    result = pipeline._result(state, ledger)
+
+    assert isinstance(result, AutoPipelineResult)
+    assert result.invoked_by == "gateway"
+    assert result.provenance == {"source": "discord", "rewrite": True}
+    assert "user_token" not in (result.provenance or {})
+
+
+def test_pipeline_result_direct_when_no_provenance() -> None:
+    pipeline = AutoPipeline(
+        interview_driver=None,  # type: ignore[arg-type]
+        seed_generator=lambda _goal: None,  # type: ignore[arg-type]
+    )
+    state = _state_with_provenance(None)
+    ledger = SeedDraftLedger.from_goal(state.goal)
+
+    result = pipeline._result(state, ledger)
+
+    assert result.invoked_by == "direct"
+    assert result.provenance is None
+
+
+def test_cli_renders_invoked_by_for_gateway_runs(monkeypatch) -> None:
+    captured: dict = {}
+    payload = {"source": "discord", "rewrite": True, "channel_id_hash": "abcdef"}
+
+    async def fake_run(state):
+        captured["provenance"] = dict(state.provenance) if state.provenance else None
+        captured["invoked_by"] = state.invoked_by()
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+            invoked_by=state.invoked_by(),
+            provenance=dict(state.provenance) if state.provenance else None,
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline") as pipeline_cls:
+        pipeline_cls.return_value.run = fake_run
+        monkeypatch.setenv(PROVENANCE_ENV_VAR, json.dumps(payload))
+        result = runner.invoke(app, ["auto", "ship a feature", "--skip-run"])
+
+    assert result.exit_code == 0, result.output
+    out = _plain(result.output)
+    assert "Invoked by:" in out
+    assert "gateway" in out
+    assert "source=discord" in out
+    # Sensitive fields must never reach CLI output.
+    assert "channel_id_hash" not in out
+    assert "abcdef" not in out
+
+
+def test_cli_escapes_rich_markup_in_source(monkeypatch) -> None:
+    """A crafted source that looks like Rich markup must render as literal text."""
+
+    # Printable, no whitespace -- passes allowlist validators but would otherwise
+    # be parsed by rich.console.Console.print and visually hijack the output.
+    async def fake_run(state):
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+            invoked_by=state.invoked_by(),
+            provenance=dict(state.provenance) if state.provenance else None,
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline") as pipeline_cls:
+        pipeline_cls.return_value.run = fake_run
+        monkeypatch.setenv(PROVENANCE_ENV_VAR, json.dumps({"source": "[bold]X[/]"}))
+        result = runner.invoke(app, ["auto", "ship a feature", "--skip-run"])
+
+    assert result.exit_code == 0, result.output
+    out = _plain(result.output)
+    # Literal characters survive escape; the markup must not be interpreted away.
+    assert "[bold]X[/]" in out
+
+
+def test_cli_omits_invoked_by_for_direct_runs(monkeypatch) -> None:
+    async def fake_run(state):
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline") as pipeline_cls:
+        pipeline_cls.return_value.run = fake_run
+        monkeypatch.delenv(PROVENANCE_ENV_VAR, raising=False)
+        result = runner.invoke(app, ["auto", "ship a feature", "--skip-run"])
+
+    assert result.exit_code == 0, result.output
+    out = _plain(result.output)
+    assert "Invoked by:" not in out
+
+
+def test_cli_status_renders_invoked_by(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _state_with_provenance({"source": "hermes", "rewrite": True})
+    state.transition(AutoPhase.INTERVIEW, "starting")
+    store.save(state)
+
+    with patch("ouroboros.cli.commands.auto.AutoStore", return_value=store):
+        result = runner.invoke(app, ["auto", "--status", "--resume", state.auto_session_id])
+
+    assert result.exit_code == 0, result.output
+    out = _plain(result.output)
+    assert "Invoked by:" in out
+    assert "gateway" in out
+    assert "source=hermes" in out

--- a/tests/unit/cli/test_auto_provenance.py
+++ b/tests/unit/cli/test_auto_provenance.py
@@ -1,0 +1,129 @@
+"""Tests for the gateway-internal provenance contract on ``ooo auto``.
+
+Provenance is delivered exclusively through the ``OUROBOROS_AUTO_PROVENANCE_JSON``
+env var; there is no user-facing CLI flag. The tests below exercise both the
+helper directly and the CLI surface (env-only) to prove that direct CLI runs
+are unaffected and gateway-tagged runs flow allowlisted metadata to state.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.provenance import PROVENANCE_ENV_VAR, resolve_provenance
+from ouroboros.cli.main import app
+
+runner = CliRunner()
+
+
+def test_resolve_provenance_returns_none_when_no_env_present() -> None:
+    assert resolve_provenance(env={}) is None
+
+
+def test_resolve_provenance_defaults_env_to_os_environ(monkeypatch) -> None:
+    monkeypatch.setenv(PROVENANCE_ENV_VAR, json.dumps({"source": "discord"}))
+    assert resolve_provenance() == {"source": "discord"}
+
+
+def test_resolve_provenance_reads_env_var() -> None:
+    payload = json.dumps({"source": "discord", "rewrite": True, "raw": "drop me"})
+    cleaned = resolve_provenance(env={PROVENANCE_ENV_VAR: payload})
+    assert cleaned == {"source": "discord", "rewrite": True}
+
+
+def test_resolve_provenance_rejects_invalid_json() -> None:
+    with pytest.raises(ValueError, match="not valid JSON"):
+        resolve_provenance(env={PROVENANCE_ENV_VAR: "{not json"})
+
+
+def test_resolve_provenance_rejects_non_object_payload() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        resolve_provenance(env={PROVENANCE_ENV_VAR: "[1, 2]"})
+
+
+def test_resolve_provenance_empty_env_returns_none() -> None:
+    assert resolve_provenance(env={PROVENANCE_ENV_VAR: ""}) is None
+    assert resolve_provenance(env={PROVENANCE_ENV_VAR: "   "}) is None
+
+
+def test_resolve_provenance_drops_unknown_keys_only() -> None:
+    payload = json.dumps({"only": "garbage"})
+    assert resolve_provenance(env={PROVENANCE_ENV_VAR: payload}) is None
+
+
+def test_resolve_provenance_rejects_oversize_env() -> None:
+    big = json.dumps({"source": "x" * 5000})
+    with pytest.raises(ValueError, match="exceeds 4096-byte cap"):
+        resolve_provenance(env={PROVENANCE_ENV_VAR: big})
+
+
+def test_auto_cli_picks_up_env_provenance(monkeypatch) -> None:
+    """The gateway env var must flow through to AutoPipelineState."""
+    captured: dict[str, object] = {}
+
+    async def fake_run(state):
+        captured["provenance"] = dict(state.provenance) if state.provenance else None
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline") as pipeline_cls:
+        pipeline_cls.return_value.run = fake_run
+        monkeypatch.setenv(
+            PROVENANCE_ENV_VAR,
+            json.dumps({"source": "discord", "rewrite": True, "leaked": "x"}),
+        )
+        result = runner.invoke(app, ["auto", "do something safe", "--skip-run"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["provenance"] == {"source": "discord", "rewrite": True}
+
+
+def test_auto_cli_resume_rejects_attaching_provenance_to_direct_session(
+    tmp_path, monkeypatch
+) -> None:
+    """Re-attribution would mislead audit; resume must refuse to add provenance."""
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="ship a feature", cwd=str(tmp_path))
+    state.runtime_backend = "claude"
+    state.transition(AutoPhase.INTERVIEW, "starting")
+    state.mark_blocked("need credentials", tool_name="auto")
+    store.save(state)
+
+    with patch("ouroboros.cli.commands.auto.AutoStore", return_value=store):
+        monkeypatch.setenv(PROVENANCE_ENV_VAR, json.dumps({"source": "discord"}))
+        result = runner.invoke(app, ["auto", "--resume", state.auto_session_id])
+
+    assert result.exit_code == 1
+    assert "cannot attach provenance on resume" in result.output
+
+
+def test_auto_cli_without_env_keeps_state_provenance_none(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_run(state):
+        captured["provenance"] = state.provenance
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline") as pipeline_cls:
+        pipeline_cls.return_value.run = fake_run
+        monkeypatch.delenv(PROVENANCE_ENV_VAR, raising=False)
+        result = runner.invoke(app, ["auto", "do something safe", "--skip-run"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["provenance"] is None


### PR DESCRIPTION
## Summary

PR 3/3 of the gateway-provenance stack — closes #691 once merged with PR-A (#701) and PR-B.

- ``AutoPipelineState.invoked_by()`` derives ``direct`` / ``gateway`` / ``unknown`` from ``state.provenance``
- ``AutoPipelineResult`` exposes ``invoked_by`` and the redacted ``provenance`` dict so MCP/CLI surfaces share one classification
- ``_print_status`` and ``_print_result`` in ``src/ouroboros/cli/commands/auto.py`` print an ``Invoked by:`` line for non-direct runs only — minimal noise for the common direct case, and only the allowlisted ``source`` token reaches the terminal
- 10 new tests in ``tests/unit/auto/test_pipeline_provenance.py`` (asserts hash fields and unknown keys never reach CLI output)

This satisfies the issue's success criterion that ``rewrite로 들어온 명령과 direct CLI 명령을 구분해 blocker report에 표시한다``.

> ⚠️ **Stacked on PR-B** (which is stacked on #701) — review/merge in order: PR-A (#701) → PR-B → this. Diff against ``main`` here includes the PR-A and PR-B commits until they land.

Closes #691. Refs epic #692. Stack: PR-A (#701) → PR-B → **PR-C (this)**.

## Test plan

- [x] ``pytest tests/unit/auto/test_pipeline_provenance.py``
- [x] ``state.invoked_by()`` parametrized across direct/gateway/unknown cases
- [x] CLI ``Invoked by:`` line appears for gateway runs and is hidden for direct runs
- [x] ``--status`` for a persisted gateway-invoked session shows ``invoked_by`` + ``source``
- [x] ``channel_id_hash`` and other hash-only fields are confirmed absent from CLI output
- [ ] Manual: replay an ``auto_<id>.json`` from a real Discord-rewrite incident and verify ``invoked_by=gateway`` in ``--status`` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)