### PR TITLE
feat(auto): add gh-CLI provider adapter for merge gate (5/6 of #689)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ docs/code-surface-inventory.yaml
 docs/code-surface-lookup.yaml
 docs/cli-inventory.yaml
 
+

--- a/src/ouroboros/auto/gh_pr_provider.py
+++ b/src/ouroboros/auto/gh_pr_provider.py
@@ -212,11 +212,23 @@ def _coerce_ci_state(rollup: object) -> CIState:
     """Map gh's ``statusCheckRollup`` into a single coarse CI tier.
 
     Pessimistic merge: any failure dominates; a single pending check
-    keeps the rollup pending; only an entirely-success list (or no
-    checks at all) yields ``SUCCESS``.
+    keeps the rollup pending; only an entirely-success list yields
+    ``SUCCESS``.
+
+    Fail-closed shape handling:
+
+    - A non-list payload (the ``gh`` schema changed or returned ``null``)
+      maps to ``UNKNOWN`` so the gate cannot be silently passed by a
+      malformed response.
+    - An empty list is treated as ``SUCCESS`` because GitHub uses an
+      empty rollup to signal "no required checks defined".
+    - A list whose items are all non-dict (or otherwise unparseable)
+      maps to ``UNKNOWN`` rather than ``SUCCESS``.
     """
-    if not isinstance(rollup, list) or not rollup:
-        return CIState.SUCCESS  # No required checks defined → treat as clean.
+    if not isinstance(rollup, list):
+        return CIState.UNKNOWN
+    if not rollup:
+        return CIState.SUCCESS
     states: list[CIState] = []
     for item in rollup:
         if not isinstance(item, dict):
@@ -229,6 +241,10 @@ def _coerce_ci_state(rollup: object) -> CIState:
             states.append(CIState.UNKNOWN)
             continue
         states.append(_CI_STATE_MAP.get(raw.upper(), CIState.UNKNOWN))
+    if not states:
+        # The list contained items but none were parseable.  Treat this
+        # as a malformed payload, not as an empty rollup.
+        return CIState.UNKNOWN
     if any(state is CIState.FAILURE for state in states):
         return CIState.FAILURE
     if any(state is CIState.PENDING for state in states):
@@ -238,7 +254,30 @@ def _coerce_ci_state(rollup: object) -> CIState:
     return CIState.SUCCESS
 
 
-def _coerce_reviews(reviews: object) -> tuple[ReviewState, ...]:
+def _coerce_reviews(reviews: object, decision: object) -> tuple[ReviewState, ...]:
+    """Combine ``latestReviews`` with the aggregate ``reviewDecision``.
+
+    GitHub's ``reviewDecision`` is the authoritative aggregate that the
+    repository UI displays: an approver who later leaves a non-blocking
+    ``COMMENTED`` review keeps the PR's aggregate at ``APPROVED`` even
+    though the reviewer's *latest* review state changed.  The previous
+    implementation rebuilt approval state from ``latestReviews`` alone
+    and would block such PRs.
+
+    Rules (the gate then enforces "≥1 APPROVED and 0 CHANGES_REQUESTED"
+    on its own):
+
+    - ``decision == "APPROVED"`` → return a single synthetic
+      ``APPROVED`` so the gate sees the aggregate, ignoring noise from
+      ``COMMENTED`` reviews.
+    - ``decision == "CHANGES_REQUESTED"`` → use ``latestReviews`` so the
+      gate sees the actual blocking reviewers.
+    - ``decision in {"REVIEW_REQUIRED", None, ""}`` → use
+      ``latestReviews`` so the gate decides on raw reviewer state.
+    """
+    decision_text = (decision or "").upper() if isinstance(decision, str) else ""
+    if decision_text == "APPROVED":
+        return (ReviewState.APPROVED,)
     if not isinstance(reviews, list):
         return ()
     out: list[ReviewState] = []
@@ -256,10 +295,7 @@ def _coerce_reviews(reviews: object) -> tuple[ReviewState, ...]:
 
 def _coerce_permission(payload: dict[str, Any]) -> bool:
     """Treat ``push``/``maintain``/``admin`` as sufficient for merge."""
-    for key in ("admin", "maintain", "push"):
-        if bool(payload.get(key)):
-            return True
-    return False
+    return any(bool(payload.get(key)) for key in ("admin", "maintain", "push"))
 
 
 def _build_status(
@@ -284,7 +320,7 @@ def _build_status(
         head_sha=head_sha,
         mergeable=_coerce_mergeable(pr.get("mergeable"), pr.get("mergeStateStatus")),
         ci_state=_coerce_ci_state(pr.get("statusCheckRollup")),
-        review_states=_coerce_reviews(pr.get("latestReviews")),
+        review_states=_coerce_reviews(pr.get("latestReviews"), pr.get("reviewDecision")),
         has_write_permission=_coerce_permission(perm),
         is_draft=bool(pr.get("isDraft")),
     )

--- a/src/ouroboros/auto/gh_pr_provider.py
+++ b/src/ouroboros/auto/gh_pr_provider.py
@@ -1,0 +1,298 @@
+"""GitHub CLI adapter that produces ``PullRequestStatus`` for the gate.
+
+The merge-policy gate (PR-D) is a pure function over an observed
+``PullRequestStatus``.  This module is the only place where the auto
+pipeline talks to GitHub for that status, and it talks via the
+``gh`` CLI rather than a HTTP client because:
+
+- ``gh`` already handles authentication via the user's existing
+  credential store.
+- The CLI is what operators run interactively, so the auth surface is
+  identical between manual and automated invocations.
+- Tests can inject a fake ``CommandRunner`` instead of monkey-patching
+  ``subprocess`` or running an HTTP server.
+
+The adapter is **read-only**.  It never invokes a destructive ``gh
+pr merge`` or ``gh pr close``; the gate decides whether such an
+action is allowed and the actual mutation lives in PR-F's wiring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+import json
+import subprocess
+from typing import Any
+
+from ouroboros.auto.merge_policy import (
+    CIState,
+    PullRequestStatus,
+    ReviewState,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """Captured output of a ``gh`` CLI invocation.
+
+    Adapter consumers only need the parsed JSON or the captured stderr
+    on failure, so we keep the wrapper minimal.
+    """
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+CommandRunner = Callable[[Sequence[str]], CommandResult]
+
+
+def _default_runner(args: Sequence[str]) -> CommandResult:
+    """Run ``args`` synchronously with a short timeout.
+
+    A 30-second cap is generous for ``gh pr view`` and short enough to
+    fail loudly when the network or auth has melted.  No retries: a
+    transient failure should be visible to the operator who can re-run
+    the auto session.
+    """
+    completed = subprocess.run(  # noqa: S603 - args are already a list, no shell
+        list(args),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    return CommandResult(
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+_REVIEW_STATE_MAP: dict[str, ReviewState] = {
+    "APPROVED": ReviewState.APPROVED,
+    "CHANGES_REQUESTED": ReviewState.CHANGES_REQUESTED,
+    "COMMENTED": ReviewState.COMMENTED,
+    "PENDING": ReviewState.PENDING,
+}
+
+
+_CI_STATE_MAP: dict[str, CIState] = {
+    "SUCCESS": CIState.SUCCESS,
+    "PENDING": CIState.PENDING,
+    "FAILURE": CIState.FAILURE,
+    "ERROR": CIState.FAILURE,
+    "CANCELLED": CIState.FAILURE,
+    "TIMED_OUT": CIState.FAILURE,
+    "ACTION_REQUIRED": CIState.FAILURE,
+    "EXPECTED": CIState.PENDING,
+    "QUEUED": CIState.PENDING,
+    "IN_PROGRESS": CIState.PENDING,
+    "WAITING": CIState.PENDING,
+    "NEUTRAL": CIState.SUCCESS,
+    "SKIPPED": CIState.SUCCESS,
+    "STALE": CIState.PENDING,
+    "STARTUP_FAILURE": CIState.FAILURE,
+}
+
+
+_PR_FIELDS = (
+    "mergeable",
+    "mergeStateStatus",
+    "headRefOid",
+    "baseRefName",
+    "isDraft",
+    "reviewDecision",
+    "latestReviews",
+    "statusCheckRollup",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GhPrProvider:
+    """Read-only adapter that turns ``gh`` CLI output into gate input."""
+
+    runner: CommandRunner = _default_runner
+
+    def fetch_status(self, repo: str, number: int) -> PullRequestStatus:
+        """Return the gate-relevant facts for ``repo`` PR ``number``.
+
+        Raises ``GhProviderError`` when the CLI is unavailable, the
+        caller is not authenticated, or the response cannot be parsed.
+        Routine "missing data" cases (mergeability still computing, no
+        statuses reported yet) are encoded in the returned status, not
+        raised, so the gate can produce its own actionable block.
+        """
+        if not isinstance(repo, str) or repo.count("/") != 1:
+            msg = f"repo must be in the form owner/repo; got {repo!r}"
+            raise ValueError(msg)
+        if not isinstance(number, int) or number <= 0:
+            msg = f"PR number must be a positive integer; got {number!r}"
+            raise ValueError(msg)
+
+        pr_payload = self._gh_pr_view(repo, number)
+        permission_payload = self._gh_repo_permission(repo)
+
+        return _build_status(repo=repo, number=number, pr=pr_payload, perm=permission_payload)
+
+    def _gh_pr_view(self, repo: str, number: int) -> dict[str, Any]:
+        result = self.runner(
+            (
+                "gh",
+                "pr",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                ",".join(_PR_FIELDS),
+            )
+        )
+        if result.returncode != 0:
+            msg = (
+                f"gh pr view failed for {repo}#{number}: "
+                f"{result.stderr.strip() or 'no stderr output'}"
+            )
+            raise GhProviderError(msg)
+        return _parse_json(result.stdout, context=f"gh pr view {repo}#{number}")
+
+    def _gh_repo_permission(self, repo: str) -> dict[str, Any]:
+        result = self.runner(("gh", "api", f"repos/{repo}", "--jq", ".permissions"))
+        if result.returncode != 0:
+            msg = (
+                f"gh api repos/{repo} (permissions) failed: "
+                f"{result.stderr.strip() or 'no stderr output'}"
+            )
+            raise GhProviderError(msg)
+        # ``--jq .permissions`` may emit ``null`` if the user has no
+        # explicit permissions block; default to denying write so the
+        # gate fails closed without a noisy error.
+        text = result.stdout.strip()
+        if not text or text == "null":
+            return {}
+        return _parse_json(text, context=f"gh api repos/{repo} permissions")
+
+
+class GhProviderError(RuntimeError):
+    """Raised when the ``gh`` CLI cannot produce a usable status payload."""
+
+
+def _parse_json(text: str, *, context: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        msg = f"{context} returned non-JSON output: {exc}"
+        raise GhProviderError(msg) from exc
+    if not isinstance(payload, dict):
+        msg = f"{context} returned a non-object payload: {type(payload).__name__}"
+        raise GhProviderError(msg)
+    return payload
+
+
+def _coerce_mergeable(mergeable_field: object, merge_state: object) -> bool | None:
+    """Normalize gh's mergeable field into a tri-state bool.
+
+    ``mergeable`` from gh is either ``"MERGEABLE"``, ``"CONFLICTING"`` or
+    ``"UNKNOWN"``.  ``mergeStateStatus`` adds ``"BLOCKED"`` (rules block
+    merge), ``"BEHIND"`` (needs rebase) which both mean "not mergeable
+    right now".  Anything we cannot map reliably is reported as ``None``
+    so the gate produces a "wait and re-run" block.
+    """
+    mergeable_text = str(mergeable_field or "").upper()
+    state_text = str(merge_state or "").upper()
+    if mergeable_text == "MERGEABLE" and state_text in {"CLEAN", "UNSTABLE", "HAS_HOOKS"}:
+        return True
+    if mergeable_text == "CONFLICTING" or state_text in {"DIRTY", "BLOCKED", "BEHIND"}:
+        return False
+    return None
+
+
+def _coerce_ci_state(rollup: object) -> CIState:
+    """Map gh's ``statusCheckRollup`` into a single coarse CI tier.
+
+    Pessimistic merge: any failure dominates; a single pending check
+    keeps the rollup pending; only an entirely-success list (or no
+    checks at all) yields ``SUCCESS``.
+    """
+    if not isinstance(rollup, list) or not rollup:
+        return CIState.SUCCESS  # No required checks defined → treat as clean.
+    states: list[CIState] = []
+    for item in rollup:
+        if not isinstance(item, dict):
+            continue
+        # ``state`` is set for status contexts; ``conclusion`` is set
+        # for completed check runs; ``status`` is "QUEUED"/"IN_PROGRESS"
+        # for in-flight check runs.  Take the most informative value.
+        raw = item.get("conclusion") or item.get("state") or item.get("status")
+        if not isinstance(raw, str) or not raw:
+            states.append(CIState.UNKNOWN)
+            continue
+        states.append(_CI_STATE_MAP.get(raw.upper(), CIState.UNKNOWN))
+    if any(state is CIState.FAILURE for state in states):
+        return CIState.FAILURE
+    if any(state is CIState.PENDING for state in states):
+        return CIState.PENDING
+    if any(state is CIState.UNKNOWN for state in states):
+        return CIState.UNKNOWN
+    return CIState.SUCCESS
+
+
+def _coerce_reviews(reviews: object) -> tuple[ReviewState, ...]:
+    if not isinstance(reviews, list):
+        return ()
+    out: list[ReviewState] = []
+    for item in reviews:
+        if not isinstance(item, dict):
+            continue
+        raw = item.get("state")
+        if not isinstance(raw, str):
+            continue
+        mapped = _REVIEW_STATE_MAP.get(raw.upper())
+        if mapped is not None:
+            out.append(mapped)
+    return tuple(out)
+
+
+def _coerce_permission(payload: dict[str, Any]) -> bool:
+    """Treat ``push``/``maintain``/``admin`` as sufficient for merge."""
+    for key in ("admin", "maintain", "push"):
+        if bool(payload.get(key)):
+            return True
+    return False
+
+
+def _build_status(
+    *,
+    repo: str,
+    number: int,
+    pr: dict[str, Any],
+    perm: dict[str, Any],
+) -> PullRequestStatus:
+    target_branch = pr.get("baseRefName")
+    head_sha = pr.get("headRefOid")
+    if not isinstance(target_branch, str) or not target_branch.strip():
+        msg = f"gh pr view payload missing baseRefName for {repo}#{number}"
+        raise GhProviderError(msg)
+    if not isinstance(head_sha, str) or not head_sha.strip():
+        msg = f"gh pr view payload missing headRefOid for {repo}#{number}"
+        raise GhProviderError(msg)
+    return PullRequestStatus(
+        repo=repo,
+        number=number,
+        target_branch=target_branch,
+        head_sha=head_sha,
+        mergeable=_coerce_mergeable(pr.get("mergeable"), pr.get("mergeStateStatus")),
+        ci_state=_coerce_ci_state(pr.get("statusCheckRollup")),
+        review_states=_coerce_reviews(pr.get("latestReviews")),
+        has_write_permission=_coerce_permission(perm),
+        is_draft=bool(pr.get("isDraft")),
+    )
+
+
+__all__ = [
+    "CommandResult",
+    "CommandRunner",
+    "GhPrProvider",
+    "GhProviderError",
+]

--- a/src/ouroboros/auto/goal_classifier.py
+++ b/src/ouroboros/auto/goal_classifier.py
@@ -30,6 +30,19 @@ class SideEffectRisk(StrEnum):
     HIGH = "high"
 
 
+class _AnchorRequirement(StrEnum):
+    """Which anchor type a verb is meaningful against.
+
+    PR mutations (merge, rebase, close, …) are only well defined against
+    a Pull Request URL: an Issue URL describing a related bug is *not*
+    a sufficient anchor for those verbs even though the URL parses.
+    Read-only verbs (review, analyze, summarize) work with either anchor.
+    """
+
+    PR_ONLY = "pr_only"
+    ANY = "any"
+
+
 _RISK_RANK: dict[SideEffectRisk, int] = {
     SideEffectRisk.NONE: 0,
     SideEffectRisk.LOW: 1,
@@ -94,7 +107,10 @@ class GoalClassification:
         """Deserialize from a JSON-compatible dictionary.
 
         Rejects malformed records eagerly so persisted state cannot smuggle
-        unexpected types past the auto pipeline.
+        unexpected types past the auto pipeline.  In particular, the
+        invariant ``interview_required != direct_run_allowed`` is enforced
+        here: contradictory records (both True or both False) are
+        rejected so downstream routing code can safely read either flag.
         """
         if not isinstance(data, dict):
             msg = "goal classification must be an object"
@@ -108,10 +124,7 @@ class GoalClassification:
         }
         missing = sorted(required - data.keys())
         if missing:
-            msg = (
-                "goal classification is missing required fields: "
-                f"{', '.join(missing)}"
-            )
+            msg = "goal classification is missing required fields: " + ", ".join(missing)
             raise ValueError(msg)
         for bool_field in (
             "interview_required",
@@ -139,6 +152,12 @@ class GoalClassification:
             isinstance(item, str) for item in signals_raw
         ):
             msg = "goal classification matched_signals must be a list of strings"
+            raise ValueError(msg)
+        if data["interview_required"] == data["direct_run_allowed"]:
+            msg = (
+                "goal classification interview_required and direct_run_allowed "
+                "must be opposite booleans; refused contradictory record"
+            )
             raise ValueError(msg)
         if data["requires_confirmation"] is False and risk is SideEffectRisk.HIGH:
             msg = (
@@ -176,33 +195,45 @@ _GITHUB_ISSUE_URL = re.compile(
 )
 
 
-# Operational verbs map to a risk tier.  English and Korean variants are
-# both included because ``ooo auto`` is invoked from Korean shells in the
-# observed incident (auto_78c98678de5d).
-_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk], ...] = (
-    # High-risk: destructive or hard-to-reverse mutations.
-    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH),
-    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH),
+# Operational verbs map to a risk tier and an anchor requirement.  PR-only
+# verbs need an unambiguous PR URL; an Issue URL alone is *not* a valid
+# anchor for them.  Read-only verbs (``ANY``) work with either anchor.
+# English and Korean variants are both included because ``ooo auto`` is
+# invoked from Korean shells in the observed incident (auto_78c98678de5d).
+_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk, _AnchorRequirement], ...] = (
+    # High-risk: destructive or hard-to-reverse mutations.  All PR-only.
+    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (
+        re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE),
+        SideEffectRisk.HIGH,
+        _AnchorRequirement.PR_ONLY,
+    ),
+    (
+        re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE),
+        SideEffectRisk.HIGH,
+        _AnchorRequirement.PR_ONLY,
+    ),
+    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH, _AnchorRequirement.PR_ONLY),
     # Medium-risk: writes to the PR but reversible (closing a PR can be
     # reopened; rebasing rewrites history that has not yet been merged).
-    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM),
-    # Low-risk: read-only or comment-only operations.
-    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW),
-    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    # All require a PR anchor; an Issue URL is the wrong target type.
+    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM, _AnchorRequirement.PR_ONLY),
+    # Low-risk: read-only or comment-only operations.  Allowed against
+    # either an Issue URL ("review #42 design") or a PR URL.
+    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
+    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW, _AnchorRequirement.ANY),
 )
 
 
@@ -238,22 +269,28 @@ def classify_goal(goal: str) -> GoalClassification:
         )
 
     signals: list[str] = []
-    pr_match = _GITHUB_PR_URL.search(text)
-    issue_match = _GITHUB_ISSUE_URL.search(text)
+    pr_matches = list(_GITHUB_PR_URL.finditer(text))
+    issue_matches = list(_GITHUB_ISSUE_URL.finditer(text))
     pr_list_match = _GITHUB_PR_LIST_URL.search(text)
-    if pr_match:
-        signals.append(f"pr_url:{pr_match.group(0)}")
-    if issue_match:
-        signals.append(f"issue_url:{issue_match.group(0)}")
-    if pr_list_match and not pr_match:
+    for match in pr_matches:
+        signals.append(f"pr_url:{match.group(0)}")
+    for match in issue_matches:
+        signals.append(f"issue_url:{match.group(0)}")
+    if pr_list_match and not pr_matches:
         signals.append(f"pr_list_url:{pr_list_match.group(0)}")
 
     verb_risk = SideEffectRisk.NONE
-    for pattern, risk in _OPERATIONAL_VERBS:
+    requires_pr_anchor = False
+    has_read_only_verb = False
+    for pattern, risk, anchor_req in _OPERATIONAL_VERBS:
         match = pattern.search(text)
         if match:
             signals.append(f"verb:{match.group(0).lower()}={risk.value}")
             verb_risk = _max_risk(verb_risk, risk)
+            if anchor_req is _AnchorRequirement.PR_ONLY:
+                requires_pr_anchor = True
+            else:
+                has_read_only_verb = True
 
     ambiguous_signals: list[str] = []
     for pattern in _AMBIGUOUS_INTENT:
@@ -261,7 +298,9 @@ def classify_goal(goal: str) -> GoalClassification:
         if match:
             ambiguous_signals.append(f"ambiguous:{match.group(0).lower()}")
 
-    has_concrete_anchor = bool(pr_match or issue_match)
+    has_pr_anchor = bool(pr_matches)
+    has_issue_anchor = bool(issue_matches)
+    has_concrete_anchor = has_pr_anchor or has_issue_anchor
     has_operational_verb = verb_risk is not SideEffectRisk.NONE
 
     if ambiguous_signals:
@@ -277,16 +316,43 @@ def classify_goal(goal: str) -> GoalClassification:
             matched_signals=tuple(signals),
         )
 
+    # Multiple PR or issue URLs make the mutation target ambiguous even
+    # when one verb is present.  "compare PR/1 and PR/2 then merge the
+    # better one" must not silently route to the wrong PR.
+    if len(pr_matches) > 1 or len(issue_matches) > 1:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="goal references multiple PR/issue URLs; mutation target is ambiguous",
+            matched_signals=tuple(signals),
+        )
+
+    # PR-only verbs paired with only an Issue URL would target the wrong
+    # artifact type ("merge issue #42").  Force interview.
+    if requires_pr_anchor and not has_pr_anchor:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason=(
+                "operational verb requires a PR URL anchor; goal has only an issue URL "
+                "or no PR anchor"
+            ),
+            matched_signals=tuple(signals),
+        )
+
     if has_concrete_anchor and has_operational_verb:
+        # Single PR or single issue URL paired with a verb whose anchor
+        # requirement is satisfied above.
         return GoalClassification(
             interview_required=False,
             direct_run_allowed=True,
             side_effect_risk=verb_risk,
             requires_confirmation=verb_risk is SideEffectRisk.HIGH,
-            reason=(
-                "concrete PR/issue URL paired with operational verb "
-                f"({verb_risk.value} risk)"
-            ),
+            reason=(f"concrete PR/issue URL paired with operational verb ({verb_risk.value} risk)"),
             matched_signals=tuple(signals),
         )
 
@@ -294,7 +360,7 @@ def classify_goal(goal: str) -> GoalClassification:
         # ``/pulls`` is a list page, not a single PR.  Allow direct path
         # only if the verb is read-only (review, analyze).  Anything that
         # mutates needs the interview to narrow the target.
-        if verb_risk in {SideEffectRisk.LOW, SideEffectRisk.NONE}:
+        if not requires_pr_anchor and has_read_only_verb:
             return GoalClassification(
                 interview_required=False,
                 direct_run_allowed=True,

--- a/src/ouroboros/auto/goal_classifier.py
+++ b/src/ouroboros/auto/goal_classifier.py
@@ -1,0 +1,345 @@
+"""Deterministic classifier for auto-mode goal strings.
+
+Most ``ooo auto`` goals are exploratory ideas that benefit from a Socratic
+interview before Seed generation.  A growing class of goals, however, are
+*operational*: they target an existing artifact (a PR or issue URL) and ask
+for a concrete action (merge, review, fix, close, rebase).  For those goals
+the interview adds only latency and surface area for ``interview.start``
+timeouts (#686, #689).
+
+This module is a pure function that turns a free-form goal string into a
+``GoalClassification``.  It performs no IO, network calls, or model
+invocations and therefore cannot itself stall the auto pipeline.  Callers
+decide whether to act on the classification (PR-C wires routing); landing
+this module changes no observable behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import re
+
+
+class SideEffectRisk(StrEnum):
+    """Coarse risk tier for the action implied by an operational goal."""
+
+    NONE = "none"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+_RISK_RANK: dict[SideEffectRisk, int] = {
+    SideEffectRisk.NONE: 0,
+    SideEffectRisk.LOW: 1,
+    SideEffectRisk.MEDIUM: 2,
+    SideEffectRisk.HIGH: 3,
+}
+
+
+def _max_risk(*risks: SideEffectRisk) -> SideEffectRisk:
+    return max(risks, key=lambda r: _RISK_RANK[r])
+
+
+@dataclass(frozen=True, slots=True)
+class GoalClassification:
+    """Structured summary of a free-form auto goal string.
+
+    Attributes:
+        interview_required: True when the goal lacks enough concrete anchor
+            (a PR/issue URL plus an operational verb) to skip the Socratic
+            interview safely.
+        direct_run_allowed: True when the auto pipeline may bypass the
+            interview phase and hand off directly to a bounded operational
+            run.  Mutually opposite of ``interview_required`` in the
+            current schema, but kept as a separate field so future
+            classifiers can add states (for example "interview optional")
+            without breaking serialized records.
+        side_effect_risk: Coarse risk tier of the implied action.  ``high``
+            covers destructive or hard-to-reverse operations (merge, push
+            --force, branch deletion).  Always pessimistic: only lowered
+            when no risky verb is present.
+        requires_confirmation: True when the implied action is irreversible
+            enough that the auto pipeline must obtain explicit confirmation
+            (policy gate, CI status, reviewer approval) before performing
+            it.  Always True when ``side_effect_risk`` is ``high``.
+        reason: Short human-readable string explaining the verdict.  Stored
+            in the ledger and surfaced in CLI output.
+        matched_signals: Snippets that influenced the verdict, in
+            discovery order.  Used both for debug output and for tests
+            asserting that a particular pattern triggered.
+    """
+
+    interview_required: bool
+    direct_run_allowed: bool
+    side_effect_risk: SideEffectRisk
+    requires_confirmation: bool
+    reason: str
+    matched_signals: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "interview_required": self.interview_required,
+            "direct_run_allowed": self.direct_run_allowed,
+            "side_effect_risk": self.side_effect_risk.value,
+            "requires_confirmation": self.requires_confirmation,
+            "reason": self.reason,
+            "matched_signals": list(self.matched_signals),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> GoalClassification:
+        """Deserialize from a JSON-compatible dictionary.
+
+        Rejects malformed records eagerly so persisted state cannot smuggle
+        unexpected types past the auto pipeline.
+        """
+        if not isinstance(data, dict):
+            msg = "goal classification must be an object"
+            raise ValueError(msg)
+        required = {
+            "interview_required",
+            "direct_run_allowed",
+            "side_effect_risk",
+            "requires_confirmation",
+            "reason",
+        }
+        missing = sorted(required - data.keys())
+        if missing:
+            msg = (
+                "goal classification is missing required fields: "
+                f"{', '.join(missing)}"
+            )
+            raise ValueError(msg)
+        for bool_field in (
+            "interview_required",
+            "direct_run_allowed",
+            "requires_confirmation",
+        ):
+            if not isinstance(data[bool_field], bool):
+                msg = f"goal classification {bool_field} must be a boolean"
+                raise ValueError(msg)
+        risk_raw = data["side_effect_risk"]
+        if not isinstance(risk_raw, str):
+            msg = "goal classification side_effect_risk must be a string"
+            raise ValueError(msg)
+        try:
+            risk = SideEffectRisk(risk_raw)
+        except ValueError as exc:
+            msg = f"goal classification side_effect_risk is unknown: {risk_raw}"
+            raise ValueError(msg) from exc
+        reason = data["reason"]
+        if not isinstance(reason, str) or not reason.strip():
+            msg = "goal classification reason must be a non-empty string"
+            raise ValueError(msg)
+        signals_raw = data.get("matched_signals", [])
+        if not isinstance(signals_raw, list) or not all(
+            isinstance(item, str) for item in signals_raw
+        ):
+            msg = "goal classification matched_signals must be a list of strings"
+            raise ValueError(msg)
+        if data["requires_confirmation"] is False and risk is SideEffectRisk.HIGH:
+            msg = (
+                "goal classification requires_confirmation must be True when "
+                "side_effect_risk is high"
+            )
+            raise ValueError(msg)
+        return cls(
+            interview_required=data["interview_required"],
+            direct_run_allowed=data["direct_run_allowed"],
+            side_effect_risk=risk,
+            requires_confirmation=data["requires_confirmation"],
+            reason=reason,
+            matched_signals=tuple(signals_raw),
+        )
+
+
+# A GitHub PR URL can take either of two shapes:
+#   https://github.com/<owner>/<repo>/pull/<number>
+#   https://github.com/<owner>/<repo>/pulls            (list page)
+# Both are sufficient anchors for an operational goal, but ``/pulls`` is
+# always treated as ambiguous merge target — the user must still narrow
+# the action through interview unless paired with an explicit verb.
+_GITHUB_PR_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pull/(?P<number>\d+)\b",
+    re.IGNORECASE,
+)
+_GITHUB_PR_LIST_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pulls\b",
+    re.IGNORECASE,
+)
+_GITHUB_ISSUE_URL = re.compile(
+    r"https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/issues/(?P<number>\d+)\b",
+    re.IGNORECASE,
+)
+
+
+# Operational verbs map to a risk tier.  English and Korean variants are
+# both included because ``ooo auto`` is invoked from Korean shells in the
+# observed incident (auto_78c98678de5d).
+_OPERATIONAL_VERBS: tuple[tuple[re.Pattern[str], SideEffectRisk], ...] = (
+    # High-risk: destructive or hard-to-reverse mutations.
+    (re.compile(r"\bmerge\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bsquash\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bforce[-\s]?push\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"\bdelete[\s-]+branch\b", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"머지", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"머지\s*가능", re.IGNORECASE), SideEffectRisk.HIGH),
+    (re.compile(r"merge 가능", re.IGNORECASE), SideEffectRisk.HIGH),
+    # Medium-risk: writes to the PR but reversible (closing a PR can be
+    # reopened; rebasing rewrites history that has not yet been merged).
+    (re.compile(r"\bclose\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\breopen\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\brebase\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"\bfix\b", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    (re.compile(r"수정", re.IGNORECASE), SideEffectRisk.MEDIUM),
+    # Low-risk: read-only or comment-only operations.
+    (re.compile(r"\breview\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\bcomment\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\banalyz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"\bsummariz[ei]\b", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"리뷰", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"분석", re.IGNORECASE), SideEffectRisk.LOW),
+    (re.compile(r"개선", re.IGNORECASE), SideEffectRisk.MEDIUM),
+)
+
+
+# Verbs/patterns that indicate the goal is *not* yet operational and an
+# interview should still run, even if a URL was mentioned for context.
+_AMBIGUOUS_INTENT = (
+    re.compile(r"\b(plan|design|brainstorm|investigate|explore)\b", re.IGNORECASE),
+    re.compile(r"\b(어떻게|어떨까|고민)\b", re.IGNORECASE),
+)
+
+
+def classify_goal(goal: str) -> GoalClassification:
+    """Classify a free-form ``ooo auto`` goal string.
+
+    The classifier is deterministic: same input → same verdict.  It does
+    not consult external state, environment, repository facts, or
+    backends.  Callers needing repository state (CI status, mergeability)
+    should fetch it separately and feed the policy gate (PR-D), keeping
+    classification cheap and side-effect free.
+    """
+    if not isinstance(goal, str):
+        msg = f"goal must be a string, got {type(goal).__name__}"
+        raise TypeError(msg)
+    text = goal.strip()
+    if not text:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=SideEffectRisk.NONE,
+            requires_confirmation=False,
+            reason="empty goal",
+            matched_signals=(),
+        )
+
+    signals: list[str] = []
+    pr_match = _GITHUB_PR_URL.search(text)
+    issue_match = _GITHUB_ISSUE_URL.search(text)
+    pr_list_match = _GITHUB_PR_LIST_URL.search(text)
+    if pr_match:
+        signals.append(f"pr_url:{pr_match.group(0)}")
+    if issue_match:
+        signals.append(f"issue_url:{issue_match.group(0)}")
+    if pr_list_match and not pr_match:
+        signals.append(f"pr_list_url:{pr_list_match.group(0)}")
+
+    verb_risk = SideEffectRisk.NONE
+    for pattern, risk in _OPERATIONAL_VERBS:
+        match = pattern.search(text)
+        if match:
+            signals.append(f"verb:{match.group(0).lower()}={risk.value}")
+            verb_risk = _max_risk(verb_risk, risk)
+
+    ambiguous_signals: list[str] = []
+    for pattern in _AMBIGUOUS_INTENT:
+        match = pattern.search(text)
+        if match:
+            ambiguous_signals.append(f"ambiguous:{match.group(0).lower()}")
+
+    has_concrete_anchor = bool(pr_match or issue_match)
+    has_operational_verb = verb_risk is not SideEffectRisk.NONE
+
+    if ambiguous_signals:
+        # Even if an operational verb is present, an ambiguous intent
+        # ("plan how we should fix this") needs interview clarity.
+        signals.extend(ambiguous_signals)
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="goal mixes operational verb with ambiguous planning intent",
+            matched_signals=tuple(signals),
+        )
+
+    if has_concrete_anchor and has_operational_verb:
+        return GoalClassification(
+            interview_required=False,
+            direct_run_allowed=True,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason=(
+                "concrete PR/issue URL paired with operational verb "
+                f"({verb_risk.value} risk)"
+            ),
+            matched_signals=tuple(signals),
+        )
+
+    if pr_list_match and has_operational_verb:
+        # ``/pulls`` is a list page, not a single PR.  Allow direct path
+        # only if the verb is read-only (review, analyze).  Anything that
+        # mutates needs the interview to narrow the target.
+        if verb_risk in {SideEffectRisk.LOW, SideEffectRisk.NONE}:
+            return GoalClassification(
+                interview_required=False,
+                direct_run_allowed=True,
+                side_effect_risk=verb_risk,
+                requires_confirmation=False,
+                reason="PR list URL with read-only verb permits direct review",
+                matched_signals=tuple(signals),
+            )
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="PR list URL needs interview to narrow target before mutating",
+            matched_signals=tuple(signals),
+        )
+
+    if has_concrete_anchor:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=SideEffectRisk.NONE,
+            requires_confirmation=False,
+            reason="PR/issue URL present but no operational verb",
+            matched_signals=tuple(signals),
+        )
+
+    if has_operational_verb:
+        return GoalClassification(
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=verb_risk,
+            requires_confirmation=verb_risk is SideEffectRisk.HIGH,
+            reason="operational verb present but no concrete PR/issue anchor",
+            matched_signals=tuple(signals),
+        )
+
+    return GoalClassification(
+        interview_required=True,
+        direct_run_allowed=False,
+        side_effect_risk=SideEffectRisk.NONE,
+        requires_confirmation=False,
+        reason="no operational signals detected",
+        matched_signals=tuple(signals),
+    )
+
+
+__all__ = ["GoalClassification", "SideEffectRisk", "classify_goal"]

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -360,9 +360,7 @@ class SeedDraftLedger:
             "sections": {name: section.to_dict() for name, section in self.sections.items()},
             "question_history": list(self.question_history),
             "direct_path_reason": self.direct_path_reason,
-            "merge_policy_decisions": [
-                dict(record) for record in self.merge_policy_decisions
-            ],
+            "merge_policy_decisions": [dict(record) for record in self.merge_policy_decisions],
         }
 
     @classmethod

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -170,6 +170,26 @@ class SeedDraftLedger:
     # ``None`` for legacy ledgers and for sessions that took the
     # interview-first route.
     direct_path_reason: str | None = None
+    # Audit log of merge-policy gate decisions (#689 PR-D).  Each entry
+    # is a JSON-shaped record produced by
+    # ``ouroboros.auto.merge_policy.record_decision_on_ledger``.  Empty
+    # for legacy ledgers and for sessions that never invoked the gate.
+    merge_policy_decisions: list[dict[str, Any]] = field(default_factory=list)
+
+    def record_merge_policy_decision(self, record: dict[str, Any]) -> None:
+        """Append a merge-policy decision record to the ledger.
+
+        The record is opaque to the ledger but must be a dict so the
+        whole ledger remains JSON-serializable.  Validation is
+        intentionally minimal here: the merge_policy module owns the
+        payload shape.
+        """
+        if not isinstance(record, dict):
+            msg = "merge policy decision record must be a dict"
+            raise ValueError(msg)
+        # Defensive deep-ish copy of top-level keys so callers cannot
+        # accidentally mutate stored audit data after the fact.
+        self.merge_policy_decisions.append(dict(record))
 
     def record_direct_path_reason(self, reason: str) -> None:
         """Persist why the auto pipeline skipped interview for this session.
@@ -340,6 +360,9 @@ class SeedDraftLedger:
             "sections": {name: section.to_dict() for name, section in self.sections.items()},
             "question_history": list(self.question_history),
             "direct_path_reason": self.direct_path_reason,
+            "merge_policy_decisions": [
+                dict(record) for record in self.merge_policy_decisions
+            ],
         }
 
     @classmethod
@@ -384,10 +407,18 @@ class SeedDraftLedger:
                 msg = "ledger direct_path_reason must be a non-empty string or null"
                 raise ValueError(msg)
 
+        merge_policy_decisions_raw = data.get("merge_policy_decisions", [])
+        if not isinstance(merge_policy_decisions_raw, list) or not all(
+            isinstance(item, dict) for item in merge_policy_decisions_raw
+        ):
+            msg = "ledger merge_policy_decisions must be a list of objects"
+            raise ValueError(msg)
+
         ledger = cls(
             sections=sections,
             question_history=[dict(item) for item in question_history],
             direct_path_reason=direct_path_reason,
+            merge_policy_decisions=[dict(record) for record in merge_policy_decisions_raw],
         )
         for required in REQUIRED_SECTIONS:
             ledger.sections.setdefault(required, LedgerSection(required))

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -165,6 +165,25 @@ class SeedDraftLedger:
 
     sections: dict[str, LedgerSection] = field(default_factory=dict)
     question_history: list[dict[str, str]] = field(default_factory=list)
+    # Recorded reason whenever the auto pipeline takes the direct
+    # operational path instead of running an interview (#689 PR-B).
+    # ``None`` for legacy ledgers and for sessions that took the
+    # interview-first route.
+    direct_path_reason: str | None = None
+
+    def record_direct_path_reason(self, reason: str) -> None:
+        """Persist why the auto pipeline skipped interview for this session.
+
+        The reason is the human-readable string from
+        ``GoalClassification.reason``; storing it on the ledger keeps the
+        explanation alongside the other Seed draft facts and survives
+        resume.  Pure assignment with empty-string guard — no IO.
+        """
+        cleaned = reason.strip() if isinstance(reason, str) else ""
+        if not cleaned:
+            msg = "direct_path_reason must be a non-empty string"
+            raise ValueError(msg)
+        self.direct_path_reason = cleaned
 
     @classmethod
     def from_goal(cls, goal: str) -> SeedDraftLedger:
@@ -320,6 +339,7 @@ class SeedDraftLedger:
         return {
             "sections": {name: section.to_dict() for name, section in self.sections.items()},
             "question_history": list(self.question_history),
+            "direct_path_reason": self.direct_path_reason,
         }
 
     @classmethod
@@ -358,7 +378,17 @@ class SeedDraftLedger:
                 msg = "ledger question_history question and answer must be strings"
                 raise ValueError(msg)
 
-        ledger = cls(sections=sections, question_history=[dict(item) for item in question_history])
+        direct_path_reason = data.get("direct_path_reason")
+        if direct_path_reason is not None:
+            if not isinstance(direct_path_reason, str) or not direct_path_reason.strip():
+                msg = "ledger direct_path_reason must be a non-empty string or null"
+                raise ValueError(msg)
+
+        ledger = cls(
+            sections=sections,
+            question_history=[dict(item) for item in question_history],
+            direct_path_reason=direct_path_reason,
+        )
         for required in REQUIRED_SECTIONS:
             ledger.sections.setdefault(required, LedgerSection(required))
         return ledger

--- a/src/ouroboros/auto/merge_policy.py
+++ b/src/ouroboros/auto/merge_policy.py
@@ -91,6 +91,28 @@ class MergeAction(StrEnum):
     DELETE_BRANCH = "delete_branch"
 
 
+# Minimum classification risk required to authorize each destructive
+# action.  The merge action is the most destructive and demands a HIGH
+# verb in the goal (``merge``, ``머지`` …); CLOSE/REBASE only need a
+# MEDIUM verb (``close``, ``rebase``, ``fix``).  A LOW (read-only)
+# classification cannot authorize any of these actions: a goal like
+# ``review https://.../pull/689`` must never trigger a default-action
+# merge just because the repo state happens to be clean.
+_ACTION_MIN_RISK: dict[MergeAction, SideEffectRisk] = {
+    MergeAction.MERGE: SideEffectRisk.HIGH,
+    MergeAction.DELETE_BRANCH: SideEffectRisk.HIGH,
+    MergeAction.CLOSE: SideEffectRisk.MEDIUM,
+    MergeAction.REBASE: SideEffectRisk.MEDIUM,
+}
+
+_RISK_RANK: dict[SideEffectRisk, int] = {
+    SideEffectRisk.NONE: 0,
+    SideEffectRisk.LOW: 1,
+    SideEffectRisk.MEDIUM: 2,
+    SideEffectRisk.HIGH: 3,
+}
+
+
 @dataclass(frozen=True, slots=True)
 class MergePolicyDecision:
     """Outcome of evaluating ``PullRequestStatus`` against the gate."""
@@ -127,6 +149,12 @@ class MergePolicy:
     # without an explicit confirmation signal because that combination
     # would mean the classifier mis-rated the destructiveness.
     require_confirmation_for_high_risk: bool = True
+    # When the requested action exceeds the goal's classified intent
+    # (e.g. action=MERGE for a goal classified LOW), fail closed so a
+    # clean PR plus a read-only goal cannot authorize a destructive
+    # default action.  Disable only in tests that want to exercise
+    # repository-only checks in isolation.
+    require_action_classification_match: bool = True
 
 
 def evaluate_merge(
@@ -166,6 +194,36 @@ def evaluate_merge(
             "Re-classify the goal or update GoalClassification semantics so a HIGH risk "
             "always forces requires_confirmation=True."
         )
+
+    if rules.require_action_classification_match:
+        required_min = _ACTION_MIN_RISK.get(action)
+        if required_min is None:
+            blocking_reasons.append(
+                f"action {action.value!r} has no policy-defined minimum risk; "
+                "gate fails closed for unrecognized actions"
+            )
+            required_actions.append(
+                "Add the action to _ACTION_MIN_RISK in merge_policy.py before "
+                "wiring it into the auto pipeline."
+            )
+            matched_signals.append(f"action:{action.value}=unmapped")
+        elif _RISK_RANK[classification.side_effect_risk] < _RISK_RANK[required_min]:
+            blocking_reasons.append(
+                f"goal classified as {classification.side_effect_risk.value} risk "
+                f"does not authorize action {action.value!r} "
+                f"(requires {required_min.value} risk)"
+            )
+            required_actions.append(
+                "Restate the goal with a verb that matches the requested action "
+                f"(for {action.value!r}, use a {required_min.value}-risk verb), "
+                "or invoke the gate with an action consistent with the goal."
+            )
+            matched_signals.append(
+                f"action:{action.value}=needs:{required_min.value}"
+                f"(have:{classification.side_effect_risk.value})"
+            )
+        else:
+            matched_signals.append(f"action:{action.value}=ok")
 
     if not status.has_write_permission:
         blocking_reasons.append("caller lacks repository write permission")
@@ -212,9 +270,7 @@ def evaluate_merge(
         blocking_reasons.append(
             f"CI state is {status.ci_state.value}; require success before merging"
         )
-        required_actions.append(
-            "Wait for CI to finish; investigate failures before re-running."
-        )
+        required_actions.append("Wait for CI to finish; investigate failures before re-running.")
         matched_signals.append(f"ci:{status.ci_state.value}")
     else:
         matched_signals.append(f"ci:{status.ci_state.value}")
@@ -225,9 +281,7 @@ def evaluate_merge(
             state is ReviewState.CHANGES_REQUESTED for state in status.review_states
         )
         if changes_requested:
-            blocking_reasons.append(
-                f"{changes_requested} reviewer(s) requested changes"
-            )
+            blocking_reasons.append(f"{changes_requested} reviewer(s) requested changes")
             required_actions.append("Address review feedback and re-request review.")
             matched_signals.append(f"reviews:changes_requested:{changes_requested}")
         if approved == 0:

--- a/src/ouroboros/auto/merge_policy.py
+++ b/src/ouroboros/auto/merge_policy.py
@@ -1,0 +1,286 @@
+"""Merge-policy gate contract for the direct operational path (#689 PR-D).
+
+Operational goals can request destructive actions (merge a PR, delete a
+branch).  The classifier (PR-A) recognizes the *shape* of the goal but
+never inspects repository state — it cannot tell whether a particular
+PR is mergeable, whether CI is green, or whether the caller has
+sufficient permission.  This module is the in-process **gate** that
+turns observed repository facts into an explicit ``allowed/blocked``
+decision before the auto pipeline performs anything destructive.
+
+Design constraints:
+
+- **No IO**: the gate is a pure function.  Tests run without network or
+  GitHub credentials.  PR-E provides the adapter that fetches
+  ``PullRequestStatus`` from ``gh`` CLI.
+- **Fail-closed**: every check defaults to *blocked* when evidence is
+  missing.  A reviewer who is reading the diff should never have to
+  reason about an implicit allow path.
+- **Audit trail**: every decision (allow or block) is recordable on
+  ``SeedDraftLedger.record_merge_policy_decision`` so resume can show
+  exactly which checks fired.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from ouroboros.auto.goal_classifier import GoalClassification, SideEffectRisk
+
+
+class CIState(StrEnum):
+    """Coarse CI status used by the gate."""
+
+    SUCCESS = "success"
+    PENDING = "pending"
+    FAILURE = "failure"
+    UNKNOWN = "unknown"
+
+
+class ReviewState(StrEnum):
+    """GitHub review decision states the gate cares about."""
+
+    APPROVED = "approved"
+    CHANGES_REQUESTED = "changes_requested"
+    COMMENTED = "commented"
+    PENDING = "pending"
+
+
+@dataclass(frozen=True, slots=True)
+class PullRequestStatus:
+    """Observed facts about the PR a destructive action targets.
+
+    The shape is the minimum the gate needs.  PR-E will populate this
+    from ``gh`` CLI output; tests construct it directly.
+    """
+
+    repo: str
+    number: int
+    target_branch: str
+    head_sha: str
+    mergeable: bool | None
+    ci_state: CIState
+    review_states: tuple[ReviewState, ...]
+    has_write_permission: bool
+    is_draft: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary for ledger persistence."""
+        return {
+            "repo": self.repo,
+            "number": self.number,
+            "target_branch": self.target_branch,
+            "head_sha": self.head_sha,
+            "mergeable": self.mergeable,
+            "ci_state": self.ci_state.value,
+            "review_states": [state.value for state in self.review_states],
+            "has_write_permission": self.has_write_permission,
+            "is_draft": self.is_draft,
+        }
+
+
+class MergeAction(StrEnum):
+    """Destructive actions the gate evaluates."""
+
+    MERGE = "merge"
+    CLOSE = "close"
+    REBASE = "rebase"
+    DELETE_BRANCH = "delete_branch"
+
+
+@dataclass(frozen=True, slots=True)
+class MergePolicyDecision:
+    """Outcome of evaluating ``PullRequestStatus`` against the gate."""
+
+    allowed: bool
+    action: MergeAction
+    blocking_reasons: tuple[str, ...] = ()
+    required_actions: tuple[str, ...] = ()
+    matched_signals: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "allowed": self.allowed,
+            "action": self.action.value,
+            "blocking_reasons": list(self.blocking_reasons),
+            "required_actions": list(self.required_actions),
+            "matched_signals": list(self.matched_signals),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class MergePolicy:
+    """Configurable thresholds for the gate."""
+
+    allowed_target_branches: frozenset[str] = field(
+        default_factory=lambda: frozenset({"main", "master"})
+    )
+    require_approval: bool = True
+    require_passing_ci: bool = True
+    block_on_draft: bool = True
+    # When the classifier marked the goal high-risk but did not also
+    # require confirmation, fail closed: the gate refuses to evaluate
+    # without an explicit confirmation signal because that combination
+    # would mean the classifier mis-rated the destructiveness.
+    require_confirmation_for_high_risk: bool = True
+
+
+def evaluate_merge(
+    *,
+    classification: GoalClassification,
+    status: PullRequestStatus,
+    policy: MergePolicy | None = None,
+    action: MergeAction = MergeAction.MERGE,
+) -> MergePolicyDecision:
+    """Run the full set of merge-policy checks.
+
+    The function is total: it never raises for routine "blocked"
+    outcomes.  It only raises ``TypeError`` when the caller passed
+    structurally-invalid input.
+    """
+    if not isinstance(classification, GoalClassification):
+        msg = "evaluate_merge requires a GoalClassification"
+        raise TypeError(msg)
+    if not isinstance(status, PullRequestStatus):
+        msg = "evaluate_merge requires a PullRequestStatus"
+        raise TypeError(msg)
+    rules = policy or MergePolicy()
+    blocking_reasons: list[str] = []
+    required_actions: list[str] = []
+    matched_signals: list[str] = []
+
+    if (
+        rules.require_confirmation_for_high_risk
+        and classification.side_effect_risk is SideEffectRisk.HIGH
+        and not classification.requires_confirmation
+    ):
+        blocking_reasons.append(
+            "classification reports HIGH side-effect risk without requires_confirmation; "
+            "gate fails closed to prevent silent destructive action"
+        )
+        required_actions.append(
+            "Re-classify the goal or update GoalClassification semantics so a HIGH risk "
+            "always forces requires_confirmation=True."
+        )
+
+    if not status.has_write_permission:
+        blocking_reasons.append("caller lacks repository write permission")
+        required_actions.append(
+            "Run with credentials that have push/merge access to the target repository."
+        )
+        matched_signals.append("permission:none")
+    else:
+        matched_signals.append("permission:write")
+
+    if status.target_branch not in rules.allowed_target_branches:
+        allowed = ", ".join(sorted(rules.allowed_target_branches))
+        blocking_reasons.append(
+            f"target branch {status.target_branch!r} not in allowed set ({allowed})"
+        )
+        required_actions.append(
+            "Re-target the PR onto an allowed branch or extend the merge policy."
+        )
+        matched_signals.append(f"branch:{status.target_branch}")
+    else:
+        matched_signals.append(f"branch:{status.target_branch}")
+
+    if rules.block_on_draft and status.is_draft:
+        blocking_reasons.append("PR is in draft state")
+        required_actions.append("Mark the PR ready for review before merging.")
+        matched_signals.append("draft:true")
+
+    if status.mergeable is False:
+        blocking_reasons.append("GitHub reports the PR is not mergeable")
+        required_actions.append(
+            "Resolve conflicts on the PR head branch, then re-run with --resume."
+        )
+        matched_signals.append("mergeable:false")
+    elif status.mergeable is None:
+        blocking_reasons.append("GitHub mergeability check has not finished yet")
+        required_actions.append(
+            "Wait for GitHub to compute mergeability, then re-run with --resume."
+        )
+        matched_signals.append("mergeable:unknown")
+    else:
+        matched_signals.append("mergeable:true")
+
+    if rules.require_passing_ci and status.ci_state is not CIState.SUCCESS:
+        blocking_reasons.append(
+            f"CI state is {status.ci_state.value}; require success before merging"
+        )
+        required_actions.append(
+            "Wait for CI to finish; investigate failures before re-running."
+        )
+        matched_signals.append(f"ci:{status.ci_state.value}")
+    else:
+        matched_signals.append(f"ci:{status.ci_state.value}")
+
+    if rules.require_approval and action is MergeAction.MERGE:
+        approved = sum(state is ReviewState.APPROVED for state in status.review_states)
+        changes_requested = sum(
+            state is ReviewState.CHANGES_REQUESTED for state in status.review_states
+        )
+        if changes_requested:
+            blocking_reasons.append(
+                f"{changes_requested} reviewer(s) requested changes"
+            )
+            required_actions.append("Address review feedback and re-request review.")
+            matched_signals.append(f"reviews:changes_requested:{changes_requested}")
+        if approved == 0:
+            blocking_reasons.append("no approving reviews on the PR")
+            required_actions.append("Obtain at least one approving review.")
+            matched_signals.append("reviews:approved:0")
+        else:
+            matched_signals.append(f"reviews:approved:{approved}")
+
+    return MergePolicyDecision(
+        allowed=not blocking_reasons,
+        action=action,
+        blocking_reasons=tuple(blocking_reasons),
+        required_actions=tuple(required_actions),
+        matched_signals=tuple(matched_signals),
+    )
+
+
+def record_decision_on_ledger(
+    ledger: object,
+    decision: MergePolicyDecision,
+    status: PullRequestStatus,
+) -> dict[str, Any]:
+    """Append a structured audit record to ``ledger.merge_policy_decisions``.
+
+    Accepts the ledger duck-typed (it must expose
+    ``record_merge_policy_decision``) so this module does not import
+    ``SeedDraftLedger`` and can be reused by the MCP-side handler later
+    without circular imports.
+    """
+    record = {
+        "recorded_at": datetime.now(UTC).isoformat(),
+        "status": status.to_dict(),
+        "decision": decision.to_dict(),
+    }
+    recorder = getattr(ledger, "record_merge_policy_decision", None)
+    if recorder is None:
+        msg = (
+            "ledger object must implement record_merge_policy_decision; "
+            "got " + type(ledger).__name__
+        )
+        raise TypeError(msg)
+    recorder(record)
+    return record
+
+
+__all__ = [
+    "CIState",
+    "MergeAction",
+    "MergePolicy",
+    "MergePolicyDecision",
+    "PullRequestStatus",
+    "ReviewState",
+    "evaluate_merge",
+    "record_decision_on_ledger",
+]

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
+import os
 from typing import Any
 
+from ouroboros.auto.goal_classifier import GoalClassification, classify_goal
 from ouroboros.auto.grading import GradeGate
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
@@ -14,6 +16,20 @@ from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore, utc_now_iso
 from ouroboros.core.seed import Seed
+
+# Master gate for the direct operational path (#689 PR-C).  Even when
+# the classifier authorizes a direct run and the user did not pick
+# ``--interview-strategy=never``, the pipeline still consults this env
+# flag before bypassing interview, because the operational executor is
+# wired in subsequent PRs.  Removing this gate is intentionally a
+# follow-up commit so the rollout is reversible.
+_OPERATIONAL_ENV_VAR = "OUROBOROS_AUTO_OPERATIONAL"
+_OPERATIONAL_PENDING_GUIDANCE = (
+    "Direct operational path is wired but the operational executor and "
+    "merge-policy gate land in subsequent PRs (#689 PR-D/E). "
+    "Re-run with --interview-strategy=always to use the interview-first "
+    "path until those land."
+)
 
 SeedGenerator = Callable[[str], Awaitable[Seed]]
 RunStarter = Callable[[Seed], Awaitable[dict[str, Any]]]
@@ -63,6 +79,9 @@ class AutoPipeline:
     skip_run: bool = False
     seed_timeout_seconds: float = 120.0
     run_start_timeout_seconds: float = 60.0
+    # Override of the env-var gate for tests.  When None (default), the
+    # pipeline reads the live ``OUROBOROS_AUTO_OPERATIONAL`` env var.
+    operational_env_override: bool | None = None
 
     async def run(self, state: AutoPipelineState) -> AutoPipelineResult:
         """Run a bounded auto pipeline using injected side-effecting dependencies."""
@@ -82,6 +101,14 @@ class AutoPipeline:
                 self._save(state)
                 return self._result(state, ledger, blocker=state.last_error)
         self._save(state)
+
+        if state.phase == AutoPhase.CREATED:
+            classification = self._ensure_classification(state, ledger)
+            routing = self._evaluate_routing(state, classification)
+            if routing is not None:
+                state.mark_blocked(routing, tool_name="goal_classifier")
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
 
         if state.phase == AutoPhase.COMPLETE:
             return self._result(state, ledger, blocker=state.last_error)
@@ -354,6 +381,61 @@ class AutoPipeline:
         )
         self._save(state)
         return self._result(state, ledger, review=review, run_subagent=run_subagent)
+
+    def _ensure_classification(
+        self, state: AutoPipelineState, ledger: SeedDraftLedger
+    ) -> GoalClassification:
+        """Return a classification for ``state.goal``, persisting on first call.
+
+        The classification is deterministic and cheap, so we recompute on
+        resume only when the persisted classification is missing.  When
+        the persisted record exists we trust it: re-classifying would let
+        a goal-string mutation silently change the routing decision after
+        the user has already committed to a strategy.
+        """
+        if state.classification is not None:
+            return GoalClassification.from_dict(state.classification)
+        classification = classify_goal(state.goal)
+        state.record_classification(classification)
+        if classification.direct_run_allowed:
+            ledger.record_direct_path_reason(classification.reason)
+            state.ledger = ledger.to_dict()
+        self._save(state)
+        return classification
+
+    def _evaluate_routing(
+        self, state: AutoPipelineState, classification: GoalClassification
+    ) -> str | None:
+        """Decide whether to bypass the interview phase.
+
+        Returns a blocker message when the auto pipeline must stop (the
+        operational executor is pending in PR-D/E, or the user requested
+        ``--interview-strategy=never`` for a goal that does not meet the
+        classifier's bar).  Returns ``None`` when the existing
+        interview-first flow should run unchanged.
+        """
+        strategy = state.interview_strategy
+        env_enabled = (
+            self.operational_env_override
+            if self.operational_env_override is not None
+            else os.environ.get(_OPERATIONAL_ENV_VAR) == "1"
+        )
+        eligible = classification.direct_run_allowed
+
+        if strategy == "always":
+            return None
+        if strategy == "never":
+            if not eligible:
+                return (
+                    "Interview is disabled (--interview-strategy=never) but the "
+                    f"goal does not authorize a direct path: {classification.reason}. "
+                    "Re-run with --interview-strategy=auto to use the interview-first path."
+                )
+            return _OPERATIONAL_PENDING_GUIDANCE
+        # strategy == "auto"
+        if eligible and env_enabled:
+            return _OPERATIONAL_PENDING_GUIDANCE
+        return None
 
     def _load_seed(self, state: AutoPipelineState, seed_path: str) -> Seed | None:
         if self.seed_loader is None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -547,6 +547,13 @@ def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
         "interview.answer",
         "auto_answerer",
         "interview_driver",
+        # ``goal_classifier`` blocks happen pre-interview from the
+        # CREATED phase (#689 PR-C).  Recovery routes the session into
+        # the interview path so that operators following the blocker
+        # guidance (re-run with ``--interview-strategy=auto`` or
+        # ``=always``) actually progress instead of hitting the same
+        # blocked state forever.
+        "goal_classifier",
     }:
         return AutoPhase.INTERVIEW
     if tool_name == "seed_generator":

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -99,6 +99,13 @@ class AutoPipelineState:
     # PR-B; PR-C reads this field to route around interview.
     classification: dict[str, Any] | None = None
     direct_path_reason: str | None = None
+    # User-controlled interview routing (#689 PR-C).  Mirrors the
+    # ``--interview-strategy`` CLI flag.  ``auto`` defers to the
+    # classifier + ``OUROBOROS_AUTO_OPERATIONAL`` env gate.  ``always``
+    # forces interview-first.  ``never`` skips interview when the
+    # classifier authorizes a direct path; otherwise blocks with an
+    # actionable message.
+    interview_strategy: str = "auto"
     seed_id: str | None = None
     seed_path: str | None = None
     seed_artifact: dict[str, Any] = field(default_factory=dict)
@@ -223,6 +230,7 @@ class AutoPipelineState:
         payload.setdefault("run_handoff_guidance", None)
         payload.setdefault("classification", None)
         payload.setdefault("direct_path_reason", None)
+        payload.setdefault("interview_strategy", "auto")
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -314,6 +322,9 @@ class AutoPipelineState:
             except Exception as exc:
                 msg = "ledger must be a valid Seed Draft Ledger"
                 raise ValueError(msg) from exc
+        if self.interview_strategy not in {"auto", "always", "never"}:
+            msg = "interview_strategy must be one of auto, always, never"
+            raise ValueError(msg)
         if self.classification is not None:
             if not isinstance(self.classification, dict):
                 msg = "classification must be an object or null"

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -93,6 +93,12 @@ class AutoPipelineState:
     max_repair_rounds: int = 5
     interview_session_id: str | None = None
     interview_completed: bool = False
+    # Goal classification (#689) -- populated when the classifier has been
+    # consulted for this session.  ``None`` for legacy records and for any
+    # pipeline that has not yet wired classification.  Persistence-only in
+    # PR-B; PR-C reads this field to route around interview.
+    classification: dict[str, Any] | None = None
+    direct_path_reason: str | None = None
     seed_id: str | None = None
     seed_path: str | None = None
     seed_artifact: dict[str, Any] = field(default_factory=dict)
@@ -138,6 +144,27 @@ class AutoPipelineState:
         self.updated_at = now
         self.last_progress_message = message
         self.last_error = error
+
+    def record_classification(self, classification: object) -> None:
+        """Persist a ``GoalClassification`` on the state record (#689 PR-B).
+
+        Accepts a ``GoalClassification`` instance directly to avoid forcing
+        callers to import the dataclass when they only care about
+        recording the verdict.  The classification is normalized to its
+        dict form so the state remains JSON-serializable for resume.
+        """
+        from ouroboros.auto.goal_classifier import GoalClassification
+
+        if not isinstance(classification, GoalClassification):
+            msg = (
+                "record_classification expects a GoalClassification, got "
+                f"{type(classification).__name__}"
+            )
+            raise TypeError(msg)
+        self.classification = classification.to_dict()
+        self.direct_path_reason = (
+            classification.reason if classification.direct_run_allowed else None
+        )
 
     def mark_progress(self, message: str, *, tool_name: str | None = None) -> None:
         """Record non-terminal progress within the current phase."""
@@ -194,6 +221,8 @@ class AutoPipelineState:
         payload.setdefault("max_repair_rounds", 5)
         payload.setdefault("run_handoff_status", None)
         payload.setdefault("run_handoff_guidance", None)
+        payload.setdefault("classification", None)
+        payload.setdefault("direct_path_reason", None)
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -285,6 +314,17 @@ class AutoPipelineState:
             except Exception as exc:
                 msg = "ledger must be a valid Seed Draft Ledger"
                 raise ValueError(msg) from exc
+        if self.classification is not None:
+            if not isinstance(self.classification, dict):
+                msg = "classification must be an object or null"
+                raise ValueError(msg)
+            try:
+                from ouroboros.auto.goal_classifier import GoalClassification
+
+                GoalClassification.from_dict(self.classification)
+            except Exception as exc:
+                msg = "classification must be a valid GoalClassification record"
+                raise ValueError(msg) from exc
         optional_string_fields = (
             "runtime_backend",
             "opencode_mode",
@@ -300,6 +340,7 @@ class AutoPipelineState:
             "pending_question",
             "last_tool_name",
             "last_error",
+            "direct_path_reason",
         )
         for field_name in optional_string_fields:
             value = getattr(self, field_name)

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -83,6 +83,19 @@ def auto_command(
     skip_run: Annotated[
         bool, typer.Option("--skip-run", help="Stop after A-grade Seed creation.")
     ] = False,
+    interview_strategy: Annotated[
+        str,
+        typer.Option(
+            "--interview-strategy",
+            help=(
+                "Auto interview routing: 'auto' (default) defers to the goal "
+                "classifier and OUROBOROS_AUTO_OPERATIONAL env gate; 'always' "
+                "forces interview-first regardless of goal shape; 'never' "
+                "skips the interview when the classifier authorizes a direct "
+                "path and otherwise blocks with an actionable message."
+            ),
+        ),
+    ] = "auto",
     show_ledger: Annotated[
         bool, typer.Option("--show-ledger", help="Print assumptions and non-goals.")
     ] = False,
@@ -109,6 +122,11 @@ def auto_command(
     if not resume and (goal is None or not goal.strip()):
         print_error("goal is required unless --resume is provided")
         raise typer.Exit(1)
+    if interview_strategy not in {"auto", "always", "never"}:
+        print_error(
+            "--interview-strategy must be one of: auto, always, never"
+        )
+        raise typer.Exit(1)
     try:
         result = asyncio.run(
             _run_auto(
@@ -118,6 +136,7 @@ def auto_command(
                 max_interview_rounds=max_interview_rounds,
                 max_repair_rounds=max_repair_rounds,
                 skip_run=skip_run,
+                interview_strategy=interview_strategy,
             )
         )
     except Exception as exc:
@@ -152,10 +171,16 @@ async def _run_auto(
     max_interview_rounds: int | None,
     max_repair_rounds: int | None,
     skip_run: bool,
+    interview_strategy: str = "auto",
 ) -> AutoPipelineResult:
     store = AutoStore()
     if resume:
         state = store.load(resume)
+        # Allow callers to switch interview strategy on resume.  This is
+        # how operators escape a CREATED-blocked session that requested a
+        # direct path before the operational executor was available.
+        if interview_strategy != "auto":
+            state.interview_strategy = interview_strategy
         persisted_runtime = state.runtime_backend
         if persisted_runtime is None and state.opencode_mode is not None:
             persisted_runtime = "opencode"
@@ -206,6 +231,7 @@ async def _run_auto(
         state.skip_run = skip_run
         state.max_interview_rounds = max_interview_rounds
         state.max_repair_rounds = max_repair_rounds
+        state.interview_strategy = interview_strategy
 
     if runtime == "opencode":
         opencode_mode = state.opencode_mode or get_opencode_mode()

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -84,7 +84,7 @@ def auto_command(
         bool, typer.Option("--skip-run", help="Stop after A-grade Seed creation.")
     ] = False,
     interview_strategy: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--interview-strategy",
             help=(
@@ -92,10 +92,12 @@ def auto_command(
                 "classifier and OUROBOROS_AUTO_OPERATIONAL env gate; 'always' "
                 "forces interview-first regardless of goal shape; 'never' "
                 "skips the interview when the classifier authorizes a direct "
-                "path and otherwise blocks with an actionable message."
+                "path and otherwise blocks with an actionable message. On "
+                "resume, an explicit value (including 'auto') overwrites the "
+                "persisted strategy; omitting the flag preserves it."
             ),
         ),
-    ] = "auto",
+    ] = None,
     show_ledger: Annotated[
         bool, typer.Option("--show-ledger", help="Print assumptions and non-goals.")
     ] = False,
@@ -122,10 +124,12 @@ def auto_command(
     if not resume and (goal is None or not goal.strip()):
         print_error("goal is required unless --resume is provided")
         raise typer.Exit(1)
-    if interview_strategy not in {"auto", "always", "never"}:
-        print_error(
-            "--interview-strategy must be one of: auto, always, never"
-        )
+    if interview_strategy is not None and interview_strategy not in {
+        "auto",
+        "always",
+        "never",
+    }:
+        print_error("--interview-strategy must be one of: auto, always, never")
         raise typer.Exit(1)
     try:
         result = asyncio.run(
@@ -171,15 +175,19 @@ async def _run_auto(
     max_interview_rounds: int | None,
     max_repair_rounds: int | None,
     skip_run: bool,
-    interview_strategy: str = "auto",
+    interview_strategy: str | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
     if resume:
         state = store.load(resume)
-        # Allow callers to switch interview strategy on resume.  This is
-        # how operators escape a CREATED-blocked session that requested a
-        # direct path before the operational executor was available.
-        if interview_strategy != "auto":
+        # Allow callers to switch interview strategy on resume.  ``None``
+        # means the flag was omitted: preserve the persisted strategy.
+        # Any explicit value (``auto``, ``always``, ``never``) overwrites
+        # the persisted strategy so operators can follow the blocker
+        # guidance precisely as it is printed -- including the
+        # ``--interview-strategy=auto`` escape hatch out of a session
+        # persisted with ``never``.
+        if interview_strategy is not None:
             state.interview_strategy = interview_strategy
         persisted_runtime = state.runtime_backend
         if persisted_runtime is None and state.opencode_mode is not None:
@@ -231,7 +239,7 @@ async def _run_auto(
         state.skip_run = skip_run
         state.max_interview_rounds = max_interview_rounds
         state.max_repair_rounds = max_repair_rounds
-        state.interview_strategy = interview_strategy
+        state.interview_strategy = interview_strategy or "auto"
 
     if runtime == "opencode":
         opencode_mode = state.opencode_mode or get_opencode_mode()

--- a/tests/unit/auto/test_gh_pr_provider.py
+++ b/tests/unit/auto/test_gh_pr_provider.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
+import json
 
 import pytest
 
 from ouroboros.auto.gh_pr_provider import (
     CommandResult,
-    GhPrProvider,
     GhProviderError,
+    GhPrProvider,
 )
 from ouroboros.auto.merge_policy import CIState, ReviewState
 
@@ -80,9 +80,7 @@ def _make_provider(
                 "--json",
                 "mergeable,mergeStateStatus,headRefOid,baseRefName,"
                 "isDraft,reviewDecision,latestReviews,statusCheckRollup",
-            ): CommandResult(
-                returncode=pr_returncode, stdout=pr_payload, stderr=pr_stderr
-            ),
+            ): CommandResult(returncode=pr_returncode, stdout=pr_payload, stderr=pr_stderr),
             ("gh", "api", f"repos/{repo}", "--jq", ".permissions"): CommandResult(
                 returncode=perm_returncode, stdout=perm_payload, stderr=perm_stderr
             ),
@@ -166,13 +164,15 @@ def test_no_status_checks_treats_ci_as_success() -> None:
 
 
 def test_review_state_mapping_filters_unknown_values() -> None:
+    """When the aggregate is not APPROVED, latestReviews drives the result."""
     provider, _ = _make_provider(
         pr=_pr_view_payload(
+            reviewDecision="CHANGES_REQUESTED",
             latestReviews=[
                 {"state": "APPROVED"},
                 {"state": "CHANGES_REQUESTED"},
                 {"state": "DISMISSED"},  # not in our enum, dropped
-            ]
+            ],
         )
     )
     status = provider.fetch_status("Q00/ouroboros", 689)
@@ -180,6 +180,69 @@ def test_review_state_mapping_filters_unknown_values() -> None:
         ReviewState.APPROVED,
         ReviewState.CHANGES_REQUESTED,
     )
+
+
+def test_review_decision_approved_overrides_stale_commented_review() -> None:
+    """An approver who later leaves a comment must not flip aggregate.
+
+    GitHub keeps ``reviewDecision=APPROVED`` even after the same
+    reviewer leaves a non-blocking COMMENTED review; the gate must see
+    that aggregate so it does not block a merge the repository UI
+    allows.
+    """
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(
+            reviewDecision="APPROVED",
+            latestReviews=[{"state": "COMMENTED"}],
+        )
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.review_states == (ReviewState.APPROVED,)
+
+
+def test_review_decision_changes_requested_uses_latest_reviews() -> None:
+    """When the aggregate is CHANGES_REQUESTED, blocking reviewers surface."""
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(
+            reviewDecision="CHANGES_REQUESTED",
+            latestReviews=[{"state": "APPROVED"}, {"state": "CHANGES_REQUESTED"}],
+        )
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert ReviewState.CHANGES_REQUESTED in status.review_states
+
+
+def test_review_decision_review_required_uses_latest_reviews_when_present() -> None:
+    """REVIEW_REQUIRED with a single APPROVED in latestReviews still surfaces it."""
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(
+            reviewDecision="REVIEW_REQUIRED",
+            latestReviews=[{"state": "APPROVED"}],
+        )
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.review_states == (ReviewState.APPROVED,)
+
+
+def test_ci_rollup_non_list_payload_is_unknown_not_success() -> None:
+    """A malformed (non-list) rollup must not silently pass the CI gate."""
+    provider, _ = _make_provider(pr=_pr_view_payload(statusCheckRollup="not-a-list"))
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.ci_state is CIState.UNKNOWN
+
+
+def test_ci_rollup_list_of_non_dicts_is_unknown_not_success() -> None:
+    """A list of unparseable items must not silently pass either."""
+    provider, _ = _make_provider(pr=_pr_view_payload(statusCheckRollup=["not-a-dict", 42, None]))
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.ci_state is CIState.UNKNOWN
+
+
+def test_ci_rollup_null_payload_is_unknown_not_success() -> None:
+    """gh sometimes returns ``null`` for the rollup field; map to UNKNOWN."""
+    provider, _ = _make_provider(pr=_pr_view_payload(statusCheckRollup=None))
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.ci_state is CIState.UNKNOWN
 
 
 def test_permission_admin_grants_write() -> None:
@@ -201,17 +264,13 @@ def test_permission_null_payload_denies_write() -> None:
 
 
 def test_pr_view_failure_raises_provider_error() -> None:
-    provider, _ = _make_provider(
-        pr_returncode=1, pr_stderr="HTTP 404: Not Found"
-    )
+    provider, _ = _make_provider(pr_returncode=1, pr_stderr="HTTP 404: Not Found")
     with pytest.raises(GhProviderError, match="HTTP 404"):
         provider.fetch_status("Q00/ouroboros", 689)
 
 
 def test_permission_failure_raises_provider_error() -> None:
-    provider, _ = _make_provider(
-        perm_returncode=1, perm_stderr="auth required"
-    )
+    provider, _ = _make_provider(perm_returncode=1, perm_stderr="auth required")
     with pytest.raises(GhProviderError, match="auth required"):
         provider.fetch_status("Q00/ouroboros", 689)
 

--- a/tests/unit/auto/test_gh_pr_provider.py
+++ b/tests/unit/auto/test_gh_pr_provider.py
@@ -1,0 +1,278 @@
+"""Tests for the gh-CLI provider adapter (#689 PR-E)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+import pytest
+
+from ouroboros.auto.gh_pr_provider import (
+    CommandResult,
+    GhPrProvider,
+    GhProviderError,
+)
+from ouroboros.auto.merge_policy import CIState, ReviewState
+
+
+class _FakeRunner:
+    """Tiny scripted ``gh`` CLI replacement.
+
+    Maps invoked argument tuples to canned ``CommandResult`` objects so
+    tests can describe the exact set of CLI calls they expect.
+    """
+
+    def __init__(self, responses: dict[tuple[str, ...], CommandResult]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, args: Sequence[str]) -> CommandResult:
+        key = tuple(args)
+        self.calls.append(key)
+        try:
+            return self.responses[key]
+        except KeyError as exc:  # pragma: no cover - test misconfiguration
+            msg = f"unexpected gh invocation: {key}"
+            raise AssertionError(msg) from exc
+
+
+def _pr_view_payload(**overrides) -> dict:
+    base = {
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "headRefOid": "deadbeef",
+        "baseRefName": "main",
+        "isDraft": False,
+        "reviewDecision": "APPROVED",
+        "latestReviews": [{"state": "APPROVED"}],
+        "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_provider(
+    *,
+    pr: dict | None = None,
+    pr_returncode: int = 0,
+    pr_stderr: str = "",
+    permissions: dict | str | None = None,
+    perm_returncode: int = 0,
+    perm_stderr: str = "",
+    repo: str = "Q00/ouroboros",
+    number: int = 689,
+) -> tuple[GhPrProvider, _FakeRunner]:
+    pr_payload = json.dumps(pr if pr is not None else _pr_view_payload())
+    perm_payload = (
+        json.dumps(permissions)
+        if isinstance(permissions, dict)
+        else (permissions if isinstance(permissions, str) else json.dumps({"push": True}))
+    )
+    runner = _FakeRunner(
+        {
+            (
+                "gh",
+                "pr",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                "mergeable,mergeStateStatus,headRefOid,baseRefName,"
+                "isDraft,reviewDecision,latestReviews,statusCheckRollup",
+            ): CommandResult(
+                returncode=pr_returncode, stdout=pr_payload, stderr=pr_stderr
+            ),
+            ("gh", "api", f"repos/{repo}", "--jq", ".permissions"): CommandResult(
+                returncode=perm_returncode, stdout=perm_payload, stderr=perm_stderr
+            ),
+        }
+    )
+    return GhPrProvider(runner=runner), runner
+
+
+def test_fetch_status_returns_clean_status_for_clean_payload() -> None:
+    provider, runner = _make_provider()
+    status = provider.fetch_status("Q00/ouroboros", 689)
+
+    assert status.repo == "Q00/ouroboros"
+    assert status.number == 689
+    assert status.target_branch == "main"
+    assert status.head_sha == "deadbeef"
+    assert status.mergeable is True
+    assert status.ci_state is CIState.SUCCESS
+    assert status.review_states == (ReviewState.APPROVED,)
+    assert status.has_write_permission is True
+    assert status.is_draft is False
+    # Both subcommands are invoked exactly once.
+    assert len(runner.calls) == 2
+
+
+def test_fetch_status_treats_unknown_mergeability_as_none() -> None:
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(mergeable="UNKNOWN", mergeStateStatus="UNKNOWN")
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.mergeable is None
+
+
+def test_fetch_status_marks_conflicting_pr_unmergeable() -> None:
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(mergeable="CONFLICTING", mergeStateStatus="DIRTY")
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.mergeable is False
+
+
+def test_fetch_status_marks_blocked_state_unmergeable() -> None:
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(mergeable="MERGEABLE", mergeStateStatus="BLOCKED")
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.mergeable is False
+
+
+def test_ci_rollup_pending_dominates_when_no_failures() -> None:
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(
+            statusCheckRollup=[
+                {"conclusion": "SUCCESS"},
+                {"status": "IN_PROGRESS"},
+            ]
+        )
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.ci_state is CIState.PENDING
+
+
+def test_ci_rollup_failure_dominates_pending_and_success() -> None:
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(
+            statusCheckRollup=[
+                {"conclusion": "SUCCESS"},
+                {"status": "IN_PROGRESS"},
+                {"conclusion": "FAILURE"},
+            ]
+        )
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.ci_state is CIState.FAILURE
+
+
+def test_no_status_checks_treats_ci_as_success() -> None:
+    provider, _ = _make_provider(pr=_pr_view_payload(statusCheckRollup=[]))
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.ci_state is CIState.SUCCESS
+
+
+def test_review_state_mapping_filters_unknown_values() -> None:
+    provider, _ = _make_provider(
+        pr=_pr_view_payload(
+            latestReviews=[
+                {"state": "APPROVED"},
+                {"state": "CHANGES_REQUESTED"},
+                {"state": "DISMISSED"},  # not in our enum, dropped
+            ]
+        )
+    )
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.review_states == (
+        ReviewState.APPROVED,
+        ReviewState.CHANGES_REQUESTED,
+    )
+
+
+def test_permission_admin_grants_write() -> None:
+    provider, _ = _make_provider(permissions={"admin": True})
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.has_write_permission is True
+
+
+def test_permission_pull_only_denies_write() -> None:
+    provider, _ = _make_provider(permissions={"pull": True})
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.has_write_permission is False
+
+
+def test_permission_null_payload_denies_write() -> None:
+    provider, _ = _make_provider(permissions="null")
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    assert status.has_write_permission is False
+
+
+def test_pr_view_failure_raises_provider_error() -> None:
+    provider, _ = _make_provider(
+        pr_returncode=1, pr_stderr="HTTP 404: Not Found"
+    )
+    with pytest.raises(GhProviderError, match="HTTP 404"):
+        provider.fetch_status("Q00/ouroboros", 689)
+
+
+def test_permission_failure_raises_provider_error() -> None:
+    provider, _ = _make_provider(
+        perm_returncode=1, perm_stderr="auth required"
+    )
+    with pytest.raises(GhProviderError, match="auth required"):
+        provider.fetch_status("Q00/ouroboros", 689)
+
+
+def test_invalid_json_raises_provider_error() -> None:
+    runner = _FakeRunner(
+        {
+            (
+                "gh",
+                "pr",
+                "view",
+                "689",
+                "--repo",
+                "Q00/ouroboros",
+                "--json",
+                "mergeable,mergeStateStatus,headRefOid,baseRefName,"
+                "isDraft,reviewDecision,latestReviews,statusCheckRollup",
+            ): CommandResult(returncode=0, stdout="not json", stderr=""),
+        }
+    )
+    provider = GhPrProvider(runner=runner)
+    with pytest.raises(GhProviderError, match="non-JSON output"):
+        provider.fetch_status("Q00/ouroboros", 689)
+
+
+def test_missing_target_branch_raises() -> None:
+    payload = _pr_view_payload(baseRefName="")
+    provider, _ = _make_provider(pr=payload)
+    with pytest.raises(GhProviderError, match="baseRefName"):
+        provider.fetch_status("Q00/ouroboros", 689)
+
+
+def test_missing_head_sha_raises() -> None:
+    payload = _pr_view_payload(headRefOid="")
+    provider, _ = _make_provider(pr=payload)
+    with pytest.raises(GhProviderError, match="headRefOid"):
+        provider.fetch_status("Q00/ouroboros", 689)
+
+
+def test_invalid_repo_format_rejected() -> None:
+    provider, _ = _make_provider()
+    with pytest.raises(ValueError, match="owner/repo"):
+        provider.fetch_status("not-a-repo", 689)
+
+
+def test_invalid_pr_number_rejected() -> None:
+    provider, _ = _make_provider()
+    with pytest.raises(ValueError, match="positive integer"):
+        provider.fetch_status("Q00/ouroboros", 0)
+
+
+def test_provider_status_feeds_gate_unchanged() -> None:
+    """End-to-end smoke: provider output → gate decision is allow."""
+    from ouroboros.auto.goal_classifier import classify_goal
+    from ouroboros.auto.merge_policy import evaluate_merge
+
+    provider, _ = _make_provider()
+    status = provider.fetch_status("Q00/ouroboros", 689)
+    classification = classify_goal(
+        "merge https://github.com/Q00/ouroboros/pull/689 once CI is green"
+    )
+
+    decision = evaluate_merge(classification=classification, status=status)
+    assert decision.allowed is True

--- a/tests/unit/auto/test_goal_classifier.py
+++ b/tests/unit/auto/test_goal_classifier.py
@@ -51,8 +51,49 @@ def test_pr_url_with_review_verb_is_low_risk_direct_path() -> None:
     assert result.requires_confirmation is False
 
 
-def test_issue_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+def test_issue_url_with_pr_only_verb_routes_to_interview() -> None:
+    """``fix`` mutates a PR; an issue URL alone is the wrong anchor type."""
     goal = "fix https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+    assert "requires a PR URL anchor" in result.reason
+
+
+def test_issue_url_with_merge_verb_routes_to_interview() -> None:
+    """Issues cannot be merged; classifier must not authorize the wrong target."""
+    goal = "merge https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_issue_url_with_rebase_verb_routes_to_interview() -> None:
+    goal = "rebase https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+
+
+def test_issue_url_with_read_only_verb_allows_direct_path() -> None:
+    """Read-only verbs (review/analyze) are well-defined for issues too."""
+    goal = "analyze https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+
+
+def test_pr_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+    goal = "fix https://github.com/Q00/ouroboros/pull/689"
     result = classify_goal(goal)
 
     assert result.interview_required is False
@@ -106,10 +147,7 @@ def test_verb_without_url_routes_to_interview() -> None:
 
 
 def test_planning_verb_with_url_keeps_interview_even_with_operational_verb() -> None:
-    goal = (
-        "plan how we should fix https://github.com/Q00/ouroboros/issues/692 "
-        "before any merge"
-    )
+    goal = "plan how we should fix https://github.com/Q00/ouroboros/issues/692 before any merge"
     result = classify_goal(goal)
 
     assert result.interview_required is True
@@ -146,9 +184,7 @@ def test_korean_merge_signal_classified_as_high() -> None:
 
 
 def test_classification_round_trips_through_dict() -> None:
-    original = classify_goal(
-        "https://github.com/Q00/ouroboros/pull/689 merge once CI is green"
-    )
+    original = classify_goal("https://github.com/Q00/ouroboros/pull/689 merge once CI is green")
     restored = GoalClassification.from_dict(original.to_dict())
     assert restored == original
 
@@ -182,6 +218,75 @@ def test_classification_from_dict_rejects_unknown_risk_tier() -> None:
 def test_classify_goal_rejects_non_string_input() -> None:
     with pytest.raises(TypeError):
         classify_goal(None)  # type: ignore[arg-type]
+
+
+def test_multiple_pr_urls_force_interview() -> None:
+    """Two PR URLs paired with a destructive verb is an ambiguous target."""
+    goal = (
+        "compare https://github.com/Q00/ouroboros/pull/694 and "
+        "https://github.com/Q00/ouroboros/pull/697, then merge the better one"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert "multiple PR/issue URLs" in result.reason
+
+
+def test_multiple_issue_urls_force_interview_for_review() -> None:
+    """Multiple issue URLs are still ambiguous even for read-only verbs."""
+    goal = (
+        "review https://github.com/Q00/ouroboros/issues/689 "
+        "and https://github.com/Q00/ouroboros/issues/692"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_one_pr_url_and_one_issue_url_with_pr_verb_is_direct() -> None:
+    """A single PR URL + a single referenced issue URL still pinpoints the target."""
+    goal = (
+        "merge https://github.com/Q00/ouroboros/pull/694 "
+        "(closes https://github.com/Q00/ouroboros/issues/689)"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_classification_from_dict_rejects_contradictory_invariant() -> None:
+    """Both flags True is not a meaningful classification."""
+    payload = {
+        "interview_required": True,
+        "direct_run_allowed": True,
+        "side_effect_risk": "low",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="opposite booleans"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classification_from_dict_rejects_both_false_invariant() -> None:
+    """Both flags False is also rejected: routing flags must be opposites."""
+    payload = {
+        "interview_required": False,
+        "direct_run_allowed": False,
+        "side_effect_risk": "low",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="opposite booleans"):
+        GoalClassification.from_dict(payload)
 
 
 def test_observed_incident_goal_keeps_interview_path() -> None:

--- a/tests/unit/auto/test_goal_classifier.py
+++ b/tests/unit/auto/test_goal_classifier.py
@@ -1,0 +1,197 @@
+"""Unit tests for the auto-mode goal classifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.goal_classifier import (
+    GoalClassification,
+    SideEffectRisk,
+    classify_goal,
+)
+
+
+def test_empty_goal_requires_interview() -> None:
+    result = classify_goal("")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+    assert result.requires_confirmation is False
+    assert "empty" in result.reason
+
+
+def test_whitespace_goal_requires_interview() -> None:
+    result = classify_goal("   \n\t  ")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_single_pr_url_with_merge_verb_allows_direct_path_with_high_risk() -> None:
+    goal = (
+        "https://github.com/shaun0927/opensafari/pull/42 의 PR을 면밀히 해석해 "
+        "merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert any(signal.startswith("pr_url:") for signal in result.matched_signals)
+    assert any("merge" in signal for signal in result.matched_signals)
+
+
+def test_pr_url_with_review_verb_is_low_risk_direct_path() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 review and summarize"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+    assert result.requires_confirmation is False
+
+
+def test_issue_url_with_fix_verb_is_medium_risk_direct_path() -> None:
+    goal = "fix https://github.com/Q00/ouroboros/issues/689"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.MEDIUM
+    assert result.requires_confirmation is False
+
+
+def test_pulls_list_url_with_merge_verb_still_routes_to_interview() -> None:
+    """List URL must not authorize a destructive verb without narrowing."""
+    goal = (
+        "https://github.com/shaun0927/opensafari/pulls 의 열린 pr을 면밀히 해석해 "
+        "merge 가능한 수준까지 반복 개선해줘. merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+    assert any(signal.startswith("pr_list_url:") for signal in result.matched_signals)
+
+
+def test_pulls_list_url_with_only_review_verb_permits_direct_path() -> None:
+    goal = "review https://github.com/Q00/ouroboros/pulls"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+    assert result.requires_confirmation is False
+
+
+def test_url_without_verb_routes_to_interview() -> None:
+    goal = "look at https://github.com/Q00/ouroboros/pull/489"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+
+
+def test_verb_without_url_routes_to_interview() -> None:
+    goal = "merge the bug-fix PR for me"
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_planning_verb_with_url_keeps_interview_even_with_operational_verb() -> None:
+    goal = (
+        "plan how we should fix https://github.com/Q00/ouroboros/issues/692 "
+        "before any merge"
+    )
+    result = classify_goal(goal)
+
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    # Highest verb in goal is "merge" (high), classifier keeps risk
+    # pessimistic for downstream policy gates.
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_idea_goal_routes_to_interview() -> None:
+    result = classify_goal("Build me a CLI tool that tracks daily habits")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk is SideEffectRisk.NONE
+    assert result.matched_signals == ()
+
+
+def test_korean_review_signal_detected() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 리뷰 부탁드립니다"
+    result = classify_goal(goal)
+
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert result.side_effect_risk is SideEffectRisk.LOW
+
+
+def test_korean_merge_signal_classified_as_high() -> None:
+    goal = "https://github.com/Q00/ouroboros/pull/689 머지 가능하면 진행해줘"
+    result = classify_goal(goal)
+
+    assert result.side_effect_risk is SideEffectRisk.HIGH
+    assert result.requires_confirmation is True
+
+
+def test_classification_round_trips_through_dict() -> None:
+    original = classify_goal(
+        "https://github.com/Q00/ouroboros/pull/689 merge once CI is green"
+    )
+    restored = GoalClassification.from_dict(original.to_dict())
+    assert restored == original
+
+
+def test_classification_from_dict_rejects_inconsistent_high_risk_record() -> None:
+    payload = {
+        "interview_required": False,
+        "direct_run_allowed": True,
+        "side_effect_risk": "high",
+        "requires_confirmation": False,
+        "reason": "fabricated",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="requires_confirmation"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classification_from_dict_rejects_unknown_risk_tier() -> None:
+    payload = {
+        "interview_required": True,
+        "direct_run_allowed": False,
+        "side_effect_risk": "catastrophic",
+        "requires_confirmation": True,
+        "reason": "bad",
+        "matched_signals": [],
+    }
+    with pytest.raises(ValueError, match="side_effect_risk"):
+        GoalClassification.from_dict(payload)
+
+
+def test_classify_goal_rejects_non_string_input() -> None:
+    with pytest.raises(TypeError):
+        classify_goal(None)  # type: ignore[arg-type]
+
+
+def test_observed_incident_goal_keeps_interview_path() -> None:
+    """Regression: the auto_78c98678de5d goal must NOT silently merge."""
+    goal = (
+        "https://github.com/shaun0927/opensafari/pulls의 열린 pr을 면밀히 해석해 "
+        "merge 가능한 수준까지 반복 개선해줘. merge 가능한 수준이라면 merge 진행해줘."
+    )
+    result = classify_goal(goal)
+    # With only a /pulls list URL and a high-risk verb, the safe default
+    # is to keep interview-first so the user clarifies which PR to merge.
+    assert result.direct_run_allowed is False
+    assert result.requires_confirmation is True

--- a/tests/unit/auto/test_merge_policy.py
+++ b/tests/unit/auto/test_merge_policy.py
@@ -22,23 +22,21 @@ from ouroboros.auto.merge_policy import (
 
 
 def _ok_classification() -> GoalClassification:
-    return classify_goal(
-        "merge https://github.com/Q00/ouroboros/pull/689 once CI is green"
-    )
+    return classify_goal("merge https://github.com/Q00/ouroboros/pull/689 once CI is green")
 
 
 def _ok_status(**overrides) -> PullRequestStatus:
-    base = dict(
-        repo="Q00/ouroboros",
-        number=689,
-        target_branch="main",
-        head_sha="0123456789abcdef0123456789abcdef01234567",
-        mergeable=True,
-        ci_state=CIState.SUCCESS,
-        review_states=(ReviewState.APPROVED,),
-        has_write_permission=True,
-        is_draft=False,
-    )
+    base: dict = {
+        "repo": "Q00/ouroboros",
+        "number": 689,
+        "target_branch": "main",
+        "head_sha": "0123456789abcdef0123456789abcdef01234567",
+        "mergeable": True,
+        "ci_state": CIState.SUCCESS,
+        "review_states": (ReviewState.APPROVED,),
+        "has_write_permission": True,
+        "is_draft": False,
+    }
     base.update(overrides)
     return PullRequestStatus(**base)
 
@@ -89,9 +87,7 @@ def test_target_branch_policy_extension_unblocks_merge() -> None:
     decision = evaluate_merge(
         classification=_ok_classification(),
         status=_ok_status(target_branch="release/2025-Q4"),
-        policy=MergePolicy(
-            allowed_target_branches=frozenset({"main", "release/2025-Q4"})
-        ),
+        policy=MergePolicy(allowed_target_branches=frozenset({"main", "release/2025-Q4"})),
     )
     assert decision.allowed is True
 
@@ -121,8 +117,7 @@ def test_unknown_mergeability_blocks_with_wait_guidance() -> None:
     )
     assert decision.allowed is False
     assert any(
-        "mergeability check has not finished" in reason
-        for reason in decision.blocking_reasons
+        "mergeability check has not finished" in reason for reason in decision.blocking_reasons
     )
     assert any("Wait for GitHub" in action for action in decision.required_actions)
 
@@ -148,9 +143,7 @@ def test_pending_ci_blocks_until_success() -> None:
 def test_changes_requested_blocks_merge() -> None:
     decision = evaluate_merge(
         classification=_ok_classification(),
-        status=_ok_status(
-            review_states=(ReviewState.CHANGES_REQUESTED, ReviewState.APPROVED)
-        ),
+        status=_ok_status(review_states=(ReviewState.CHANGES_REQUESTED, ReviewState.APPROVED)),
     )
     assert decision.allowed is False
     assert any("requested changes" in reason for reason in decision.blocking_reasons)
@@ -163,6 +156,61 @@ def test_no_approving_reviews_blocks_merge() -> None:
     )
     assert decision.allowed is False
     assert any("approving reviews" in reason for reason in decision.blocking_reasons)
+
+
+def test_low_risk_review_classification_does_not_authorize_merge() -> None:
+    """A read-only goal (``review ...``) must never authorize MERGE.
+
+    Without the action/classification check, a clean PR + a review-only
+    goal would have allowed the gate to authorize a merge that the user
+    never asked for.
+    """
+    review_classification = classify_goal("review https://github.com/Q00/ouroboros/pull/689")
+    decision = evaluate_merge(
+        classification=review_classification,
+        status=_ok_status(),
+        action=MergeAction.MERGE,
+    )
+
+    assert decision.allowed is False
+    assert any("does not authorize action 'merge'" in r for r in decision.blocking_reasons)
+    assert any("action:merge=needs:high" in s for s in decision.matched_signals)
+
+
+def test_low_risk_review_classification_does_not_authorize_close() -> None:
+    """Read-only verbs do not authorize CLOSE either (CLOSE needs MEDIUM)."""
+    review_classification = classify_goal("review https://github.com/Q00/ouroboros/pull/689")
+    decision = evaluate_merge(
+        classification=review_classification,
+        status=_ok_status(),
+        action=MergeAction.CLOSE,
+    )
+
+    assert decision.allowed is False
+    assert any("does not authorize action 'close'" in r for r in decision.blocking_reasons)
+
+
+def test_high_risk_classification_authorizes_close_via_min_risk_floor() -> None:
+    """HIGH ≥ MEDIUM, so a merge-classified goal can also authorize close."""
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(),
+        action=MergeAction.CLOSE,
+    )
+
+    assert decision.allowed is True
+
+
+def test_action_classification_match_can_be_disabled_for_isolation() -> None:
+    """Tests of repository-only checks may opt out of the consistency rule."""
+    decision = evaluate_merge(
+        classification=classify_goal("review https://github.com/Q00/ouroboros/pull/689"),
+        status=_ok_status(),
+        action=MergeAction.MERGE,
+        policy=MergePolicy(require_action_classification_match=False),
+    )
+
+    assert decision.allowed is True
 
 
 def test_review_requirement_does_not_apply_to_close_action() -> None:
@@ -205,9 +253,7 @@ def test_record_decision_appends_audit_entry_to_ledger() -> None:
 
 
 def test_record_decision_rejects_object_without_required_method() -> None:
-    decision = evaluate_merge(
-        classification=_ok_classification(), status=_ok_status()
-    )
+    decision = evaluate_merge(classification=_ok_classification(), status=_ok_status())
 
     class _Stub:
         pass

--- a/tests/unit/auto/test_merge_policy.py
+++ b/tests/unit/auto/test_merge_policy.py
@@ -1,0 +1,239 @@
+"""Unit tests for the merge-policy gate (#689 PR-D)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.goal_classifier import (
+    GoalClassification,
+    SideEffectRisk,
+    classify_goal,
+)
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.merge_policy import (
+    CIState,
+    MergeAction,
+    MergePolicy,
+    PullRequestStatus,
+    ReviewState,
+    evaluate_merge,
+    record_decision_on_ledger,
+)
+
+
+def _ok_classification() -> GoalClassification:
+    return classify_goal(
+        "merge https://github.com/Q00/ouroboros/pull/689 once CI is green"
+    )
+
+
+def _ok_status(**overrides) -> PullRequestStatus:
+    base = dict(
+        repo="Q00/ouroboros",
+        number=689,
+        target_branch="main",
+        head_sha="0123456789abcdef0123456789abcdef01234567",
+        mergeable=True,
+        ci_state=CIState.SUCCESS,
+        review_states=(ReviewState.APPROVED,),
+        has_write_permission=True,
+        is_draft=False,
+    )
+    base.update(overrides)
+    return PullRequestStatus(**base)
+
+
+def test_clean_status_with_high_risk_classification_is_allowed() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(),
+    )
+    assert decision.allowed is True
+    assert decision.blocking_reasons == ()
+    assert decision.action is MergeAction.MERGE
+
+
+def test_high_risk_without_requires_confirmation_fails_closed() -> None:
+    fabricated = GoalClassification(
+        interview_required=False,
+        direct_run_allowed=True,
+        side_effect_risk=SideEffectRisk.HIGH,
+        requires_confirmation=False,
+        reason="fabricated",
+        matched_signals=(),
+    )
+    decision = evaluate_merge(classification=fabricated, status=_ok_status())
+    assert decision.allowed is False
+    assert any("HIGH side-effect risk" in reason for reason in decision.blocking_reasons)
+
+
+def test_missing_write_permission_blocks() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(has_write_permission=False),
+    )
+    assert decision.allowed is False
+    assert any("write permission" in reason for reason in decision.blocking_reasons)
+
+
+def test_disallowed_target_branch_blocks() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(target_branch="release/2025-Q4"),
+    )
+    assert decision.allowed is False
+    assert any("not in allowed set" in reason for reason in decision.blocking_reasons)
+
+
+def test_target_branch_policy_extension_unblocks_merge() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(target_branch="release/2025-Q4"),
+        policy=MergePolicy(
+            allowed_target_branches=frozenset({"main", "release/2025-Q4"})
+        ),
+    )
+    assert decision.allowed is True
+
+
+def test_draft_pr_is_blocked_by_default() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(is_draft=True),
+    )
+    assert decision.allowed is False
+    assert any("draft" in reason for reason in decision.blocking_reasons)
+
+
+def test_unmergeable_pr_blocks() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(mergeable=False),
+    )
+    assert decision.allowed is False
+    assert any("not mergeable" in reason for reason in decision.blocking_reasons)
+
+
+def test_unknown_mergeability_blocks_with_wait_guidance() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(mergeable=None),
+    )
+    assert decision.allowed is False
+    assert any(
+        "mergeability check has not finished" in reason
+        for reason in decision.blocking_reasons
+    )
+    assert any("Wait for GitHub" in action for action in decision.required_actions)
+
+
+def test_failing_ci_blocks() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(ci_state=CIState.FAILURE),
+    )
+    assert decision.allowed is False
+    assert any("CI state is failure" in reason for reason in decision.blocking_reasons)
+
+
+def test_pending_ci_blocks_until_success() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(ci_state=CIState.PENDING),
+    )
+    assert decision.allowed is False
+    assert any("CI state is pending" in reason for reason in decision.blocking_reasons)
+
+
+def test_changes_requested_blocks_merge() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(
+            review_states=(ReviewState.CHANGES_REQUESTED, ReviewState.APPROVED)
+        ),
+    )
+    assert decision.allowed is False
+    assert any("requested changes" in reason for reason in decision.blocking_reasons)
+
+
+def test_no_approving_reviews_blocks_merge() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(review_states=(ReviewState.COMMENTED,)),
+    )
+    assert decision.allowed is False
+    assert any("approving reviews" in reason for reason in decision.blocking_reasons)
+
+
+def test_review_requirement_does_not_apply_to_close_action() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(review_states=()),
+        action=MergeAction.CLOSE,
+    )
+    # CI/permission still apply, but missing reviews must not block close.
+    blocking = " ".join(decision.blocking_reasons)
+    assert "approving reviews" not in blocking
+
+
+def test_evaluate_merge_rejects_invalid_input() -> None:
+    with pytest.raises(TypeError):
+        evaluate_merge(  # type: ignore[arg-type]
+            classification="bad", status=_ok_status()
+        )
+    with pytest.raises(TypeError):
+        evaluate_merge(  # type: ignore[arg-type]
+            classification=_ok_classification(), status="bad"
+        )
+
+
+def test_record_decision_appends_audit_entry_to_ledger() -> None:
+    ledger = SeedDraftLedger.from_goal("merge https://github.com/Q00/ouroboros/pull/689")
+    decision = evaluate_merge(
+        classification=_ok_classification(),
+        status=_ok_status(ci_state=CIState.PENDING),
+    )
+
+    record = record_decision_on_ledger(ledger, decision, _ok_status(ci_state=CIState.PENDING))
+
+    assert record["decision"]["allowed"] is False
+    assert record in ledger.merge_policy_decisions
+    # Round-trip through dict to ensure JSON-safe.
+    serialized = ledger.to_dict()
+    restored = SeedDraftLedger.from_dict(serialized)
+    assert restored.merge_policy_decisions == ledger.merge_policy_decisions
+
+
+def test_record_decision_rejects_object_without_required_method() -> None:
+    decision = evaluate_merge(
+        classification=_ok_classification(), status=_ok_status()
+    )
+
+    class _Stub:
+        pass
+
+    with pytest.raises(TypeError, match="record_merge_policy_decision"):
+        record_decision_on_ledger(_Stub(), decision, _ok_status())
+
+
+def test_pull_request_status_serializes_to_dict() -> None:
+    status = _ok_status()
+    payload = status.to_dict()
+    assert payload["repo"] == "Q00/ouroboros"
+    assert payload["number"] == 689
+    assert payload["ci_state"] == "success"
+    assert payload["review_states"] == ["approved"]
+
+
+def test_legacy_ledger_loads_without_merge_policy_decisions_field() -> None:
+    payload = SeedDraftLedger.from_goal("Build a CLI").to_dict()
+    payload.pop("merge_policy_decisions", None)
+    restored = SeedDraftLedger.from_dict(payload)
+    assert restored.merge_policy_decisions == []
+
+
+def test_ledger_rejects_malformed_decision_list() -> None:
+    payload = SeedDraftLedger.from_goal("Build a CLI").to_dict()
+    payload["merge_policy_decisions"] = ["not a dict"]
+    with pytest.raises(ValueError, match="merge_policy_decisions"):
+        SeedDraftLedger.from_dict(payload)

