### PR TITLE
feat(plugin): UserLevel program registry

### DIFF
--- a/src/ouroboros/plugin/userlevel_registry.py
+++ b/src/ouroboros/plugin/userlevel_registry.py
@@ -62,11 +62,26 @@ class RegisteredProgram:
 
 
 class UserLevelProgramRegistry:
-    """In-memory registry of installed UserLevel programs."""
+    """In-memory registry of installed UserLevel programs.
+
+    Maintains three indexes that must stay in lockstep with `_by_name`:
+
+    - `_namespace_owner` — `namespace → plugin name` (one namespace per
+      plugin).
+    - `_command_owner` — `command name → plugin name` (command names are
+      globally unique because `lookup_command(name)` resolves bare command
+      names; without uniqueness the same name could dispatch to different
+      plugins depending on registration order).
+
+    Every mutation (`register`, `unregister`) is performed under `_lock`
+    and updates all relevant indexes atomically; tests that manipulate
+    these indexes from the outside are expected to use the public API.
+    """
 
     def __init__(self) -> None:
         self._by_name: dict[str, RegisteredProgram] = {}
         self._namespace_owner: dict[str, str] = {}  # namespace -> plugin name
+        self._command_owner: dict[str, str] = {}  # command name -> plugin name
         self._lock = RLock()
 
     def register(self, manifest: PluginManifest, *, replace: bool = False) -> RegisteredProgram:
@@ -81,7 +96,8 @@ class UserLevelProgramRegistry:
             The registered program.
 
         Raises:
