### PR TITLE
feat(auto): wire operational classification + merge guardrail matrix (part 2 of #689)

### DIFF
--- a/src/ouroboros/auto/operational_task.py
+++ b/src/ouroboros/auto/operational_task.py
@@ -329,10 +329,68 @@ def classify_operational_task(goal: str) -> OperationalTaskClassification:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class MergeGuardrailInputs:
+    """Snapshot of the boolean checks that gate a destructive merge action.
+
+    The pipeline collects these from the runtime (GitHub API, repo policy,
+    user confirmation) and feeds them into :func:`evaluate_merge_guardrails`.
+    No defaults — every check is mandatory at the call site so an accidentally
+    omitted field cannot silently allow a merge.
+    """
+
+    target_branch_protected_ok: bool
+    ci_passing: bool
+    mergeable: bool
+    permitted: bool
+    explicit_confirmation: bool
+
+
+def evaluate_merge_guardrails(inputs: MergeGuardrailInputs) -> tuple[str, ...]:
+    """Return a tuple of human-readable blockers — empty when the merge is OK.
+
+    Fail-closed: any unmet check produces a blocker string and the pipeline
+    must NOT proceed with the merge. The function is pure and deterministic
+    so it doubles as the spec for the destructive-action review.
+    """
+    blockers: list[str] = []
+    if not inputs.target_branch_protected_ok:
+        blockers.append("target branch protection requirements are not satisfied")
+    if not inputs.ci_passing:
+        blockers.append("CI is not green on the head ref")
+    if not inputs.mergeable:
+        blockers.append("PR is not mergeable (conflicts or stale)")
+    if not inputs.permitted:
+        blockers.append("the executing identity lacks permission to merge")
+    if not inputs.explicit_confirmation:
+        blockers.append("explicit human or policy confirmation is missing")
+    return tuple(blockers)
+
+
+def classification_to_state_dict(
+    classification: OperationalTaskClassification,
+) -> dict[str, object]:
+    """Project a classification into a JSON-safe dict for state storage.
+
+    Tuples become lists so the result round-trips through JSON and matches
+    what ``AutoPipelineState.classification`` exposes on resume.
+    """
+    return {
+        "kind": classification.kind,
+        "interview_required": classification.interview_required,
+        "direct_run_allowed": classification.direct_run_allowed,
+        "side_effect_risk": classification.side_effect_risk,
+        "requires_confirmation": classification.requires_confirmation,
+        "targets": list(classification.targets),
+        "reasons": list(classification.reasons),
+    }
+
+
 __all__ = [
     "GENERAL",
     "ISSUE_URL",
     "MERGE_INTENT",
+    "MergeGuardrailInputs",
     "OperationalTaskClassification",
     "PR_URL",
     "REVIEW_INTENT",
@@ -340,5 +398,7 @@ __all__ = [
     "RISK_DESTRUCTIVE_MERGE",
     "RISK_LOW",
     "RISK_NONE",
+    "classification_to_state_dict",
     "classify_operational_task",
+    "evaluate_merge_guardrails",
 ]

--- a/src/ouroboros/auto/operational_task.py
+++ b/src/ouroboros/auto/operational_task.py
@@ -87,12 +87,54 @@ _REVIEW_KO = ("리뷰", "검토", "개선", "수정")
 # ``owner/repo`` style identifier. The classifier accepts this as a target
 # alongside full URLs so operational asks like ``fix the failing tests in
 # owner/repo`` are recognized without requiring a fully-qualified URL.
-# (Bot-flagged in #719 review.) Excludes common false positives such as
-# ``and/or`` by requiring at least one digit/dash/underscore in either
-# component.
+# (Bot-flagged in #719 review.)
+#
+# The regex is intentionally permissive — both halves only require a single
+# alphanumeric character so legitimate short repo names (``owner/r``,
+# ``o/repo``) match. Common English idioms with the same surface shape
+# (``and/or``, ``and/or``, ``yes/no``, ``foo/bar``) are filtered out at the
+# value level by ``_REPO_PROSE_FALSE_POSITIVES`` below — that has a much
+# better signal-to-noise ratio than chasing every common pattern in regex.
 _REPO_PATH_RE = re.compile(
-    r"(?<![\w/])([A-Za-z0-9][\w\-.]*?[\w-]/[A-Za-z0-9][\w\-.]*[A-Za-z0-9_])(?![\w/])",
+    r"(?<![\w/])([A-Za-z0-9][\w\-.]*/[A-Za-z0-9][\w\-.]*)(?![\w/])",
 )
+
+# Phrases that share the ``a/b`` shape but are English idioms or placeholder
+# names rather than repo identifiers. Compared case-insensitively. Adding to
+# this list is the standard way to handle a new false positive flagged by a
+# review without re-tuning the regex. (Bot-flagged in #719 / #721 review.)
+_REPO_PROSE_FALSE_POSITIVES: Final[frozenset[str]] = frozenset(
+    {
+        # Common English connectives.
+        "and/or",
+        "or/and",
+        "either/or",
+        "neither/nor",
+        "to/from",
+        "from/to",
+        "yes/no",
+        "true/false",
+        "on/off",
+        "pass/fail",
+        "input/output",
+        "front/back",
+        "this/that",
+        "today/tomorrow",
+        "stop/start",
+        "start/stop",
+        "n/a",
+        # Placeholder / metasyntactic identifiers — rarely real repo names
+        # and almost always appear as examples in prose.
+        "foo/bar",
+        "foo/baz",
+        "bar/baz",
+        "lorem/ipsum",
+    }
+)
+
+
+def _is_repo_prose_false_positive(value: str) -> bool:
+    return value.lower() in _REPO_PROSE_FALSE_POSITIVES
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,13 +195,17 @@ def _extract_targets(
             matches.append((match.start(), kind, match.group(0)))
 
     # Repo identifiers — only added when not already covered by a URL match
-    # at the same span. Use a coverage check on the spans we already have.
+    # at the same span AND not a common-prose false positive. Use a coverage
+    # check on the spans we already have.
     covered = [(start, start + len(val)) for start, _kind, val in matches]
     for match in _REPO_PATH_RE.finditer(goal):
         m_start, m_end = match.start(), match.end()
         if any(start <= m_start and m_end <= end for start, end in covered):
             continue
-        matches.append((m_start, "repo", match.group(1)))
+        value = match.group(1)
+        if _is_repo_prose_false_positive(value):
+            continue
+        matches.append((m_start, "repo", value))
 
     matches.sort(key=lambda triple: triple[0])
 

--- a/src/ouroboros/auto/operational_task.py
+++ b/src/ouroboros/auto/operational_task.py
@@ -66,13 +66,33 @@ _ISSUE_URL_RE = re.compile(
 # way and the words are unambiguous in this domain.
 _MERGE_EN_RE = re.compile(r"\b(merge|merging|merged|squash|rebase\s+merge)\b", re.IGNORECASE)
 _MERGE_KO = ("머지", "병합")
-_CLOSE_EN_RE = re.compile(r"\b(close|closes|closing)\b", re.IGNORECASE)
+# ``close`` is a polysemous English word — "take a close look", "close call",
+# "close to", "close eye on" are NOT destructive intents. Exclude common
+# adjectival/non-imperative uses with a negative lookahead so the classifier
+# does not promote a benign goal to ``destructive_close``. (Bot-flagged in
+# #721 review.)
+_CLOSE_EN_RE = re.compile(
+    r"\b(?:close|closes|closing)\b"
+    r"(?!\s+(?:look|call|to|eye|enough|attention|range|reading|"
+    r"relationship|cousin|encounter|second|game|race|by|with))",
+    re.IGNORECASE,
+)
 _CLOSE_KO = ("닫", "종료")
 _REVIEW_EN_RE = re.compile(
     r"\b(review|reviewing|fix(?:es|ed|ing)?|address|resolve|improve)\b",
     re.IGNORECASE,
 )
 _REVIEW_KO = ("리뷰", "검토", "개선", "수정")
+
+# ``owner/repo`` style identifier. The classifier accepts this as a target
+# alongside full URLs so operational asks like ``fix the failing tests in
+# owner/repo`` are recognized without requiring a fully-qualified URL.
+# (Bot-flagged in #719 review.) Excludes common false positives such as
+# ``and/or`` by requiring at least one digit/dash/underscore in either
+# component.
+_REPO_PATH_RE = re.compile(
+    r"(?<![\w/])([A-Za-z0-9][\w\-.]*?[\w-]/[A-Za-z0-9][\w\-.]*[A-Za-z0-9_])(?![\w/])",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,16 +127,23 @@ def _has_korean_keyword(text: str, keywords: tuple[str, ...]) -> bool:
     return any(keyword in text for keyword in keywords)
 
 
-def _extract_targets(goal: str) -> tuple[tuple[str, ...], bool, bool, bool]:
-    """Return (urls, has_pr, has_pr_index, has_issue) preserving first-seen order.
+def _extract_targets(
+    goal: str,
+) -> tuple[tuple[str, ...], bool, bool, bool, bool]:
+    """Return (targets, has_pr, has_pr_index, has_issue, has_repo) in
+    first-seen order.
 
-    Implementation note: matches from all three URL classes are collected
-    together and sorted by their offset in the goal string. This guarantees
-    real first-appearance order across types — a goal like
-    ``see issues/9 then pull/1`` returns ``(issues/9, pull/1)``, not
-    ``(pull/1, issues/9)`` which an earlier per-class loop produced.
+    Implementation note: matches from every URL class plus the
+    ``owner/repo`` identifier pattern are collected together and sorted by
+    their offset in the goal string. This guarantees first-appearance order
+    across types and avoids double-counting — a ``/pull/1`` URL already
+    contains ``owner/repo`` substring, so the URL match shadows the bare
+    identifier when their start offsets line up.
     """
-    matches: list[tuple[int, str, str]] = []  # (start, kind, url)
+    matches: list[tuple[int, str, str]] = []  # (start, kind, value)
+
+    # URL classes first — their matches take precedence over a bare repo
+    # identifier embedded inside them.
     for kind, pattern in (
         ("pr", _PR_URL_RE),
         ("pr_index", _PR_INDEX_URL_RE),
@@ -124,22 +151,35 @@ def _extract_targets(goal: str) -> tuple[tuple[str, ...], bool, bool, bool]:
     ):
         for match in pattern.finditer(goal):
             matches.append((match.start(), kind, match.group(0)))
+
+    # Repo identifiers — only added when not already covered by a URL match
+    # at the same span. Use a coverage check on the spans we already have.
+    covered = [(start, start + len(val)) for start, _kind, val in matches]
+    for match in _REPO_PATH_RE.finditer(goal):
+        m_start, m_end = match.start(), match.end()
+        if any(start <= m_start and m_end <= end for start, end in covered):
+            continue
+        matches.append((m_start, "repo", match.group(1)))
+
     matches.sort(key=lambda triple: triple[0])
 
     seen: list[str] = []
     has_pr = False
     has_pr_index = False
     has_issue = False
-    for _start, kind, url in matches:
-        if url not in seen:
-            seen.append(url)
+    has_repo = False
+    for _start, kind, value in matches:
+        if value not in seen:
+            seen.append(value)
         if kind == "pr":
             has_pr = True
         elif kind == "pr_index":
             has_pr_index = True
-        else:
+        elif kind == "issue":
             has_issue = True
-    return tuple(seen), has_pr, has_pr_index, has_issue
+        else:
+            has_repo = True
+    return tuple(seen), has_pr, has_pr_index, has_issue, has_repo
 
 
 def classify_operational_task(goal: str) -> OperationalTaskClassification:
@@ -160,7 +200,7 @@ def classify_operational_task(goal: str) -> OperationalTaskClassification:
             reasons=("empty goal",),
         )
 
-    targets, has_pr, has_pr_index, has_issue = _extract_targets(goal)
+    targets, has_pr, has_pr_index, has_issue, has_repo = _extract_targets(goal)
 
     has_merge = bool(_MERGE_EN_RE.search(goal)) or _has_korean_keyword(goal, _MERGE_KO)
     has_close = bool(_CLOSE_EN_RE.search(goal)) or _has_korean_keyword(goal, _CLOSE_KO)
@@ -173,6 +213,8 @@ def classify_operational_task(goal: str) -> OperationalTaskClassification:
         reasons.append("pr_index_url")
     if has_issue:
         reasons.append("issue_url")
+    if has_repo:
+        reasons.append("repo_path")
     if has_merge:
         reasons.append("merge_keyword")
     if has_close:
@@ -180,7 +222,9 @@ def classify_operational_task(goal: str) -> OperationalTaskClassification:
     if has_review:
         reasons.append("review_keyword")
 
-    operational = (has_pr or has_pr_index or has_issue) or (has_merge or has_close or has_review)
+    operational = (has_pr or has_pr_index or has_issue or has_repo) or (
+        has_merge or has_close or has_review
+    )
     if not operational:
         return OperationalTaskClassification(
             kind=GENERAL,
@@ -218,11 +262,14 @@ def classify_operational_task(goal: str) -> OperationalTaskClassification:
         requires_confirmation = False
 
     # The operational path is only safe to skip the interview when the goal
-    # carries a concrete target URL. A destructive verb on its own ("merge it
-    # once CI is green", "close it") is not actionable — there is no object
-    # to operate on — so it falls back to interview-first regardless of risk
-    # label. (Bot-flagged in #719 review.)
-    has_target = has_pr or has_pr_index or has_issue
+    # carries a concrete target — either a full URL OR an ``owner/repo``
+    # identifier paired with a review/fix intent (so the pipeline knows
+    # what to act on). A destructive verb on its own ("merge it once CI is
+    # green", "close it") is not actionable; an ``owner/repo`` reference
+    # without any verb is also too thin. (Bot-flagged in #719 review.)
+    has_url_target = has_pr or has_pr_index or has_issue
+    has_actionable_repo = has_repo and (has_review or has_merge or has_close)
+    has_target = has_url_target or has_actionable_repo
     interview_required = not has_target
 
     return OperationalTaskClassification(

--- a/src/ouroboros/auto/operational_task.py
+++ b/src/ouroboros/auto/operational_task.py
@@ -1,0 +1,238 @@
+"""Classify ``ooo auto`` goals as operational vs ideation.
+
+Operational goals — concrete asks like "review PR <url>", "merge PR <url>",
+"fix the failing tests in <repo>" — already carry enough execution context
+that the Socratic interview is at best a tax and at worst the wrong tool
+(a single first-question timeout strands the entire session, see #692).
+
+This module is **pure**: a deterministic function over a goal string
+returning a structured classification. The pipeline-side rewiring lives in
+the follow-up PR (#689 part 2) so the classifier can be reviewed and
+exercised under test in isolation.
+
+The classification carries the *intent* the pipeline needs to choose a
+direct path or an interview-first path, plus a side-effect risk label so
+later code can require an explicit confirmation gate before any destructive
+action (merge, close).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Final
+
+# A closed set of intent kinds. Keep this tight — adding a kind requires a
+# matching update to the pipeline path that consumes the classification.
+GENERAL: Final[str] = "general"
+PR_URL: Final[str] = "pr_url"
+ISSUE_URL: Final[str] = "issue_url"
+MERGE_INTENT: Final[str] = "merge_intent"
+REVIEW_INTENT: Final[str] = "review_intent"
+
+# Side-effect risk labels in increasing severity.
+RISK_NONE: Final[str] = "none"
+RISK_LOW: Final[str] = "low"
+RISK_DESTRUCTIVE_MERGE: Final[str] = "destructive_merge"
+RISK_DESTRUCTIVE_CLOSE: Final[str] = "destructive_close"
+
+
+# Match GitHub PR / issue URLs. Capture only the canonical form to avoid
+# silently classifying e.g. doc links to ``/pulls`` index pages as PRs.
+_PR_URL_RE = re.compile(
+    r"https?://github\.com/[\w\-.]+/[\w\-.]+/pull/(\d+)\b",
+    re.IGNORECASE,
+)
+# Use an explicit URL-terminator group so the match works when the goal text
+# concatenates non-ASCII characters (e.g. Korean particles) directly after the
+# URL — Python's ``\b`` treats Hangul as a word character, so it would not
+# count as a boundary against ``s|의`` and the match would silently fail.
+_PR_INDEX_URL_RE = re.compile(
+    r"https?://github\.com/[\w\-.]+/[\w\-.]+/pulls(?:[/?#][^\s)]*)?",
+    re.IGNORECASE,
+)
+_ISSUE_URL_RE = re.compile(
+    r"https?://github\.com/[\w\-.]+/[\w\-.]+/issues/(\d+)\b",
+    re.IGNORECASE,
+)
+
+# Intent keywords (English + Korean). Whole-word match for English; substring
+# match acceptable for Korean since the language doesn't word-break the same
+# way and the words are unambiguous in this domain.
+_MERGE_EN_RE = re.compile(r"\b(merge|merging|merged|squash|rebase\s+merge)\b", re.IGNORECASE)
+_MERGE_KO = ("머지", "병합")
+_CLOSE_EN_RE = re.compile(r"\b(close|closes|closing)\b", re.IGNORECASE)
+_CLOSE_KO = ("닫", "종료")
+_REVIEW_EN_RE = re.compile(
+    r"\b(review|reviewing|fix(?:es|ed|ing)?|address|resolve|improve)\b",
+    re.IGNORECASE,
+)
+_REVIEW_KO = ("리뷰", "검토", "개선", "수정")
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalTaskClassification:
+    """Structured intent extracted from an auto goal string.
+
+    Attributes mirror the contract specified in #689:
+
+    * ``interview_required`` — when True, the pipeline must run the Socratic
+      interview before doing anything else (the goal is too vague to act on).
+    * ``direct_run_allowed`` — when True, the operational path is a candidate.
+      The pipeline may still fall back to interview-first based on policy.
+    * ``side_effect_risk`` — coarse risk label; ``destructive_*`` REQUIRES the
+      pipeline to gate execution on a confirmation matrix.
+    * ``requires_confirmation`` — explicit shortcut for the destructive cases.
+    * ``targets`` — canonical URLs extracted from the goal (deduplicated, in
+      first-appearance order).
+    * ``reasons`` — short labels explaining the classification, useful for
+      logging/ledger entries.
+    """
+
+    kind: str
+    interview_required: bool
+    direct_run_allowed: bool
+    side_effect_risk: str
+    requires_confirmation: bool
+    targets: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+
+def _has_korean_keyword(text: str, keywords: tuple[str, ...]) -> bool:
+    return any(keyword in text for keyword in keywords)
+
+
+def _extract_targets(goal: str) -> tuple[tuple[str, ...], bool, bool, bool]:
+    """Return (urls, has_pr, has_pr_index, has_issue) preserving first-seen order."""
+    seen: list[str] = []
+    has_pr = False
+    has_pr_index = False
+    has_issue = False
+    for match in _PR_URL_RE.finditer(goal):
+        url = match.group(0)
+        if url not in seen:
+            seen.append(url)
+        has_pr = True
+    for match in _PR_INDEX_URL_RE.finditer(goal):
+        url = match.group(0)
+        if url not in seen:
+            seen.append(url)
+        has_pr_index = True
+    for match in _ISSUE_URL_RE.finditer(goal):
+        url = match.group(0)
+        if url not in seen:
+            seen.append(url)
+        has_issue = True
+    return tuple(seen), has_pr, has_pr_index, has_issue
+
+
+def classify_operational_task(goal: str) -> OperationalTaskClassification:
+    """Classify ``goal`` for the auto pipeline's path-selection step.
+
+    Returns a default ``GENERAL`` classification with ``interview_required``
+    when the goal is empty or carries no operational signal — so callers can
+    safely use this as the only entry point.
+    """
+    if not goal or not goal.strip():
+        return OperationalTaskClassification(
+            kind=GENERAL,
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=RISK_NONE,
+            requires_confirmation=False,
+            targets=(),
+            reasons=("empty goal",),
+        )
+
+    targets, has_pr, has_pr_index, has_issue = _extract_targets(goal)
+
+    has_merge = bool(_MERGE_EN_RE.search(goal)) or _has_korean_keyword(goal, _MERGE_KO)
+    has_close = bool(_CLOSE_EN_RE.search(goal)) or _has_korean_keyword(goal, _CLOSE_KO)
+    has_review = bool(_REVIEW_EN_RE.search(goal)) or _has_korean_keyword(goal, _REVIEW_KO)
+
+    reasons: list[str] = []
+    if has_pr:
+        reasons.append("pr_url")
+    if has_pr_index:
+        reasons.append("pr_index_url")
+    if has_issue:
+        reasons.append("issue_url")
+    if has_merge:
+        reasons.append("merge_keyword")
+    if has_close:
+        reasons.append("close_keyword")
+    if has_review:
+        reasons.append("review_keyword")
+
+    operational = (has_pr or has_pr_index or has_issue) or (has_merge or has_close or has_review)
+    if not operational:
+        return OperationalTaskClassification(
+            kind=GENERAL,
+            interview_required=True,
+            direct_run_allowed=False,
+            side_effect_risk=RISK_NONE,
+            requires_confirmation=False,
+            targets=targets,
+            reasons=tuple(reasons) or ("no operational signal",),
+        )
+
+    if has_merge:
+        kind = MERGE_INTENT
+        risk = RISK_DESTRUCTIVE_MERGE
+        requires_confirmation = True
+    elif has_close:
+        kind = MERGE_INTENT  # close shares the destructive shape; pipeline distinguishes
+        risk = RISK_DESTRUCTIVE_CLOSE
+        requires_confirmation = True
+    elif has_pr:
+        kind = PR_URL
+        risk = RISK_LOW if has_review else RISK_NONE
+        requires_confirmation = False
+    elif has_issue:
+        kind = ISSUE_URL
+        risk = RISK_LOW if has_review else RISK_NONE
+        requires_confirmation = False
+    elif has_pr_index:
+        kind = PR_URL
+        risk = RISK_LOW if has_review else RISK_NONE
+        requires_confirmation = False
+    else:
+        kind = REVIEW_INTENT
+        risk = RISK_LOW
+        requires_confirmation = False
+
+    # Operational signal alone reduces but does not eliminate the case for an
+    # interview: the pipeline owns that policy decision. We expose
+    # ``direct_run_allowed`` so it can choose; ``interview_required`` is only
+    # set when the operational signal is too thin to act on (no concrete
+    # target URL AND no destructive intent that demands confirmation).
+    interview_required = (
+        not (has_pr or has_pr_index or has_issue)
+        and not has_merge
+        and not has_close
+    )
+
+    return OperationalTaskClassification(
+        kind=kind,
+        interview_required=interview_required,
+        direct_run_allowed=not interview_required,
+        side_effect_risk=risk,
+        requires_confirmation=requires_confirmation,
+        targets=targets,
+        reasons=tuple(reasons),
+    )
+
+
+__all__ = [
+    "GENERAL",
+    "ISSUE_URL",
+    "MERGE_INTENT",
+    "OperationalTaskClassification",
+    "PR_URL",
+    "REVIEW_INTENT",
+    "RISK_DESTRUCTIVE_CLOSE",
+    "RISK_DESTRUCTIVE_MERGE",
+    "RISK_LOW",
+    "RISK_NONE",
+    "classify_operational_task",
+]

--- a/src/ouroboros/auto/operational_task.py
+++ b/src/ouroboros/auto/operational_task.py
@@ -39,20 +39,25 @@ RISK_DESTRUCTIVE_CLOSE: Final[str] = "destructive_close"
 
 # Match GitHub PR / issue URLs. Capture only the canonical form to avoid
 # silently classifying e.g. doc links to ``/pulls`` index pages as PRs.
+#
+# Use a negative-lookahead ``(?!\d)`` after the captured digit run instead of
+# ``\b``: Python's ``\b`` treats Hangul (and other non-ASCII word characters)
+# as word characters, so ``/pull/1을 ...`` had no boundary between ``1`` and
+# ``을`` and the match silently failed. ``(?!\d)`` only forbids another digit,
+# which is the actual semantic we want.
 _PR_URL_RE = re.compile(
-    r"https?://github\.com/[\w\-.]+/[\w\-.]+/pull/(\d+)\b",
+    r"https?://github\.com/[\w\-.]+/[\w\-.]+/pull/(\d+)(?!\d)",
     re.IGNORECASE,
 )
-# Use an explicit URL-terminator group so the match works when the goal text
-# concatenates non-ASCII characters (e.g. Korean particles) directly after the
-# URL — Python's ``\b`` treats Hangul as a word character, so it would not
-# count as a boundary against ``s|의`` and the match would silently fail.
+# Index URL ends in literal ``pulls`` (no trailing digit), so an optional
+# URL-continuation group is enough; non-ASCII suffixes are not URL-safe and
+# implicitly terminate the match.
 _PR_INDEX_URL_RE = re.compile(
     r"https?://github\.com/[\w\-.]+/[\w\-.]+/pulls(?:[/?#][^\s)]*)?",
     re.IGNORECASE,
 )
 _ISSUE_URL_RE = re.compile(
-    r"https?://github\.com/[\w\-.]+/[\w\-.]+/issues/(\d+)\b",
+    r"https?://github\.com/[\w\-.]+/[\w\-.]+/issues/(\d+)(?!\d)",
     re.IGNORECASE,
 )
 
@@ -103,26 +108,37 @@ def _has_korean_keyword(text: str, keywords: tuple[str, ...]) -> bool:
 
 
 def _extract_targets(goal: str) -> tuple[tuple[str, ...], bool, bool, bool]:
-    """Return (urls, has_pr, has_pr_index, has_issue) preserving first-seen order."""
+    """Return (urls, has_pr, has_pr_index, has_issue) preserving first-seen order.
+
+    Implementation note: matches from all three URL classes are collected
+    together and sorted by their offset in the goal string. This guarantees
+    real first-appearance order across types — a goal like
+    ``see issues/9 then pull/1`` returns ``(issues/9, pull/1)``, not
+    ``(pull/1, issues/9)`` which an earlier per-class loop produced.
+    """
+    matches: list[tuple[int, str, str]] = []  # (start, kind, url)
+    for kind, pattern in (
+        ("pr", _PR_URL_RE),
+        ("pr_index", _PR_INDEX_URL_RE),
+        ("issue", _ISSUE_URL_RE),
+    ):
+        for match in pattern.finditer(goal):
+            matches.append((match.start(), kind, match.group(0)))
+    matches.sort(key=lambda triple: triple[0])
+
     seen: list[str] = []
     has_pr = False
     has_pr_index = False
     has_issue = False
-    for match in _PR_URL_RE.finditer(goal):
-        url = match.group(0)
+    for _start, kind, url in matches:
         if url not in seen:
             seen.append(url)
-        has_pr = True
-    for match in _PR_INDEX_URL_RE.finditer(goal):
-        url = match.group(0)
-        if url not in seen:
-            seen.append(url)
-        has_pr_index = True
-    for match in _ISSUE_URL_RE.finditer(goal):
-        url = match.group(0)
-        if url not in seen:
-            seen.append(url)
-        has_issue = True
+        if kind == "pr":
+            has_pr = True
+        elif kind == "pr_index":
+            has_pr_index = True
+        else:
+            has_issue = True
     return tuple(seen), has_pr, has_pr_index, has_issue
 
 
@@ -201,16 +217,13 @@ def classify_operational_task(goal: str) -> OperationalTaskClassification:
         risk = RISK_LOW
         requires_confirmation = False
 
-    # Operational signal alone reduces but does not eliminate the case for an
-    # interview: the pipeline owns that policy decision. We expose
-    # ``direct_run_allowed`` so it can choose; ``interview_required`` is only
-    # set when the operational signal is too thin to act on (no concrete
-    # target URL AND no destructive intent that demands confirmation).
-    interview_required = (
-        not (has_pr or has_pr_index or has_issue)
-        and not has_merge
-        and not has_close
-    )
+    # The operational path is only safe to skip the interview when the goal
+    # carries a concrete target URL. A destructive verb on its own ("merge it
+    # once CI is green", "close it") is not actionable — there is no object
+    # to operate on — so it falls back to interview-first regardless of risk
+    # label. (Bot-flagged in #719 review.)
+    has_target = has_pr or has_pr_index or has_issue
+    interview_required = not has_target
 
     return OperationalTaskClassification(
         kind=kind,

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -125,6 +125,10 @@ class AutoPipelineState:
             AutoPhase.RUN.value: 60,
         }
     )
+    # Operational-task classification recorded at session creation by the CLI.
+    # Pipeline path-selection consults this to decide direct-run vs interview.
+    # Empty dict for legacy/general goals (back-compat).
+    classification: dict[str, Any] = field(default_factory=dict)
 
     def transition(self, next_phase: AutoPhase, message: str, *, error: str | None = None) -> None:
         """Move to ``next_phase`` after validating the phase state machine."""
@@ -194,6 +198,7 @@ class AutoPipelineState:
         payload.setdefault("max_repair_rounds", 5)
         payload.setdefault("run_handoff_status", None)
         payload.setdefault("run_handoff_guidance", None)
+        payload.setdefault("classification", {})
         required_fields = {item.name for item in fields(cls)}
         missing_fields = sorted(required_fields - payload.keys())
         if missing_fields:
@@ -277,6 +282,56 @@ class AutoPipelineState:
         if not isinstance(self.run_subagent, dict):
             msg = "run_subagent must be an object"
             raise ValueError(msg)
+        # ``classification`` is the operational-task classifier output; an
+        # empty dict means "no classification persisted yet" (legacy/general
+        # goals). When present, it MUST be an object so ``--status``
+        # rendering and pipeline path-selection can use ``.get(...)`` without
+        # crashing on a list/string masquerading as classification.
+        # (Bot-flagged in #721 review.)
+        if not isinstance(self.classification, dict):
+            msg = "classification must be an object"
+            raise ValueError(msg)
+        if self.classification:
+            from ouroboros.auto.operational_task import (
+                GENERAL,
+                ISSUE_URL,
+                MERGE_INTENT,
+                PR_URL,
+                REVIEW_INTENT,
+                RISK_DESTRUCTIVE_CLOSE,
+                RISK_DESTRUCTIVE_MERGE,
+                RISK_LOW,
+                RISK_NONE,
+            )
+
+            valid_kinds = {GENERAL, PR_URL, ISSUE_URL, MERGE_INTENT, REVIEW_INTENT}
+            valid_risks = {
+                RISK_NONE,
+                RISK_LOW,
+                RISK_DESTRUCTIVE_MERGE,
+                RISK_DESTRUCTIVE_CLOSE,
+            }
+            kind = self.classification.get("kind")
+            if not isinstance(kind, str) or kind not in valid_kinds:
+                msg = "classification.kind must be a known classifier kind"
+                raise ValueError(msg)
+            risk = self.classification.get("side_effect_risk")
+            if not isinstance(risk, str) or risk not in valid_risks:
+                msg = "classification.side_effect_risk must be a known risk label"
+                raise ValueError(msg)
+            for bool_field in (
+                "interview_required",
+                "direct_run_allowed",
+                "requires_confirmation",
+            ):
+                if type(self.classification.get(bool_field)) is not bool:
+                    msg = f"classification.{bool_field} must be a boolean"
+                    raise ValueError(msg)
+            for list_field in ("targets", "reasons"):
+                value = self.classification.get(list_field)
+                if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+                    msg = f"classification.{list_field} must be a list of strings"
+                    raise ValueError(msg)
         if self.ledger:
             try:
                 from ouroboros.auto.ledger import SeedDraftLedger

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -18,6 +18,10 @@ from ouroboros.auto.adapters import (
     save_seed,
 )
 from ouroboros.auto.interview_driver import AutoInterviewDriver
+from ouroboros.auto.operational_task import (
+    classification_to_state_dict,
+    classify_operational_task,
+)
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.state import AutoPipelineState, AutoStore
@@ -204,6 +208,7 @@ async def _run_auto(
         state = AutoPipelineState(goal=goal.strip(), cwd=str(_safe_default_cwd()))
         state.runtime_backend = runtime
         state.skip_run = skip_run
+        state.classification = classification_to_state_dict(classify_operational_task(state.goal))
         state.max_interview_rounds = max_interview_rounds
         state.max_repair_rounds = max_repair_rounds
 
@@ -275,6 +280,12 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Run handoff status: [bold]{state.run_handoff_status}[/]")
     if state.run_handoff_guidance:
         console.print(f"Run handoff guidance: [yellow]{state.run_handoff_guidance}[/]")
+    if state.classification:
+        kind = state.classification.get("kind", "general")
+        risk = state.classification.get("side_effect_risk", "none")
+        console.print(f"Goal classification: [bold]{kind}[/] (risk={risk})")
+        if state.classification.get("requires_confirmation"):
+            console.print("  [yellow]requires explicit confirmation before destructive action[/]")
     if state.last_error:
         console.print(f"Blocker: [yellow]{state.last_error}[/]")
     console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")

--- a/tests/unit/auto/test_operational_task.py
+++ b/tests/unit/auto/test_operational_task.py
@@ -279,3 +279,54 @@ def test_repo_path_does_not_double_count_when_inside_url() -> None:
     assert result.targets == ("https://github.com/owner/repo/pull/1",)
     # The repo identifier alone should not appear as an extra target.
     assert "owner/repo" not in result.targets
+
+
+# Bot follow-up: false-positive prose phrases must NOT be classified as repos.
+# (Bot-flagged in #719 / #721 review.)
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "and/or",
+        "yes/no",
+        "true/false",
+        "input/output",
+        "to/from",
+        "either/or",
+        "n/a",
+        "foo/bar",
+        "foo/baz",
+        "lorem/ipsum",
+    ],
+)
+def test_prose_slash_phrases_are_not_treated_as_repo_targets(phrase: str) -> None:
+    """English idioms and metasyntactic placeholders that share the
+    ``a/b`` shape MUST NOT enter ``targets`` and MUST NOT flip the
+    pipeline into the direct-run path."""
+    result = classify_operational_task(f"review and improve {phrase} docs")
+    assert phrase not in result.targets
+    assert "repo_path" not in result.reasons
+    # Falls back to the interview because no actual target was identified.
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+@pytest.mark.parametrize(
+    "repo",
+    ["owner/r", "o/repo", "a/b1", "u-1/r-2", "u_1/r_2"],
+)
+def test_short_or_minimal_repo_names_are_recognized(repo: str) -> None:
+    """Legitimate but short repo names like ``owner/r`` or ``o/repo`` MUST
+    classify as repo targets (with a review/fix verb) instead of falling
+    back to the interview path. (Bot-flagged in #719 review, third round.)"""
+    result = classify_operational_task(f"fix the failing tests in {repo}")
+    assert repo in result.targets
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+
+
+def test_repo_with_digits_or_dashes_recognized() -> None:
+    """Realistic repo names with digits / dashes / dots (no idiom shape)
+    classify as targets immediately."""
+    result = classify_operational_task("fix failing tests in shaun0927/ouroboros-ai")
+    assert "shaun0927/ouroboros-ai" in result.targets
+    assert result.interview_required is False

--- a/tests/unit/auto/test_operational_task.py
+++ b/tests/unit/auto/test_operational_task.py
@@ -206,3 +206,76 @@ def test_targets_preserve_first_seen_order_across_types() -> None:
         "https://github.com/o/r/pull/1",
         "https://github.com/o/r/pulls",
     )
+
+
+# ---------------------------------------------------------------------------
+# Bot review follow-ups (#719 + #721, second round)
+# ---------------------------------------------------------------------------
+
+
+def test_repo_path_with_review_intent_is_operational_no_url_required() -> None:
+    """Module docstring lists ``fix the failing tests in <repo>`` as an
+    operational ask; an ``owner/repo`` identifier paired with a review/fix
+    intent must skip the interview rather than fall back to it.
+    (Bot-flagged in #719 review, second round.)"""
+    result = classify_operational_task("fix the failing tests in shaun0927/opensafari")
+    assert result.interview_required is False
+    assert result.direct_run_allowed is True
+    assert "shaun0927/opensafari" in result.targets
+    assert "repo_path" in result.reasons
+
+
+def test_repo_path_alone_without_intent_still_requires_interview() -> None:
+    """A bare ``owner/repo`` without any review/merge intent is too thin to
+    act on — keep interview-first."""
+    result = classify_operational_task("look at owner/repo sometime")
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_close_adjective_is_not_destructive_intent() -> None:
+    """``take a close look at <url>`` MUST NOT classify as destructive_close.
+    (Bot-flagged in #721 review.) The PR url alone keeps the kind PR_URL
+    and the side-effect risk stays low (review keyword present)."""
+    result = classify_operational_task("take a close look at https://github.com/o/r/pull/1")
+    assert result.kind == PR_URL
+    assert result.side_effect_risk != RISK_DESTRUCTIVE_CLOSE
+    assert result.requires_confirmation is False
+    assert "close_keyword" not in result.reasons
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "close look",
+        "close call",
+        "close to merging",
+        "close eye on this",
+        "close attention",
+        "close enough",
+    ],
+)
+def test_close_adjectival_phrases_do_not_trigger_destructive(phrase: str) -> None:
+    """A range of common ``close <word>`` adjectival/idiomatic uses must NOT
+    be promoted to ``destructive_close``."""
+    result = classify_operational_task(f"please {phrase} on https://github.com/o/r/pull/1")
+    assert result.side_effect_risk != RISK_DESTRUCTIVE_CLOSE
+    assert "close_keyword" not in result.reasons
+
+
+def test_close_imperative_still_marks_destructive_close() -> None:
+    """Make sure the negative-lookahead refinement does NOT lose the real
+    destructive-close case (``close <url>``)."""
+    result = classify_operational_task("close https://github.com/o/r/pull/2")
+    assert result.kind == MERGE_INTENT
+    assert result.side_effect_risk == RISK_DESTRUCTIVE_CLOSE
+    assert result.requires_confirmation is True
+
+
+def test_repo_path_does_not_double_count_when_inside_url() -> None:
+    """A PR URL contains an ``owner/repo`` substring; the targets list MUST
+    NOT include the bare identifier in addition to the URL."""
+    result = classify_operational_task("review https://github.com/owner/repo/pull/1")
+    assert result.targets == ("https://github.com/owner/repo/pull/1",)
+    # The repo identifier alone should not appear as an extra target.
+    assert "owner/repo" not in result.targets

--- a/tests/unit/auto/test_operational_task.py
+++ b/tests/unit/auto/test_operational_task.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.operational_task import (
+    GENERAL,
+    ISSUE_URL,
+    MERGE_INTENT,
+    PR_URL,
+    REVIEW_INTENT,
+    RISK_DESTRUCTIVE_CLOSE,
+    RISK_DESTRUCTIVE_MERGE,
+    RISK_LOW,
+    RISK_NONE,
+    classify_operational_task,
+)
+
+
+def test_general_goal_requires_interview() -> None:
+    result = classify_operational_task("Build a CLI tool that tracks daily habits")
+    assert result.kind == GENERAL
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+    assert result.side_effect_risk == RISK_NONE
+    assert result.requires_confirmation is False
+    assert result.targets == ()
+
+
+def test_empty_goal_requires_interview() -> None:
+    result = classify_operational_task("   ")
+    assert result.kind == GENERAL
+    assert result.interview_required is True
+    assert "empty goal" in result.reasons
+
+
+def test_pr_url_alone_allows_direct_run() -> None:
+    result = classify_operational_task(
+        "Take a look at https://github.com/shaun0927/opensafari/pull/12"
+    )
+    assert result.kind == PR_URL
+    assert result.direct_run_allowed is True
+    assert result.interview_required is False
+    assert result.side_effect_risk == RISK_NONE
+    assert result.targets == ("https://github.com/shaun0927/opensafari/pull/12",)
+
+
+def test_pr_url_with_review_keyword_marks_low_risk() -> None:
+    result = classify_operational_task(
+        "review and improve https://github.com/owner/repo/pull/1"
+    )
+    assert result.kind == PR_URL
+    assert result.side_effect_risk == RISK_LOW
+    assert result.requires_confirmation is False
+
+
+def test_pr_url_with_merge_keyword_marks_destructive_and_requires_confirmation() -> None:
+    result = classify_operational_task(
+        "merge https://github.com/owner/repo/pull/1 once CI is green"
+    )
+    assert result.kind == MERGE_INTENT
+    assert result.side_effect_risk == RISK_DESTRUCTIVE_MERGE
+    assert result.requires_confirmation is True
+    assert result.direct_run_allowed is True
+
+
+def test_korean_merge_intent_detected_with_pr_index_url() -> None:
+    """Mirrors the auto_78c98678de5d incident goal shape."""
+    result = classify_operational_task(
+        "https://github.com/shaun0927/opensafari/pulls의 열린 pr을 면밀히 해석해 "
+        "merge 가능한 수준까지 반복 개선해줘. merge 가능한 수준이라면 머지 진행해줘."
+    )
+    assert result.kind == MERGE_INTENT
+    assert result.side_effect_risk == RISK_DESTRUCTIVE_MERGE
+    assert result.requires_confirmation is True
+    assert result.direct_run_allowed is True
+    assert "https://github.com/shaun0927/opensafari/pulls" in result.targets
+    assert "merge_keyword" in result.reasons
+    assert "pr_index_url" in result.reasons
+
+
+def test_close_keyword_marked_destructive_close() -> None:
+    result = classify_operational_task(
+        "close https://github.com/owner/repo/pull/2 — superseded"
+    )
+    assert result.side_effect_risk == RISK_DESTRUCTIVE_CLOSE
+    assert result.requires_confirmation is True
+
+
+def test_issue_url_alone_allows_direct_run() -> None:
+    result = classify_operational_task(
+        "look at https://github.com/owner/repo/issues/42"
+    )
+    assert result.kind == ISSUE_URL
+    assert result.direct_run_allowed is True
+
+
+def test_review_keyword_without_url_still_operational() -> None:
+    result = classify_operational_task("리뷰만 해줘 (url 없음)")
+    assert result.kind == REVIEW_INTENT
+    assert result.side_effect_risk == RISK_LOW
+    # No URL means the pipeline still needs the interview to find a target.
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_targets_deduplicated_in_first_seen_order() -> None:
+    goal = (
+        "see https://github.com/o/r/pull/1 and https://github.com/o/r/pull/2 "
+        "and again https://github.com/o/r/pull/1"
+    )
+    result = classify_operational_task(goal)
+    assert result.targets == (
+        "https://github.com/o/r/pull/1",
+        "https://github.com/o/r/pull/2",
+    )
+
+
+def test_pr_url_pattern_does_not_match_pulls_index() -> None:
+    """PR-URL pattern must require /pull/<n> to avoid mis-classifying the
+    /pulls index as a single-PR target."""
+    result = classify_operational_task("see https://github.com/o/r/pulls")
+    # Index URL is recognized via has_pr_index, not as a single PR.
+    assert result.kind == PR_URL
+    assert "pr_index_url" in result.reasons
+    assert "pr_url" not in result.reasons
+
+
+def test_classification_is_pure_and_repeatable() -> None:
+    goal = "merge https://github.com/owner/repo/pull/1"
+    a = classify_operational_task(goal)
+    b = classify_operational_task(goal)
+    assert a == b
+
+
+@pytest.mark.parametrize(
+    "goal,expected_kind",
+    [
+        ("merge https://github.com/o/r/pull/1", MERGE_INTENT),
+        ("close https://github.com/o/r/pull/1", MERGE_INTENT),
+        ("https://github.com/o/r/pull/1 only", PR_URL),
+        ("https://github.com/o/r/issues/9", ISSUE_URL),
+        ("just review some code", REVIEW_INTENT),
+        ("nothing actionable here", GENERAL),
+    ],
+)
+def test_classification_kind_table(goal: str, expected_kind: str) -> None:
+    assert classify_operational_task(goal).kind == expected_kind

--- a/tests/unit/auto/test_operational_task.py
+++ b/tests/unit/auto/test_operational_task.py
@@ -330,3 +330,147 @@ def test_repo_with_digits_or_dashes_recognized() -> None:
     result = classify_operational_task("fix failing tests in shaun0927/ouroboros-ai")
     assert "shaun0927/ouroboros-ai" in result.targets
     assert result.interview_required is False
+
+
+# ---------------------------------------------------------------------------
+# Merge guardrail matrix (#689 part 2)
+# ---------------------------------------------------------------------------
+
+from dataclasses import replace
+
+from ouroboros.auto.operational_task import (
+    MergeGuardrailInputs,
+    classification_to_state_dict,
+    evaluate_merge_guardrails,
+)
+from ouroboros.auto.state import AutoPipelineState, AutoStore
+
+
+def _all_ok() -> MergeGuardrailInputs:
+    return MergeGuardrailInputs(
+        target_branch_protected_ok=True,
+        ci_passing=True,
+        mergeable=True,
+        permitted=True,
+        explicit_confirmation=True,
+    )
+
+
+def test_evaluate_merge_guardrails_all_ok_returns_no_blockers() -> None:
+    assert evaluate_merge_guardrails(_all_ok()) == ()
+
+
+@pytest.mark.parametrize(
+    "field,expected_substring",
+    [
+        ("target_branch_protected_ok", "target branch protection"),
+        ("ci_passing", "CI is not green"),
+        ("mergeable", "not mergeable"),
+        ("permitted", "lacks permission"),
+        ("explicit_confirmation", "explicit human or policy confirmation"),
+    ],
+)
+def test_evaluate_merge_guardrails_each_failure_blocks(field: str, expected_substring: str) -> None:
+    inputs = replace(_all_ok(), **{field: False})
+    blockers = evaluate_merge_guardrails(inputs)
+    assert any(expected_substring in b for b in blockers), blockers
+
+
+def test_evaluate_merge_guardrails_collects_all_failures() -> None:
+    inputs = MergeGuardrailInputs(
+        target_branch_protected_ok=False,
+        ci_passing=False,
+        mergeable=False,
+        permitted=False,
+        explicit_confirmation=False,
+    )
+    blockers = evaluate_merge_guardrails(inputs)
+    assert len(blockers) == 5
+
+
+def test_classification_to_state_dict_is_json_safe() -> None:
+    cls = classify_operational_task("merge https://github.com/o/r/pull/1 once CI is green")
+    out = classification_to_state_dict(cls)
+    import json
+
+    json.dumps(out)  # must not raise
+    assert out["kind"] == MERGE_INTENT
+    assert out["targets"] == ["https://github.com/o/r/pull/1"]
+
+
+def test_state_persists_classification_through_roundtrip(tmp_path) -> None:
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="merge https://github.com/o/r/pull/1", cwd="/repo")
+    state.classification = classification_to_state_dict(classify_operational_task(state.goal))
+    store.save(state)
+    loaded = store.load(state.auto_session_id)
+    assert loaded.classification["kind"] == MERGE_INTENT
+    assert loaded.classification["requires_confirmation"] is True
+
+
+def test_state_treats_missing_classification_as_empty(tmp_path) -> None:
+    state = AutoPipelineState(goal="general task", cwd="/repo")
+    raw = state.to_dict()
+    del raw["classification"]
+    revived = AutoPipelineState.from_dict(raw)
+    assert revived.classification == {}
+
+
+def test_state_rejects_classification_of_wrong_type() -> None:
+    """A malformed durable state file with ``classification`` as a list or
+    string MUST be rejected at load time so ``ooo auto --status`` does not
+    crash later when calling ``state.classification.get(...)``.
+    (Bot-flagged in #721 review.)"""
+    state = AutoPipelineState(goal="x", cwd="/repo")
+    raw = state.to_dict()
+    raw["classification"] = ["not", "a", "dict"]
+    with pytest.raises(ValueError, match="classification must be an object"):
+        AutoPipelineState.from_dict(raw)
+
+
+def test_state_rejects_classification_with_unknown_kind() -> None:
+    state = AutoPipelineState(goal="x", cwd="/repo")
+    raw = state.to_dict()
+    raw["classification"] = {
+        "kind": "totally-fake",
+        "interview_required": True,
+        "direct_run_allowed": False,
+        "side_effect_risk": "none",
+        "requires_confirmation": False,
+        "targets": [],
+        "reasons": [],
+    }
+    with pytest.raises(ValueError, match="classification.kind"):
+        AutoPipelineState.from_dict(raw)
+
+
+def test_state_rejects_classification_with_non_bool_flag() -> None:
+    state = AutoPipelineState(goal="x", cwd="/repo")
+    raw = state.to_dict()
+    raw["classification"] = {
+        "kind": "general",
+        "interview_required": "yes",  # bug: should be bool
+        "direct_run_allowed": False,
+        "side_effect_risk": "none",
+        "requires_confirmation": False,
+        "targets": [],
+        "reasons": [],
+    }
+    with pytest.raises(ValueError, match="interview_required must be a boolean"):
+        AutoPipelineState.from_dict(raw)
+
+
+def test_state_rejects_classification_with_non_string_targets() -> None:
+    state = AutoPipelineState(goal="x", cwd="/repo")
+    raw = state.to_dict()
+    raw["classification"] = {
+        "kind": "general",
+        "interview_required": True,
+        "direct_run_allowed": False,
+        "side_effect_risk": "none",
+        "requires_confirmation": False,
+        "targets": [123, 456],  # bug: must be strings
+        "reasons": [],
+    }
+    with pytest.raises(ValueError, match="classification.targets"):
+        AutoPipelineState.from_dict(raw)

--- a/tests/unit/auto/test_operational_task.py
+++ b/tests/unit/auto/test_operational_task.py
@@ -45,9 +45,7 @@ def test_pr_url_alone_allows_direct_run() -> None:
 
 
 def test_pr_url_with_review_keyword_marks_low_risk() -> None:
-    result = classify_operational_task(
-        "review and improve https://github.com/owner/repo/pull/1"
-    )
+    result = classify_operational_task("review and improve https://github.com/owner/repo/pull/1")
     assert result.kind == PR_URL
     assert result.side_effect_risk == RISK_LOW
     assert result.requires_confirmation is False
@@ -79,17 +77,13 @@ def test_korean_merge_intent_detected_with_pr_index_url() -> None:
 
 
 def test_close_keyword_marked_destructive_close() -> None:
-    result = classify_operational_task(
-        "close https://github.com/owner/repo/pull/2 — superseded"
-    )
+    result = classify_operational_task("close https://github.com/owner/repo/pull/2 — superseded")
     assert result.side_effect_risk == RISK_DESTRUCTIVE_CLOSE
     assert result.requires_confirmation is True
 
 
 def test_issue_url_alone_allows_direct_run() -> None:
-    result = classify_operational_task(
-        "look at https://github.com/owner/repo/issues/42"
-    )
+    result = classify_operational_task("look at https://github.com/owner/repo/issues/42")
     assert result.kind == ISSUE_URL
     assert result.direct_run_allowed is True
 
@@ -145,3 +139,70 @@ def test_classification_is_pure_and_repeatable() -> None:
 )
 def test_classification_kind_table(goal: str, expected_kind: str) -> None:
     assert classify_operational_task(goal).kind == expected_kind
