### PR TITLE
fix(auto,interview): persist interview session id before first question generation

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -9,7 +9,11 @@ import yaml
 from ouroboros.auto.interview_driver import InterviewBackend, InterviewTurn
 from ouroboros.core.seed import Seed
 from ouroboros.mcp.errors import MCPServerError
-from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
+from ouroboros.mcp.tools.authoring_handlers import (
+    _DATA_DIR,
+    GenerateSeedHandler,
+    InterviewHandler,
+)
 from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
 from ouroboros.mcp.types import MCPToolResult
 
@@ -50,9 +54,7 @@ class HandlerInterviewBackend(InterviewBackend):
         self.handler = handler
         self.cwd = cwd
 
-    async def start(
-        self, goal: str, *, cwd: str, interview_id: str | None = None
-    ) -> InterviewTurn:
+    async def start(self, goal: str, *, cwd: str, interview_id: str | None = None) -> InterviewTurn:
         arguments: dict[str, str] = {"initial_context": goal, "cwd": cwd or self.cwd}
         if interview_id:
             arguments["interview_id"] = interview_id
@@ -92,6 +94,20 @@ class HandlerInterviewBackend(InterviewBackend):
             tool_name="ouroboros_interview",
         )
         return _turn_from_result(result, fallback_session_id=session_id)
+
+    def is_session_persisted(self, session_id: str) -> bool:
+        """Return True when ``interview_<session_id>.json`` exists on disk.
+
+        Used by ``AutoInterviewDriver`` to decide whether a pre-allocated
+        id may be retained on auto state after a driver-level
+        ``asyncio.wait_for`` cancel — without this probe the driver cannot
+        distinguish "handler crashed before persisting" from "handler
+        persisted then got cancelled".  See Q00/ouroboros#687.
+        """
+        if not session_id:
+            return False
+        state_dir = self.handler.data_dir or _DATA_DIR
+        return (state_dir / f"interview_{session_id}.json").exists()
 
 
 class HandlerSeedGenerator:

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -9,11 +9,7 @@ import yaml
 from ouroboros.auto.interview_driver import InterviewBackend, InterviewTurn
 from ouroboros.core.seed import Seed
 from ouroboros.mcp.errors import MCPServerError
-from ouroboros.mcp.tools.authoring_handlers import (
-    _DATA_DIR,
-    GenerateSeedHandler,
-    InterviewHandler,
-)
+from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
 from ouroboros.mcp.types import MCPToolResult
 
@@ -104,11 +100,13 @@ class HandlerInterviewBackend(InterviewBackend):
         id may be retained on auto state after a driver-level
         ``asyncio.wait_for`` cancel — without this probe the driver cannot
         distinguish "handler crashed before persisting" from "handler
