### PR TITLE
feat(auto): persist source-tagged auto answer log

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -144,6 +144,13 @@ class AutoInterviewDriver:
             self.answerer.apply(answer, ledger, question=turn.question)
             state.ledger = ledger.to_dict()
             state.pending_question = None
+            _record_auto_answer(
+                state,
+                round_number=round_number,
+                source=answer.source.value,
+                question=turn.question,
+                answer=answer.text,
+            )
             state.mark_progress(
                 f"answered round {round_number}/{self.max_rounds} from {answer.source.value}",
                 tool_name="auto_answerer",
@@ -312,6 +319,44 @@ def _gap_prompt(gap: Gap) -> str:
         "runtime_context": "Which runtime stack, repo, and project patterns should be used?",
     }
     return prompts.get(gap.section, gap.message)
+
+
+_AUTO_ANSWER_LOG_LIMIT = 25
+_AUTO_ANSWER_LOG_TEXT_LIMIT = 200
+
+
+def _record_auto_answer(
+    state: AutoPipelineState,
+    *,
+    round_number: int,
+    source: str,
+    question: str,
+    answer: str,
+) -> None:
+    """Append a source-tagged auto answer entry to ``state.auto_answer_log``.
+
+    The log is bounded to the last :data:`_AUTO_ANSWER_LOG_LIMIT` entries so the
+    persisted state file stays compact across long sessions.
+    """
+    state.auto_answer_log.append(
+        {
+            "round": round_number,
+            "source": source,
+            "question": _truncate(question, _AUTO_ANSWER_LOG_TEXT_LIMIT),
+            "answer": _truncate(answer, _AUTO_ANSWER_LOG_TEXT_LIMIT),
+        }
+    )
+    if len(state.auto_answer_log) > _AUTO_ANSWER_LOG_LIMIT:
+        del state.auto_answer_log[: len(state.auto_answer_log) - _AUTO_ANSWER_LOG_LIMIT]
+
+
+def _truncate(text: str, limit: int) -> str:
+    if not isinstance(text, str):
+        text = str(text)
+    flat = " ".join(text.split())
+    if len(flat) <= limit:
+        return flat
+    return f"{flat[: limit - 3]}..."
 
 
 def _validate_turn(value: object) -> InterviewTurn:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -207,6 +207,7 @@ class AutoPipelineState:
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
+    auto_answer_log: list[dict[str, Any]] = field(default_factory=list)
     repair_round: int = 0
     current_round: int = 0
     pending_question: str | None = None
@@ -313,6 +314,7 @@ class AutoPipelineState:
         payload.setdefault("run_reconciliation_source", None)
         payload.setdefault("run_reconciled_at", None)
         payload.setdefault("provenance", None)
+        payload.setdefault("auto_answer_log", [])
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -448,7 +450,7 @@ class AutoPipelineState:
             if type(getattr(self, field_name)) is not bool:
                 msg = f"{field_name} must be a boolean"
                 raise ValueError(msg)
-        for field_name in ("findings",):
+        for field_name in ("findings", "auto_answer_log"):
             value = getattr(self, field_name)
             if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
                 msg = f"{field_name} must be a list of objects"

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from typing import Annotated
 
