### PR TITLE
fix(auto): truthful resume/retry semantics across surfaces (#688)

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -17,6 +17,7 @@ from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
     AutoPhase,
     AutoPipelineState,
+    AutoResumeCapability,
     AutoStore,
     SeedOrigin,
     utc_now_iso,
@@ -65,11 +66,12 @@ class AutoPipelineResult:
     invoked_by: str = "direct"
     provenance: dict[str, Any] | None = None
     last_authoring_backend: str | None = None
-    resume_capability: str = "resume"
-    """String form of :class:`AutoResumeCapability`. Defaults to ``"resume"``
-    so existing test constructions of ``AutoPipelineResult(...)`` keep their
-    historical behavior. ``AutoPipeline._result()`` overrides it from the
-    persisted state's :meth:`AutoPipelineState.resume_capability`."""
+    resume_capability: AutoResumeCapability = AutoResumeCapability.RESUME
+    """Typed :class:`AutoResumeCapability` value. Defaults to
+    :attr:`AutoResumeCapability.RESUME` so existing test constructions of
+    ``AutoPipelineResult(...)`` keep their historical behavior.
+    ``AutoPipeline._result()`` overrides it from the persisted state's
+    :meth:`AutoPipelineState.resume_capability`."""
 
 
 @dataclass(slots=True)
@@ -510,7 +512,7 @@ class AutoPipeline:
             invoked_by=state.invoked_by(),
             provenance=dict(state.provenance) if state.provenance else None,
             last_authoring_backend=state.last_authoring_backend,
-            resume_capability=state.resume_capability().value,
+            resume_capability=state.resume_capability(),
         )
 
     def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -65,6 +65,11 @@ class AutoPipelineResult:
     invoked_by: str = "direct"
     provenance: dict[str, Any] | None = None
     last_authoring_backend: str | None = None
+    resume_capability: str = "resume"
+    """String form of :class:`AutoResumeCapability`. Defaults to ``"resume"``
+    so existing test constructions of ``AutoPipelineResult(...)`` keep their
+    historical behavior. ``AutoPipeline._result()`` overrides it from the
+    persisted state's :meth:`AutoPipelineState.resume_capability`."""
 
 
 @dataclass(slots=True)
@@ -505,6 +510,7 @@ class AutoPipeline:
             invoked_by=state.invoked_by(),
             provenance=dict(state.provenance) if state.provenance else None,
             last_authoring_backend=state.last_authoring_backend,
+            resume_capability=state.resume_capability().value,
         )
 
     def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:

--- a/src/ouroboros/auto/resume_render.py
+++ b/src/ouroboros/auto/resume_render.py
@@ -1,0 +1,72 @@
+"""Shared rendering for ``ooo auto`` resume/retry/start-fresh hint lines.
+
+The CLI (``cli/commands/auto.py``) and the MCP surface
+(``mcp/tools/auto_handler.py``) both display a hint after every status or
+result print. The exact wording depends on the persisted
+``AutoResumeCapability`` for the session — :func:`render_resume_lines`
+centralizes that matrix so all surfaces stay in lockstep.
+
+Three call sites consume this helper:
+
+* ``_print_status`` (CLI) — has full :class:`AutoPipelineState`; passes the
+  goal so a ``Start fresh:`` hint can be produced when the capability is
+  ``NONE`` and the phase is terminal.
+* ``_print_result`` (CLI) — only has :class:`AutoPipelineResult`; cannot
+  reconstruct ``goal``, so it omits the ``Start fresh:`` hint entirely
+  for ``NONE``.
+* ``_format_result`` (MCP) — same constraint as ``_print_result``.
+"""
+
+from __future__ import annotations
+
+from ouroboros.auto.state import AutoResumeCapability
+
+
+def render_resume_lines(
+    capability: AutoResumeCapability,
+    auto_session_id: str,
+    *,
+    goal: str | None = None,
+    use_markup: bool = False,
+) -> list[str]:
+    """Return the hint lines to render for ``capability``.
+
+    Args:
+        capability: Classification of what ``--resume`` would actually do.
+        auto_session_id: The persisted auto session id.
+        goal: Optional original goal string. When provided and the capability
+            is ``NONE``, a ``Start fresh:`` hint is emitted. Pass ``None``
+            (the default) when the goal is not available — for example
+            from result-only surfaces.
+        use_markup: When ``True`` wrap the command portion in Rich
+            ``[bold]...[/]`` markup. CLI surfaces use this for inline
+            highlighting; MCP plain-text rendering must leave it ``False``.
+
+    Returns:
+        A list of strings, one per console line. May be empty (e.g. when
+        capability is ``NONE`` and no goal is supplied — the COMPLETE
+        phase falls into this bucket).
+    """
+
+    def cmd(text: str) -> str:
+        return f"[bold]{text}[/]" if use_markup else text
+
+    if capability is AutoResumeCapability.RESUME:
+        return [f"Resume: {cmd(f'ooo auto --resume {auto_session_id}')}"]
+    if capability is AutoResumeCapability.PARTIAL_RESUME:
+        return [
+            f"Resume (partial): {cmd(f'ooo auto --resume {auto_session_id}')}",
+            "  Note: some progress preserved but the exact pick-up point may be approximate",
+        ]
+    if capability is AutoResumeCapability.RETRY:
+        return [
+            f"Retry: {cmd(f'ooo auto --resume {auto_session_id}')}",
+            "  Note: no prior session context — this re-runs the failed step from scratch",
+        ]
+    # AutoResumeCapability.NONE
+    if goal is not None and goal.strip():
+        return [f"Start fresh: {cmd(f'ooo auto "{goal}"')}"]
+    return []
+
+
+__all__ = ["render_resume_lines"]

--- a/src/ouroboros/auto/resume_render.py
+++ b/src/ouroboros/auto/resume_render.py
@@ -19,6 +19,10 @@ Three call sites consume this helper:
 
 from __future__ import annotations
 