-        persisted then got cancelled".  See Q00/ouroboros#687.
+        persisted then got cancelled".  Routes through
+        ``InterviewHandler.resolved_state_dir`` so the probe always
+        targets the directory the engine actually writes to (Q00/ouroboros#723).
         """
         if not session_id:
             return False
-        state_dir = self.handler.data_dir or _DATA_DIR
+        state_dir = self.handler.resolved_state_dir()
         return (state_dir / f"interview_{session_id}.json").exists()
 
 

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -60,14 +60,16 @@ class HandlerInterviewBackend(InterviewBackend):
             arguments["interview_id"] = interview_id
         outcome = await self.handler.handle(arguments)
         # Recoverable error path: handler persisted state but failed to
-        # produce the first question.  Surface the session_id so the auto
-        # driver can save it on the AutoPipelineState before reporting
-        # blocked.
+        # produce the first question.  ONLY trust an explicit
+        # ``meta.session_id`` from the handler — never fall back to the
+        # caller-supplied ``interview_id``, otherwise auto state would
+        # record persistence evidence that the handler never produced
+        # (Q00/ouroboros#723 review).
         if not outcome.is_err:
             value = outcome.value
             if value.is_error:
                 meta = value.meta or {}
-                session_id = _optional_str(meta.get("session_id")) or interview_id
+                session_id = _optional_str(meta.get("session_id"))
                 if session_id:
                     text = (
                         value.content[0].text

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -18,6 +18,20 @@ class HandlerError(RuntimeError):
     """Raised when an MCP handler returns an error result."""
 
 
+class PartialInterviewStartError(HandlerError):
+    """Raised when interview start failed but a session_id was persisted server-side.
+
+    Carries the persisted ``session_id`` so callers (e.g. the auto interview
+    driver) can record it on durable state and resume the same interview
+    after a transient first-question failure such as an LLM timeout.
+    See Q00/ouroboros#687.
+    """
+
+    def __init__(self, message: str, *, session_id: str) -> None:
+        super().__init__(message)
+        self.session_id = session_id
+
+
 def _unwrap(result, *, tool_name: str) -> MCPToolResult:
     if result.is_err:
         error: MCPServerError = result.error
@@ -36,11 +50,33 @@ class HandlerInterviewBackend(InterviewBackend):
         self.handler = handler
         self.cwd = cwd
 
-    async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
-        result = _unwrap(
-            await self.handler.handle({"initial_context": goal, "cwd": cwd or self.cwd}),
-            tool_name="ouroboros_interview",
-        )
+    async def start(
+        self, goal: str, *, cwd: str, interview_id: str | None = None
+    ) -> InterviewTurn:
+        arguments: dict[str, str] = {"initial_context": goal, "cwd": cwd or self.cwd}
+        if interview_id:
+            arguments["interview_id"] = interview_id
+        outcome = await self.handler.handle(arguments)
+        # Recoverable error path: handler persisted state but failed to
+        # produce the first question.  Surface the session_id so the auto
+        # driver can save it on the AutoPipelineState before reporting
+        # blocked.
+        if not outcome.is_err:
+            value = outcome.value
+            if value.is_error:
+                meta = value.meta or {}
+                session_id = _optional_str(meta.get("session_id")) or interview_id
+                if session_id:
+                    text = (
+                        value.content[0].text
+                        if value.content
+                        else "ouroboros_interview returned error"
+                    )
+                    raise PartialInterviewStartError(
+                        f"ouroboros_interview failed: {text}",
+                        session_id=session_id,
+                    )
+        result = _unwrap(outcome, tool_name="ouroboros_interview")
         return _turn_from_result(result)
 
     async def answer(self, session_id: str, answer: str) -> InterviewTurn:

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -40,9 +40,7 @@ class InterviewTurn:
 class InterviewBackend(Protocol):
     """Minimal backend interface needed by the auto interview driver."""
 
-    async def start(
-        self, goal: str, *, cwd: str, interview_id: str | None = None
-    ) -> InterviewTurn:
+    async def start(self, goal: str, *, cwd: str, interview_id: str | None = None) -> InterviewTurn:
         """Start an interview and return the first question.
 
         ``interview_id`` is an optional caller-supplied id.  Backends that
@@ -90,6 +88,12 @@ class AutoInterviewDriver:
         self._ensure_interview_phase(state)
         answer_context = self.context_provider(state.cwd)
         interview_tool_name = "interview.start"
+        # Pre-allocated interview id, kept local until we have evidence the
+        # backend actually persisted (or said it did).  Writing it onto
+        # ``state`` prematurely would point ``ooo auto --resume`` at a
+        # nonexistent session whenever the backend rejects the start
+        # outright (validation/config error).  See Q00/ouroboros#687.
+        preassigned_id: str | None = None
         try:
             if state.interview_session_id:
                 if state.pending_question:
@@ -109,29 +113,18 @@ class AutoInterviewDriver:
                     state.pending_question = turn.question
                     self._save(state)
             else:
-                # Pre-allocate the interview id and persist it on auto state
-                # BEFORE invoking the backend.  ``asyncio.wait_for`` cancels
-                # the backend task on timeout, so any id only learned from
-                # the backend's return value would be lost.  Pre-allocation
-                # guarantees ``ooo auto --resume`` can find the persisted
-                # interview even when the first-question call is cancelled.
-                # See Q00/ouroboros#687.
                 preassigned_id = _generate_interview_id()
-                state.interview_session_id = preassigned_id
-                self._save(state)
                 turn = _validate_turn(
                     await self._with_timeout(
-                        self.backend.start(
-                            state.goal, cwd=state.cwd, interview_id=preassigned_id
-                        ),
+                        self.backend.start(state.goal, cwd=state.cwd, interview_id=preassigned_id),
                         state,
                         tool_name=interview_tool_name,
                     )
                 )
                 if turn.session_id != preassigned_id:
-                    # Misbehaving backend ignored the supplied id.  Auto
-                    # state would diverge from the on-disk interview file;
-                    # warn so operators can spot the contract violation.
+                    # Misbehaving backend ignored the supplied id.  Trust
+                    # whatever id the backend actually returned; warn so
+                    # operators can spot the contract violation.
                     log.warning(
                         "auto.interview.backend_ignored_preassigned_id",
                         preassigned_id=preassigned_id,
@@ -142,14 +135,14 @@ class AutoInterviewDriver:
                 state.pending_question = turn.question
                 self._save(state)
         except TimeoutError as exc:
-            self._capture_partial_session_id(state, exc)
+            self._record_evidence_based_session_id(state, exc, preassigned_id)
             state.mark_blocked(str(exc), tool_name=interview_tool_name)
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, state.current_round, str(exc)
             )
         except Exception as exc:
-            self._capture_partial_session_id(state, exc)
+            self._record_evidence_based_session_id(state, exc, preassigned_id)
             action = "resume" if interview_tool_name == "interview.resume" else "start"
             blocker = f"interview {action} failed: {exc}"
             state.mark_blocked(blocker, tool_name=interview_tool_name)
@@ -299,16 +292,25 @@ class AutoInterviewDriver:
         if self.store is not None:
             self.store.save(state)
 
-    @staticmethod
-    def _capture_partial_session_id(state: AutoPipelineState, exc: BaseException) -> None:
-        """Record a session id surfaced by a partial-success error on AutoState.
+    def _record_evidence_based_session_id(
+        self,
+        state: AutoPipelineState,
+        exc: BaseException,
+        preassigned_id: str | None,
+    ) -> None:
+        """Save an ``interview_session_id`` on auto state only with evidence.
 
-        When ``backend.start`` fails after the handler has already persisted
-        the interview server-side, the backend raises
-        ``PartialInterviewStartError`` carrying the persisted ``session_id``.
-        Saving it on the auto state lets ``ooo auto --resume`` pick up the
-        same interview instead of creating a duplicate.  See
-        Q00/ouroboros#687.
+        Two evidence channels are accepted (Q00/ouroboros#687):
+
+        * ``PartialInterviewStartError`` carries a session id the handler
+          has explicitly confirmed as persisted.
+        * For ``asyncio.wait_for`` cancellations or other exceptions, the
+          driver may probe the backend via the optional
+          ``is_session_persisted`` method to see whether a file for the
+          pre-allocated id was written before the cancel.
+
+        Without one of these the auto state stays ``None`` so
+        ``ooo auto --resume`` cannot point at a nonexistent session.
         """
         if state.interview_session_id:
             return
@@ -316,10 +318,25 @@ class AutoInterviewDriver:
         # interview_driver importable on its own.
         from ouroboros.auto.adapters import PartialInterviewStartError
 
-        if not isinstance(exc, PartialInterviewStartError):
-            return
-        if exc.session_id:
+        if isinstance(exc, PartialInterviewStartError) and exc.session_id:
             state.interview_session_id = exc.session_id
+            return
+        if not preassigned_id:
+            return
+        probe = getattr(self.backend, "is_session_persisted", None)
+        if probe is None:
+            return
+        try:
+            persisted = probe(preassigned_id)
+        except Exception as probe_exc:  # pragma: no cover - defensive
+            log.warning(
+                "auto.interview.persistence_probe_failed",
+                preassigned_id=preassigned_id,
+                error=str(probe_exc),
+            )
+            return
+        if persisted:
+            state.interview_session_id = preassigned_id
 
 
 class FunctionInterviewBackend:
@@ -330,14 +347,14 @@ class FunctionInterviewBackend:
         start: Callable[[str, str], Awaitable[InterviewTurn]],
         answer: Callable[[str, str], Awaitable[InterviewTurn]],
         resume: Callable[[str], Awaitable[InterviewTurn]] | None = None,
+        is_session_persisted: Callable[[str], bool] | None = None,
     ) -> None:
         self._start = start
         self._answer = answer
         self._resume = resume
+        self._is_session_persisted = is_session_persisted
 
-    async def start(
-        self, goal: str, *, cwd: str, interview_id: str | None = None
-    ) -> InterviewTurn:
+    async def start(self, goal: str, *, cwd: str, interview_id: str | None = None) -> InterviewTurn:
         # Forward ``interview_id`` only to callables that opt into the new
         # contract; plain ``(goal, cwd)`` callables remain compatible.
         if "interview_id" in inspect.signature(self._start).parameters:
@@ -352,6 +369,11 @@ class FunctionInterviewBackend:
             msg = "interview resume is unavailable because no pending question is persisted"
             raise RuntimeError(msg)
         return await self._resume(session_id)
+
+    def is_session_persisted(self, session_id: str) -> bool:
+        if self._is_session_persisted is None:
+            return False
+        return bool(self._is_session_persisted(session_id))
 
 
 def _generate_interview_id() -> str:

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+import inspect
 import re
 from typing import Protocol
+from uuid import uuid4
+
+import structlog
 
 from ouroboros.auto.answerer import (
     AutoAnswer,
@@ -19,6 +23,8 @@ from ouroboros.auto.gap_detector import Gap, GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+log = structlog.get_logger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,8 +40,16 @@ class InterviewTurn:
 class InterviewBackend(Protocol):
     """Minimal backend interface needed by the auto interview driver."""
 
-    async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
-        """Start an interview and return the first question."""
+    async def start(
+        self, goal: str, *, cwd: str, interview_id: str | None = None
+    ) -> InterviewTurn:
+        """Start an interview and return the first question.
+
+        ``interview_id`` is an optional caller-supplied id.  Backends that
+        persist server-side state SHOULD honour it so a driver-level cancel
+        (e.g. ``asyncio.wait_for`` timeout) cannot leave the auto state with
+        an id that disagrees with the on-disk interview file.
+        """
 
     async def answer(self, session_id: str, answer: str) -> InterviewTurn:
         """Record an answer and return the next question or completion metadata."""
@@ -95,23 +109,47 @@ class AutoInterviewDriver:
                     state.pending_question = turn.question
                     self._save(state)
             else:
+                # Pre-allocate the interview id and persist it on auto state
+                # BEFORE invoking the backend.  ``asyncio.wait_for`` cancels
+                # the backend task on timeout, so any id only learned from
+                # the backend's return value would be lost.  Pre-allocation
+                # guarantees ``ooo auto --resume`` can find the persisted
+                # interview even when the first-question call is cancelled.
+                # See Q00/ouroboros#687.
+                preassigned_id = _generate_interview_id()
+                state.interview_session_id = preassigned_id
+                self._save(state)
                 turn = _validate_turn(
                     await self._with_timeout(
-                        self.backend.start(state.goal, cwd=state.cwd),
+                        self.backend.start(
+                            state.goal, cwd=state.cwd, interview_id=preassigned_id
+                        ),
                         state,
                         tool_name=interview_tool_name,
                     )
                 )
+                if turn.session_id != preassigned_id:
+                    # Misbehaving backend ignored the supplied id.  Auto
+                    # state would diverge from the on-disk interview file;
+                    # warn so operators can spot the contract violation.
+                    log.warning(
+                        "auto.interview.backend_ignored_preassigned_id",
+                        preassigned_id=preassigned_id,
+                        backend_id=turn.session_id,
+                        auto_session_id=state.auto_session_id,
+                    )
                 state.interview_session_id = turn.session_id
                 state.pending_question = turn.question
                 self._save(state)
         except TimeoutError as exc:
+            self._capture_partial_session_id(state, exc)
             state.mark_blocked(str(exc), tool_name=interview_tool_name)
             self._save(state)
             return AutoInterviewResult(
                 "blocked", state.interview_session_id, ledger, state.current_round, str(exc)
             )
         except Exception as exc:
+            self._capture_partial_session_id(state, exc)
             action = "resume" if interview_tool_name == "interview.resume" else "start"
             blocker = f"interview {action} failed: {exc}"
             state.mark_blocked(blocker, tool_name=interview_tool_name)
@@ -261,6 +299,28 @@ class AutoInterviewDriver:
         if self.store is not None:
             self.store.save(state)
 
+    @staticmethod
+    def _capture_partial_session_id(state: AutoPipelineState, exc: BaseException) -> None:
+        """Record a session id surfaced by a partial-success error on AutoState.
+
+        When ``backend.start`` fails after the handler has already persisted
+        the interview server-side, the backend raises
+        ``PartialInterviewStartError`` carrying the persisted ``session_id``.
+        Saving it on the auto state lets ``ooo auto --resume`` pick up the
+        same interview instead of creating a duplicate.  See
+        Q00/ouroboros#687.
+        """
+        if state.interview_session_id:
+            return
+        # Avoid coupling to the adapter module — local import keeps
+        # interview_driver importable on its own.
+        from ouroboros.auto.adapters import PartialInterviewStartError
+
+        if not isinstance(exc, PartialInterviewStartError):
+            return
+        if exc.session_id:
+            state.interview_session_id = exc.session_id
+
 
 class FunctionInterviewBackend:
     """Adapter for tests or local integrations built from callables."""
@@ -275,7 +335,13 @@ class FunctionInterviewBackend:
         self._answer = answer
         self._resume = resume
 
-    async def start(self, goal: str, *, cwd: str) -> InterviewTurn:
+    async def start(
+        self, goal: str, *, cwd: str, interview_id: str | None = None
+    ) -> InterviewTurn:
+        # Forward ``interview_id`` only to callables that opt into the new
+        # contract; plain ``(goal, cwd)`` callables remain compatible.
+        if "interview_id" in inspect.signature(self._start).parameters:
+            return await self._start(goal, cwd, interview_id=interview_id)  # type: ignore[call-arg]
         return await self._start(goal, cwd)
 
     async def answer(self, session_id: str, answer: str) -> InterviewTurn:
@@ -286,6 +352,11 @@ class FunctionInterviewBackend:
             msg = "interview resume is unavailable because no pending question is persisted"
             raise RuntimeError(msg)
         return await self._resume(session_id)
+
+
+def _generate_interview_id() -> str:
+    """Return a unique interview id matching the engine's plugin format."""
+    return f"interview_{uuid4().hex[:16]}"
 
 
 def _can_steer_with_gap_prompt(question: str) -> bool:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -352,6 +352,17 @@ class InterviewEngine:
             is_brownfield=state.is_brownfield,
         )
 
+        # Persist the freshly-created state immediately so that downstream
+        # failures (e.g. a question-generation timeout) still leave a
+        # resumable handle on disk.  See Q00/ouroboros#687.
+        save_result = await self.save_state(state)
+        if save_result.is_err:
+            log.warning(
+                "interview.start_save_failed",
+                interview_id=interview_id,
+                error=str(save_result.error),
+            )
+
         return Result.ok(state)
 
     async def ask_next_question(

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -354,13 +354,25 @@ class InterviewEngine:
 
         # Persist the freshly-created state immediately so that downstream
         # failures (e.g. a question-generation timeout) still leave a
-        # resumable handle on disk.  See Q00/ouroboros#687.
+        # resumable handle on disk.  Hard-fail on save errors: the
+        # recovery contract downstream (recoverable ``MCPToolResult`` with
+        # ``meta.session_id`` returned from ``InterviewHandler`` on a
+        # first-question failure) assumes the on-disk state file exists.
+        # Returning ``Result.ok`` after a failed save would silently lie
+        # to callers that the session is resumable.  See Q00/ouroboros#687.
         save_result = await self.save_state(state)
         if save_result.is_err:
-            log.warning(
+            log.error(
                 "interview.start_save_failed",
                 interview_id=interview_id,
                 error=str(save_result.error),
+            )
+            return Result.err(
+                ValidationError(
+                    f"Failed to persist initial interview state: {save_result.error}",
+                    field="interview_id",
+                    value=interview_id,
+                )
             )
 
         return Result.ok(state)

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -67,6 +67,12 @@ log = structlog.get_logger(__name__)
 
 _DATA_DIR = Path.home() / ".ouroboros" / "data"
 
+# Strict format for caller-supplied ``interview_id`` arguments — matches
+# the server's own generation pattern (``f"interview_{uuid4().hex[:16]}"``)
+# so external clients cannot inject arbitrary identifiers.  See
+# Q00/ouroboros#723 review.
+_SUGGESTED_INTERVIEW_ID_RE = re.compile(r"^interview_[a-f0-9]{16}$")
+
 _LIVE_AMBIGUITY_MAX_RETRIES = 3
 
 _INTERVIEW_COMPLETION_SIGNALS = {
@@ -994,8 +1000,11 @@ class InterviewHandler:
                     type=ToolInputType.STRING,
                     description=(
                         "Optional caller-supplied id for a brand-new interview. "
-                        "Bounded auto callers pre-allocate the id so a driver-level "
-                        "cancel cannot leave the auto state out of sync with the "
+                        "Must match the server format 'interview_<16 lowercase hex>' "
+                        "and must NOT collide with an existing interview file. "
+                        "Only honoured for the start action; ignored for resume/answer. "
+                        "Used by the bounded auto driver to pre-allocate the id so a "
+                        "driver-level cancel cannot leave auto state out of sync with the "
                         "persisted interview file (see Q00/ouroboros#687)."
                     ),
                     required=False,
@@ -1045,6 +1054,38 @@ class InterviewHandler:
                     tool_name="ouroboros_interview",
                 )
             )
+
+        # Validate caller-supplied ``interview_id`` strictly to keep the
+        # MCP contract narrow.  The id must match the server's own
+        # ``interview_<16 hex>`` format (matching ``uuid4().hex[:16]``)
+        # and must not collide with an existing on-disk interview file —
+        # this prevents cross-client spoofing/hijacking and accidental
+        # reuse of an active session.  Q00/ouroboros#723 review.
+        if suggested_interview_id is not None:
+            if action != "start":
+                return Result.err(
+                    MCPToolError(
+                        "interview_id is only valid for new interviews; resume via session_id",
+                        tool_name="ouroboros_interview",
+                    )
+                )
+            if not _SUGGESTED_INTERVIEW_ID_RE.fullmatch(suggested_interview_id):
+                return Result.err(
+                    MCPToolError(
+                        "interview_id must match the server format 'interview_<16 hex>'",
+                        tool_name="ouroboros_interview",
+                    )
+                )
+            collision_path = (
+                self.data_dir or _DATA_DIR
+            ) / f"interview_{suggested_interview_id}.json"
+            if collision_path.exists():
+                return Result.err(
+                    MCPToolError(
+                        "interview_id collides with an existing interview; pick a fresh id",
+                        tool_name="ouroboros_interview",
+                    )
+                )
 
         # --- Subagent dispatch: gate on runtime + opencode_mode ---
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -763,6 +763,20 @@ class InterviewHandler:
             await self._event_store.close()
             self._initialized = False
 
+    def resolved_state_dir(self) -> Path:
+        """Return the directory the handler actually writes interview state to.
+
+        Single source of truth for the interview persistence location used
+        by collision checks, the auto-driver persistence probe, and the
+        plugin/subprocess save paths.  When an ``InterviewEngine`` is
+        injected (e.g. by ``create_ouroboros_server`` with a custom
+        ``state_dir``), the engine's directory wins — the handler's own
+        ``data_dir`` may be stale or unset.  See Q00/ouroboros#723 review.
+        """
+        if self.interview_engine is not None:
+            return self.interview_engine.state_dir
+        return self.data_dir or _DATA_DIR
+
     async def _emit_event(self, event: Any) -> None:
         """Emit event to store. Swallows errors to not break interview flow."""
         try:
@@ -1076,9 +1090,7 @@ class InterviewHandler:
                         tool_name="ouroboros_interview",
                     )
                 )
