### PR TITLE
feat(hook): route 'ooo publish' and 'ooo resume-session' keywords

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -31,10 +31,13 @@ _configure_utf8_stdio()
 
 # Skills that work without MCP setup (bypass the setup gate)
 # qa has a built-in fallback that adopts the qa-judge agent directly
+# resume-session reads the EventStore directly — its purpose is recovering after
+# an MCP disconnect, so the no-MCP path is exactly when the user needs it.
 SETUP_BYPASS_SKILLS = [
     "/ouroboros:setup",
     "/ouroboros:help",
     "/ouroboros:qa",
+    "/ouroboros:resume-session",
 ]
 
 # Keyword → skill mapping

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -63,7 +63,11 @@ KEYWORD_MAP = [
     {"patterns": ["ooo update", "ooo upgrade"], "skill": "/ouroboros:update"},
     {"patterns": ["ooo brownfield"], "skill": "/ouroboros:brownfield"},
     {"patterns": ["ooo publish"], "skill": "/ouroboros:publish"},
-    {"patterns": ["ooo resume-session", "ooo resume"], "skill": "/ouroboros:resume-session"},
+    # Canonical form only. The short `ooo resume` alias was rejected because
+    # word-boundary matching would route prose like "please ooo resume work on
+    # this" to /ouroboros:resume-session, and skills/resume-session/SKILL.md
+    # explicitly chose the hyphenated name to avoid /resume collision.
+    {"patterns": ["ooo resume-session"], "skill": "/ouroboros:resume-session"},
     # Natural language triggers
     # PM triggers must precede generic interview to avoid "pm interview" being shadowed
     {

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -59,6 +59,8 @@ KEYWORD_MAP = [
     {"patterns": ["ooo cancel", "ooo abort"], "skill": "/ouroboros:cancel"},
     {"patterns": ["ooo update", "ooo upgrade"], "skill": "/ouroboros:update"},
     {"patterns": ["ooo brownfield"], "skill": "/ouroboros:brownfield"},
+    {"patterns": ["ooo publish"], "skill": "/ouroboros:publish"},
+    {"patterns": ["ooo resume-session", "ooo resume"], "skill": "/ouroboros:resume-session"},
     # Natural language triggers
     # PM triggers must precede generic interview to avoid "pm interview" being shadowed
     {

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -139,6 +139,11 @@ class TestSetupBypass:
         assert "/ouroboros:setup" in SETUP_BYPASS_SKILLS
         assert "/ouroboros:help" in SETUP_BYPASS_SKILLS
 
+    def test_resume_session_in_bypass_list(self):
+        # resume-session reads the EventStore directly and is meant to be used
+        # exactly when the MCP server is unreachable. It must bypass the gate.
+        assert "/ouroboros:resume-session" in SETUP_BYPASS_SKILLS
+
 
 class TestMainGate:
     """When MCP is not configured, bypass skills should NOT redirect to setup."""
@@ -204,3 +209,23 @@ class TestMainGate:
         out = capsys.readouterr().out
         assert "/ouroboros:auto" in out
         assert "/ouroboros:setup" not in out
+
+    @patch.object(_mod, "is_mcp_configured", return_value=False)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_resume_session_bypasses_setup_gate(self, _first, _mcp, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "ooo resume-session"
+            main()
+        out = capsys.readouterr().out
+        assert "/ouroboros:setup" not in out
+        assert "/ouroboros:resume-session" in out
+
+    @patch.object(_mod, "is_mcp_configured", return_value=False)
+    @patch.object(_mod, "is_first_time", return_value=False)
+    def test_resume_short_alias_bypasses_setup_gate(self, _first, _mcp, capsys):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.read.return_value = "ooo resume"
+            main()
+        out = capsys.readouterr().out
+        assert "/ouroboros:setup" not in out
+        assert "/ouroboros:resume-session" in out

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -108,6 +108,26 @@ class TestDetectKeywords:
             "bare 'autopilot' should not route to ooo auto"
         )
 
+    def test_ooo_publish_detected(self):
+        result = detect_keywords("ooo publish")
+        assert result["detected"] is True
+        assert result["suggested_skill"] == "/ouroboros:publish"
+
+    def test_ooo_publish_with_args(self):
+        result = detect_keywords("ooo publish --dry-run")
+        assert result["detected"] is True
+        assert result["suggested_skill"] == "/ouroboros:publish"
+
+    def test_ooo_resume_session_detected(self):
+        result = detect_keywords("ooo resume-session")
+        assert result["detected"] is True
+        assert result["suggested_skill"] == "/ouroboros:resume-session"
+
+    def test_ooo_resume_short_alias(self):
+        result = detect_keywords("ooo resume")
+        assert result["detected"] is True
+        assert result["suggested_skill"] == "/ouroboros:resume-session"
+
 
 class TestSetupBypass:
     """qa skill has a no-MCP fallback, so it must bypass the setup gate."""

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -123,10 +123,24 @@ class TestDetectKeywords:
         assert result["detected"] is True
         assert result["suggested_skill"] == "/ouroboros:resume-session"
 
-    def test_ooo_resume_short_alias(self):
-        result = detect_keywords("ooo resume")
+    def test_ooo_resume_session_with_args(self):
+        result = detect_keywords("ooo resume-session --all")
         assert result["detected"] is True
         assert result["suggested_skill"] == "/ouroboros:resume-session"
+
+    def test_ooo_resume_prose_does_not_route(self):
+        # Guards the canonical-form-only decision: a prose mention of "ooo
+        # resume" inside a sentence must NOT route to resume-session, because
+        # word-boundary matching would otherwise mis-suggest session recovery
+        # for ordinary text like "please ooo resume work on this".
+        result = detect_keywords("please ooo resume work on this")
+        assert result["suggested_skill"] != "/ouroboros:resume-session"
+
+    def test_ooo_resume_bare_does_not_route(self):
+        # The bare short form is intentionally unsupported — users must type
+        # the unambiguous canonical "ooo resume-session".
+        result = detect_keywords("ooo resume")
+        assert result["suggested_skill"] != "/ouroboros:resume-session"
 
 
 class TestSetupBypass:
@@ -222,9 +236,9 @@ class TestMainGate:
 
     @patch.object(_mod, "is_mcp_configured", return_value=False)
     @patch.object(_mod, "is_first_time", return_value=False)
-    def test_resume_short_alias_bypasses_setup_gate(self, _first, _mcp, capsys):
+    def test_resume_session_with_args_bypasses_setup_gate(self, _first, _mcp, capsys):
         with patch("sys.stdin") as mock_stdin:
-            mock_stdin.read.return_value = "ooo resume"
+            mock_stdin.read.return_value = "ooo resume-session --all"
             main()
         out = capsys.readouterr().out
         assert "/ouroboros:setup" not in out


### PR DESCRIPTION
## Summary

Two `ooo` subcommands are documented and have skills shipped, but the UserPromptSubmit keyword detector never routes to them:

| Command | Skill file | Documented in CLAUDE.md? | In `KEYWORD_MAP`? |
|---|---|---|---|
| `ooo publish` | `skills/publish/SKILL.md` | yes (row in ooo table) | **no** |
| `ooo resume-session` | `skills/resume-session/SKILL.md` | yes (row in ooo table) | **no** |

So typing `ooo publish ...` or `ooo resume-session` produces no `<skill-suggestion>` output. With other Claude Code plugins installed alongside Ouroboros, those plugins' UserPromptSubmit hooks then own the prompt by default.

This PR fills in the missing inventory entries to match what is already documented and shipped, and keeps the setup-gate routing in lockstep with the new entries.

## Changes

- `scripts/keyword-detector.py`:
  - Add `{"patterns": ["ooo publish"], "skill": "/ouroboros:publish"}`.
  - Add `{"patterns": ["ooo resume-session"], "skill": "/ouroboros:resume-session"}` — canonical form only. The short `ooo resume` alias was tried and rejected after bot review: with word-boundary matching, prose like *"please ooo resume work on this"* would silently route to `/ouroboros:resume-session`, and `skills/resume-session/SKILL.md` explicitly chose the hyphenated name to avoid Claude Code's reserved `/resume` collision. Keeping a non-hyphenated alias would re-introduce the ambiguity the canonical name was picked to avoid.
  - Add `/ouroboros:resume-session` to `SETUP_BYPASS_SKILLS`. The skill reads `~/.ouroboros/ouroboros.db` directly via the CLI and is specifically designed for the case where the MCP server is unreachable — without the bypass, the setup gate would redirect the very command meant to recover from a broken MCP setup.
  - Publish stays gated. `skills/publish/SKILL.md` reads from `~/.ouroboros/seeds/`, which is the seed flow bootstrapped by setup, so the no-MCP redirect is the right UX nudge for it.
- `tests/unit/scripts/test_keyword_detector.py`:
  - Detection: `ooo publish`, `ooo publish --dry-run`, `ooo resume-session`, `ooo resume-session --all`.
  - Negative regression: prose containing `ooo resume` and bare `ooo resume` must not route to `resume-session`.
  - Bypass list: `/ouroboros:resume-session in SETUP_BYPASS_SKILLS`.
  - Main gate: with MCP unconfigured, `ooo resume-session` and `ooo resume-session --all` reach the matched-skill branch (not the setup-redirect branch).

## Test plan

- [x] `pytest tests/unit/scripts/test_keyword_detector.py` — 27 passed.
- [x] CI green on the latest commit (Ruff Lint, MyPy Type Check, Bridge TypeScript, Test Python 3.12/3.13/3.14).
- [ ] Manual: in a Claude Code session, type `ooo publish` and confirm a `<skill-suggestion>` block points at `/ouroboros:publish`.
- [ ] Manual: type `ooo resume-session` and confirm it routes to `/ouroboros:resume-session` even with no MCP configured.

## Out of scope

- Inter-plugin keyword arbitration. As with the companion PR for `ooo auto`, this is a strict inventory fix — no new defenses against other plugins' hooks.

## Related

Companion to #741 (`ooo auto` keyword). The two PRs are independent and can be merged in either order.