+from rich.markup import escape as _rich_escape
 import typer
 
 from ouroboros.auto.adapters import (
@@ -347,9 +348,15 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Recent auto answers (last {len(recent)}):")
         for entry in recent:
             round_value = entry.get("round", "?")
-            source = entry.get("source", "?")
-            question = entry.get("question", "")
-            answer = entry.get("answer", "")
+            source = _rich_escape(str(entry.get("source", "?")))
+            # Persisted question/answer text comes straight from the
+            # interview backend and may contain "[" / "]" sequences that
+            # Rich would otherwise interpret as markup, breaking the
+            # rendered text or raising a parse error. Escape both fields
+            # before printing so the status surface stays robust against
+            # arbitrary backend output.
+            question = _rich_escape(str(entry.get("question", "")))
+            answer = _rich_escape(str(entry.get("answer", "")))
             console.print(f"  round {round_value} \\[{source}] Q: {question}")
             console.print(f"    A: {answer}")
     console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -342,6 +342,16 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Run reconciled at: {state.run_reconciled_at}")
     if state.last_error:
         console.print(f"Blocker: [yellow]{state.last_error}[/]")
+    if state.auto_answer_log:
+        recent = state.auto_answer_log[-5:]
+        console.print(f"Recent auto answers (last {len(recent)}):")
+        for entry in recent:
+            round_value = entry.get("round", "?")
+            source = entry.get("source", "?")
+            question = entry.get("question", "")
+            answer = entry.get("answer", "")
+            console.print(f"  round {round_value} \\[{source}] Q: {question}")
+            console.print(f"    A: {answer}")
     console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")
 
 

--- a/tests/unit/auto/test_answer_source_log.py
+++ b/tests/unit/auto/test_answer_source_log.py
@@ -117,9 +117,7 @@ def test_cli_status_renders_recent_source_tagged_answers(monkeypatch, tmp_path) 
 
     monkeypatch.setattr("ouroboros.cli.commands.auto.AutoStore", lambda: store)
 
-    cli_result = CliRunner().invoke(
-        app, ["auto", "--resume", state.auto_session_id, "--status"]
-    )
+    cli_result = CliRunner().invoke(app, ["auto", "--resume", state.auto_session_id, "--status"])
     output = _strip_ansi(cli_result.output)
 
     assert cli_result.exit_code == 0
@@ -131,6 +129,38 @@ def test_cli_status_renders_recent_source_tagged_answers(monkeypatch, tmp_path) 
     assert "A: Local-only, no network calls" in output
 
 
+def test_cli_status_escapes_rich_markup_in_persisted_answer_text(monkeypatch, tmp_path) -> None:
+    """Backend question/answer text that contains ``[`` must not be parsed as Rich markup.
+
+    Without the escape, ``console.print`` would interpret ``[bold]`` as a
+    style and either swallow it from the output or raise a markup parse
+    error, making ``ooo auto --status`` brittle for sessions whose
+    interview text legitimately contains square brackets.
+    """
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "asking interview round 4/12")
+    state.auto_answer_log = [
+        {
+            "round": 1,
+            "source": "repo_fact",
+            "question": "Use [bold]uv[/] toolchain or pip?",
+            "answer": "Use uv [from existing setup]",
+        },
+    ]
+    store.save(state)
+
+    monkeypatch.setattr("ouroboros.cli.commands.auto.AutoStore", lambda: store)
+
+    cli_result = CliRunner().invoke(app, ["auto", "--resume", state.auto_session_id, "--status"])
+    output = _strip_ansi(cli_result.output)
+
+    assert cli_result.exit_code == 0
+    # The literal bracketed segments must survive verbatim.
+    assert "[bold]uv[/]" in output
+    assert "[from existing setup]" in output
+
+
 def test_cli_status_omits_recent_section_when_log_empty(monkeypatch, tmp_path) -> None:
     store = AutoStore(tmp_path)
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
@@ -139,9 +169,7 @@ def test_cli_status_omits_recent_section_when_log_empty(monkeypatch, tmp_path) -
 
     monkeypatch.setattr("ouroboros.cli.commands.auto.AutoStore", lambda: store)
 
-    cli_result = CliRunner().invoke(
-        app, ["auto", "--resume", state.auto_session_id, "--status"]
-    )
+    cli_result = CliRunner().invoke(app, ["auto", "--resume", state.auto_session_id, "--status"])
     output = _strip_ansi(cli_result.output)
 
     assert cli_result.exit_code == 0