-            RegistryError: on namespace collision or duplicate name without
+            RegistryError: on namespace collision, command-name collision
+                across plugins, or duplicate plugin name without
                 `replace=True`.
         """
         if not manifest.commands:
@@ -96,6 +112,24 @@ class UserLevelProgramRegistry:
             )
         namespace = namespaces.pop()
 
+        # Within-manifest command-name uniqueness. The vendored 0.1 schema
+        # does not enforce uniqueness on `commands[*].name`, but the
+        # registry treats command names as a primary lookup key — without
+        # this guard a manifest with two commands named `review` would
+        # accept silently and `find_command()` / `get_by_command()` would
+        # always return the first array entry, hiding the second spec.
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for c in manifest.commands:
+            if c.name in seen and c.name not in duplicates:
+                duplicates.append(c.name)
+            seen.add(c.name)
+        if duplicates:
+            raise RegistryError(
+                f"{manifest.name}: duplicate command name(s) within manifest: {sorted(duplicates)}"
+            )
+        new_command_names = seen
+
         with self._lock:
             existing = self._by_name.get(manifest.name)
             if existing is not None and not replace:
@@ -104,25 +138,61 @@ class UserLevelProgramRegistry:
                     f"(version {existing.manifest.version}); pass replace=True to update"
                 )
 
-            owner = self._namespace_owner.get(namespace)
-            if owner is not None and owner != manifest.name:
-                raise RegistryError(
-                    f"namespace {namespace!r} already owned by {owner!r}; "
-                    f"refusing to register {manifest.name!r}"
-                )
+            # Cross-axis collision check.
+            # `lookup_command()` resolves one string across three axes in
+            # priority order (namespace → plugin name → command name). If
+            # the same string is reserved on a higher-priority axis by
+            # another plugin, the lower-priority match becomes unreachable.
+            # Treat the union of (incoming namespace, plugin name, command
+            # names) as a single identifier space; any collision with an
+            # axis owned by *another* plugin is rejected. Self-owned
+            # identifiers are exempt because the replace branch below
+            # releases stale ones before the new ones are installed.
+            new_identifiers = {manifest.name, namespace} | new_command_names
+            other_namespaces = {
+                ns: o for ns, o in self._namespace_owner.items() if o != manifest.name
+            }
+            other_plugin_names = {n for n in self._by_name if n != manifest.name}
+            other_commands = {c: o for c, o in self._command_owner.items() if o != manifest.name}
+            for ident in new_identifiers:
+                if ident in other_namespaces:
+                    raise RegistryError(
+                        f"identifier {ident!r} would shadow namespace "
+                        f"already owned by {other_namespaces[ident]!r}; "
+                        f"refusing to register {manifest.name!r}"
+                    )
+                if ident in other_plugin_names:
+                    raise RegistryError(
+                        f"identifier {ident!r} would shadow existing plugin name; "
+                        f"refusing to register {manifest.name!r}"
+                    )
+                if ident in other_commands:
+                    raise RegistryError(
+                        f"identifier {ident!r} would shadow command "
+                        f"already owned by plugin {other_commands[ident]!r}; "
+                        f"refusing to register {manifest.name!r}"
+                    )
 
-            # On replace, release the previous namespace mapping if the new
-            # manifest moved to a different namespace under the same plugin
-            # name. Otherwise the old namespace stays permanently owned by
-            # this plugin: lookup_command(old_ns) still resolves to the new
-            # program (wrong target), and other plugins are blocked from
-            # claiming that namespace forever.
-            if existing is not None and existing.namespace != namespace:
-                self._namespace_owner.pop(existing.namespace, None)
+            # Replace must be transactional across all indexes: release any
+            # namespace and command-name slots the previous incarnation owned
+            # but the new manifest no longer claims. Without this, stale
+            # entries linger and either block future registrations or skew
+            # the lookup result for a name that should be free.
+            if existing is not None:
+                if existing.namespace != namespace and (
+                    self._namespace_owner.get(existing.namespace) == manifest.name
+                ):
+                    self._namespace_owner.pop(existing.namespace)
+                old_command_names = {c.name for c in existing.manifest.commands}
+                for stale in old_command_names - new_command_names:
+                    if self._command_owner.get(stale) == manifest.name:
+                        self._command_owner.pop(stale)
 
             program = RegisteredProgram(manifest=manifest)
             self._by_name[manifest.name] = program
             self._namespace_owner[namespace] = manifest.name
+            for cmd_name in new_command_names:
+                self._command_owner[cmd_name] = manifest.name
             return program
 
     def unregister(self, name: str) -> bool:
@@ -134,6 +204,9 @@ class UserLevelProgramRegistry:
             ns = program.namespace
             if self._namespace_owner.get(ns) == name:
                 self._namespace_owner.pop(ns)
+            for cmd in program.manifest.commands:
+                if self._command_owner.get(cmd.name) == name:
+                    self._command_owner.pop(cmd.name)
             return True
 
     def get(self, name: str) -> RegisteredProgram | None:
@@ -143,6 +216,18 @@ class UserLevelProgramRegistry:
     def get_by_namespace(self, namespace: str) -> RegisteredProgram | None:
         with self._lock:
             owner = self._namespace_owner.get(namespace)
+            if owner is None:
+                return None
+            return self._by_name.get(owner)
+
+    def get_by_command(self, command_name: str) -> RegisteredProgram | None:
+        """Return the program whose manifest declares `command_name`, or None.
+
+        Backed by `_command_owner` and therefore O(1); register() enforces
+        global uniqueness so this never has to disambiguate across plugins.
+        """
+        with self._lock:
+            owner = self._command_owner.get(command_name)
             if owner is None:
                 return None
             return self._by_name.get(owner)
@@ -199,13 +284,27 @@ def lookup_command(name: str) -> LookupResult:
     """Look up a name across both the UserLevel registry and the bundled
     skills registry. Returns the first match.
 
