### PR TITLE
feat(auto): expose ledger provenance in pipeline result meta as ledger_provenance (#640)

### DIFF
--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -47,6 +47,40 @@ REQUIRED_SECTIONS = (
 )
 
 
+# Invariant: a section is "evidence-backed" only when its resolution is
+# anchored in something the user said, something we read off the repo, an
+# existing convention we can point to, or an explicit user-stated non-goal.
+# INFERENCE entries are model-derived guesses (not anchored in any of the
+# above) and therefore land in ``assumption_only_sections`` — the whole point
+# of this surface is to let MCP clients distinguish trustable evidence from
+# speculative content, so inferred reasoning must not be presented as grounded.
+_EVIDENCE_BACKED_SOURCES: frozenset[LedgerSource] = frozenset(
+    {
+        LedgerSource.USER_GOAL,
+        LedgerSource.REPO_FACT,
+        LedgerSource.EXISTING_CONVENTION,
+        LedgerSource.NON_GOAL,
+    }
+)
+
+_INACTIVE_STATUSES: frozenset[LedgerStatus] = frozenset(
+    {
+        LedgerStatus.WEAK,
+        LedgerStatus.CONFLICTING,
+        LedgerStatus.BLOCKED,
+    }
+)
+
+
+_RESOLVED_STATUSES: frozenset[LedgerStatus] = frozenset(
+    {
+        LedgerStatus.CONFIRMED,
+        LedgerStatus.DEFAULTED,
+        LedgerStatus.INFERRED,
+    }
+)
+
+
 @dataclass(slots=True)
 class LedgerEntry:
     """A single machine-readable fact in the Seed Draft Ledger."""
@@ -292,6 +326,23 @@ class SeedDraftLedger:
     def summary(self) -> dict[str, Any]:
         """Return a bounded summary suitable for CLI/MCP output."""
         statuses = self.section_statuses()
+        # Only resolved sections (CONFIRMED/DEFAULTED/INFERRED) appear in the
+        # provenance surface.  Sections that are still MISSING/WEAK/CONFLICTING/
+        # BLOCKED at the aggregate level are reported via ``open_gaps`` instead,
+        # so a section with a defaulted entry plus a later blocker is not
+        # misrepresented as grounded in either the raw provenance map or the
+        # derived evidence/assumption classification.
+        resolved_sections = {
+            name for name, status in statuses.items() if status in _RESOLVED_STATUSES
+        }
+        provenance = self._provenance_index(resolved_sections)
+        evidence_backed_set = {
+            section
+            for source in _EVIDENCE_BACKED_SOURCES
+            for section in provenance.get(source.value, ())
+        }
+        evidence_backed = sorted(evidence_backed_set)
+        assumption_only = sorted(resolved_sections - evidence_backed_set)
         return {
             "complete_sections": [
                 name
@@ -313,7 +364,28 @@ class SeedDraftLedger:
                 for entry in section.entries
                 if entry.key.startswith("risk.")
             ],
+            "provenance": provenance,
+            "evidence_backed_sections": evidence_backed,
+            "assumption_only_sections": assumption_only,
         }
+
+    def _provenance_index(self, resolved_sections: set[str]) -> dict[str, list[str]]:
+        """Group resolved section names by ledger source for #640 surface visibility.
+
+        ``resolved_sections`` is the set of sections whose aggregate status is
+        CONFIRMED/DEFAULTED/INFERRED.  Sections still in
+        MISSING/WEAK/CONFLICTING/BLOCKED are excluded so the surface never
+        attributes a source to a section the ledger reports as unresolved.
+        """
+        index: dict[str, set[str]] = {source.value: set() for source in LedgerSource}
+        for section in self.sections.values():
+            if section.name not in resolved_sections:
+                continue
+            for entry in section.entries:
+                if entry.status in _INACTIVE_STATUSES:
+                    continue
+                index[entry.source.value].add(section.name)
+        return {key: sorted(values) for key, values in index.items() if values}
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the ledger."""

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -72,6 +72,9 @@ class AutoPipelineResult:
     ``AutoPipelineResult(...)`` keep their historical behavior.
     ``AutoPipeline._result()`` overrides it from the persisted state's
     :meth:`AutoPipelineState.resume_capability`."""
+    ledger_provenance: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    evidence_backed_sections: tuple[str, ...] = ()
+    assumption_only_sections: tuple[str, ...] = ()
 
 
 @dataclass(slots=True)
@@ -479,6 +482,10 @@ class AutoPipeline:
         run_subagent: dict[str, Any] | None = None,
         status_override: str | None = None,
     ) -> AutoPipelineResult:
+        summary = ledger.summary()
+        ledger_provenance = {
+            source: tuple(sections) for source, sections in summary.get("provenance", {}).items()
+        }
         return AutoPipelineResult(
             status=status_override or state.phase.value,
             auto_session_id=state.auto_session_id,
@@ -513,6 +520,9 @@ class AutoPipeline:
             provenance=dict(state.provenance) if state.provenance else None,
             last_authoring_backend=state.last_authoring_backend,
             resume_capability=state.resume_capability(),
+            ledger_provenance=ledger_provenance,
+            evidence_backed_sections=tuple(summary.get("evidence_backed_sections", ())),
+            assumption_only_sections=tuple(summary.get("assumption_only_sections", ())),
         )
 
     def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -281,6 +281,15 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["run_reconciliation_status"] = result.run_reconciliation_status
         meta["run_reconciliation_source"] = result.run_reconciliation_source
         meta["run_reconciled_at"] = result.run_reconciled_at
+    # Always emit the ledger-provenance surface so MCP clients can distinguish
+    # "computed and empty" (no resolved sections yet, or no per-source split
+    # available) from "field not provided at all".  Empty containers are part
+    # of the contract — consumers should treat absence as a protocol error.
+    meta["ledger_provenance"] = {
+        source: list(sections) for source, sections in result.ledger_provenance.items()
+    }
+    meta["evidence_backed_sections"] = list(result.evidence_backed_sections)
+    meta["assumption_only_sections"] = list(result.assumption_only_sections)
     return meta
 
 

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -1555,3 +1555,187 @@ def test_auto_answerer_routes_safe_regulated_product_questions_to_product_behavi
         assert regulated_noun in combined.lower(), (
             f"Regulated noun {regulated_noun!r} not found in answer/ledger for {question!r}"
         )