--- a/tests/unit/auto/test_pipeline_direct_run.py
+++ b/tests/unit/auto/test_pipeline_direct_run.py
@@ -1,0 +1,193 @@
+"""Pipeline routing tests for the direct operational path (#689 PR-C).
+
+These tests exercise the routing decision in isolation: the pipeline
+either keeps the existing interview-first flow or short-circuits to a
+``BLOCKED`` phase with explicit "PR-D/E pending" guidance.  The
+operational executor itself is wired in PR-D/E, so a successful
+direct path here means a recognizable BLOCKED message — not a green
+run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.goal_classifier import classify_goal
+from ouroboros.auto.interview_driver import AutoInterviewDriver, AutoInterviewResult
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import Seed
+
+
+class _StubBackend:
+    async def start(self, goal: str, *, cwd: str):  # pragma: no cover - never invoked
+        msg = "interview backend should not be invoked when direct path is taken"
+        raise AssertionError(msg)
+
+    async def answer(self, session_id: str, answer: str):  # pragma: no cover
+        raise AssertionError("answer must not be called")
+
+    async def resume(self, session_id: str):  # pragma: no cover
+        raise AssertionError("resume must not be called")
+
+
+@dataclass(slots=True)
+class _RecordingDriver:
+    """Driver double that records whether interview was attempted."""
+
+    called: bool = False
+
+    async def run(self, state: AutoPipelineState, ledger: SeedDraftLedger) -> AutoInterviewResult:
+        self.called = True
+        return AutoInterviewResult(
+            status="blocked",
+            session_id=None,
+            ledger=ledger,
+            rounds=0,
+            blocker="interview should not be reached in direct-path tests",
+        )
+
+
+def _make_pipeline(
+    *,
+    operational_env_override: bool | None,
+) -> tuple[AutoPipeline, _RecordingDriver]:
+    driver = _RecordingDriver()
+    seed_calls: list[str] = []
+
+    async def _seed_generator(session_id: str) -> Seed:  # pragma: no cover
+        seed_calls.append(session_id)
+        msg = "seed_generator must not be called when direct path blocks early"
+        raise AssertionError(msg)
+
+    pipeline = AutoPipeline(
+        interview_driver=driver,  # type: ignore[arg-type]
+        seed_generator=_seed_generator,
+        operational_env_override=operational_env_override,
+    )
+    return pipeline, driver
+
+
+def _operational_goal() -> str:
+    return "https://github.com/Q00/ouroboros/pull/689 review please"
+
+
+def _idea_goal() -> str:
+    return "Build a CLI tool that tracks daily habits"
+
+
+def test_strategy_always_keeps_interview_path_for_operational_goal(tmp_path) -> None:
+    pipeline, driver = _make_pipeline(operational_env_override=True)
+    state = AutoPipelineState(goal=_operational_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "always"
+    asyncio.run(pipeline.run(state))
+
+    assert driver.called is True, "strategy=always must reach the interview driver"
+    # The driver double returns blocked, but the pipeline did consult it.
+    assert state.classification is not None
+    assert state.classification["direct_run_allowed"] is True
+    assert state.direct_path_reason == state.classification["reason"]
+
+
+def test_strategy_auto_with_env_blocks_with_pending_executor_guidance(tmp_path) -> None:
+    pipeline, driver = _make_pipeline(operational_env_override=True)
+    state = AutoPipelineState(goal=_operational_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "auto"
+
+    asyncio.run(pipeline.run(state))
+
+    assert driver.called is False
+    assert state.phase is AutoPhase.BLOCKED
+    assert "PR-D/E" in (state.last_error or "")
+    assert state.last_tool_name == "goal_classifier"
+
+
+def test_strategy_auto_without_env_keeps_interview_path(tmp_path) -> None:
+    pipeline, driver = _make_pipeline(operational_env_override=False)
+    state = AutoPipelineState(goal=_operational_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "auto"
+
+    asyncio.run(pipeline.run(state))
+
+    assert driver.called is True
+    # Even without env enabled, classification is still recorded so the
+    # CLI can surface why the direct path was not taken.
+    assert state.classification is not None
+    assert state.classification["direct_run_allowed"] is True
+
+
+def test_strategy_never_with_eligible_goal_blocks_pending_executor(tmp_path) -> None:
+    pipeline, driver = _make_pipeline(operational_env_override=False)
+    state = AutoPipelineState(goal=_operational_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "never"
+
+    asyncio.run(pipeline.run(state))
+
+    assert driver.called is False
+    assert state.phase is AutoPhase.BLOCKED
+    assert "PR-D/E" in (state.last_error or "")
+
+
+def test_strategy_never_with_idea_goal_blocks_with_actionable_message(tmp_path) -> None:
+    pipeline, driver = _make_pipeline(operational_env_override=True)
+    state = AutoPipelineState(goal=_idea_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "never"
+
+    asyncio.run(pipeline.run(state))
+
+    assert driver.called is False
+    assert state.phase is AutoPhase.BLOCKED
+    assert "interview-strategy" in (state.last_error or "").lower()
+    assert state.classification is not None
+    assert state.classification["direct_run_allowed"] is False
+
+
+def test_classification_persists_on_resume(tmp_path) -> None:
+    pipeline, driver = _make_pipeline(operational_env_override=True)
+    store = AutoStore(tmp_path)
+    pipeline.store = store
+    state = AutoPipelineState(goal=_operational_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "auto"
+
+    asyncio.run(pipeline.run(state))
+
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded.classification is not None
+    assert reloaded.classification == classify_goal(_operational_goal()).to_dict()
+    assert reloaded.direct_path_reason == reloaded.classification["reason"]
+    # Ledger stores the same explanation for resume.
+    assert reloaded.ledger
+    ledger = SeedDraftLedger.from_dict(reloaded.ledger)
+    assert ledger.direct_path_reason == reloaded.direct_path_reason
+
+
+def test_resume_does_not_reclassify_after_goal_drift(tmp_path) -> None:
+    """A persisted classification is sticky: tampering with goal must not flip routing."""
+    pipeline, _ = _make_pipeline(operational_env_override=True)
+    store = AutoStore(tmp_path)
+    pipeline.store = store
+    state = AutoPipelineState(goal=_operational_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "always"
+
+    asyncio.run(pipeline.run(state))
+
+    # Mutate goal field on the persisted state and rerun.  The classifier
+    # must NOT be reconsulted for a sticky classification — operators
+    # must not be able to flip routing after the fact.
+    reloaded = store.load(state.auto_session_id)
+    reloaded.goal = "Build a CLI"
+    classification_before = dict(reloaded.classification or {})
+    reloaded.transition(AutoPhase.BLOCKED, "force re-entry")
+    reloaded.recover(AutoPhase.INTERVIEW, "resume after manual drift")
+    # Use a fresh pipeline that would have classified differently if it
+    # were free to do so:
+    pipeline_fresh, _ = _make_pipeline(operational_env_override=True)
+    pipeline_fresh.store = store
+    asyncio.run(pipeline_fresh.run(reloaded))
+
+    assert reloaded.classification == classification_before

--- a/tests/unit/auto/test_pipeline_direct_run.py
+++ b/tests/unit/auto/test_pipeline_direct_run.py
@@ -12,12 +12,9 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any
-
-import pytest
 
 from ouroboros.auto.goal_classifier import classify_goal
-from ouroboros.auto.interview_driver import AutoInterviewDriver, AutoInterviewResult
+from ouroboros.auto.interview_driver import AutoInterviewResult
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipeline
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
@@ -164,6 +161,55 @@ def test_classification_persists_on_resume(tmp_path) -> None:
     assert reloaded.ledger
     ledger = SeedDraftLedger.from_dict(reloaded.ledger)
     assert ledger.direct_path_reason == reloaded.direct_path_reason
+
+
+def test_goal_classifier_blocked_session_is_resumable(tmp_path) -> None:
+    """Sessions blocked at classification must be recoverable on resume."""
+    store = AutoStore(tmp_path)
+    pipeline_initial, driver_initial = _make_pipeline(operational_env_override=True)
+    pipeline_initial.store = store
+    state = AutoPipelineState(goal=_operational_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "auto"
+
+    asyncio.run(pipeline_initial.run(state))
+
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "goal_classifier"
+    assert driver_initial.called is False
+
+    reloaded = store.load(state.auto_session_id)
+    # Operator follows blocker guidance: switch strategy and resume.
+    reloaded.interview_strategy = "always"
+    pipeline_resume, driver_resume = _make_pipeline(operational_env_override=False)
+    pipeline_resume.store = store
+
+    asyncio.run(pipeline_resume.run(reloaded))
+
+    # Without the goal_classifier branch in _recoverable_phase_for_tool,
+    # the resumed session would have returned the persisted blocked
+    # result without ever invoking the interview driver.
+    assert driver_resume.called is True
+
+
+def test_strategy_never_idea_session_resumes_with_strategy_auto(tmp_path) -> None:
+    """The blocker guidance ("rerun with --interview-strategy=auto") works."""
+    store = AutoStore(tmp_path)
+    pipeline_initial, _ = _make_pipeline(operational_env_override=True)
+    pipeline_initial.store = store
+    state = AutoPipelineState(goal=_idea_goal(), cwd=str(tmp_path))
+    state.interview_strategy = "never"
+
+    asyncio.run(pipeline_initial.run(state))
+    assert state.phase is AutoPhase.BLOCKED
+
+    reloaded = store.load(state.auto_session_id)
+    reloaded.interview_strategy = "auto"
+    pipeline_resume, driver_resume = _make_pipeline(operational_env_override=False)
+    pipeline_resume.store = store
+
+    asyncio.run(pipeline_resume.run(reloaded))
+
+    assert driver_resume.called is True
 
 
 def test_resume_does_not_reclassify_after_goal_drift(tmp_path) -> None:

--- a/tests/unit/auto/test_state_classification.py
+++ b/tests/unit/auto/test_state_classification.py
@@ -23,9 +23,7 @@ def test_state_default_classification_is_none() -> None:
 
 def test_record_classification_persists_dict_and_reason() -> None:
     state = _make_state()
-    classification = classify_goal(
-        "https://github.com/Q00/ouroboros/pull/689 review please"
-    )
+    classification = classify_goal("https://github.com/Q00/ouroboros/pull/689 review please")
 
     state.record_classification(classification)
 

--- a/tests/unit/auto/test_state_classification.py
+++ b/tests/unit/auto/test_state_classification.py
@@ -1,0 +1,150 @@
+"""Persistence tests for the goal-classification state extension (#689 PR-B)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.auto.goal_classifier import classify_goal
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+
+def _make_state() -> AutoPipelineState:
+    return AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+
+
+def test_state_default_classification_is_none() -> None:
+    state = _make_state()
+    assert state.classification is None
+    assert state.direct_path_reason is None
+
+
+def test_record_classification_persists_dict_and_reason() -> None:
+    state = _make_state()
+    classification = classify_goal(
+        "https://github.com/Q00/ouroboros/pull/689 review please"
+    )
+
+    state.record_classification(classification)
+
+    assert state.classification == classification.to_dict()
+    assert state.direct_path_reason == classification.reason
+
+
+def test_record_classification_clears_reason_when_interview_required() -> None:
+    state = _make_state()
+    classification = classify_goal("just plan the migration please")
+    state.record_classification(classification)
+
+    # Goal routed to interview, so direct_path_reason must remain None to
+    # avoid confusing CLI output that suggests a direct path was taken.
+    assert classification.direct_run_allowed is False
+    assert state.classification == classification.to_dict()
+    assert state.direct_path_reason is None
+
+
+def test_record_classification_rejects_non_classification() -> None:
+    state = _make_state()
+    with pytest.raises(TypeError):
+        state.record_classification({"reason": "not a classification"})  # type: ignore[arg-type]
+
+
+def test_state_round_trips_classification_through_store(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _make_state()
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+    classification = classify_goal(
+        "merge https://github.com/Q00/ouroboros/pull/689 once CI is green"
+    )
+    state.record_classification(classification)
+
+    path = store.save(state)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["classification"] == classification.to_dict()
+    assert raw["direct_path_reason"] == classification.reason
+
+    loaded = store.load(state.auto_session_id)
+    assert loaded.classification == classification.to_dict()
+    assert loaded.direct_path_reason == classification.reason
+
+
+def test_state_loads_legacy_record_without_classification(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _make_state()
+    path = store.save(state)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw.pop("classification", None)
+    raw.pop("direct_path_reason", None)
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    loaded = store.load(state.auto_session_id)
+    assert loaded.classification is None
+    assert loaded.direct_path_reason is None
+
+
+def test_state_rejects_invalid_classification_payload(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _make_state()
+    path = store.save(state)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["classification"] = {"interview_required": True}  # missing fields
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="classification"):
+        store.load(state.auto_session_id)
+
+
+def test_state_rejects_blank_direct_path_reason(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = _make_state()
+    path = store.save(state)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["direct_path_reason"] = "   "
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="direct_path_reason"):
+        store.load(state.auto_session_id)
+
+
+def test_ledger_default_direct_path_reason_is_none() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    assert ledger.direct_path_reason is None
+
+
+def test_ledger_record_direct_path_reason_persists_through_round_trip() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    ledger.record_direct_path_reason(
+        "concrete PR/issue URL paired with operational verb (low risk)"
+    )
+    serialized = ledger.to_dict()
+    assert (
+        serialized["direct_path_reason"]
+        == "concrete PR/issue URL paired with operational verb (low risk)"
+    )
+
+    restored = SeedDraftLedger.from_dict(serialized)
+    assert restored.direct_path_reason == ledger.direct_path_reason
+
+
+def test_ledger_legacy_dict_without_direct_path_reason_loads_clean() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    payload = ledger.to_dict()
+    payload.pop("direct_path_reason", None)
+    restored = SeedDraftLedger.from_dict(payload)
+    assert restored.direct_path_reason is None
+
+
+def test_ledger_rejects_blank_direct_path_reason() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    with pytest.raises(ValueError, match="direct_path_reason"):
+        ledger.record_direct_path_reason("   ")
+
+
+def test_ledger_from_dict_rejects_blank_direct_path_reason() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a CLI tool")
+    payload = ledger.to_dict()
+    payload["direct_path_reason"] = "   "
+    with pytest.raises(ValueError, match="direct_path_reason"):
+        SeedDraftLedger.from_dict(payload)

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -158,6 +158,105 @@ def test_resume_raises_persisted_bound_when_cli_overrides_higher(tmp_path) -> No
     assert captured["state_max_repair_rounds"] == 1
 
 
+def test_explicit_interview_strategy_auto_overrides_persisted_never_on_resume(
+    tmp_path,
+) -> None:
+    """Resume with --interview-strategy=auto must update persisted strategy.
+
+    Without the sentinel-default fix, Typer always supplied the default
+    string ``"auto"``, making explicit ``--interview-strategy=auto``
+    indistinguishable from omission and silently ignored on resume.
+    The blocker guidance "rerun with --interview-strategy=auto" depends
+    on this distinction working.
+    """
+    import asyncio
+
+    from ouroboros.auto.state import AutoPipelineState, AutoStore
+    from ouroboros.cli.commands.auto import _run_auto
+
+    state = AutoPipelineState(goal="some operational goal", cwd=str(tmp_path))
+    state.runtime_backend = "claude"
+    state.interview_strategy = "never"
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    captured: dict[str, str] = {}
+
+    async def fake_pipeline_run(self, run_state):  # noqa: ARG001
+        captured["interview_strategy"] = run_state.interview_strategy
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id=run_state.auto_session_id,
+            phase="blocked",
+        )
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run),
+    ):
+        store_cls.return_value = store
+
+        asyncio.run(
+            _run_auto(
+                goal=None,
+                resume=state.auto_session_id,
+                runtime=None,
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=False,
+                interview_strategy="auto",
+            )
+        )
+
+    assert captured["interview_strategy"] == "auto"
+
+
+def test_omitted_interview_strategy_preserves_persisted_strategy_on_resume(
+    tmp_path,
+) -> None:
+    """Omitting --interview-strategy keeps the persisted strategy unchanged."""
+    import asyncio
+
+    from ouroboros.auto.state import AutoPipelineState, AutoStore
+    from ouroboros.cli.commands.auto import _run_auto
+
+    state = AutoPipelineState(goal="some operational goal", cwd=str(tmp_path))
+    state.runtime_backend = "claude"
+    state.interview_strategy = "never"
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    captured: dict[str, str] = {}
+
+    async def fake_pipeline_run(self, run_state):  # noqa: ARG001
+        captured["interview_strategy"] = run_state.interview_strategy
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id=run_state.auto_session_id,
+            phase="blocked",
+        )
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run),
+    ):
+        store_cls.return_value = store
+
+        asyncio.run(
+            _run_auto(
+                goal=None,
+                resume=state.auto_session_id,
+                runtime=None,
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=False,
+                interview_strategy=None,
+            )
+        )
+
+    assert captured["interview_strategy"] == "never"
+
+
 def test_resume_rejects_lower_bound_override(tmp_path) -> None:
     """Tightening a bound on resume must be refused — never trap a session further."""
     import asyncio