-    Order:
-      1. UserLevel namespaces (e.g. "github-pr") — fast, in-memory.
-      2. UserLevel plugin names (e.g. "github-pr-ops").
-      3. Bundled skill names (loaded from .claude-plugin/skills/).
+    Resolution order:
+      1. UserLevel namespace (e.g. "github-pr") — fast, in-memory.
+      2. UserLevel plugin name (e.g. "github-pr-ops").
+      3. UserLevel command name (e.g. "review") — first plugin whose
+         command list contains it. Ambiguity is prevented at registration
+         time by namespace + name uniqueness.
+      4. Bundled skill name (e.g. "review-pr").
+
+    Skills branch precondition:
+        The bundled `SkillRegistry` is discovered lazily via
+        `await get_registry().discover_all()`. The caller (CLI bootstrap,
+        firewall, integration tests) is responsible for driving discovery
+        before relying on the skill branch — this helper deliberately does
+        not trigger discovery itself, because doing so would either block
+        on async-from-sync (fragile under an active event loop) or hide
+        an I/O cost in a pure lookup. Callers that have not discovered
+        skills will still get correct UserLevel results; they will simply
+        miss skill matches and receive `kind="none"` instead.
 
     Args:
-        name: The command name, namespace, or plugin name to look up.
+        name: a command name, namespace, or plugin name to look up.
 
     Returns:
         `LookupResult` indicating which registry matched.
@@ -220,8 +319,17 @@ def lookup_command(name: str) -> LookupResult:
     if program is not None:
         return LookupResult(kind="userlevel", userlevel_program=program)
 
+    # Resolve via command name (e.g. "review" → plugin owning the command).
+    # `register()` enforces global command-name uniqueness so this lookup is
+    # unambiguous and O(1) via the dedicated index.
+    program = ul.get_by_command(name)
+    if program is not None:
+        return LookupResult(kind="userlevel", userlevel_program=program)
+
     # Skills lookup: import lazily so this module doesn't pull in watchdog
-    # and yaml at import time.
+    # and yaml at import time. Returns kind="none" if discovery has not run
+    # (see precondition note above) — callers that need authoritative skill
+    # results must drive `discover_all()` themselves.
     try:
         from ouroboros.plugin.skills.registry import get_registry as _get_skill_registry
     except ImportError:  # pragma: no cover - defensive

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -109,19 +109,208 @@ def test_unregister(tmp_path: Path) -> None:
     registry.register(other)  # must not raise
 
 
+def test_replace_with_different_namespace_releases_old(tmp_path: Path) -> None:
+    """Regression: replace=True must release the previously owned namespace.
+
+    Before the fix at userlevel_registry.py:register, a plugin re-registering
+    under a *different* namespace left a stale entry in `_namespace_owner`,
+    so `get_by_namespace(old_ns)` returned the wrong program and other
+    plugins could never claim the old namespace again.
+    """
+    registry = UserLevelProgramRegistry()
+
+    old = _load_ref(tmp_path / "old")  # name="github-pr-ops", namespace="github-pr"
+    registry.register(old)
+
+    # Re-register under a brand new namespace; same plugin name.
+    new_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    new_payload["commands"][0]["namespace"] = "pr-tools"
+    new_payload["commands"][0]["usage"] = "ooo pr-tools review <pull-request-url>"
+    new = load_manifest(_write_manifest(tmp_path / "new", new_payload))
+    registry.register(new, replace=True)
+
+    # Old namespace must be fully released.
+    assert registry.get_by_namespace("github-pr") is None
+    # New namespace owns the plugin.
+    program = registry.get_by_namespace("pr-tools")
+    assert program is not None
+    assert program.namespace == "pr-tools"
+    # And another plugin can now claim the old namespace. Give it a
+    # distinct command name — the global command-name uniqueness rule means
+    # we cannot reuse "review" while github-pr-ops still owns it.
+    other_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    other_payload["name"] = "plugin-other"
+    other_payload["commands"][0]["name"] = "scan"
+    other_payload["commands"][0]["usage"] = "ooo github-pr scan <url>"
+    other = load_manifest(_write_manifest(tmp_path / "other", other_payload))
+    registry.register(other)
+    other_program = registry.get_by_namespace("github-pr")
+    assert other_program is not None
+    assert other_program.name == "plugin-other"
+
+    # unregister still cleans up the *current* namespace.
+    assert registry.unregister("github-pr-ops") is True
+    assert registry.get_by_namespace("pr-tools") is None
+    # And old plugin's previous (already released) namespace remains owned by
+    # the third plugin we registered above.
+    assert registry.get_by_namespace("github-pr") is not None
+
+
 def test_all_programs(tmp_path: Path) -> None:
     """Test 5: all_programs returns every registered program."""
     registry = UserLevelProgramRegistry()
     a = _load_ref(tmp_path / "a", name="plugin-a")