+import shlex
+
+from rich.markup import escape as rich_escape
+
 from ouroboros.auto.state import AutoResumeCapability
 
 
@@ -49,6 +53,10 @@ def render_resume_lines(
     """
 
     def cmd(text: str) -> str:
+        # Markup-mode renders the command in Rich [bold]; the surrounding
+        # surface (CLI ``console.print``) will interpret markup tokens, so
+        # text that may contain Rich tags must already be escaped before it
+        # gets here. Non-markup mode is plain text and needs no escaping.
         return f"[bold]{text}[/]" if use_markup else text
 
     if capability is AutoResumeCapability.RESUME:
@@ -65,7 +73,14 @@ def render_resume_lines(
         ]
     # AutoResumeCapability.NONE
     if goal is not None and goal.strip():
-        return [f"Start fresh: {cmd(f'ooo auto "{goal}"')}"]
+        # Shell-quote the goal so the rendered suggestion is safe to copy
+        # into a shell even when the goal contains quotes, ``$``, ``\\`` or
+        # other meta-characters. When markup is enabled the goal must also
+        # be Rich-escaped so brackets are not interpreted as markup tokens.
+        quoted = shlex.quote(goal)
+        if use_markup:
+            quoted = rich_escape(quoted)
+        return [f"Start fresh: {cmd(f'ooo auto {quoted}')}"]
     return []
 
 

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -146,6 +146,27 @@ def redact_provenance(raw: Any) -> dict[str, Any] | None:
     return cleaned
 
 
+class AutoResumeCapability(StrEnum):
+    """Classification of what ``--resume`` will actually do for a session.
+
+    The value is **never persisted** — it is a pure derivation from the
+    persisted :class:`AutoPipelineState` fields. See
+    :meth:`AutoPipelineState.resume_capability` for the decision matrix.
+    """
+
+    NONE = "none"
+    """Cannot resume; the session is done or unrecoverable."""
+
+    RETRY = "retry"
+    """Re-runs the failed step from scratch — no prior progress is reused."""
+
+    PARTIAL_RESUME = "partial_resume"
+    """Resumes with some context preserved; pick-up point is approximate."""
+
+    RESUME = "resume"
+    """Continues exactly where it left off with full context."""
+
+
 TERMINAL_PHASES = {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED}
 _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
     AutoPhase.CREATED: {AutoPhase.INTERVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
@@ -333,6 +354,103 @@ class AutoPipelineState:
         current = now or datetime.now(UTC)
         last = datetime.fromisoformat(self.last_progress_at)
         return (current - last).total_seconds() > timeout
+
+    def resume_capability(self) -> AutoResumeCapability:
+        """Classify what ``--resume`` will actually do for the current state.
+
+        This is a pure derivation — the result is never persisted. The
+        classification mirrors the actual control flow in
+        :meth:`AutoPipeline.run` and :meth:`AutoInterviewDriver.run`.
+
+        Decision matrix (only the highlights — see the plan and tests for
+        the full table):
+
+        * :attr:`AutoPhase.COMPLETE` -> :attr:`AutoResumeCapability.NONE`
+          (completed sessions render no resume hint).
+        * :attr:`AutoPhase.REPAIR` is non-terminal — a fresh ``--resume``
+          will transition the state back to ``REVIEW``, so the capability
+          is :attr:`AutoResumeCapability.RESUME`.
+        * Other non-terminal phases also classify as ``RESUME``.
+        * :attr:`AutoPhase.BLOCKED` / :attr:`AutoPhase.FAILED` consult
+          ``_recoverable_phase_for_tool`` first; an unmapped or missing
+          ``last_tool_name`` yields ``NONE``.
+        * The hot ``#688`` cell: ``BLOCKED`` + ``last_tool_name ==
+          "interview.start"`` + ``interview_session_id is None``
+          classifies as :attr:`AutoResumeCapability.RETRY` because
+          resuming re-runs ``interview.start`` from scratch with no
+          recovered state.
+
+        Returns:
+            The :class:`AutoResumeCapability` value for the current state.
+        """
+        # Lazy import to avoid the ``state.py`` <-> ``pipeline.py`` cycle.
+        from ouroboros.auto.pipeline import _recoverable_phase_for_tool  # noqa: PLC0415
+
+        if self.phase == AutoPhase.COMPLETE:
+            return AutoResumeCapability.NONE
+
+        if self.phase not in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
+            # CREATED, INTERVIEW, SEED_GENERATION, REVIEW, REPAIR, RUN.
+            # Pipeline.run() will simply continue from the current phase.
+            # REPAIR explicitly transitions to REVIEW on resume, so this is
+            # still a true RESUME (not a partial one).
+            return AutoResumeCapability.RESUME
+
+        # --- BLOCKED or FAILED ---
+        recoverable = _recoverable_phase_for_tool(self.last_tool_name)
+        if recoverable is None:
+            return AutoResumeCapability.NONE
+
+        tool = self.last_tool_name
+
+        # Interview phase tools.
+        if recoverable == AutoPhase.INTERVIEW:
+            if tool == "interview.start" and not self.interview_session_id:
+                # The #688 case: interview.start timed out before producing
+                # a session id. Resuming re-runs interview.start from
+                # scratch — that is a retry, not a continuation.
+                return AutoResumeCapability.RETRY
+            if self.interview_session_id:
+                if self.pending_question:
+                    return AutoResumeCapability.RESUME
+                return AutoResumeCapability.PARTIAL_RESUME
+            # Interview-tool but no session id (rare for tools other than
+            # interview.start); treat as a retry rather than asserting.
+            return AutoResumeCapability.RETRY
+
+        # Seed generation. We reconcile seed_artifact, seed_path, and
+        # interview_session_id: a persisted artifact is the strongest
+        # signal; a seed_path means we can re-load the Seed; otherwise we
+        # need the interview session to regenerate.
+        if recoverable == AutoPhase.SEED_GENERATION:
+            if self.seed_artifact:
+                return AutoResumeCapability.RESUME
+            if self.seed_path:
+                return AutoResumeCapability.PARTIAL_RESUME
+            if self.interview_session_id:
+                return AutoResumeCapability.RESUME
+            return AutoResumeCapability.NONE
+
+        # Review phase tools (seed_saver / grade_gate / seed_loader).
+        if recoverable == AutoPhase.REVIEW:
+            if self.seed_artifact:
+                return AutoResumeCapability.RESUME
+            if self.seed_path:
+                return AutoResumeCapability.PARTIAL_RESUME
+            return AutoResumeCapability.NONE
+
+        # Run phase. Persisted run handles let us short-circuit to
+        # COMPLETE; otherwise we need a Seed (artifact > path).
+        if recoverable == AutoPhase.RUN:
+            if any((self.job_id, self.execution_id, self.run_session_id)):
+                return AutoResumeCapability.RESUME
+            if self.seed_artifact:
+                return AutoResumeCapability.RESUME
+            if self.seed_path:
+                return AutoResumeCapability.PARTIAL_RESUME
+            return AutoResumeCapability.NONE
+
+        return AutoResumeCapability.NONE  # defensive
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -428,7 +428,10 @@ class AutoPipelineState:
             if self.seed_path:
                 return AutoResumeCapability.PARTIAL_RESUME
             if self.interview_session_id:
-                return AutoResumeCapability.RESUME
+                # Interview context carries forward, but seed generation
+                # itself re-runs from scratch — no prior generation work
+                # is reused. That matches the RETRY semantics, not RESUME.
+                return AutoResumeCapability.RETRY
             return AutoResumeCapability.NONE
 
         # Review phase tools (seed_saver / grade_gate / seed_loader).

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -443,10 +443,16 @@ class AutoPipelineState:
             return AutoResumeCapability.NONE
 
         # Run phase. Persisted run handles let us short-circuit to
-        # COMPLETE; otherwise we need a Seed (artifact > path).
+        # COMPLETE; otherwise we need a Seed (artifact > path). When the
+        # pipeline already attempted to start a run but produced no durable
+        # handle, ``AutoPipeline.run()`` immediately re-blocks at
+        # ``run_starter`` to refuse a duplicate execution — so ``--resume``
+        # cannot make progress and the capability must be ``NONE``.
         if recoverable == AutoPhase.RUN:
             if any((self.job_id, self.execution_id, self.run_session_id)):
                 return AutoResumeCapability.RESUME
+            if self.run_start_attempted:
+                return AutoResumeCapability.NONE
             if self.seed_artifact:
                 return AutoResumeCapability.RESUME
             if self.seed_path:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -22,8 +22,9 @@ from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.provenance import resolve_provenance
+from ouroboros.auto.resume_render import render_resume_lines
 from ouroboros.auto.seed_repairer import SeedRepairer
-from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoResumeCapability, AutoStore
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success
 from ouroboros.config import get_opencode_mode
@@ -466,7 +467,16 @@ def _print_status(state: AutoPipelineState) -> None:
             answer = _rich_escape(str(entry.get("answer", "")))
             console.print(f"  round {round_value} \\[{source}] Q: {question}")
             console.print(f"    A: {answer}")
-    console.print(f"Resume: [bold]ooo auto --resume {state.auto_session_id}[/]")
+    # Only emit a "Start fresh" hint for terminal-but-recoverable signals
+    # (BLOCKED/FAILED). COMPLETE is terminal *and* successful — no hint.
+    goal_for_hint = state.goal if state.phase is not AutoPhase.COMPLETE else None
+    for line in render_resume_lines(
+        state.resume_capability(),
+        state.auto_session_id,
+        goal=goal_for_hint,
+        use_markup=True,
+    ):
+        console.print(line)
 
 
 def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
@@ -519,7 +529,14 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
                 console.print(f"  - {item}")
     if result.blocker:
         console.print(f"Blocker: [yellow]{result.blocker}[/]")
-    console.print(f"Resume: [bold]ooo auto --resume {result.auto_session_id}[/]")
+    capability = AutoResumeCapability(result.resume_capability)
+    for line in render_resume_lines(
+        capability,
+        result.auto_session_id,
+        goal=None,
+        use_markup=True,
+    ):
+        console.print(line)
 
 
 __all__ = ["app"]

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -24,7 +24,7 @@ from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.provenance import resolve_provenance
 from ouroboros.auto.resume_render import render_resume_lines
 from ouroboros.auto.seed_repairer import SeedRepairer
-from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoResumeCapability, AutoStore
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success
 from ouroboros.config import get_opencode_mode
@@ -529,9 +529,8 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
                 console.print(f"  - {item}")
     if result.blocker:
         console.print(f"Blocker: [yellow]{result.blocker}[/]")
-    capability = AutoResumeCapability(result.resume_capability)
     for line in render_resume_lines(
-        capability,
+        result.resume_capability,
         result.auto_session_id,
         goal=None,
         use_markup=True,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -248,7 +248,7 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "current_round": result.current_round,
         "last_progress_message": result.last_progress_message,
         "last_progress_at": result.last_progress_at,
-        "resume_command": f"ooo auto --resume {result.auto_session_id}",
+        "resume_capability": result.resume_capability,
         "blocker": result.blocker,
         "seed_path": result.seed_path,
         "seed_origin": result.seed_origin,
@@ -259,6 +259,14 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "job_id": result.job_id,
         "run_session_id": result.run_session_id,
     }
+    # Only advertise a runnable resume_command when --resume actually has
+    # something to do. NONE-capability sessions (COMPLETE, or unrecoverable
+    # BLOCKED/FAILED) must not surface a resume action via metadata —
+    # otherwise clients keying off ``meta.resume_command`` would push users
+    # into a guaranteed-failing ``--resume`` path even though the
+    # human-readable text intentionally omits the hint.
+    if result.resume_capability != "none":
+        meta["resume_command"] = f"ooo auto --resume {result.auto_session_id}"
     if result.pending_question:
         meta["pending_question"] = result.pending_question
     if result.run_handoff_status:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -17,8 +17,9 @@ from ouroboros.auto.adapters import (
 )
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.resume_render import render_resume_lines
 from ouroboros.auto.seed_repairer import SeedRepairer
-from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoResumeCapability, AutoStore
 from ouroboros.config import get_opencode_mode
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
@@ -475,5 +476,13 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.extend(f"- {item}" for item in result.non_goals)
     if result.blocker:
         lines.append(f"Blocker: {result.blocker}")
-    lines.append(f"Resume: ooo auto --resume {result.auto_session_id}")
+    capability = AutoResumeCapability(result.resume_capability)
+    lines.extend(
+        render_resume_lines(
+            capability,
+            result.auto_session_id,
+            goal=None,
+            use_markup=False,
+        )
+    )
     return "\n".join(lines)

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -248,7 +248,7 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "current_round": result.current_round,
         "last_progress_message": result.last_progress_message,
         "last_progress_at": result.last_progress_at,
-        "resume_capability": result.resume_capability,
+        "resume_capability": result.resume_capability.value,
         "blocker": result.blocker,
         "seed_path": result.seed_path,
         "seed_origin": result.seed_origin,
@@ -265,7 +265,7 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
     # otherwise clients keying off ``meta.resume_command`` would push users
     # into a guaranteed-failing ``--resume`` path even though the
     # human-readable text intentionally omits the hint.
-    if result.resume_capability != "none":
+    if result.resume_capability is not AutoResumeCapability.NONE:
         meta["resume_command"] = f"ooo auto --resume {result.auto_session_id}"
     if result.pending_question:
         meta["pending_question"] = result.pending_question
@@ -484,7 +484,7 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.extend(f"- {item}" for item in result.non_goals)
     if result.blocker:
         lines.append(f"Blocker: {result.blocker}")
-    capability = AutoResumeCapability(result.resume_capability)
+    capability = result.resume_capability
     lines.extend(
         render_resume_lines(
             capability,

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2738,3 +2738,30 @@ async def test_interview_driver_resumes_existing_session_after_partial_failure(
     assert not start_calls
     assert result.session_id == persisted_session
     assert state.interview_session_id == persisted_session
+
+
+def test_interview_start_timeout_state_routes_to_interview_on_resume_with_retry_capability() -> (
+    None
+):
+    """An ``interview.start`` timeout is a recoverable resume path but classifies as RETRY.
+
+    The #688 invariant: ``_recoverable_phase_for_tool('interview.start')`` returns
+    :class:`AutoPhase.INTERVIEW` (so :meth:`AutoPipeline.run` routes the resume
+    back into the interview phase), *and* :meth:`AutoPipelineState.resume_capability`
+    classifies the post-timeout state as :class:`AutoResumeCapability.RETRY`
+    because no ``interview_session_id`` was persisted — there is no prior
+    progress to recover.
+    """
+    from ouroboros.auto.pipeline import _recoverable_phase_for_tool
+    from ouroboros.auto.state import AutoResumeCapability
+
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("interview.start timed out", tool_name="interview.start")
+
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "interview.start"
+    assert state.interview_session_id is None
+    assert state.pending_question is None
+    assert _recoverable_phase_for_tool("interview.start") is AutoPhase.INTERVIEW
+    assert state.resume_capability() is AutoResumeCapability.RETRY

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -614,6 +614,44 @@ def test_resume_capability_run_starter_seed_path_only_returns_partial() -> None:
     assert state.resume_capability() is AutoResumeCapability.PARTIAL_RESUME
 
 
+def test_resume_capability_run_starter_attempted_without_handle_returns_none() -> None:
+    """Bot finding (#724): a run_starter attempt that left no durable handle is
+    NOT recoverable. ``AutoPipeline.run()`` short-circuits at
+    ``state.run_start_attempted`` to refuse a duplicate execution, so
+    ``--resume`` cannot make progress and capability must be NONE.
+    """
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.seed_artifact = {"id": "seed_1"}  # would otherwise classify as RESUME
+    state.run_start_attempted = True
+    state.mark_blocked("run start timed out", tool_name="run_starter")
+
+    assert state.run_start_attempted is True
+    assert not any((state.job_id, state.execution_id, state.run_session_id))
+    # Despite seed_artifact being present, the duplicate-execution guard means
+    # --resume will immediately re-block. Classify as NONE.
+    assert state.resume_capability() is AutoResumeCapability.NONE
+
+
+def test_resume_capability_run_starter_attempted_seed_path_only_returns_none() -> None:
+    """Same guard applies even when only seed_path is available."""
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.seed_path = "/tmp/seed.yaml"
+    state.run_start_attempted = True
+    state.mark_blocked("run start timed out", tool_name="run_starter")
+
+    assert state.run_start_attempted is True
+    assert not state.seed_artifact
+    assert state.resume_capability() is AutoResumeCapability.NONE
+
+
 def test_resume_capability_failed_mirrors_blocked() -> None:
     """FAILED states classify identically to BLOCKED for the same signals."""
     state = _state()

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -8,6 +8,7 @@ from ouroboros.auto.state import (
     DEFAULT_TIMEOUT_SECONDS_BY_PHASE,
     AutoPhase,
     AutoPipelineState,
+    AutoResumeCapability,
     AutoStore,
 )
 
@@ -394,3 +395,229 @@ def test_recover_uses_transition_table_from_failed_state() -> None:
 
     assert state.phase is AutoPhase.REVIEW
     assert state.last_error is None
+
+
+# ---------------------------------------------------------------------------
+# resume_capability matrix (#688)
+# ---------------------------------------------------------------------------
+
+
+def _state(**overrides: object) -> AutoPipelineState:
+    """Build an :class:`AutoPipelineState` with sensible defaults for matrix tests."""
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    for key, value in overrides.items():
+        setattr(state, key, value)
+    return state
+
+
+def test_resume_capability_complete_returns_none() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.COMPLETE, "done")
+
+    assert state.resume_capability() is AutoResumeCapability.NONE
+
+
+def test_resume_capability_non_terminal_returns_resume() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_repair_phase_returns_resume() -> None:
+    """Critic fix C2: REPAIR is non-terminal — resume transitions back to REVIEW."""
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.REPAIR, "repair")
+
+    assert state.phase is AutoPhase.REPAIR
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_blocked_unmapped_tool_returns_none() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("internal guard fired", tool_name="auto_pipeline")
+
+    assert state.resume_capability() is AutoResumeCapability.NONE
+
+
+def test_resume_capability_interview_start_timeout_no_session_returns_retry() -> None:
+    """The #688 case: interview.start blew up before persisting a session id."""
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("interview.start timed out", tool_name="interview.start")
+
+    assert state.interview_session_id is None
+    assert state.resume_capability() is AutoResumeCapability.RETRY
+
+
+def test_resume_capability_interview_start_with_session_returns_partial() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.mark_blocked("interview.start blocked late", tool_name="interview.start")
+
+    assert state.resume_capability() is AutoResumeCapability.PARTIAL_RESUME
+
+
+def test_resume_capability_interview_resume_with_pending_returns_resume() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.pending_question = "What is the deadline?"
+    state.mark_blocked("interview.resume timed out", tool_name="interview.resume")
+
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_interview_answer_no_pending_returns_partial() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.pending_question = None
+    state.mark_blocked("interview.answer timed out", tool_name="interview.answer")
+
+    assert state.resume_capability() is AutoResumeCapability.PARTIAL_RESUME
+
+
+def test_resume_capability_auto_answerer_with_pending_returns_resume() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.pending_question = "What is the deadline?"
+    state.mark_blocked("auto_answerer timed out", tool_name="auto_answerer")
+
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_seed_generator_with_artifact_returns_resume() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.seed_artifact = {"id": "seed_1"}
+    state.mark_blocked("seed_generator timed out", tool_name="seed_generator")
+
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_seed_generator_seed_path_only_returns_partial() -> None:
+    """Critic fix C3: ``seed_path``-only must return PARTIAL_RESUME."""
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.seed_path = "/tmp/seed.yaml"
+    state.mark_blocked("seed_generator timed out", tool_name="seed_generator")
+
+    assert not state.seed_artifact
+    assert state.seed_path
+    assert state.resume_capability() is AutoResumeCapability.PARTIAL_RESUME
+
+
+def test_resume_capability_seed_generator_no_artifact_with_session_returns_resume() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_1"
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.mark_blocked("seed_generator timed out", tool_name="seed_generator")
+
+    assert not state.seed_artifact
+    assert state.seed_path is None
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_seed_generator_no_artifact_no_session_returns_none() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.mark_blocked("seed_generator timed out", tool_name="seed_generator")
+
+    assert state.interview_session_id is None
+    assert state.resume_capability() is AutoResumeCapability.NONE
+
+
+def test_resume_capability_grade_gate_with_artifact_returns_resume() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.seed_artifact = {"id": "seed_1"}
+    state.mark_blocked("Seed did not reach A-grade", tool_name="grade_gate")
+
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_grade_gate_with_seed_path_returns_partial() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.seed_path = "/tmp/seed.yaml"
+    state.mark_blocked("seed_loader could not read seed", tool_name="seed_loader")
+
+    assert state.resume_capability() is AutoResumeCapability.PARTIAL_RESUME
+
+
+def test_resume_capability_grade_gate_nothing_returns_none() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.mark_blocked("seed_saver could not persist seed", tool_name="seed_saver")
+
+    assert state.resume_capability() is AutoResumeCapability.NONE
+
+
+def test_resume_capability_run_starter_with_handles_returns_resume() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.job_id = "job_42"
+    state.mark_blocked("run start timed out", tool_name="run_starter")
+
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_run_starter_with_artifact_returns_resume() -> None:
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.seed_artifact = {"id": "seed_1"}
+    state.mark_blocked("run start timed out", tool_name="run_starter")
+
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_run_starter_seed_path_only_returns_partial() -> None:
+    """Critic fix C4: ``run_starter`` + ``seed_path`` only → PARTIAL_RESUME."""
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.seed_path = "/tmp/seed.yaml"
+    state.mark_blocked("run start timed out", tool_name="run_starter")
+
+    assert not state.seed_artifact
+    assert not any((state.job_id, state.execution_id, state.run_session_id))
+    assert state.resume_capability() is AutoResumeCapability.PARTIAL_RESUME
+
+
+def test_resume_capability_failed_mirrors_blocked() -> None:
+    """FAILED states classify identically to BLOCKED for the same signals."""
+    state = _state()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_failed("interview.start timed out", tool_name="interview.start")
+
+    assert state.phase is AutoPhase.FAILED
+    assert state.interview_session_id is None
+    assert state.resume_capability() is AutoResumeCapability.RETRY

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -519,7 +519,7 @@ def test_resume_capability_seed_generator_seed_path_only_returns_partial() -> No
     assert state.resume_capability() is AutoResumeCapability.PARTIAL_RESUME
 
 
-def test_resume_capability_seed_generator_no_artifact_with_session_returns_resume() -> None:
+def test_resume_capability_seed_generator_no_artifact_with_session_returns_retry() -> None:
     state = _state()
     state.transition(AutoPhase.INTERVIEW, "interview")
     state.interview_session_id = "interview_1"
@@ -528,7 +528,9 @@ def test_resume_capability_seed_generator_no_artifact_with_session_returns_resum
 
     assert not state.seed_artifact
     assert state.seed_path is None
-    assert state.resume_capability() is AutoResumeCapability.RESUME
+    # Interview session carries forward, but seed generation itself re-runs
+    # from scratch — RETRY semantics, not RESUME.
+    assert state.resume_capability() is AutoResumeCapability.RETRY
 
 
 def test_resume_capability_seed_generator_no_artifact_no_session_returns_none() -> None:

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -472,6 +472,7 @@ async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> No
         "current_round": 2,
         "last_progress_message": "asking interview round 2/12",
         "last_progress_at": "2026-05-01T12:00:00+00:00",
+        "resume_capability": "resume",
         "resume_command": "ooo auto --resume auto_test",
         "blocker": "waiting for interview answer",
         "seed_path": "/tmp/seed.yaml",

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.state import AutoPhase, AutoPipelineState
+from ouroboros.cli.commands.auto import _print_result, _print_status
 from ouroboros.cli.main import app
 
 runner = CliRunner()
@@ -426,3 +428,156 @@ def test_run_auto_demotes_plugin_to_subprocess_in_state(tmp_path) -> None:
 
     assert captured["runtime"] == "opencode"
     assert captured["mode"] == "subprocess"
+
+
+# ---------------------------------------------------------------------------
+# _print_status / _print_result — capability-aware resume hint rendering (#688)
+# ---------------------------------------------------------------------------
+
+
+def _capture_status(state: AutoPipelineState) -> str:
+    """Capture the bare-text rendering of :func:`_print_status` for assertions."""
+    from ouroboros.cli.formatters import console
+
+    with console.capture() as capture:
+        _print_status(state)
+    return _plain(capture.get())
+
+
+def _capture_result(result: AutoPipelineResult) -> str:
+    """Capture the bare-text rendering of :func:`_print_result` for assertions."""
+    from ouroboros.cli.formatters import console
+
+    with console.capture() as capture:
+        _print_result(result, show_ledger=False)
+    return _plain(capture.get())
+
+
+def _state_in_phase(phase: AutoPhase) -> AutoPipelineState:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.auto_session_id = "auto_render"
+    if phase is AutoPhase.CREATED:
+        return state
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    if phase is AutoPhase.INTERVIEW:
+        return state
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    if phase is AutoPhase.SEED_GENERATION:
+        return state
+    state.transition(AutoPhase.REVIEW, "review")
+    if phase is AutoPhase.REVIEW:
+        return state
+    state.transition(AutoPhase.RUN, "run")
+    return state
+
+
+def test_print_status_resume_capability_resume() -> None:
+    state = _state_in_phase(AutoPhase.INTERVIEW)
+    output = _capture_status(state)
+
+    assert "Resume: ooo auto --resume auto_render" in output
+    assert "Resume (partial)" not in output
+    assert "Retry:" not in output
+    assert "Start fresh" not in output
+
+
+def test_print_status_resume_capability_partial() -> None:
+    state = _state_in_phase(AutoPhase.INTERVIEW)
+    state.interview_session_id = "interview_1"
+    state.mark_blocked("interview.answer timed out", tool_name="interview.answer")
+
+    output = _capture_status(state)
+
+    assert "Resume (partial): ooo auto --resume auto_render" in output
+    assert "some progress preserved but the exact pick-up point may be approximate" in output
+
+
+def test_print_status_resume_capability_retry() -> None:
+    state = _state_in_phase(AutoPhase.INTERVIEW)
+    state.mark_blocked("interview.start timed out", tool_name="interview.start")
+
+    output = _capture_status(state)
+
+    assert "Retry: ooo auto --resume auto_render" in output
+    assert "no prior session context" in output
+    assert "re-runs the failed step from scratch" in output
+
+
+def test_print_status_resume_capability_none_blocked_emits_start_fresh() -> None:
+    state = _state_in_phase(AutoPhase.INTERVIEW)
+    state.mark_blocked("internal guard fired", tool_name="auto_pipeline")
+
+    output = _capture_status(state)
+
+    assert 'Start fresh: ooo auto "Build a CLI"' in output
+    assert "Resume:" not in output
+    assert "Retry:" not in output
+
+
+def test_print_status_resume_capability_none_complete_emits_no_resume_line() -> None:
+    """Critic fix C5: COMPLETE produces no resume/retry/start-fresh hint."""
+    state = _state_in_phase(AutoPhase.REVIEW)
+    state.transition(AutoPhase.COMPLETE, "done")
+
+    output = _capture_status(state)
+
+    assert "Resume:" not in output
+    assert "Retry:" not in output
+    assert "Start fresh" not in output
+
+
+def test_print_result_resume_capability_resume() -> None:
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_r1",
+        phase="complete",
+        resume_capability="resume",
+    )
+
+    output = _capture_result(result)
+
+    assert "Resume: ooo auto --resume auto_r1" in output
+
+
+def test_print_result_resume_capability_partial() -> None:
+    result = AutoPipelineResult(
+        status="blocked",
+        auto_session_id="auto_r2",
+        phase="blocked",
+        resume_capability="partial_resume",
+    )
+
+    output = _capture_result(result)
+
+    assert "Resume (partial): ooo auto --resume auto_r2" in output
+    assert "some progress preserved" in output
+
+
+def test_print_result_resume_capability_retry() -> None:
+    result = AutoPipelineResult(
+        status="blocked",
+        auto_session_id="auto_r3",
+        phase="blocked",
+        resume_capability="retry",
+    )
+
+    output = _capture_result(result)
+
+    assert "Retry: ooo auto --resume auto_r3" in output
+    assert "re-runs the failed step from scratch" in output
+
+
+def test_print_result_resume_capability_none_emits_no_resume_line() -> None:
+    """``_print_result`` cannot reach ``state.goal``, so NONE prints nothing."""
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_r4",
+        phase="complete",
+        resume_capability="none",
+    )
+
+    output = _capture_result(result)
+
+    assert "Resume:" not in output
+    assert "Retry:" not in output
+    assert "Start fresh" not in output

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -509,9 +509,41 @@ def test_print_status_resume_capability_none_blocked_emits_start_fresh() -> None
 
     output = _capture_status(state)
 
