### PR TITLE
feat(auto): add AutoProgressEvent callback contract

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from ouroboros.auto.grading import GradeGate
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore, utc_now_iso
@@ -75,9 +76,16 @@ class AutoPipeline:
     reconcile_source: str | None = None
     seed_timeout_seconds: float = 120.0
     run_start_timeout_seconds: float = 60.0
+    progress_callback: AutoProgressCallback | None = None
+    _last_emitted_phase: str | None = field(default=None, init=False, repr=False)
+    _last_emitted_grade: str | None = field(default=None, init=False, repr=False)
+    _last_emitted_repair: int | None = field(default=None, init=False, repr=False)
 
     async def run(self, state: AutoPipelineState) -> AutoPipelineResult:
         """Run a bounded auto pipeline using injected side-effecting dependencies."""
+        self._last_emitted_phase = None
+        self._last_emitted_grade = None
+        self._last_emitted_repair = None
         ledger = (
             SeedDraftLedger.from_dict(state.ledger)
             if state.ledger
@@ -251,6 +259,8 @@ class AutoPipeline:
             state.last_grade = review.grade_result.grade.value
             state.findings = [asdict(finding) for finding in review.findings]
             state.ledger = ledger.to_dict()
+            self._maybe_emit_repair(state)
+            self._maybe_emit_grade(state)
             if self.seed_saver is not None:
                 try:
                     state.seed_path = self.seed_saver(seed)
@@ -559,6 +569,53 @@ class AutoPipeline:
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:
             self.store.save(state)
+        self._maybe_emit_phase(state)
+
+    def _maybe_emit_phase(self, state: AutoPipelineState) -> None:
+        phase = state.phase.value
+        if phase == self._last_emitted_phase:
+            return
+        self._last_emitted_phase = phase
+        self._emit(state, "phase", state.last_progress_message)
+
+    def _maybe_emit_grade(self, state: AutoPipelineState) -> None:
+        grade = state.last_grade
+        if grade is None or grade == self._last_emitted_grade:
+            return
+        self._last_emitted_grade = grade
+        self._emit(state, "grade", f"Seed grade {grade}", grade=grade)
+
+    def _maybe_emit_repair(self, state: AutoPipelineState) -> None:
+        rounds = state.repair_round
+        if rounds <= 0 or rounds == self._last_emitted_repair:
+            return
+        self._last_emitted_repair = rounds
+        self._emit(state, "repair", f"repair round {rounds}", round=rounds)
+
+    def _emit(
+        self,
+        state: AutoPipelineState,
+        kind: str,
+        message: str,
+        *,
+        round: int | None = None,
+        grade: str | None = None,
+    ) -> None:
+        if self.progress_callback is None:
+            return
+        event = AutoProgressEvent(
+            auto_session_id=state.auto_session_id,
+            phase=state.phase.value,
+            kind=kind,
+            message=message,
+            round=round,
+            grade=grade,
+        )
+        try:
+            self.progress_callback(event)
+        except Exception:
+            # Observers must never break the pipeline. Swallow callback errors.
+            pass
 
 
 def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -332,6 +332,7 @@ class AutoPipeline:
                 review = reviewer.review(seed, ledger=ledger)
                 state.last_grade = review.grade_result.grade.value
                 state.findings = [asdict(finding) for finding in review.findings]
+                self._maybe_emit_grade(state)
                 self._save(state)
             if not review.may_run:
                 state.mark_blocked(

--- a/src/ouroboros/auto/progress.py
+++ b/src/ouroboros/auto/progress.py
@@ -21,11 +21,21 @@ AutoProgressKind = Literal["phase", "grade", "repair"]
 class AutoProgressEvent:
     """Immutable observation of an auto pipeline state change.
 
+    Each event is a *snapshot* of the current pipeline state at the
+    moment of emission, not a delta. Consumers should treat the stream
+    as "the latest known state plus selected milestones".
+
     ``kind`` is the discriminant:
 
-    - ``phase``: a phase transition (including terminal phases) just occurred.
-    - ``grade``: a Seed review produced a grade.
-    - ``repair``: the repair round counter advanced.
+    - ``phase``: the pipeline phase just changed since the last
+      observation. ``AutoPipeline`` also emits a ``phase`` event on the
+      first save of every ``run()`` invocation — including resume paths
+      where no fresh transition occurred in this process — so observers
+      always learn the current phase without polling the store.
+    - ``grade``: a Seed review produced a new grade since the last
+      observation.
+    - ``repair``: the repair round counter advanced since the last
+      observation.
     """
 
     auto_session_id: str

--- a/src/ouroboros/auto/progress.py
+++ b/src/ouroboros/auto/progress.py
@@ -1,0 +1,40 @@
+"""Structured progress events for ``ooo auto`` sessions.
+
+Observers (CLI streaming, MCP history, TUI/HUD) subscribe to a single
+``AutoProgressCallback`` to render auto pipeline progress without scraping the
+persisted JSON state. The dataclass is intentionally narrow so future surfaces
+can extend it without a breaking change to the contract that lives here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal
+
+from ouroboros.auto.state import utc_now_iso
+
+AutoProgressKind = Literal["phase", "grade", "repair"]
+
+
+@dataclass(frozen=True, slots=True)
+class AutoProgressEvent:
+    """Immutable observation of an auto pipeline state change.
+
+    ``kind`` is the discriminant:
+
+    - ``phase``: a phase transition (including terminal phases) just occurred.
+    - ``grade``: a Seed review produced a grade.
+    - ``repair``: the repair round counter advanced.
+    """
+
+    auto_session_id: str
+    phase: str
+    kind: AutoProgressKind
+    message: str
+    round: int | None = None
+    grade: str | None = None
+    timestamp: str = field(default_factory=utc_now_iso)
+
+
+AutoProgressCallback = Callable[[AutoProgressEvent], None]

--- a/tests/unit/auto/test_progress.py
+++ b/tests/unit/auto/test_progress.py
@@ -205,6 +205,49 @@ async def test_auto_pipeline_callback_errors_do_not_break_run(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_auto_pipeline_emits_repair_event_when_repairer_changes_seed(tmp_path) -> None:
+    """A non-zero ``repair_round`` after converge must emit a ``repair`` event."""
+    captured: list[AutoProgressEvent] = []
+
+    async def fake_seed_generator(_session_id: str) -> Seed:
+        return _make_seed()
+
+    def fake_seed_saver(_seed: Seed) -> str:
+        return str(tmp_path / "seed.yaml")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.interview_session_id = "interview_xyz"
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.skip_run = True
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        skip_run=True,
+        # ``_PassingRepairer(repair_rounds=2)`` synthesizes a converge
+        # history of length 2 so ``state.repair_round`` becomes non-zero.
+        reviewer=_PassingReviewer(),
+        repairer=_PassingRepairer(repair_rounds=2),
+        progress_callback=captured.append,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    repair_events = [event for event in captured if event.kind == "repair"]
+    assert len(repair_events) == 1
+    assert repair_events[0].round == 2
+
+
+@pytest.mark.asyncio
 async def test_auto_pipeline_emits_phase_for_blocked_terminal(tmp_path) -> None:
     async def fake_seed_generator(_session_id: str) -> Seed:
         raise AssertionError("seed generator should not be invoked when interview blocks")

--- a/tests/unit/auto/test_progress.py
+++ b/tests/unit/auto/test_progress.py
@@ -1,0 +1,233 @@
+"""Unit tests for the auto pipeline progress event contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.grading import GradeResult, SeedGrade
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.progress import AutoProgressEvent
+from ouroboros.auto.seed_repairer import RepairResult
+from ouroboros.auto.seed_reviewer import SeedReview
+from ouroboros.auto.state import (
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+)
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+class _PassingReviewer:
+    """Reviewer stub that always returns an A-grade may_run review."""
+
+    def review(self, _seed, *, ledger=None):  # noqa: ARG002
+        grade = GradeResult(grade=SeedGrade.A, scores={}, may_run=True)
+        return SeedReview(grade_result=grade, findings=())
+
+
+class _PassingRepairer:
+    """Repairer stub that returns the input seed unchanged with an A grade."""
+
+    def __init__(self, repair_rounds: int = 0) -> None:
+        self._repair_rounds = repair_rounds
+
+    def converge(self, seed, *, ledger=None):
+        review = _PassingReviewer().review(seed, ledger=ledger)
+        history = [
+            RepairResult(changed=False, seed=seed, applied_repairs=(), unresolved_findings=())
+            for _ in range(self._repair_rounds)
+        ]
+        return seed, review, history
+
+
+def _make_seed() -> Seed:
+    return Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(
+                OntologyField(
+                    name="command",
+                    field_type="string",
+                    description="Command",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="testability",
+                description="Observable behavior",
+                weight=1.0,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+class _StubInterviewDriver:
+    async def run(self, _state, _ledger):  # noqa: ARG002
+        raise AssertionError("interview driver should not be invoked at SEED_GENERATION")
+
+
+def test_auto_progress_event_is_immutable_dataclass() -> None:
+    event = AutoProgressEvent(
+        auto_session_id="auto_x",
+        phase="interview",
+        kind="phase",
+        message="asking interview round 1/12",
+    )
+    assert event.round is None
+    assert event.grade is None
+    assert event.timestamp  # populated via factory
+    with pytest.raises(Exception):
+        event.kind = "grade"  # type: ignore[misc]
+
+
+def test_auto_pipeline_with_no_callback_does_not_raise(tmp_path) -> None:
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _unused_seed_generator,
+        store=AutoStore(tmp_path),
+    )
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    pipeline._maybe_emit_phase(state)
+    pipeline._maybe_emit_grade(state)
+    pipeline._maybe_emit_repair(state)
+
+
+async def _unused_seed_generator(_session_id: str) -> Seed:
+    raise AssertionError("seed generator should not be invoked")
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_emits_phase_grade_and_repair_in_order(tmp_path) -> None:
+    captured: list[AutoProgressEvent] = []
+
+    async def fake_seed_generator(_session_id: str) -> Seed:
+        return _make_seed()
+
+    def fake_seed_saver(_seed: Seed) -> str:
+        return str(tmp_path / "seed.yaml")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.interview_session_id = "interview_xyz"
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.skip_run = True
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        skip_run=True,
+        reviewer=_PassingReviewer(),
+        repairer=_PassingRepairer(),
+        progress_callback=captured.append,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    kinds = [event.kind for event in captured]
+    # Phase events fire on each transition; grade fires once after review.
+    assert "phase" in kinds
+    assert "grade" in kinds
+    grade_event = next(event for event in captured if event.kind == "grade")
+    assert grade_event.grade == result.grade
+    # Repair counter is 0 in this happy path so no repair event is emitted.
+    assert "repair" not in kinds
+    # Phase events must monotonically advance — no duplicate consecutive phases.
+    phase_sequence = [event.phase for event in captured if event.kind == "phase"]
+    assert phase_sequence == list(dict.fromkeys(phase_sequence))
+    assert phase_sequence[-1] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_callback_errors_do_not_break_run(tmp_path) -> None:
+    async def fake_seed_generator(_session_id: str) -> Seed:
+        return _make_seed()
+
+    def fake_seed_saver(_seed: Seed) -> str:
+        return str(tmp_path / "seed.yaml")
+
+    def exploding_callback(_event: AutoProgressEvent) -> None:
+        raise RuntimeError("observer failure")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.interview_session_id = "interview_xyz"
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.skip_run = True
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        skip_run=True,
+        reviewer=_PassingReviewer(),
+        repairer=_PassingRepairer(),
+        progress_callback=exploding_callback,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_emits_phase_for_blocked_terminal(tmp_path) -> None:
+    async def fake_seed_generator(_session_id: str) -> Seed:
+        raise AssertionError("seed generator should not be invoked when interview blocks")
+
+    captured: list[AutoProgressEvent] = []
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.interview_session_id = None  # missing → triggers blocked
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        progress_callback=captured.append,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    blocked_events = [event for event in captured if event.phase == "blocked"]
+    assert blocked_events
+    assert blocked_events[-1].kind == "phase"


### PR DESCRIPTION
## Summary

Lays down the **observer contract** for live `ooo auto` progress reporting. This is the foundation that the follow-up CLI / MCP / TUI surface PRs in the #639 series will plug into. No user-visible behavior changes by itself.

## Changes

- New module `src/ouroboros/auto/progress.py`:
  - `AutoProgressEvent` — frozen, slotted dataclass with `auto_session_id`, `phase`, `kind` (`phase` / `grade` / `repair`), `message`, optional `round` / `grade`, and an ISO timestamp.
  - `AutoProgressCallback` type alias for the subscriber signature.
- `src/ouroboros/auto/pipeline.py`:
  - `AutoPipeline.progress_callback` (optional, defaults to `None`).
  - Internal `_maybe_emit_phase` / `_maybe_emit_grade` / `_maybe_emit_repair` helpers that dedupe so observers don't see noisy duplicate events for unchanged state.
  - `_save` now opportunistically emits a `phase` event when the persisted phase has actually changed since the last emission, so we don't have to instrument every `state.transition` site.
  - Grade/repair emissions live alongside the existing `repairer.converge(...)` block.
  - Callback exceptions are swallowed — observers can never break the pipeline.
- `tests/unit/auto/test_progress.py`:
  - Dataclass immutability + default factory.
  - No-op behavior when no callback is registered.
  - Happy-path emit ordering through `SEED_GENERATION` → `REVIEW` → `COMPLETE` with `phase` and `grade` events captured (uses stub reviewer/repairer to avoid coupling to grading internals).
  - Exploding callback does not break a successful run.
  - Terminal `BLOCKED` path emits a final `phase` event.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/progress.py src/ouroboros/auto/pipeline.py tests/unit/auto/test_progress.py` → passes.
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto -q` → 204 passed.

## Risks / Notes

- The contract is intentionally narrow (3 event kinds). Future PRs may extend it (e.g. `round`-kind events emitted from `AutoInterviewDriver`), but this PR keeps every emission inside `AutoPipeline` to limit churn.
- Phase emission uses a per-instance dedup tracker. Concurrent reuse of the same `AutoPipeline` instance across overlapping `run()` calls would race; the codebase does not do this today.

## Stacking / dependencies

This PR is the prerequisite for the next two #639 follow-ups:

- **PR-C** — wire the callback into the CLI (`ooo auto`) for live phase trace.
- **PR-D** — record an event history on the MCP `_result_meta` so non-CLI clients render the same trace.

Both will be opened against `main` and will include this PR's commits at the bottom of their stacks; rebase will be straightforward once this lands.

Refs #639