### PR TITLE
test(auto): pin codex/non-opencode authoring path stays in-process (#690)

### DIFF
--- a/tests/unit/cli/test_auto_runtime_dispatch.py
+++ b/tests/unit/cli/test_auto_runtime_dispatch.py
@@ -54,7 +54,7 @@ async def _noop_run(self, state):  # noqa: ARG001
 
 @pytest.mark.parametrize(
     "runtime",
-    ["claude", "codex", "hermes", "gemini", "kiro"],
+    ["claude", "codex", "hermes", "gemini", "kiro", "copilot"],
 )
 def test_run_auto_keeps_authoring_in_process_for_non_opencode_runtimes(
     runtime: str,

--- a/tests/unit/cli/test_auto_runtime_dispatch.py
+++ b/tests/unit/cli/test_auto_runtime_dispatch.py
@@ -1,0 +1,198 @@
+"""Pin the per-runtime authoring path that ``ooo auto`` selects (#690).
+
+`--runtime <X>` chooses the run-handoff backend only. The interview and
+seed authoring handlers always run in-process inside the Ouroboros MCP
+server unless the caller is an OpenCode bridge plugin session that can
+intercept the dispatch envelope. The ``ooo auto`` CLI shim itself
+demotes ``opencode-mode plugin`` to ``subprocess`` because the CLI
+process is not running inside an OpenCode session.
+
+These tests pin both rules so a future change cannot silently start
+dispatching authoring envelopes from ``ooo auto`` (which would simply
+hang — there would be no plugin on the receiving end).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.state import AutoPipelineState, AutoStore
+from ouroboros.cli.commands.auto import _run_auto
+from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
+
+
+def _capture_handler_construction() -> dict[str, MagicMock]:
+    """Patch the four handler classes constructed by ``_run_auto``.
+
+    Returns a dict of ``MagicMock`` instances so tests can assert the
+    exact constructor kwargs ``_run_auto`` passed to each handler.
+    """
+    interview_mock = MagicMock(name="InterviewHandler")
+    generate_mock = MagicMock(name="GenerateSeedHandler")
+    execute_mock = MagicMock(name="ExecuteSeedHandler")
+    start_execute_mock = MagicMock(name="StartExecuteSeedHandler")
+    return {
+        "interview": interview_mock,
+        "generate": generate_mock,
+        "execute": execute_mock,
+        "start_execute": start_execute_mock,
+    }
+
+
+async def _noop_run(self, state):  # noqa: ARG001
+    return AutoPipelineResult(
+        status="complete",
+        auto_session_id=state.auto_session_id,
+        phase="complete",
+        grade="A",
+    )
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    ["claude", "codex", "hermes", "gemini", "kiro"],
+)
+def test_run_auto_keeps_authoring_in_process_for_non_opencode_runtimes(
+    runtime: str,
+) -> None:
+    """Authoring handlers must be in-process for every non-OpenCode runtime."""
+    handlers = _capture_handler_construction()
+
+    with (
+        patch("ouroboros.cli.commands.auto.InterviewHandler", handlers["interview"]),
+        patch("ouroboros.cli.commands.auto.GenerateSeedHandler", handlers["generate"]),
+        patch("ouroboros.cli.commands.auto.ExecuteSeedHandler", handlers["execute"]),
+        patch(
+            "ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]
+        ),
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=_noop_run),
+    ):
+        asyncio.run(
+            _run_auto(
+                goal="safe goal",
+                resume=None,
+                runtime=runtime,
+                max_interview_rounds=2,
+                max_repair_rounds=1,
+                skip_run=True,
+            )
+        )
+
+    interview_kwargs = handlers["interview"].call_args.kwargs
+    generate_kwargs = handlers["generate"].call_args.kwargs
+    execute_kwargs = handlers["execute"].call_args.kwargs
+    start_kwargs = handlers["start_execute"].call_args.kwargs
+
+    assert interview_kwargs == {"agent_runtime_backend": runtime, "opencode_mode": None}
+    assert generate_kwargs == {"agent_runtime_backend": runtime, "opencode_mode": None}
+    assert execute_kwargs == {"agent_runtime_backend": runtime, "opencode_mode": None}
+    assert start_kwargs.get("agent_runtime_backend") == runtime
+    assert start_kwargs.get("opencode_mode") is None
+
+    # Cross-check: the dispatch gate would also refuse to dispatch.
+    assert should_dispatch_via_plugin(runtime, None) is False
+
+
+def test_run_auto_demotes_persisted_opencode_plugin_to_subprocess(tmp_path) -> None:
+    """`ooo auto` resume with persisted opencode-plugin mode must demote to subprocess.
+
+    Background: the bridge plugin only exists inside an OpenCode session.
+    The `ouroboros auto` CLI shim runs as a standalone process, so
+    dispatching a `_subagent` envelope would hang with no receiver.
+    `_run_auto` therefore demotes `opencode_mode="plugin"` to
+    `"subprocess"` before constructing handlers.
+    """
+    state = AutoPipelineState(goal="resume goal", cwd=str(tmp_path))
+    state.runtime_backend = "opencode"
+    state.opencode_mode = "plugin"
+    state.skip_run = True
+    state.max_interview_rounds = 2
+    state.max_repair_rounds = 1
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    handlers = _capture_handler_construction()
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto.InterviewHandler", handlers["interview"]),
+        patch("ouroboros.cli.commands.auto.GenerateSeedHandler", handlers["generate"]),
+        patch("ouroboros.cli.commands.auto.ExecuteSeedHandler", handlers["execute"]),
+        patch(
+            "ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]
+        ),
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=_noop_run),
+    ):
+        store_cls.return_value = store
+        asyncio.run(
+            _run_auto(
+                goal=None,
+                resume=state.auto_session_id,
+                runtime=None,
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=False,
+            )
+        )
+
+    interview_kwargs = handlers["interview"].call_args.kwargs
+    generate_kwargs = handlers["generate"].call_args.kwargs
+    execute_kwargs = handlers["execute"].call_args.kwargs
+    start_kwargs = handlers["start_execute"].call_args.kwargs
+
+    assert interview_kwargs["agent_runtime_backend"] == "opencode"
+    assert interview_kwargs["opencode_mode"] == "subprocess"
+    assert generate_kwargs["opencode_mode"] == "subprocess"
+    assert execute_kwargs["opencode_mode"] == "subprocess"
+    assert start_kwargs["opencode_mode"] == "subprocess"
+
+    # The demoted args also fail the dispatch gate, so nothing is sent
+    # through the bridge plugin envelope from the auto CLI shim.
+    assert should_dispatch_via_plugin("opencode", "subprocess") is False
+
+
+def test_run_auto_keeps_opencode_subprocess_in_process(tmp_path) -> None:
+    """OpenCode in subprocess mode (no persisted plugin) stays in-process."""
+    state = AutoPipelineState(goal="resume goal", cwd=str(tmp_path))
+    state.runtime_backend = "opencode"
+    state.opencode_mode = "subprocess"
+    state.skip_run = True
+    state.max_interview_rounds = 2
+    state.max_repair_rounds = 1
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    handlers = _capture_handler_construction()
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto.InterviewHandler", handlers["interview"]),
+        patch("ouroboros.cli.commands.auto.GenerateSeedHandler", handlers["generate"]),
+        patch("ouroboros.cli.commands.auto.ExecuteSeedHandler", handlers["execute"]),
+        patch(
+            "ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]
+        ),
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=_noop_run),
+    ):
+        store_cls.return_value = store
+        asyncio.run(
+            _run_auto(
+                goal=None,
+                resume=state.auto_session_id,
+                runtime=None,
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=False,
+            )
+        )
+
+    for handler in ("interview", "generate", "execute", "start_execute"):
+        kwargs = handlers[handler].call_args.kwargs
+        assert kwargs["agent_runtime_backend"] == "opencode"
+        assert kwargs["opencode_mode"] == "subprocess"
+
+    assert should_dispatch_via_plugin("opencode", "subprocess") is False

--- a/tests/unit/cli/test_auto_runtime_dispatch.py
+++ b/tests/unit/cli/test_auto_runtime_dispatch.py
@@ -151,6 +151,52 @@ def test_run_auto_demotes_persisted_opencode_plugin_to_subprocess(tmp_path) -> N
     assert should_dispatch_via_plugin("opencode", "subprocess") is False
 
 
+def test_run_auto_demotes_fresh_session_opencode_plugin_to_subprocess(tmp_path) -> None:
+    """Fresh `--runtime opencode` session with `get_opencode_mode() == "plugin"` is demoted.
+
+    This pins the *fresh-session* branch of the OpenCode plugin
+    demotion. `_run_auto()` reads the persisted opencode_mode for
+    resumes but falls back to ``get_opencode_mode()`` (the configured
+    default) for new sessions; both paths must demote ``"plugin"`` to
+    ``"subprocess"`` for both authoring and run-handoff handlers,
+    because the standalone CLI process cannot host the OpenCode bridge
+    plugin envelope.
+    """
+    handlers = _capture_handler_construction()
+
+    with (
+        patch("ouroboros.cli.commands.auto.get_opencode_mode", return_value="plugin"),
+        patch("ouroboros.cli.commands.auto.InterviewHandler", handlers["interview"]),
+        patch("ouroboros.cli.commands.auto.GenerateSeedHandler", handlers["generate"]),
+        patch("ouroboros.cli.commands.auto.ExecuteSeedHandler", handlers["execute"]),
+        patch("ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]),
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=_noop_run),
+    ):
+        asyncio.run(
+            _run_auto(
+                goal="safe goal",
+                resume=None,
+                runtime="opencode",
+                max_interview_rounds=2,
+                max_repair_rounds=1,
+                skip_run=True,
+            )
+        )
+
+    interview_kwargs = handlers["interview"].call_args.kwargs
+    generate_kwargs = handlers["generate"].call_args.kwargs
+    execute_kwargs = handlers["execute"].call_args.kwargs
+    start_kwargs = handlers["start_execute"].call_args.kwargs
+
+    assert interview_kwargs["agent_runtime_backend"] == "opencode"
+    assert interview_kwargs["opencode_mode"] == "subprocess"
+    assert generate_kwargs["opencode_mode"] == "subprocess"
+    assert execute_kwargs["opencode_mode"] == "subprocess"
+    assert start_kwargs["opencode_mode"] == "subprocess"
+
+    assert should_dispatch_via_plugin("opencode", "subprocess") is False
+
+
 def test_run_auto_keeps_opencode_subprocess_in_process(tmp_path) -> None:
     """OpenCode in subprocess mode (no persisted plugin) stays in-process."""
     state = AutoPipelineState(goal="resume goal", cwd=str(tmp_path))

--- a/tests/unit/cli/test_auto_runtime_dispatch.py
+++ b/tests/unit/cli/test_auto_runtime_dispatch.py
@@ -66,9 +66,7 @@ def test_run_auto_keeps_authoring_in_process_for_non_opencode_runtimes(
         patch("ouroboros.cli.commands.auto.InterviewHandler", handlers["interview"]),
         patch("ouroboros.cli.commands.auto.GenerateSeedHandler", handlers["generate"]),
         patch("ouroboros.cli.commands.auto.ExecuteSeedHandler", handlers["execute"]),
-        patch(
-            "ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]
-        ),
+        patch("ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]),
         patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=_noop_run),
     ):
         asyncio.run(
@@ -122,9 +120,7 @@ def test_run_auto_demotes_persisted_opencode_plugin_to_subprocess(tmp_path) -> N
         patch("ouroboros.cli.commands.auto.InterviewHandler", handlers["interview"]),
         patch("ouroboros.cli.commands.auto.GenerateSeedHandler", handlers["generate"]),
         patch("ouroboros.cli.commands.auto.ExecuteSeedHandler", handlers["execute"]),
-        patch(
-            "ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]
-        ),
+        patch("ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]),
         patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=_noop_run),
     ):
         store_cls.return_value = store
@@ -173,9 +169,7 @@ def test_run_auto_keeps_opencode_subprocess_in_process(tmp_path) -> None:
         patch("ouroboros.cli.commands.auto.InterviewHandler", handlers["interview"]),
         patch("ouroboros.cli.commands.auto.GenerateSeedHandler", handlers["generate"]),
         patch("ouroboros.cli.commands.auto.ExecuteSeedHandler", handlers["execute"]),
-        patch(
-            "ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]
-        ),
+        patch("ouroboros.cli.commands.auto.StartExecuteSeedHandler", handlers["start_execute"]),
         patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=_noop_run),
     ):
         store_cls.return_value = store


### PR DESCRIPTION
## Summary

Issue #690 asked for regression tests that pin the per-phase backend
selection inside `ooo auto` so a future change cannot silently start
dispatching authoring envelopes from the CLI shim.

Add `tests/unit/cli/test_auto_runtime_dispatch.py` with three pinning
checks:

- For every non-OpenCode runtime (`claude`, `codex`, `hermes`,
  `gemini`, `kiro`), `_run_auto` constructs `InterviewHandler`,
  `GenerateSeedHandler`, `ExecuteSeedHandler`, and
  `StartExecuteSeedHandler` with `opencode_mode=None`, and
  `should_dispatch_via_plugin` refuses to dispatch.
- A persisted `opencode + plugin` session resumed via `ooo auto` is
  demoted to `subprocess` for all four handlers, because the standalone
  CLI process cannot host the OpenCode bridge plugin that would
  otherwise receive the envelope.
- A persisted `opencode + subprocess` session keeps its mode and also
  fails the dispatch gate.

This PR adds tests only — no production-code changes. It complements
the existing
`tests/unit/mcp/tools/test_subagent.py::TestShouldDispatchViaPlugin`
truth-table tests by pinning the *call-site* behaviour inside the auto
CLI shim, not just the gate function in isolation.

## Note re: ouroboros-agent[bot] needs-info on #690

`src/ouroboros/cli/commands/auto.py` and the MCP authoring handlers
exist on `main` (`6dd84291`); these tests run against that current
state.

Closes #690 (partial: regression-test scope only).

## Test plan

- [x] `pytest tests/unit/cli/test_auto_runtime_dispatch.py -v` — 7 passing.
- [x] `pytest tests/unit/mcp/tools/test_subagent.py` — 69 passing.
- [x] `ruff check` on the new test file — clean.