### PR TITLE
feat(plugin): lockfile + per-user trust store

### DIFF
--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -28,12 +28,35 @@ from datetime import UTC, datetime
 import json
 import os
 from pathlib import Path
+import re
 import tempfile
 
 TRUST_SCHEMA_VERSION = "0.1"
 
 # Default location root. Each plugin gets a subdirectory here.
 DEFAULT_TRUST_ROOT = Path.home() / ".ouroboros" / "plugins"
+
+# Plugin name pattern, matching plugin.schema.json `/name`. Enforced here at
+# the persistence-API boundary so that a plugin name with path separators or
+# `..` cannot escape the trust root via `<root>/<plugin>/trust.json` and
+# read/write/delete arbitrary files. Higher layers (manifest validation,
+# manager) also reject malformed names; this is defence in depth.
+_PLUGIN_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$")
+
+
+def _validate_plugin_name(plugin: str) -> None:
+    """Reject plugin identifiers that could escape the trust root.
+
+    Raises:
+        ValueError: if ``plugin`` does not match the locked manifest name
+            pattern (lowercase alphanumeric + dashes, 3-64 chars, no leading
+            or trailing dash, no path separators).
+    """
+    if not isinstance(plugin, str) or not _PLUGIN_NAME_RE.fullmatch(plugin):
+        raise ValueError(
+            f"invalid plugin name {plugin!r}: must match "
+            r"^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+        )
 
 
 @dataclass(frozen=True)
@@ -71,6 +94,7 @@ class TrustStore:
 
     def read(self, plugin: str) -> TrustRecord | None:
         """Read the trust record for `plugin`, or None if not present."""
+        _validate_plugin_name(plugin)
         path = self._path(plugin)
         if not path.is_file():
             return None
@@ -155,6 +179,7 @@ class TrustStore:
         a per-plugin POSIX file lock so two concurrent `grant()` calls
         cannot drop one another's scope.
         """
+        _validate_plugin_name(plugin)
         when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -188,6 +213,7 @@ class TrustStore:
         per-plugin lock as `grant()` so a reset cannot race with a
         concurrent grant for the prior version.
         """
+        _validate_plugin_name(plugin)
         payload = {
             "schema_version": TRUST_SCHEMA_VERSION,
             "plugin": plugin,
@@ -208,6 +234,7 @@ class TrustStore:
         dropping grants. The lock makes the unlink/prune sequence
         observable as a single critical section.
         """
+        _validate_plugin_name(plugin)
         path = self._path(plugin)
         with self._grant_lock(plugin):
             if not path.is_file():

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -38,8 +38,8 @@ def test_grant_then_read(tmp_path: Path) -> None:
 def test_grant_is_idempotent(tmp_path: Path) -> None:
     """Test 2: granting the same scope twice does not duplicate."""
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    record = store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
     assert len(record.granted_scopes) == 1
 
 
@@ -50,7 +50,7 @@ def test_exact_scope_only(tmp_path: Path) -> None:
     """
     store = TrustStore(root=tmp_path)
     record = store.grant(
-        plugin="X",
+        plugin="test-plugin",
         version="0.1.0",
         scope="github:pull_request",
         granted_by="u",
@@ -64,11 +64,11 @@ def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
     """Test 4: granting against a new version drops the previous grants
     (Q00/ouroboros-plugins#9 Q4 lock)."""
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    store.grant(plugin="X", version="0.1.0", scope="github:repo:read", granted_by="u")
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:repo:read", granted_by="u")
 
     # Now bump to 0.2.0 and grant a different scope.
-    record = store.grant(plugin="X", version="0.2.0", scope="github:read", granted_by="u")
+    record = store.grant(plugin="test-plugin", version="0.2.0", scope="github:read", granted_by="u")
     assert record.version == "0.2.0"
     # Previous github:repo:read grant is invalidated.
     assert not record.has_scope("github:repo:read")
@@ -79,10 +79,10 @@ def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
 def test_reset_for_version_bump(tmp_path: Path) -> None:
     """Test 5: explicit version-bump reset writes an empty grant list."""
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    store.reset_for_version_bump("X", new_version="0.2.0")
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    store.reset_for_version_bump("test-plugin", new_version="0.2.0")
 
-    record = store.read("X")
+    record = store.read("test-plugin")
     assert isinstance(record, TrustRecord)
     assert record.version == "0.2.0"
     assert record.granted_scopes == ()
@@ -94,13 +94,13 @@ def test_remove_drops_trust_file(tmp_path: Path) -> None:
     so the directory is only pruned when the lock file isn't there
     (e.g. on platforms without flock support)."""
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    file_path = tmp_path / "X" / "trust.json"
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    file_path = tmp_path / "test-plugin" / "trust.json"
     assert file_path.is_file()
-    assert store.remove("X") is True
+    assert store.remove("test-plugin") is True
     assert not file_path.exists()
     # Removing again is a no-op.
-    assert store.remove("X") is False
+    assert store.remove("test-plugin") is False
 
 
 def test_remove_keeps_lock_file_to_avoid_inode_race(tmp_path: Path) -> None:
@@ -116,26 +116,26 @@ def test_remove_keeps_lock_file_to_avoid_inode_race(tmp_path: Path) -> None:
     operations, so `remove()` now leaves it in place.
     """
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    lock_path = tmp_path / "X" / "trust.json.lock"
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    lock_path = tmp_path / "test-plugin" / "trust.json.lock"
     assert lock_path.exists(), "fixture sanity: lock file must have been created"
-    assert store.remove("X") is True
+    assert store.remove("test-plugin") is True
     # The trust.json itself is gone, but the lock file is preserved
     # so subsequent grant/remove operations on the same plugin name
     # share the same inode-stable synchronization primitive.
-    assert not (tmp_path / "X" / "trust.json").exists()
+    assert not (tmp_path / "test-plugin" / "trust.json").exists()
     assert lock_path.exists(), "lock file must persist across remove() to keep flock semantics safe"
 
 
 def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
     """Test 7: a trust file with the wrong schema_version raises on read."""
-    plugin_dir = tmp_path / "X"
+    plugin_dir = tmp_path / "test-plugin"
     plugin_dir.mkdir()
     (plugin_dir / "trust.json").write_text(
         json.dumps(
             {
                 "schema_version": "99.0",
-                "plugin": "X",
+                "plugin": "test-plugin",
                 "version": "0.1.0",
                 "granted_scopes": [],
             }
@@ -143,7 +143,7 @@ def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
     )
     store = TrustStore(root=tmp_path)
     with pytest.raises(ValueError, match="unsupported trust file schema_version"):
-        store.read("X")
+        store.read("test-plugin")
 
 
 def test_no_raw_token_in_persisted_file(tmp_path: Path) -> None:
@@ -152,12 +152,12 @@ def test_no_raw_token_in_persisted_file(tmp_path: Path) -> None:
     check that future contributors don't add one without notice."""
     store = TrustStore(root=tmp_path)
     store.grant(
-        plugin="X",
+        plugin="test-plugin",
         version="0.1.0",
         scope="github:read",
         granted_by="user:shaun0927",
     )
-    raw = (tmp_path / "X" / "trust.json").read_text()
+    raw = (tmp_path / "test-plugin" / "trust.json").read_text()
     # Keys present
     assert '"scope"' in raw
     assert '"granted_by"' in raw
@@ -171,10 +171,51 @@ def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
     """Test 9: TrustRecord.missing() returns missing required scopes in
     the input iteration order — useful for predictable error messages."""
     store = TrustStore(root=tmp_path)
-    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    record = store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
     # `github:read` is granted; the others are missing.
     missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
     assert missing == ["github:pull_request:write", "shell:execute"]
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "../escape",
+        "..",
+        "x/y",
+        "x\\y",
+        ".hidden",
+        "X",  # uppercase, fails the locked manifest pattern
+        "",
+        "ab",  # too short
+        "-leading-dash",
+        "trailing-dash-",
+        "with space",
+    ],
+)
+def test_invalid_plugin_name_rejected(tmp_path: Path, bad_name: str) -> None:
+    """Test 11: every public TrustStore method that takes a plugin name must
+    reject names that could escape the trust root via path separators or
+    parent traversal, or that violate the locked manifest name pattern.
+
+    The bot review flagged ``self.root / plugin / "trust.json"`` as a
+    boundary that must defensively validate caller input even when higher
+    layers also validate.
+    """
+    store = TrustStore(root=tmp_path)
+    with pytest.raises(ValueError, match="invalid plugin name"):
+        store.read(bad_name)
+    with pytest.raises(ValueError, match="invalid plugin name"):
+        store.grant(
+            plugin=bad_name,
+            version="0.1.0",
+            scope="github:read",
+            granted_by="user:tester",
+        )
+    with pytest.raises(ValueError, match="invalid plugin name"):
+        store.reset_for_version_bump(bad_name, new_version="0.2.0")
+    with pytest.raises(ValueError, match="invalid plugin name"):
+        store.remove(bad_name)
 
 
 def test_concurrent_grants_do_not_lose_scopes(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #732. Sub-issue of #725 (Phase 2). **Stacked on #745 (CR-3 manifest loader)** — review after that lands; the diff against `main` will be larger until then.

## Modules

### `src/ouroboros/plugin/lockfile.py`

`LockEntry` dataclass + `Lockfile` manager. Persists at `~/.ouroboros/plugins.lock` (TOML).

- Atomic writes (temp file + `os.replace`) — partial-write crash leaves the original intact.
- POSIX `fcntl.flock` for concurrent-write safety.
- Deterministic name-sorted entry order so diffs are reviewable.
- Schema versioned (`schema_version = "0.1"`); unsupported versions raise on read.
- Hand-rolled minimal TOML serialization (the shape is small and fixed); reading uses stdlib `tomllib`.

### `src/ouroboros/plugin/trust_store.py`

`GrantedScope`, `TrustRecord` dataclasses + `TrustStore` manager. Implements all four locked answers from Q00/ouroboros-plugins#9 that affect persistence:

| Q | Behavior |
|---|---|
| Q3 | Exact-scope only. `TrustRecord.has_scope("github:pull_request")` does **not** match `github:pull_request:write`. |
| Q4 | Version-bump invalidation. `grant(plugin=X, version=0.2.0, ...)` after `0.1.0` was trusted drops the prior grants. Explicit `reset_for_version_bump()` available too. |
| Q5 | Per-user storage at `~/.ouroboros/plugins/<name>/trust.json`. Each plugin gets its own file. |
| Q6 | `granted_by`, `granted_scope`, `granted_at` recorded. Firewall (#729) and CLI (#731) source `plugin.trusted` audit events from these fields. |

**No tokens stored.** The store has no token API; `test_no_raw_token_in_persisted_file` enforces this.

## Tests (16/16 pass)

```
$ PYTHONPATH=src python3 -m pytest \
    tests/unit/plugin/test_lockfile.py \
    tests/unit/plugin/test_trust_store.py -v
============================== 16 passed in 0.78s ==============================
```

### Lockfile (7)

1. install → read round-trip
2. remove drops entry; idempotent on already-absent
3. entries written in sorted name order
4. `schema_version` header present
5. unsupported `schema_version` rejected on read
6. atomic write: simulated `os.replace` crash leaves the original file intact, no leftover temp file
7. concurrent multiprocess writes (10 entries from 2 procs) do not corrupt the file or lose entries

### Trust store (9)

1. grant + read round-trip; file at locked Q5 path
2. grant idempotent on already-granted scope
3. exact-scope rule (Q3 lock)
4. grant against new version drops previous (Q4 lock)
5. explicit `reset_for_version_bump` writes empty grants
6. remove drops trust file and prunes empty dir
7. unsupported `schema_version` rejected on read
8. **no-raw-token invariant**: `token`/`secret`/`auth`/`Bearer`/`ghp_` markers absent from persisted file
9. `TrustRecord.missing(required)` returns missing scopes in input order (predictable error messages)

## Cross-repo

Consumes the locked Q00/ouroboros-plugins#9 spec for trust UX. Trust event shape (Q6) matches the example in `docs/audit.md` (added in Q00/ouroboros-plugins#22).

## What's next

#729 (firewall) and #731 (CLI) consume both modules. The firewall calls `TrustStore.read()` for the pre-invocation check; the CLI calls `Lockfile.add` / `TrustStore.grant` on `ooo plugin install` / `ooo plugin trust`.