### PR TITLE
docs(auto): clarify --runtime semantics and pin dispatch behavior

### DIFF
--- a/docs/auto-runtime-semantics.md
+++ b/docs/auto-runtime-semantics.md
@@ -1,0 +1,64 @@
+<!--
+doc_metadata:
+  runtime_scope: [all]
+-->
+
+# `ooo auto --runtime <backend>`: phase-by-phase semantics
+
+This page documents what `--runtime` actually controls inside `ooo auto`. The
+short version: **`--runtime` is the same value for both authoring and
+run-handoff**, but the *delivery mechanism* differs by phase. Reading this
+before reporting an "interview is too slow" issue saves a round-trip.
+
+## Phase × backend matrix
+
+| Phase | What runs | Where it runs | Knob that picks the path |
+|---|---|---|---|
+| `INTERVIEW` (`interview.start`, `interview.answer`, `interview.resume`) | Socratic question generation through `InterviewHandler` | **In-process** authoring handler (same Python process as `ooo auto`) | `--runtime` selects the backend the in-process handler talks to. There is **no plugin/subagent dispatch** for the first question, regardless of which backend you pick. |
+| `SEED_GENERATION` | `GenerateSeedHandler` | **In-process** authoring handler | Same as above. |
+| `REVIEW` / `REPAIR` | `SeedReviewer` + `SeedRepairer` | In-process; backend choice is forwarded so review/repair can call out for analysis | Bound to `state.runtime_backend`. |
+| `RUN` (handoff) | `StartExecuteSeedHandler` via `HandlerRunStarter` | Dispatches to the configured runtime; for `opencode` plugin mode this is a true subagent dispatch, for other runtimes this is the executor adapter that owns long-running execution | `--runtime` + (for opencode) `OUROBOROS_OPENCODE_MODE=plugin` |
+
+## What the flag does NOT mean
+
+- `--runtime codex` does **not** mean "Codex picks up the entire pipeline as a single subagent task". The first interview question is still generated in-process by the authoring handler that talks to Codex. If the first call is slow, you see `interview.start timed out after <N>s` in the auto state — not a Codex subagent error.
+- `--runtime` does **not** silently change between phases. Resume rejects a runtime mismatch (`resume runtime mismatch: session uses <X>, but --runtime <Y> was requested`).
+- `--runtime` does **not** disable the Socratic interview for operational goals (PR URLs, merge intents). Path selection lives in [`auto/operational_task.py`](../src/ouroboros/auto/operational_task.py) and is independent of runtime selection — see #689.
+
+## Reading a blocker through this lens
+
+The `auto_78c98678de5d` incident (`auto-blocked-session.json` fixture) is a
+canonical example. The state shows:
+
+```
+runtime_backend: codex
+last_tool_name: interview.start
+last_error: interview.start timed out after 60s for auto_78c98678de5d
+```
+
+Reading the table above, this is unambiguously an authoring-side timeout,
+not a Codex run-handoff failure: phase `INTERVIEW`, tool `interview.start`,
+delivered through the in-process authoring handler that talks to Codex. The
+fixes for the incident split into:
+
+- #686 — wire the durable interview-phase timeout (was hardcoded 60s).
+- #687 — persist `interview_session_id` before the first question generation
+  call returns, so a timeout still leaves a resumable handle.
+- #688 — make `Resume:` vs `Retry:` truthful given that handle's presence.
+- #689 — give operational goals a direct path so they don't enter the
+  authoring loop at all.
+- #690 (this doc) — make the meaning of `--runtime` legible so users do not
+  expect `--runtime codex` to bypass the authoring handler.
+
+## Pinning current behavior with tests
+
+`tests/unit/auto/test_runtime_semantics.py` pins:
+
+- `--runtime codex` (and any other backend) ends up persisted as
+  `state.runtime_backend` and is used by **both** the authoring handler and
+  the run-handoff dispatcher.
+- Plugin/subagent dispatch in the run handoff is gated on opencode plugin
+  mode (`should_dispatch_via_plugin`).
+
+These tests are intentionally observation-grade — they document the current
+contract so any future change to the dispatch table is a deliberate edit.

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -54,7 +54,18 @@ def auto_command(
     ] = None,
     runtime: Annotated[
         AgentRuntimeBackend | None,
-        typer.Option("--runtime", help="Execution runtime backend.", case_sensitive=False),
+        typer.Option(
+            "--runtime",
+            help=(
+                "Runtime backend used by ooo auto. The same flag is applied to "
+                "BOTH (a) interview/Seed authoring (in-process via the matching "
+                "MCP authoring handler) AND (b) the run-handoff that dispatches "
+                "the executor. The first interview question is generated "
+                "in-process even when --runtime is set to a heavyweight backend "
+                "like codex; see docs/auto-runtime-semantics.md."
+            ),
+            case_sensitive=False,
+        ),
     ] = None,
     max_interview_rounds: Annotated[
         int | None,

--- a/tests/unit/auto/test_runtime_semantics.py
+++ b/tests/unit/auto/test_runtime_semantics.py
@@ -3,15 +3,20 @@
 Documented in ``docs/auto-runtime-semantics.md``: ``--runtime`` is the same
 value for both authoring (in-process MCP handler) and run-handoff
 (dispatcher), and plugin/subagent dispatch in the run handoff is gated on
-opencode plugin mode. These tests are observation-grade — they document the
-contract so any future change is a deliberate edit, not an accident.
+opencode plugin mode. These tests pin the actual CLI-to-handler wiring —
+not just dataclass field assignment.
 """
 
 from __future__ import annotations
 
+import asyncio
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 from ouroboros.auto.state import AutoPipelineState, AutoStore
+from ouroboros.cli.commands import auto as auto_cli
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import (
     ExecuteSeedHandler,
@@ -20,28 +25,128 @@ from ouroboros.mcp.tools.execution_handlers import (
 from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
 
 
+def _spy_handler_constructions(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
+    """Replace each handler constructor in the CLI module with a spy that
+    records the ``agent_runtime_backend`` it received and returns a stub
+    object. The pipeline's run is also short-circuited so no real backend is
+    invoked.
+    """
+    captured: dict[str, list[Any]] = {
+        "interview": [],
+        "generate_seed": [],
+        "execute_seed": [],
+        "start_execute": [],
+    }
+
+    def _make_spy(name: str, sentinel: Any):
+        def _spy(*args: Any, **kwargs: Any) -> Any:
+            captured[name].append(kwargs.get("agent_runtime_backend"))
+            return sentinel
+
+        return _spy
+
+    interview_stub = object()
+    generate_stub = object()
+    execute_stub = object()
+    start_execute_stub = object()
+
+    monkeypatch.setattr(auto_cli, "InterviewHandler", _make_spy("interview", interview_stub))
+    monkeypatch.setattr(auto_cli, "GenerateSeedHandler", _make_spy("generate_seed", generate_stub))
+    monkeypatch.setattr(auto_cli, "ExecuteSeedHandler", _make_spy("execute_seed", execute_stub))
+    monkeypatch.setattr(
+        auto_cli, "StartExecuteSeedHandler", _make_spy("start_execute", start_execute_stub)
+    )
+
+    # The CLI also wraps each handler in HandlerInterviewBackend / HandlerSeedGenerator /
+    # HandlerRunStarter; replace those with no-ops so AutoPipeline construction does not
+    # trip over the stubs.
+    monkeypatch.setattr(auto_cli, "HandlerInterviewBackend", lambda *a, **kw: object())
+    monkeypatch.setattr(auto_cli, "HandlerSeedGenerator", lambda *a, **kw: object())
+    monkeypatch.setattr(auto_cli, "HandlerRunStarter", lambda *a, **kw: object())
+
+    # Short-circuit the pipeline so no real backend runs. AutoPipelineResult only
+    # needs ``status`` / ``auto_session_id`` / ``phase`` for the CLI rendering path,
+    # but we never reach printing because _run_auto returns the result and the test
+    # just asserts on captured constructor args.
+    from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+
+    async def _stub_run(self: AutoPipeline, state: AutoPipelineState) -> AutoPipelineResult:
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id=state.auto_session_id,
+            phase=state.phase.value,
+            blocker="stubbed for runtime-wiring contract test",
+        )
+
+    monkeypatch.setattr(AutoPipeline, "run", _stub_run)
+    return captured
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    ["claude", "codex", "opencode", "hermes", "gemini", "copilot", "kiro"],
+)
+def test_run_auto_threads_runtime_through_all_four_handlers(
+    runtime: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end CLI wiring contract (#690): ``_run_auto`` must construct all
+    four MCP handlers — InterviewHandler, GenerateSeedHandler,
+    ExecuteSeedHandler, StartExecuteSeedHandler — with the same
+    ``agent_runtime_backend`` derived from ``--runtime``.
+
+    Bot review on #722 flagged that asserting on manually-instantiated
+    handlers does not protect this contract: a future change could stop
+    threading ``runtime`` into one of the construction sites and the older
+    test would still pass. This test patches the constructors with spies,
+    runs ``_run_auto``, and asserts on the captured kwargs.
+    """
+    captured = _spy_handler_constructions(monkeypatch)
+    monkeypatch.setattr(AutoStore, "__init__", lambda self, root=None: None)
+    monkeypatch.setattr(AutoStore, "root", tmp_path, raising=False)
+    monkeypatch.setattr(AutoStore, "save", lambda self, state: tmp_path / "noop.json")
+    # _run_auto resolves opencode_mode from get_opencode_mode() for the opencode
+    # runtime; pin a stable value so the test is deterministic.
+    monkeypatch.setattr(auto_cli, "get_opencode_mode", lambda: "subprocess")
+
+    asyncio.run(
+        auto_cli._run_auto(
+            goal="end-to-end runtime wiring test",
+            resume=None,
+            runtime=runtime,
+            max_interview_rounds=1,
+            max_repair_rounds=1,
+            skip_run=True,
+        )
+    )
+
+    # The interview handler in opencode mode is constructed with
+    # ``opencode_mode="subprocess"`` (CLI rewrites "plugin" → "subprocess" for
+    # authoring), but ``agent_runtime_backend`` is the input runtime in every
+    # case. Authoring handlers and run-handoff handlers receive the same value.
+    assert captured["interview"] == [runtime]
+    assert captured["generate_seed"] == [runtime]
+    assert captured["execute_seed"] == [runtime]
+    assert captured["start_execute"] == [runtime]
+
+
 @pytest.mark.parametrize(
     "runtime",
     ["claude", "codex", "hermes", "gemini", "copilot", "kiro"],
 )
 def test_runtime_propagates_to_authoring_and_run_handoff(runtime: str) -> None:
-    """The same ``--runtime`` value reaches authoring (interview / Seed
-    generation) AND run-handoff (execute / start-execute) handlers. This
-    locks the contract documented in #690 — a future change that fans the
-    runtime out per phase will fail this test rather than silently drift.
+    """Lower-level invariant: each handler stores the runtime it was built
+    with. Complements the end-to-end wiring test above so an unrelated
+    refactor that only breaks one side of the contract still fails loudly.
     """
     interview = InterviewHandler(agent_runtime_backend=runtime)
     generate = GenerateSeedHandler(agent_runtime_backend=runtime)
     execute = ExecuteSeedHandler(agent_runtime_backend=runtime)
     start_execute = StartExecuteSeedHandler(execute_handler=execute, agent_runtime_backend=runtime)
 
-    # Authoring side
     assert interview.agent_runtime_backend == runtime
     assert generate.agent_runtime_backend == runtime
-    # Run-handoff side
     assert execute.agent_runtime_backend == runtime
     assert start_execute.agent_runtime_backend == runtime
-    # Cross-phase invariant: every handler agrees on the runtime.
     assert (
         interview.agent_runtime_backend
         == generate.agent_runtime_backend

--- a/tests/unit/auto/test_runtime_semantics.py
+++ b/tests/unit/auto/test_runtime_semantics.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 import pytest
 
 from ouroboros.auto.state import AutoPipelineState, AutoStore
+from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
+from ouroboros.mcp.tools.execution_handlers import (
+    ExecuteSeedHandler,
+    StartExecuteSeedHandler,
+)
 from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
 
 
@@ -19,10 +24,39 @@ from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
     "runtime",
     ["claude", "codex", "hermes", "gemini", "copilot", "kiro"],
 )
-def test_runtime_persisted_on_state_for_authoring_and_handoff(runtime, tmp_path) -> None:
-    """For non-opencode runtimes, the same backend value is what the
-    authoring handler reads (state.runtime_backend) and what the run handoff
-    receives downstream. There is no per-phase override path."""
+def test_runtime_propagates_to_authoring_and_run_handoff(runtime: str) -> None:
+    """The same ``--runtime`` value reaches authoring (interview / Seed
+    generation) AND run-handoff (execute / start-execute) handlers. This
+    locks the contract documented in #690 — a future change that fans the
+    runtime out per phase will fail this test rather than silently drift.
+    """
+    interview = InterviewHandler(agent_runtime_backend=runtime)
+    generate = GenerateSeedHandler(agent_runtime_backend=runtime)
+    execute = ExecuteSeedHandler(agent_runtime_backend=runtime)
+    start_execute = StartExecuteSeedHandler(execute_handler=execute, agent_runtime_backend=runtime)
+
+    # Authoring side
+    assert interview.agent_runtime_backend == runtime
+    assert generate.agent_runtime_backend == runtime
+    # Run-handoff side
+    assert execute.agent_runtime_backend == runtime
+    assert start_execute.agent_runtime_backend == runtime
+    # Cross-phase invariant: every handler agrees on the runtime.
+    assert (
+        interview.agent_runtime_backend
+        == generate.agent_runtime_backend
+        == execute.agent_runtime_backend
+        == start_execute.agent_runtime_backend
+    )
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    ["claude", "codex", "hermes", "gemini", "copilot", "kiro"],
+)
+def test_runtime_persisted_on_state_round_trip(runtime: str, tmp_path) -> None:
+    """``state.runtime_backend`` survives JSON round-trip — handlers that
+    read this field on resume see the original value."""
     store = AutoStore(tmp_path)
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.runtime_backend = runtime
@@ -30,9 +64,6 @@ def test_runtime_persisted_on_state_for_authoring_and_handoff(runtime, tmp_path)
 
     loaded = store.load(state.auto_session_id)
     assert loaded.runtime_backend == runtime
-    # Authoring and run handoff both read state.runtime_backend; this is the
-    # whole contract that documentation #690 is trying to make legible.
-    assert loaded.runtime_backend == loaded.runtime_backend
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/auto/test_runtime_semantics.py
+++ b/tests/unit/auto/test_runtime_semantics.py
@@ -1,0 +1,62 @@
+"""Pin the current ``ooo auto --runtime <backend>`` semantics.
+
+Documented in ``docs/auto-runtime-semantics.md``: ``--runtime`` is the same
+value for both authoring (in-process MCP handler) and run-handoff
+(dispatcher), and plugin/subagent dispatch in the run handoff is gated on
+opencode plugin mode. These tests are observation-grade — they document the
+contract so any future change is a deliberate edit, not an accident.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.state import AutoPipelineState, AutoStore
+from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    ["claude", "codex", "hermes", "gemini", "copilot", "kiro"],
+)
+def test_runtime_persisted_on_state_for_authoring_and_handoff(runtime, tmp_path) -> None:
+    """For non-opencode runtimes, the same backend value is what the
+    authoring handler reads (state.runtime_backend) and what the run handoff
+    receives downstream. There is no per-phase override path."""
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.runtime_backend = runtime
+    store.save(state)
+
+    loaded = store.load(state.auto_session_id)
+    assert loaded.runtime_backend == runtime
+    # Authoring and run handoff both read state.runtime_backend; this is the
+    # whole contract that documentation #690 is trying to make legible.
+    assert loaded.runtime_backend == loaded.runtime_backend
+
+
+@pytest.mark.parametrize(
+    "runtime,opencode_mode,expected",
+    [
+        ("claude", None, False),
+        ("codex", None, False),
+        ("codex", "plugin", False),  # plugin mode irrelevant for non-opencode
+        ("opencode", None, False),
+        ("opencode", "subprocess", False),
+        ("opencode", "plugin", True),
+    ],
+)
+def test_should_dispatch_via_plugin_matrix(
+    runtime: str, opencode_mode: str | None, expected: bool
+) -> None:
+    """Plugin/subagent dispatch is opt-in via opencode plugin mode only."""
+    assert should_dispatch_via_plugin(runtime, opencode_mode) is expected
+
+
+def test_codex_runtime_does_not_imply_plugin_dispatch() -> None:
+    """Regression: ``--runtime codex`` MUST NOT trigger plugin dispatch.
+    The first interview question is generated in-process by the authoring
+    handler that talks to Codex; it does not become a Codex subagent task."""
+    assert should_dispatch_via_plugin("codex", None) is False
+    assert should_dispatch_via_plugin("codex", "plugin") is False
+    assert should_dispatch_via_plugin("codex", "subprocess") is False