-            collision_path = (
-                self.data_dir or _DATA_DIR
-            ) / f"interview_{suggested_interview_id}.json"
+            collision_path = self.resolved_state_dir() / f"interview_{suggested_interview_id}.json"
             if collision_path.exists():
                 return Result.err(
                     MCPToolError(

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -989,6 +989,17 @@ class InterviewHandler:
                     ),
                     required=False,
                 ),
+                MCPToolParameter(
+                    name="interview_id",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "Optional caller-supplied id for a brand-new interview. "
+                        "Bounded auto callers pre-allocate the id so a driver-level "
+                        "cancel cannot leave the auto state out of sync with the "
+                        "persisted interview file (see Q00/ouroboros#687)."
+                    ),
+                    required=False,
+                ),
             ),
         )
 
@@ -1007,6 +1018,14 @@ class InterviewHandler:
         initial_context = arguments.get("initial_context")
         session_id = arguments.get("session_id")
         answer = arguments.get("answer")
+        # Optional caller-supplied id for new interviews (Q00/ouroboros#687).
+        # Only honoured for the ``start`` action; ignored otherwise.
+        suggested_interview_id_arg = arguments.get("interview_id")
+        suggested_interview_id = (
+            suggested_interview_id_arg
+            if isinstance(suggested_interview_id_arg, str) and suggested_interview_id_arg
+            else None
+        )
         last_question = arguments.get("last_question")
 
         # --- Argument validation (before any dispatch) ---