+
+
+def test_ledger_summary_groups_active_sections_by_provenance_source() -> None:
+    ledger = SeedDraftLedger.from_goal("Build hello CLI")
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime.repo_fact",
+            value="Python 3.14",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.9,
+            status=LedgerStatus.CONFIRMED,
+            evidence=["pyproject.toml"],
+        ),
+    )
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.mvp",
+            value="Smallest safe MVP",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.assumed",
+            value="Single local user",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.7,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    summary = ledger.summary()
+    provenance = summary["provenance"]
+
+    assert "runtime_context" in provenance["repo_fact"]
+    assert "goal" in provenance["user_goal"]
+    assert "constraints" in provenance["conservative_default"]
+    assert "actors" in provenance["assumption"]
+    assert "runtime_context" in summary["evidence_backed_sections"]
+    assert "goal" in summary["evidence_backed_sections"]
+    assert "constraints" in summary["assumption_only_sections"]
+    assert "actors" in summary["assumption_only_sections"]
+    assert "runtime_context" not in summary["assumption_only_sections"]
+
+
+def test_ledger_summary_excludes_inactive_entries_from_provenance() -> None:
+    ledger = SeedDraftLedger.from_goal("Build hello CLI")
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime.weak_guess",
+            value="maybe Python",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.4,
+            status=LedgerStatus.WEAK,
+        ),
+    )
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.blocked",
+            value="needs human input",
+            source=LedgerSource.BLOCKER,
+            confidence=1.0,
+            status=LedgerStatus.BLOCKED,
+        ),
+    )
+
+    summary = ledger.summary()
+    provenance = summary["provenance"]
+
+    assert "runtime_context" not in provenance.get("repo_fact", [])
+    assert "constraints" not in provenance.get("blocker", [])
+    assert "runtime_context" not in summary["evidence_backed_sections"]
+    assert "runtime_context" not in summary["assumption_only_sections"]
+    assert "constraints" not in summary["assumption_only_sections"]
+
+
+def test_ledger_summary_excludes_unresolved_sections_from_classification() -> None:
+    """Sections that are not aggregate-resolved must not surface as grounded.
+
+    A section can carry both a resolved entry (DEFAULTED) and a later blocker
+    (BLOCKED), in which case ``LedgerSection.status()`` returns ``BLOCKED``.
+    The provenance summary must respect the section's aggregate status so
+    consumers do not see ``constraints`` listed as "evidence-backed" or
+    "assumption-only" while the section is actually unresolved.
+    """
+    ledger = SeedDraftLedger.from_goal("Build hello CLI")
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.mvp",
+            value="Smallest safe MVP",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="blocker.constraints",
+            value="needs human input",
+            source=LedgerSource.BLOCKER,
+            confidence=1.0,
+            status=LedgerStatus.BLOCKED,
+        ),
+    )
+
+    summary = ledger.summary()
+    assert ledger.sections["constraints"].status() == LedgerStatus.BLOCKED
+    assert "constraints" not in summary["evidence_backed_sections"]
+    assert "constraints" not in summary["assumption_only_sections"]
+    assert "constraints" in summary["open_gaps"]
+    # The raw provenance dict must also exclude unresolved sections so MCP
+    # consumers cannot attribute a source to a section the ledger considers
+    # blocked.
+    for source_sections in summary["provenance"].values():
+        assert "constraints" not in source_sections
+
+
+def test_ledger_summary_treats_non_goal_entries_as_evidence_backed() -> None:
+    """Explicit non-goals are user-stated policy, not bare assumptions.
+
+    Both user-supplied non-goals (CONFIRMED) and auto-defaulted non-goals
+    (DEFAULTED) represent deliberate scope boundaries, so the section should
+    surface as evidence-backed rather than assumption-only.
+    """
+    explicit_ledger = SeedDraftLedger.from_goal(
+        "Build hello CLI. Non-goals are cloud sync and authentication."
+    )
+    explicit_summary = explicit_ledger.summary()
+
+    assert "non_goals" in explicit_summary["provenance"].get("non_goal", [])
+    assert "non_goals" in explicit_summary["evidence_backed_sections"]
+    assert "non_goals" not in explicit_summary["assumption_only_sections"]
+
+    defaulted_ledger = SeedDraftLedger.from_goal("Build hello CLI")
+    defaulted_ledger.add_entry(
+        "non_goals",
+        LedgerEntry(
+            key="non_goals.mvp_scope",
+            value="No cloud sync; no paid services.",
+            source=LedgerSource.NON_GOAL,
+            confidence=0.86,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    defaulted_summary = defaulted_ledger.summary()
+
+    assert "non_goals" in defaulted_summary["evidence_backed_sections"]
+    assert "non_goals" not in defaulted_summary["assumption_only_sections"]
+
+
+def test_ledger_summary_treats_inference_only_sections_as_assumption_only() -> None:
+    """Inference is a model-derived guess, not anchored evidence.
+
+    A section resolved purely from INFERENCE entries must surface in
+    ``assumption_only_sections``, never in ``evidence_backed_sections`` —
+    otherwise the surface would present speculative content as grounded fact
+    and defeat the trust-signal purpose of the split.
+    """
+    ledger = SeedDraftLedger.from_goal("Build hello CLI")
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.inferred",
+            value="Local developer",
+            source=LedgerSource.INFERENCE,
+            confidence=0.7,
+            status=LedgerStatus.INFERRED,
+        ),
+    )
+
+    summary = ledger.summary()
+
+    assert "actors" in summary["provenance"].get("inference", [])
+    assert "actors" not in summary["evidence_backed_sections"]
+    assert "actors" in summary["assumption_only_sections"]

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -484,6 +484,9 @@ async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> No
         "job_id": "job_1",
         "run_session_id": "session_1",
         "pending_question": "Which runtime should be used?",
+        "ledger_provenance": {},
+        "evidence_backed_sections": [],
+        "assumption_only_sections": [],
     }
 
 
@@ -1608,8 +1611,12 @@ def test_print_result_renders_seed_origin_line() -> None:
     assert "Seed origin: auto_pipeline" in output
 
 
-def test_mcp_format_result_renders_seed_origin_line() -> None:
-    """The MCP text body must surface the seed_origin field too."""
+def test_format_result_keeps_evidence_provenance_out_of_user_text() -> None:
+    """Detailed provenance should live in MCP meta, not in the human-readable body.
+
+    The user-facing text stays simple (status/phase/grade/seed_path/etc.); rich
+    provenance breakdown is consumed by clients via ``MCPToolResult.meta``.
+    """
     from ouroboros.auto.pipeline import AutoPipelineResult
     from ouroboros.mcp.tools.auto_handler import _format_result
 
@@ -1624,7 +1631,9 @@ def test_mcp_format_result_renders_seed_origin_line() -> None:
 
     text = _format_result(result)
 
-    assert "Seed origin: auto_pipeline" in text
+    assert "Evidence:" not in text
+    assert "evidence-backed" not in text
+    assert "assumption-only" not in text
 
 
 @pytest.mark.asyncio
