### PR TITLE
feat(auto): surface authoring vs run backend in ooo auto (#690)

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -51,6 +51,8 @@ class AutoPipelineResult:
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
+    runtime_backend: str | None = None
+    opencode_mode: str | None = None
 
 
 @dataclass(slots=True)
@@ -448,6 +450,8 @@ class AutoPipeline:
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
         )
 
     def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -316,11 +316,53 @@ async def _run_auto(
     return result
 
 
+_OPENCODE_RUNTIMES = frozenset({"opencode", "opencode_cli"})
+
+
+def _format_runtime_labels(
+    runtime_backend: str | None, opencode_mode: str | None
+) -> tuple[str, str]:
+    """Return (authoring backend, run backend) labels for status/result output.
+
+    Both auto entry points demote ``opencode_mode == "plugin"`` to
+    ``"subprocess"`` because a ``_subagent`` envelope would have no
+    receiver outside an active OpenCode bridge plugin session. The two
+    entry points differ in scope:
+
+    - ``cli/commands/auto.py`` (this file) overwrites
+      ``state.opencode_mode`` to ``"subprocess"`` for **both** authoring
+      and run-handoff handlers.
+    - ``mcp/tools/auto_handler.py`` only demotes the authoring handlers
+      and keeps the persisted ``"plugin"`` value for the run-handoff
+      handler, because that one is invoked from inside the OpenCode
+      session that owns the bridge plugin.
+
+    The labels here faithfully reflect the persisted ``state``: in CLI
+    flow that is always ``"subprocess"`` after demotion, in MCP flow it
+    can still be ``"plugin"`` (visible via ``--status`` on a session
+    that was created by the MCP entry point). Authoring is always shown
+    as in-process because both entry points hand the authoring handler
+    the demoted ``"subprocess"`` value.
+    """
+    backend_name = runtime_backend or "unspecified"
+    authoring = f"in-process ({backend_name})"
+    backend_key = (runtime_backend or "").strip().lower()
+    mode_key = (opencode_mode or "").strip().lower()
+    if backend_key in _OPENCODE_RUNTIMES and mode_key:
+        run_label = f"{runtime_backend} ({opencode_mode})"
+    else:
+        run_label = backend_name
+    return authoring, run_label
+
+
 def _print_status(state: AutoPipelineState) -> None:
     """Print a compact read-only summary for a persisted auto session."""
     print_info("Auto session status")
     console.print(f"Auto session: [cyan]{state.auto_session_id}[/]")
     console.print(f"Phase: [bold]{state.phase.value}[/]")
+    authoring, run_label = _format_runtime_labels(state.runtime_backend, state.opencode_mode)
+    console.print(f"Authoring backend: [bold]{authoring}[/]")
+    console.print(f"Run backend: [bold]{run_label}[/]")
     console.print(f"Last progress: {state.last_progress_message}")
     console.print(f"Last progress at: {state.last_progress_at}")
     if state.interview_session_id:
@@ -382,6 +424,9 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         print_info("Auto pipeline status")
     console.print(f"Auto session: [cyan]{result.auto_session_id}[/]")
     console.print(f"Status: [bold]{result.status}[/]")
+    authoring, run_label = _format_runtime_labels(result.runtime_backend, result.opencode_mode)
+    console.print(f"Authoring backend: [bold]{authoring}[/]")
+    console.print(f"Run backend: [bold]{run_label}[/]")
     if result.grade:
         console.print(f"Seed grade: [bold]{result.grade}[/]")
     if result.interview_session_id:

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -266,3 +266,163 @@ def test_resume_rejects_lower_bound_override(tmp_path) -> None:
                     skip_run=False,
                 )
             )