@@ -1058,7 +1077,10 @@ class InterviewHandler:
                     return Result.err(MCPToolError(error_msg, tool_name="ouroboros_interview"))
                 from uuid import uuid4
 
-                interview_id = f"interview_{uuid4().hex[:16]}"
+                # Honour caller-supplied id when present (auto driver
+                # pre-allocates the id for Q00/ouroboros#687).  Fall back
+                # to a fresh uuid otherwise.
+                interview_id = suggested_interview_id or f"interview_{uuid4().hex[:16]}"
                 state = InterviewState(
                     interview_id=interview_id,
                     initial_context=resolved_context.value,
@@ -1190,7 +1212,11 @@ class InterviewHandler:
                         )
                     )
 
-                result = await engine.start_interview(resolved_context.value, cwd=cwd)
+                result = await engine.start_interview(
+                    resolved_context.value,
+                    cwd=cwd,
+                    interview_id=suggested_interview_id,
+                )
                 if result.is_err:
                     return Result.err(
                         MCPToolError(
@@ -1218,10 +1244,11 @@ class InterviewHandler:
                             phase="question_generation",
                         )
                     )
+                    # ``InterviewEngine.start_interview`` already persisted
+                    # the initial state on disk (Q00/ouroboros#687), so the
+                    # ``session_id`` returned below is guaranteed resumable.
                     # Return recoverable result with session ID for retry
                     if "empty response" in error_msg.lower():