-    assert 'Start fresh: ooo auto "Build a CLI"' in output
+    assert "Start fresh: ooo auto 'Build a CLI'" in output
     assert "Resume:" not in output
     assert "Retry:" not in output
+
+
+def test_print_status_start_fresh_shell_quotes_goal_with_metacharacters() -> None:
+    """Security: a goal with shell meta-characters must be safely quoted."""
+    state = AutoPipelineState(goal='evil"; rm -rf /; echo "', cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("internal guard fired", tool_name="auto_pipeline")
+
+    output = _capture_status(state)
+
+    # The rendered command, when tokenised by ``shlex.split``, must recover
+    # the original goal exactly — i.e. the payload cannot break out of the
+    # shell quoting and become its own argument.
+    import shlex
+
+    rendered = next(line for line in output.splitlines() if "Start fresh" in line)
+    cmd = rendered.split("Start fresh:", 1)[1].strip()
+    tokens = shlex.split(cmd)
+    assert tokens == ["ooo", "auto", 'evil"; rm -rf /; echo "']
+
+
+def test_print_status_start_fresh_escapes_rich_markup_in_goal() -> None:
+    """Security: a goal with Rich markup tokens must not render as styled."""
+    state = AutoPipelineState(goal="[red]ALERT[/]", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked("internal guard fired", tool_name="auto_pipeline")
+
+    output = _capture_status(state)
+
+    # The literal markup must survive into the rendered output (since it was
+    # escaped before Rich could interpret it).
+    assert "[red]ALERT[/]" in output
 
 
 def test_print_status_resume_capability_none_complete_emits_no_resume_line() -> None:

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from ouroboros.auto.pipeline import AutoPipelineResult
-from ouroboros.auto.state import AutoPhase, AutoPipelineState
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoResumeCapability
 from ouroboros.cli.commands.auto import _print_result, _print_status
 from ouroboros.cli.main import app
 
@@ -563,7 +563,7 @@ def test_print_result_resume_capability_resume() -> None:
         status="complete",
         auto_session_id="auto_r1",
         phase="complete",
-        resume_capability="resume",
+        resume_capability=AutoResumeCapability.RESUME,
     )
 
     output = _capture_result(result)
@@ -576,7 +576,7 @@ def test_print_result_resume_capability_partial() -> None:
         status="blocked",
         auto_session_id="auto_r2",
         phase="blocked",
-        resume_capability="partial_resume",
+        resume_capability=AutoResumeCapability.PARTIAL_RESUME,
     )
 
     output = _capture_result(result)
