### PR TITLE
feat(auto): record optional gateway provenance with redaction

### DIFF
--- a/src/ouroboros/auto/provenance.py
+++ b/src/ouroboros/auto/provenance.py
@@ -102,17 +102,22 @@ def load_provenance_from_env(
 
 
 def invoked_by_label(provenance: Mapping[str, Any] | None) -> str:
-    """Return the human label for ``invoked_by``; ``"direct"`` when unknown.
+    """Return the human label for ``invoked_by``.
 
-    Used by CLI/blocker output to make rewrite-vs-direct provenance visible
-    without exposing any other metadata.
+    * No provenance at all → ``"direct"`` (legitimate direct CLI use).
+    * Provenance present with a recognized ``invoked_by`` → that value.
+    * Provenance present **without** a recognized ``invoked_by`` →
+      ``"unknown"``. Returning ``"direct"`` here would lie: a gateway can
+      persist ``source_platform`` / ``request_correlation_id`` / ``notes``
+      without an ``invoked_by`` field, and showing ``Invoked by: direct``
+      in incident analysis defeats the feature's purpose.
     """
     if not provenance:
         return "direct"
     value = provenance.get("invoked_by")
     if isinstance(value, str) and value in KNOWN_INVOKED_BY:
         return value
-    return "direct"
+    return "unknown"
 
 
 __all__ = [

--- a/src/ouroboros/auto/provenance.py
+++ b/src/ouroboros/auto/provenance.py
@@ -1,0 +1,126 @@
+"""External invocation provenance for ``ooo auto`` sessions.
+
+When ``ooo auto`` is launched by an external rewrite gateway (e.g. a Discord
+bot translating a natural-language request into a shell command) the durable
+auto state should record *that fact* — not the raw user message, not channel
+identifiers, not credentials — so post-hoc incident analysis can distinguish
+direct CLI use from rewritten invocations.
+
+This module defines the narrow contract:
+
+* The runtime accepts provenance via the ``OUROBOROS_AUTO_PROVENANCE_JSON``
+  environment variable. The payload MUST be a JSON object.
+* :func:`load_provenance_from_env` returns a redacted dict suitable for
+  persistence into ``AutoPipelineState.provenance``.
+* :func:`redact_provenance` enforces an allowlist + length cap and returns a
+  shallow copy. Nothing outside the allowlist is ever persisted.
+* The default invocation (no env var, no flag) records nothing — the field is
+  an empty dict and the CLI continues to behave as before.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import os
+from typing import Any, Final
+
+PROVENANCE_ENV_VAR: Final[str] = "OUROBOROS_AUTO_PROVENANCE_JSON"
+
+#: Allowlist of provenance keys that may be persisted. Anything outside this
+#: set is dropped silently by :func:`redact_provenance`. Keep this list short
+#: and review every addition for sensitive-data risk.
+ALLOWED_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "invoked_by",  # "direct" | "gateway" | "unknown"
+        "source_platform",  # high-level system name, e.g. "discord-hermes"
+        "command_kind",  # "rewrite" | "direct" | other low-card label
+        "requested_at",  # ISO-8601 timestamp string
+        "request_correlation_id",  # opaque id (NOT a token)
+        "notes",  # short free-form note (truncated)
+    }
+)
+
+#: Recognized values for ``invoked_by``. Other values are mapped to
+#: ``"unknown"`` so persisted state stays a closed set.
+KNOWN_INVOKED_BY: Final[frozenset[str]] = frozenset({"direct", "gateway", "unknown"})
+
+#: Per-string truncation cap to keep arbitrarily long fields out of state JSON.
+MAX_STRING_LEN: Final[int] = 256
+
+
+def redact_provenance(raw: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a redacted, allowlisted, length-capped copy of ``raw``.
+
+    Keys outside :data:`ALLOWED_KEYS` are dropped. Non-string values for
+    string-typed keys are dropped rather than coerced. Strings longer than
+    :data:`MAX_STRING_LEN` are truncated. Empty/whitespace-only strings are
+    dropped. ``invoked_by`` outside :data:`KNOWN_INVOKED_BY` is mapped to
+    ``"unknown"``.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        return {}
+    out: dict[str, Any] = {}
+    for key, value in raw.items():
+        if key not in ALLOWED_KEYS:
+            continue
+        if not isinstance(value, str):
+            continue
+        cleaned = value.strip()
+        if not cleaned:
+            continue
+        if len(cleaned) > MAX_STRING_LEN:
+            cleaned = cleaned[:MAX_STRING_LEN]
+        if key == "invoked_by" and cleaned not in KNOWN_INVOKED_BY:
+            cleaned = "unknown"
+        out[key] = cleaned
+    return out
+
+
+def load_provenance_from_env(
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Parse provenance metadata from ``OUROBOROS_AUTO_PROVENANCE_JSON``.
+
+    Returns ``{}`` when the env var is unset, empty, malformed, or non-object;
+    never raises. The returned dict is already redacted via
+    :func:`redact_provenance`.
+    """
+    source = env if env is not None else os.environ
+    raw = source.get(PROVENANCE_ENV_VAR)
+    if not raw or not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return redact_provenance(parsed)
+
+
+def invoked_by_label(provenance: Mapping[str, Any] | None) -> str:
+    """Return the human label for ``invoked_by``; ``"direct"`` when unknown.
+
+    Used by CLI/blocker output to make rewrite-vs-direct provenance visible
+    without exposing any other metadata.
+    """
+    if not provenance:
+        return "direct"
+    value = provenance.get("invoked_by")
+    if isinstance(value, str) and value in KNOWN_INVOKED_BY:
+        return value
+    return "direct"
+
+
+__all__ = [
+    "ALLOWED_KEYS",
+    "KNOWN_INVOKED_BY",
+    "MAX_STRING_LEN",
+    "PROVENANCE_ENV_VAR",
+    "invoked_by_label",
+    "load_provenance_from_env",
+    "redact_provenance",
+]

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -125,6 +125,7 @@ class AutoPipelineState:
             AutoPhase.RUN.value: 60,
         }
     )
+    provenance: dict[str, Any] = field(default_factory=dict)
 
     def transition(self, next_phase: AutoPhase, message: str, *, error: str | None = None) -> None:
         """Move to ``next_phase`` after validating the phase state machine."""
@@ -194,6 +195,7 @@ class AutoPipelineState:
         payload.setdefault("max_repair_rounds", 5)
         payload.setdefault("run_handoff_status", None)
         payload.setdefault("run_handoff_guidance", None)
+        payload.setdefault("provenance", {})
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -277,6 +279,20 @@ class AutoPipelineState:
         if not isinstance(self.run_subagent, dict):
             msg = "run_subagent must be an object"
             raise ValueError(msg)
+        if not isinstance(self.provenance, dict):
+            msg = "provenance must be an object"
+            raise ValueError(msg)
+        if self.provenance:
+            from ouroboros.auto.provenance import redact_provenance
+
+            redacted = redact_provenance(self.provenance)
+            # Reject anything that would have been dropped — protects against a
+            # caller persisting raw rewrite payloads with sensitive fields.
+            extras = sorted(set(self.provenance) - set(redacted))
+            if extras:
+                msg = f"provenance contains disallowed keys: {', '.join(extras)}"
+                raise ValueError(msg)
+            self.provenance = redacted
         if self.ledger:
             try:
                 from ouroboros.auto.ledger import SeedDraftLedger

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -19,6 +19,7 @@ from ouroboros.auto.adapters import (
 )
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.provenance import invoked_by_label, load_provenance_from_env
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.state import AutoPipelineState, AutoStore
 from ouroboros.cli.formatters import console
@@ -204,6 +205,9 @@ async def _run_auto(
         state = AutoPipelineState(goal=goal.strip(), cwd=str(_safe_default_cwd()))
         state.runtime_backend = runtime
         state.skip_run = skip_run
+        provenance = load_provenance_from_env()
+        if provenance:
+            state.provenance = provenance
         state.max_interview_rounds = max_interview_rounds
         state.max_repair_rounds = max_repair_rounds
 
@@ -275,6 +279,11 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Run handoff status: [bold]{state.run_handoff_status}[/]")
     if state.run_handoff_guidance:
         console.print(f"Run handoff guidance: [yellow]{state.run_handoff_guidance}[/]")
+    if state.provenance:
+        console.print(
+            f"Invoked by: [bold]{invoked_by_label(state.provenance)}[/]"
+            f" (provenance keys: {', '.join(sorted(state.provenance))})"
+        )
     if state.last_error:
         console.print(f"Blocker: [yellow]{state.last_error}[/]")
     console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")

--- a/tests/unit/auto/test_provenance.py
+++ b/tests/unit/auto/test_provenance.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.auto.provenance import (
+    ALLOWED_KEYS,
+    KNOWN_INVOKED_BY,
+    MAX_STRING_LEN,
+    PROVENANCE_ENV_VAR,
+    invoked_by_label,
+    load_provenance_from_env,
+    redact_provenance,
+)
+from ouroboros.auto.state import AutoPipelineState, AutoStore
+
+
+def test_redact_drops_unknown_keys() -> None:
+    raw = {
+        "invoked_by": "gateway",
+        "source_platform": "discord-hermes",
+        # Unknown keys MUST be dropped — never leak channel/token-like data.
+        "channel_id": "1234567890",
+        "user_token": "ghp_secretsecretsecret",
+        "raw_user_message": "long private chat content",
+    }
+    out = redact_provenance(raw)
+    assert set(out) == {"invoked_by", "source_platform"}
+    assert out["invoked_by"] == "gateway"
+    assert out["source_platform"] == "discord-hermes"
+
+
+def test_redact_normalizes_unknown_invoked_by() -> None:
+    out = redact_provenance({"invoked_by": "definitely-not-real"})
+    assert out["invoked_by"] == "unknown"
+
+
+def test_redact_truncates_long_strings_and_drops_blanks() -> None:
+    long_note = "x" * (MAX_STRING_LEN + 50)
+    out = redact_provenance({"notes": long_note, "command_kind": "  "})
+    assert "command_kind" not in out
+    assert len(out["notes"]) == MAX_STRING_LEN
+
+
+def test_redact_drops_non_string_values() -> None:
+    out = redact_provenance({"invoked_by": 1, "notes": ["list", "not", "str"]})
+    assert out == {}
+
+
+def test_redact_handles_none_and_non_mapping() -> None:
+    assert redact_provenance(None) == {}
+    assert redact_provenance("not a mapping") == {}  # type: ignore[arg-type]
+
+
+def test_load_from_env_returns_empty_when_unset() -> None:
+    assert load_provenance_from_env({}) == {}
+
+
+def test_load_from_env_parses_and_redacts() -> None:
+    payload = {
+        "invoked_by": "gateway",
+        "source_platform": "discord-hermes",
+        "command_kind": "rewrite",
+        "channel_id": "leaked-id",  # must be dropped
+    }
+    env = {PROVENANCE_ENV_VAR: json.dumps(payload)}
+    out = load_provenance_from_env(env)
+    assert out == {
+        "invoked_by": "gateway",
+        "source_platform": "discord-hermes",
+        "command_kind": "rewrite",
+    }
+
+
+def test_load_from_env_returns_empty_on_malformed_json() -> None:
+    env = {PROVENANCE_ENV_VAR: "{not json"}
+    assert load_provenance_from_env(env) == {}
+
+
+def test_load_from_env_returns_empty_on_non_object_payload() -> None:
+    env = {PROVENANCE_ENV_VAR: "[1, 2, 3]"}
+    assert load_provenance_from_env(env) == {}
+
+
+def test_invoked_by_label_defaults_to_direct() -> None:
+    assert invoked_by_label({}) == "direct"
+    assert invoked_by_label(None) == "direct"
+    assert invoked_by_label({"invoked_by": "gateway"}) == "gateway"
+    # Unknown values fall back to direct so blocker output never lies.
+    assert invoked_by_label({"invoked_by": "totally-fake"}) == "direct"
+
+
+def test_state_persists_redacted_provenance(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    state.provenance = {
+        "invoked_by": "gateway",
+        "source_platform": "discord-hermes",
+    }
+    store.save(state)
+    loaded = store.load(state.auto_session_id)
+    assert loaded.provenance == {
+        "invoked_by": "gateway",
+        "source_platform": "discord-hermes",
+    }
+
+
+def test_state_rejects_disallowed_provenance_keys(tmp_path) -> None:
+    """Persisting a payload that contains a non-allowlisted key (e.g. a token)
+    must fail loudly so callers cannot route sensitive data through the
+    provenance field."""
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    state.provenance = {
+        "invoked_by": "gateway",
+        "user_token": "ghp_secret",
+    }
+    with pytest.raises(ValueError, match="provenance contains disallowed keys"):
+        AutoStore(tmp_path).save(state)
+
+
+def test_state_treats_missing_provenance_as_empty(tmp_path) -> None:
+    """Legacy state files without a `provenance` key must load successfully
+    with an empty dict (back-compat)."""
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    raw = state.to_dict()
+    del raw["provenance"]
+    revived = AutoPipelineState.from_dict(raw)
+    assert revived.provenance == {}
+
+
+def test_allowed_keys_invariants() -> None:
+    """Guard against accidental allowlist drift in review."""
+    assert "invoked_by" in ALLOWED_KEYS
+    # These are explicitly forbidden — if anyone adds them, this test fails so
+    # the security review can intervene.
+    for forbidden in {"channel_id", "user_token", "raw_user_message", "private_message"}:
+        assert forbidden not in ALLOWED_KEYS
+    assert "unknown" in KNOWN_INVOKED_BY

--- a/tests/unit/auto/test_provenance.py
+++ b/tests/unit/auto/test_provenance.py
@@ -83,12 +83,28 @@ def test_load_from_env_returns_empty_on_non_object_payload() -> None:
     assert load_provenance_from_env(env) == {}
 
 
-def test_invoked_by_label_defaults_to_direct() -> None:
+def test_invoked_by_label_defaults_to_direct_when_provenance_absent() -> None:
+    # Empty / no provenance is a legitimate direct CLI run.
     assert invoked_by_label({}) == "direct"
     assert invoked_by_label(None) == "direct"
+    # Recognized value passes through.
     assert invoked_by_label({"invoked_by": "gateway"}) == "gateway"
-    # Unknown values fall back to direct so blocker output never lies.
-    assert invoked_by_label({"invoked_by": "totally-fake"}) == "direct"
+
+
+def test_invoked_by_label_returns_unknown_when_other_provenance_present() -> None:
+    """When provenance carries gateway-side metadata but no invoked_by, the
+    label MUST be 'unknown' rather than 'direct' — otherwise incident
+    analysis sees a falsely-direct invocation. (Bot-flagged in #717 review.)"""
+    # Recognized non-invoked_by keys persisted without invoked_by → unknown.
+    assert invoked_by_label({"source_platform": "discord-hermes"}) == "unknown"
+    assert (
+        invoked_by_label(
+            {"source_platform": "discord-hermes", "command_kind": "rewrite"}
+        )
+        == "unknown"
+    )
+    # Unknown / non-string invoked_by also yields unknown, not direct.
+    assert invoked_by_label({"invoked_by": "totally-fake"}) == "unknown"
 
 
 def test_state_persists_redacted_provenance(tmp_path) -> None:

--- a/tests/unit/auto/test_provenance.py
+++ b/tests/unit/auto/test_provenance.py
@@ -98,9 +98,7 @@ def test_invoked_by_label_returns_unknown_when_other_provenance_present() -> Non
     # Recognized non-invoked_by keys persisted without invoked_by → unknown.
     assert invoked_by_label({"source_platform": "discord-hermes"}) == "unknown"
     assert (
-        invoked_by_label(
-            {"source_platform": "discord-hermes", "command_kind": "rewrite"}
-        )
+        invoked_by_label({"source_platform": "discord-hermes", "command_kind": "rewrite"})
         == "unknown"
     )
     # Unknown / non-string invoked_by also yields unknown, not direct.


### PR DESCRIPTION
## Summary
- New `src/ouroboros/auto/provenance.py` defines an allowlisted provenance schema (`invoked_by`, `source_platform`, `command_kind`, `requested_at`, `request_correlation_id`, `notes`) with strict redaction (drop unknown keys, drop non-string values, truncate to 256 chars, normalize `invoked_by` to a closed set).
- `AutoPipelineState.provenance: dict[str, Any]` (back-compat: missing key defaults to `{}` on load) is validated at save: any non-allowlisted key (e.g. `user_token`, `channel_id`, `raw_user_message`) raises a `ValueError` so callers cannot route sensitive data through the field.
- Callers populate provenance via `OUROBOROS_AUTO_PROVENANCE_JSON` env var; the CLI loads it only on **new** sessions (resume preserves what was persisted).
- CLI's `_print_status` surfaces provenance as a single low-risk line: `Invoked by: gateway (provenance keys: invoked_by, source_platform)`. Direct invocations stay unchanged (empty provenance prints nothing).
- 14 new unit tests in `test_provenance.py` covering: allowlist drops, invoked_by normalization, length truncation, env parsing happy/sad paths, state round-trip, disallowed-key rejection, legacy-state forward compat.

## Why
The `auto_78c98678de5d` incident was launched by a Discord/Hermes rewrite gateway translating a natural-language request into `ooo auto --runtime codex '...'`. The Ouroboros repo had no way to record *that fact*, so post-hoc analysis could not distinguish gateway-driven failures from direct CLI use.

This PR ships the **Ouroboros-side contract** only. The gateway will set `OUROBOROS_AUTO_PROVENANCE_JSON` (a follow-up on the gateway repo). After this PR a similar incident would persist:

```json
"provenance": {
  "invoked_by": "gateway",
  "source_platform": "discord-hermes",
  "command_kind": "rewrite"
}
```

…and the CLI would print `Invoked by: gateway (provenance keys: ...)` next to the blocker.

## Security posture
The biggest risk for an issue like this is accidentally persisting tokens, raw user messages, or channel ids. Three layers prevent that:

1. **Allowlist at parse time**: anything outside `ALLOWED_KEYS` is silently dropped by `redact_provenance`.
2. **Hard reject at save time**: `_validate_loaded` raises if a caller bypasses the parser and stuffs raw payloads into `state.provenance` directly. (`test_state_rejects_disallowed_provenance_keys`)
3. **Test invariant**: `test_allowed_keys_invariants` fails if anyone adds `channel_id` / `user_token` / `raw_user_message` / `private_message` to the allowlist — forces a security review before any addition.

Per-string truncation (256 chars) bounds total state JSON growth.

## Tests
- `pytest tests/unit/auto/test_provenance.py` — 14 passed (14 new)
- `pytest tests/unit/auto/ tests/unit/cli/` — 886 passed (full module green)

## Notes for reviewers
- This is the only new state-schema field in the #692 epic; back-compat is covered by `test_state_treats_missing_provenance_as_empty`.
- The CLI does not expose a `--provenance-file` flag yet — env-only is intentional so the gateway pipes provenance via subprocess env without changing argv (and thus without surfacing it in shell history).
- Independent of #686/#687/#688/#689/#690.

Closes #691
Tracker: #692