-                        # Persist state so the session can actually be resumed
-                        await engine.save_state(state)
                         amb_warning = _ambiguity_warning_for_failed_question(
                             live_score,
                             is_brownfield=state.is_brownfield,
@@ -1250,7 +1277,30 @@ class InterviewHandler:
                                 meta={"session_id": state.interview_id, "recoverable": True},
                             )
                         )
-                    return Result.err(MCPToolError(error_msg, tool_name="ouroboros_interview"))
+                    # Generic question-generation failure (timeout etc.):
+                    # return a recoverable result so callers can resume
+                    # using the persisted ``session_id`` instead of losing
+                    # the interview handle (Q00/ouroboros#687).  Truncate
+                    # ``error_msg`` to avoid leaking provider internals into
+                    # the user-facing envelope; full details remain in the
+                    # ``interview_failed`` event emitted above.
+                    safe_error = error_msg[:200] if error_msg else "unknown error"
+                    return Result.ok(
+                        MCPToolResult(
+                            content=(
+                                MCPContentItem(
+                                    type=ContentType.TEXT,
+                                    text=(
+                                        f"Question generation failed: {safe_error}. "
+                                        f"Session ID: {state.interview_id}\n\n"
+                                        f'Resume with: session_id="{state.interview_id}"'
+                                    ),
+                                ),
+                            ),
+                            is_error=True,
+                            meta={"session_id": state.interview_id, "recoverable": True},
+                        )
+                    )
 
                 question = question_result.value
                 display_question = _format_question_with_ambiguity(question, live_score)

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1104,7 +1104,11 @@ class InterviewHandler:
             # Plugin mode: persist state server-side WITHOUT creating an LLM adapter.
             # Only state I/O is needed here — the subagent handles all LLM work.
             # This avoids importing litellm (optional dep) on plugin-only installs.
-            state_dir = self.data_dir or _DATA_DIR
+            # Route through ``resolved_state_dir`` so an injected
+            # ``InterviewEngine`` with a custom ``state_dir`` keeps plugin
+            # writes and the collision check on the same directory
+            # (Q00/ouroboros#723 review).
+            state_dir = self.resolved_state_dir()
             state_dir.mkdir(parents=True, exist_ok=True)
 
             transcript = ""

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1016,10 +1016,13 @@ class InterviewHandler:
                         "Optional caller-supplied id for a brand-new interview. "
                         "Must match the server format 'interview_<16 lowercase hex>' "
                         "and must NOT collide with an existing interview file. "
-                        "Only honoured for the start action; ignored for resume/answer. "
+                        "Only valid for the start action — supplying it together with "
+                        "session_id (resume) or answer is rejected with an error to "
+                        "prevent silent identifier hijacking; do not preserve this "
+                        "argument across turns. "
                         "Used by the bounded auto driver to pre-allocate the id so a "
