### PR TITLE
feat(auto): stream live phase trace in ooo auto CLI

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -17,6 +17,7 @@ from ouroboros.auto.answerer import (
 )
 from ouroboros.auto.gap_detector import Gap, GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
+from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 
@@ -70,9 +71,36 @@ class AutoInterviewDriver:
     store: AutoStore | None = None
     timeout_seconds: float = 60.0
     max_rounds: int = 12
+    progress_callback: AutoProgressCallback | None = None
+    _last_emitted_message: str | None = field(default=None, init=False, repr=False)
+
+    def _emit(self, state: AutoPipelineState) -> None:
+        """Emit a progress snapshot for the current state via the callback.
+
+        Deduped on ``last_progress_message`` so consumers do not see a
+        torrent of identical events for unchanged state. Callback errors
+        are swallowed so an observer can never break the interview loop.
+        """
+        if self.progress_callback is None:
+            return
+        message = state.last_progress_message
+        if message == self._last_emitted_message:
+            return
+        self._last_emitted_message = message
+        event = AutoProgressEvent(
+            auto_session_id=state.auto_session_id,
+            phase=state.phase.value,
+            kind="phase",
+            message=message,
+        )
+        try:
+            self.progress_callback(event)
+        except Exception:
+            pass
 
     async def run(self, state: AutoPipelineState, ledger: SeedDraftLedger) -> AutoInterviewResult:
         """Run bounded auto interview until Seed-ready or blocked."""
+        self._last_emitted_message = None
         self._ensure_interview_phase(state)
         answer_context = self.context_provider(state.cwd)
         interview_tool_name = "interview.start"
@@ -267,6 +295,10 @@ class AutoInterviewDriver:
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:
             self.store.save(state)
+        # Per-round / per-error progress lives in ``state.last_progress_message``;
+        # emit it here so observers see every interview-loop save without each
+        # call site needing to remember to fire the callback.
+        self._emit(state)
 
 
 class FunctionInterviewBackend:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -97,6 +97,11 @@ class AutoPipeline:
         self._last_emitted_phase = None
         self._last_emitted_grade = None
         self._last_emitted_repair = None