+
+
+# ---------------------------------------------------------------------------
+# Bot review follow-ups (#719)
+# ---------------------------------------------------------------------------
+
+
+def test_targetless_merge_intent_falls_back_to_interview() -> None:
+    """`merge it once CI is green` has no URL — pipeline cannot act without a
+    target, so this MUST require the interview rather than entering the
+    direct path. (Bot-flagged in #719 review.)"""
+    result = classify_operational_task("merge it once CI is green")
+    assert result.kind == MERGE_INTENT
+    assert result.requires_confirmation is True
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_targetless_close_intent_falls_back_to_interview() -> None:
+    result = classify_operational_task("close it — superseded")
+    assert result.kind == MERGE_INTENT
+    assert result.side_effect_risk == RISK_DESTRUCTIVE_CLOSE
+    assert result.requires_confirmation is True
+    assert result.interview_required is True
+    assert result.direct_run_allowed is False
+
+
+def test_pr_url_recognized_with_korean_particle_suffix() -> None:
+    """A canonical PR URL immediately followed by a Hangul particle (which
+    Python regex treats as a word character) MUST still be detected — the
+    same boundary fix applied to /pulls index URLs is now applied to
+    /pull/<n>. (Bot-flagged in #719 review.)"""
+    result = classify_operational_task("https://github.com/o/r/pull/1을 리뷰해줘")
+    assert result.kind == PR_URL
+    assert result.targets == ("https://github.com/o/r/pull/1",)
+    assert result.interview_required is False
+
+
+def test_issue_url_recognized_with_korean_particle_suffix() -> None:
+    """Same boundary fix for /issues/<n> URLs."""
+    result = classify_operational_task("https://github.com/o/r/issues/42를 확인해줘")
+    assert result.kind == ISSUE_URL
+    assert result.targets == ("https://github.com/o/r/issues/42",)
+    assert result.interview_required is False
+
+
+def test_pr_url_does_not_match_partial_digit_run() -> None:
+    """The negative lookahead prevents `pull/1` from matching inside
+    `pull/12345` so the captured number is exactly the canonical id."""
+    result = classify_operational_task("review https://github.com/o/r/pull/12345")
+    assert result.targets == ("https://github.com/o/r/pull/12345",)
+
+
+def test_targets_preserve_first_seen_order_across_types() -> None:
+    """A goal mixing /issues/ and /pull/ URLs returns targets in actual
+    first-appearance order — the previous per-class loop returned them in
+    the wrong order. (Bot-flagged in #719 review.)"""
+    goal = (
+        "first https://github.com/o/r/issues/9 then "
+        "https://github.com/o/r/pull/1 and https://github.com/o/r/pulls"
+    )
+    result = classify_operational_task(goal)
+    assert result.targets == (
+        "https://github.com/o/r/issues/9",
+        "https://github.com/o/r/pull/1",
+        "https://github.com/o/r/pulls",
+    )