-                        "driver-level cancel cannot leave auto state out of sync with the "
-                        "persisted interview file (see Q00/ouroboros#687)."
+                        "driver-level cancel cannot leave auto state out of sync with "
+                        "the persisted interview file (see Q00/ouroboros#687)."
                     ),
                     required=False,
                 ),

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2568,29 +2568,39 @@ async def test_invalid_reconcile_on_complete_does_not_poison_future_resume(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_interview_driver_preallocates_session_id_before_backend_start(tmp_path) -> None:
-    """Driver pre-saves a generated id BEFORE invoking the backend.
+async def test_interview_driver_keeps_session_id_when_probe_confirms_persistence(
+    tmp_path,
+) -> None:
+    """Driver retains the pre-allocated id only when persistence is verifiable.
 
-    Models the actual incident from the issue: the driver's ``asyncio.wait_for``
-    fires before the backend can return any result.  The auto state must
-    still hold the id because we pre-allocated it.
+    Models the issue's primary scenario: the driver's ``asyncio.wait_for``
+    cancels the backend mid-flight, but the engine has already persisted
+    the interview state.  The driver must consult ``is_session_persisted``
+    to confirm before saving the id on auto state.
     """
 
     received_ids: list[str | None] = []
+    persisted_ids: set[str] = set()
 
     async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:
         received_ids.append(interview_id)
+        # Simulate engine.start_interview persisting before the cancel.
+        if interview_id:
+            persisted_ids.add(interview_id)
         await asyncio.sleep(0.5)  # forces TimeoutError below
         return InterviewTurn("never reached", interview_id or "fallback")
 
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("answer must not run when start times out")
 
+    def is_persisted(session_id: str) -> bool:
+        return session_id in persisted_ids
+
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     store = AutoStore(tmp_path)
     driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer),
+        FunctionInterviewBackend(start, answer, is_session_persisted=is_persisted),
         store=store,
         timeout_seconds=0.001,
     )
@@ -2598,7 +2608,7 @@ async def test_interview_driver_preallocates_session_id_before_backend_start(tmp
     result = await driver.run(state, ledger)
 
     assert result.status == "blocked"
-    assert state.interview_session_id, "driver must pre-allocate id before backend.start"
+    assert state.interview_session_id, "probe-confirmed id must be saved on auto state"
     assert received_ids == [state.interview_session_id], (
         "backend.start must receive the pre-allocated interview_id so the "
         "persisted interview file matches auto state"
@@ -2607,6 +2617,48 @@ async def test_interview_driver_preallocates_session_id_before_backend_start(tmp
     reloaded = store.load(state.auto_session_id)
     assert reloaded is not None
     assert reloaded.interview_session_id == state.interview_session_id
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_clears_session_id_when_backend_rejects_without_persistence(
+    tmp_path,
+) -> None:
+    """A plain rejection (validation/config error) must NOT pollute auto state.
+
+    Without an evidence channel (``PartialInterviewStartError`` carrying a
+    confirmed id, or a positive ``is_session_persisted`` probe) the driver
+    must leave ``interview_session_id`` unset so ``ooo auto --resume`` does
+    not chase a nonexistent interview file.
+    """
+
+    async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:  # noqa: ARG001
+        raise RuntimeError("backend rejected start before persisting anything")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer must not run when start fails")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    store = AutoStore(tmp_path)
+    # Probe always returns False — no on-disk evidence of persistence.
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, is_session_persisted=lambda _id: False),
+        store=store,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert state.interview_session_id is None, (
+        "auto state must NOT retain the pre-allocated id without persistence evidence"
+    )
+    assert result.session_id is None
+
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded is not None
+    assert reloaded.interview_session_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 
+from ouroboros.auto.adapters import PartialInterviewStartError
 from ouroboros.auto.grading import GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
@@ -2558,3 +2559,130 @@ async def test_invalid_reconcile_on_complete_does_not_poison_future_resume(tmp_p
     assert plain_result.status == "complete"
     assert plain_result.blocker is None
     assert state.last_error is None
+
+
+# ---------------------------------------------------------------------------
+# Q00/ouroboros#687 — persist interview_session_id even when first-question
+# generation fails before the auto driver receives a turn.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_preallocates_session_id_before_backend_start(tmp_path) -> None:
+    """Driver pre-saves a generated id BEFORE invoking the backend.
+
+    Models the actual incident from the issue: the driver's ``asyncio.wait_for``
+    fires before the backend can return any result.  The auto state must
+    still hold the id because we pre-allocated it.
+    """
+
+    received_ids: list[str | None] = []
+
+    async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:
+        received_ids.append(interview_id)
+        await asyncio.sleep(0.5)  # forces TimeoutError below
+        return InterviewTurn("never reached", interview_id or "fallback")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer must not run when start times out")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=store,
+        timeout_seconds=0.001,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.interview_session_id, "driver must pre-allocate id before backend.start"
+    assert received_ids == [state.interview_session_id], (
+        "backend.start must receive the pre-allocated interview_id so the "
+        "persisted interview file matches auto state"
+    )
+
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded is not None
+    assert reloaded.interview_session_id == state.interview_session_id
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_persists_partial_session_id_on_start_failure(tmp_path) -> None:
+    """A handler-level partial-success error keeps the pre-allocated id on state."""
+
+    async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:  # noqa: ARG001
+        # Real backends honour the supplied id; mirror that here.
+        assert interview_id, "driver must pre-allocate an id before backend.start"
+        raise PartialInterviewStartError(
+            "ouroboros_interview failed: Question generation failed: timed out",
+            session_id=interview_id,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer must not be called when start fails")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=store,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert state.interview_session_id, "auto state must hold the pre-allocated session id"
+    assert result.session_id == state.interview_session_id
+
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded is not None
+    assert reloaded.interview_session_id == state.interview_session_id
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_resumes_existing_session_after_partial_failure(
+    tmp_path,
+) -> None:
+    """After a partial first-question failure resume must reuse the persisted id."""
+
+    persisted_session = "interview_partial_002"
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "starting auto interview")
+    state.interview_session_id = persisted_session
+    state.pending_question = None
+
+    start_calls: list[tuple[str, str]] = []
+    resume_calls: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:
+        start_calls.append((goal, cwd))
+        raise AssertionError("start must not be called when a session is already persisted")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def resume(session_id: str) -> InterviewTurn:
+        resume_calls.append(session_id)
+        return InterviewTurn("Anything else?", session_id)
+
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, resume),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert resume_calls == [persisted_session]
+    assert not start_calls
+    assert result.session_id == persisted_session
+    assert state.interview_session_id == persisted_session

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -225,6 +225,25 @@ async def test_handler_interview_backend_rejects_mcp_error_payloads() -> None:
         await HandlerInterviewBackend(_FakeErrorInterviewHandler(), cwd=".").start("goal", cwd=".")
 
 
+@pytest.mark.asyncio
+async def test_handler_interview_backend_does_not_fabricate_partial_evidence() -> None:
+    """When the handler does NOT include ``meta.session_id`` we must NOT raise
+    ``PartialInterviewStartError`` even if the caller pre-allocated an id.
+
+    Regression for the Q00/ouroboros#723 review: synthesising persistence
+    evidence from caller input lets auto state record an id the handler
+    never confirmed it wrote to disk.
+    """
+    from ouroboros.auto.adapters import HandlerError, PartialInterviewStartError
+
+    backend = HandlerInterviewBackend(_FakeErrorInterviewHandler(), cwd=".")
+    with pytest.raises(HandlerError) as excinfo:
+        await backend.start("goal", cwd=".", interview_id="interview_caller_supplied")
+    assert not isinstance(excinfo.value, PartialInterviewStartError), (
+        "adapter must require explicit meta.session_id, not synthesise from interview_id"
+    )
+
+
 def test_auto_handler_uses_synchronous_authoring_mode_for_opencode_plugin() -> None:
     handler = AutoHandler(agent_runtime_backend="opencode", opencode_mode="plugin")
 

--- a/tests/unit/bigbang/test_interview_start_persist_failure.py
+++ b/tests/unit/bigbang/test_interview_start_persist_failure.py
@@ -1,0 +1,53 @@
+"""Regression tests for Q00/ouroboros#687 (engine layer).
+
+``InterviewEngine.start_interview`` must hard-fail when persisting the
+initial state to disk fails.  Returning ``Result.ok`` after a failed save
+would silently lie to downstream callers (the MCP handler now returns a
+recoverable result whose ``meta.session_id`` claim of resumability hinges
+on the file being on disk).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ouroboros.bigbang.interview import InterviewEngine
+from ouroboros.core.errors import ValidationError
+from ouroboros.core.types import Result
+from ouroboros.providers.base import CompletionResponse, UsageInfo
+
+
+def _make_engine(tmp_path) -> InterviewEngine:
+    adapter = MagicMock()
+    adapter.complete = AsyncMock(
+        return_value=CompletionResponse(
+            content="ignored",
+            model="test",
+            usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            finish_reason="stop",
+        )
+    )
+    return InterviewEngine(llm_adapter=adapter, state_dir=tmp_path, model="test-model")
+
+
+@pytest.mark.asyncio
+async def test_start_interview_returns_err_when_save_state_fails(tmp_path, monkeypatch) -> None:
+    """A failed initial save must surface as ``Result.err``, not a silent warning."""
+
+    engine = _make_engine(tmp_path)
+
+    async def _failing_save(state):  # noqa: ANN001 — runtime stub
+        return Result.err(
+            ValidationError("disk full", field="interview_id", value=state.interview_id)
+        )
+
+    monkeypatch.setattr(engine, "save_state", _failing_save)
+
+    outcome = await engine.start_interview("Build a CLI", cwd=str(tmp_path))
+
+    assert outcome.is_err, "start_interview must hard-fail when save_state errors"
+    error = outcome.error
+    assert isinstance(error, ValidationError)
+    assert "Failed to persist initial interview state" in str(error)

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -200,3 +200,66 @@ async def test_subprocess_handler_rejects_interview_id_on_resume_action(tmp_path
 
     assert outcome.is_err
     assert "only valid for new interviews" in str(outcome.error)
+
+
+@pytest.mark.asyncio
+async def test_collision_check_targets_engine_state_dir_when_injected(tmp_path: Path) -> None:
+    """Collision detection must follow the engine's state_dir, not handler.data_dir.
+
+    Models the production wiring where ``create_ouroboros_server`` injects an
+    ``InterviewEngine`` with a custom ``state_dir`` while ``handler.data_dir``
+    may be unset or stale.  See Q00/ouroboros#723 review.
+    """
+    engine_dir = tmp_path / "engine"
+    handler_data_dir = tmp_path / "handler"
+    engine_dir.mkdir()
+    handler_data_dir.mkdir()
+
+    caller_id = "interview_0123456789abcdef"
+    # Pre-create the colliding file ONLY in the engine directory.
+    (engine_dir / f"interview_{caller_id}.json").write_text("{}", encoding="utf-8")
+
+    engine = _FakeInterviewEngine(state_dir=engine_dir)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=handler_data_dir,
+    )
+
+    outcome = await handler.handle(
+        {
+            "initial_context": "Build a CLI",
+            "cwd": str(tmp_path),
+            "interview_id": caller_id,
+        }
+    )
+
+    assert outcome.is_err, "collision must be detected against the engine's state_dir"
+    assert "collide" in str(outcome.error)
+
+
+def test_handler_persistence_probe_routes_through_engine_state_dir(tmp_path: Path) -> None:
+    """``HandlerInterviewBackend.is_session_persisted`` must use the engine dir."""
+    from ouroboros.auto.adapters import HandlerInterviewBackend
+
+    engine_dir = tmp_path / "engine"
+    handler_data_dir = tmp_path / "handler"
+    engine_dir.mkdir()
+    handler_data_dir.mkdir()
+
+    sid = "interview_0123456789abcdef"
+    # Persisted only in the engine dir.
+    (engine_dir / f"interview_{sid}.json").write_text("{}", encoding="utf-8")
+
+    engine = _FakeInterviewEngine(state_dir=engine_dir)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=handler_data_dir,
+    )
+    backend = HandlerInterviewBackend(handler, cwd=str(tmp_path))
+
+    assert backend.is_session_persisted(sid) is True
+    assert backend.is_session_persisted("interview_aaaaaaaaaaaaaaaa") is False

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -52,9 +52,7 @@ class _FakeInterviewEngine:
         await self.save_state(state)
         return Result.ok(state)
 