-    # Different namespace for b
+    # Distinct namespace AND command name for b — both must be unique
+    # globally now that command-name collisions are rejected.
     b_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
     b_payload["name"] = "plugin-b"
     b_payload["commands"][0]["namespace"] = "other-ns"
+    b_payload["commands"][0]["name"] = "audit"
+    b_payload["commands"][0]["usage"] = "ooo other-ns audit"
     b = load_manifest(_write_manifest(tmp_path / "b", b_payload))
     registry.register(a)
     registry.register(b)
     names = {p.name for p in registry.all_programs()}
     assert names == {"plugin-a", "plugin-b"}
+
+
+def test_within_manifest_duplicate_command_rejected(tmp_path: Path) -> None:
+    """A single manifest declaring the same command name twice (even within
+    the same namespace) is rejected. The vendored 0.1 schema doesn't
+    enforce this, but the registry treats command names as a primary key
+    so the duplicate would otherwise hide the second spec from
+    `find_command()` and `get_by_command()`.
+    """
+    registry = UserLevelProgramRegistry()
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["commands"] = [
+        payload["commands"][0],
+        {
+            "namespace": "github-pr",
+            "name": "review",  # duplicate
+            "summary": "A second `review` definition.",
+            "usage": "ooo github-pr review --shadow",
+            "risk": "read_only",
+        },
+    ]
+    manifest = load_manifest(_write_manifest(tmp_path / "dup", payload))
+    with pytest.raises(RegistryError, match="duplicate command name"):
+        registry.register(manifest)
+
+
+def test_command_name_collision_rejected(tmp_path: Path) -> None:
+    """Two plugins claiming the same bare command name → error.
+
+    Without this rule, `lookup_command("review")` would resolve to
+    whichever plugin happened to register first, producing nondeterministic
+    dispatch.
+    """
+    registry = UserLevelProgramRegistry()
+    a = _load_ref(tmp_path / "a", name="plugin-a")  # command "review" / ns "github-pr"
+    b_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    b_payload["name"] = "plugin-b"
+    b_payload["commands"][0]["namespace"] = "other-ns"
+    # Same command name "review" — collision on a different axis from namespace.
+    b = load_manifest(_write_manifest(tmp_path / "b", b_payload))
+    registry.register(a)
+    with pytest.raises(RegistryError, match="shadow command already owned"):
+        registry.register(b)
+
+
+def test_cross_axis_collision_rejected(tmp_path: Path) -> None:
+    """A name reserved on one axis (plugin name, namespace, command name)
+    cannot be reused on a different axis by a different plugin.
+
+    Without this guard, plugin-A could register `name="review"` and
+    plugin-B could register `command name="review"` in some other
+    namespace, after which `lookup_command("review")` would always
+    resolve to plugin-A by the higher-priority "plugin name" arm and
+    plugin-B's `review` command would be unreachable. The same axis
+    asymmetry holds for namespace vs command name and plugin name vs
+    namespace, so the registry rejects any cross-axis shadowing.
+    """
+    registry = UserLevelProgramRegistry()
+
+    # Case 1: plugin name vs another plugin's command name.
+    a_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    a_payload["name"] = "review"  # plugin name == "review"
+    a_payload["commands"][0]["namespace"] = "namespace-a"
+    a_payload["commands"][0]["name"] = "run"
+    a_payload["commands"][0]["usage"] = "ooo namespace-a run"
+    a = load_manifest(_write_manifest(tmp_path / "a", a_payload))
+    registry.register(a)
+
+    b_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    b_payload["name"] = "plugin-b"
+    b_payload["commands"][0]["namespace"] = "namespace-b"
+    b_payload["commands"][0]["name"] = "review"  # collides with plugin-A's plugin name
+    b_payload["commands"][0]["usage"] = "ooo namespace-b review"
+    b = load_manifest(_write_manifest(tmp_path / "b", b_payload))
+    with pytest.raises(RegistryError, match="shadow existing plugin name"):
+        registry.register(b)
+
+    # Case 2: namespace vs another plugin's plugin name.
+    c_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    c_payload["name"] = "plugin-c"
+    c_payload["commands"][0]["namespace"] = "review"  # collides with plugin-A's plugin name
+    c_payload["commands"][0]["name"] = "scan"
+    c_payload["commands"][0]["usage"] = "ooo review scan"
+    c = load_manifest(_write_manifest(tmp_path / "c", c_payload))
+    with pytest.raises(RegistryError, match="shadow existing plugin name"):
+        registry.register(c)
+
+    # Case 3: namespace vs another plugin's command name.
+    d_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    d_payload["name"] = "plugin-d"
+    d_payload["commands"][0]["namespace"] = "run"  # collides with plugin-A's command "run"
+    d_payload["commands"][0]["name"] = "trace"
+    d_payload["commands"][0]["usage"] = "ooo run trace"
+    d = load_manifest(_write_manifest(tmp_path / "d", d_payload))
+    with pytest.raises(RegistryError, match="shadow command already owned"):
+        registry.register(d)
+
+
+def test_replace_with_different_commands_releases_old(tmp_path: Path) -> None:
+    """Regression: replace=True must release command names the previous
+    incarnation owned but the new manifest no longer claims, and another
+    plugin must then be allowed to register the released command."""
+    registry = UserLevelProgramRegistry()
+
+    # Old manifest exposes two commands.
+    old_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    old_payload["commands"] = [
+        old_payload["commands"][0],
+        {
+            "namespace": "github-pr",
+            "name": "audit",
+            "summary": "Audit a pull request.",
+            "usage": "ooo github-pr audit <url>",
+            "risk": "read_only",
+        },
+    ]
+    old = load_manifest(_write_manifest(tmp_path / "old", old_payload))
+    registry.register(old)
+
+    # New manifest drops "audit"; same plugin name, replace=True.
+    new_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    new = load_manifest(_write_manifest(tmp_path / "new", new_payload))
+    registry.register(new, replace=True)
+
+    # "audit" is no longer claimed → another plugin can take it.
+    other_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    other_payload["name"] = "auditor"
+    other_payload["commands"][0]["namespace"] = "auditor"
+    other_payload["commands"][0]["name"] = "audit"
+    other_payload["commands"][0]["usage"] = "ooo auditor audit"
+    other = load_manifest(_write_manifest(tmp_path / "other", other_payload))
+    registry.register(other)
+    by_command = registry.get_by_command("audit")
+    assert by_command is not None
+    assert by_command.name == "auditor"
+    # And "review" still routes to the original plugin.
+    review_owner = registry.get_by_command("review")
+    assert review_owner is not None
+    assert review_owner.name == "github-pr-ops"
 
 
 def test_lookup_command_finds_userlevel_by_namespace(tmp_path: Path) -> None:
@@ -144,6 +333,58 @@ def test_lookup_command_finds_userlevel_by_name(tmp_path: Path) -> None:
     assert result.kind == "userlevel"
 
 
+def test_lookup_command_finds_userlevel_by_command_name(tmp_path: Path) -> None:
+    """lookup_command resolves bare command names (e.g. `review`) against
+    the registered programs' command lists, matching the docstring contract
+    of name | namespace | plugin name."""
+    manifest = _load_ref(tmp_path)  # has a "review" command in the github-pr namespace
+    get_userlevel_registry().register(manifest)
+    result = lookup_command("review")
+    assert result.found
+    assert result.kind == "userlevel"
+    assert result.userlevel_program is not None
+    assert result.userlevel_program.name == "github-pr-ops"
+
+
+def test_lookup_command_finds_bundled_skill_after_discover(tmp_path: Path) -> None:
+    """lookup_command returns kind='skill' once the bundled SkillRegistry
+    has been driven through discover_all(). The lookup deliberately does
+    not trigger discovery itself; this test exercises the post-discovery
+    success path the bot flagged as previously uncovered."""
+    import asyncio
+
+    from ouroboros.plugin.skills import registry as skill_registry_module
+    from ouroboros.plugin.skills.registry import SkillRegistry
+
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    skill = skill_root / "demo-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "description: A demo skill for the lookup test.\n"
+        "triggers:\n"
+        "  - demo\n"
+        "---\n\n"
+        "# Demo Skill\n\nBody.\n"
+    )
+
+    fresh = SkillRegistry(skill_dir=skill_root)
+    asyncio.run(fresh.discover_all())
+
+    # Substitute the global skill registry singleton so lookup_command's
+    # lazy `get_registry()` returns our preloaded one.
+    original = skill_registry_module._global_registry
+    skill_registry_module._global_registry = fresh
+    try:
+        result = lookup_command("demo-skill")
+        assert result.found
+        assert result.kind == "skill"
+        assert result.skill_metadata is not None
+    finally:
+        skill_registry_module._global_registry = original
+
+
 def test_lookup_command_returns_none_for_unknown(tmp_path: Path) -> None:
     """Test 8: lookup_command returns kind='none' for unknown names."""
     result = lookup_command("totally-unknown-plugin")