### PR DESCRIPTION
## Summary
**Stacks on top of #719** (`feat/692-689-operational-task-classifier`). The diff against `main` includes the classifier from part 1 — review part 2's incremental changes by comparing against the part 1 branch (or wait for part 1 to merge, after which this PR will rebase down to only its own commits).

- `AutoPipelineState.classification: dict[str, Any]` (back-compat: missing key on load defaults to `{}`) records the classifier output at session creation. Resume keeps the same path decision; `--status` prints a one-line classification + risk summary.
- `MergeGuardrailInputs` + `evaluate_merge_guardrails(...)` is a pure function returning a tuple of human-readable blockers. **Fail-closed**: any unmet check produces a blocker; the pipeline must NOT proceed with the merge until the tuple is empty.
- CLI persists classification on every new `ooo auto` session and prints, e.g.:

  ```
  Goal classification: merge_intent (risk=destructive_merge)
    requires explicit confirmation before destructive action
  ```

- 11 new tests on top of the 18 from part 1 (28 total in `test_operational_task.py`): all-ok matrix, each-failure-blocks (parametrized over the 5 inputs), all-fail collects every blocker, classification-to-state-dict JSON safety, state round-trip preserves classification, legacy state without `classification` loads as `{}`.

## Why this is split from a "real" direct-run
The destructive merge call site is intentionally NOT in this PR. It needs:
- A GitHub API integration to read CI / mergeability / branch protection.
- A repository-permission check.
- An explicit human-or-policy confirmation channel.

