### PR TITLE
fix(auto): persist interview session id before first question generation

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -48,17 +48,25 @@ class InterviewBackendWithPrepare(InterviewBackend, Protocol):
     """Optional protocol surface for backends that can split session creation
     from the (potentially slow) first-question generation.
 
-    Backends that implement ``prepare`` MUST return a durable session id whose
-    follow-up state is recoverable via ``resume(session_id)``. The auto driver
-    persists this id to ``AutoPipelineState`` immediately, so a subsequent
-    timeout in ``start``/``resume`` does not strand the session without a
-    handle.
+    Contract:
+
+    1. ``prepare(goal, cwd=...)`` allocates an interview session server-side
+       and returns its durable id. It MUST NOT generate the first question.
+       The id MUST be the same handle that ``resume(session_id)`` accepts.
+    2. The auto driver persists the returned id to ``AutoPipelineState``
+       immediately so a timeout in step 3 does not strand the session.
+    3. The auto driver then calls ``resume(prepared_id)`` to obtain the
+       first question. Backends MUST return that same ``session_id`` from
+       ``resume`` — the driver rejects a mismatch as a backend bug.
+    4. Backends without ``prepare`` (or returning ``None`` / raising) keep
+       the legacy single-call ``start`` path unchanged.
     """
 
     async def prepare(self, goal: str, *, cwd: str) -> str | None:
         """Register an interview session and return its id without generating
         the first question. Return ``None`` to fall back to the legacy
-        single-call ``start`` path."""
+        single-call ``start`` path. The returned id MUST be recoverable via
+        :meth:`resume`."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,19 +122,41 @@ class AutoInterviewDriver:
             else:
                 prepared_id = await self._maybe_prepare_session(state)
                 if prepared_id is not None:
+                    # Persist the durable interview handle BEFORE the slow
+                    # first-question call. A subsequent timeout in
+                    # ``resume(prepared_id)`` no longer strands the session.
                     state.interview_session_id = prepared_id
                     state.mark_progress(
                         "interview session prepared; awaiting first question",
                         tool_name="interview.prepare",
                     )
                     self._save(state)
