### PR TITLE
feat(auto): expose auto progress event history through MCP meta

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from ouroboros.auto.grading import GradeGate
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore, utc_now_iso
@@ -75,9 +76,16 @@ class AutoPipeline:
     reconcile_source: str | None = None
     seed_timeout_seconds: float = 120.0
     run_start_timeout_seconds: float = 60.0
+    progress_callback: AutoProgressCallback | None = None
+    _last_emitted_phase: str | None = field(default=None, init=False, repr=False)
+    _last_emitted_grade: str | None = field(default=None, init=False, repr=False)
+    _last_emitted_repair: int | None = field(default=None, init=False, repr=False)
 
     async def run(self, state: AutoPipelineState) -> AutoPipelineResult:
         """Run a bounded auto pipeline using injected side-effecting dependencies."""
+        self._last_emitted_phase = None
+        self._last_emitted_grade = None
+        self._last_emitted_repair = None
         ledger = (
             SeedDraftLedger.from_dict(state.ledger)
             if state.ledger
@@ -251,6 +259,8 @@ class AutoPipeline:
             state.last_grade = review.grade_result.grade.value
             state.findings = [asdict(finding) for finding in review.findings]
             state.ledger = ledger.to_dict()
+            self._maybe_emit_repair(state)
+            self._maybe_emit_grade(state)
             if self.seed_saver is not None:
                 try:
                     state.seed_path = self.seed_saver(seed)
@@ -559,6 +569,53 @@ class AutoPipeline:
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:
             self.store.save(state)
+        self._maybe_emit_phase(state)
+
+    def _maybe_emit_phase(self, state: AutoPipelineState) -> None:
+        phase = state.phase.value
+        if phase == self._last_emitted_phase:
+            return
+        self._last_emitted_phase = phase
+        self._emit(state, "phase", state.last_progress_message)
+
+    def _maybe_emit_grade(self, state: AutoPipelineState) -> None:
+        grade = state.last_grade
+        if grade is None or grade == self._last_emitted_grade:
+            return
+        self._last_emitted_grade = grade
+        self._emit(state, "grade", f"Seed grade {grade}", grade=grade)
+
+    def _maybe_emit_repair(self, state: AutoPipelineState) -> None:
+        rounds = state.repair_round
+        if rounds <= 0 or rounds == self._last_emitted_repair:
+            return
+        self._last_emitted_repair = rounds
+        self._emit(state, "repair", f"repair round {rounds}", round=rounds)
+
+    def _emit(
+        self,
+        state: AutoPipelineState,
+        kind: str,
+        message: str,
+        *,
+        round: int | None = None,
+        grade: str | None = None,
+    ) -> None:
+        if self.progress_callback is None:
+            return
+        event = AutoProgressEvent(
+            auto_session_id=state.auto_session_id,
+            phase=state.phase.value,
+            kind=kind,
+            message=message,
+            round=round,
+            grade=grade,
+        )
+        try:
+            self.progress_callback(event)
+        except Exception:
+            # Observers must never break the pipeline. Swallow callback errors.
+            pass
 
 
 def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -89,9 +89,16 @@ class AutoPipeline:
 
     async def run(self, state: AutoPipelineState) -> AutoPipelineResult:
         """Run a bounded auto pipeline using injected side-effecting dependencies."""
-        self._last_emitted_phase = None
-        self._last_emitted_grade = None
-        self._last_emitted_repair = None
+        # Seed the dedup trackers from the *current* persisted state so a
+        # no-op resume — including a resume of an already-terminal session
+        # — does not synthesize a fake phase/grade/repair event for state
+        # that has not actually changed since the last run. The persisted
+        # progress_events log is the public history surfaced through MCP
+        # metadata, so spurious entries here would mislead clients that
+        # replay or render this history.
+        self._last_emitted_phase = state.phase.value
+        self._last_emitted_grade = state.last_grade
+        self._last_emitted_repair = state.repair_round if state.repair_round > 0 else None
         ledger = (
             SeedDraftLedger.from_dict(state.ledger)
             if state.ledger

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -574,9 +574,16 @@ class AutoPipeline:
         return False, None
 
     def _save(self, state: AutoPipelineState) -> None:
+        # Emit *before* persisting so the new phase event lands in
+        # ``state.progress_events`` and gets durably written by the same
+        # save call. Otherwise terminal phase transitions
+        # (complete / blocked / failed) — which are followed only by an
+        # immediate ``return`` — would never be persisted, and
+        # AutoHandler.handle()'s post-run reload would surface a
+        # progress history that is always one save behind.
+        self._maybe_emit_phase(state)
         if self.store is not None:
             self.store.save(state)
-        self._maybe_emit_phase(state)
 
     def _maybe_emit_phase(self, state: AutoPipelineState) -> None:
         phase = state.phase.value

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -21,6 +21,12 @@ RunStarter = Callable[[Seed], Awaitable[dict[str, Any]]]
 SeedSaver = Callable[[Seed], str]
 SeedLoader = Callable[[str], Seed]
 
+# Cap the persisted progress event ring buffer so resume states stay compact
+# even on long-running sessions. With per-phase dedup in _maybe_emit_phase,
+# the worst-case sequence (12 interview rounds + 5 repair rounds + grade
+# updates + terminal phases) sits well below 100 entries.
+_PROGRESS_EVENT_LIMIT = 100
+
 
 @dataclass(frozen=True, slots=True)
 class AutoPipelineResult:
@@ -602,8 +608,6 @@ class AutoPipeline:
         round: int | None = None,
         grade: str | None = None,
     ) -> None:
-        if self.progress_callback is None:
-            return
         event = AutoProgressEvent(
             auto_session_id=state.auto_session_id,
             phase=state.phase.value,
@@ -612,6 +616,27 @@ class AutoPipeline:
             round=round,
             grade=grade,
         )
+        # Persist a JSON-friendly copy on state so MCP/CLI surfaces can
+        # rebuild the full progress history across resumes — without this,
+        # ``progress_events`` would only ever describe the current
+        # invocation. The log is bounded to the last
+        # ``_PROGRESS_EVENT_LIMIT`` entries so the persisted state file
+        # stays compact even on long-running sessions.
+        state.progress_events.append(
+            {
+                "phase": event.phase,
+                "kind": event.kind,
+                "message": event.message,
+                "round": event.round,
+                "grade": event.grade,
+                "timestamp": event.timestamp,
+            }
+        )
+        if len(state.progress_events) > _PROGRESS_EVENT_LIMIT:
+            del state.progress_events[: len(state.progress_events) - _PROGRESS_EVENT_LIMIT]
+
+        if self.progress_callback is None:
+            return
         try:
             self.progress_callback(event)
         except Exception:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -332,6 +332,7 @@ class AutoPipeline:
                 review = reviewer.review(seed, ledger=ledger)
                 state.last_grade = review.grade_result.grade.value
                 state.findings = [asdict(finding) for finding in review.findings]
+                self._maybe_emit_grade(state)
                 self._save(state)
             if not review.may_run:
                 state.mark_blocked(

--- a/src/ouroboros/auto/progress.py
+++ b/src/ouroboros/auto/progress.py
@@ -21,11 +21,21 @@ AutoProgressKind = Literal["phase", "grade", "repair"]
 class AutoProgressEvent:
     """Immutable observation of an auto pipeline state change.
 
+    Each event is a *snapshot* of the current pipeline state at the
+    moment of emission, not a delta. Consumers should treat the stream
+    as "the latest known state plus selected milestones".
+
     ``kind`` is the discriminant:
 
-    - ``phase``: a phase transition (including terminal phases) just occurred.
-    - ``grade``: a Seed review produced a grade.
-    - ``repair``: the repair round counter advanced.
+    - ``phase``: the pipeline phase just changed since the last
+      observation. ``AutoPipeline`` also emits a ``phase`` event on the
+      first save of every ``run()`` invocation — including resume paths
+      where no fresh transition occurred in this process — so observers
+      always learn the current phase without polling the store.
+    - ``grade``: a Seed review produced a new grade since the last
+      observation.
+    - ``repair``: the repair round counter advanced since the last
+      observation.
     """
 
     auto_session_id: str

--- a/src/ouroboros/auto/progress.py
+++ b/src/ouroboros/auto/progress.py
@@ -1,0 +1,40 @@
+"""Structured progress events for ``ooo auto`` sessions.
+
+Observers (CLI streaming, MCP history, TUI/HUD) subscribe to a single
+``AutoProgressCallback`` to render auto pipeline progress without scraping the
+persisted JSON state. The dataclass is intentionally narrow so future surfaces
+can extend it without a breaking change to the contract that lives here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal
+
+from ouroboros.auto.state import utc_now_iso
+
+AutoProgressKind = Literal["phase", "grade", "repair"]
+
+
+@dataclass(frozen=True, slots=True)
+class AutoProgressEvent:
+    """Immutable observation of an auto pipeline state change.
+
+    ``kind`` is the discriminant:
+
+    - ``phase``: a phase transition (including terminal phases) just occurred.
+    - ``grade``: a Seed review produced a grade.
+    - ``repair``: the repair round counter advanced.
+    """
+
+    auto_session_id: str
+    phase: str
+    kind: AutoProgressKind
+    message: str
+    round: int | None = None
+    grade: str | None = None
+    timestamp: str = field(default_factory=utc_now_iso)
+
+
+AutoProgressCallback = Callable[[AutoProgressEvent], None]

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -207,6 +207,7 @@ class AutoPipelineState:
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
+    progress_events: list[dict[str, Any]] = field(default_factory=list)
     repair_round: int = 0
     current_round: int = 0
     pending_question: str | None = None
@@ -313,6 +314,7 @@ class AutoPipelineState:
         payload.setdefault("run_reconciliation_source", None)
         payload.setdefault("run_reconciled_at", None)
         payload.setdefault("provenance", None)
+        payload.setdefault("progress_events", [])
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -448,7 +450,7 @@ class AutoPipelineState:
             if type(getattr(self, field_name)) is not bool:
                 msg = f"{field_name} must be a boolean"
                 raise ValueError(msg)
-        for field_name in ("findings",):
+        for field_name in ("findings", "progress_events"):
             value = getattr(self, field_name)
             if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
                 msg = f"{field_name} must be a list of objects"

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -17,7 +17,6 @@ from ouroboros.auto.adapters import (
 )
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
-from ouroboros.auto.progress import AutoProgressEvent
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.config import get_opencode_mode
@@ -128,14 +127,27 @@ class AutoHandler:
         )
 
     async def handle(self, arguments: dict[str, Any]) -> Result[MCPToolResult, MCPServerError]:
-        progress_events: list[AutoProgressEvent] = []
         try:
-            result = await self._run(arguments, progress_events=progress_events)
+            result = await self._run(arguments)
         except Exception as exc:
             return Result.err(
                 MCPToolError(f"Auto pipeline failed: {exc}", tool_name="ouroboros_auto")
             )
-        meta = _result_meta(result, progress_events=progress_events)
+        # Hydrate progress event history from the persisted state so the
+        # MCP meta payload includes events emitted by *prior* invocations
+        # of this auto session as well, not just the events emitted by
+        # this single ``handle()`` call. The pipeline persists every
+        # event onto ``state.progress_events`` so a session-scoped read
+        # is the single source of truth.
+        persisted_events: list[dict[str, Any]] = []
+        try:
+            store = self.store or AutoStore()
+            persisted_state = store.load(result.auto_session_id)
+            persisted_events = list(persisted_state.progress_events)
+        except Exception:
+            # An unloadable session must not break the immediate result.
+            persisted_events = []
+        meta = _result_meta(result, progress_events=persisted_events)
         text = _format_result(result)
         if result.run_subagent is not None:
             meta["_subagent"] = result.run_subagent
@@ -148,12 +160,7 @@ class AutoHandler:
             )
         )
 
-    async def _run(
-        self,
-        arguments: dict[str, Any],
-        *,
-        progress_events: list[AutoProgressEvent] | None = None,
-    ) -> AutoPipelineResult:
+    async def _run(self, arguments: dict[str, Any]) -> AutoPipelineResult:
         store = self.store or AutoStore()
         resume = arguments.get("resume")
         requested_skip_run = bool(arguments.get("skip_run", False))
@@ -226,7 +233,6 @@ class AutoHandler:
             max_rounds=max_interview_rounds,
             timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
         )
-        progress_callback = progress_events.append if progress_events is not None else None
         pipeline = AutoPipeline(
             driver,
             HandlerSeedGenerator(generate_seed_handler),
@@ -242,7 +248,6 @@ class AutoHandler:
             attach_source=attach_source,
             reconcile_run=reconcile_run,
             reconcile_source=reconcile_source,
-            progress_callback=progress_callback,
         )
         return await pipeline.run(state)
 
@@ -250,9 +255,14 @@ class AutoHandler:
 def _result_meta(
     result: AutoPipelineResult,
     *,
-    progress_events: list[AutoProgressEvent] | None = None,
+    progress_events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    """Build MCP metadata for clients that render auto progress outside CLI text."""
+    """Build MCP metadata for clients that render auto progress outside CLI text.
+
+    ``progress_events`` is the persisted ``state.progress_events`` log copied
+    out of ``AutoStore``. Each entry is already a JSON-friendly dict with
+    keys ``{phase, kind, message, round, grade, timestamp}``.
+    """
     meta: dict[str, Any] = {
         "status": result.status,
         "auto_session_id": result.auto_session_id,
@@ -285,24 +295,8 @@ def _result_meta(
         meta["run_reconciliation_source"] = result.run_reconciliation_source
         meta["run_reconciled_at"] = result.run_reconciled_at
     if progress_events:
-        meta["progress_events"] = [_progress_event_to_dict(event) for event in progress_events]
+        meta["progress_events"] = list(progress_events)
     return meta
-
-
-def _progress_event_to_dict(event: AutoProgressEvent) -> dict[str, Any]:
-    """Serialize a single AutoProgressEvent to a JSON-friendly dict.
-
-    The ``auto_session_id`` field is intentionally elided — it duplicates the
-    sibling top-level ``meta["auto_session_id"]`` for every entry.
-    """
-    return {
-        "phase": event.phase,
-        "kind": event.kind,
-        "message": event.message,
-        "round": event.round,
-        "grade": event.grade,
-        "timestamp": event.timestamp,
-    }
 
 
 def _resolved_opencode_mode(runtime_backend: str | None, opencode_mode: str | None) -> str | None:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -17,6 +17,7 @@ from ouroboros.auto.adapters import (
 )
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.progress import AutoProgressEvent
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.config import get_opencode_mode
@@ -127,13 +128,14 @@ class AutoHandler:
         )
 
     async def handle(self, arguments: dict[str, Any]) -> Result[MCPToolResult, MCPServerError]:
+        progress_events: list[AutoProgressEvent] = []
         try:
-            result = await self._run(arguments)
+            result = await self._run(arguments, progress_events=progress_events)
         except Exception as exc:
             return Result.err(
                 MCPToolError(f"Auto pipeline failed: {exc}", tool_name="ouroboros_auto")
             )
-        meta = _result_meta(result)
+        meta = _result_meta(result, progress_events=progress_events)
         text = _format_result(result)
         if result.run_subagent is not None:
             meta["_subagent"] = result.run_subagent
@@ -146,7 +148,12 @@ class AutoHandler:
             )
         )
 
-    async def _run(self, arguments: dict[str, Any]) -> AutoPipelineResult:
+    async def _run(
+        self,
+        arguments: dict[str, Any],
+        *,
+        progress_events: list[AutoProgressEvent] | None = None,
+    ) -> AutoPipelineResult:
         store = self.store or AutoStore()
         resume = arguments.get("resume")
         requested_skip_run = bool(arguments.get("skip_run", False))
@@ -219,6 +226,7 @@ class AutoHandler:
             max_rounds=max_interview_rounds,
             timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
         )
+        progress_callback = progress_events.append if progress_events is not None else None
         pipeline = AutoPipeline(
             driver,
             HandlerSeedGenerator(generate_seed_handler),
@@ -234,11 +242,16 @@ class AutoHandler:
             attach_source=attach_source,
             reconcile_run=reconcile_run,
             reconcile_source=reconcile_source,
+            progress_callback=progress_callback,
         )
         return await pipeline.run(state)
 
 
-def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
+def _result_meta(
+    result: AutoPipelineResult,
+    *,
+    progress_events: list[AutoProgressEvent] | None = None,
+) -> dict[str, Any]:
     """Build MCP metadata for clients that render auto progress outside CLI text."""
     meta: dict[str, Any] = {
         "status": result.status,
@@ -271,7 +284,25 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["run_reconciliation_status"] = result.run_reconciliation_status
         meta["run_reconciliation_source"] = result.run_reconciliation_source
         meta["run_reconciled_at"] = result.run_reconciled_at
+    if progress_events:
+        meta["progress_events"] = [_progress_event_to_dict(event) for event in progress_events]
     return meta
+
+
+def _progress_event_to_dict(event: AutoProgressEvent) -> dict[str, Any]:
+    """Serialize a single AutoProgressEvent to a JSON-friendly dict.
+
+    The ``auto_session_id`` field is intentionally elided — it duplicates the
+    sibling top-level ``meta["auto_session_id"]`` for every entry.
+    """
+    return {
+        "phase": event.phase,
+        "kind": event.kind,
+        "message": event.message,
+        "round": event.round,
+        "grade": event.grade,
+        "timestamp": event.timestamp,
+    }
 
 
 def _resolved_opencode_mode(runtime_backend: str | None, opencode_mode: str | None) -> str | None:

--- a/tests/unit/auto/test_mcp_progress_history.py
+++ b/tests/unit/auto/test_mcp_progress_history.py
@@ -1,0 +1,162 @@
+"""Tests for the MCP progress event history surfaced by AutoHandler."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.progress import AutoProgressEvent
+from ouroboros.auto.state import AutoStore
+from ouroboros.mcp.tools import auto_handler as auto_module
+from ouroboros.mcp.tools.auto_handler import AutoHandler, _result_meta
+
+
+def _result() -> AutoPipelineResult:
+    return AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_test",
+        phase="complete",
+        last_progress_message="execution started for grade A Seed",
+        last_progress_at="2026-05-01T12:30:00+00:00",
+    )
+
+
+def test_result_meta_omits_progress_events_when_empty() -> None:
+    meta = _result_meta(_result(), progress_events=[])
+
+    assert "progress_events" not in meta
+
+
+def test_result_meta_serializes_progress_events_in_order() -> None:
+    events = [
+        AutoProgressEvent(
+            auto_session_id="auto_test",
+            phase="interview",
+            kind="phase",
+            message="asking interview round 1/12",
+            timestamp="2026-05-01T12:00:00+00:00",
+        ),
+        AutoProgressEvent(
+            auto_session_id="auto_test",
+            phase="review",
+            kind="grade",
+            message="Seed grade A",
+            grade="A",
+            timestamp="2026-05-01T12:25:00+00:00",
+        ),
+        AutoProgressEvent(
+            auto_session_id="auto_test",
+            phase="repair",
+            kind="repair",
+            message="repair round 1",
+            round=1,
+            timestamp="2026-05-01T12:20:00+00:00",
+        ),
+    ]
+
+    meta = _result_meta(_result(), progress_events=events)
+
+    history = meta["progress_events"]
+    assert len(history) == 3
+    # Each entry must be JSON-friendly (no enums/dataclasses left behind) and
+    # must elide the redundant top-level auto_session_id.
+    for entry in history:
+        assert "auto_session_id" not in entry
+        assert set(entry.keys()) == {"phase", "kind", "message", "round", "grade", "timestamp"}
+    assert [entry["kind"] for entry in history] == ["phase", "grade", "repair"]
+    assert history[1]["grade"] == "A"
+    assert history[2]["round"] == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_meta_includes_progress_events_emitted_during_run(
+    monkeypatch, tmp_path
+) -> None:
+    captured_session: dict[str, str] = {}
+
+    class FakePipeline:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            self._cb = kwargs.get("progress_callback")
+
+        async def run(self, run_state):  # noqa: ANN001
+            captured_session["id"] = run_state.auto_session_id
+            if self._cb is not None:
+                self._cb(
+                    AutoProgressEvent(
+                        auto_session_id=run_state.auto_session_id,
+                        phase="interview",
+                        kind="phase",
+                        message="asking interview round 1/12",
+                        timestamp="2026-05-01T12:00:00+00:00",
+                    )
+                )
+                self._cb(
+                    AutoProgressEvent(
+                        auto_session_id=run_state.auto_session_id,
+                        phase="review",
+                        kind="grade",
+                        message="Seed grade A",
+                        grade="A",
+                        timestamp="2026-05-01T12:25:00+00:00",
+                    )
+                )
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    class FakeHandler:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            pass
+
+    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(auto_module, "InterviewHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "GenerateSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "ExecuteSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "StartExecuteSeedHandler", FakeHandler)
+
+    result = await AutoHandler().handle({"goal": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert result.is_ok
+    history = result.value.meta["progress_events"]
+    assert len(history) == 2
+    assert history[0]["kind"] == "phase"
+    assert history[0]["phase"] == "interview"
+    assert history[1]["kind"] == "grade"
+    assert history[1]["grade"] == "A"
+    # Top-level auto_session_id is still authoritative.
+    assert result.value.meta["auto_session_id"] == captured_session["id"]
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_meta_omits_progress_events_when_pipeline_emits_none(
+    monkeypatch, tmp_path
+) -> None:
+    class FakePipeline:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            pass
+
+        async def run(self, run_state):  # noqa: ANN001
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    class FakeHandler:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            pass
+
+    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(auto_module, "InterviewHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "GenerateSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "ExecuteSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "StartExecuteSeedHandler", FakeHandler)
+
+    result = await AutoHandler().handle({"goal": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert result.is_ok
+    assert "progress_events" not in result.value.meta

--- a/tests/unit/auto/test_mcp_progress_history.py
+++ b/tests/unit/auto/test_mcp_progress_history.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from ouroboros.auto.pipeline import AutoPipelineResult
-from ouroboros.auto.progress import AutoProgressEvent
 from ouroboros.auto.state import AutoStore
 from ouroboros.mcp.tools import auto_handler as auto_module
 from ouroboros.mcp.tools.auto_handler import AutoHandler, _result_meta
@@ -27,79 +28,127 @@ def test_result_meta_omits_progress_events_when_empty() -> None:
     assert "progress_events" not in meta
 
 
-def test_result_meta_serializes_progress_events_in_order() -> None:
-    events = [
-        AutoProgressEvent(
-            auto_session_id="auto_test",
-            phase="interview",
-            kind="phase",
-            message="asking interview round 1/12",
-            timestamp="2026-05-01T12:00:00+00:00",
-        ),
-        AutoProgressEvent(
-            auto_session_id="auto_test",
-            phase="review",
-            kind="grade",
-            message="Seed grade A",
-            grade="A",
-            timestamp="2026-05-01T12:25:00+00:00",
-        ),
-        AutoProgressEvent(
-            auto_session_id="auto_test",
-            phase="repair",
-            kind="repair",
-            message="repair round 1",
-            round=1,
-            timestamp="2026-05-01T12:20:00+00:00",
-        ),
+def test_result_meta_passes_persisted_progress_events_through_unchanged() -> None:
+    persisted: list[dict[str, Any]] = [
+        {
+            "phase": "interview",
+            "kind": "phase",
+            "message": "asking interview round 1/12",
+            "round": None,
+            "grade": None,
+            "timestamp": "2026-05-01T12:00:00+00:00",
+        },
+        {
+            "phase": "review",
+            "kind": "grade",
+            "message": "Seed grade A",
+            "round": None,
+            "grade": "A",
+            "timestamp": "2026-05-01T12:25:00+00:00",
+        },
+        {
+            "phase": "repair",
+            "kind": "repair",
+            "message": "repair round 1",
+            "round": 1,
+            "grade": None,
+            "timestamp": "2026-05-01T12:20:00+00:00",
+        },
     ]
 
-    meta = _result_meta(_result(), progress_events=events)
+    meta = _result_meta(_result(), progress_events=persisted)
 
     history = meta["progress_events"]
-    assert len(history) == 3
-    # Each entry must be JSON-friendly (no enums/dataclasses left behind) and
-    # must elide the redundant top-level auto_session_id.
+    assert history == persisted
+    # The handler returns a defensive copy so consumers cannot mutate
+    # the persisted log through the meta payload.
+    assert history is not persisted
     for entry in history:
         assert "auto_session_id" not in entry
         assert set(entry.keys()) == {"phase", "kind", "message", "round", "grade", "timestamp"}
-    assert [entry["kind"] for entry in history] == ["phase", "grade", "repair"]
-    assert history[1]["grade"] == "A"
-    assert history[2]["round"] == 1
 
 
 @pytest.mark.asyncio
-async def test_auto_handler_meta_includes_progress_events_emitted_during_run(
+async def test_auto_handler_meta_includes_persisted_progress_events_after_resume(
     monkeypatch, tmp_path
 ) -> None:
+    """A second handle() invocation must keep prior session events.
+
+    The progress event history is persisted on ``AutoPipelineState`` so a
+    resumed session reads back every event from earlier invocations,
+    not just the events emitted by the current ``handle()`` call.
+    """
     captured_session: dict[str, str] = {}
+    store_root = tmp_path / "store"
 
     class FakePipeline:
         def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
-            self._cb = kwargs.get("progress_callback")
+            pass
 
         async def run(self, run_state):  # noqa: ANN001
             captured_session["id"] = run_state.auto_session_id
-            if self._cb is not None:
-                self._cb(
-                    AutoProgressEvent(
-                        auto_session_id=run_state.auto_session_id,
-                        phase="interview",
-                        kind="phase",
-                        message="asking interview round 1/12",
-                        timestamp="2026-05-01T12:00:00+00:00",
-                    )
-                )
-                self._cb(
-                    AutoProgressEvent(
-                        auto_session_id=run_state.auto_session_id,
-                        phase="review",
-                        kind="grade",
-                        message="Seed grade A",
-                        grade="A",
-                        timestamp="2026-05-01T12:25:00+00:00",
-                    )
-                )
+            # Pre-existing history persisted by an earlier invocation.
+            run_state.progress_events.append(
+                {
+                    "phase": "interview",
+                    "kind": "phase",
+                    "message": "asking interview round 1/12",
+                    "round": None,
+                    "grade": None,
+                    "timestamp": "2026-05-01T12:00:00+00:00",
+                }
+            )
+            # New event recorded during *this* invocation.
+            run_state.progress_events.append(
+                {
+                    "phase": "review",
+                    "kind": "grade",
+                    "message": "Seed grade A",
+                    "round": None,
+                    "grade": "A",
+                    "timestamp": "2026-05-01T12:25:00+00:00",
+                }
+            )
+            AutoStore(store_root).save(run_state)
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    class FakeHandler:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            pass
+
+    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(store_root))
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(auto_module, "InterviewHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "GenerateSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "ExecuteSeedHandler", FakeHandler)
+    monkeypatch.setattr(auto_module, "StartExecuteSeedHandler", FakeHandler)
+
+    result = await AutoHandler().handle({"goal": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert result.is_ok
+    history = result.value.meta["progress_events"]
+    assert len(history) == 2
+    assert history[0]["kind"] == "phase"
+    assert history[0]["phase"] == "interview"
+    assert history[1]["kind"] == "grade"
+    assert history[1]["grade"] == "A"
+    assert result.value.meta["auto_session_id"] == captured_session["id"]
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_meta_omits_progress_events_when_state_log_empty(
+    monkeypatch, tmp_path
+) -> None:
+    class FakePipeline:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
+            pass
+
+        async def run(self, run_state):  # noqa: ANN001
+            AutoStore(tmp_path / "store").save(run_state)
             return AutoPipelineResult(
                 status="complete",
                 auto_session_id=run_state.auto_session_id,
@@ -120,20 +169,18 @@ async def test_auto_handler_meta_includes_progress_events_emitted_during_run(
     result = await AutoHandler().handle({"goal": "Build a CLI", "cwd": str(tmp_path)})
 
     assert result.is_ok
-    history = result.value.meta["progress_events"]
-    assert len(history) == 2
-    assert history[0]["kind"] == "phase"
-    assert history[0]["phase"] == "interview"
-    assert history[1]["kind"] == "grade"
-    assert history[1]["grade"] == "A"
-    # Top-level auto_session_id is still authoritative.
-    assert result.value.meta["auto_session_id"] == captured_session["id"]
+    assert "progress_events" not in result.value.meta
 
 
 @pytest.mark.asyncio
-async def test_auto_handler_meta_omits_progress_events_when_pipeline_emits_none(
+async def test_auto_handler_meta_tolerates_unloadable_state_after_run(
     monkeypatch, tmp_path
 ) -> None:
+    """If the store cannot be re-read, the meta payload is still produced.
+
+    A degraded store must never poison an otherwise-successful run.
+    """
+
     class FakePipeline:
         def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
             pass
@@ -149,7 +196,17 @@ async def test_auto_handler_meta_omits_progress_events_when_pipeline_emits_none(
         def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003, ARG002
             pass
 
-    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    class _ExplodingStore:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def load(self, _session_id):
+            raise RuntimeError("simulated store failure")
+
+        def save(self, _state):  # pragma: no cover - unused in this path
+            return None
+
+    monkeypatch.setattr(auto_module, "AutoStore", _ExplodingStore)
     monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
     monkeypatch.setattr(auto_module, "InterviewHandler", FakeHandler)
     monkeypatch.setattr(auto_module, "GenerateSeedHandler", FakeHandler)

--- a/tests/unit/auto/test_mcp_progress_history.py
+++ b/tests/unit/auto/test_mcp_progress_history.py
@@ -173,6 +173,121 @@ async def test_auto_handler_meta_omits_progress_events_when_state_log_empty(
 
 
 @pytest.mark.asyncio
+async def test_auto_handler_meta_includes_terminal_phase_event_persisted_during_run(
+    monkeypatch, tmp_path
+) -> None:
+    """The save that records a terminal phase transition must persist the matching event.
+
+    Regression for the bot finding that ``_save()`` previously persisted
+    ``state`` *before* ``_maybe_emit_phase`` appended the new event, so
+    a terminal ``complete`` / ``blocked`` / ``failed`` transition (which
+    is always followed by an immediate ``return``) was never written to
+    ``state.progress_events`` on disk. The handler then re-loaded a
+    history that was always one save behind.
+    """
+    from ouroboros.auto.grading import GradeResult, SeedGrade
+    from ouroboros.auto.ledger import SeedDraftLedger
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.seed_repairer import RepairResult
+    from ouroboros.auto.seed_reviewer import SeedReview
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState
+    from ouroboros.core.seed import (
+        EvaluationPrinciple,
+        ExitCondition,
+        OntologyField,
+        OntologySchema,
+        Seed,
+        SeedMetadata,
+    )
+
+    seed = Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+    class _StubInterviewDriver:
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            raise AssertionError("interview driver must not run on this resume path")
+
+    async def fake_seed_generator(_session_id):  # noqa: ARG001
+        raise AssertionError("seed generator must not run when seed_artifact is persisted")
+
+    def fake_seed_saver(_seed):
+        return str(tmp_path / "seed.yaml")
+
+    store = AutoStore(tmp_path / "store")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.seed_artifact = seed.to_dict()
+    state.seed_path = str(tmp_path / "seed.yaml")
+    state.last_grade = "A"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.transition(AutoPhase.INTERVIEW, "primed")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.transition(AutoPhase.REVIEW, "review queued")
+    state.skip_run = True
+    store.save(state)
+
+    class _PassingReviewer:
+        def review(self, _seed, *, ledger=None):  # noqa: ARG002
+            grade = GradeResult(grade=SeedGrade.A, scores={}, may_run=True)
+            return SeedReview(grade_result=grade, findings=())
+
+    class _PassingRepairer:
+        def converge(self, seed_in, *, ledger=None):
+            review = _PassingReviewer().review(seed_in, ledger=ledger)
+            return (
+                seed_in,
+                review,
+                [
+                    RepairResult(
+                        changed=False,
+                        seed=seed_in,
+                        applied_repairs=(),
+                        unresolved_findings=(),
+                    )
+                ],
+            )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        skip_run=True,
+        reviewer=_PassingReviewer(),
+        repairer=_PassingRepairer(),
+        progress_callback=None,
+    )
+    await pipeline.run(state)
+
+    persisted = store.load(state.auto_session_id)
+    assert persisted.phase is AutoPhase.COMPLETE
+    persisted_kinds = [event["kind"] for event in persisted.progress_events]
+    persisted_phases = [event["phase"] for event in persisted.progress_events]
+    assert "complete" in persisted_phases, persisted.progress_events
+    assert persisted_kinds[-1] == "phase"
+    assert persisted_phases[-1] == "complete"
+
+
+@pytest.mark.asyncio
 async def test_auto_handler_meta_tolerates_unloadable_state_after_run(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/unit/auto/test_mcp_progress_history.py
+++ b/tests/unit/auto/test_mcp_progress_history.py
@@ -288,6 +288,60 @@ async def test_auto_handler_meta_includes_terminal_phase_event_persisted_during_
 
 
 @pytest.mark.asyncio
+async def test_auto_pipeline_resume_does_not_synthesize_spurious_phase_event(
+    tmp_path,
+) -> None:
+    """A no-op re-run on a complete session must not append a duplicate phase event.
+
+    Regression for the bot finding that ``run()`` previously reset the
+    dedup trackers to ``None`` and then immediately fired ``_save()``,
+    so every resume — including resumes of already-terminal sessions —
+    appended a fresh ``phase`` event for the unchanged current phase.
+    That would cause the persisted history surfaced through MCP to grow
+    on every retry and to report fake transitions for state that did
+    not actually change.
+    """
+    from ouroboros.auto.pipeline import AutoPipeline
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState
+
+    class _StubInterviewDriver:
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            raise AssertionError("interview driver must not run on a complete session")
+
+    async def fake_seed_generator(_session_id):  # noqa: ARG001
+        raise AssertionError("seed generator must not run on a complete session")
+
+    store = AutoStore(tmp_path / "store")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "primed")
+    state.transition(AutoPhase.SEED_GENERATION, "ready")
+    state.transition(AutoPhase.REVIEW, "review queued")
+    state.transition(AutoPhase.COMPLETE, "skip-run requested")
+    # Pre-existing persisted history from the run that produced this
+    # session — the ``complete`` event already lives here.
+    state.progress_events = [
+        {
+            "phase": "complete",
+            "kind": "phase",
+            "message": "skip-run requested",
+            "round": None,
+            "grade": None,
+            "timestamp": "2026-05-01T12:30:00+00:00",
+        }
+    ]
+    store.save(state)
+
+    pipeline = AutoPipeline(_StubInterviewDriver(), fake_seed_generator, store=store)
+    await pipeline.run(state)
+
+    persisted = store.load(state.auto_session_id)
+    # No new entries: a no-op resume of an already-complete session
+    # produced no fresh transition.
+    assert len(persisted.progress_events) == 1
+    assert persisted.progress_events[0]["phase"] == "complete"
+
+
+@pytest.mark.asyncio
 async def test_auto_handler_meta_tolerates_unloadable_state_after_run(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/unit/auto/test_mcp_progress_history.py
+++ b/tests/unit/auto/test_mcp_progress_history.py
@@ -341,6 +341,42 @@ async def test_auto_pipeline_resume_does_not_synthesize_spurious_phase_event(
     assert persisted.progress_events[0]["phase"] == "complete"
 
 
+def test_auto_pipeline_progress_events_ring_buffer_caps_at_limit() -> None:
+    """The persisted progress_events log must cap at ``_PROGRESS_EVENT_LIMIT``.
+
+    Regression for the bot non-blocking note: the new ring-buffer
+    behavior was previously untested at the boundary, so an accidental
+    off-by-one truncation or unbounded growth bug could quietly bloat
+    the persisted state file across long-running sessions.
+    """
+    from ouroboros.auto.pipeline import _PROGRESS_EVENT_LIMIT, AutoPipeline
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState
+
+    class _StubInterviewDriver:
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            raise AssertionError("driver must not run for this unit-test")
+
+    async def _stub_seed_generator(_session_id):  # noqa: ARG001
+        raise AssertionError("seed generator must not run for this unit-test")
+
+    pipeline = AutoPipeline(_StubInterviewDriver(), _stub_seed_generator)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp")
+    state.transition(AutoPhase.INTERVIEW, "primed")
+
+    # Force-fire ``_emit`` past the cap. Each call mutates the phase
+    # message and bumps repair so dedup never short-circuits.
+    for tick in range(_PROGRESS_EVENT_LIMIT + 25):
+        pipeline._emit(state, kind="phase", message=f"phase tick {tick}")
+
+    assert len(state.progress_events) == _PROGRESS_EVENT_LIMIT
+    # The eviction is FIFO: the oldest (`tick=0`) entries are dropped
+    # and the newest (`tick=_PROGRESS_EVENT_LIMIT + 24`) survives.
+    first_tick = state.progress_events[0]["message"]
+    last_tick = state.progress_events[-1]["message"]
+    assert first_tick == "phase tick 25"
+    assert last_tick == f"phase tick {_PROGRESS_EVENT_LIMIT + 24}"
+
+
 @pytest.mark.asyncio
 async def test_auto_handler_meta_tolerates_unloadable_state_after_run(
     monkeypatch, tmp_path

--- a/tests/unit/auto/test_progress.py
+++ b/tests/unit/auto/test_progress.py
@@ -205,6 +205,49 @@ async def test_auto_pipeline_callback_errors_do_not_break_run(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_auto_pipeline_emits_repair_event_when_repairer_changes_seed(tmp_path) -> None:
+    """A non-zero ``repair_round`` after converge must emit a ``repair`` event."""
+    captured: list[AutoProgressEvent] = []
+
+    async def fake_seed_generator(_session_id: str) -> Seed:
+        return _make_seed()
+
+    def fake_seed_saver(_seed: Seed) -> str:
+        return str(tmp_path / "seed.yaml")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.interview_session_id = "interview_xyz"
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.skip_run = True
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        skip_run=True,
+        # ``_PassingRepairer(repair_rounds=2)`` synthesizes a converge
+        # history of length 2 so ``state.repair_round`` becomes non-zero.
+        reviewer=_PassingReviewer(),
+        repairer=_PassingRepairer(repair_rounds=2),
+        progress_callback=captured.append,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    repair_events = [event for event in captured if event.kind == "repair"]
+    assert len(repair_events) == 1
+    assert repair_events[0].round == 2
+
+
+@pytest.mark.asyncio
 async def test_auto_pipeline_emits_phase_for_blocked_terminal(tmp_path) -> None:
     async def fake_seed_generator(_session_id: str) -> Seed:
         raise AssertionError("seed generator should not be invoked when interview blocks")

--- a/tests/unit/auto/test_progress.py
+++ b/tests/unit/auto/test_progress.py
@@ -1,0 +1,233 @@
+"""Unit tests for the auto pipeline progress event contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.grading import GradeResult, SeedGrade
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.progress import AutoProgressEvent
+from ouroboros.auto.seed_repairer import RepairResult
+from ouroboros.auto.seed_reviewer import SeedReview
+from ouroboros.auto.state import (
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+)
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+class _PassingReviewer:
+    """Reviewer stub that always returns an A-grade may_run review."""
+
+    def review(self, _seed, *, ledger=None):  # noqa: ARG002
+        grade = GradeResult(grade=SeedGrade.A, scores={}, may_run=True)
+        return SeedReview(grade_result=grade, findings=())
+
+
+class _PassingRepairer:
+    """Repairer stub that returns the input seed unchanged with an A grade."""
+
+    def __init__(self, repair_rounds: int = 0) -> None:
+        self._repair_rounds = repair_rounds
+
+    def converge(self, seed, *, ledger=None):
+        review = _PassingReviewer().review(seed, ledger=ledger)
+        history = [
+            RepairResult(changed=False, seed=seed, applied_repairs=(), unresolved_findings=())
+            for _ in range(self._repair_rounds)
+        ]
+        return seed, review, history
+
+
+def _make_seed() -> Seed:
+    return Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(
+                OntologyField(
+                    name="command",
+                    field_type="string",
+                    description="Command",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="testability",
+                description="Observable behavior",
+                weight=1.0,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+class _StubInterviewDriver:
+    async def run(self, _state, _ledger):  # noqa: ARG002
+        raise AssertionError("interview driver should not be invoked at SEED_GENERATION")
+
+
+def test_auto_progress_event_is_immutable_dataclass() -> None:
+    event = AutoProgressEvent(
+        auto_session_id="auto_x",
+        phase="interview",
+        kind="phase",
+        message="asking interview round 1/12",
+    )
+    assert event.round is None
+    assert event.grade is None
+    assert event.timestamp  # populated via factory
+    with pytest.raises(Exception):
+        event.kind = "grade"  # type: ignore[misc]
+
+
+def test_auto_pipeline_with_no_callback_does_not_raise(tmp_path) -> None:
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _unused_seed_generator,
+        store=AutoStore(tmp_path),
+    )
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    pipeline._maybe_emit_phase(state)
+    pipeline._maybe_emit_grade(state)
+    pipeline._maybe_emit_repair(state)
+
+
+async def _unused_seed_generator(_session_id: str) -> Seed:
+    raise AssertionError("seed generator should not be invoked")
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_emits_phase_grade_and_repair_in_order(tmp_path) -> None:
+    captured: list[AutoProgressEvent] = []
+
+    async def fake_seed_generator(_session_id: str) -> Seed:
+        return _make_seed()
+
+    def fake_seed_saver(_seed: Seed) -> str:
+        return str(tmp_path / "seed.yaml")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.interview_session_id = "interview_xyz"
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.skip_run = True
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        skip_run=True,
+        reviewer=_PassingReviewer(),
+        repairer=_PassingRepairer(),
+        progress_callback=captured.append,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    kinds = [event.kind for event in captured]
+    # Phase events fire on each transition; grade fires once after review.
+    assert "phase" in kinds
+    assert "grade" in kinds
+    grade_event = next(event for event in captured if event.kind == "grade")
+    assert grade_event.grade == result.grade
+    # Repair counter is 0 in this happy path so no repair event is emitted.
+    assert "repair" not in kinds
+    # Phase events must monotonically advance — no duplicate consecutive phases.
+    phase_sequence = [event.phase for event in captured if event.kind == "phase"]
+    assert phase_sequence == list(dict.fromkeys(phase_sequence))
+    assert phase_sequence[-1] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_callback_errors_do_not_break_run(tmp_path) -> None:
+    async def fake_seed_generator(_session_id: str) -> Seed:
+        return _make_seed()
+
+    def fake_seed_saver(_seed: Seed) -> str:
+        return str(tmp_path / "seed.yaml")
+
+    def exploding_callback(_event: AutoProgressEvent) -> None:
+        raise RuntimeError("observer failure")
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    state.ledger = ledger.to_dict()
+    state.interview_session_id = "interview_xyz"
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.transition(AutoPhase.SEED_GENERATION, "ready for seed generation")
+    state.skip_run = True
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        seed_saver=fake_seed_saver,
+        skip_run=True,
+        reviewer=_PassingReviewer(),
+        repairer=_PassingRepairer(),
+        progress_callback=exploding_callback,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+
+
+@pytest.mark.asyncio
+async def test_auto_pipeline_emits_phase_for_blocked_terminal(tmp_path) -> None:
+    async def fake_seed_generator(_session_id: str) -> Seed:
+        raise AssertionError("seed generator should not be invoked when interview blocks")
+
+    captured: list[AutoProgressEvent] = []
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.interview_completed = True
+    state.transition(AutoPhase.INTERVIEW, "primed for resume")
+    state.interview_session_id = None  # missing → triggers blocked
+    store.save(state)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        fake_seed_generator,
+        store=store,
+        progress_callback=captured.append,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    blocked_events = [event for event in captured if event.phase == "blocked"]
+    assert blocked_events
+    assert blocked_events[-1].kind == "phase"

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -381,7 +381,7 @@ def test_get_ouroboros_tools_forwards_bridge_wiring_to_auto_handler() -> None:
 
 @pytest.mark.asyncio
 async def test_auto_handler_forwards_run_subagent_envelope(monkeypatch) -> None:
-    async def fake_run(self, arguments, **_kwargs):  # noqa: ARG001
+    async def fake_run(self, arguments):  # noqa: ARG001
         from ouroboros.auto.pipeline import AutoPipelineResult
 
         return AutoPipelineResult(
@@ -403,7 +403,7 @@ async def test_auto_handler_forwards_run_subagent_envelope(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> None:
-    async def fake_run(self, arguments, **_kwargs):  # noqa: ARG001
+    async def fake_run(self, arguments):  # noqa: ARG001
         from ouroboros.auto.pipeline import AutoPipelineResult
 
         return AutoPipelineResult(

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -381,7 +381,7 @@ def test_get_ouroboros_tools_forwards_bridge_wiring_to_auto_handler() -> None:
 
 @pytest.mark.asyncio
 async def test_auto_handler_forwards_run_subagent_envelope(monkeypatch) -> None:
-    async def fake_run(self, arguments):  # noqa: ARG001
+    async def fake_run(self, arguments, **_kwargs):  # noqa: ARG001
         from ouroboros.auto.pipeline import AutoPipelineResult
 
         return AutoPipelineResult(
@@ -403,7 +403,7 @@ async def test_auto_handler_forwards_run_subagent_envelope(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> None:
-    async def fake_run(self, arguments):  # noqa: ARG001
+    async def fake_run(self, arguments, **_kwargs):  # noqa: ARG001
         from ouroboros.auto.pipeline import AutoPipelineResult
 
         return AutoPipelineResult(


### PR DESCRIPTION
## Summary

Records every `AutoProgressEvent` emitted during a single `ouroboros_auto` invocation and surfaces the accumulated list as `meta[\"progress_events\"]` so non-CLI bridges (Codex / OMX) can render the same phase / grade / repair trace the CLI streams.

This is the MCP-side companion to the CLI live trace (#713) and depends on the same `AutoProgressEvent` callback contract introduced in #705.

## Stacking / dependency

Stacked on **#705** (\`feat/639-B-progress-contract\`). This branch contains those commits at the bottom of its history; please review **#705 first**, then the single new commit on top here. Once #705 merges I will rebase this on `main` and the diff will collapse to the MCP-only changes.

This PR is independent of #713 (CLI trace) and can land in either order.

## Changes

- `src/ouroboros/mcp/tools/auto_handler.py`
  - `handle()` now allocates a `progress_events: list[AutoProgressEvent]` and threads `progress_events.append` as the pipeline's `progress_callback`.
  - `_run()` accepts an optional `progress_events` list (keyword-only) and wires the callback into `AutoPipeline(progress_callback=...)` only when the caller supplied a list.
  - `_result_meta()` accepts the optional list and adds `meta[\"progress_events\"] = [...]` only when at least one event was captured.
  - New helper `_progress_event_to_dict()` returns a JSON-friendly dict with the keys `{phase, kind, message, round, grade, timestamp}`. The redundant per-event `auto_session_id` is intentionally elided.
- `tests/unit/auto/test_mcp_progress_history.py` (new):
  - Empty event list omits `progress_events` from meta.
  - Three serialized events appear in emit order with the expected keys.
  - End-to-end `AutoHandler.handle({...})` pipes events emitted by a fake pipeline into `meta[\"progress_events\"]`.
  - Pipeline that emits no events leaves the meta key absent.
- `tests/unit/auto/test_surface.py`:
  - Two pre-existing `_run` monkeypatches grew a `**_kwargs` parameter to absorb the new `progress_events` keyword. No functional changes.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_mcp_progress_history.py` → passes.
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto -q` → 208 passed.

## Risks / Notes

- Long-running auto sessions accumulate one entry per phase change + one per grade + one per repair round. With the existing dedup in `AutoPipeline._maybe_emit_phase`, the worst case for a 12-round interview + 5 repair rounds is ~25 entries — comfortably below any reasonable MCP payload threshold.
- The `meta[\"progress_events\"]` key is additive and absent when no events were emitted, so existing clients that do not consume it are unaffected.

Refs #639