--- a/tests/unit/auto/test_runtime_semantics.py
+++ b/tests/unit/auto/test_runtime_semantics.py
@@ -60,9 +60,9 @@ def _spy_handler_constructions(monkeypatch: pytest.MonkeyPatch) -> dict[str, lis
     # The CLI also wraps each handler in HandlerInterviewBackend / HandlerSeedGenerator /
     # HandlerRunStarter; replace those with no-ops so AutoPipeline construction does not
     # trip over the stubs.
-    monkeypatch.setattr(auto_cli, "HandlerInterviewBackend", lambda *a, **kw: object())
-    monkeypatch.setattr(auto_cli, "HandlerSeedGenerator", lambda *a, **kw: object())
-    monkeypatch.setattr(auto_cli, "HandlerRunStarter", lambda *a, **kw: object())
+    monkeypatch.setattr(auto_cli, "HandlerInterviewBackend", lambda *_a, **_kw: object())
+    monkeypatch.setattr(auto_cli, "HandlerSeedGenerator", lambda *_a, **_kw: object())
+    monkeypatch.setattr(auto_cli, "HandlerRunStarter", lambda *_a, **_kw: object())
 
     # Short-circuit the pipeline so no real backend runs. AutoPipelineResult only
     # needs ``status`` / ``auto_session_id`` / ``phase`` for the CLI rendering path,

--- a/tests/unit/auto/test_runtime_semantics.py
+++ b/tests/unit/auto/test_runtime_semantics.py
@@ -101,9 +101,9 @@ def test_run_auto_threads_runtime_through_all_four_handlers(
     runs ``_run_auto``, and asserts on the captured kwargs.
     """
     captured = _spy_handler_constructions(monkeypatch)
-    monkeypatch.setattr(AutoStore, "__init__", lambda self, root=None: None)
+    monkeypatch.setattr(AutoStore, "__init__", lambda _self, root=None: None)  # noqa: ARG005
     monkeypatch.setattr(AutoStore, "root", tmp_path, raising=False)
-    monkeypatch.setattr(AutoStore, "save", lambda self, state: tmp_path / "noop.json")
+    monkeypatch.setattr(AutoStore, "save", lambda _self, _state: tmp_path / "noop.json")
     # _run_auto resolves opencode_mode from get_opencode_mode() for the opencode
     # runtime; pin a stable value so the test is deterministic.
     monkeypatch.setattr(auto_cli, "get_opencode_mode", lambda: "subprocess")


### PR DESCRIPTION
## Summary
- New doc `docs/auto-runtime-semantics.md` with a phase-by-phase backend matrix making clear that `--runtime` is the **same value for both authoring and run-handoff**, and that the *delivery mechanism* differs by phase (in-process authoring handler vs. dispatcher).
- CLI `--runtime` help text rewritten to surface the same point and link to the new doc.
- New regression file `tests/unit/auto/test_runtime_semantics.py` pins the current contract:
  - `state.runtime_backend` round-trips for non-opencode runtimes.
  - `should_dispatch_via_plugin(...)` matrix: only `runtime=opencode + opencode_mode=plugin` returns `True`.
  - Explicit assertion that **`--runtime codex` never triggers plugin dispatch** — addresses the misconception called out in #690.

## Why
The `auto_78c98678de5d` incident state showed `runtime_backend=codex` and `last_tool_name=interview.start timed out after 60s`. A reasonable user reading `--runtime codex` could expect the entire pipeline to be handed to a Codex subagent, when in fact the first interview question is generated in-process by the MCP authoring handler. This documentation/test pair makes the contract legible so similar incidents are easy to triage.

## What this PR is NOT
- It does **not** change dispatch behavior. The intent is to pin and document; any actual dispatch-table change should be a deliberate follow-up referencing this PR.
- It does **not** wait for #685 (`run handoff reconciliation`) to land. The doc references the run-handoff phase as the dispatcher boundary; the wiring inside that boundary is what #685 cleans up. If #685 lands first, this PR's doc is still accurate; if this PR lands first, the doc text continues to describe the contract correctly.

## Tests
- `pytest tests/unit/auto/test_runtime_semantics.py` — 13 passed (13 new)
- `pytest tests/unit/auto/ tests/unit/cli/` — 885 passed (full module green)

## Notes
- Single-line docstring change in CLI help — `ooo auto --help` now points users at the doc instead of leaving them to infer.
- Independent of #686 / #687 / #688 / #689 / #691; cross-references them in the doc to give the incident triager a contiguous reading order.

Closes #690
Tracker: #692