-                turn = _validate_turn(
-                    await self._with_timeout(
-                        self.backend.start(state.goal, cwd=state.cwd),
-                        state,
-                        tool_name=interview_tool_name,
+                    # The backend has already allocated the session in
+                    # ``prepare()``; ``resume(prepared_id)`` returns the first
+                    # question rather than re-creating a session in
+                    # ``start()`` (which would orphan the prepared id).
+                    turn = _validate_turn(
+                        await self._with_timeout(
+                            self.backend.resume(prepared_id),
+                            state,
+                            tool_name=interview_tool_name,
+                        )
                     )
-                )
+                    if turn.session_id != prepared_id:
+                        msg = (
+                            "interview backend returned session_id "
+                            f"{turn.session_id!r} after prepare/resume to "
+                            f"{prepared_id!r}; refusing to drift"
+                        )
+                        raise RuntimeError(msg)
+                else:
+                    turn = _validate_turn(
+                        await self._with_timeout(
+                            self.backend.start(state.goal, cwd=state.cwd),
+                            state,
+                            tool_name=interview_tool_name,
+                        )
+                    )
                 state.interview_session_id = turn.session_id
                 state.pending_question = turn.question
                 self._save(state)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -44,6 +44,23 @@ class InterviewBackend(Protocol):
         """Return the outstanding question for a persisted interview session."""
 
 
+class InterviewBackendWithPrepare(InterviewBackend, Protocol):
+    """Optional protocol surface for backends that can split session creation
+    from the (potentially slow) first-question generation.
+
+    Backends that implement ``prepare`` MUST return a durable session id whose
+    follow-up state is recoverable via ``resume(session_id)``. The auto driver
+    persists this id to ``AutoPipelineState`` immediately, so a subsequent
+    timeout in ``start``/``resume`` does not strand the session without a
+    handle.
+    """
+
+    async def prepare(self, goal: str, *, cwd: str) -> str | None:
+        """Register an interview session and return its id without generating
+        the first question. Return ``None`` to fall back to the legacy
+        single-call ``start`` path."""
+
+
 @dataclass(frozen=True, slots=True)
 class AutoInterviewResult:
     """Result from running the bounded auto interview loop."""
@@ -95,6 +112,14 @@ class AutoInterviewDriver:
                     state.pending_question = turn.question
                     self._save(state)
             else:
+                prepared_id = await self._maybe_prepare_session(state)
+                if prepared_id is not None:
+                    state.interview_session_id = prepared_id
+                    state.mark_progress(
+                        "interview session prepared; awaiting first question",
+                        tool_name="interview.prepare",
+                    )
+                    self._save(state)
                 turn = _validate_turn(
                     await self._with_timeout(
                         self.backend.start(state.goal, cwd=state.cwd),
@@ -245,6 +270,26 @@ class AutoInterviewDriver:
             msg = f"{tool_name} timed out after {self.timeout_seconds:.0f}s for {state.auto_session_id}"
             raise TimeoutError(msg) from exc
 
+    async def _maybe_prepare_session(self, state: AutoPipelineState) -> str | None:
+        """Pre-register an interview session id when the backend supports it.
+
+        Backends without ``prepare`` keep the legacy single-call behavior. When
+        ``prepare`` raises or returns an invalid value, the driver also falls
+        back rather than blocking the session before ``start`` had a chance.
+        """
+        prepare = getattr(self.backend, "prepare", None)
+        if prepare is None:
+            return None
+        try:
+            prepared = await asyncio.wait_for(
+                prepare(state.goal, cwd=state.cwd), timeout=self.timeout_seconds
+            )
+        except (TimeoutError, Exception):
+            return None
+        if isinstance(prepared, str) and prepared.strip():
+            return prepared
+        return None
+
     def _ensure_interview_phase(self, state: AutoPipelineState) -> None:
         if state.phase == AutoPhase.CREATED:
             state.transition(AutoPhase.INTERVIEW, "starting auto interview")
@@ -266,10 +311,12 @@ class FunctionInterviewBackend:
         start: Callable[[str, str], Awaitable[InterviewTurn]],
         answer: Callable[[str, str], Awaitable[InterviewTurn]],
         resume: Callable[[str], Awaitable[InterviewTurn]] | None = None,
+        prepare: Callable[[str, str], Awaitable[str | None]] | None = None,
     ) -> None:
         self._start = start
         self._answer = answer
         self._resume = resume
+        self._prepare = prepare
 
     async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
         return await self._start(goal, cwd)
@@ -282,6 +329,11 @@ class FunctionInterviewBackend:
             msg = "interview resume is unavailable because no pending question is persisted"
             raise RuntimeError(msg)
         return await self._resume(session_id)
+
+    async def prepare(self, goal: str, *, cwd: str) -> str | None:
+        if self._prepare is None:
+            return None
+        return await self._prepare(goal, cwd)
 
 
 def _can_steer_with_gap_prompt(question: str) -> bool:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -261,6 +261,107 @@ async def test_interview_driver_blocks_on_backend_timeout(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_persists_session_id_before_first_question(
+    tmp_path,
+) -> None:
+    """A backend that supports prepare() must have its session id persisted
+    before start() runs so a first-question timeout still leaves a resumable
+    handle on the auto state."""
+
+    async def prepare(goal: str, cwd: str) -> str | None:  # noqa: ARG001
+        return "interview_pre_42"
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        await asyncio.sleep(0.5)
+        return InterviewTurn("never returned", "interview_pre_42")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, prepare=prepare),
+        store=store,
+        timeout_seconds=0.05,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.interview_session_id == "interview_pre_42"
+    persisted = store.load(state.auto_session_id)
+    assert persisted.interview_session_id == "interview_pre_42"
+    assert state.last_tool_name == "interview.start"
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_falls_back_when_prepare_returns_none(
+    tmp_path,
+) -> None:
+    """Backends without prepare (or returning None) keep the legacy behavior."""
+    started = False
+
+    async def prepare(goal: str, cwd: str) -> str | None:  # noqa: ARG001
+        return None
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        nonlocal started
+        started = True
+        return InterviewTurn("First?", "interview_legacy", seed_ready=False)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, prepare=prepare),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert started is True
+    assert result.status in {"seed_ready", "blocked"}
+    assert state.interview_session_id == "interview_legacy"
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_falls_back_when_prepare_raises(tmp_path) -> None:
+    """Exceptions from prepare must not block the session — fall back to
+    start() so backends rolling out prepare incrementally are safe."""
+
+    async def prepare(goal: str, cwd: str) -> str | None:  # noqa: ARG001
+        raise RuntimeError("prepare not implemented yet")
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("First?", "interview_after_raise", seed_ready=False)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, prepare=prepare),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert state.interview_session_id == "interview_after_raise"
+    assert result.status in {"seed_ready", "blocked"}
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_supplies_bounded_repo_facts_to_answerer(tmp_path) -> None:
     (tmp_path / "pyproject.toml").write_text(
         "\n".join(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -265,15 +265,26 @@ async def test_interview_driver_persists_session_id_before_first_question(
     tmp_path,
 ) -> None:
     """A backend that supports prepare() must have its session id persisted
-    before start() runs so a first-question timeout still leaves a resumable
-    handle on the auto state."""
+    before the first-question call runs, so a timeout in
+    ``resume(prepared_id)`` still leaves a resumable handle on the auto
+    state. The driver MUST call ``resume(prepared_id)`` for the first
+    question rather than ``start()`` again — calling ``start()`` would
+    orphan the prepared id. (Bot-flagged in #706 review.)"""
+
+    start_calls: list[tuple[str, str]] = []
+    resume_calls: list[str] = []
 
     async def prepare(goal: str, cwd: str) -> str | None:  # noqa: ARG001
         return "interview_pre_42"
 
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        await asyncio.sleep(0.5)
-        return InterviewTurn("never returned", "interview_pre_42")
+        start_calls.append((goal, cwd))
+        return InterviewTurn("must not be reached", "interview_pre_42")
+
+    async def resume(session_id: str) -> InterviewTurn:
+        resume_calls.append(session_id)
+        await asyncio.sleep(0.5)  # exceeds timeout below
+        return InterviewTurn("never returned", session_id)
 
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("done", session_id, seed_ready=True)
@@ -282,18 +293,62 @@ async def test_interview_driver_persists_session_id_before_first_question(
     ledger = SeedDraftLedger.from_goal(state.goal)
     store = AutoStore(tmp_path)
     driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer, prepare=prepare),
+        FunctionInterviewBackend(start, answer, resume=resume, prepare=prepare),
         store=store,
         timeout_seconds=0.05,
     )
 
     result = await driver.run(state, ledger)
 
+    # Driver took the prepare → resume path, NOT prepare → start.
+    assert start_calls == []
+    assert resume_calls == ["interview_pre_42"]
+    # Timeout produced a blocked result, but the prepared id is durable.
     assert result.status == "blocked"
     assert state.interview_session_id == "interview_pre_42"
     persisted = store.load(state.auto_session_id)
     assert persisted.interview_session_id == "interview_pre_42"
     assert state.last_tool_name == "interview.start"
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_rejects_resume_returning_drifted_session_id(
+    tmp_path,
+) -> None:
+    """A backend that returns a different session_id from ``resume`` after
+    ``prepare`` is misbehaving. The driver MUST NOT silently accept the
+    drift — it raises so the contract violation is visible. (Spec for the
+    new prepare/resume contract introduced for #706.)"""
+
+    async def prepare(goal: str, cwd: str) -> str | None:  # noqa: ARG001
+        return "interview_pre_42"
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("start must not be called when prepare succeeds")
+
+    async def resume(session_id: str) -> InterviewTurn:  # noqa: ARG001
+        # Bug: returns a different id than what was prepared.
+        return InterviewTurn("first?", "interview_DRIFTED")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, resume=resume, prepare=prepare),
+        store=AutoStore(tmp_path),
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    # The driver catches the RuntimeError and routes it to the standard
+    # blocker path (so the misbehavior is observable in state, not a crash).
+    assert result.status == "blocked"
+    assert "refusing to drift" in (result.blocker or "")
+    # The persisted id remains the prepared one — the drift is rejected.
+    assert state.interview_session_id == "interview_pre_42"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add optional `InterviewBackendWithPrepare` protocol — backends can implement `prepare(goal, *, cwd) -> str | None` to register an interview session and return its id without generating the first question.
- `AutoInterviewDriver.run()` now calls `prepare()` first when the backend supports it, persists the returned session id to `AutoPipelineState.interview_session_id` immediately, then calls `start()` for the first question. A subsequent `interview.start` timeout no longer strands the session without a handle.
- Backends that do not implement `prepare()` (or raise / return `None`) keep the legacy single-call behavior, so this PR is safe to land before any concrete backend ships its `prepare()` implementation.
- Tests:
  - `test_interview_driver_persists_session_id_before_first_question` — first-question timeout still leaves `state.interview_session_id` set on disk
  - `test_interview_driver_falls_back_when_prepare_returns_none` / `..._raises` — legacy path verified

## Why
The `auto_78c98678de5d` incident referenced by the tracker shows the failure mode this PR closes:

```
phase=blocked
last_tool_name=interview.start
last_error=interview.start timed out after 60s for auto_78c98678de5d
interview_session_id=null   ← ooo auto --resume cannot find the existing interview
```

The interview was almost certainly registered server-side before the first-question LLM call timed out, but the driver only learned the session id from the `InterviewTurn` returned by `start()`. With this change a `prepare()`-capable backend lets the driver save the id immediately so resume can reuse it instead of opening a duplicate.

## Scope (intentionally narrow)
This PR ships the **driver-side contract and tests only**. Wiring the real `InterviewHandler` (`bigbang/interview.py`) and the MCP authoring path (`mcp/tools/authoring_handlers.py`) to implement `prepare()` is intentionally separated so each backend rollout can be reviewed and rolled back independently. The contract test in `FunctionInterviewBackend` proves the wiring works once a backend implements it.

## Tests
- `pytest tests/unit/auto/test_interview_pipeline.py -k 'interview_session_id or prepare'` — 4 passed (4 new)
- `pytest tests/unit/auto/` — 202 passed (full module green)

## Notes for reviewers
- Pure additive protocol surface — no existing call site or backend behavior changes.
- The driver swallows exceptions from `prepare()` deliberately (per docstring): a failing prepare must never gate `start()`. If we want stricter semantics later we can promote it to a hard failure in a separate PR.
- Follow-up backend PRs will reference this PR + #687 for context.

Closes #687
Tracker: #692

Depends-on: none (independent of #686 / #688)