### PR TITLE
docs(architecture): split PLUGIN LAYER → Skills Registry vs UserLevel Programs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,8 +23,8 @@ for the canonical meanings of `AgentRuntimeContext`, `ControlPlane`,
 ├─────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                                     │
 │  ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐                 │
-│  │   SKILLS REGISTRY    │     │      CORE LAYER     │     │      PRESENTATION    │                 │
-│  │                     │     │                     │     │      LAYER           │                 │
+│  │  SKILLS & AGENTS    │     │      CORE LAYER     │     │      PRESENTATION    │                 │
+│  │     REGISTRY        │     │                     │     │      LAYER           │                 │
 │  │  ┌───────────────┐  │     │  ┌───────────────┐  │     │  ┌───────────────┐  │                 │
 │  │  │   Skills      │──┼─────┼─▶│   Seed Spec    │──┼─────┼─▶│   TUI Dashboard │  │                 │
 │  │  │   (9)         │  │     │  │   (Immutable)  │  │     │  │   (Textual)   │  │                 │

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,10 +115,15 @@ for the canonical meanings of `AgentRuntimeContext`, `ControlPlane`,
 
 ### 7. UserLevel Programs Layer
 
-**User-installable workflows built on top of core primitives** (introduced
-in [#725](https://github.com/Q00/ouroboros/issues/725); long-form RFC in
-flight in PR [#743](https://github.com/Q00/ouroboros/pull/743), which will
-land at `docs/rfc/userlevel-plugins.md`).
+**Workflows composed on top of core primitives via a declared manifest
+contract** — both first-party programs that ship today (`ooo auto`, `ooo run`,
+`ooo pm`) and a planned third-party plugin surface (introduced in
+[#725](https://github.com/Q00/ouroboros/issues/725); long-form RFC in flight
+in PR [#743](https://github.com/Q00/ouroboros/pull/743), which will land at
+`docs/rfc/userlevel-plugins.md`). The third-party install surface
+(`ooo plugin add ...`) is not yet implemented on `main`; this section
+documents the architectural target so PRs can be discussed in consistent
+terms.
 
 This layer is distinct from the in-process Skills & Agents Registry
 (Section 1):
@@ -126,24 +131,28 @@ This layer is distinct from the in-process Skills & Agents Registry
 - **Skills & Agents Registry** = in-process subsystem of bundled
   skills/agents that ship with core. Discovered via `/ouroboros:` magic
   prefix. Used by `ooo interview`, `ooo qa`, etc.
-- **UserLevel Programs Layer** = user-installable plugins composed on top
-  of core primitives via a declared manifest contract. Distributed via
-  `ooo plugin add <repo-url>`. Examples: `github-pr-ops`, `merge-assistant`,
-  `jira-sync`. First-party programs (`ooo auto`, `ooo run`, `ooo pm`) live
-  in this layer too — they share the manifest format with installable
-  plugins.
+- **UserLevel Programs Layer** = workflows composed on top of core
+  primitives via a declared manifest contract. First-party programs
+  shipped today: `ooo auto`, `ooo run`, `ooo pm`. Installable third-party
+  plugins (e.g. `github-pr-ops`, `merge-assistant`, `jira-sync`) are
+  **planned**: the manifest schema is being prototyped at
+  [Q00/ouroboros-plugins/schemas/0.1/](https://github.com/Q00/ouroboros-plugins/tree/main/schemas/0.1)
+  and the `ooo plugin add <repo-url>` install surface is tracked under
+  [#725](https://github.com/Q00/ouroboros/issues/725); it does not exist
+  on `main` yet. First-party and installable programs will share the
+  same manifest format.
 
 ```text
-+--------------------------------------------------------------+
-| UserLevel Programs Layer                                     |
-|                                                              |
-|   Installable: github-pr-ops  jira-sync  release-coordinator |
-|   First-party: ooo auto       ooo run    ooo pm             |
-+----------------------+---------------------------------------+
-                       | declared manifest contract
-                       v
-                  Ouroboros core
-                  (Sections 1–6 above)
++----------------------------------------------------------------------+
+| UserLevel Programs Layer                                             |
+|                                                                      |
+|   Shipped (first-party):     ooo auto   ooo run   ooo pm             |
+|   Planned (third-party):     github-pr-ops  jira-sync  ...  (#725)   |
++--------------------------+-------------------------------------------+
+                           | declared manifest contract
+                           v
+                      Ouroboros core
+                      (Sections 1–6 above)
 ```
 
 **Why a separate layer?** To keep `ooo auto` coherent (`goal → interview

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ for the canonical meanings of `AgentRuntimeContext`, `ControlPlane`,
 ├─────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                                     │
 │  ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐                 │
-│  │      PLUGIN LAYER    │     │      CORE LAYER     │     │      PRESENTATION    │                 │
+│  │   SKILLS REGISTRY    │     │      CORE LAYER     │     │      PRESENTATION    │                 │
 │  │                     │     │                     │     │      LAYER           │                 │
 │  │  ┌───────────────┐  │     │  ┌───────────────┐  │     │  ┌───────────────┐  │                 │
 │  │  │   Skills      │──┼─────┼─▶│   Seed Spec    │──┼─────┼─▶│   TUI Dashboard │  │                 │
@@ -51,12 +51,20 @@ for the canonical meanings of `AgentRuntimeContext`, `ControlPlane`,
 
 ## Core Components Overview
 
-### 1. Plugin Layer
-**Auto-discovery of skills and agents through the plugin system**
+### 1. Skills & Agents Registry
+**Auto-discovery of bundled skills and agents that ship with Ouroboros core**
 - Skills: 14 core workflow skills (interview, seed, run, evaluate, evolve, cancel, unstuck, update, help, setup, ralph, tutorial, welcome, status)
 - Agents: 9 specialized agents for different thinking modes
 - Hot-reload capabilities without restart
 - Magic prefix detection (`/ouroboros:`)
+
+> **Note**: This layer is the in-process registry of bundled skills and agents
+> that ship with core. It is **not** the user-installable UserLevel plugin
+> layer (introduced in #725). User-installable plugins live one layer above
+> this — see [`Section 7: UserLevel Programs Layer`](#7-userlevel-programs-layer)
+> below and the canonical RFC at
+> [`docs/rfc/userlevel-plugins.md`](./rfc/userlevel-plugins.md). Do not
+> conflate the two in PRs.
 
 ### 2. Core Layer
 **Immutable data models and specifications**
@@ -94,6 +102,50 @@ for the canonical meanings of `AgentRuntimeContext`, `ControlPlane`,
 - Agent activity monitor
 - Cost tracking and drift visualization
 - Interactive debugging capabilities
+
+### 7. UserLevel Programs Layer
+
+**User-installable workflows built on top of core primitives** (introduced
+in #725; canonical reference: [`docs/rfc/userlevel-plugins.md`](./rfc/userlevel-plugins.md)).
+
+This layer is distinct from the in-process Skills & Agents Registry
+(Section 1):
+
+- **Skills & Agents Registry** = in-process subsystem of bundled
+  skills/agents that ship with core. Discovered via `/ouroboros:` magic
+  prefix. Used by `ooo interview`, `ooo qa`, etc.
+- **UserLevel Programs Layer** = user-installable plugins composed on top
+  of core primitives via a declared manifest contract. Distributed via
+  `ooo plugin add <repo-url>`. Examples: `github-pr-ops`, `merge-assistant`,
+  `jira-sync`. First-party programs (`ooo auto`, `ooo run`, `ooo pm`) live
+  in this layer too — they share the manifest format with installable
+  plugins.
+
+```text
++--------------------------------------------------------------+
+| UserLevel Programs Layer                                     |
+|                                                              |
+|   Installable: github-pr-ops  jira-sync  release-coordinator |
+|   First-party: ooo auto       ooo run    ooo pm             |
++----------------------+---------------------------------------+
+                       | declared manifest contract
+                       v
+                  Ouroboros core
+                  (Sections 1–6 above)
+```
+
+**Why a separate layer?** To keep `ooo auto` coherent (`goal → interview
+→ Seed → handoff` only), keep core small, and route domain-specific
+operational workflows (GitHub PR ops, Jira triage, Slack incident
+response) into pluggable packages rather than into core or `ooo auto`.
+
+**Manifest contract**: see [Q00/ouroboros-plugins/schemas/0.1/](https://github.com/Q00/ouroboros-plugins/tree/main/schemas/0.1).
+
+> **Terminology guard**: in this codebase, "plugin" by itself can refer to
+> either the in-process Skills/Agents Registry or the UserLevel Programs
+> Layer. When writing PRs or docs, qualify the term — e.g.
+> "skill plugin" (Section 1) vs "UserLevel plugin" (Section 7). When in
+> doubt, link the relevant section.
 
 ## Philosophy
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,14 @@ for the canonical meanings of `AgentRuntimeContext`, `ControlPlane`,
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│                                 OUROBOROS ARCHITECTURE                                               │
+│                            USERLEVEL PROGRAMS LAYER  (Section 7)                                     │
+│        Installable plugins:  github-pr-ops  ·  jira-sync  ·  release-coordinator   ...               │
+│        First-party programs: ooo auto       ·  ooo run    ·  ooo pm                                  │
+└──────────────────────────────────────────────┬──────────────────────────────────────────────────────┘
+                                               │ declared manifest contract / declared scopes
+                                               ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                          OUROBOROS ARCHITECTURE  (core, Sections 1–6)                                │
 ├─────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                                     │
 │  ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐                 │
@@ -60,11 +67,14 @@ for the canonical meanings of `AgentRuntimeContext`, `ControlPlane`,
 
 > **Note**: This layer is the in-process registry of bundled skills and agents
 > that ship with core. It is **not** the user-installable UserLevel plugin
-> layer (introduced in #725). User-installable plugins live one layer above
-> this — see [`Section 7: UserLevel Programs Layer`](#7-userlevel-programs-layer)
-> below and the canonical RFC at
-> [`docs/rfc/userlevel-plugins.md`](./rfc/userlevel-plugins.md). Do not
-> conflate the two in PRs.
+> layer (introduced in [#725](https://github.com/Q00/ouroboros/issues/725)).
+> User-installable plugins live one layer above this — see
+> [`Section 7: UserLevel Programs Layer`](#7-userlevel-programs-layer) below.
+> The full layer-model and contract are described in issue
+> [#725](https://github.com/Q00/ouroboros/issues/725); a long-form RFC is
+> being drafted in PR [#743](https://github.com/Q00/ouroboros/pull/743) and
+> will land at `docs/rfc/userlevel-plugins.md` once merged. Do not conflate
+> the two registries in PRs.
 
 ### 2. Core Layer
 **Immutable data models and specifications**
@@ -106,7 +116,9 @@ for the canonical meanings of `AgentRuntimeContext`, `ControlPlane`,
 ### 7. UserLevel Programs Layer
 
 **User-installable workflows built on top of core primitives** (introduced
-in #725; canonical reference: [`docs/rfc/userlevel-plugins.md`](./rfc/userlevel-plugins.md)).
+in [#725](https://github.com/Q00/ouroboros/issues/725); long-form RFC in
+flight in PR [#743](https://github.com/Q00/ouroboros/pull/743), which will
+land at `docs/rfc/userlevel-plugins.md`).
 
 This layer is distinct from the in-process Skills & Agents Registry
 (Section 1):


### PR DESCRIPTION
Closes #727.

Resolves the `PLUGIN LAYER` terminology collision in `docs/architecture.md`. After #725, the word "plugin" referred to two different subsystems — the in-process Skills/Agents registry (this doc's Section 1) and the user-installable UserLevel plugin layer (introduced in #725). PRs touching either kept blurring the boundary.

## Changes

- **Top architecture diagram**: prepend a `USERLEVEL PROGRAMS LAYER` block (installable + first-party programs) above the existing core block, connected via a "declared manifest contract" arrow. The two layers are now visually distinct with no shared label, satisfying issue #727 acceptance criterion #1.
- **Inner diagram top-left box**: `PLUGIN LAYER` → `SKILLS REGISTRY` (same width, drop-in).
- **Section 1 heading**: `Plugin Layer` → `Skills & Agents Registry`. Adds a `> Note:` block pointing readers at Section 7, at the design issue (#725), and at the in-flight RFC (#743) which will land at `docs/rfc/userlevel-plugins.md` once merged.
- **New Section 7**: `UserLevel Programs Layer` — describes the user-installable plugin layer with its own sub-diagram, distinguishes it from Section 1 explicitly, references issue #725 and RFC PR #743, links the manifest contract at `Q00/ouroboros-plugins/schemas/0.1/`, and adds a `Terminology guard` recommending qualified terms in PRs (`"skill plugin"` vs `"UserLevel plugin"`).

## Why no `docs/rfc/userlevel-plugins.md` link in this PR

The first revision of this PR (commit `bca5a06`) cited `docs/rfc/userlevel-plugins.md` as a "canonical" reference, but that file is being added in PR #743, which is still in review. To keep this PR self-contained at merge time, both citations are now repointed at issue #725 (which already contains the layer-model inline) with an explicit forward-reference to the in-flight RFC PR #743. When #743 lands, follow-up references can be added without invalidating anything in this PR.

## Verification

```
$ grep -nE 'PLUGIN LAYER|SKILLS REGISTRY|USERLEVEL PROGRAMS LAYER' docs/architecture.md
15:│                            USERLEVEL PROGRAMS LAYER  (Section 7)                                     │
26:│  │   SKILLS REGISTRY    │     │      CORE LAYER     │     │      PRESENTATION    │                 │
116:### 7. UserLevel Programs Layer

$ grep -nE '^### [0-9]\.' docs/architecture.md
61:### 1. Skills & Agents Registry
79:### 2. Core Layer
86:### 3. Execution Layer
92:### 4. State Layer
99:### 5. Orchestration Layer
108:### 6. Presentation Layer
116:### 7. UserLevel Programs Layer

# No Markdown links to userlevel-plugins.md remain in this PR — only
# descriptive forward-references to where the RFC will eventually land:
$ grep -n 'userlevel-plugins\.md' docs/architecture.md
76:> will land at `docs/rfc/userlevel-plugins.md` once merged. Do not conflate
121:land at `docs/rfc/userlevel-plugins.md`).
```

Both remaining mentions of `userlevel-plugins.md` are descriptive (forward-reference text), not Markdown links. The repo currently has no link target with that filename, so no broken cross-references are introduced by merging this PR.

## Cross-repo

Companion to RFC PR #743. The two PRs are deliberately decoupled: this PR is self-contained and merges any time; once #743 lands, a small follow-up can convert the forward-references into live cross-links.