@@ -156,49 +397,6 @@ def test_global_singleton_persists_within_session(tmp_path: Path) -> None:
     a = get_userlevel_registry()
     b = get_userlevel_registry()
     assert a is b
-
-
-def test_replace_releases_old_namespace(tmp_path: Path) -> None:
-    """Regression: register(replace=True) with a different namespace must
-    free the old namespace so other plugins can claim it AND so
-    `get_by_namespace(old_ns)` no longer returns the new program.
-
-    Previously the old namespace mapping persisted, leaving the
-    registry in an inconsistent state where the old namespace was
-    permanently owned by a plugin whose commands no longer used it.
-    """
-    registry = UserLevelProgramRegistry()
-
-    # Initial registration owns "github-pr".
-    initial = _load_ref(tmp_path / "v0")
-    registry.register(initial)
-    assert registry.get_by_namespace("github-pr") is not None
-
-    # Same plugin name, but the new manifest moved to "github-issue".
-    moved = json.loads(json.dumps(REFERENCE_MANIFEST))
-    moved["version"] = "0.2.0"
-    moved["commands"][0]["namespace"] = "github-issue"
-    moved_manifest = load_manifest(_write_manifest(tmp_path / "v1", moved))
-    registry.register(moved_manifest, replace=True)
-
-    # The old namespace is now free.
-    assert registry.get_by_namespace("github-pr") is None, (
-        "old namespace must be released so lookups don't resolve to a "
-        "plugin that no longer claims it"
-    )
-    # The new namespace resolves to the replaced program.
-    moved_program = registry.get_by_namespace("github-issue")
-    assert moved_program is not None
-    assert moved_program.manifest.version == "0.2.0"
-
-    # And another plugin can now legitimately claim the old namespace.
-    other = json.loads(json.dumps(REFERENCE_MANIFEST))
-    other["name"] = "other-plugin"
-    other["commands"][0]["namespace"] = "github-pr"
-    other_manifest = load_manifest(_write_manifest(tmp_path / "other", other))
-    registry.register(other_manifest)  # MUST NOT raise
-    assert registry.get_by_namespace("github-pr") is not None
-    assert registry.get_by_namespace("github-pr").name == "other-plugin"
 
 
 def test_skill_registry_unaffected(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #730. Sub-issue of #725 (Phase 1). **Stacked on #745 (CR-3 manifest loader)**.

## Module: `src/ouroboros/plugin/userlevel_registry.py`

In-memory registry of installed UserLevel programs, keyed by plugin name and namespace.

- `register(manifest, replace=False)` — namespace ownership enforced; first registration wins, subsequent for the same namespace raise `RegistryError`. Duplicate name requires `replace=True`.
- `unregister(name)` — releases both name AND namespace.
- `get(name)`, `get_by_namespace(namespace)`, `all_programs()`.
- Process-wide singleton via `get_userlevel_registry()`; `reset_userlevel_registry()` for tests.

### Cross-registry lookup

`lookup_command(name)` — top-level helper that satisfies the locked spec's "single lookup":

```
lookup_command(name)
  → UserLevel registry by namespace
  → UserLevel registry by name
  → bundled SkillRegistry by name
  → LookupResult(kind="none")
```

Returns `LookupResult` with `kind ∈ {"userlevel", "skill", "none"}`.

## Design choice — alongside, not merged into SkillRegistry

The locked spec asked to "extend `src/ouroboros/plugin/skills/registry.py`". After reading the existing module (700 LOC, watchdog hot-reload, YAML frontmatter parsing) I concluded that **merging JSON-manifest plugins into SkillRegistry's class would more than double its size and lifecycle complexity**. The two artifact shapes have fundamentally different semantics:

- Skills: `.claude-plugin/skills/<name>/SKILL.md`, hot-reloaded via watchdog, YAML frontmatter.
- UserLevel programs: `~/.ouroboros/plugins/<name>/ouroboros.plugin.json`, install/trust lifecycle, JSON manifest with audit contract.

Instead, the new registry sits alongside. The cross-registry helper is the "one lookup table" the spec implies — and existing skill tests are **unchanged** (regression checked: 46 passed, 1 skipped).

If the maintainer prefers the literal "extend the same class" interpretation, that's a follow-up refactor; this PR's interface (`lookup_command`) lets the firewall (#729) and CLI (#731) consume both registries without caring about the underlying class structure.

## Tests — 10/10 pass; no regression on skills/test_registry.py

```
$ PYTHONPATH=src python3 -m pytest tests/unit/plugin/test_userlevel_registry.py -v
============================== 10 passed in 0.24s ==============================

$ PYTHONPATH=src python3 -m pytest tests/unit/plugin/skills/test_registry.py
======================== 46 passed, 1 skipped in 0.29s =========================
```

| # | Test | Asserts |
|---|---|---|
| 1 | register/get/get_by_namespace happy path | round-trip, unknown returns None |
| 2 | namespace collision rejected | `RegistryError("already owned")` |
| 3 | duplicate name requires `replace=True` | first error, then succeeds with `replace=True` |
| 4 | unregister releases name AND namespace | another plugin can claim the namespace after |
| 5 | `all_programs()` returns every entry | set-equality check |
| 6 | `lookup_command` via namespace | `kind="userlevel"` |
| 7 | `lookup_command` via name | `kind="userlevel"` |
| 8 | unknown name returns `kind="none"` | |
| 9 | global singleton identity | `get_userlevel_registry()` is `get_userlevel_registry()` |
| 10 | skill registry unaffected | regression guard |

## What's next

#729 (firewall) and #731 (CLI) consume `lookup_command` to dispatch. The firewall instantiates an in-memory `UserLevelProgramRegistry` from the lockfile (#732 — already in #746) on startup; the CLI registers/unregisters as plugins are installed/removed.