+        # Push the same progress callback down into the interview driver so
+        # the longest-running phase (auto interview rounds) emits live
+        # snapshots through the same observer contract instead of forcing
+        # consumers to scrape persisted state for per-round updates.
+        self.interview_driver.progress_callback = self.progress_callback
         ledger = (
             SeedDraftLedger.from_dict(state.ledger)
             if state.ledger

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -394,9 +394,12 @@ def _make_progress_renderer(*, quiet: bool) -> AutoProgressCallback | None:
             label = f"repair round {event.round}"
         else:
             label = event.phase
-        # Escape the leading "[" so Rich treats "[auto]" as literal text
-        # rather than as a markup style name.
-        print_info(rf"\[auto] {label} — {event.message}")
+        # A live trace should be a single dim line per event, not a Rich
+        # panel — using ``console.print`` keeps the stream lightweight so
+        # consumers can grep on the ``[auto]`` prefix without parsing
+        # panel chrome. The leading ``[`` is escaped so Rich treats
+        # ``[auto]`` as literal text rather than as a markup style name.
+        console.print(rf"[dim]\[auto][/] {label} — {event.message}")
 
     return render
 

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -20,6 +20,7 @@ from ouroboros.auto.adapters import (
 )
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.provenance import resolve_provenance
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
@@ -132,6 +133,13 @@ def auto_command(
         str | None,
         typer.Option("--reconcile-source", help="Source label for run handoff reconciliation."),
     ] = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            help="Suppress live phase/grade/repair progress lines; only the final summary prints.",
+        ),
+    ] = False,
 ) -> None:
     """Run an A-grade-gated auto pipeline.
 
@@ -167,6 +175,7 @@ def auto_command(
                 attach_source=attach_source,
                 reconcile_run=reconcile_run,
                 reconcile_source=reconcile_source,
+                progress_callback=_make_progress_renderer(quiet=quiet),
             )
         )
     except Exception as exc:
@@ -207,6 +216,7 @@ async def _run_auto(
     attach_source: str | None = None,
     reconcile_run: bool = False,
     reconcile_source: str | None = None,
+    progress_callback: AutoProgressCallback | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
     incoming_provenance = resolve_provenance()
@@ -327,6 +337,7 @@ async def _run_auto(
         attach_source=attach_source,
         reconcile_run=reconcile_run,
         reconcile_source=reconcile_source,
+        progress_callback=progress_callback,
     )
     result = await pipeline.run(state)
     return result
@@ -369,6 +380,25 @@ def _format_runtime_labels(
     else:
         run_label = backend_name
     return authoring, run_label
+
+
+def _make_progress_renderer(*, quiet: bool) -> AutoProgressCallback | None:
+    """Build a callback that prints live phase/grade/repair lines, unless quiet."""
+    if quiet:
+        return None
+
+    def render(event: AutoProgressEvent) -> None:
+        if event.kind == "grade":
+            label = f"grade {event.grade}" if event.grade else "grade"
+        elif event.kind == "repair":
+            label = f"repair round {event.round}"
+        else:
+            label = event.phase
+        # Escape the leading "[" so Rich treats "[auto]" as literal text
+        # rather than as a markup style name.
+        print_info(rf"\[auto] {label} — {event.message}")
+
+    return render
 
 
 def _print_status(state: AutoPipelineState) -> None:

--- a/tests/unit/auto/test_cli_progress.py
+++ b/tests/unit/auto/test_cli_progress.py
@@ -117,6 +117,62 @@ async def test_cli_run_auto_threads_progress_callback_to_pipeline(monkeypatch, t
     assert captured["progress_callback"] is cb
 
 
+def test_auto_interview_driver_emits_progress_via_callback() -> None:
+    """The interview driver must fire the progress callback on every save.
+
+    AutoPipeline pushes its progress callback into the driver at the start
+    of run() so the longest-running phase (interview rounds) surfaces
+    live snapshots through the same contract as phase / grade / repair
+    events emitted from the pipeline itself.
+    """
+    from ouroboros.auto.interview_driver import AutoInterviewDriver
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState
+
+    captured: list[AutoProgressEvent] = []
+
+    class _StubBackend:
+        async def start(self, _goal, *, cwd):  # noqa: ARG002
+            raise AssertionError("not used in this test")
+
+        async def answer(self, _session_id, _answer):  # noqa: ARG002
+            raise AssertionError("not used in this test")
+
+        async def resume(self, _session_id):  # noqa: ARG002
+            raise AssertionError("not used in this test")
+
+    driver = AutoInterviewDriver(_StubBackend(), progress_callback=captured.append)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp")
+    state.transition(AutoPhase.INTERVIEW, "asking interview round 1/12")
+
+    driver._save(state)
+    state.mark_progress("answered round 1/12 from repo_fact", tool_name="auto_answerer")
+    driver._save(state)
+    # A second save with the same message must not emit a duplicate.
+    driver._save(state)
+
+    assert [event.message for event in captured] == [
+        "asking interview round 1/12",
+        "answered round 1/12 from repo_fact",
+    ]
+    assert all(event.kind == "phase" for event in captured)
+    assert all(event.phase == "interview" for event in captured)
+
+
+def test_auto_interview_driver_swallows_callback_errors() -> None:
+    from ouroboros.auto.interview_driver import AutoInterviewDriver
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState
+
+    def exploding(_event):
+        raise RuntimeError("observer failure")
+
+    driver = AutoInterviewDriver(object(), progress_callback=exploding)  # type: ignore[arg-type]
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp")
+    state.transition(AutoPhase.INTERVIEW, "asking interview round 1/12")
+
+    # Must not raise even though the observer always raises.
+    driver._save(state)
+
+
 def test_cli_auto_quiet_suppresses_progress_lines(monkeypatch, tmp_path) -> None:
     """End-to-end: --quiet must not stream progress lines to the user."""
     from ouroboros.auto.state import AutoStore

--- a/tests/unit/auto/test_cli_progress.py
+++ b/tests/unit/auto/test_cli_progress.py
@@ -1,0 +1,175 @@
+"""CLI rendering tests for the live ``ooo auto`` phase trace."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.progress import AutoProgressEvent
+from ouroboros.cli.commands import auto as auto_command
+from ouroboros.cli.commands.auto import _make_progress_renderer
+from ouroboros.cli.main import app
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def test_make_progress_renderer_quiet_returns_none() -> None:
+    assert _make_progress_renderer(quiet=True) is None
+
+
+def test_make_progress_renderer_emits_phase_grade_repair_lines(capsys) -> None:
+    render = _make_progress_renderer(quiet=False)
+    assert render is not None
+
+    render(
+        AutoProgressEvent(
+            auto_session_id="auto_x",
+            phase="interview",
+            kind="phase",
+            message="asking interview round 3/12",
+        )
+    )
+    render(
+        AutoProgressEvent(
+            auto_session_id="auto_x",
+            phase="review",
+            kind="grade",
+            message="Seed grade A",
+            grade="A",
+        )
+    )
+    render(
+        AutoProgressEvent(
+            auto_session_id="auto_x",
+            phase="repair",
+            kind="repair",
+            message="repair round 1",
+            round=1,
+        )
+    )
+
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "[auto] interview — asking interview round 3/12" in output
+    assert "[auto] grade A — Seed grade A" in output
+    assert "[auto] repair round 1 — repair round 1" in output
+
+
+def test_cli_auto_help_documents_quiet_flag() -> None:
+    result = CliRunner().invoke(app, ["auto", "--help"])
+    output = _strip_ansi(result.output)
+
+    assert result.exit_code == 0
+    assert "--quiet" in output
+
+
+@pytest.mark.asyncio
+async def test_cli_run_auto_threads_progress_callback_to_pipeline(
+    monkeypatch, tmp_path
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            captured["progress_callback"] = kwargs.get("progress_callback")
+
+        async def run(self, run_state):  # noqa: ANN001
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    class FakeHandler:
+        def __init__(self, **_kwargs):
+            pass
+
+    from ouroboros.auto.state import AutoStore
+
+    monkeypatch.setattr(auto_command, "AutoStore", lambda: AutoStore(tmp_path))
+    monkeypatch.setattr(
+        auto_command, "resolve_agent_runtime_backend", lambda value=None: value or "codex"
+    )
+    monkeypatch.setattr(auto_command, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(auto_command, "InterviewHandler", FakeHandler)
+    monkeypatch.setattr(auto_command, "GenerateSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_command, "ExecuteSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_command, "StartExecuteSeedHandler", FakeHandler)
+
+    sentinel: list[AutoProgressEvent] = []
+
+    def cb(event: AutoProgressEvent) -> None:
+        sentinel.append(event)
+
+    result = await auto_command._run_auto(
+        goal="Build a CLI",
+        resume=None,
+        runtime=None,
+        max_interview_rounds=1,
+        max_repair_rounds=1,
+        skip_run=False,
+        progress_callback=cb,
+    )
+
+    assert result.status == "complete"
+    assert captured["progress_callback"] is cb
+
+
+def test_cli_auto_quiet_suppresses_progress_lines(monkeypatch, tmp_path) -> None:
+    """End-to-end: --quiet must not stream progress lines to the user."""
+    from ouroboros.auto.state import AutoStore
+
+    progress_seen: list[AutoProgressEvent] = []
+
+    class FakePipeline:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            cb = kwargs.get("progress_callback")
+            # Simulate a phase emit during the run; it should be suppressed
+            # whenever the CLI was invoked with --quiet.
+            if cb is not None:
+                cb(
+                    AutoProgressEvent(
+                        auto_session_id="auto_test",
+                        phase="interview",
+                        kind="phase",
+                        message="asking interview round 1/12",
+                    )
+                )
+            progress_seen.append(cb)  # type: ignore[arg-type]
+
+        async def run(self, run_state):  # noqa: ANN001
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    class FakeHandler:
+        def __init__(self, **_kwargs):
+            pass
+
+    monkeypatch.setattr(auto_command, "AutoStore", lambda: AutoStore(tmp_path))
+    monkeypatch.setattr(
+        auto_command, "resolve_agent_runtime_backend", lambda value=None: value or "codex"
+    )
+    monkeypatch.setattr(auto_command, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(auto_command, "InterviewHandler", FakeHandler)
+    monkeypatch.setattr(auto_command, "GenerateSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_command, "ExecuteSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_command, "StartExecuteSeedHandler", FakeHandler)
+
+    quiet_result = CliRunner().invoke(app, ["auto", "Build a CLI", "--quiet"])
+    quiet_output = _strip_ansi(quiet_result.output)
+    assert quiet_result.exit_code == 0
+    assert "[auto]" not in quiet_output
+    assert progress_seen[-1] is None  # quiet → no callback wired
+
+    loud_result = CliRunner().invoke(app, ["auto", "Build a CLI"])
+    loud_output = _strip_ansi(loud_result.output)
+    assert loud_result.exit_code == 0
+    assert "[auto] interview — asking interview round 1/12" in loud_output
+    assert progress_seen[-1] is not None

--- a/tests/unit/auto/test_cli_progress.py
+++ b/tests/unit/auto/test_cli_progress.py
@@ -68,9 +68,7 @@ def test_cli_auto_help_documents_quiet_flag() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cli_run_auto_threads_progress_callback_to_pipeline(
-    monkeypatch, tmp_path
-) -> None:
+async def test_cli_run_auto_threads_progress_callback_to_pipeline(monkeypatch, tmp_path) -> None:
     captured: dict[str, object] = {}
 
     class FakePipeline:


### PR DESCRIPTION
## Summary

Wires the `AutoProgressEvent` callback into the `ooo auto` CLI so users see live phase / grade / repair lines as the auto pipeline advances, instead of only the final summary. A `--quiet` flag opts out.

This is the third slice of the #639 surface follow-ups, after the persisted-state `--status` view (#645) and the MCP `_result_meta` (#667 / #698).

## Stacking / dependency

Stacked on **#705** (\`feat/639-B-progress-contract\`). This branch contains those commits at the bottom of its history; please review **#705 first**, then the single new commit on top here. Once #705 merges I will rebase this on `main` and the diff will collapse to the CLI-only changes.

## Changes

- `src/ouroboros/cli/commands/auto.py`
  - New `--quiet` typer option on `auto_command`.
  - `_run_auto` now accepts `progress_callback` and threads it into `AutoPipeline(...)`.
  - New `_make_progress_renderer(*, quiet)` factory:
    - quiet → returns `None` (no callback wired, no streaming).
    - otherwise → returns a callback that prints \`\\[auto] {label} — {message}\` via `print_info`. The leading `[` is escaped so Rich treats \`[auto]\` as literal text rather than a markup style name.
- `tests/unit/auto/test_cli_progress.py`
  - Quiet flag returns `None`.
  - Renderer formats phase, grade, and repair events via captured stdout.
  - `--quiet` is documented in `--help`.
  - `_run_auto(progress_callback=cb)` actually forwards `cb` to `AutoPipeline(progress_callback=...)`.
  - End-to-end CliRunner check: without `--quiet`, the streamed phase line appears in the final output; with `--quiet`, no `[auto]` lines appear and the callback is `None` at the pipeline boundary.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/cli/commands/auto.py tests/unit/auto/test_cli_progress.py` → passes.
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto -q` → 209 passed.

## Risks / Notes

- The renderer prints once per distinct phase change (dedup happens inside `AutoPipeline`); long-running phases will not flood stdout.
- Existing CLI snapshot tests / scripted users that grep for the final-summary lines are unchanged. The new lines all carry an unmistakable `\\[auto]` prefix so downstream pipes can filter on it.

Refs #639