@@ -1870,3 +1879,82 @@ async def test_auto_pipeline_marks_seed_origin_after_seed_generation(tmp_path) -
 
     assert state.seed_origin is SeedOrigin.AUTO_PIPELINE
     assert result.seed_origin == "auto_pipeline"
+
+
+def test_format_result_omits_evidence_block_when_unknown() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _format_result
+
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_test",
+        phase="complete",
+    )
+
+    text = _format_result(result)
+
+    assert "Evidence:" not in text
+    assert "evidence-backed" not in text
+    assert "assumption-only" not in text
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_meta_exposes_ledger_provenance_breakdown(monkeypatch) -> None:
+    async def fake_run(self, arguments):  # noqa: ARG001
+        from ouroboros.auto.pipeline import AutoPipelineResult
+
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+            ledger_provenance={
+                "user_goal": ("goal", "actors"),
+                "repo_fact": ("runtime_context",),
+                "conservative_default": ("constraints",),
+            },
+            evidence_backed_sections=("actors", "goal", "runtime_context"),
+            assumption_only_sections=("constraints",),
+        )
+
+    monkeypatch.setattr(AutoHandler, "_run", fake_run)
+
+    result = await AutoHandler().handle({"goal": "Build a CLI"})
+
+    assert result.is_ok
+    meta = result.value.meta
+    assert meta["ledger_provenance"] == {
+        "user_goal": ["goal", "actors"],
+        "repo_fact": ["runtime_context"],
+        "conservative_default": ["constraints"],
+    }
+    assert meta["evidence_backed_sections"] == ["actors", "goal", "runtime_context"]
+    assert meta["assumption_only_sections"] == ["constraints"]
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_meta_always_emits_provenance_keys_when_empty(monkeypatch) -> None:
+    """Empty provenance must still surface as ``[]``/``{}``, not be omitted.
+
+    The contract distinguishes "computed and empty" from "field not provided",
+    so MCP clients can treat absence of these keys as a protocol error rather
+    than silently degrading to defaults.
+    """
+
+    async def fake_run(self, arguments):  # noqa: ARG001
+        from ouroboros.auto.pipeline import AutoPipelineResult
+
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+        )
+
+    monkeypatch.setattr(AutoHandler, "_run", fake_run)
+
+    result = await AutoHandler().handle({"goal": "Build a CLI"})
+
+    assert result.is_ok
+    meta = result.value.meta
+    assert meta["ledger_provenance"] == {}
+    assert meta["evidence_backed_sections"] == []
+    assert meta["assumption_only_sections"] == []


### PR DESCRIPTION
## Summary
Re-do of #693, addressing @Q00's prior `CHANGES_REQUESTED` feedback:

> adding an Evidence block to the human-readable MCP result plus multiple meta fields increases Program and UserLevel surface area. Please keep detailed provenance in structured meta/status and make the default user text simpler.

The final commit (`ux(auto): keep provenance breakdown in meta only, not in user text`) drops the Evidence block from the user-facing text. Provenance now lives in `result.meta` / `result.status.provenance` only. The default user text is unchanged from `main` aside from one short status line.

Renamed from the original `provenance` to `ledger_provenance` to coexist with @Q00's #691 gateway-source `provenance` field that landed on `main` after the original PR. The rename additionally honors Q00's "minimize surface area" feedback by keeping the new key explicitly namespaced.

## Scope
- `AutoPipelineResult.ledger_provenance` (meta only) carrying:
  - `evidence_backed_sections`
  - `assumption_only_sections`
  - per-section `LedgerSource` summary (raw dict, gated)
- `ouroboros_auto` MCP `result.meta["ledger_provenance"]` mirror.
- `non_goals` classified as evidence-backed in the provenance summary (correctness fix).
- Raw per-section provenance dict is gated on resolved section status — does not leak before the section settles.
- Both `provenance` (gateway/source, from #691) and `ledger_provenance` (ledger evidence) coexist on `AutoPipelineResult` with distinct types and semantics.

## Bot history
The original PR #693 had `ouroboros-agent[bot]` APPROVE on commit `e71f081` (the final commit included here). Q00's scope feedback was the only remaining blocker, and this branch's last commit explicitly addresses it.

## Test plan
- `pytest tests/unit/auto/test_ledger_grading_answerer.py`
- `pytest tests/unit/auto -k provenance`

Refs #640 (closing criteria 1/2 — paired with the risky-fallback gate PR for the second half)