Each of those is its own design call. By landing the spec (`evaluate_merge_guardrails`) + storage (`state.classification`) first, the destructive site PR can show diffs only against this contract — much smaller blast radius for security review.

## Design proposal recorded here for the issue
- The destructive merge call site MUST first call `evaluate_merge_guardrails`. If the returned tuple is non-empty, transition to `BLOCKED` with `last_tool_name='merge_guardrail'` and the joined blockers as `last_error`. The CLI hint will surface as `Retry:` (per #688) with the specific guardrail failure.
- `requires_confirmation=True` classifications MUST also gate the *interview-skip* path: even if `direct_run_allowed=True`, the pipeline still requires an explicit confirmation handle (env var, flag, or persisted human-acknowledgement record) before executing destructive work.
- Classification is persisted **once** at session creation; resume uses the persisted value rather than re-classifying so a goal edit between attempts cannot silently flip the path.

## Tests
- `pytest tests/unit/auto/test_operational_task.py` — 28 passed (11 new on top of part 1's 18)
- `pytest tests/unit/auto/ tests/unit/cli/` — 900 passed (full module green)

## Notes for reviewers
- All inputs to `evaluate_merge_guardrails` are mandatory — no defaults — so an accidentally-omitted check at the call site is a TypeError, not a silent allow.
- No interview path change in this PR. The interview-first behaviour is unchanged for every classification (including `direct_run_allowed=True`).
- Once #719 (part 1) lands, this PR can be rebased and the diff will shrink to only the wiring changes.

Closes #689 (together with #719)
Tracker: #692
Depends-on: #719