@@ -590,7 +590,7 @@ def test_print_result_resume_capability_retry() -> None:
         status="blocked",
         auto_session_id="auto_r3",
         phase="blocked",
-        resume_capability="retry",
+        resume_capability=AutoResumeCapability.RETRY,
     )
 
     output = _capture_result(result)
@@ -605,7 +605,7 @@ def test_print_result_resume_capability_none_emits_no_resume_line() -> None:
         status="complete",
         auto_session_id="auto_r4",
         phase="complete",
-        resume_capability="none",
+        resume_capability=AutoResumeCapability.NONE,
     )
 
     output = _capture_result(result)

--- a/tests/unit/mcp/tools/test_auto_handler_resume_lines.py
+++ b/tests/unit/mcp/tools/test_auto_handler_resume_lines.py
@@ -2,13 +2,18 @@
 
 These tests assert that :func:`ouroboros.mcp.tools.auto_handler._format_result`
 emits the same capability-driven hint substrings as the CLI, but without Rich
-markup since MCP renders plain text.
+markup since MCP renders plain text. They also pin the metadata contract so
+that ``meta.resume_command`` only appears when the rendered text invites the
+client to resume.
 """
 
 from __future__ import annotations
 
+import asyncio
+from typing import Any
+
 from ouroboros.auto.pipeline import AutoPipelineResult
-from ouroboros.mcp.tools.auto_handler import _format_result
+from ouroboros.mcp.tools.auto_handler import AutoHandler, _format_result
 
 
 def _result(
@@ -54,3 +59,53 @@ def test_format_result_resume_capability_none_emits_no_resume_line() -> None:
     assert "Resume (partial)" not in output
     assert "Retry:" not in output
     assert "Start fresh" not in output
+
+
+# --- meta gating (#688 bot follow-up) ---------------------------------------
+
+
+class _StubAutoHandler(AutoHandler):
+    """Test double that bypasses pipeline construction."""
+
+    def __init__(self, fixture: AutoPipelineResult) -> None:
+        super().__init__()
+        self._fixture = fixture
+
+    async def _run(self, arguments: dict[str, Any]) -> AutoPipelineResult:  # type: ignore[override]
+        return self._fixture
+
+
+def _invoke(handler: AutoHandler) -> dict[str, Any]:
+    result = asyncio.run(handler.handle({}))
+    assert result.is_ok, result.error
+    return dict(result.value.meta)
+
+
+def test_handle_meta_includes_resume_capability_field() -> None:
+    handler = _StubAutoHandler(_result("retry"))
+    meta = _invoke(handler)
+    assert meta["resume_capability"] == "retry"
+
+
+def test_handle_meta_resume_command_gated_on_capability_resume() -> None:
+    handler = _StubAutoHandler(_result("resume"))
+    meta = _invoke(handler)
+    assert meta["resume_capability"] == "resume"
+    assert meta["resume_command"] == "ooo auto --resume auto_mcp"
+
+
+def test_handle_meta_resume_command_omitted_for_capability_none() -> None:
+    """Bot blocking finding (#724): NONE-capability sessions must not advertise
+    a resume_command in MCP metadata, otherwise clients will route users into
+    a guaranteed-failing ``--resume`` call."""
+    handler = _StubAutoHandler(_result("none", status="complete"))
+    meta = _invoke(handler)
+    assert meta["resume_capability"] == "none"
+    assert "resume_command" not in meta
+
+
+def test_handle_meta_resume_command_present_for_partial_resume() -> None:
+    handler = _StubAutoHandler(_result("partial_resume"))
+    meta = _invoke(handler)
+    assert meta["resume_capability"] == "partial_resume"
+    assert meta["resume_command"] == "ooo auto --resume auto_mcp"

--- a/tests/unit/mcp/tools/test_auto_handler_resume_lines.py
+++ b/tests/unit/mcp/tools/test_auto_handler_resume_lines.py
@@ -13,17 +13,26 @@ import asyncio
 from typing import Any
 
 from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.state import AutoResumeCapability
 from ouroboros.mcp.tools.auto_handler import AutoHandler, _format_result
 
 
 def _result(
-    capability: str, *, status: str = "blocked", session_id: str = "auto_mcp"
+    capability: AutoResumeCapability | str,
+    *,
+    status: str = "blocked",
+    session_id: str = "auto_mcp",
 ) -> AutoPipelineResult:
+    cap = (
+        capability
+        if isinstance(capability, AutoResumeCapability)
+        else AutoResumeCapability(capability)
+    )
     return AutoPipelineResult(
         status=status,
         auto_session_id=session_id,
         phase=status,
-        resume_capability=capability,
+        resume_capability=cap,
     )
 
 

--- a/tests/unit/mcp/tools/test_auto_handler_resume_lines.py
+++ b/tests/unit/mcp/tools/test_auto_handler_resume_lines.py
@@ -1,0 +1,56 @@
+"""Resume-hint rendering for the MCP ``ouroboros_auto`` surface (#688).
+
+These tests assert that :func:`ouroboros.mcp.tools.auto_handler._format_result`
+emits the same capability-driven hint substrings as the CLI, but without Rich
+markup since MCP renders plain text.
+"""
+
+from __future__ import annotations
+
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.mcp.tools.auto_handler import _format_result
+
+
+def _result(
+    capability: str, *, status: str = "blocked", session_id: str = "auto_mcp"
+) -> AutoPipelineResult:
+    return AutoPipelineResult(
+        status=status,
+        auto_session_id=session_id,
+        phase=status,
+        resume_capability=capability,
+    )
+
+
+def test_format_result_resume_capability_resume_emits_resume_line() -> None:
+    output = _format_result(_result("resume", status="complete"))
+
+    assert "Resume: ooo auto --resume auto_mcp" in output
+    assert "Resume (partial)" not in output
+    assert "Retry:" not in output
+    assert "Start fresh" not in output
+
+
+def test_format_result_resume_capability_partial_emits_partial_resume_line() -> None:
+    output = _format_result(_result("partial_resume"))
+
+    assert "Resume (partial): ooo auto --resume auto_mcp" in output
+    assert "some progress preserved but the exact pick-up point may be approximate" in output
+
+
+def test_format_result_resume_capability_retry_emits_retry_line() -> None:
+    output = _format_result(_result("retry"))
+
+    assert "Retry: ooo auto --resume auto_mcp" in output
+    assert "no prior session context" in output
+    assert "re-runs the failed step from scratch" in output
+
+
+def test_format_result_resume_capability_none_emits_no_resume_line() -> None:
+    """``_format_result`` has no ``state.goal`` so NONE prints nothing."""
+    output = _format_result(_result("none", status="complete"))
+
+    assert "Resume:" not in output
+    assert "Resume (partial)" not in output
+    assert "Retry:" not in output
+    assert "Start fresh" not in output


### PR DESCRIPTION
## Summary
Closes #688 by making the `Resume:` / `Retry:` hint match what `--resume` actually does in each blocked state.

- New `AutoPipelineResult.resume_capability` enum with state classifier helper.
- Matrix renderer keyed on `(interview_session_id, pending_question, phase, last_tool_name)`.
- `interview.start` timeout w/ null id → "retry available"; persisted id → "resume available"; `seed_generator` regen → RETRY; `run_start_attempted` w/o handle → NONE.
- MCP `resume_command` meta gated on capability (no misleading hint when retry is the real path).
- Shell-quote + Rich-escape the goal in the "Start fresh" hint to handle quotes / shell metacharacters.
- Tests cover the full resume capability matrix and the CLI / MCP rendering surfaces.

## Acceptance check (vs #688 body)
- [x] Helper that computes resume capability from auto state.
- [x] CLI message matrix on `(interview_session_id, pending_question, phase, last_tool_name)`.
- [x] `interview.start` timeout-with-null-id rendered as `retry available`.
- [x] Persisted-id case rendered as `resume available`.
- [x] CLI output / state transition tests.

## Why this PR exists
Earlier attempts (#714, #724) closed without merge. This branch carries the work that landed locally and pulls it forward onto current `main` after the #686/#687/#690/#700 churn. Single coherent #688 closer.

## #692 follow-up
This was the last open leaf in the #692 epic (children #686, #687, #689, #690, #691 all closed). After this PR merges, #692 is also closeable.

## Test plan
- `pytest tests/unit/auto/test_state.py tests/unit/cli/test_auto_command.py`
- `pytest tests -k 'auto and resume'`
- CI green on Python 3.12 / 3.13 / 3.14

Refs #692