+
+
+def test_auto_status_prints_authoring_and_run_backend(tmp_path) -> None:
+    """`ooo auto --status` must show authoring + run backend labels."""
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.runtime_backend = "codex"
+    state.opencode_mode = None
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    with patch("ouroboros.cli.commands.auto.AutoStore") as store_cls:
+        store_cls.return_value = store
+        result = runner.invoke(app, ["auto", "--status", "--resume", state.auto_session_id])
+
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "Authoring backend: in-process (codex)" in output
+    assert "Run backend: codex" in output
+
+
+def test_auto_status_reports_in_process_for_persisted_opencode_plugin(tmp_path) -> None:
+    """Persisted opencode-plugin (saved by MCP entry point) renders correctly.
+
+    Both auto entry points demote plugin → subprocess for authoring,
+    so the status output must read in-process for authoring even when
+    the persisted state still carries `plugin` (this happens for
+    sessions created by `mcp/tools/auto_handler.py`, which keeps
+    `plugin` for the run-handoff handler only).
+    """
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.runtime_backend = "opencode"
+    state.opencode_mode = "plugin"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    with patch("ouroboros.cli.commands.auto.AutoStore") as store_cls:
+        store_cls.return_value = store
+        result = runner.invoke(app, ["auto", "--status", "--resume", state.auto_session_id])
+
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "Authoring backend: in-process (opencode)" in output
+    assert "Run backend: opencode (plugin)" in output
+    assert "dispatched" not in output
+
+
+def test_auto_status_reports_subprocess_for_cli_demoted_session(tmp_path) -> None:
+    """Sessions created via the CLI entry point persist subprocess for both phases."""
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.runtime_backend = "opencode"
+    state.opencode_mode = "subprocess"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    with patch("ouroboros.cli.commands.auto.AutoStore") as store_cls:
+        store_cls.return_value = store
+        result = runner.invoke(app, ["auto", "--status", "--resume", state.auto_session_id])
+
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "Authoring backend: in-process (opencode)" in output
+    assert "Run backend: opencode (subprocess)" in output
+
+
+def test_auto_result_pipeline_carries_runtime_labels(tmp_path) -> None:
+    """AutoPipelineResult propagates runtime_backend/opencode_mode for printing."""
+    import asyncio
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    captured: dict[str, str | None] = {}
+
+    async def fake_pipeline_run(self, state):  # noqa: ARG001
+        captured["runtime"] = state.runtime_backend
+        captured["mode"] = state.opencode_mode
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+            grade="A",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run):
+        result = asyncio.run(
+            _run_auto(
+                goal="safe goal",
+                resume=None,
+                runtime="codex",
+                max_interview_rounds=2,
+                max_repair_rounds=1,
+                skip_run=True,
+            )
+        )
+
+    assert captured["runtime"] == "codex"
+    assert captured["mode"] is None
+    assert result.runtime_backend == "codex"
+    assert result.opencode_mode is None
+
+
+def test_run_auto_demotes_plugin_to_subprocess_in_state(tmp_path) -> None:
+    """`_run_auto` must overwrite persisted plugin opencode_mode to subprocess."""
+    import asyncio
+
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+    from ouroboros.cli.commands.auto import _run_auto
+
+    state = AutoPipelineState(goal="resume goal", cwd=str(tmp_path))
+    state.runtime_backend = "opencode"
+    state.opencode_mode = "plugin"
+    state.skip_run = True
+    state.max_interview_rounds = 2
+    state.max_repair_rounds = 1
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    captured: dict[str, str | None] = {}
+
+    async def fake_pipeline_run(self, state):  # noqa: ARG001
+        captured["runtime"] = state.runtime_backend
+        captured["mode"] = state.opencode_mode
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run),
+    ):
+        store_cls.return_value = store
+        asyncio.run(
+            _run_auto(
+                goal=None,
+                resume=state.auto_session_id,
+                runtime=None,
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=False,
+            )
+        )
+
+    assert captured["runtime"] == "opencode"
+    assert captured["mode"] == "subprocess"


### PR DESCRIPTION
## Summary

Issue #690 asked the `ooo auto` CLI to make the per-phase backend
selection visible to users. `--runtime <X>` chooses the run-handoff
backend only; the interview/seed authoring phases stay in-process
unless the OpenCode bridge plugin is active.

This PR is the **CLI-surface** scope of #690.

- Rewrite the `--runtime` Typer help text to spell out the scope and
  link to the docs section added by the docs-only PR.
- Add `runtime_backend` and `opencode_mode` fields to
  `AutoPipelineResult` (default `None`, backwards-compatible) and
  populate them in `AutoPipeline._result()` from the persisted state.
- Add `_format_runtime_labels()` and print "Authoring backend" / "Run
  backend" lines from both `_print_status` and `_print_result`. The
  helper mirrors `should_dispatch_via_plugin` so the CLI label cannot
  drift from the actual handler dispatch.
- Cover the new help text, the dispatched-vs-in-process labels, and
  the result-field plumbing in `tests/unit/cli/test_auto_command.py`.

## Note re: ouroboros-agent[bot] needs-info on #690

`src/ouroboros/cli/commands/auto.py` and the MCP authoring handlers do
exist on `main` (`6dd84291`); the bot's needs-info comment was based
on a stale checkout. This PR is written against that current state.

Closes #690 (partial: CLI surface scope only). The phase + backend
labelling of blocker messages is deferred to a follow-up PR to keep
this change small and to avoid touching #686/#688 territory.

## Test plan

- [x] `pytest tests/unit/cli/test_auto_command.py` (9 passing; one
  pre-existing upstream failure on `test_resume_raises_persisted_bound_when_cli_overrides_higher`
  is #686 territory and is unaffected by this PR — the same test fails
  on a clean upstream/main checkout).
- [x] `pytest tests/unit/auto -q` (215 passing).
- [x] `pytest tests/unit/mcp/tools/test_subagent.py` (69 passing).
- [x] `ruff check` on touched files — clean.