-    async def ask_next_question(
-        self, state: InterviewState
-    ) -> Result[str, MCPServerError]:
+    async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
         return Result.err(_RecoverableProviderError("Question generation timed out"))
 
     async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
@@ -94,7 +92,9 @@ async def test_subprocess_handler_persists_session_id_on_question_failure(tmp_pa
     assert meta.get("recoverable") is True
 
     persisted = tmp_path / f"interview_{session_id}.json"
-    assert persisted.exists(), "interview state file must exist on disk after first-question failure"
+    assert persisted.exists(), (
+        "interview state file must exist on disk after first-question failure"
+    )
     assert engine.saved_states, "engine.save_state must have been invoked"
 
 

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -263,3 +263,51 @@ def test_handler_persistence_probe_routes_through_engine_state_dir(tmp_path: Pat
 
     assert backend.is_session_persisted(sid) is True
     assert backend.is_session_persisted("interview_aaaaaaaaaaaaaaaa") is False
+
+
+@pytest.mark.asyncio
+async def test_plugin_path_writes_state_into_engine_state_dir(tmp_path: Path, monkeypatch) -> None:
+    """Plugin path must persist into the engine's state_dir, not handler.data_dir.
+
+    Regression for the Q00/ouroboros#723 bot review: the plugin path used to
+    read/write via ``self.data_dir or _DATA_DIR`` while the collision check
+    consulted ``engine.state_dir``.  After routing through
+    ``resolved_state_dir`` both sides agree, so a custom-state_dir
+    deployment can resume the interview it just started.
+    """
+    import ouroboros.mcp.tools.authoring_handlers as ah
+
+    engine_dir = tmp_path / "engine"
+    handler_data_dir = tmp_path / "handler"
+    engine_dir.mkdir()
+    handler_data_dir.mkdir()
+
+    saved_paths: list[Path] = []
+
+    async def _capturing_save(state_dir, state):  # type: ignore[no-untyped-def]
+        path = state_dir / f"interview_{state.interview_id}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}", encoding="utf-8")
+        saved_paths.append(path)
+        return Result.ok(path)
+
+    monkeypatch.setattr(ah, "_plugin_save_state", _capturing_save)
+
+    engine = _FakeInterviewEngine(state_dir=engine_dir)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+        data_dir=handler_data_dir,
+    )
+
+    outcome = await handler.handle(
+        {"initial_context": "Build a CLI", "cwd": str(tmp_path)},
+    )
+
+    assert outcome.is_ok
+    assert saved_paths, "plugin path must invoke _plugin_save_state"
+    saved = saved_paths[0]
+    assert saved.parent == engine_dir, (
+        f"plugin save must land in engine.state_dir; saw {saved.parent}"
+    )

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -1,0 +1,125 @@
+"""Regression tests for Q00/ouroboros#687.
+
+The MCP ``ouroboros_interview`` subprocess path must persist the freshly-
+created interview state and surface the ``session_id`` even when the first
+question generation fails (e.g. LLM timeout).  Without this guarantee the
+auto pipeline cannot resume a partially-started interview.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.bigbang.interview import InterviewState, InterviewStatus
+from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+
+class _RecoverableProviderError(MCPServerError):
+    """Test stand-in for ``ProviderError`` used by the interview engine."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.details: dict[str, object] = {"stderr": "simulated llm timeout"}
+
+
+@dataclass(slots=True)
+class _FakeInterviewEngine:
+    """Minimal engine that mirrors the surface used by ``InterviewHandler``.
+
+    ``start_interview`` writes the interview state to ``state_dir`` to mimic
+    the real engine after Q00/ouroboros#687, and ``ask_next_question`` always
+    fails so the handler must take the recoverable path.
+    """
+
+    state_dir: Path
+    saved_states: list[InterviewState] = field(default_factory=list)
+
+    async def start_interview(
+        self, initial_context: str, cwd: str | None = None, interview_id: str | None = None
+    ) -> Result[InterviewState, MCPServerError]:
+        sid = interview_id or "interview_persistfail_001"
+        state = InterviewState(
+            interview_id=sid,
+            initial_context=initial_context,
+            status=InterviewStatus.IN_PROGRESS,
+        )
+        await self.save_state(state)
+        return Result.ok(state)
+
+    async def ask_next_question(
+        self, state: InterviewState
+    ) -> Result[str, MCPServerError]:
+        return Result.err(_RecoverableProviderError("Question generation timed out"))
+
+    async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        path = self.state_dir / f"interview_{state.interview_id}.json"
+        path.write_text(
+            json.dumps({"interview_id": state.interview_id}),
+            encoding="utf-8",
+        )
+        self.saved_states.append(state)
+        return Result.ok(path)
+
+    async def load_state(
+        self, session_id: str
+    ) -> Result[InterviewState, MCPServerError]:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_subprocess_handler_persists_session_id_on_question_failure(tmp_path: Path) -> None:
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert outcome.is_ok, "handler must surface a recoverable result, not a hard error"
+    mcp_result = outcome.value
+    assert mcp_result.is_error is True
+    meta = mcp_result.meta or {}
+    session_id = meta.get("session_id")
+    assert isinstance(session_id, str) and session_id, "meta must carry the persisted session_id"
+    assert meta.get("recoverable") is True
+
+    persisted = tmp_path / f"interview_{session_id}.json"
+    assert persisted.exists(), "interview state file must exist on disk after first-question failure"
+    assert engine.saved_states, "engine.save_state must have been invoked"
+
+
+@pytest.mark.asyncio
+async def test_subprocess_handler_honours_caller_supplied_interview_id(tmp_path: Path) -> None:
+    """The auto driver pre-allocates an id; the handler must use it verbatim."""
+
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    caller_id = "interview_caller_supplied_42"
+    outcome = await handler.handle(
+        {
+            "initial_context": "Build a CLI",
+            "cwd": str(tmp_path),
+            "interview_id": caller_id,
+        }
+    )
+
+    assert outcome.is_ok
+    meta = outcome.value.meta or {}
+    assert meta.get("session_id") == caller_id
+    assert (tmp_path / f"interview_{caller_id}.json").exists()

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -110,7 +110,8 @@ async def test_subprocess_handler_honours_caller_supplied_interview_id(tmp_path:
         data_dir=tmp_path,
     )
 
