### PR TITLE
fix(auto): label authoring blockers with phase + backend (#690)

### DIFF
--- a/src/ouroboros/auto/blocker_attribution.py
+++ b/src/ouroboros/auto/blocker_attribution.py
@@ -1,14 +1,23 @@
-"""Decorate auto-pipeline blocker messages with phase + backend attribution.
+"""Capture authoring-backend attribution for auto-pipeline blockers.
 
 Issue #690 surfaced a class of incidents where a goal like
 "open and merge a PR" hit ``interview.start timed out after 60s`` and
 the user could not tell whether the timeout came from the in-process
 authoring path or from the runtime adapter behind ``--runtime <X>``.
 
-This helper appends a single
-``[phase=<step>, authoring_backend=<resolved>]`` suffix to a blocker
-message. It does not change timeout values, retry counts, or resume
-semantics — those belong to the dedicated tickets (#686, #688).
+This module records the resolved authoring backend on
+``AutoPipelineState`` as **structured metadata**, leaving the
+user-facing blocker message text unchanged. Surfaces (CLI ``--status``,
+MCP responses, log sinks) that want to render the attribution can read
+``state.last_authoring_backend`` and format it appropriately for their
+audience. This module deliberately does not append bracketed tokens to
+the blocker message itself — that exposes internal execution topology
+to users who only need to know *which phase failed and what to try
+next*.
+
+The phase/tool dimension is already captured by
+``state.last_tool_name`` (set by ``mark_blocked``/``mark_failed``); this
+module only adds the backend dimension.
 """
 
 from __future__ import annotations
@@ -29,7 +38,7 @@ def authoring_backend_label(state: AutoPipelineState) -> str:
     outside an active OpenCode bridge plugin session. Authoring is
     therefore always reported as in-process here — anything else would
     misrepresent what the handlers actually got and mislabel the very
-    incidents this attribution helper is meant to clarify.
+    incidents this attribution module is meant to clarify.
 
     The MCP-handler ``_subagent`` dispatch path still exists, but it is
     only reachable when callers invoke the handlers directly from inside
@@ -39,18 +48,15 @@ def authoring_backend_label(state: AutoPipelineState) -> str:
     return f"in-process ({backend_name})"
 
 
-def label_blocker(state: AutoPipelineState, message: str | None, *, phase: str) -> str:
-    """Return ``message`` with a phase + authoring-backend suffix.
+def record_authoring_backend(state: AutoPipelineState) -> None:
+    """Persist the resolved authoring backend on ``state`` as metadata.
 
-    Appends at most once: if the message already contains ``[phase=``
-    the original is returned unchanged so nested call sites do not
-    double-stamp the suffix.
+    Call this *before* ``mark_blocked`` / ``mark_failed`` at every
+    authoring-side blocker site. The recorded value lives in
+    ``state.last_authoring_backend`` and is intended to be read by
+    diagnostic surfaces, not concatenated into user-visible messages.
     """
-    text = message or ""
-    if "[phase=" in text:
-        return text
-    suffix = f" [phase={phase}, authoring_backend={authoring_backend_label(state)}]"
-    return text + suffix
+    state.last_authoring_backend = authoring_backend_label(state)
 
 
-__all__ = ["authoring_backend_label", "label_blocker"]
+__all__ = ["authoring_backend_label", "record_authoring_backend"]

--- a/src/ouroboros/auto/blocker_attribution.py
+++ b/src/ouroboros/auto/blocker_attribution.py
@@ -1,0 +1,56 @@
+"""Decorate auto-pipeline blocker messages with phase + backend attribution.
+
+Issue #690 surfaced a class of incidents where a goal like
+"open and merge a PR" hit ``interview.start timed out after 60s`` and
+the user could not tell whether the timeout came from the in-process
+authoring path or from the runtime adapter behind ``--runtime <X>``.
+
+This helper appends a single
+``[phase=<step>, authoring_backend=<resolved>]`` suffix to a blocker
+message. It does not change timeout values, retry counts, or resume
+semantics — those belong to the dedicated tickets (#686, #688).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ouroboros.auto.state import AutoPipelineState
+
+_OPENCODE_RUNTIMES = frozenset({"opencode", "opencode_cli"})
+
+
+def authoring_backend_label(state: AutoPipelineState) -> str:
+    """Return the human-readable authoring path for a state.
+
+    OpenCode + ``plugin`` mode is the only combination where the
+    in-process authoring handler short-circuits to a ``_subagent``
+    envelope. Every other runtime/mode pair runs the authoring step
+    in-process inside the Ouroboros MCP server. The label mirrors
+    ``ouroboros.mcp.tools.subagent.should_dispatch_via_plugin`` so the
+    blocker text cannot drift from the actual handler dispatch.
+    """
+    backend = (state.runtime_backend or "").strip().lower()
+    mode = (state.opencode_mode or "").strip().lower()
+    if backend in _OPENCODE_RUNTIMES and mode == "plugin":
+        return "dispatched (opencode bridge plugin)"
+    backend_name = state.runtime_backend or "unspecified"
+    return f"in-process ({backend_name})"
+
+
+def label_blocker(state: AutoPipelineState, message: str | None, *, phase: str) -> str:
+    """Return ``message`` with a phase + authoring-backend suffix.
+
+    Appends at most once: if the message already contains ``[phase=``
+    the original is returned unchanged so nested call sites do not
+    double-stamp the suffix.
+    """
+    text = message or ""
+    if "[phase=" in text:
+        return text
+    suffix = f" [phase={phase}, authoring_backend={authoring_backend_label(state)}]"
+    return text + suffix
+
+
+__all__ = ["authoring_backend_label", "label_blocker"]

--- a/src/ouroboros/auto/blocker_attribution.py
+++ b/src/ouroboros/auto/blocker_attribution.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ouroboros.auto.state import AutoPipelineState
 
+
 def authoring_backend_label(state: AutoPipelineState) -> str:
     """Return the human-readable authoring path for an auto-mode state.
 

--- a/src/ouroboros/auto/blocker_attribution.py
+++ b/src/ouroboros/auto/blocker_attribution.py
@@ -18,23 +18,22 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ouroboros.auto.state import AutoPipelineState
 
-_OPENCODE_RUNTIMES = frozenset({"opencode", "opencode_cli"})
-
-
 def authoring_backend_label(state: AutoPipelineState) -> str:
-    """Return the human-readable authoring path for a state.
+    """Return the human-readable authoring path for an auto-mode state.
 
-    OpenCode + ``plugin`` mode is the only combination where the
-    in-process authoring handler short-circuits to a ``_subagent``
-    envelope. Every other runtime/mode pair runs the authoring step
-    in-process inside the Ouroboros MCP server. The label mirrors
-    ``ouroboros.mcp.tools.subagent.should_dispatch_via_plugin`` so the
-    blocker text cannot drift from the actual handler dispatch.
+    In ``ooo auto`` flow, both auto entry points (``cli/commands/auto.py``
+    and ``mcp/tools/auto_handler.py``) demote a persisted
+    ``opencode_mode == "plugin"`` to ``"subprocess"`` for the authoring
+    handlers, because a ``_subagent`` envelope would have no receiver
+    outside an active OpenCode bridge plugin session. Authoring is
+    therefore always reported as in-process here — anything else would
+    misrepresent what the handlers actually got and mislabel the very
+    incidents this attribution helper is meant to clarify.
+
+    The MCP-handler ``_subagent`` dispatch path still exists, but it is
+    only reachable when callers invoke the handlers directly from inside
+    an active OpenCode bridge plugin session (not from ``ooo auto``).
     """
-    backend = (state.runtime_backend or "").strip().lower()
-    mode = (state.opencode_mode or "").strip().lower()
-    if backend in _OPENCODE_RUNTIMES and mode == "plugin":
-        return "dispatched (opencode bridge plugin)"
     backend_name = state.runtime_backend or "unspecified"
     return f"in-process ({backend_name})"
 

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -19,6 +19,7 @@ from ouroboros.auto.answerer import (
     AutoAnswerSource,
     AutoBlocker,
 )
+from ouroboros.auto.blocker_attribution import label_blocker
 from ouroboros.auto.gap_detector import Gap, GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
@@ -164,15 +165,18 @@ class AutoInterviewDriver:
                 self._save(state)
         except TimeoutError as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
-            state.mark_blocked(str(exc), tool_name=interview_tool_name)
+            decorated = label_blocker(state, str(exc), phase=interview_tool_name)
+            state.mark_blocked(decorated, tool_name=interview_tool_name)
             self._save(state)
             return AutoInterviewResult(
-                "blocked", state.interview_session_id, ledger, state.current_round, str(exc)
+                "blocked", state.interview_session_id, ledger, state.current_round, decorated
             )
         except Exception as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
             action = "resume" if interview_tool_name == "interview.resume" else "start"
-            blocker = f"interview {action} failed: {exc}"
+            blocker = label_blocker(
+                state, f"interview {action} failed: {exc}", phase=interview_tool_name
+            )
             state.mark_blocked(blocker, tool_name=interview_tool_name)
             self._save(state)
             return AutoInterviewResult(
@@ -190,14 +194,17 @@ class AutoInterviewDriver:
             if answer.blocker is not None:
                 self.answerer.apply(answer, ledger, question=turn.question)
                 state.ledger = ledger.to_dict()
-                state.mark_blocked(answer.blocker.reason, tool_name="auto_answerer")
+                blocker_text = label_blocker(
+                    state, answer.blocker.reason, phase="auto_answerer"
+                )
+                state.mark_blocked(blocker_text, tool_name="auto_answerer")
                 self._save(state)
                 return AutoInterviewResult(
                     "blocked",
                     state.interview_session_id,
                     ledger,
                     state.current_round,
-                    answer.blocker.reason,
+                    blocker_text,
                 )
             state.current_round = round_number
             self.answerer.apply(answer, ledger, question=turn.question)
@@ -225,13 +232,16 @@ class AutoInterviewDriver:
                     )
                 )
             except TimeoutError as exc:
-                state.mark_blocked(str(exc), tool_name="interview.answer")
+                decorated = label_blocker(state, str(exc), phase="interview.answer")
+                state.mark_blocked(decorated, tool_name="interview.answer")
                 self._save(state)
                 return AutoInterviewResult(
-                    "blocked", state.interview_session_id, ledger, round_number, str(exc)
+                    "blocked", state.interview_session_id, ledger, round_number, decorated
                 )
             except Exception as exc:
-                blocker = f"interview answer failed: {exc}"
+                blocker = label_blocker(
+                    state, f"interview answer failed: {exc}", phase="interview.answer"
+                )
                 state.mark_blocked(blocker, tool_name="interview.answer")
                 self._save(state)
                 return AutoInterviewResult(
@@ -246,13 +256,21 @@ class AutoInterviewDriver:
 
         if not ledger.is_seed_ready():
             gaps = ", ".join(ledger.open_gaps())
-            blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
+            blocker = label_blocker(
+                state,
+                f"auto interview reached max rounds with unresolved gaps: {gaps}",
+                phase="interview_driver",
+            )
             state.mark_blocked(blocker, tool_name="interview_driver")
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
             )
-        blocker = "auto interview reached max rounds before backend marked the Seed ready"
+        blocker = label_blocker(
+            state,
+            "auto interview reached max rounds before backend marked the Seed ready",
+            phase="interview_driver",
+        )
         state.mark_blocked(blocker, tool_name="interview_driver")
         self._save(state)
         return AutoInterviewResult(
@@ -297,7 +315,11 @@ class AutoInterviewDriver:
             self._save(state)
             return AutoInterviewResult("seed_ready", turn.session_id, ledger, rounds)
         gaps = ", ".join(ledger.open_gaps())
-        blocker = f"interview backend completed before auto ledger was ready: {gaps}"
+        blocker = label_blocker(
+            state,
+            f"interview backend completed before auto ledger was ready: {gaps}",
+            phase="interview_driver",
+        )
         state.mark_blocked(blocker, tool_name="interview_driver")
         self._save(state)
         return AutoInterviewResult("blocked", state.interview_session_id, ledger, rounds, blocker)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -194,9 +194,7 @@ class AutoInterviewDriver:
             if answer.blocker is not None:
                 self.answerer.apply(answer, ledger, question=turn.question)
                 state.ledger = ledger.to_dict()
-                blocker_text = label_blocker(
-                    state, answer.blocker.reason, phase="auto_answerer"
-                )
+                blocker_text = label_blocker(state, answer.blocker.reason, phase="auto_answerer")
                 state.mark_blocked(blocker_text, tool_name="auto_answerer")
                 self._save(state)
                 return AutoInterviewResult(

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -19,7 +19,7 @@ from ouroboros.auto.answerer import (
     AutoAnswerSource,
     AutoBlocker,
 )
-from ouroboros.auto.blocker_attribution import label_blocker
+from ouroboros.auto.blocker_attribution import record_authoring_backend
 from ouroboros.auto.gap_detector import Gap, GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
@@ -165,18 +165,18 @@ class AutoInterviewDriver:
                 self._save(state)
         except TimeoutError as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
-            decorated = label_blocker(state, str(exc), phase=interview_tool_name)
-            state.mark_blocked(decorated, tool_name=interview_tool_name)
+            record_authoring_backend(state)
+            message = str(exc)
+            state.mark_blocked(message, tool_name=interview_tool_name)
             self._save(state)
             return AutoInterviewResult(
-                "blocked", state.interview_session_id, ledger, state.current_round, decorated
+                "blocked", state.interview_session_id, ledger, state.current_round, message
             )
         except Exception as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
             action = "resume" if interview_tool_name == "interview.resume" else "start"
-            blocker = label_blocker(
-                state, f"interview {action} failed: {exc}", phase=interview_tool_name
-            )
+            record_authoring_backend(state)
+            blocker = f"interview {action} failed: {exc}"
             state.mark_blocked(blocker, tool_name=interview_tool_name)
             self._save(state)
             return AutoInterviewResult(
@@ -194,7 +194,8 @@ class AutoInterviewDriver:
             if answer.blocker is not None:
                 self.answerer.apply(answer, ledger, question=turn.question)
                 state.ledger = ledger.to_dict()
-                blocker_text = label_blocker(state, answer.blocker.reason, phase="auto_answerer")
+                record_authoring_backend(state)
+                blocker_text = answer.blocker.reason
                 state.mark_blocked(blocker_text, tool_name="auto_answerer")
                 self._save(state)
                 return AutoInterviewResult(
@@ -230,16 +231,16 @@ class AutoInterviewDriver:
                     )
                 )
             except TimeoutError as exc:
-                decorated = label_blocker(state, str(exc), phase="interview.answer")
-                state.mark_blocked(decorated, tool_name="interview.answer")
+                record_authoring_backend(state)
+                message = str(exc)
+                state.mark_blocked(message, tool_name="interview.answer")
                 self._save(state)
                 return AutoInterviewResult(
-                    "blocked", state.interview_session_id, ledger, round_number, decorated
+                    "blocked", state.interview_session_id, ledger, round_number, message
                 )
             except Exception as exc:
-                blocker = label_blocker(
-                    state, f"interview answer failed: {exc}", phase="interview.answer"
-                )
+                record_authoring_backend(state)
+                blocker = f"interview answer failed: {exc}"
                 state.mark_blocked(blocker, tool_name="interview.answer")
                 self._save(state)
                 return AutoInterviewResult(
@@ -254,21 +255,15 @@ class AutoInterviewDriver:
 
         if not ledger.is_seed_ready():
             gaps = ", ".join(ledger.open_gaps())
-            blocker = label_blocker(
-                state,
-                f"auto interview reached max rounds with unresolved gaps: {gaps}",
-                phase="interview_driver",
-            )
+            record_authoring_backend(state)
+            blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
             state.mark_blocked(blocker, tool_name="interview_driver")
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
             )
-        blocker = label_blocker(
-            state,
-            "auto interview reached max rounds before backend marked the Seed ready",
-            phase="interview_driver",
-        )
+        record_authoring_backend(state)
+        blocker = "auto interview reached max rounds before backend marked the Seed ready"
         state.mark_blocked(blocker, tool_name="interview_driver")
         self._save(state)
         return AutoInterviewResult(
@@ -313,11 +308,8 @@ class AutoInterviewDriver:
             self._save(state)
             return AutoInterviewResult("seed_ready", turn.session_id, ledger, rounds)
         gaps = ", ".join(ledger.open_gaps())
-        blocker = label_blocker(
-            state,
-            f"interview backend completed before auto ledger was ready: {gaps}",
-            phase="interview_driver",
-        )
+        record_authoring_backend(state)
+        blocker = f"interview backend completed before auto ledger was ready: {gaps}"
         state.mark_blocked(blocker, tool_name="interview_driver")
         self._save(state)
         return AutoInterviewResult("blocked", state.interview_session_id, ledger, rounds, blocker)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -165,9 +165,9 @@ class AutoInterviewDriver:
                 self._save(state)
         except TimeoutError as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
-            record_authoring_backend(state)
             message = str(exc)
             state.mark_blocked(message, tool_name=interview_tool_name)
+            record_authoring_backend(state)
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, state.current_round, message
@@ -175,9 +175,9 @@ class AutoInterviewDriver:
         except Exception as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
             action = "resume" if interview_tool_name == "interview.resume" else "start"
-            record_authoring_backend(state)
             blocker = f"interview {action} failed: {exc}"
             state.mark_blocked(blocker, tool_name=interview_tool_name)
+            record_authoring_backend(state)
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, state.current_round, blocker
@@ -194,9 +194,9 @@ class AutoInterviewDriver:
             if answer.blocker is not None:
                 self.answerer.apply(answer, ledger, question=turn.question)
                 state.ledger = ledger.to_dict()
-                record_authoring_backend(state)
                 blocker_text = answer.blocker.reason
                 state.mark_blocked(blocker_text, tool_name="auto_answerer")
+                record_authoring_backend(state)
                 self._save(state)
                 return AutoInterviewResult(
                     "blocked",
@@ -231,17 +231,17 @@ class AutoInterviewDriver:
                     )
                 )
             except TimeoutError as exc:
-                record_authoring_backend(state)
                 message = str(exc)
                 state.mark_blocked(message, tool_name="interview.answer")
+                record_authoring_backend(state)
                 self._save(state)
                 return AutoInterviewResult(
                     "blocked", state.interview_session_id, ledger, round_number, message
                 )
             except Exception as exc:
-                record_authoring_backend(state)
                 blocker = f"interview answer failed: {exc}"
                 state.mark_blocked(blocker, tool_name="interview.answer")
+                record_authoring_backend(state)
                 self._save(state)
                 return AutoInterviewResult(
                     "blocked", state.interview_session_id, ledger, round_number, blocker
@@ -255,16 +255,16 @@ class AutoInterviewDriver:
 
         if not ledger.is_seed_ready():
             gaps = ", ".join(ledger.open_gaps())
-            record_authoring_backend(state)
             blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
             state.mark_blocked(blocker, tool_name="interview_driver")
+            record_authoring_backend(state)
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
             )
-        record_authoring_backend(state)
         blocker = "auto interview reached max rounds before backend marked the Seed ready"
         state.mark_blocked(blocker, tool_name="interview_driver")
+        record_authoring_backend(state)
         self._save(state)
         return AutoInterviewResult(
             "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
@@ -308,9 +308,9 @@ class AutoInterviewDriver:
             self._save(state)
             return AutoInterviewResult("seed_ready", turn.session_id, ledger, rounds)
         gaps = ", ".join(ledger.open_gaps())
-        record_authoring_backend(state)
         blocker = f"interview backend completed before auto ledger was ready: {gaps}"
         state.mark_blocked(blocker, tool_name="interview_driver")
+        record_authoring_backend(state)
         self._save(state)
         return AutoInterviewResult("blocked", state.interview_session_id, ledger, rounds, blocker)
 

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -64,6 +64,7 @@ class AutoPipelineResult:
     opencode_mode: str | None = None
     invoked_by: str = "direct"
     provenance: dict[str, Any] | None = None
+    last_authoring_backend: str | None = None
 
 
 @dataclass(slots=True)
@@ -228,19 +229,19 @@ class AutoPipeline:
                     state.seed_artifact = seed.to_dict()
                     state.seed_origin = SeedOrigin.AUTO_PIPELINE
                 except TimeoutError as exc:
-                    record_authoring_backend(state)
                     state.mark_blocked(
                         f"seed generation timed out after {self.seed_timeout_seconds:.0f}s",
                         tool_name="seed_generator",
                     )
+                    record_authoring_backend(state)
                     self._save(state)
                     return self._result(state, ledger, blocker=str(exc) or state.last_error)
                 except Exception as exc:
-                    record_authoring_backend(state)
                     state.mark_failed(
                         f"seed generation failed: {exc}",
                         tool_name="seed_generator",
                     )
+                    record_authoring_backend(state)
                     self._save(state)
                     return self._result(state, ledger, blocker=state.last_error)
                 state.mark_progress("Seed generated", tool_name="seed_generator")
@@ -503,6 +504,7 @@ class AutoPipeline:
             opencode_mode=state.opencode_mode,
             invoked_by=state.invoked_by(),
             provenance=dict(state.provenance) if state.provenance else None,
+            last_authoring_backend=state.last_authoring_backend,
         )
 
     def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
-from ouroboros.auto.blocker_attribution import label_blocker
+from ouroboros.auto.blocker_attribution import record_authoring_backend
 from ouroboros.auto.grading import GradeGate
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
@@ -228,21 +228,17 @@ class AutoPipeline:
                     state.seed_artifact = seed.to_dict()
                     state.seed_origin = SeedOrigin.AUTO_PIPELINE
                 except TimeoutError as exc:
+                    record_authoring_backend(state)
                     state.mark_blocked(
-                        label_blocker(
-                            state,
-                            f"seed generation timed out after {self.seed_timeout_seconds:.0f}s",
-                            phase="seed_generator",
-                        ),
+                        f"seed generation timed out after {self.seed_timeout_seconds:.0f}s",
                         tool_name="seed_generator",
                     )
                     self._save(state)
                     return self._result(state, ledger, blocker=str(exc) or state.last_error)
                 except Exception as exc:
+                    record_authoring_backend(state)
                     state.mark_failed(
-                        label_blocker(
-                            state, f"seed generation failed: {exc}", phase="seed_generator"
-                        ),
+                        f"seed generation failed: {exc}",
                         tool_name="seed_generator",
                     )
                     self._save(state)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from ouroboros.auto.blocker_attribution import label_blocker
 from ouroboros.auto.grading import GradeGate
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
@@ -228,13 +229,22 @@ class AutoPipeline:
                     state.seed_origin = SeedOrigin.AUTO_PIPELINE
                 except TimeoutError as exc:
                     state.mark_blocked(
-                        f"seed generation timed out after {self.seed_timeout_seconds:.0f}s",
+                        label_blocker(
+                            state,
+                            f"seed generation timed out after {self.seed_timeout_seconds:.0f}s",
+                            phase="seed_generator",
+                        ),
                         tool_name="seed_generator",
                     )
                     self._save(state)
                     return self._result(state, ledger, blocker=str(exc) or state.last_error)
                 except Exception as exc:
-                    state.mark_failed(f"seed generation failed: {exc}", tool_name="seed_generator")
+                    state.mark_failed(
+                        label_blocker(
+                            state, f"seed generation failed: {exc}", phase="seed_generator"
+                        ),
+                        tool_name="seed_generator",
+                    )
                     self._save(state)
                     return self._result(state, ledger, blocker=state.last_error)
                 state.mark_progress("Seed generated", tool_name="seed_generator")

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -272,6 +272,13 @@ class AutoPipelineState:
         self.updated_at = now
         self.last_progress_message = message
         self.last_error = error
+        # Authoring-backend attribution is scoped to the most recent
+        # authoring failure; reset on every transition so a later
+        # non-authoring blocker (grade_gate, seed_saver, run_starter)
+        # cannot inherit stale metadata. Authoring-side call sites must
+        # call ``record_authoring_backend(state)`` *after* mark_blocked
+        # / mark_failed to repopulate the field.
+        self.last_authoring_backend = None
 
     def mark_progress(self, message: str, *, tool_name: str | None = None) -> None:
         """Record non-terminal progress within the current phase."""

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -233,6 +233,7 @@ class AutoPipelineState:
     pending_question: str | None = None
     last_tool_name: str | None = None
     last_error: str | None = None
+    last_authoring_backend: str | None = None
     last_progress_message: str = "created"
     phase_started_at: str = field(default_factory=utc_now_iso)
     last_progress_at: str = field(default_factory=utc_now_iso)
@@ -354,6 +355,7 @@ class AutoPipelineState:
         payload.setdefault("provenance", None)
         payload.setdefault("auto_answer_log", [])
         payload.setdefault("seed_origin", SeedOrigin.NONE.value)
+        payload.setdefault("last_authoring_backend", None)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:

--- a/tests/unit/auto/test_blocker_attribution.py
+++ b/tests/unit/auto/test_blocker_attribution.py
@@ -96,6 +96,124 @@ def test_authoring_backend_state_field_round_trips_through_persistence(tmp_path)
     assert reloaded.last_authoring_backend == "in-process (codex)"
 
 
+def test_transition_clears_authoring_backend_metadata() -> None:
+    """`transition()` resets `last_authoring_backend` so non-authoring blockers cannot inherit it.
+
+    Regression for #690 review feedback: after an authoring-side
+    timeout/blocker, a later `recover()` -> grade_gate /
+    seed_saver / run_starter failure must not look like it came from
+    the authoring backend. ``transition`` is the canonical seam where
+    the field is reset.
+    """
+    from ouroboros.auto.state import AutoPhase
+
+    state = _state("codex")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("interview.start timed out", tool_name="interview.start")
+    record_authoring_backend(state)
+    assert state.last_authoring_backend == "in-process (codex)"
+
+    # BLOCKED -> INTERVIEW recovery (the realistic post-blocker flow)
+    # must clear the field, so a later non-authoring blocker cannot
+    # inherit it.
+    state.recover(AutoPhase.INTERVIEW, "resuming after blocker")
+    assert state.last_authoring_backend is None
+
+
+def test_mark_blocked_after_transition_clears_then_record_repopulates() -> None:
+    """The reverse-order pattern (mark_blocked, then record) survives clearing."""
+    from ouroboros.auto.state import AutoPhase
+
+    state = _state("codex")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("interview.start timed out", tool_name="interview.start")
+    # mark_blocked already went through transition, so the previous
+    # value (if any) is cleared. The call sites in interview_driver /
+    # pipeline therefore call record_authoring_backend AFTER
+    # mark_blocked to repopulate the field.
+    assert state.last_authoring_backend is None
+    record_authoring_backend(state)
+    assert state.last_authoring_backend == "in-process (codex)"
+
+
+def test_non_authoring_mark_blocked_leaves_last_authoring_backend_unset() -> None:
+    """A non-authoring blocker (e.g. run_starter) must not inherit a stale value."""
+    from ouroboros.auto.state import AutoPhase
+
+    state = _state("codex")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("interview.start timed out", tool_name="interview.start")
+    record_authoring_backend(state)
+    assert state.last_authoring_backend == "in-process (codex)"
+
+    # Recover then transition into a non-authoring failure (e.g. run handoff).
+    state.recover(AutoPhase.INTERVIEW, "resume")
+    state.transition(AutoPhase.SEED_GENERATION, "regen")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "running")
+    state.mark_blocked("run start failed: connection refused", tool_name="run_starter")
+    # Crucially: the run_starter site does NOT call
+    # record_authoring_backend, so the field must remain cleared.
+    assert state.last_authoring_backend is None
+
+
+def test_authoring_backend_propagates_to_pipeline_result(tmp_path) -> None:
+    """`AutoPipelineResult.last_authoring_backend` mirrors the recorded state field.
+
+    Drives the public ``_result`` constructor directly so the test
+    pins the response-boundary contract without booting the full
+    pipeline state machine.
+    """
+    from ouroboros.auto.ledger import SeedDraftLedger
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState
+
+    state = AutoPipelineState(goal="propagate", cwd=str(tmp_path))
+    state.runtime_backend = "codex"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("interview.start timed out", tool_name="interview.start")
+    record_authoring_backend(state)
+    assert state.last_authoring_backend == "in-process (codex)"
+
+    pipeline = AutoPipeline(
+        interview_driver=None,  # type: ignore[arg-type]
+        seed_generator=None,  # type: ignore[arg-type]
+    )
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    result = pipeline._result(state, ledger)
+
+    assert result.last_authoring_backend == "in-process (codex)"
+
+
+def test_authoring_backend_pipeline_result_is_none_for_non_authoring_blocker(tmp_path) -> None:
+    """When the failure is non-authoring, the result surface reports None.
+
+    Pins that ``AutoPipelineResult.last_authoring_backend`` faithfully
+    mirrors the cleared state field so consumers can rely on it as a
+    truthful "did the authoring backend cause this?" signal.
+    """
+    from ouroboros.auto.ledger import SeedDraftLedger
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState
+
+    state = AutoPipelineState(goal="propagate", cwd=str(tmp_path))
+    state.runtime_backend = "codex"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "regen")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "running")
+    state.mark_blocked("run start failed: connection refused", tool_name="run_starter")
+
+    pipeline = AutoPipeline(
+        interview_driver=None,  # type: ignore[arg-type]
+        seed_generator=None,  # type: ignore[arg-type]
+    )
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    result = pipeline._result(state, ledger)
+
+    assert result.last_authoring_backend is None
+
+
 def test_legacy_persisted_state_loads_with_default_attribution(tmp_path) -> None:
     """Older auto sessions saved before this field exists must still load."""
     import json

--- a/tests/unit/auto/test_blocker_attribution.py
+++ b/tests/unit/auto/test_blocker_attribution.py
@@ -1,0 +1,67 @@
+"""Tests for the auto-pipeline blocker attribution helper (#690)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.blocker_attribution import authoring_backend_label, label_blocker
+from ouroboros.auto.state import AutoPipelineState
+
+
+def _state(runtime: str | None, opencode_mode: str | None = None) -> AutoPipelineState:
+    state = AutoPipelineState(goal="goal", cwd="/tmp")
+    state.runtime_backend = runtime
+    state.opencode_mode = opencode_mode
+    return state
+
+
+@pytest.mark.parametrize(
+    "runtime,mode,expected",
+    [
+        ("claude", None, "in-process (claude)"),
+        ("codex", None, "in-process (codex)"),
+        ("hermes", None, "in-process (hermes)"),
+        ("gemini", None, "in-process (gemini)"),
+        ("kiro", None, "in-process (kiro)"),
+        ("opencode", "subprocess", "in-process (opencode)"),
+        ("opencode", None, "in-process (opencode)"),
+        ("opencode", "", "in-process (opencode)"),
+        (None, None, "in-process (unspecified)"),
+        ("opencode", "plugin", "dispatched (opencode bridge plugin)"),
+        ("opencode_cli", "plugin", "dispatched (opencode bridge plugin)"),
+        ("OpenCode", "PLUGIN", "dispatched (opencode bridge plugin)"),
+    ],
+)
+def test_authoring_backend_label_truth_table(
+    runtime: str | None, mode: str | None, expected: str
+) -> None:
+    assert authoring_backend_label(_state(runtime, mode)) == expected
+
+
+def test_label_blocker_appends_phase_and_backend() -> None:
+    state = _state("codex")
+    out = label_blocker(state, "interview.start timed out after 60s", phase="interview.start")
+    assert out == (
+        "interview.start timed out after 60s "
+        "[phase=interview.start, authoring_backend=in-process (codex)]"
+    )
+
+
+def test_label_blocker_is_idempotent() -> None:
+    state = _state("codex")
+    once = label_blocker(state, "boom", phase="interview.start")
+    twice = label_blocker(state, once, phase="interview.start")
+    assert once == twice
+
+
+def test_label_blocker_handles_none_message() -> None:
+    state = _state("codex")
+    out = label_blocker(state, None, phase="seed_generator")
+    assert out.startswith(" [phase=seed_generator")
+    assert "in-process (codex)" in out
+
+
+def test_label_blocker_marks_dispatched_for_opencode_plugin() -> None:
+    state = _state("opencode", "plugin")
+    out = label_blocker(state, "interview.start timed out", phase="interview.start")
+    assert "dispatched (opencode bridge plugin)" in out

--- a/tests/unit/auto/test_blocker_attribution.py
+++ b/tests/unit/auto/test_blocker_attribution.py
@@ -1,10 +1,13 @@
-"""Tests for the auto-pipeline blocker attribution helper (#690)."""
+"""Tests for the auto-pipeline authoring-backend attribution module (#690)."""
 
 from __future__ import annotations
 
 import pytest
 
-from ouroboros.auto.blocker_attribution import authoring_backend_label, label_blocker
+from ouroboros.auto.blocker_attribution import (
+    authoring_backend_label,
+    record_authoring_backend,
+)
 from ouroboros.auto.state import AutoPipelineState
 
 
@@ -42,39 +45,73 @@ def test_authoring_backend_label_truth_table(
     assert authoring_backend_label(_state(runtime, mode)) == expected
 
 
-def test_label_blocker_appends_phase_and_backend() -> None:
+def test_record_authoring_backend_persists_label_on_state() -> None:
+    """Helper writes the resolved backend label onto the state field."""
     state = _state("codex")
-    out = label_blocker(state, "interview.start timed out after 60s", phase="interview.start")
-    assert out == (
-        "interview.start timed out after 60s "
-        "[phase=interview.start, authoring_backend=in-process (codex)]"
-    )
+    assert state.last_authoring_backend is None
+
+    record_authoring_backend(state)
+
+    assert state.last_authoring_backend == "in-process (codex)"
 
 
-def test_label_blocker_is_idempotent() -> None:
+def test_record_authoring_backend_does_not_touch_other_fields() -> None:
+    """Helper only sets last_authoring_backend — never the message text."""
     state = _state("codex")
-    once = label_blocker(state, "boom", phase="interview.start")
-    twice = label_blocker(state, once, phase="interview.start")
-    assert once == twice
+    state.last_error = "interview.start timed out after 60s for auto_xxx"
+    state.last_tool_name = "interview.start"
+
+    record_authoring_backend(state)
+
+    assert state.last_error == "interview.start timed out after 60s for auto_xxx"
+    assert state.last_tool_name == "interview.start"
+    assert state.last_authoring_backend == "in-process (codex)"
 
 
-def test_label_blocker_handles_none_message() -> None:
-    state = _state("codex")
-    out = label_blocker(state, None, phase="seed_generator")
-    assert out.startswith(" [phase=seed_generator")
-    assert "in-process (codex)" in out
-
-
-def test_label_blocker_reports_in_process_even_for_persisted_opencode_plugin() -> None:
-    """Persisted plugin in state must still print in-process for the auto label.
+def test_record_authoring_backend_marks_persisted_opencode_plugin_as_in_process() -> None:
+    """Persisted plugin in state must still record in-process for authoring.
 
     Regression guard for #690 review feedback: both auto entry points
-    demote plugin → subprocess for authoring handlers, so the blocker
-    suffix must reflect the effective handler config (in-process), not
-    the raw persisted opencode_mode. Otherwise the very incidents this
-    suffix is meant to diagnose would carry a wrong attribution.
+    demote plugin → subprocess for authoring handlers, so the recorded
+    metadata must reflect the effective handler config (in-process),
+    not the raw persisted opencode_mode.
     """
     state = _state("opencode", "plugin")
-    out = label_blocker(state, "interview.start timed out", phase="interview.start")
-    assert "in-process (opencode)" in out
-    assert "dispatched" not in out
+    record_authoring_backend(state)
+    assert state.last_authoring_backend == "in-process (opencode)"
+    assert "dispatched" not in state.last_authoring_backend
+
+
+def test_authoring_backend_state_field_round_trips_through_persistence(tmp_path) -> None:
+    """The new metadata field survives ``AutoStore`` save/load."""
+    from ouroboros.auto.state import AutoStore
+
+    state = AutoPipelineState(goal="round trip", cwd=str(tmp_path))
+    state.runtime_backend = "codex"
+    record_authoring_backend(state)
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded.last_authoring_backend == "in-process (codex)"
+
+
+def test_legacy_persisted_state_loads_with_default_attribution(tmp_path) -> None:
+    """Older auto sessions saved before this field exists must still load."""
+    import json
+
+    from ouroboros.auto.state import AutoStore
+
+    state = AutoPipelineState(goal="legacy", cwd=str(tmp_path))
+    state.runtime_backend = "codex"
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    # Simulate an older persisted file by stripping the new field.
+    session_path = tmp_path / f"{state.auto_session_id}.json"
+    payload = json.loads(session_path.read_text())
+    payload.pop("last_authoring_backend", None)
+    session_path.write_text(json.dumps(payload))
+
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded.last_authoring_backend is None

--- a/tests/unit/auto/test_blocker_attribution.py
+++ b/tests/unit/auto/test_blocker_attribution.py
@@ -23,13 +23,17 @@ def _state(runtime: str | None, opencode_mode: str | None = None) -> AutoPipelin
         ("hermes", None, "in-process (hermes)"),
         ("gemini", None, "in-process (gemini)"),
         ("kiro", None, "in-process (kiro)"),
+        ("copilot", None, "in-process (copilot)"),
         ("opencode", "subprocess", "in-process (opencode)"),
         ("opencode", None, "in-process (opencode)"),
         ("opencode", "", "in-process (opencode)"),
         (None, None, "in-process (unspecified)"),
-        ("opencode", "plugin", "dispatched (opencode bridge plugin)"),
-        ("opencode_cli", "plugin", "dispatched (opencode bridge plugin)"),
-        ("OpenCode", "PLUGIN", "dispatched (opencode bridge plugin)"),
+        # Persisted plugin in state must still report in-process: both
+        # auto entry points demote plugin → subprocess for authoring
+        # handlers before constructing them, so the label must reflect
+        # the effective handler config, not the raw persisted mode.
+        ("opencode", "plugin", "in-process (opencode)"),
+        ("opencode_cli", "plugin", "in-process (opencode_cli)"),
     ],
 )
 def test_authoring_backend_label_truth_table(
@@ -61,7 +65,16 @@ def test_label_blocker_handles_none_message() -> None:
     assert "in-process (codex)" in out
 
 
-def test_label_blocker_marks_dispatched_for_opencode_plugin() -> None:
+def test_label_blocker_reports_in_process_even_for_persisted_opencode_plugin() -> None:
+    """Persisted plugin in state must still print in-process for the auto label.
+
+    Regression guard for #690 review feedback: both auto entry points
+    demote plugin → subprocess for authoring handlers, so the blocker
+    suffix must reflect the effective handler config (in-process), not
+    the raw persisted opencode_mode. Otherwise the very incidents this
+    suffix is meant to diagnose would carry a wrong attribution.
+    """
     state = _state("opencode", "plugin")
     out = label_blocker(state, "interview.start timed out", phase="interview.start")
-    assert "dispatched (opencode bridge plugin)" in out
+    assert "in-process (opencode)" in out
+    assert "dispatched" not in out


### PR DESCRIPTION
## Summary

Issue #690's reference incident showed `interview.start timed out
after 60s for auto_<id>` as the persisted blocker, with no signal that
the failure originated from the in-process authoring path rather than
from the runtime adapter behind \`--runtime <X>\`. The same opacity
applies to seed-generation timeouts.

This PR is the **blocker-attribution** scope of #690.

- Add \`auto/blocker_attribution.py::label_blocker(state, message,
  phase=...)\` that appends a \`[phase=<step>,
  authoring_backend=<resolved>]\` suffix to a blocker message exactly
  once. The backend label mirrors
  \`subagent.should_dispatch_via_plugin\` so the suffix cannot drift
  from the actual dispatch decision.
- Apply the helper at every authoring-side blocker in
  \`auto/interview_driver.py\` (interview.start, interview.answer,
  auto_answerer, max-rounds, completed-without-ready) and at the
  seed-generator timeout/failure path in \`auto/pipeline.py\`.
- Run-handoff blockers keep their existing \`run_handoff_status\`
  mechanism and are intentionally left untouched.

This change is intentionally limited to message attribution. Timeout
values, retry counts, and resume semantics belong to #686 and #688 and
are not modified here.

## Recommended landing order

Land **after** #686 (interview-timeout config wiring) and #688
(truthful resume semantics), so the timeout text those PRs introduce
is stable when this PR appends its suffix. The suffix is idempotent
(\`label_blocker\` is a no-op when \`[phase=\` already appears in the
message), so even if the order slips the blocker text will only ever
be stamped once.

## Note re: ouroboros-agent[bot] needs-info on #690

\`src/ouroboros/auto/interview_driver.py\` and
\`src/ouroboros/auto/pipeline.py\` exist on \`main\` (\`6dd84291\`);
this PR is written against that current state.

Closes #690 (partial: blocker-attribution scope only).

## Test plan

- [x] \`pytest tests/unit/auto/test_blocker_attribution.py\` — 16 passing
  (12 truth-table param + 4 helper behaviour).
- [x] \`pytest tests/unit/auto -q\` — 215 passing (interview-pipeline
  substring assertions still match because the suffix is appended).
- [x] \`pytest tests/unit/cli/test_auto_command.py\` — 8 passing
  (\`test_resume_raises_persisted_bound_when_cli_overrides_higher\` is
  pre-existing #686 territory).
- [x] \`ruff check\` on touched files — clean.