### PR TITLE
feat(plugin): manifest loader + vendored 0.1 schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "aiosqlite>=0.20.0,<1.0.0",
     "anyio>=4.0.0,<5.0.0",
+    "jsonschema>=4.21.0,<5.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "prompt-toolkit>=3.0.0,<4.0.0",
     "pyyaml>=6.0.0,<7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ packages = ["src/ouroboros"]
 # the same wheel via this same config.
 exclude = [
     "src/ouroboros/opencode/plugin/**",
+    "src/ouroboros/plugin/schemas/**",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]
@@ -73,6 +74,11 @@ exclude = [
 # reliably finds ouroboros-bridge.ts / package.json / tsconfig.json in the
 # installed wheel, independent of hatchling's implicit asset handling.
 "src/ouroboros/opencode/plugin" = "ouroboros/opencode/plugin"
+# Same pattern for the vendored UserLevel plugin schemas — `_load_schema`
+# in `ouroboros.plugin.manifest` resolves them via `importlib.resources`,
+# so they must reach the installed wheel as package data, not just the
+# source tree.
+"src/ouroboros/plugin/schemas" = "ouroboros/plugin/schemas"
 
 [dependency-groups]
 dev = [

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -160,9 +160,7 @@ class PluginManifest:
     audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
 
 
-def _load_schema(
-    schema_version: str, *, manifest_path: str | Path
-) -> dict[str, Any]:
+def _load_schema(schema_version: str, *, manifest_path: str | Path) -> dict[str, Any]:
     """Load the vendored schema for `schema_version`.
 
     Reuses `manifest_path` as the `path` field on any raised error so the

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -160,18 +160,52 @@ class PluginManifest:
     audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
 
 
-def _load_schema(schema_version: str) -> dict[str, Any]:
+def _load_schema(
+    schema_version: str, *, manifest_path: str | Path
+) -> dict[str, Any]:
+    """Load the vendored schema for `schema_version`.
+
+    Reuses `manifest_path` as the `path` field on any raised error so the
+    caller's structured-error contract still points back at the manifest
+    that triggered the lookup, not at an internal vendored file the user
+    cannot fix.
+    """
     schema_path = _SCHEMAS_ROOT / schema_version / "plugin.schema.json"
     if not schema_path.is_file():
         raise PluginManifestError(
             f"vendored schema for version {schema_version!r} not found",
-            path=str(schema_path),
+            path=str(manifest_path),
             json_pointer="/schema_version",
             expected=f"one of {list(SUPPORTED_SCHEMA_VERSIONS)}",
             got=f"{schema_version!r} (no vendored schema)",
         )
-    with schema_path.open(encoding="utf-8") as handle:
-        return json.load(handle)
+    try:
+        with schema_path.open(encoding="utf-8") as handle:
+            return json.load(handle)
+    except OSError as exc:
+        raise PluginManifestError(
+            f"vendored schema is unreadable: {exc.strerror or exc}",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected="readable vendored schema file",
+            got=f"{type(exc).__name__} on {schema_path}",
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise PluginManifestError(
+            "vendored schema is not valid UTF-8",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected="UTF-8 encoded JSON file",
+            got=f"UnicodeDecodeError on {schema_path}",
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise PluginManifestError(
+            f"vendored schema is not valid JSON: {exc.msg}",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected="valid JSON object",
+            got=f"JSON decode error at line {exc.lineno}, col {exc.colno}",
+        ) from exc
 
 
 def _build_command(raw: dict[str, Any]) -> CommandSpec:
@@ -205,8 +239,11 @@ def load_manifest(path: str | Path) -> PluginManifest:
         A frozen, validated `PluginManifest`.
 
     Raises:
-        PluginManifestError: on JSON decode failure, schema violation, or
-            unsupported `schema_version`.
+        PluginManifestError: on missing file, unreadable file (permission
+            denied, non-UTF-8 bytes), JSON decode failure, schema
+            violation, or unsupported `schema_version`. All structured
+            failures surface through this single exception type so callers
+            never need to catch raw `OSError`/`UnicodeDecodeError`.
     """
     manifest_path = Path(path)
     if not manifest_path.is_file():
@@ -228,6 +265,24 @@ def load_manifest(path: str | Path) -> PluginManifest:
             json_pointer=None,
             expected="valid JSON object",
             got=f"JSON decode error at line {exc.lineno}, col {exc.colno}",
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise PluginManifestError(
+            "manifest is not valid UTF-8",
+            path=str(manifest_path),
+            json_pointer=None,
+            expected="UTF-8 encoded JSON file",
+            got=f"{exc.reason} at byte {exc.start}",
+        ) from exc
+    except OSError as exc:
+        # Reaches here on permission denied, transient filesystem errors,
+        # or a TOCTOU between the is_file() check and the open() call.
+        raise PluginManifestError(
+            f"manifest is unreadable: {exc.strerror or exc}",
+            path=str(manifest_path),
+            json_pointer=None,
+            expected="readable file",
+            got=f"{type(exc).__name__}: {exc.strerror or exc}",
         ) from exc
 
     if not isinstance(raw, dict):
@@ -258,7 +313,7 @@ def load_manifest(path: str | Path) -> PluginManifest:
             got=schema_version,
         )
 
-    schema = _load_schema(schema_version)
+    schema = _load_schema(schema_version, manifest_path=manifest_path)
     validator = Draft202012Validator(schema)
     errors = sorted(
         validator.iter_errors(raw),

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -24,8 +24,8 @@ runtime side effects.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
 from typing import Any
 
@@ -128,7 +128,7 @@ class AuditSpec:
     events: tuple[str, ...]
 
     @staticmethod
-    def standard_four_events() -> "AuditSpec":
+    def standard_four_events() -> AuditSpec:
         return AuditSpec(
             events=(
                 "plugin.invoked",

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -192,6 +192,19 @@ def _load_schema(schema_version: str, *, manifest_path: str | Path) -> dict[str,
                 got=f"{schema_version!r} (no vendored schema in installed package)",
             )
         raw = schema_resource.read_text(encoding="utf-8")
+    except (ModuleNotFoundError, ImportError) as exc:
+        # `importlib.resources.files("ouroboros.plugin.schemas")` raises
+        # ModuleNotFoundError if the namespace package is missing from the
+        # installed wheel (force-include misconfigured) or if the parent
+        # package fails to import. Surface it through the same structured
+        # error as every other loader failure.
+        raise PluginManifestError(
+            f"vendored schema package is not importable: {exc}",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected="ouroboros.plugin.schemas package on the import path",
+            got=f"{type(exc).__name__}: {exc}",
+        ) from exc
     except FileNotFoundError as exc:
         # Raised by importlib.resources when the package itself is missing
         # the asset directory entirely (e.g. wheel built without

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -25,8 +25,9 @@ runtime side effects.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from importlib import resources
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 try:
@@ -42,7 +43,12 @@ except ImportError as exc:  # pragma: no cover
 # below the latest is unsupported.
 SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1",)
 
-_SCHEMAS_ROOT = Path(__file__).resolve().parent / "schemas"
+# Source types whose `path` must be a sandboxed relative slug — no absolute
+# paths and no parent-directory traversal. `local_path` resolves relative to
+# the manifest's directory; `plugin_home` resolves relative to the user's
+# plugin home. Either one becoming an absolute or escaping path is a real
+# trust-boundary leak, not a cosmetic issue.
+_PATH_SANDBOXED_SOURCE_TYPES: frozenset[str] = frozenset({"local_path", "plugin_home"})
 
 
 class PluginManifestError(Exception):
@@ -163,30 +169,48 @@ class PluginManifest:
 def _load_schema(schema_version: str, *, manifest_path: str | Path) -> dict[str, Any]:
     """Load the vendored schema for `schema_version`.
 
-    Reuses `manifest_path` as the `path` field on any raised error so the
-    caller's structured-error contract still points back at the manifest
-    that triggered the lookup, not at an internal vendored file the user
-    cannot fix.
+    Resolved via `importlib.resources` so the lookup works whether the
+    package is installed as a wheel, an editable install, or a zipapp —
+    the same pattern `ouroboros.opencode.plugin` uses for its bridge
+    assets. Reuses `manifest_path` as the `path` field on any raised
+    error so the caller's structured-error contract still points back at
+    the manifest that triggered the lookup, not at an internal vendored
+    file the user cannot fix.
     """
-    schema_path = _SCHEMAS_ROOT / schema_version / "plugin.schema.json"
-    if not schema_path.is_file():
+    try:
+        schema_resource = (
+            resources.files("ouroboros.plugin.schemas")
+            .joinpath(schema_version)
+            .joinpath("plugin.schema.json")
+        )
+        if not schema_resource.is_file():
+            raise PluginManifestError(
+                f"vendored schema for version {schema_version!r} not found",
+                path=str(manifest_path),
+                json_pointer="/schema_version",
+                expected=f"one of {list(SUPPORTED_SCHEMA_VERSIONS)}",
+                got=f"{schema_version!r} (no vendored schema in installed package)",
+            )
+        raw = schema_resource.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        # Raised by importlib.resources when the package itself is missing
+        # the asset directory entirely (e.g. wheel built without
+        # force-include). This is exactly the failure mode the bot's
+        # follow-up flagged.
         raise PluginManifestError(
-            f"vendored schema for version {schema_version!r} not found",
+            f"vendored schema directory missing from installed package: {exc}",
             path=str(manifest_path),
             json_pointer="/schema_version",
-            expected=f"one of {list(SUPPORTED_SCHEMA_VERSIONS)}",
-            got=f"{schema_version!r} (no vendored schema)",
-        )
-    try:
-        with schema_path.open(encoding="utf-8") as handle:
-            return json.load(handle)
+            expected="schema directory packaged with ouroboros.plugin",
+            got=f"FileNotFoundError on ouroboros.plugin.schemas/{schema_version}",
+        ) from exc
     except OSError as exc:
         raise PluginManifestError(
             f"vendored schema is unreadable: {exc.strerror or exc}",
             path=str(manifest_path),
             json_pointer="/schema_version",
             expected="readable vendored schema file",
-            got=f"{type(exc).__name__} on {schema_path}",
+            got=f"{type(exc).__name__}: {exc.strerror or exc}",
         ) from exc
     except UnicodeDecodeError as exc:
         raise PluginManifestError(
@@ -194,8 +218,10 @@ def _load_schema(schema_version: str, *, manifest_path: str | Path) -> dict[str,
             path=str(manifest_path),
             json_pointer="/schema_version",
             expected="UTF-8 encoded JSON file",
-            got=f"UnicodeDecodeError on {schema_path}",
+            got=f"UnicodeDecodeError: {exc.reason}",
         ) from exc
+    try:
+        return json.loads(raw)
     except json.JSONDecodeError as exc:
         raise PluginManifestError(
             f"vendored schema is not valid JSON: {exc.msg}",
@@ -204,6 +230,37 @@ def _load_schema(schema_version: str, *, manifest_path: str | Path) -> dict[str,
             expected="valid JSON object",
             got=f"JSON decode error at line {exc.lineno}, col {exc.colno}",
         ) from exc
+
+
+def _validate_sandboxed_path(raw_path: str, *, source_type: str, manifest_path: str | Path) -> None:
+    """Reject absolute paths and parent-directory traversal in `path`.
+
+    The locked spec says `local_path` resolves relative to the manifest's
+    directory and `plugin_home` resolves relative to the user's plugin
+    home. Either one accepting `/etc/passwd` or `../../foo` would let a
+    plugin escape its sandbox the moment a downstream consumer joined the
+    path naively. Catch it at load time, with the same JSON-pointer
+    contract the rest of the loader uses.
+    """
+    pointer = "/source/path"
+    posix = PurePosixPath(raw_path)
+    if posix.is_absolute() or raw_path.startswith(("/", "\\")):
+        raise PluginManifestError(
+            f"source.path for {source_type!r} must be relative, not absolute",
+            path=str(manifest_path),
+            json_pointer=pointer,
+            expected="relative path under the source root",
+            got=raw_path,
+        )
+    # Reject any `..` segment, including ones embedded mid-path like `a/../b`.
+    if any(part == ".." for part in posix.parts):
+        raise PluginManifestError(
+            f"source.path for {source_type!r} must not contain '..' segments",
+            path=str(manifest_path),
+            json_pointer=pointer,
+            expected="path with no parent-directory traversal",
+            got=raw_path,
+        )
 
 
 def _build_command(raw: dict[str, Any]) -> CommandSpec:
@@ -329,9 +386,13 @@ def load_manifest(path: str | Path) -> PluginManifest:
         )
 
     source_raw = raw["source"]
+    source_type = source_raw["type"]
+    source_path = source_raw.get("path")
+    if source_type in _PATH_SANDBOXED_SOURCE_TYPES and isinstance(source_path, str):
+        _validate_sandboxed_path(source_path, source_type=source_type, manifest_path=manifest_path)
     source = SourceSpec(
-        type=source_raw["type"],
-        path=source_raw.get("path"),
+        type=source_type,
+        path=source_path,
         repository=source_raw.get("repository"),
     )
 

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -1,0 +1,336 @@
+"""Plugin manifest loader.
+
+Loads UserLevel plugin manifests (`ouroboros.plugin.json`) and validates them
+against the vendored JSON Schema under `src/ouroboros/plugin/schemas/<major>/`.
+
+The locked spec (Q00/ouroboros#728) requires:
+
+  - `PluginManifest` is a frozen dataclass with 8 required + 2 optional fields
+    (per Q00/ouroboros-plugins#6 lock).
+  - `load_manifest(path)` returns a frozen, validated manifest.
+  - On any schema violation, raise `PluginManifestError` with structured
+    fields: `path`, `json_pointer`, `expected`, `got`. A reviewer can match
+    on `json_pointer` rather than parsing message text.
+  - `source.type=first_party` is a real branch; the loader does not require
+    `source.path`/`source.repository` for first-party manifests.
+  - Manifest's `schema_version` selects the matching archived schema.
+    Unsupported versions raise with a clear message naming the support
+    window.
+
+This module is intentionally narrow. It does not load remote URLs (that is
+the manager's job in #731), does not cache (premature), and does not perform
+runtime side effects.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "jsonschema>=4.21 is required. Install it via `pip install jsonschema`."
+    ) from exc
+
+
+# Support window per Q00/ouroboros-plugins#11 lock: current MAJOR + previous MAJOR.
+# Today we only ship 0.1; once 1.0 ships, both "0.1" and "1.0" are accepted, "0.x"
+# below the latest is unsupported.
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1",)
+
+_SCHEMAS_ROOT = Path(__file__).resolve().parent / "schemas"
+
+
+class PluginManifestError(Exception):
+    """Raised when a manifest fails to load or validate.
+
+    Attributes:
+        path: Filesystem path of the manifest that failed.
+        json_pointer: JSON Pointer (RFC 6901) to the failing field, or None
+            for whole-file failures.
+        expected: Human-readable description of what was expected.
+        got: Human-readable description of what was actually present.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: str | Path,
+        json_pointer: str | None = None,
+        expected: str = "",
+        got: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.path = str(path)
+        self.json_pointer = json_pointer
+        self.expected = expected
+        self.got = got
+
+    def __str__(self) -> str:  # pragma: no cover - convenience
+        loc = self.json_pointer if self.json_pointer is not None else "(root)"
+        return f"{self.path}: {loc}: {self.args[0] if self.args else ''}"
+
+
+@dataclass(frozen=True)
+class CommandArgument:
+    name: str
+    type: str
+    required: bool
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    namespace: str
+    name: str
+    summary: str
+    usage: str
+    risk: str
+    requires_confirmation: bool = False
+    arguments: tuple[CommandArgument, ...] = ()
+
+
+@dataclass(frozen=True)
+class Capability:
+    name: str
+    access: str
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class Permission:
+    scope: str
+    risk: str
+    required: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    type: str
+    path: str | None = None
+    repository: str | None = None
+
+
+@dataclass(frozen=True)
+class Entrypoint:
+    type: str
+    command: str
+
+
+@dataclass(frozen=True)
+class AuditSpec:
+    events: tuple[str, ...]
+
+    @staticmethod
+    def standard_four_events() -> "AuditSpec":
+        return AuditSpec(
+            events=(
+                "plugin.invoked",
+                "plugin.permission_used",
+                "plugin.completed",
+                "plugin.failed",
+            )
+        )
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Frozen representation of a validated plugin manifest.
+
+    Field shape matches Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json
+    after the locked Q00/ouroboros-plugins#6 (8 required + 2 optional)
+    decision is applied.
+    """
+
+    schema_version: str
+    name: str
+    version: str
+    source: SourceSpec
+    commands: tuple[CommandSpec, ...]
+    capabilities: frozenset[Capability]
+    permissions: frozenset[Permission]
+    entrypoint: Entrypoint
+    description: str = ""
+    audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
+
+
+def _load_schema(schema_version: str) -> dict[str, Any]:
+    schema_path = _SCHEMAS_ROOT / schema_version / "plugin.schema.json"
+    if not schema_path.is_file():
+        raise PluginManifestError(
+            f"vendored schema for version {schema_version!r} not found",
+            path=str(schema_path),
+            json_pointer="/schema_version",
+            expected=f"one of {list(SUPPORTED_SCHEMA_VERSIONS)}",
+            got=f"{schema_version!r} (no vendored schema)",
+        )
+    with schema_path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _build_command(raw: dict[str, Any]) -> CommandSpec:
+    args = tuple(
+        CommandArgument(
+            name=a["name"],
+            type=a["type"],
+            required=a["required"],
+            description=a.get("description", ""),
+        )
+        for a in raw.get("arguments", [])
+    )
+    return CommandSpec(
+        namespace=raw["namespace"],
+        name=raw["name"],
+        summary=raw["summary"],
+        usage=raw["usage"],
+        risk=raw["risk"],
+        requires_confirmation=raw.get("requires_confirmation", False),
+        arguments=args,
+    )
+
+
+def load_manifest(path: str | Path) -> PluginManifest:
+    """Load and validate a plugin manifest from `path`.
+
+    Args:
+        path: Filesystem path to an `ouroboros.plugin.json` file.
+
+    Returns:
+        A frozen, validated `PluginManifest`.
+
+    Raises:
+        PluginManifestError: on JSON decode failure, schema violation, or
+            unsupported `schema_version`.
+    """
+    manifest_path = Path(path)
+    if not manifest_path.is_file():
+        raise PluginManifestError(
+            f"manifest file not found: {manifest_path}",
+            path=str(manifest_path),
+            json_pointer=None,
+            expected="readable file",
+            got="missing",
+        )
+
+    try:
+        with manifest_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise PluginManifestError(
+            f"manifest is not valid JSON: {exc.msg}",
+            path=str(manifest_path),
+            json_pointer=None,
+            expected="valid JSON object",
+            got=f"JSON decode error at line {exc.lineno}, col {exc.colno}",
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise PluginManifestError(
+            "manifest must be a JSON object",
+            path=str(manifest_path),
+            json_pointer="",
+            expected="object",
+            got=type(raw).__name__,
+        )
+
+    schema_version = raw.get("schema_version")
+    if not isinstance(schema_version, str):
+        raise PluginManifestError(
+            "manifest is missing `schema_version`",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected="string (e.g. '0.1')",
+            got=type(schema_version).__name__,
+        )
+
+    if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+        raise PluginManifestError(
+            f"schema_version {schema_version!r} is not in the support window",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected=f"schema_version in supported window {list(SUPPORTED_SCHEMA_VERSIONS)}",
+            got=schema_version,
+        )
+
+    schema = _load_schema(schema_version)
+    validator = Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(raw),
+        key=lambda e: list(e.absolute_path),
+    )
+    if errors:
+        err = errors[0]
+        pointer = "/" + "/".join(str(p) for p in err.absolute_path) if err.absolute_path else ""
+        raise PluginManifestError(
+            err.message,
+            path=str(manifest_path),
+            json_pointer=pointer,
+            expected=str(err.schema),
+            got=str(err.instance)[:200],
+        )
+
+    source_raw = raw["source"]
+    source = SourceSpec(
+        type=source_raw["type"],
+        path=source_raw.get("path"),
+        repository=source_raw.get("repository"),
+    )
+
+    commands = tuple(_build_command(c) for c in raw["commands"])
+    capabilities = frozenset(
+        Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
+        for c in raw["capabilities"]
+    )
+    permissions = frozenset(
+        Permission(
+            scope=p["scope"],
+            risk=p["risk"],
+            required=p["required"],
+            reason=p.get("reason", ""),
+        )
+        for p in raw["permissions"]
+    )
+    entrypoint = Entrypoint(
+        type=raw["entrypoint"]["type"],
+        command=raw["entrypoint"]["command"],
+    )
+
+    audit_raw = raw.get("audit")
+    if audit_raw is None:
+        audit = AuditSpec.standard_four_events()
+    else:
+        audit = AuditSpec(events=tuple(audit_raw["events"]))
+
+    return PluginManifest(
+        schema_version=schema_version,
+        name=raw["name"],
+        version=raw["version"],
+        source=source,
+        commands=commands,
+        capabilities=capabilities,
+        permissions=permissions,
+        entrypoint=entrypoint,
+        description=raw.get("description", ""),
+        audit=audit,
+    )
+
+
+__all__ = [
+    "Capability",
+    "CommandArgument",
+    "CommandSpec",
+    "Entrypoint",
+    "Permission",
+    "PluginManifest",
+    "PluginManifestError",
+    "SourceSpec",
+    "AuditSpec",
+    "load_manifest",
+    "SUPPORTED_SCHEMA_VERSIONS",
+]

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from importlib import resources
 import json
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 
 try:
@@ -237,14 +237,42 @@ def _validate_sandboxed_path(raw_path: str, *, source_type: str, manifest_path: 
 
     The locked spec says `local_path` resolves relative to the manifest's
     directory and `plugin_home` resolves relative to the user's plugin
-    home. Either one accepting `/etc/passwd` or `../../foo` would let a
+    home. Either one accepting `/etc/passwd`, `C:/Windows/System32`,
+    `..\\escape`, or any other absolute / traversal form would let a
     plugin escape its sandbox the moment a downstream consumer joined the
-    path naively. Catch it at load time, with the same JSON-pointer
-    contract the rest of the loader uses.
+    path naively. Validation is platform-agnostic — even when the loader
+    runs on Linux it must reject Windows escape forms, because the
+    consumer of the manifest may run on Windows.
+
+    Catch it at load time, with the same JSON-pointer contract the rest
+    of the loader uses.
     """
     pointer = "/source/path"
-    posix = PurePosixPath(raw_path)
-    if posix.is_absolute() or raw_path.startswith(("/", "\\")):
+
+    # Backslash is never legal in a manifest source.path: these are POSIX
+    # slugs, and accepting `..\\foo` on a POSIX host would let a Windows
+    # consumer's `ntpath.join` treat it as parent traversal.
+    if "\\" in raw_path:
+        raise PluginManifestError(
+            f"source.path for {source_type!r} must use forward slashes only",
+            path=str(manifest_path),
+            json_pointer=pointer,
+            expected="POSIX-style relative path with no '\\\\' separators",
+            got=raw_path,
+        )
+
+    # Windows drive prefix: `C:/foo`, `c:foo`, etc.
+    if len(raw_path) >= 2 and raw_path[1] == ":" and raw_path[0].isalpha():
+        raise PluginManifestError(
+            f"source.path for {source_type!r} must not be drive-qualified",
+            path=str(manifest_path),
+            json_pointer=pointer,
+            expected="relative path with no Windows drive prefix",
+            got=raw_path,
+        )
+
+    # POSIX absolute or UNC-style leading separator.
+    if raw_path.startswith("/"):
         raise PluginManifestError(
             f"source.path for {source_type!r} must be relative, not absolute",
             path=str(manifest_path),
@@ -252,8 +280,11 @@ def _validate_sandboxed_path(raw_path: str, *, source_type: str, manifest_path: 
             expected="relative path under the source root",
             got=raw_path,
         )
-    # Reject any `..` segment, including ones embedded mid-path like `a/../b`.
-    if any(part == ".." for part in posix.parts):
+
+    # Reject any `..` segment, including ones embedded mid-path like
+    # `a/../b`. Splitting on '/' is sufficient because backslashes were
+    # already rejected above.
+    if any(part == ".." for part in raw_path.split("/")):
         raise PluginManifestError(
             f"source.path for {source_type!r} must not contain '..' segments",
             path=str(manifest_path),

--- a/src/ouroboros/plugin/schemas/0.1/_source.json
+++ b/src/ouroboros/plugin/schemas/0.1/_source.json
@@ -1,0 +1,6 @@
+{
+  "repo": "Q00/ouroboros-plugins",
+  "schema_version": "0.1",
+  "vendored_at": "2026-05-07",
+  "note": "These schemas mirror Q00/ouroboros-plugins/schemas/0.1/. They reflect the locked decisions in Q00/ouroboros-plugins #6 (manifest 8+2 fields), #10 (3-value risk enum), #11 (per-major archive). Sync via scripts/sync-plugin-schemas.sh once Q00/ouroboros-plugins#13/#16/#19/#20 land on upstream main."
+}

--- a/src/ouroboros/plugin/schemas/0.1/audit-event.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/audit-event.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros-plugins/schemas/0.1/audit-event.schema.json",
+  "title": "Ouroboros Plugin Audit Event (v0.1)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "occurred_at",
+    "plugin",
+    "command",
+    "trust_state",
+    "capabilities_used",
+    "permissions_used",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "plugin.discovered",
+        "plugin.installed",
+        "plugin.trusted",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed"
+      ]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "plugin": {
+      "type": "object",
+      "required": ["name", "version", "source_type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "source_type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["namespace", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": { "type": "string" },
+        "name": { "type": "string" },
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "trust_state": {
+      "type": "string",
+      "enum": ["discovered", "installed", "trusted", "disabled", "blocked", "first_party"]
+    },
+    "capabilities_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "permissions_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "result": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["success", "blocked", "failed"]
+        },
+        "message": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
@@ -41,12 +41,34 @@
           "enum": ["local_path", "plugin_home", "first_party"]
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "repository": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"type": {"const": "local_path"}},
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["type", "path"]
+          }
+        },
+        {
+          "if": {
+            "properties": {"type": {"const": "plugin_home"}},
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["type", "path"]
+          }
+        }
+      ]
     },
     "commands": {
       "type": "array",

--- a/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json",
+  "title": "Ouroboros Plugin Manifest (v0.1)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "version",
+    "source",
+    "commands",
+    "capabilities",
+    "permissions",
+    "entrypoint"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "description": {
+      "type": "string",
+      "default": ""
+    },
+    "source": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        },
+        "path": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        }
+      }
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["namespace", "name", "summary", "usage", "risk"],
+        "additionalProperties": false,
+        "properties": {
+          "namespace": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "usage": {
+            "type": "string",
+            "minLength": 1
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "requires_confirmation": {
+            "type": "boolean",
+            "default": false
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "type", "required"],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_-]*$"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["string", "boolean", "integer", "path", "url"]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "access"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "seed",
+              "ledger",
+              "state",
+              "provenance",
+              "runtime",
+              "mcp",
+              "handoff",
+              "progress"
+            ]
+          },
+          "access": {
+            "type": "string",
+            "enum": ["read", "write", "execute", "attach"]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scope", "risk", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "scope": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "entrypoint": {
+      "type": "object",
+      "required": ["type", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "command"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": ["events"],
+      "additionalProperties": false,
+      "default": {
+        "events": [
+          "plugin.invoked",
+          "plugin.permission_used",
+          "plugin.completed",
+          "plugin.failed"
+        ]
+      },
+      "properties": {
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "plugin.discovered",
+              "plugin.installed",
+              "plugin.trusted",
+              "plugin.invoked",
+              "plugin.permission_used",
+              "plugin.completed",
+              "plugin.failed"
+            ]
+          },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/plugin/test_wheel_packaging.py
+++ b/tests/integration/plugin/test_wheel_packaging.py
@@ -1,0 +1,81 @@
+"""Integration test: built wheel ships the vendored 0.1 schema assets.
+
+This guards the failure mode the round-2 bot review flagged and
+round-4 sharpened: the unit-level `resources.files()` check passes
+against the editable source tree even when `pyproject.toml` is
+mis-configured, so it cannot catch a `force-include` regression on
+its own. This test rebuilds the wheel for real and inspects the
+shipped archive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+import zipfile
+
+import pytest
+
+from ouroboros.plugin.manifest import SUPPORTED_SCHEMA_VERSIONS
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.skipif(
+    shutil.which("uv") is None,
+    reason="uv not on PATH — wheel build cannot run in this environment.",
+)
+def test_built_wheel_ships_vendored_schemas(tmp_path: Path) -> None:
+    """Build the wheel for real and assert each supported schema version's
+    `plugin.schema.json` and `audit-event.schema.json` are present in the
+    shipped archive — exactly once each, with no duplicate ZIP entries.
+
+    A future change that drops the `force-include` for
+    `src/ouroboros/plugin/schemas` from `pyproject.toml` will fail this
+    test before it can ship a broken wheel that raises
+    `vendored schema directory missing from installed package` for every
+    `load_manifest()` call in production.
+    """
+    out_dir = tmp_path / "dist"
+    result = subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(out_dir)],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"`uv build --wheel` failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    wheels = list(out_dir.glob("*.whl"))
+    assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
+
+    expected = {
+        f"ouroboros/plugin/schemas/{version}/{asset}"
+        for version in SUPPORTED_SCHEMA_VERSIONS
+        for asset in ("plugin.schema.json", "audit-event.schema.json")
+    }
+    with zipfile.ZipFile(wheels[0]) as archive:
+        names = archive.namelist()
+        present = [n for n in names if n.startswith("ouroboros/plugin/schemas/")]
+        # Each schema asset must appear exactly once. Hatchling's
+        # `force-include` plus the matching `exclude` in the wheel target
+        # is the existing pattern that prevents duplicate ZIP local
+        # headers (which PyPI rejects); regressing into a duplicate would
+        # also fail this assertion.
+        for path in present:
+            assert names.count(path) == 1, (
+                f"{path} appears {names.count(path)} times — duplicate ZIP entries "
+                "indicate the wheel `exclude`/`force-include` pair is misaligned."
+            )
+
+        present_set = set(present)
+        missing = expected - present_set
+        assert not missing, (
+            "wheel is missing required schema assets — likely a "
+            "`pyproject.toml` `force-include` regression. "
+            f"Missing: {sorted(missing)}. Wheel ships: {sorted(present_set)}"
+        )

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -258,6 +258,66 @@ def test_non_utf8_manifest_reports_structured_error(tmp_path: Path) -> None:
     assert excinfo.value.path == str(target)
 
 
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "/etc/passwd",
+        "/absolute/install",
+        "../escape",
+        "a/../escape",
+        "nested/../../escape",
+    ],
+)
+@pytest.mark.parametrize("source_type", ["local_path", "plugin_home"])
+def test_sandboxed_source_path_rejects_traversal(
+    tmp_path: Path, source_type: str, bad_path: str
+) -> None:
+    """Path-bearing source types must reject absolute paths and `..` segments.
+
+    Without this, a `plugin_home` manifest could declare
+    `source.path = "/etc/passwd"` or `"../foo"` and the loader would
+    happily return it — turning a naive downstream `os.path.join` into a
+    sandbox escape. The schema's `minLength: 1` only stopped empty strings.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": source_type, "path": bad_path}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    err = excinfo.value
+    assert err.json_pointer == "/source/path"
+    assert err.got == bad_path
+
+
+def test_plugin_home_with_relative_path_loads(tmp_path: Path) -> None:
+    """Positive control: a sandboxed relative `plugin_home` path loads."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["source"] = {"type": "plugin_home", "path": "vendor/ooo-pr-ops"}
+    manifest = load_manifest(_write(tmp_path, fp))
+    assert manifest.source.type == "plugin_home"
+    assert manifest.source.path == "vendor/ooo-pr-ops"
+
+
+def test_vendored_schemas_are_packaged_resources() -> None:
+    """The vendored schema must be reachable through `importlib.resources`,
+    not via a filesystem-relative read.
+
+    A wheel built without explicit `force-include` may silently drop the
+    `schemas/` directory, and `_load_schema()` would then raise
+    `vendored schema directory missing from installed package` for every
+    manifest load. Asserting the resource is reachable here gives that
+    failure mode a unit-test guard alongside the hatch packaging config.
+    """
+    from importlib import resources
+
+    schema_pkg = resources.files("ouroboros.plugin.schemas")
+    for version in SUPPORTED_SCHEMA_VERSIONS:
+        plugin_schema = schema_pkg.joinpath(version).joinpath("plugin.schema.json")
+        assert plugin_schema.is_file(), f"plugin.schema.json missing for v{version}"
+        # And it must be parseable JSON, not an empty placeholder.
+        body = plugin_schema.read_text(encoding="utf-8")
+        assert json.loads(body)["title"].startswith("Ouroboros Plugin Manifest")
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("win"),
     reason="POSIX permission semantics; Windows handles read perms differently.",

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -261,23 +261,38 @@ def test_non_utf8_manifest_reports_structured_error(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "bad_path",
     [
+        # POSIX absolute / traversal
         "/etc/passwd",
         "/absolute/install",
         "../escape",
         "a/../escape",
         "nested/../../escape",
+        # Windows drive prefix — must be rejected even on POSIX hosts because
+        # the manifest may be consumed on Windows where ntpath treats these
+        # as absolute.
+        "C:/Windows/System32",
+        "c:foo",
+        # Backslash separator — never legal in a POSIX-slug source.path,
+        # and accepting it on POSIX would let a Windows consumer's
+        # `ntpath.join` interpret it as parent traversal.
+        "..\\escape",
+        "foo\\..\\bar",
+        "C:\\Windows",
     ],
 )
 @pytest.mark.parametrize("source_type", ["local_path", "plugin_home"])
 def test_sandboxed_source_path_rejects_traversal(
     tmp_path: Path, source_type: str, bad_path: str
 ) -> None:
-    """Path-bearing source types must reject absolute paths and `..` segments.
+    """Path-bearing source types must reject absolute paths and `..` segments
+    in both POSIX and Windows forms.
 
     Without this, a `plugin_home` manifest could declare
-    `source.path = "/etc/passwd"` or `"../foo"` and the loader would
-    happily return it — turning a naive downstream `os.path.join` into a
-    sandbox escape. The schema's `minLength: 1` only stopped empty strings.
+    `source.path = "C:/Windows/System32"` or `"..\\foo"` and the loader
+    would happily return it — turning a naive downstream `os.path.join`
+    on the consumer side into a sandbox escape. Validation has to be
+    platform-agnostic because the host that loads the manifest may not
+    be the host that resolves it.
     """
     bad = json.loads(json.dumps(REFERENCE_MANIFEST))
     bad["source"] = {"type": source_type, "path": bad_path}

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -1,0 +1,203 @@
+"""Tests for the plugin manifest loader (Q00/ouroboros#728).
+
+Each test asserts BOTH the rejection AND the JSON Pointer to the failing
+field, so a future schema change cannot silently relax constraints.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.manifest import (
+    PluginManifest,
+    PluginManifestError,
+    load_manifest,
+    SUPPORTED_SCHEMA_VERSIONS,
+)
+
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "description": "Reference skeleton for GitHub PR operational workflows.",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness without mutating it.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+            "requires_confirmation": False,
+            "arguments": [
+                {
+                    "name": "pull_request_url",
+                    "type": "url",
+                    "required": True,
+                    "description": "GitHub pull request URL to inspect.",
+                }
+            ],
+        }
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write", "reason": "Record decisions."},
+        {"name": "provenance", "access": "write", "reason": "Record context."},
+    ],
+    "permissions": [
+        {
+            "scope": "github:read",
+            "risk": "read_only",
+            "required": True,
+            "reason": "Read PR status.",
+        }
+    ],
+    "entrypoint": {"type": "command", "command": "python -m github_pr_ops"},
+}
+
+
+def _write(tmp_path: Path, payload: dict | str) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    if isinstance(payload, str):
+        target.write_text(payload)
+    else:
+        target.write_text(json.dumps(payload))
+    return target
+
+
+def test_load_reference_manifest(tmp_path: Path) -> None:
+    """Test 1: github-pr-ops reference manifest loads cleanly."""
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    assert isinstance(manifest, PluginManifest)
+    assert manifest.name == "github-pr-ops"
+    assert manifest.version == "0.1.0"
+    assert manifest.schema_version == "0.1"
+    assert len(manifest.commands) == 1
+    assert manifest.commands[0].name == "review"
+    assert manifest.source.type == "local_path"
+
+
+def test_missing_required_top_level_field(tmp_path: Path) -> None:
+    """Test 2: missing `name` raises with empty json_pointer (root-level)."""
+    bad = {**REFERENCE_MANIFEST}
+    bad.pop("name")
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    err = excinfo.value
+    assert err.json_pointer == ""
+    assert "name" in err.args[0]
+
+
+def test_pattern_violation_on_name(tmp_path: Path) -> None:
+    """Test 3: pattern violation reports json_pointer=/name."""
+    bad = {**REFERENCE_MANIFEST, "name": "Bad Name"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/name"
+    assert "match" in excinfo.value.args[0].lower() or "pattern" in excinfo.value.expected.lower()
+
+
+def test_unknown_capability(tmp_path: Path) -> None:
+    """Test 4: unknown capability name reports nested pointer."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["capabilities"][0]["name"] = "fake_cap"
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/capabilities/0/name"
+
+
+def test_unknown_source_type(tmp_path: Path) -> None:
+    """Test 5: unknown source.type reports /source/type pointer."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "remote"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/source/type"
+
+
+def test_additional_property_rejected(tmp_path: Path) -> None:
+    """Test 6: additionalProperties:false catches unknown top-level keys."""
+    bad = {**REFERENCE_MANIFEST, "weird_key": 1}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert "weird_key" in excinfo.value.args[0]
+
+
+def test_unsupported_schema_version(tmp_path: Path) -> None:
+    """Test 7: schema_version outside support window is rejected."""
+    bad = {**REFERENCE_MANIFEST, "schema_version": "99.0"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/schema_version"
+    assert "99.0" in excinfo.value.got
+    assert str(list(SUPPORTED_SCHEMA_VERSIONS)) in excinfo.value.expected
+
+
+def test_returned_manifest_is_frozen(tmp_path: Path) -> None:
+    """Test 8: PluginManifest dataclass is frozen — attribute mutation raises."""
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        manifest.name = "other"  # type: ignore[misc]
+
+
+def test_optional_fields_omitted(tmp_path: Path) -> None:
+    """Test 9: manifest without description and audit loads with defaults
+    (per Q00/ouroboros-plugins#6 lock — 8 required + 2 optional)."""
+    bare = {k: v for k, v in REFERENCE_MANIFEST.items() if k not in ("description", "audit")}
+    manifest = load_manifest(_write(tmp_path, bare))
+    assert manifest.description == ""
+    assert "plugin.invoked" in manifest.audit.events
+    assert "plugin.completed" in manifest.audit.events
+    assert "plugin.failed" in manifest.audit.events
+
+
+def test_first_party_source_branch(tmp_path: Path) -> None:
+    """Test 10: source.type=first_party loads without requiring path/repository
+    (per Q00/ouroboros-plugins#8 lock)."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-auto"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []
+    fp["commands"] = [
+        {
+            "namespace": "auto",
+            "name": "run",
+            "summary": "Take a goal, run interview, produce Seed, hand off execution.",
+            "usage": "ooo auto <goal-text>",
+            "risk": "write",
+        }
+    ]
+    manifest = load_manifest(_write(tmp_path, fp))
+    assert manifest.source.type == "first_party"
+    assert manifest.source.path is None
+    assert manifest.source.repository is None
+
+
+def test_old_risk_enum_value_rejected(tmp_path: Path) -> None:
+    """Test 11: command.risk='writes_state' rejected by 3-value enum
+    (per Q00/ouroboros-plugins#10 lock)."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["commands"][0]["risk"] = "writes_state"
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/commands/0/risk"
+
+
+def test_invalid_json_decodes_to_useful_error(tmp_path: Path) -> None:
+    """Bonus: garbage JSON is reported with a useful message."""
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text("{invalid json")
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(target)
+    assert "JSON" in excinfo.value.args[0] or "json" in excinfo.value.args[0].lower()
+
+
+def test_missing_file_reports_clean_error(tmp_path: Path) -> None:
+    """Bonus: missing file path reports a clean error, not a stack trace."""
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(tmp_path / "does-not-exist.json")
+    assert "not found" in excinfo.value.args[0]

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -176,6 +176,49 @@ def test_first_party_source_branch(tmp_path: Path) -> None:
     assert manifest.source.repository is None
 
 
+def test_local_path_source_requires_path(tmp_path: Path) -> None:
+    """source.type=local_path must reject manifests that omit `path`.
+
+    Without the conditional `required`, a manifest like
+    `{"source": {"type": "local_path"}}` would validate and the loader
+    would return `SourceSpec(path=None)`, pushing the failure into
+    downstream code instead of catching it at load time.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "local_path"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    err = excinfo.value
+    assert err.json_pointer is not None
+    assert err.json_pointer.startswith("/source")
+    assert "path" in err.args[0]
+
+
+def test_plugin_home_source_requires_path(tmp_path: Path) -> None:
+    """source.type=plugin_home must also reject manifests that omit `path`.
+
+    plugin_home sources reference a slot under the user's plugin home
+    directory; the loader needs the relative path to resolve them.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "plugin_home"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    err = excinfo.value
+    assert err.json_pointer is not None
+    assert err.json_pointer.startswith("/source")
+    assert "path" in err.args[0]
+
+
+def test_local_path_source_with_path_loads(tmp_path: Path) -> None:
+    """Positive control: source.type=local_path with `path` loads cleanly."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["source"] = {"type": "local_path", "path": "plugins/whatever"}
+    manifest = load_manifest(_write(tmp_path, fp))
+    assert manifest.source.type == "local_path"
+    assert manifest.source.path == "plugins/whatever"
+
+
 def test_old_risk_enum_value_rejected(tmp_path: Path) -> None:
     """Test 11: command.risk='writes_state' rejected by 3-value enum
     (per Q00/ouroboros-plugins#10 lock)."""

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -243,3 +245,35 @@ def test_missing_file_reports_clean_error(tmp_path: Path) -> None:
     with pytest.raises(PluginManifestError) as excinfo:
         load_manifest(tmp_path / "does-not-exist.json")
     assert "not found" in excinfo.value.args[0]
+
+
+def test_non_utf8_manifest_reports_structured_error(tmp_path: Path) -> None:
+    """Non-UTF-8 manifest bytes must surface as PluginManifestError, not
+    a raw UnicodeDecodeError (structured-error contract)."""
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_bytes(b"\xff\xfe\x00not utf-8")
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(target)
+    assert "UTF-8" in excinfo.value.args[0] or "utf-8" in excinfo.value.args[0]
+    assert excinfo.value.path == str(target)
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX permission semantics; Windows handles read perms differently.",
+)
+def test_unreadable_manifest_reports_structured_error(tmp_path: Path) -> None:
+    """Permission-denied reads must surface as PluginManifestError, not
+    a raw OSError (structured-error contract)."""
+    target = _write(tmp_path, REFERENCE_MANIFEST)
+    target.chmod(0o000)
+    try:
+        # Skip if running as root, where chmod 0o000 cannot deny reads.
+        if os.geteuid() == 0:
+            pytest.skip("root bypasses POSIX read permissions")
+        with pytest.raises(PluginManifestError) as excinfo:
+            load_manifest(target)
+        assert "unreadable" in excinfo.value.args[0]
+        assert excinfo.value.path == str(target)
+    finally:
+        target.chmod(0o644)

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -13,12 +13,11 @@ from pathlib import Path
 import pytest
 
 from ouroboros.plugin.manifest import (
+    SUPPORTED_SCHEMA_VERSIONS,
     PluginManifest,
     PluginManifestError,
     load_manifest,
-    SUPPORTED_SCHEMA_VERSIONS,
 )
-
 
 REFERENCE_MANIFEST: dict = {
     "schema_version": "0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1494,6 +1494,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "anyio" },
+    { name = "jsonschema" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -1553,6 +1554,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0.0,<5.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'all'", specifier = ">=0.1.0,<1.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'claude'", specifier = ">=0.1.0,<1.0.0" },
+    { name = "jsonschema", specifier = ">=4.21.0,<5.0.0" },
     { name = "litellm", marker = "extra == 'all'", specifier = ">=1.80.0,<=1.82.6" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80.0,<=1.82.6" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.26.0,<2.0.0" },


### PR DESCRIPTION
Closes #728. Sub-issue of #725 (Phase 1).

Implements the locked spec for the UserLevel plugin manifest loader.

## Module: `src/ouroboros/plugin/manifest.py`

- `PluginManifest` — frozen dataclass with the locked **8 required + 2 optional** field shape (per Q00/ouroboros-plugins#6).
- `load_manifest(path)` — returns a frozen, validated manifest.
- `PluginManifestError` exposes structured fields: `path`, `json_pointer`, `expected`, `got`. Tests assert on `json_pointer` rather than parsing message text — schema changes that move the failing field cannot silently slip through.
- `source.type=first_party` is a real branch (per Q00/ouroboros-plugins#8); `source.path` / `source.repository` optional for it.
- `schema_version` routes to `schemas/<major>/plugin.schema.json` (per Q00/ouroboros-plugins#11). Out-of-window versions reject with a clear message naming the supported window.

## Vendored schemas

`src/ouroboros/plugin/schemas/0.1/{plugin,audit-event}.schema.json` mirror upstream `Q00/ouroboros-plugins/schemas/0.1/` with all locked decisions applied:

- 8 required + 2 optional (#6)
- 3-value risk enum (#10)
- per-major archive layout (#11)

`schemas/0.1/_source.json` records the upstream repo + intent. A `scripts/sync-plugin-schemas.sh` follow-up will sync these once Q00/ouroboros-plugins#13 / #16 / #19 / #20 land on upstream main.

## Dependency

`pyproject.toml` adds `jsonschema>=4.21.0,<5.0.0` as a runtime dep.

## Tests — `tests/unit/plugin/test_manifest.py` (13/13 pass)

| # | Test | Asserts |
|---|---|---|
| 1 | Reference manifest loads cleanly | `name == "github-pr-ops"`, command count, source.type |
| 2 | Missing required field | `json_pointer == ""`; message names "name" |
| 3 | Pattern violation on `name` | `json_pointer == "/name"` |
| 4 | Unknown capability | `json_pointer == "/capabilities/0/name"` |
| 5 | Unknown source.type | `json_pointer == "/source/type"` |
| 6 | additionalProperties:false | unknown key reported by name |
| 7 | Unsupported `schema_version` | `json_pointer == "/schema_version"`; message names support window |
| 8 | Returned manifest is frozen | `FrozenInstanceError` |
| 9 | Optional fields omitted | description default `""`; audit default 4-event list |
| 10 | first_party source branch | loads without `source.path` |
| 11 | Old `risk = "writes_state"` | rejected at `/commands/0/risk` |
| 12 | Invalid JSON | clean error message, not stack trace |
| 13 | Missing file | clean error message |

```
$ PYTHONPATH=src python3 -m pytest tests/unit/plugin/test_manifest.py -v
============================== 13 passed in 0.26s ==============================
```

## Cross-repo dependency note

This PR vendors the post-Sprint-1 schema content directly. The upstream PRs at Q00/ouroboros-plugins (#13 validator, #16 manifest 8+2, #19 risk enum, #20 schemas/0.1 archive) carry the same content; once they merge to upstream main, `scripts/sync-plugin-schemas.sh` (a Sprint-2 follow-up) will keep the vendored copies in sync.

## What's next

Stacked PRs that consume this module:
- CR-5 (#730) — registry extension
- CR-4 (#729) — invocation firewall
- CR-7 (#732) — lockfile + trust store
- CR-10 (#737) — audit-event ledger compat