### PR TITLE
docs(auto): clarify --runtime phase semantics for ooo auto (#690)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -66,7 +66,7 @@ ouroboros auto "Build a local-first habit tracker CLI"
 | Option | Description |
 |--------|-------------|
 | `--resume TEXT` | Resume an existing auto session id |
-| `--runtime TEXT` | Runtime backend for the **run-handoff** phase (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro`). Interview/Seed authoring stays in-process for every value except `opencode` with `--opencode-mode plugin`. See [What `--runtime` controls in `ooo auto`](#what---runtime-controls-in-ooo-auto) below. |
+| `--runtime TEXT` | Runtime backend for the **run-handoff** phase. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro`, `copilot`. Authoring phases (interview, seed generation, seed repair) **always run in-process** inside the Ouroboros MCP server in `ooo auto` flow — see [What `--runtime` controls in `ooo auto`](#what---runtime-controls-in-ooo-auto) below. |
 | `--max-interview-rounds INTEGER` | Maximum automatic interview rounds; prevents unbounded interview loops |
 | `--max-repair-rounds INTEGER` | Maximum Seed repair rounds; prevents unbounded repair loops |
 | `--skip-run` | Stop after creating an A-grade Seed |
@@ -75,37 +75,30 @@ ouroboros auto "Build a local-first habit tracker CLI"
 
 Auto mode starts execution only after the generated Seed reaches A-grade. If a phase times out or hits a hard blocker, the command prints the auto session id and a resume command instead of hanging indefinitely.
 
+> **`ooo auto` does not accept `--opencode-mode`.** OpenCode mode is
+> selected once at install time via `ouroboros setup --opencode-mode
+> <plugin|subprocess>` (recorded in `~/.ouroboros/config.yaml`); the auto
+> CLI reads that persisted value but never exposes it as a flag.
+
 ### What `--runtime` controls in `ooo auto`
 
 `ooo auto` runs four logical phases. `--runtime` selects the backend for the
 **run-handoff** phase only. The three preceding *authoring* phases
-(interview, seed generation, seed repair) always run in-process inside the
-Ouroboros MCP server unless the caller is an OpenCode bridge plugin session
-that can intercept the dispatch envelope.
+(interview, seed generation, seed repair) **always run in-process** inside
+the Ouroboros MCP server in `ooo auto` flow, regardless of `--runtime` or
+the persisted `opencode_mode`. Both auto entry points
+([`cli/commands/auto.py`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/cli/commands/auto.py)
+and [`mcp/tools/auto_handler.py`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/auto_handler.py))
+demote a persisted `opencode_mode == "plugin"` to `subprocess` before
+constructing the authoring handlers, because a `_subagent` envelope would
+have no receiver outside an active OpenCode bridge plugin session.
 
-| Phase                 | Handler                                        | Backend used                                                                                                                                       |
-| --------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1. Interview authoring | `mcp.tools.authoring_handlers.InterviewHandler` | In-process for every `--runtime` value. Only `--runtime opencode --opencode-mode plugin` short-circuits to a `_subagent` envelope for the bridge plugin. |
-| 2. Seed generation    | `mcp.tools.authoring_handlers.GenerateSeedHandler` | Same rule as interview authoring (in-process unless `opencode + plugin`).                                                                          |
-| 3. Seed repair        | `auto.seed_repairer.SeedRepairer`              | In-process; never dispatched.                                                                                                                      |
-| 4. Run handoff        | `mcp.tools.execution_handlers.StartExecuteSeedHandler` | Routed through the runtime adapter selected by `--runtime`. This is the *only* phase where the chosen backend executes agent work. |
-
-The dispatch gate lives in
-[`should_dispatch_via_plugin()`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/subagent.py)
-and is exhaustively tested in
-`tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPlugin`. The
-truth table:
-
-| `--runtime`        | `--opencode-mode` | Authoring path           |
-| ------------------ | ----------------- | ------------------------ |
-| `claude`           | (any)             | In-process               |
-| `codex`            | (any)             | In-process               |
-| `hermes`           | (any)             | In-process               |
-| `gemini`           | (any)             | In-process               |
-| `kiro`             | (any)             | In-process               |
-| `opencode`         | `subprocess`      | In-process               |
-| `opencode`         | (unset/None)      | In-process (safe default for upgraded users) |
-| `opencode`         | `plugin`          | Dispatched via `_subagent` envelope to the OpenCode bridge plugin |
+| Phase                  | Handler                                                | `ooo auto` behaviour                                                                                                                                                       |
+| ---------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Interview authoring | `mcp.tools.authoring_handlers.InterviewHandler`        | In-process for every `--runtime` value. `opencode + plugin` is demoted to `subprocess` before the handler is constructed, so authoring never short-circuits to the bridge. |
+| 2. Seed generation     | `mcp.tools.authoring_handlers.GenerateSeedHandler`     | Same rule as interview authoring — always in-process for `ooo auto`.                                                                                                       |
+| 3. Seed repair         | `auto.seed_repairer.SeedRepairer`                      | In-process; never dispatched.                                                                                                                                               |
+| 4. Run handoff         | `mcp.tools.execution_handlers.StartExecuteSeedHandler` | Routed through the runtime adapter selected by `--runtime`. This is the *only* phase where the chosen backend executes agent work, and the only phase that can keep `opencode + plugin`. |
 
 > **Why this matters:** `--runtime codex` does **not** mean "Codex performs
 > the interview". The Ouroboros MCP server still owns the first authoring
@@ -114,15 +107,28 @@ truth table:
 > authoring path, not from the Codex CLI. Set realistic expectations when
 > chaining `ooo auto` from external gateways.
 
-> **`ooo auto` extra rule:** the `ouroboros auto` CLI runs as a standalone
-> process and is therefore *not* itself an OpenCode bridge plugin host.
-> Even when a resumed session was started with `--runtime opencode
-> --opencode-mode plugin`, the auto CLI demotes the mode to `subprocess`
-> before constructing the authoring handlers, so a `_subagent` envelope
-> would have no receiver. In other words: from the `ooo auto` CLI surface,
-> authoring is **always** in-process. The `plugin` row of the truth table
-> applies only when the same handlers are invoked from inside an active
-> OpenCode bridge plugin session.
+#### Underlying MCP-handler dispatch (outside `ooo auto`)
+
+The same `InterviewHandler` / `GenerateSeedHandler` classes can short-circuit
+to a `_subagent` envelope **only when called directly from inside an
+active OpenCode bridge plugin session** — not from `ooo auto`. The dispatch
+gate lives in
+[`should_dispatch_via_plugin()`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/subagent.py)
+and is exhaustively tested in
+`tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPlugin`. This
+truth table describes the gate function alone, not the auto flow:
+
+| `runtime_backend` | `opencode_mode` | Gate result        |
+| ----------------- | --------------- | ------------------ |
+| `claude`          | (any)           | False (in-process) |
+| `codex`           | (any)           | False (in-process) |
+| `hermes`          | (any)           | False (in-process) |
+| `gemini`          | (any)           | False (in-process) |
+| `kiro`            | (any)           | False (in-process) |
+| `copilot`         | (any)           | False (in-process) |
+| `opencode`        | `subprocess`    | False (in-process) |
+| `opencode`        | (unset/None)    | False (in-process — safe default) |
+| `opencode`        | `plugin`        | True (dispatched via `_subagent`) — reachable from inside an OpenCode bridge plugin session, **not** from `ooo auto` |
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -66,13 +66,63 @@ ouroboros auto "Build a local-first habit tracker CLI"
 | Option | Description |
 |--------|-------------|
 | `--resume TEXT` | Resume an existing auto session id |
-| `--runtime claude|codex|opencode` | Runtime backend for execution handoff |
+| `--runtime TEXT` | Runtime backend for the **run-handoff** phase (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro`). Interview/Seed authoring stays in-process for every value except `opencode` with `--opencode-mode plugin`. See [What `--runtime` controls in `ooo auto`](#what---runtime-controls-in-ooo-auto) below. |
 | `--max-interview-rounds INTEGER` | Maximum automatic interview rounds; prevents unbounded interview loops |
 | `--max-repair-rounds INTEGER` | Maximum Seed repair rounds; prevents unbounded repair loops |
 | `--skip-run` | Stop after creating an A-grade Seed |
 | `--show-ledger` | Print assumptions and non-goals captured during auto convergence |
+| `--status` | Print the persisted state for `--resume <id>` without running |
 
 Auto mode starts execution only after the generated Seed reaches A-grade. If a phase times out or hits a hard blocker, the command prints the auto session id and a resume command instead of hanging indefinitely.
+
+### What `--runtime` controls in `ooo auto`
+
+`ooo auto` runs four logical phases. `--runtime` selects the backend for the
+**run-handoff** phase only. The three preceding *authoring* phases
+(interview, seed generation, seed repair) always run in-process inside the
+Ouroboros MCP server unless the caller is an OpenCode bridge plugin session
+that can intercept the dispatch envelope.
+
+| Phase                 | Handler                                        | Backend used                                                                                                                                       |
+| --------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Interview authoring | `mcp.tools.authoring_handlers.InterviewHandler` | In-process for every `--runtime` value. Only `--runtime opencode --opencode-mode plugin` short-circuits to a `_subagent` envelope for the bridge plugin. |
+| 2. Seed generation    | `mcp.tools.authoring_handlers.GenerateSeedHandler` | Same rule as interview authoring (in-process unless `opencode + plugin`).                                                                          |
+| 3. Seed repair        | `auto.seed_repairer.SeedRepairer`              | In-process; never dispatched.                                                                                                                      |
+| 4. Run handoff        | `mcp.tools.execution_handlers.StartExecuteSeedHandler` | Routed through the runtime adapter selected by `--runtime`. This is the *only* phase where the chosen backend executes agent work. |
+
+The dispatch gate lives in
+[`should_dispatch_via_plugin()`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/subagent.py)
+and is exhaustively tested in
+`tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPlugin`. The
+truth table:
+
+| `--runtime`        | `--opencode-mode` | Authoring path           |
+| ------------------ | ----------------- | ------------------------ |
+| `claude`           | (any)             | In-process               |
+| `codex`            | (any)             | In-process               |
+| `hermes`           | (any)             | In-process               |
+| `gemini`           | (any)             | In-process               |
+| `kiro`             | (any)             | In-process               |
+| `opencode`         | `subprocess`      | In-process               |
+| `opencode`         | (unset/None)      | In-process (safe default for upgraded users) |
+| `opencode`         | `plugin`          | Dispatched via `_subagent` envelope to the OpenCode bridge plugin |
+
+> **Why this matters:** `--runtime codex` does **not** mean "Codex performs
+> the interview". The Ouroboros MCP server still owns the first authoring
+> question and may time out before any Codex subagent is invoked. If
+> `interview.start` blocks, the timeout originates from the in-process
+> authoring path, not from the Codex CLI. Set realistic expectations when
+> chaining `ooo auto` from external gateways.
+
+> **`ooo auto` extra rule:** the `ouroboros auto` CLI runs as a standalone
+> process and is therefore *not* itself an OpenCode bridge plugin host.
+> Even when a resumed session was started with `--runtime opencode
+> --opencode-mode plugin`, the auto CLI demotes the mode to `subprocess`
+> before constructing the authoring handlers, so a `_subagent` envelope
+> would have no receiver. In other words: from the `ooo auto` CLI surface,
+> authoring is **always** in-process. The `plugin` row of the truth table
+> applies only when the same handlers are invoked from inside an active
+> OpenCode bridge plugin session.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -98,7 +98,7 @@ have no receiver outside an active OpenCode bridge plugin session.
 | 1. Interview authoring | `mcp.tools.authoring_handlers.InterviewHandler`        | In-process for every `--runtime` value. `opencode + plugin` is demoted to `subprocess` before the handler is constructed, so authoring never short-circuits to the bridge. |
 | 2. Seed generation     | `mcp.tools.authoring_handlers.GenerateSeedHandler`     | Same rule as interview authoring — always in-process for `ooo auto`.                                                                                                       |
 | 3. Seed repair         | `auto.seed_repairer.SeedRepairer`                      | In-process; never dispatched.                                                                                                                                               |
-| 4. Run handoff         | `mcp.tools.execution_handlers.StartExecuteSeedHandler` | Routed through the runtime adapter selected by `--runtime`. This is the *only* phase where the chosen backend executes agent work, and the only phase that can keep `opencode + plugin`. |
+| 4. Run handoff         | `mcp.tools.execution_handlers.StartExecuteSeedHandler` | Routed through the runtime adapter selected by `--runtime`. **CLI entry point** (`ouroboros auto`) also demotes `opencode + plugin` to `subprocess` here, because the standalone CLI process is not the OpenCode session that owns the bridge plugin. **MCP entry point** (`mcp/tools/auto_handler.py`) keeps `plugin` for run-handoff because it is invoked from inside the OpenCode session. |
 
 > **Why this matters:** `--runtime codex` does **not** mean "Codex performs
 > the interview". The Ouroboros MCP server still owns the first authoring

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -95,24 +95,21 @@ The runtime backend affects:
 
 `ooo auto` runs four logical phases, but `--runtime <X>` only decides which
 backend handles the **run-handoff** phase. The three preceding *authoring*
-phases (interview, seed generation, seed repair) always execute in-process
-inside the Ouroboros MCP server. The single exception is OpenCode in
-`plugin` mode, which intercepts authoring via a `_subagent` envelope.
+phases (interview, seed generation, seed repair) **always execute
+in-process** inside the Ouroboros MCP server in auto flow, regardless of
+runtime backend. Both auto entry points
+([`cli/commands/auto.py`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/cli/commands/auto.py)
+and [`mcp/tools/auto_handler.py`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/auto_handler.py))
+demote a persisted `opencode_mode == "plugin"` to `subprocess` for the
+authoring handlers, because a `_subagent` envelope would have no receiver
+outside an active OpenCode bridge plugin session.
 
-| Phase                   | `claude` | `codex` | `opencode` (subprocess) | `opencode` (plugin)        | `hermes` | `gemini` | `kiro` | `copilot` |
-| ----------------------- | :------: | :-----: | :---------------------: | :------------------------: | :------: | :------: | :----: | :-------: |
-| 1. Interview authoring  |  in-process  |  in-process  |       in-process        | dispatched (bridge plugin) |  in-process  |  in-process  | in-process | in-process |
-| 2. Seed generation      |  in-process  |  in-process  |       in-process        | dispatched (bridge plugin) |  in-process  |  in-process  | in-process | in-process |
-| 3. Seed repair          |  in-process  |  in-process  |       in-process        |        in-process          |  in-process  |  in-process  | in-process | in-process |
-| 4. Run handoff (Seed →) | claude adapter | codex adapter | opencode adapter (subprocess) | opencode adapter (plugin) | hermes adapter | gemini adapter | kiro adapter | copilot adapter |
-
-The dispatch gate lives in
-[`should_dispatch_via_plugin()`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/subagent.py)
-and is pinned by `tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPlugin`:
-
-- `runtime` not in `{opencode, opencode_cli}` → never dispatches.
-- `runtime` in `{opencode, opencode_cli}` and `opencode_mode == "plugin"` → dispatch envelope.
-- `runtime` in `{opencode, opencode_cli}` and `opencode_mode in {None, "", "subprocess", anything else}` → in-process. The safe default exists so users who upgraded without re-running `ouroboros setup` are not silently switched to envelope dispatch their session cannot intercept.
+| Phase                   | `claude` | `codex` | `opencode` | `hermes` | `gemini` | `kiro` | `copilot` |
+| ----------------------- | :------: | :-----: | :--------: | :------: | :------: | :----: | :-------: |
+| 1. Interview authoring  | in-process | in-process | in-process | in-process | in-process | in-process | in-process |
+| 2. Seed generation      | in-process | in-process | in-process | in-process | in-process | in-process | in-process |
+| 3. Seed repair          | in-process | in-process | in-process | in-process | in-process | in-process | in-process |
+| 4. Run handoff (Seed →) | claude adapter | codex adapter | opencode adapter (mode preserved for run only) | hermes adapter | gemini adapter | kiro adapter | copilot adapter |
 
 > **Common misconception:** `ooo auto --runtime codex` does **not** mean
 > "Codex runs the entire pipeline". The Ouroboros MCP server itself runs
@@ -122,13 +119,24 @@ and is pinned by `tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPl
 > in the Codex CLI. See the [`ooo auto` CLI reference](cli-reference.md#what---runtime-controls-in-ooo-auto)
 > for the per-phase breakdown and resume guidance.
 
-> **The `opencode (plugin)` column is MCP-level.** It applies when an
-> OpenCode bridge plugin session calls the MCP authoring handlers
-> directly. The `ouroboros auto` CLI is a standalone process and not an
-> OpenCode plugin host, so it demotes a persisted `plugin` mode to
-> `subprocess` before constructing handlers — the auto CLI surface
-> therefore behaves like the `opencode (subprocess)` column even when the
-> persisted state declared `plugin`.
+### Underlying MCP-handler dispatch (outside `ooo auto`)
+
+The same `InterviewHandler` / `GenerateSeedHandler` classes can short-circuit
+to a `_subagent` envelope **only when called directly from inside an
+active OpenCode bridge plugin session** — not from `ouroboros auto`. The
+dispatch gate lives in
+[`should_dispatch_via_plugin()`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/subagent.py)
+and is pinned by
+`tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPlugin`:
+
+- `runtime_backend` not in `{opencode, opencode_cli}` → never dispatches.
+- `runtime_backend` in `{opencode, opencode_cli}` and `opencode_mode == "plugin"` → dispatch envelope.
+- `runtime_backend` in `{opencode, opencode_cli}` and `opencode_mode in {None, "", "subprocess", anything else}` → in-process. The safe default exists so users who upgraded without re-running `ouroboros setup` are not silently switched to envelope dispatch their session cannot intercept.
+
+This rule describes the gate function in isolation. It is reachable from
+an OpenCode plugin session calling the MCP authoring tools directly. From
+`ouroboros auto` it is **not** reachable — the auto entry points always
+hand `opencode_mode="subprocess"` to the authoring handlers.
 
 ## Choosing a Runtime
 

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -109,7 +109,17 @@ outside an active OpenCode bridge plugin session.
 | 1. Interview authoring  | in-process | in-process | in-process | in-process | in-process | in-process | in-process |
 | 2. Seed generation      | in-process | in-process | in-process | in-process | in-process | in-process | in-process |
 | 3. Seed repair          | in-process | in-process | in-process | in-process | in-process | in-process | in-process |
-| 4. Run handoff (Seed →) | claude adapter | codex adapter | opencode adapter (mode preserved for run only) | hermes adapter | gemini adapter | kiro adapter | copilot adapter |
+| 4. Run handoff (Seed →) | claude adapter | codex adapter | opencode adapter (see entry-point note below) | hermes adapter | gemini adapter | kiro adapter | copilot adapter |
+
+> **Run-handoff `opencode_mode` differs by entry point.** The CLI
+> entry point [`cli/commands/auto.py`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/cli/commands/auto.py)
+> demotes `opencode_mode == "plugin"` to `"subprocess"` for the
+> run-handoff handler too, because the standalone CLI process is not
+> running inside the OpenCode session that owns the bridge plugin.
+> The MCP entry point [`mcp/tools/auto_handler.py`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/auto_handler.py)
+> only demotes the authoring handlers and keeps `"plugin"` for the
+> run-handoff handler, since it *is* invoked from inside the OpenCode
+> session. Authoring is in-process for both entry points.
 
 > **Common misconception:** `ooo auto --runtime codex` does **not** mean
 > "Codex runs the entire pipeline". The Ouroboros MCP server itself runs

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -91,6 +91,45 @@ The runtime backend affects:
 
 > **No implied parity:** Each supported runtime is an independent product with its own strengths, limitations, and behavior. Ouroboros provides a unified workflow harness, but does not guarantee identical behavior or output quality across runtimes. This applies equally to any future or custom adapter implementations.
 
+## `ooo auto`: Authoring vs Run Handoff
+
+`ooo auto` runs four logical phases, but `--runtime <X>` only decides which
+backend handles the **run-handoff** phase. The three preceding *authoring*
+phases (interview, seed generation, seed repair) always execute in-process
+inside the Ouroboros MCP server. The single exception is OpenCode in
+`plugin` mode, which intercepts authoring via a `_subagent` envelope.
+
+| Phase                   | `claude` | `codex` | `opencode` (subprocess) | `opencode` (plugin)        | `hermes` | `gemini` | `kiro` | `copilot` |
+| ----------------------- | :------: | :-----: | :---------------------: | :------------------------: | :------: | :------: | :----: | :-------: |
+| 1. Interview authoring  |  in-process  |  in-process  |       in-process        | dispatched (bridge plugin) |  in-process  |  in-process  | in-process | in-process |
+| 2. Seed generation      |  in-process  |  in-process  |       in-process        | dispatched (bridge plugin) |  in-process  |  in-process  | in-process | in-process |
+| 3. Seed repair          |  in-process  |  in-process  |       in-process        |        in-process          |  in-process  |  in-process  | in-process | in-process |
+| 4. Run handoff (Seed →) | claude adapter | codex adapter | opencode adapter (subprocess) | opencode adapter (plugin) | hermes adapter | gemini adapter | kiro adapter | copilot adapter |
+
+The dispatch gate lives in
+[`should_dispatch_via_plugin()`](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/mcp/tools/subagent.py)
+and is pinned by `tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPlugin`:
+
+- `runtime` not in `{opencode, opencode_cli}` → never dispatches.
+- `runtime` in `{opencode, opencode_cli}` and `opencode_mode == "plugin"` → dispatch envelope.
+- `runtime` in `{opencode, opencode_cli}` and `opencode_mode in {None, "", "subprocess", anything else}` → in-process. The safe default exists so users who upgraded without re-running `ouroboros setup` are not silently switched to envelope dispatch their session cannot intercept.
+
+> **Common misconception:** `ooo auto --runtime codex` does **not** mean
+> "Codex runs the entire pipeline". The Ouroboros MCP server itself runs
+> the interview question and seed generation, and only hands the executed
+> Seed off to the Codex runtime adapter at phase 4. If `interview.start`
+> blocks or times out, the failure is in the in-process authoring path, not
+> in the Codex CLI. See the [`ooo auto` CLI reference](cli-reference.md#what---runtime-controls-in-ooo-auto)
+> for the per-phase breakdown and resume guidance.
+
+> **The `opencode (plugin)` column is MCP-level.** It applies when an
+> OpenCode bridge plugin session calls the MCP authoring handlers
+> directly. The `ouroboros auto` CLI is a standalone process and not an
+> OpenCode plugin host, so it demotes a persisted `plugin` mode to
+> `subprocess` before constructing handlers — the auto CLI surface
+> therefore behaves like the `opencode (subprocess)` column even when the
+> persisted state declared `plugin`.
+
 ## Choosing a Runtime
 
 The table below covers the three currently shipped backends. Because Ouroboros uses a pluggable `AgentRuntime` protocol, teams can register additional backends without modifying the core engine.


### PR DESCRIPTION
## Summary

Issue #690 asked for documentation that distinguishes which `ooo auto`
phases each runtime backend actually runs. `--runtime <X>` only chooses
the run-handoff backend; the three preceding authoring phases (interview,
seed generation, seed repair) stay in-process unless the caller is an
OpenCode bridge plugin session.

This PR is the **docs-only** scope of #690 — no behaviour change.

- `docs/cli-reference.md` — expands the `ouroboros auto` section with a
  per-phase × backend table, references the dispatch gate
  (`should_dispatch_via_plugin`) and its truth-table tests, and adds a
  note that the `ooo auto` CLI shim demotes a persisted
  `opencode + plugin` session to `subprocess` (the standalone CLI is not
  itself a bridge-plugin host).
- `docs/runtime-capability-matrix.md` — adds an "ooo auto: Authoring vs
  Run Handoff" section with the same matrix, plus a misconception note
  that `--runtime codex` does **not** mean "Codex runs the entire
  pipeline".

## Note re: ouroboros-agent[bot] needs-info

The bot comment on #690 reported that `src/ouroboros/cli/commands/auto.py`,
`src/ouroboros/auto/pipeline.py`, and the MCP authoring/subagent paths
do not exist on `main`. They do — all four are present on `main`
(`6dd84291`, `fix(auto): expose unknown run handoff guidance`). This PR
is written against that current state and the dispatch gate is already
covered by `tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPlugin`
(opencode/codex/claude truth-table).

Closes #690 (partial: docs scope only). The CLI help text, the
authoring regression test, and the blocker-attribution work are sent as
separate small PRs.

## Test plan

- [x] No code changes; reviewers can confirm the linked dispatch gate matches the table.
- [x] Cross-link from CLI reference to the runtime matrix and back.