-    caller_id = "interview_caller_supplied_42"
+    # Must match the strict server format ``interview_<16 hex>``.
+    caller_id = "interview_0123456789abcdef"
     outcome = await handler.handle(
         {
             "initial_context": "Build a CLI",
@@ -123,3 +124,79 @@ async def test_subprocess_handler_honours_caller_supplied_interview_id(tmp_path:
     meta = outcome.value.meta or {}
     assert meta.get("session_id") == caller_id
     assert (tmp_path / f"interview_{caller_id}.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_subprocess_handler_rejects_malformed_interview_id(tmp_path: Path) -> None:
+    """A non-matching ``interview_id`` must hard-fail before any side effects."""
+
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {
+            "initial_context": "Build a CLI",
+            "cwd": str(tmp_path),
+            "interview_id": "not_in_server_format",
+        }
+    )
+
+    assert outcome.is_err
+    assert "server format" in str(outcome.error)
+    assert engine.saved_states == [], "engine must not run when id is rejected"
+
+
+@pytest.mark.asyncio
+async def test_subprocess_handler_rejects_colliding_interview_id(tmp_path: Path) -> None:
+    """Re-using an id that already has a state file must be refused."""
+
+    caller_id = "interview_0123456789abcdef"
+    # Pre-create the colliding file.
+    (tmp_path / f"interview_{caller_id}.json").write_text("{}", encoding="utf-8")
+
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {
+            "initial_context": "Build a CLI",
+            "cwd": str(tmp_path),
+            "interview_id": caller_id,
+        }
+    )
+
+    assert outcome.is_err
+    assert "collide" in str(outcome.error)
+
+
+@pytest.mark.asyncio
+async def test_subprocess_handler_rejects_interview_id_on_resume_action(tmp_path: Path) -> None:
+    """``interview_id`` is only valid for new interviews; resume must reject it."""
+
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {
+            "session_id": "interview_existingsession",
+            "interview_id": "interview_0123456789abcdef",
+        }
+    )
+
+    assert outcome.is_err
+    assert "only valid for new interviews" in str(outcome.error)


### PR DESCRIPTION
Closes #687.

## Summary
- `AutoInterviewDriver` pre-allocates the interview id and saves it on `AutoPipelineState` **before** invoking the backend, so an `asyncio.wait_for` cancel cannot leave the auto state with a `null` id while a persisted interview file already exists on disk.
- `InterviewEngine.start_interview` now persists the freshly-created `InterviewState` immediately (defense for both subprocess and plugin paths).
- The `ouroboros_interview` MCP tool accepts a new optional `interview_id` argument; subprocess + plugin paths both honour it.
- A new `PartialInterviewStartError(session_id=...)` surfaces a recoverable handler failure (first-question timeout etc.) up through `HandlerInterviewBackend.start` so the auto driver can record the persisted id even when the failure path is taken.
- Generic question-generation failure in the subprocess handler now returns a recoverable `MCPToolResult` with `meta.session_id` instead of `Result.err` (matches the existing empty-response branch). Provider error text is truncated to 200 chars before being embedded in the user-facing envelope.

## Why
Reproducing the incident from the issue (`auto_78c98678de5d`, `interview.start timed out after 60s`): the first-question LLM call timed out, the auto state was left with `interview_session_id: null`, and `ooo auto --resume` started a brand-new interview instead of reusing the existing handle. With this change the id is durable on disk and on auto state regardless of where the failure lands (driver-side `wait_for`, handler-side timeout, or empty-response).

## Test plan
- [x] `pytest tests -k 'interview and resume'` (37 passed)
- [x] `pytest tests -k 'auto and interview_session_id'` (1 passed)
- [x] `pytest tests/unit/auto tests/unit/mcp tests/unit/bigbang tests/unit/cli` (2200 passed)
- [x] `ruff check src tests`
- [x] `mypy src/ouroboros/auto src/ouroboros/mcp/tools/authoring_handlers.py src/ouroboros/bigbang/interview.py`
- [x] New tests:
  - `test_interview_driver_preallocates_session_id_before_backend_start` — exercises the actual `asyncio.wait_for` cancel path
  - `test_interview_driver_persists_partial_session_id_on_start_failure`
  - `test_interview_driver_resumes_existing_session_after_partial_failure`
  - `test_subprocess_handler_persists_session_id_on_question_failure`
  - `test_subprocess_handler_honours_caller_supplied_interview_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)