### PR DESCRIPTION
## Summary
- Adds `src/ouroboros/auto/gh_pr_provider.py`: read-only adapter that turns `gh pr view` and `gh api repos/...` output into the `PullRequestStatus` consumed by the merge-policy gate (PR-D).
- Mockable via injected `CommandRunner` — tests script a `dict[args, CommandResult]` instead of monkey-patching `subprocess`.
- **Read-only by construction**: never invokes `gh pr merge` / `gh pr close`. PR-F wires the destructive call site behind the gate.

## Coercions (pessimistic)
| gh field | Mapping |
|---|---|
| `mergeable=MERGEABLE` + `mergeStateStatus∈{CLEAN,UNSTABLE,HAS_HOOKS}` | `True` |
| `mergeable=CONFLICTING` or state ∈ `{DIRTY,BLOCKED,BEHIND}` | `False` |
| `UNKNOWN` | `None` (gate produces wait block) |
| `statusCheckRollup` failure / pending / success | failure dominates; any pending → pending; empty list → success |
| `latestReviews` | unknown states dropped |
| permissions | only `push`/`maintain`/`admin` grant write |

`GhProviderError` is raised for unrecoverable conditions (CLI failure, auth missing, malformed JSON, missing required fields). Routine "data not yet available" cases are encoded in the returned status.

## Stack
- PR-A — classifier ([#694](https://github.com/Q00/ouroboros/pull/694))
- PR-B — state/ledger persistence ([#697](https://github.com/Q00/ouroboros/pull/697))
- PR-C — pipeline routing + CLI flag ([#703](https://github.com/Q00/ouroboros/pull/703))
- PR-D — merge policy gate ([#707](https://github.com/Q00/ouroboros/pull/707))
- **PR-E (this) — gh-CLI provider adapter**
- PR-F — docs + e2e integration

## Test plan
- [x] `pytest tests/unit/auto/test_gh_pr_provider.py` — 19 cases (clean path, mergeability tri-state, CI rollup precedence, review filtering, permission tiers, error surfaces, end-to-end smoke into the gate)
- [x] `pytest tests/unit/auto/ tests/unit/cli/test_auto_command.py` — 280 passed, no regression
- [ ] Reviewer: confirm 30s subprocess timeout is reasonable for `gh pr view` (no retries; transient failures surface to operator)
- [ ] Reviewer: confirm `--jq .permissions` is the right approach vs reading the full repo payload (the latter would also expose the user/org permissions block but at higher cost)

Closes part of #689. Tracker: #692.