--- a/tests/unit/auto/test_answer_source_log.py
+++ b/tests/unit/auto/test_answer_source_log.py
@@ -1,0 +1,148 @@
+"""Tests for the source-tagged auto answer ledger view."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.auto.interview_driver import (
+    _AUTO_ANSWER_LOG_LIMIT,
+    _AUTO_ANSWER_LOG_TEXT_LIMIT,
+    _record_auto_answer,
+    _truncate,
+)
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.cli.main import app
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def test_auto_answer_log_default_is_empty_list() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+
+    assert state.auto_answer_log == []
+
+
+def test_auto_answer_log_round_trips_through_state_persistence() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    state.auto_answer_log = [
+        {"round": 1, "source": "repo_fact", "question": "Q1?", "answer": "A1"},
+    ]
+
+    restored = AutoPipelineState.from_dict(state.to_dict())
+
+    assert restored.auto_answer_log == [
+        {"round": 1, "source": "repo_fact", "question": "Q1?", "answer": "A1"},
+    ]
+
+
+def test_auto_answer_log_legacy_session_hydrates_to_empty_list() -> None:
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/repo").to_dict()
+    payload.pop("auto_answer_log")
+
+    restored = AutoPipelineState.from_dict(payload)
+
+    assert restored.auto_answer_log == []
+
+
+def test_auto_answer_log_rejects_non_list() -> None:
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/repo").to_dict()
+    payload["auto_answer_log"] = "not a list"
+
+    with pytest.raises(ValueError, match="auto_answer_log must be a list"):
+        AutoPipelineState.from_dict(payload)
+
+
+def test_record_auto_answer_truncates_long_text() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    long_question = "Q " * 500
+
+    _record_auto_answer(
+        state,
+        round_number=1,
+        source="repo_fact",
+        question=long_question,
+        answer="OK",
+    )
+
+    entry = state.auto_answer_log[-1]
+    assert len(entry["question"]) <= _AUTO_ANSWER_LOG_TEXT_LIMIT
+    assert entry["question"].endswith("...")
+
+
+def test_record_auto_answer_caps_log_at_limit() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/repo")
+    for round_number in range(_AUTO_ANSWER_LOG_LIMIT + 5):
+        _record_auto_answer(
+            state,
+            round_number=round_number,
+            source="repo_fact",
+            question=f"Q{round_number}",
+            answer=f"A{round_number}",
+        )
+
+    assert len(state.auto_answer_log) == _AUTO_ANSWER_LOG_LIMIT
+    # Oldest entries are evicted; the most recent round survives.
+    assert state.auto_answer_log[-1]["round"] == _AUTO_ANSWER_LOG_LIMIT + 4
+    assert state.auto_answer_log[0]["round"] == 5
+
+
+def test_truncate_collapses_whitespace() -> None:
+    assert _truncate("hello   world", 50) == "hello world"
+
+
+def test_cli_status_renders_recent_source_tagged_answers(monkeypatch, tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "asking interview round 3/12")
+    state.auto_answer_log = [
+        {
+            "round": 1,
+            "source": "repo_fact",
+            "question": "Which runtime should be used?",
+            "answer": "Python 3.12 with uv",
+        },
+        {
+            "round": 2,
+            "source": "conservative_default",
+            "question": "What constraints bound the MVP?",
+            "answer": "Local-only, no network calls",
+        },
+    ]
+    store.save(state)
+
+    monkeypatch.setattr("ouroboros.cli.commands.auto.AutoStore", lambda: store)
+
+    cli_result = CliRunner().invoke(
+        app, ["auto", "--resume", state.auto_session_id, "--status"]
+    )
+    output = _strip_ansi(cli_result.output)
+
+    assert cli_result.exit_code == 0
+    assert "Recent auto answers (last 2):" in output
+    assert "round 1 [repo_fact]" in output
+    assert "Q: Which runtime should be used?" in output
+    assert "A: Python 3.12 with uv" in output
+    assert "round 2 [conservative_default]" in output
+    assert "A: Local-only, no network calls" in output
+
+
+def test_cli_status_omits_recent_section_when_log_empty(monkeypatch, tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "asking interview round 1/12")
+    store.save(state)
+
+    monkeypatch.setattr("ouroboros.cli.commands.auto.AutoStore", lambda: store)
+
+    cli_result = CliRunner().invoke(
+        app, ["auto", "--resume", state.auto_session_id, "--status"]
+    )
+    output = _strip_ansi(cli_result.output)
+
+    assert cli_result.exit_code == 0
+    assert "Recent auto answers" not in output


### PR DESCRIPTION
## Summary

Closes the last #639 surface gap: \"Interview progress shows round count and **source-tagged auto answer summaries**.\"

Records each auto-answered interview round on `AutoPipelineState.auto_answer_log` as a small dict (round, `AutoAnswerSource` tag, truncated question/answer). `ooo auto --status` renders the most recent five entries so users can see why the auto pipeline made each answer choice without scraping \`~/.ouroboros/data/auto_*.json\`.

## Changes

- `src/ouroboros/auto/state.py`
  - New field `auto_answer_log: list[dict[str, Any]] = field(default_factory=list)`.
  - `from_dict` backfills missing field to `[]` for legacy persisted sessions.
  - `_validate_loaded` extends the existing list-of-dicts check (previously only `findings`) to cover `auto_answer_log`.
- `src/ouroboros/auto/interview_driver.py`
  - New module-level helper `_record_auto_answer(state, *, round_number, source, question, answer)` appends to the log right after each successful answer is selected and capped at the last 25 entries.
  - `_truncate(text, limit)` collapses whitespace and trims long Q/A text to 200 chars.
  - Constants `_AUTO_ANSWER_LOG_LIMIT = 25` and `_AUTO_ANSWER_LOG_TEXT_LIMIT = 200`.
- `src/ouroboros/cli/commands/auto.py`
  - `_print_status` renders \`Recent auto answers (last N):\` followed by \`round X \\[source] Q: ...\` / \`A: ...\` lines, when the log is non-empty. The leading `[` is escaped so Rich treats `[source]` as literal text.
- `tests/unit/auto/test_answer_source_log.py` (new):
  - Default empty list, round-trip persistence, legacy hydration, non-list rejection.
  - `_record_auto_answer` truncation and ring-buffer eviction.
  - `_truncate` whitespace collapsing.
  - End-to-end CLI \`--status\` rendering.
  - CLI omits the \`Recent auto answers\` block when the log is empty.

## Pre-flight: PR collision check

The other in-flight #675 work (#682 \"add selected-driver answer metadata\" and #683 \"classify selected-driver answer risk\") touches `src/ouroboros/auto/answerer.py`, `src/ouroboros/auto/driver_answerer.py`, `src/ouroboros/auto/__init__.py`, and `tests/unit/auto/test_driver_answerer.py`. **This PR touches none of those files.** PR-E intentionally records only the existing `AutoAnswer.source` enum tag rather than the richer `AutoAnswerMetadata` introduced by #682, so the two efforts are orthogonal and can land in either order. A future slice can extend the log entry shape with `AutoAnswerMetadata` fields once #682 / #683 land.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ouroboros/auto/state.py src/ouroboros/auto/interview_driver.py src/ouroboros/cli/commands/auto.py tests/unit/auto/test_answer_source_log.py` → passes.
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto -q` → 208 passed.

## Risks / Notes

- Field is additive; legacy sessions hydrate cleanly with an empty log.
- The bounded ring-buffer keeps the persisted JSON compact even on long-running sessions (worst case: 25 × ~500 bytes ≈ 13 KB).
- The CLI rendering is intentionally conservative (last 5 entries) to avoid flooding terminal output. A future PR can add `--show-answer-log` for the full log if needed.

Refs #639