### PR TITLE
feat(plugin): invocation firewall + audit-event emitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "aiosqlite>=0.20.0,<1.0.0",
     "anyio>=4.0.0,<5.0.0",
+    "jsonschema>=4.21.0,<5.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "prompt-toolkit>=3.0.0,<4.0.0",
     "pyyaml>=6.0.0,<7.0.0",

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -144,6 +144,25 @@ def _scope_risk_index(manifest: PluginManifest) -> dict[str, str]:
     return {p.scope: p.risk for p in manifest.permissions}
 
 
+def _classify_launcher_oserror(exc: OSError) -> tuple[int, str]:
+    """Classify a launcher-side OSError into (exit_code, descriptor).
+
+    Exit codes follow POSIX shell convention so callers can distinguish
+    "missing entrypoint" (127) from "found but not executable" (126).
+    Other launcher-side OSErrors fall through to 126 with a descriptor
+    that names the underlying condition for the audit trail.
+    """
+    if isinstance(exc, FileNotFoundError):
+        return 127, "entrypoint not found"
+    if isinstance(exc, PermissionError):
+        return 126, "entrypoint not executable"
+    if isinstance(exc, IsADirectoryError):
+        return 126, "entrypoint is a directory"
+    if isinstance(exc, NotADirectoryError):
+        return 126, "entrypoint path component is not a directory"
+    return 126, "entrypoint launcher error"
+
+
 def invoke_plugin(
     program: RegisteredProgram,
     *,
@@ -291,8 +310,17 @@ def invoke_plugin(
             text=True,
             check=False,
         )
-    except FileNotFoundError as exc:
-        message = f"entrypoint not found: {cmd_argv[0]!r} ({exc})"
+    except OSError as exc:
+        # Map every launcher-side OSError to a terminal `plugin.failed` so
+        # the firewall contract holds: once `plugin.invoked` has been
+        # emitted, a terminal event ALWAYS follows. Pre-fix only
+        # `FileNotFoundError` was caught; `PermissionError`,
+        # `NotADirectoryError`, `IsADirectoryError`, and generic `OSError`
+        # would escape uncaught after `plugin.invoked` and
+        # `plugin.permission_used` had already been emitted, leaving a
+        # hung audit trail.
+        exit_code, descriptor = _classify_launcher_oserror(exc)
+        message = f"{descriptor}: {cmd_argv[0]!r} ({exc})"
         _emit(
             _event_envelope(
                 event_type="plugin.failed",
@@ -307,7 +335,7 @@ def invoke_plugin(
         )
         return InvocationResult(
             status="failed",
-            exit_code=127,
+            exit_code=exit_code,
             message=message,
             events=tuple(emitted),
         )

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -30,18 +30,17 @@ ledger writer (#737). Tests pass a list-appender for inspection.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 import hashlib
 import shlex
 import subprocess
-from collections.abc import Callable
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Iterable, Literal
+from typing import Literal
 
 from ouroboros.plugin.manifest import PluginManifest
 from ouroboros.plugin.trust_store import TrustRecord
 from ouroboros.plugin.userlevel_registry import RegisteredProgram
-
 
 SCHEMA_VERSION = "0.1"
 
@@ -60,7 +59,7 @@ class InvocationResult:
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _source_type_for_event(manifest: PluginManifest) -> str:

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -315,6 +315,31 @@ def invoke_plugin(
     # 5. Run entrypoint out-of-process.
     cmd_template = manifest.entrypoint.command
     cmd_argv = shlex.split(cmd_template) + [command_name] + list(argv)
+    # Defense-in-depth: `load_manifest` already rejects empty / blank
+    # entrypoint commands, but the firewall is the last chokepoint
+    # before launch — guard explicitly so a hand-crafted manifest or a
+    # future loader regression cannot cause `subprocess.run([])` to
+    # raise `IndexError` AFTER `plugin.invoked` has been emitted.
+    if not cmd_argv or not cmd_argv[0]:
+        message = "entrypoint command resolves to empty argv"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={"correlation_id": correlation_id},
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=126,
+            message=message,
+            events=tuple(emitted),
+        )
     runner = subprocess_runner or subprocess.run
     try:
         completed = runner(

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -1,0 +1,380 @@
+"""Plugin invocation firewall.
+
+Every UserLevel plugin command must pass through `invoke_plugin`. The
+firewall is the single chokepoint that:
+
+  1. Pre-invocation trust check (locked Q1 of Q00/ouroboros-plugins#9):
+     refuse + clean error if a `required: true` permission is not trusted;
+     emit only `plugin.failed (status=blocked)`. NO `plugin.invoked` is
+     emitted in this case.
+  2. Single confirmation gate (locked Q2): if the command sets
+     `requires_confirmation: true`, prompt the user once. No second
+     prompt for permission risk.
+  3. Emit `plugin.invoked` before launching the entrypoint subprocess.
+  4. Emit `plugin.permission_used` for each `required: true` permission
+     declared by the manifest. v0 uses Option (a): coarse declared-set
+     emission, not per-call granular tracking.
+  5. Run the entrypoint out-of-process via subprocess.
+  6. Emit `plugin.completed` (status=success) or `plugin.failed`
+     (status=failed) on terminal.
+
+Audit events conform to schemas/0.1/audit-event.schema.json. Bounded
+payloads: argv stored as-is, raw stdout/stderr replaced with a sha256
+hash. Tokens, channel IDs, free-form user messages are forbidden by
+contract.
+
+The firewall does NOT own the audit log. Callers pass an `event_sink`
+(any callable taking a dict) which is typically wired to the core
+ledger writer (#737). Tests pass a list-appender for inspection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Literal
+
+from ouroboros.plugin.manifest import PluginManifest
+from ouroboros.plugin.trust_store import TrustRecord
+from ouroboros.plugin.userlevel_registry import RegisteredProgram
+
+
+SCHEMA_VERSION = "0.1"
+
+EventSink = Callable[[dict], None]
+ConfirmFn = Callable[[str], bool]
+
+
+@dataclass(frozen=True)
+class InvocationResult:
+    status: Literal["success", "blocked", "failed"]
+    exit_code: int | None = None
+    message: str = ""
+    stdout_sha256: str | None = None
+    stderr_sha256: str | None = None
+    events: tuple[dict, ...] = field(default_factory=tuple)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _source_type_for_event(manifest: PluginManifest) -> str:
+    return manifest.source.type
+
+
+def _event_envelope(
+    *,
+    event_type: str,
+    manifest: PluginManifest,
+    namespace: str,
+    command_name: str,
+    argv: list[str] | None,
+    trust_state: str,
+    capabilities_used: Iterable[str] = (),
+    permissions_used: Iterable[str] = (),
+    result: dict | None = None,
+    provenance: dict[str, str] | None = None,
+) -> dict:
+    """Build an event matching schemas/0.1/audit-event.schema.json."""
+    cmd: dict = {"namespace": namespace, "name": command_name}
+    if argv is not None:
+        cmd["argv"] = list(argv)
+    event: dict = {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": event_type,
+        "occurred_at": _utc_now_iso(),
+        "plugin": {
+            "name": manifest.name,
+            "version": manifest.version,
+            "source_type": _source_type_for_event(manifest),
+        },
+        "command": cmd,
+        "trust_state": trust_state,
+        "capabilities_used": list(capabilities_used),
+        "permissions_used": list(permissions_used),
+        "result": result or {"status": "success"},
+    }
+    if provenance is not None:
+        event["provenance"] = dict(provenance)
+    return event
+
+
+def _required_permissions(manifest: PluginManifest) -> list[str]:
+    return [p.scope for p in manifest.permissions if p.required]
+
+
+def _trust_state_label(
+    manifest: PluginManifest,
+    trust_record: TrustRecord | None,
+) -> str:
+    if manifest.source.type == "first_party":
+        return "first_party"
+    if trust_record is not None and trust_record.granted_scopes:
+        return "trusted"
+    return "installed"
+
+
+def _missing_required(
+    manifest: PluginManifest,
+    trust_record: TrustRecord | None,
+) -> list[str]:
+    required = _required_permissions(manifest)
+    if not required:
+        return []
+    if trust_record is None:
+        return list(required)
+    return trust_record.missing(required)
+
+
+def _format_blocked_message(plugin_name: str, missing: list[str], risks: dict[str, str]) -> str:
+    """Per locked Q1: name the missing scope and the exact trust command."""
+    first = missing[0]
+    risk = risks.get(first, "?")
+    return (
+        f"plugin requires `{first}` ({risk}), which is not yet trusted. "
+        f"Run: ooo plugin trust {plugin_name} --scope {first}"
+    )
+
+
+def _scope_risk_index(manifest: PluginManifest) -> dict[str, str]:
+    return {p.scope: p.risk for p in manifest.permissions}
+
+
+def invoke_plugin(
+    program: RegisteredProgram,
+    *,
+    command_name: str,
+    argv: list[str],
+    trust_record: TrustRecord | None,
+    event_sink: EventSink,
+    correlation_id: str,
+    confirm: ConfirmFn = lambda _msg: True,
+    subprocess_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> InvocationResult:
+    """Invoke a UserLevel plugin command through the firewall.
+
+    Args:
+        program: Registered UserLevel program (from `userlevel_registry`).
+        command_name: The name of the command within the plugin's namespace.
+        argv: User-provided argument vector for the command.
+        trust_record: The plugin's TrustRecord (None if not yet trusted).
+            For first-party programs, may be None — the firewall does not
+            consult it for them.
+        event_sink: Callable that receives audit events. Wire to the core
+            ledger writer (#737) in production; pass `events.append` in
+            tests.
+        correlation_id: Cross-event correlation id for the ledger.
+        confirm: Optional callable for confirmation prompts. Default is
+            "auto-confirm" (returns True). CLI passes a function that
+            actually prompts.
+        subprocess_runner: Optional override (for tests) of subprocess.run.
+
+    Returns:
+        `InvocationResult` with status, exit code, sha256 hashes of
+        stdout/stderr, and the events emitted (also pushed to event_sink).
+    """
+    manifest = program.manifest
+    namespace = program.namespace
+    command = program.find_command(command_name)
+    if command is None:
+        # Treat unknown command as a failure that emits no events — the
+        # caller (CLI) is responsible for surfacing this. Returning a
+        # failed result keeps the contract simple.
+        return InvocationResult(
+            status="failed",
+            exit_code=2,
+            message=f"unknown command {command_name!r} in namespace {namespace!r}",
+        )
+
+    trust_state = _trust_state_label(manifest, trust_record)
+    risks = _scope_risk_index(manifest)
+    emitted: list[dict] = []
+
+    def _emit(event: dict) -> None:
+        event_sink(event)
+        emitted.append(event)
+
+    # 1. Pre-invocation trust check (locked Q1).
+    # First-party programs skip the trust check (per Q00/ouroboros-plugins#8).
+    if manifest.source.type != "first_party":
+        missing = _missing_required(manifest, trust_record)
+        if missing:
+            message = _format_blocked_message(manifest.name, missing, risks)
+            _emit(
+                _event_envelope(
+                    event_type="plugin.failed",
+                    manifest=manifest,
+                    namespace=namespace,
+                    command_name=command_name,
+                    argv=argv,
+                    trust_state=trust_state,
+                    result={"status": "blocked", "message": message},
+                    provenance={"correlation_id": correlation_id},
+                )
+            )
+            return InvocationResult(
+                status="blocked",
+                exit_code=None,
+                message=message,
+                events=tuple(emitted),
+            )
+
+    # 2. Confirmation gate (locked Q2 — ONE prompt, command-level).
+    if command.requires_confirmation:
+        prompt = (
+            f"This command is destructive and requires confirmation.\n"
+            f"Plugin: {manifest.name} {manifest.version}\n"
+            f"Action: {command_name} {' '.join(argv)}\n"
+            f"Continue?"
+        )
+        if not confirm(prompt):
+            message = "user declined confirmation"
+            _emit(
+                _event_envelope(
+                    event_type="plugin.failed",
+                    manifest=manifest,
+                    namespace=namespace,
+                    command_name=command_name,
+                    argv=argv,
+                    trust_state=trust_state,
+                    result={"status": "blocked", "message": message},
+                    provenance={"correlation_id": correlation_id},
+                )
+            )
+            return InvocationResult(
+                status="blocked",
+                exit_code=None,
+                message=message,
+                events=tuple(emitted),
+            )
+
+    # 3. Emit `plugin.invoked` before launch.
+    _emit(
+        _event_envelope(
+            event_type="plugin.invoked",
+            manifest=manifest,
+            namespace=namespace,
+            command_name=command_name,
+            argv=argv,
+            trust_state=trust_state,
+            provenance={"correlation_id": correlation_id},
+        )
+    )
+
+    # 4. Emit one `plugin.permission_used` per required permission.
+    for scope in _required_permissions(manifest):
+        _emit(
+            _event_envelope(
+                event_type="plugin.permission_used",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                permissions_used=[scope],
+                provenance={"correlation_id": correlation_id, "scope": scope},
+            )
+        )
+
+    # 5. Run entrypoint out-of-process.
+    cmd_template = manifest.entrypoint.command
+    cmd_argv = shlex.split(cmd_template) + [command_name] + list(argv)
+    runner = subprocess_runner or subprocess.run
+    try:
+        completed = runner(
+            cmd_argv,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        message = f"entrypoint not found: {cmd_argv[0]!r} ({exc})"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={"correlation_id": correlation_id},
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=127,
+            message=message,
+            events=tuple(emitted),
+        )
+
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    stdout_hash = hashlib.sha256(stdout.encode("utf-8")).hexdigest()
+    stderr_hash = hashlib.sha256(stderr.encode("utf-8")).hexdigest()
+
+    # 6. Terminal event: completed or failed.
+    if completed.returncode == 0:
+        _emit(
+            _event_envelope(
+                event_type="plugin.completed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "success"},
+                provenance={
+                    "correlation_id": correlation_id,
+                    "stdout_sha256": stdout_hash,
+                    "stderr_sha256": stderr_hash,
+                },
+            )
+        )
+        return InvocationResult(
+            status="success",
+            exit_code=0,
+            stdout_sha256=stdout_hash,
+            stderr_sha256=stderr_hash,
+            events=tuple(emitted),
+        )
+    else:
+        message = f"entrypoint exited with code {completed.returncode}"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={
+                    "correlation_id": correlation_id,
+                    "stdout_sha256": stdout_hash,
+                    "stderr_sha256": stderr_hash,
+                },
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=completed.returncode,
+            message=message,
+            stdout_sha256=stdout_hash,
+            stderr_sha256=stderr_hash,
+            events=tuple(emitted),
+        )
+
+
+__all__ = [
+    "ConfirmFn",
+    "EventSink",
+    "InvocationResult",
+    "SCHEMA_VERSION",
+    "invoke_plugin",
+]

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -209,6 +209,19 @@ def invoke_plugin(
             message=f"unknown command {command_name!r} in namespace {namespace!r}",
         )
 
+    # Per Q00/ouroboros-plugins#9 Q4 lock: a version bump invalidates the
+    # trust record. The TrustStore enforces this at write time, but the
+    # firewall must also enforce it at INVOCATION time — otherwise a
+    # caller holding a stale `TrustRecord` (e.g. read before an upgrade,
+    # or for a different plugin name entirely) could authorize the new
+    # code with consent that was given to the old code. Treat any
+    # mismatched record as if no trust existed; the missing-permissions
+    # path then fires and the user is asked to re-grant.
+    if trust_record is not None and (
+        trust_record.plugin != manifest.name or trust_record.version != manifest.version
+    ):
+        trust_record = None
+
     trust_state = _trust_state_label(manifest, trust_record)
     risks = _scope_risk_index(manifest)
     emitted: list[dict] = []

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -1,0 +1,193 @@
+"""Plugin lockfile.
+
+Persists records of installed plugins at `~/.ouroboros/plugins.lock` (TOML).
+The lockfile is the source of truth for "what is installed" — the trust store
+(see `trust_store.py`) is the source of truth for "what is trusted."
+
+Per the locked Q00/ouroboros#732 spec:
+  - Atomic writes (temp file + rename).
+  - Concurrent-write safety via a POSIX file lock (fcntl).
+  - Deterministic ordering: entries sorted by `name` so diffs are reviewable.
+  - Schema versioned (`schema_version = "0.1"`).
+  - Removal is atomic (no orphaned entries).
+
+The TOML shape is fixed and small. We hand-roll serialization rather than
+take on a `tomli_w` dependency. Reading uses stdlib `tomllib`.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import tomllib
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+LOCKFILE_SCHEMA_VERSION = "0.1"
+
+# Default location. Overridable via constructor for tests.
+DEFAULT_LOCKFILE_PATH = Path.home() / ".ouroboros" / "plugins.lock"
+
+
+@dataclass(frozen=True)
+class LockEntry:
+    """One installed plugin's lockfile record."""
+
+    name: str
+    version: str
+    source_kind: str  # "git" | "local"
+    repository: str | None  # git URL when source_kind="git"; else None
+    git_sha: str | None
+    manifest_checksum: str  # "sha256:<hex>"
+    installed_at: str  # RFC3339
+    plugin_home: str  # filesystem path
+
+    def to_toml_lines(self) -> list[str]:
+        lines = ["[[plugin]]"]
+        lines.append(f"name = {_toml_str(self.name)}")
+        lines.append(f"version = {_toml_str(self.version)}")
+        lines.append(f"source_kind = {_toml_str(self.source_kind)}")
+        if self.repository is not None:
+            lines.append(f"repository = {_toml_str(self.repository)}")
+        if self.git_sha is not None:
+            lines.append(f"git_sha = {_toml_str(self.git_sha)}")
+        lines.append(f"manifest_checksum = {_toml_str(self.manifest_checksum)}")
+        lines.append(f"installed_at = {_toml_str(self.installed_at)}")
+        lines.append(f"plugin_home = {_toml_str(self.plugin_home)}")
+        return lines
+
+
+def _toml_str(value: str) -> str:
+    """Serialize a string value as TOML basic string. Restricts content to
+    avoid escaping edge cases — the lockfile only stores names, paths, hashes
+    and timestamps, none of which contain control chars or non-ASCII in
+    practice."""
+    if any(ch == "\\" or ch == '"' or ord(ch) < 0x20 for ch in value):
+        # Use TOML's basic string escapes for the small set we actually need.
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+            .replace("\r", "\\r")
+        )
+        return f'"{escaped}"'
+    return f'"{value}"'
+
+
+class Lockfile:
+    """Atomic, file-locked plugins lockfile manager."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or DEFAULT_LOCKFILE_PATH
+
+    def _ensure_dir(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def read(self) -> dict[str, LockEntry]:
+        """Read the lockfile, returning entries keyed by plugin name.
+
+        Returns an empty dict if the file does not exist.
+        Raises ValueError if the schema_version is unsupported.
+        """
+        if not self.path.is_file():
+            return {}
+        with self.path.open("rb") as handle:
+            data = tomllib.load(handle)
+        version = data.get("schema_version")
+        if version != LOCKFILE_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported lockfile schema_version {version!r}; "
+                f"expected {LOCKFILE_SCHEMA_VERSION!r}"
+            )
+        result: dict[str, LockEntry] = {}
+        for raw in data.get("plugin", []):
+            entry = LockEntry(
+                name=raw["name"],
+                version=raw["version"],
+                source_kind=raw["source_kind"],
+                repository=raw.get("repository"),
+                git_sha=raw.get("git_sha"),
+                manifest_checksum=raw["manifest_checksum"],
+                installed_at=raw["installed_at"],
+                plugin_home=raw["plugin_home"],
+            )
+            result[entry.name] = entry
+        return result
+
+    def _write_atomic(self, entries: dict[str, LockEntry]) -> None:
+        """Write the lockfile atomically (temp file + rename)."""
+        self._ensure_dir()
+        ordered = sorted(entries.values(), key=lambda e: e.name)
+        lines = [f'schema_version = "{LOCKFILE_SCHEMA_VERSION}"', ""]
+        for entry in ordered:
+            lines.extend(entry.to_toml_lines())
+            lines.append("")
+        body = "\n".join(lines).rstrip() + "\n"
+
+        # Write to temp file in the same directory, then atomic rename.
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".plugins.lock.", dir=str(self.path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(body)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, self.path)
+        except Exception:
+            # Best-effort cleanup of the temp file on failure.
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    @contextmanager
+    def _file_lock(self) -> Iterator[None]:
+        """Acquire an exclusive flock for concurrent-write safety.
+
+        POSIX-only. Falls through gracefully on platforms without fcntl
+        (the file is still atomically replaced via os.replace, which gives
+        last-writer-wins semantics — acceptable for non-concurrent use).
+        """
+        self._ensure_dir()
+        try:
+            import fcntl
+        except ImportError:  # pragma: no cover — non-POSIX platforms
+            yield
+            return
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        with lock_path.open("w") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def add(self, entry: LockEntry) -> None:
+        """Add or replace an entry. Holds the file lock for the duration."""
+        with self._file_lock():
+            entries = self.read()
+            entries[entry.name] = entry
+            self._write_atomic(entries)
+
+    def remove(self, name: str) -> bool:
+        """Remove an entry by name. Returns True if removed, False if absent."""
+        with self._file_lock():
+            entries = self.read()
+            if name not in entries:
+                return False
+            entries.pop(name)
+            self._write_atomic(entries)
+            return True
+
+
+__all__ = [
+    "DEFAULT_LOCKFILE_PATH",
+    "LOCKFILE_SCHEMA_VERSION",
+    "LockEntry",
+    "Lockfile",
+]

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -17,13 +17,13 @@ take on a `tomli_w` dependency. Reading uses stdlib `tomllib`.
 
 from __future__ import annotations
 
-import os
-import tempfile
-import tomllib
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+import os
 from pathlib import Path
-from typing import Iterator
+import tempfile
+import tomllib
 
 LOCKFILE_SCHEMA_VERSION = "0.1"
 

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -128,9 +128,7 @@ class Lockfile:
         body = "\n".join(lines).rstrip() + "\n"
 
         # Write to temp file in the same directory, then atomic rename.
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=".plugins.lock.", dir=str(self.path.parent)
-        )
+        fd, tmp_path = tempfile.mkstemp(prefix=".plugins.lock.", dir=str(self.path.parent))
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 handle.write(body)

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -309,6 +309,22 @@ def load_manifest(path: str | Path) -> PluginManifest:
         Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
         for c in raw["capabilities"]
     )
+    # Reject duplicate capability names. Downstream code keys capability
+    # decisions on `name`, so a duplicate would silently shadow another
+    # entry's `access` / `reason`.
+    seen_capability_names: set[str] = set()
+    for cap in capabilities:
+        if cap.name in seen_capability_names:
+            idx = next(i for i, c in enumerate(capabilities) if c.name == cap.name and c is cap)
+            raise PluginManifestError(
+                f"duplicate capability name {cap.name!r}",
+                path=str(manifest_path),
+                json_pointer=f"/capabilities/{idx}/name",
+                expected="unique capability name within the plugin",
+                got=f"second occurrence of {cap.name!r}",
+            )
+        seen_capability_names.add(cap.name)
+
     permissions = tuple(
         Permission(
             scope=p["scope"],
@@ -318,6 +334,25 @@ def load_manifest(path: str | Path) -> PluginManifest:
         )
         for p in raw["permissions"]
     )
+    # Reject duplicate permission scopes. The firewall treats `scope` as
+    # the unique permission identifier: `_required_permissions()` would
+    # emit one `plugin.permission_used` event per duplicate, and
+    # `_scope_risk_index()` would silently let the last entry win for
+    # the blocked-message risk label. Two `github:read` entries with
+    # different `risk` or `required` values therefore produce
+    # inconsistent UX and audit data instead of being rejected.
+    seen_scopes: set[str] = set()
+    for perm in permissions:
+        if perm.scope in seen_scopes:
+            idx = next(i for i, p in enumerate(permissions) if p.scope == perm.scope and p is perm)
+            raise PluginManifestError(
+                f"duplicate permission scope {perm.scope!r}",
+                path=str(manifest_path),
+                json_pointer=f"/permissions/{idx}/scope",
+                expected="unique permission scope within the plugin",
+                got=f"second occurrence of {perm.scope!r}",
+            )
+        seen_scopes.add(perm.scope)
     entrypoint = Entrypoint(
         type=raw["entrypoint"]["type"],
         command=raw["entrypoint"]["command"],

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -24,8 +24,8 @@ runtime side effects.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
 from typing import Any
 
@@ -128,7 +128,7 @@ class AuditSpec:
     events: tuple[str, ...]
 
     @staticmethod
-    def standard_four_events() -> "AuditSpec":
+    def standard_four_events() -> AuditSpec:
         return AuditSpec(
             events=(
                 "plugin.invoked",

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -288,6 +288,23 @@ def load_manifest(path: str | Path) -> PluginManifest:
     )
 
     commands = tuple(_build_command(c) for c in raw["commands"])
+    # Reject duplicate command names within a plugin. The JSON Schema
+    # enforces shape, but does not enforce uniqueness across the
+    # `commands` array. `RegisteredProgram.find_command()` returns the
+    # first match by name, so a duplicate would silently shadow a
+    # different command's risk level, confirmation policy, or arguments.
+    seen_command_names: set[str] = set()
+    for cmd in commands:
+        if cmd.name in seen_command_names:
+            idx = next(i for i, c in enumerate(commands) if c.name == cmd.name and c is cmd)
+            raise PluginManifestError(
+                f"duplicate command name {cmd.name!r}",
+                path=str(manifest_path),
+                json_pointer=f"/commands/{idx}/name",
+                expected="unique command name within the plugin",
+                got=f"second occurrence of {cmd.name!r}",
+            )
+        seen_command_names.add(cmd.name)
     capabilities = tuple(
         Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
         for c in raw["capabilities"]

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import json
 from pathlib import Path
+import shlex
 from typing import Any
 
 try:
@@ -368,9 +369,34 @@ def load_manifest(path: str | Path) -> PluginManifest:
                 got=f"second occurrence of {perm.scope!r}",
             )
         seen_scopes.add(perm.scope)
+    entrypoint_command = raw["entrypoint"]["command"]
+    # The JSON Schema only enforces `minLength: 1`, so a manifest with
+    # `"   "` (or any whitespace string) would pass shape validation but
+    # `shlex.split()` returns `[]` at invocation time. The firewall
+    # would then call `subprocess.run([])` which raises `IndexError`
+    # AFTER `plugin.invoked` has been emitted, leaving an incomplete
+    # audit trail. Reject blank or shlex-empty commands at load.
+    try:
+        _entrypoint_argv = shlex.split(entrypoint_command)
+    except ValueError as exc:
+        raise PluginManifestError(
+            f"entrypoint.command is not a valid shell-like token sequence: {exc}",
+            path=str(manifest_path),
+            json_pointer="/entrypoint/command",
+            expected="non-empty shell-tokenizable command",
+            got=repr(entrypoint_command)[:200],
+        ) from exc
+    if not _entrypoint_argv:
+        raise PluginManifestError(
+            "entrypoint.command must be a non-empty command",
+            path=str(manifest_path),
+            json_pointer="/entrypoint/command",
+            expected="non-empty command (at least one shlex token)",
+            got=repr(entrypoint_command)[:200],
+        )
     entrypoint = Entrypoint(
         type=raw["entrypoint"]["type"],
-        command=raw["entrypoint"]["command"],
+        command=entrypoint_command,
     )
 
     audit_raw = raw.get("audit")

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -139,6 +139,21 @@ class AuditSpec:
         )
 
 
+# Events the invocation firewall may emit during a single call. A manifest
+# whose `audit.events` omits any of these is asserting a contract the
+# runtime cannot honor — `invoke_plugin` would still emit them. The
+# loader enforces that all four are present so the manifest's declared
+# contract matches the firewall's actual behavior.
+FIREWALL_REQUIRED_EVENTS: frozenset[str] = frozenset(
+    {
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed",
+    }
+)
+
+
 @dataclass(frozen=True)
 class PluginManifest:
     """Frozen representation of a validated plugin manifest.
@@ -363,6 +378,23 @@ def load_manifest(path: str | Path) -> PluginManifest:
         audit = AuditSpec.standard_four_events()
     else:
         audit = AuditSpec(events=tuple(audit_raw["events"]))
+        # Enforce that the manifest's declared `audit.events` include every
+        # event the firewall may emit. Otherwise a manifest could opt out
+        # of (e.g.) `plugin.permission_used` while the runtime still emits
+        # it, breaking any consumer that treats the manifest as
+        # authoritative for the event set.
+        declared = frozenset(audit.events)
+        missing = sorted(FIREWALL_REQUIRED_EVENTS - declared)
+        if missing:
+            raise PluginManifestError(
+                f"audit.events must include the firewall-emitted events; missing: {missing}",
+                path=str(manifest_path),
+                json_pointer="/audit/events",
+                expected=(
+                    f"array containing all firewall events {sorted(FIREWALL_REQUIRED_EVENTS)}"
+                ),
+                got=f"declared: {sorted(declared)}",
+            )
 
     return PluginManifest(
         schema_version=schema_version,
@@ -379,15 +411,16 @@ def load_manifest(path: str | Path) -> PluginManifest:
 
 
 __all__ = [
+    "AuditSpec",
     "Capability",
     "CommandArgument",
     "CommandSpec",
     "Entrypoint",
+    "FIREWALL_REQUIRED_EVENTS",
     "Permission",
     "PluginManifest",
     "PluginManifestError",
-    "SourceSpec",
-    "AuditSpec",
-    "load_manifest",
     "SUPPORTED_SCHEMA_VERSIONS",
+    "SourceSpec",
+    "load_manifest",
 ]

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -1,0 +1,336 @@
+"""Plugin manifest loader.
+
+Loads UserLevel plugin manifests (`ouroboros.plugin.json`) and validates them
+against the vendored JSON Schema under `src/ouroboros/plugin/schemas/<major>/`.
+
+The locked spec (Q00/ouroboros#728) requires:
+
+  - `PluginManifest` is a frozen dataclass with 8 required + 2 optional fields
+    (per Q00/ouroboros-plugins#6 lock).
+  - `load_manifest(path)` returns a frozen, validated manifest.
+  - On any schema violation, raise `PluginManifestError` with structured
+    fields: `path`, `json_pointer`, `expected`, `got`. A reviewer can match
+    on `json_pointer` rather than parsing message text.
+  - `source.type=first_party` is a real branch; the loader does not require
+    `source.path`/`source.repository` for first-party manifests.
+  - Manifest's `schema_version` selects the matching archived schema.
+    Unsupported versions raise with a clear message naming the support
+    window.
+
+This module is intentionally narrow. It does not load remote URLs (that is
+the manager's job in #731), does not cache (premature), and does not perform
+runtime side effects.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "jsonschema>=4.21 is required. Install it via `pip install jsonschema`."
+    ) from exc
+
+
+# Support window per Q00/ouroboros-plugins#11 lock: current MAJOR + previous MAJOR.
+# Today we only ship 0.1; once 1.0 ships, both "0.1" and "1.0" are accepted, "0.x"
+# below the latest is unsupported.
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1",)
+
+_SCHEMAS_ROOT = Path(__file__).resolve().parent / "schemas"
+
+
+class PluginManifestError(Exception):
+    """Raised when a manifest fails to load or validate.
+
+    Attributes:
+        path: Filesystem path of the manifest that failed.
+        json_pointer: JSON Pointer (RFC 6901) to the failing field, or None
+            for whole-file failures.
+        expected: Human-readable description of what was expected.
+        got: Human-readable description of what was actually present.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: str | Path,
+        json_pointer: str | None = None,
+        expected: str = "",
+        got: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.path = str(path)
+        self.json_pointer = json_pointer
+        self.expected = expected
+        self.got = got
+
+    def __str__(self) -> str:  # pragma: no cover - convenience
+        loc = self.json_pointer if self.json_pointer is not None else "(root)"
+        return f"{self.path}: {loc}: {self.args[0] if self.args else ''}"
+
+
+@dataclass(frozen=True)
+class CommandArgument:
+    name: str
+    type: str
+    required: bool
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    namespace: str
+    name: str
+    summary: str
+    usage: str
+    risk: str
+    requires_confirmation: bool = False
+    arguments: tuple[CommandArgument, ...] = ()
+
+
+@dataclass(frozen=True)
+class Capability:
+    name: str
+    access: str
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class Permission:
+    scope: str
+    risk: str
+    required: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    type: str
+    path: str | None = None
+    repository: str | None = None
+
+
+@dataclass(frozen=True)
+class Entrypoint:
+    type: str
+    command: str
+
+
+@dataclass(frozen=True)
+class AuditSpec:
+    events: tuple[str, ...]
+
+    @staticmethod
+    def standard_four_events() -> "AuditSpec":
+        return AuditSpec(
+            events=(
+                "plugin.invoked",
+                "plugin.permission_used",
+                "plugin.completed",
+                "plugin.failed",
+            )
+        )
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Frozen representation of a validated plugin manifest.
+
+    Field shape matches Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json
+    after the locked Q00/ouroboros-plugins#6 (8 required + 2 optional)
+    decision is applied.
+    """
+
+    schema_version: str
+    name: str
+    version: str
+    source: SourceSpec
+    commands: tuple[CommandSpec, ...]
+    capabilities: frozenset[Capability]
+    permissions: frozenset[Permission]
+    entrypoint: Entrypoint
+    description: str = ""
+    audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
+
+
+def _load_schema(schema_version: str) -> dict[str, Any]:
+    schema_path = _SCHEMAS_ROOT / schema_version / "plugin.schema.json"
+    if not schema_path.is_file():
+        raise PluginManifestError(
+            f"vendored schema for version {schema_version!r} not found",
+            path=str(schema_path),
+            json_pointer="/schema_version",
+            expected=f"one of {list(SUPPORTED_SCHEMA_VERSIONS)}",
+            got=f"{schema_version!r} (no vendored schema)",
+        )
+    with schema_path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _build_command(raw: dict[str, Any]) -> CommandSpec:
+    args = tuple(
+        CommandArgument(
+            name=a["name"],
+            type=a["type"],
+            required=a["required"],
+            description=a.get("description", ""),
+        )
+        for a in raw.get("arguments", [])
+    )
+    return CommandSpec(
+        namespace=raw["namespace"],
+        name=raw["name"],
+        summary=raw["summary"],
+        usage=raw["usage"],
+        risk=raw["risk"],
+        requires_confirmation=raw.get("requires_confirmation", False),
+        arguments=args,
+    )
+
+
+def load_manifest(path: str | Path) -> PluginManifest:
+    """Load and validate a plugin manifest from `path`.
+
+    Args:
+        path: Filesystem path to an `ouroboros.plugin.json` file.
+
+    Returns:
+        A frozen, validated `PluginManifest`.
+
+    Raises:
+        PluginManifestError: on JSON decode failure, schema violation, or
+            unsupported `schema_version`.
+    """
+    manifest_path = Path(path)
+    if not manifest_path.is_file():
+        raise PluginManifestError(
+            f"manifest file not found: {manifest_path}",
+            path=str(manifest_path),
+            json_pointer=None,
+            expected="readable file",
+            got="missing",
+        )
+
+    try:
+        with manifest_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise PluginManifestError(
+            f"manifest is not valid JSON: {exc.msg}",
+            path=str(manifest_path),
+            json_pointer=None,
+            expected="valid JSON object",
+            got=f"JSON decode error at line {exc.lineno}, col {exc.colno}",
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise PluginManifestError(
+            "manifest must be a JSON object",
+            path=str(manifest_path),
+            json_pointer="",
+            expected="object",
+            got=type(raw).__name__,
+        )
+
+    schema_version = raw.get("schema_version")
+    if not isinstance(schema_version, str):
+        raise PluginManifestError(
+            "manifest is missing `schema_version`",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected="string (e.g. '0.1')",
+            got=type(schema_version).__name__,
+        )
+
+    if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+        raise PluginManifestError(
+            f"schema_version {schema_version!r} is not in the support window",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected=f"schema_version in supported window {list(SUPPORTED_SCHEMA_VERSIONS)}",
+            got=schema_version,
+        )
+
+    schema = _load_schema(schema_version)
+    validator = Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(raw),
+        key=lambda e: list(e.absolute_path),
+    )
+    if errors:
+        err = errors[0]
+        pointer = "/" + "/".join(str(p) for p in err.absolute_path) if err.absolute_path else ""
+        raise PluginManifestError(
+            err.message,
+            path=str(manifest_path),
+            json_pointer=pointer,
+            expected=str(err.schema),
+            got=str(err.instance)[:200],
+        )
+
+    source_raw = raw["source"]
+    source = SourceSpec(
+        type=source_raw["type"],
+        path=source_raw.get("path"),
+        repository=source_raw.get("repository"),
+    )
+
+    commands = tuple(_build_command(c) for c in raw["commands"])
+    capabilities = frozenset(
+        Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
+        for c in raw["capabilities"]
+    )
+    permissions = frozenset(
+        Permission(
+            scope=p["scope"],
+            risk=p["risk"],
+            required=p["required"],
+            reason=p.get("reason", ""),
+        )
+        for p in raw["permissions"]
+    )
+    entrypoint = Entrypoint(
+        type=raw["entrypoint"]["type"],
+        command=raw["entrypoint"]["command"],
+    )
+
+    audit_raw = raw.get("audit")
+    if audit_raw is None:
+        audit = AuditSpec.standard_four_events()
+    else:
+        audit = AuditSpec(events=tuple(audit_raw["events"]))
+
+    return PluginManifest(
+        schema_version=schema_version,
+        name=raw["name"],
+        version=raw["version"],
+        source=source,
+        commands=commands,
+        capabilities=capabilities,
+        permissions=permissions,
+        entrypoint=entrypoint,
+        description=raw.get("description", ""),
+        audit=audit,
+    )
+
+
+__all__ = [
+    "Capability",
+    "CommandArgument",
+    "CommandSpec",
+    "Entrypoint",
+    "Permission",
+    "PluginManifest",
+    "PluginManifestError",
+    "SourceSpec",
+    "AuditSpec",
+    "load_manifest",
+    "SUPPORTED_SCHEMA_VERSIONS",
+]

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -153,8 +153,13 @@ class PluginManifest:
     version: str
     source: SourceSpec
     commands: tuple[CommandSpec, ...]
-    capabilities: frozenset[Capability]
-    permissions: frozenset[Permission]
+    # Capabilities and permissions preserve manifest declaration order.
+    # The firewall's `permission_used` emission and blocked-scope error
+    # message both walk these in order, so the persisted audit trail and
+    # user-facing UX are deterministic. Using `tuple` (instead of
+    # `frozenset`) makes that explicit at the type level.
+    capabilities: tuple[Capability, ...]
+    permissions: tuple[Permission, ...]
     entrypoint: Entrypoint
     description: str = ""
     audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
@@ -283,11 +288,11 @@ def load_manifest(path: str | Path) -> PluginManifest:
     )
 
     commands = tuple(_build_command(c) for c in raw["commands"])
-    capabilities = frozenset(
+    capabilities = tuple(
         Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
         for c in raw["capabilities"]
     )
-    permissions = frozenset(
+    permissions = tuple(
         Permission(
             scope=p["scope"],
             risk=p["risk"],

--- a/src/ouroboros/plugin/schemas/0.1/_source.json
+++ b/src/ouroboros/plugin/schemas/0.1/_source.json
@@ -1,0 +1,6 @@
+{
+  "repo": "Q00/ouroboros-plugins",
+  "schema_version": "0.1",
+  "vendored_at": "2026-05-07",
+  "note": "These schemas mirror Q00/ouroboros-plugins/schemas/0.1/. They reflect the locked decisions in Q00/ouroboros-plugins #6 (manifest 8+2 fields), #10 (3-value risk enum), #11 (per-major archive). Sync via scripts/sync-plugin-schemas.sh once Q00/ouroboros-plugins#13/#16/#19/#20 land on upstream main."
+}

--- a/src/ouroboros/plugin/schemas/0.1/audit-event.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/audit-event.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros-plugins/schemas/0.1/audit-event.schema.json",
+  "title": "Ouroboros Plugin Audit Event (v0.1)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "occurred_at",
+    "plugin",
+    "command",
+    "trust_state",
+    "capabilities_used",
+    "permissions_used",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "plugin.discovered",
+        "plugin.installed",
+        "plugin.trusted",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed"
+      ]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "plugin": {
+      "type": "object",
+      "required": ["name", "version", "source_type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "source_type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["namespace", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": { "type": "string" },
+        "name": { "type": "string" },
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "trust_state": {
+      "type": "string",
+      "enum": ["discovered", "installed", "trusted", "disabled", "blocked", "first_party"]
+    },
+    "capabilities_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "permissions_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "result": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["success", "blocked", "failed"]
+        },
+        "message": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json",
+  "title": "Ouroboros Plugin Manifest (v0.1)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "version",
+    "source",
+    "commands",
+    "capabilities",
+    "permissions",
+    "entrypoint"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "description": {
+      "type": "string",
+      "default": ""
+    },
+    "source": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        },
+        "path": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        }
+      }
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["namespace", "name", "summary", "usage", "risk"],
+        "additionalProperties": false,
+        "properties": {
+          "namespace": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "usage": {
+            "type": "string",
+            "minLength": 1
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "requires_confirmation": {
+            "type": "boolean",
+            "default": false
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "type", "required"],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_-]*$"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["string", "boolean", "integer", "path", "url"]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "access"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "seed",
+              "ledger",
+              "state",
+              "provenance",
+              "runtime",
+              "mcp",
+              "handoff",
+              "progress"
+            ]
+          },
+          "access": {
+            "type": "string",
+            "enum": ["read", "write", "execute", "attach"]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scope", "risk", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "scope": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "entrypoint": {
+      "type": "object",
+      "required": ["type", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "command"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": ["events"],
+      "additionalProperties": false,
+      "default": {
+        "events": [
+          "plugin.invoked",
+          "plugin.permission_used",
+          "plugin.completed",
+          "plugin.failed"
+        ]
+      },
+      "properties": {
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "plugin.discovered",
+              "plugin.installed",
+              "plugin.trusted",
+              "plugin.invoked",
+              "plugin.permission_used",
+              "plugin.completed",
+              "plugin.failed"
+            ]
+          },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -21,13 +21,13 @@ from this store.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 import json
 import os
-import tempfile
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+import tempfile
 
 TRUST_SCHEMA_VERSION = "0.1"
 
@@ -122,7 +122,7 @@ class TrustStore:
     ) -> TrustRecord:
         """Grant `scope` to `plugin@version`. Idempotent: granting an
         already-granted scope is a no-op (timestamps preserved)."""
-        when = when or datetime.now(tz=timezone.utc)
+        when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         existing = self.read(plugin)

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -21,7 +21,8 @@ from this store.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import json
@@ -67,6 +68,37 @@ class TrustStore:
 
     def _path(self, plugin: str) -> Path:
         return self.root / plugin / "trust.json"
+
+    def _lock_path(self, plugin: str) -> Path:
+        return self.root / plugin / "trust.json.lock"
+
+    @contextmanager
+    def _file_lock(self, plugin: str) -> Iterator[None]:
+        """Acquire an exclusive flock around read-modify-write operations.
+
+        Two concurrent `grant()` calls on the same plugin would otherwise
+        race the read-modify-write through `_write_atomic`'s `os.replace`,
+        silently dropping one writer's appended scope. The lock serializes
+        the whole RMW so the second writer reads the first writer's
+        result.
+
+        Falls through gracefully on platforms without `fcntl`. Mirrors the
+        approach used by `lockfile.Lockfile._file_lock`.
+        """
+        path = self._path(plugin)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            import fcntl
+        except ImportError:  # pragma: no cover - non-POSIX
+            yield
+            return
+        lock_path = self._lock_path(plugin)
+        with lock_path.open("w") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
     def read(self, plugin: str) -> TrustRecord | None:
         """Read the trust record for `plugin`, or None if not present."""
@@ -125,26 +157,31 @@ class TrustStore:
         when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        existing = self.read(plugin)
-        # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
-        if existing is not None and existing.version != version:
-            existing = None  # treat as fresh
+        with self._file_lock(plugin):
+            existing = self.read(plugin)
+            # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
+            if existing is not None and existing.version != version:
+                existing = None  # treat as fresh
 
-        granted = list(existing.granted_scopes) if existing else []
-        if all(g.scope != scope for g in granted):
-            granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
+            granted = list(existing.granted_scopes) if existing else []
+            if all(g.scope != scope for g in granted):
+                granted.append(
+                    GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by)
+                )
 
-        payload = {
-            "schema_version": TRUST_SCHEMA_VERSION,
-            "plugin": plugin,
-            "version": version,
-            "granted_scopes": [
-                {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
-                for g in granted
-            ],
-        }
-        self._write_atomic(plugin, payload)
-        return TrustRecord(plugin=plugin, version=version, granted_scopes=tuple(granted))
+            payload = {
+                "schema_version": TRUST_SCHEMA_VERSION,
+                "plugin": plugin,
+                "version": version,
+                "granted_scopes": [
+                    {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
+                    for g in granted
+                ],
+            }
+            self._write_atomic(plugin, payload)
+            return TrustRecord(
+                plugin=plugin, version=version, granted_scopes=tuple(granted)
+            )
 
     def reset_for_version_bump(self, plugin: str, new_version: str) -> None:
         """Invalidate trust because the plugin's version changed.
@@ -158,20 +195,27 @@ class TrustStore:
             "version": new_version,
             "granted_scopes": [],
         }
-        self._write_atomic(plugin, payload)
+        with self._file_lock(plugin):
+            self._write_atomic(plugin, payload)
 
     def remove(self, plugin: str) -> bool:
         """Remove the trust file for `plugin`. Returns True if removed."""
-        path = self._path(plugin)
-        if not path.is_file():
-            return False
-        path.unlink()
-        # Best-effort: remove the empty plugin dir if it's empty afterwards.
-        try:
-            path.parent.rmdir()
-        except OSError:
-            pass
-        return True
+        with self._file_lock(plugin):
+            path = self._path(plugin)
+            if not path.is_file():
+                return False
+            path.unlink()
+            # Best-effort: clean up the lock file as well.
+            try:
+                self._lock_path(plugin).unlink()
+            except FileNotFoundError:
+                pass
+            # Best-effort: remove the empty plugin dir if it's empty afterwards.
+            try:
+                path.parent.rmdir()
+            except OSError:
+                pass
+            return True
 
 
 __all__ = [

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -165,9 +165,7 @@ class TrustStore:
 
             granted = list(existing.granted_scopes) if existing else []
             if all(g.scope != scope for g in granted):
-                granted.append(
-                    GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by)
-                )
+                granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
 
             payload = {
                 "schema_version": TRUST_SCHEMA_VERSION,
@@ -179,9 +177,7 @@ class TrustStore:
                 ],
             }
             self._write_atomic(plugin, payload)
-            return TrustRecord(
-                plugin=plugin, version=version, granted_scopes=tuple(granted)
-            )
+            return TrustRecord(plugin=plugin, version=version, granted_scopes=tuple(granted))
 
     def reset_for_version_bump(self, plugin: str, new_version: str) -> None:
         """Invalidate trust because the plugin's version changed.

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -1,0 +1,183 @@
+"""Per-plugin trust store.
+
+Persists granted trust scopes per plugin at
+`~/.ouroboros/plugins/<name>/trust.json`. Per the locked Q00/ouroboros#732
+spec (which consumes the locked Q00/ouroboros-plugins#9 trust UX answers):
+
+- **Per-user storage** (Q5): one trust file per installed plugin, in the
+  same per-user directory as the plugin home.
+- **Version-bump invalidation** (Q4): when a plugin's version changes,
+  the trust file is reset (granted_scopes emptied). The user must re-grant
+  scopes via `ooo plugin trust` after upgrading.
+- **Exact scope grants** (Q3): each grant records the exact scope string;
+  parent scopes do not imply children.
+- **No raw tokens stored.** Only the scope name, timestamp, and granting
+  user identity are persisted.
+
+The trust store does NOT emit audit events itself; the firewall (#729) and
+CLI (#731) emit `plugin.trusted` when grants happen, sourcing the data
+from this store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+TRUST_SCHEMA_VERSION = "0.1"
+
+# Default location root. Each plugin gets a subdirectory here.
+DEFAULT_TRUST_ROOT = Path.home() / ".ouroboros" / "plugins"
+
+
+@dataclass(frozen=True)
+class GrantedScope:
+    scope: str
+    granted_at: str  # RFC3339
+    granted_by: str  # e.g. "user:<id>"
+
+
+@dataclass(frozen=True)
+class TrustRecord:
+    plugin: str
+    version: str
+    granted_scopes: tuple[GrantedScope, ...] = ()
+
+    def has_scope(self, scope: str) -> bool:
+        """Exact-string scope check (per Q00/ouroboros-plugins#9 Q3 lock —
+        parent scope does NOT imply child)."""
+        return any(g.scope == scope for g in self.granted_scopes)
+
+    def missing(self, required_scopes: Iterable[str]) -> list[str]:
+        """Return required scopes that are not granted, in order."""
+        granted = {g.scope for g in self.granted_scopes}
+        return [s for s in required_scopes if s not in granted]
+
+
+class TrustStore:
+    """Per-plugin trust store at <root>/<plugin-name>/trust.json."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or DEFAULT_TRUST_ROOT
+
+    def _path(self, plugin: str) -> Path:
+        return self.root / plugin / "trust.json"
+
+    def read(self, plugin: str) -> TrustRecord | None:
+        """Read the trust record for `plugin`, or None if not present."""
+        path = self._path(plugin)
+        if not path.is_file():
+            return None
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+        version = data.get("schema_version")
+        if version != TRUST_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported trust file schema_version {version!r}; "
+                f"expected {TRUST_SCHEMA_VERSION!r}"
+            )
+        return TrustRecord(
+            plugin=data["plugin"],
+            version=data["version"],
+            granted_scopes=tuple(
+                GrantedScope(
+                    scope=g["scope"],
+                    granted_at=g["granted_at"],
+                    granted_by=g["granted_by"],
+                )
+                for g in data.get("granted_scopes", [])
+            ),
+        )
+
+    def _write_atomic(self, plugin: str, payload: dict) -> None:
+        path = self._path(plugin)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".trust.", dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def grant(
+        self,
+        *,
+        plugin: str,
+        version: str,
+        scope: str,
+        granted_by: str,
+        when: datetime | None = None,
+    ) -> TrustRecord:
+        """Grant `scope` to `plugin@version`. Idempotent: granting an
+        already-granted scope is a no-op (timestamps preserved)."""
+        when = when or datetime.now(tz=timezone.utc)
+        ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        existing = self.read(plugin)
+        # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
+        if existing is not None and existing.version != version:
+            existing = None  # treat as fresh
+
+        granted = list(existing.granted_scopes) if existing else []
+        if all(g.scope != scope for g in granted):
+            granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
+
+        payload = {
+            "schema_version": TRUST_SCHEMA_VERSION,
+            "plugin": plugin,
+            "version": version,
+            "granted_scopes": [
+                {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
+                for g in granted
+            ],
+        }
+        self._write_atomic(plugin, payload)
+        return TrustRecord(plugin=plugin, version=version, granted_scopes=tuple(granted))
+
+    def reset_for_version_bump(self, plugin: str, new_version: str) -> None:
+        """Invalidate trust because the plugin's version changed.
+
+        Writes a new trust file with version=new_version and empty grants.
+        Per Q00/ouroboros-plugins#9 Q4 lock.
+        """
+        payload = {
+            "schema_version": TRUST_SCHEMA_VERSION,
+            "plugin": plugin,
+            "version": new_version,
+            "granted_scopes": [],
+        }
+        self._write_atomic(plugin, payload)
+
+    def remove(self, plugin: str) -> bool:
+        """Remove the trust file for `plugin`. Returns True if removed."""
+        path = self._path(plugin)
+        if not path.is_file():
+            return False
+        path.unlink()
+        # Best-effort: remove the empty plugin dir if it's empty afterwards.
+        try:
+            path.parent.rmdir()
+        except OSError:
+            pass
+        return True
+
+
+__all__ = [
+    "DEFAULT_TRUST_ROOT",
+    "TRUST_SCHEMA_VERSION",
+    "GrantedScope",
+    "TrustRecord",
+    "TrustStore",
+]

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -195,22 +195,22 @@ class TrustStore:
             self._write_atomic(plugin, payload)
 
     def remove(self, plugin: str) -> bool:
-        """Remove the trust file for `plugin`. Returns True if removed."""
+        """Remove the trust file for `plugin`. Returns True if removed.
+
+        The lock file is intentionally NOT unlinked. POSIX flocks are
+        inode-based: if `remove()` deleted `trust.json.lock` while still
+        holding the flock, another process arriving immediately after
+        could `open()` the path, create a *new* inode, and acquire an
+        independent flock on that new inode. Two writers would then run
+        concurrently and silently lose or resurrect trust state.
+        Keeping the lock file (a single empty marker file per plugin)
+        avoids that cross-process race entirely.
+        """
         with self._file_lock(plugin):
             path = self._path(plugin)
             if not path.is_file():
                 return False
             path.unlink()
-            # Best-effort: clean up the lock file as well.
-            try:
-                self._lock_path(plugin).unlink()
-            except FileNotFoundError:
-                pass
-            # Best-effort: remove the empty plugin dir if it's empty afterwards.
-            try:
-                path.parent.rmdir()
-            except OSError:
-                pass
             return True
 
 

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -28,12 +28,42 @@ from datetime import UTC, datetime
 import json
 import os
 from pathlib import Path
+import re
 import tempfile
 
 TRUST_SCHEMA_VERSION = "0.1"
 
 # Default location root. Each plugin gets a subdirectory here.
 DEFAULT_TRUST_ROOT = Path.home() / ".ouroboros" / "plugins"
+
+# Plugin names that the trust store will accept. Mirrors the manifest
+# schema's `name` pattern (`^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$`). The
+# pattern matters because we use the name as a filesystem path segment:
+# no path separators, no parent traversal, no leading dots.
+_PLUGIN_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$")
+
+
+class TrustStoreError(ValueError):
+    """Raised when an unsafe plugin identifier is rejected."""
+
+
+def _validate_plugin_name(plugin: str) -> None:
+    """Reject plugin identifiers that could escape the trust root.
+
+    `TrustStore` builds filesystem paths as `root / plugin / "trust.json"`,
+    so a value containing path separators or `..` segments would let
+    callers read, write, or delete files outside the configured trust
+    root. The manifest loader already enforces this pattern at parse
+    time, but the trust store is a public API that may be invoked with
+    untrusted strings (e.g. via CLI arguments), so re-validate here.
+    """
+    if not isinstance(plugin, str) or not plugin:
+        raise TrustStoreError(f"invalid plugin name: {plugin!r}")
+    if not _PLUGIN_NAME_PATTERN.fullmatch(plugin):
+        raise TrustStoreError(
+            f"plugin name {plugin!r} is not a safe identifier; "
+            "expected pattern ^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+        )
 
 
 @dataclass(frozen=True)
@@ -67,9 +97,11 @@ class TrustStore:
         self.root = root or DEFAULT_TRUST_ROOT
 
     def _path(self, plugin: str) -> Path:
+        _validate_plugin_name(plugin)
         return self.root / plugin / "trust.json"
 
     def _lock_path(self, plugin: str) -> Path:
+        _validate_plugin_name(plugin)
         return self.root / plugin / "trust.json.lock"
 
     @contextmanager
@@ -220,4 +252,5 @@ __all__ = [
     "GrantedScope",
     "TrustRecord",
     "TrustStore",
+    "TrustStoreError",
 ]

--- a/src/ouroboros/plugin/userlevel_registry.py
+++ b/src/ouroboros/plugin/userlevel_registry.py
@@ -111,6 +111,19 @@ class UserLevelProgramRegistry:
                     f"refusing to register {manifest.name!r}"
                 )
 
+            # When `replace=True` is used to update a plugin that previously
+            # claimed a different namespace, drop the stale mapping so the
+            # old namespace becomes free again. Without this, the old entry
+            # in `_namespace_owner` keeps pointing at this plugin and a
+            # subsequent `unregister(name)` only frees the *new* namespace,
+            # leaving the old one permanently shadowed.
+            if existing is not None:
+                old_namespace = existing.namespace
+                if old_namespace != namespace and (
+                    self._namespace_owner.get(old_namespace) == manifest.name
+                ):
+                    self._namespace_owner.pop(old_namespace, None)
+
             program = RegisteredProgram(manifest=manifest)
             self._by_name[manifest.name] = program
             self._namespace_owner[namespace] = manifest.name

--- a/src/ouroboros/plugin/userlevel_registry.py
+++ b/src/ouroboros/plugin/userlevel_registry.py
@@ -111,6 +111,28 @@ class UserLevelProgramRegistry:
                     f"refusing to register {manifest.name!r}"
                 )
 
+            # Reject identifier-shadowing across the by-name and
+            # by-namespace tables. `lookup_command()` resolves namespaces
+            # before plugin names, so:
+            #   * if `manifest.name` matches another plugin's namespace,
+            #     the plugin we are registering becomes unreachable by
+            #     name; and
+            #   * if the new `namespace` matches another plugin's name,
+            #     `lookup_command(name)` would suddenly resolve to this
+            #     plugin instead of the original one.
+            colliding_owner = self._namespace_owner.get(manifest.name)
+            if colliding_owner is not None and colliding_owner != manifest.name:
+                raise RegistryError(
+                    f"plugin name {manifest.name!r} collides with namespace "
+                    f"already owned by {colliding_owner!r}; pick a different name"
+                )
+            colliding_program = self._by_name.get(namespace)
+            if colliding_program is not None and colliding_program.name != manifest.name:
+                raise RegistryError(
+                    f"namespace {namespace!r} collides with existing plugin name "
+                    f"{colliding_program.name!r}; pick a different namespace"
+                )
+
             # When `replace=True` is used to update a plugin that previously
             # claimed a different namespace, drop the stale mapping so the
             # old namespace becomes free again. Without this, the old entry

--- a/src/ouroboros/plugin/userlevel_registry.py
+++ b/src/ouroboros/plugin/userlevel_registry.py
@@ -1,0 +1,237 @@
+"""UserLevel program registry.
+
+Tracks installed UserLevel plugins (and first-party programs) by their
+manifest. Sits alongside the existing `skills/registry.py` SkillRegistry —
+both are queryable via the top-level `lookup_command(...)` helper at the
+bottom of this module.
+
+Per the locked Q00/ouroboros#730 spec:
+  - One in-memory registry shared across the process.
+  - Namespace ownership: the first plugin to register `namespace=foo`
+    owns it; subsequent registrations for the same namespace are
+    rejected with a clear error.
+  - Names ARE used as primary keys (one program per name); re-registering
+    the same name without explicit replace is rejected.
+  - The registry is decoupled from discovery — callers (CLI, firewall,
+    integration tests) build a registry from already-loaded `PluginManifest`
+    instances.
+
+This module deliberately does NOT subsume or modify the SkillRegistry. The
+two cover different artifact shapes (JSON manifest vs SKILL.md frontmatter)
+and have different lifecycle semantics (install/trust vs hot-reload). They
+share only the cross-registry lookup helper at the bottom.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import RLock
+
+from ouroboros.plugin.manifest import CommandSpec, PluginManifest
+
+
+class RegistryError(Exception):
+    """Raised on namespace collision, duplicate registration, etc."""
+
+
+@dataclass(frozen=True)
+class RegisteredProgram:
+    """One entry in the UserLevel program registry.
+
+    The registry stores manifest references rather than copies — the
+    manifest is already frozen and value-equal.
+    """
+
+    manifest: PluginManifest
+
+    @property
+    def name(self) -> str:
+        return self.manifest.name
+
+    @property
+    def namespace(self) -> str:
+        # All commands of one plugin share one namespace per the schema's
+        # pattern + the manager's collision check; pick the first.
+        return self.manifest.commands[0].namespace
+
+    def find_command(self, name: str) -> CommandSpec | None:
+        for command in self.manifest.commands:
+            if command.name == name:
+                return command
+        return None
+
+
+class UserLevelProgramRegistry:
+    """In-memory registry of installed UserLevel programs."""
+
+    def __init__(self) -> None:
+        self._by_name: dict[str, RegisteredProgram] = {}
+        self._namespace_owner: dict[str, str] = {}  # namespace -> plugin name
+        self._lock = RLock()
+
+    def register(self, manifest: PluginManifest, *, replace: bool = False) -> RegisteredProgram:
+        """Register a program from its loaded manifest.
+
+        Args:
+            manifest: The validated `PluginManifest` (from `load_manifest`).
+            replace: If True, replace an existing entry with the same name.
+                Default False — duplicate registrations raise.
+
+        Returns:
+            The registered program.
+
+        Raises:
+            RegistryError: on namespace collision or duplicate name without
+                `replace=True`.
+        """
+        if not manifest.commands:
+            raise RegistryError(f"{manifest.name}: manifest has no commands")
+
+        # All commands must share the same namespace per the schema's pattern.
+        namespaces = {c.namespace for c in manifest.commands}
+        if len(namespaces) != 1:
+            raise RegistryError(
+                f"{manifest.name}: commands declare multiple namespaces "
+                f"{sorted(namespaces)}; one plugin must own one namespace"
+            )
+        namespace = namespaces.pop()
+
+        with self._lock:
+            existing = self._by_name.get(manifest.name)
+            if existing is not None and not replace:
+                raise RegistryError(
+                    f"{manifest.name} is already registered "
+                    f"(version {existing.manifest.version}); pass replace=True to update"
+                )
+
+            owner = self._namespace_owner.get(namespace)
+            if owner is not None and owner != manifest.name:
+                raise RegistryError(
+                    f"namespace {namespace!r} already owned by {owner!r}; "
+                    f"refusing to register {manifest.name!r}"
+                )
+
+            program = RegisteredProgram(manifest=manifest)
+            self._by_name[manifest.name] = program
+            self._namespace_owner[namespace] = manifest.name
+            return program
+
+    def unregister(self, name: str) -> bool:
+        """Remove a program by name. Returns True if removed."""
+        with self._lock:
+            program = self._by_name.pop(name, None)
+            if program is None:
+                return False
+            ns = program.namespace
+            if self._namespace_owner.get(ns) == name:
+                self._namespace_owner.pop(ns)
+            return True
+
+    def get(self, name: str) -> RegisteredProgram | None:
+        with self._lock:
+            return self._by_name.get(name)
+
+    def get_by_namespace(self, namespace: str) -> RegisteredProgram | None:
+        with self._lock:
+            owner = self._namespace_owner.get(namespace)
+            if owner is None:
+                return None
+            return self._by_name.get(owner)
+
+    def all_programs(self) -> list[RegisteredProgram]:
+        with self._lock:
+            return list(self._by_name.values())
+
+
+# Global singleton — modeled after skills/registry.py's pattern.
+_global: UserLevelProgramRegistry | None = None
+_global_lock = RLock()
+
+
+def get_userlevel_registry() -> UserLevelProgramRegistry:
+    """Return the process-wide UserLevel program registry singleton."""
+    global _global
+    with _global_lock:
+        if _global is None:
+            _global = UserLevelProgramRegistry()
+        return _global
+
+
+def reset_userlevel_registry() -> None:
+    """Reset the singleton. Tests use this to isolate state."""
+    global _global
+    with _global_lock:
+        _global = None
+
+
+# ---------------------------------------------------------------------------
+# Cross-registry lookup
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LookupResult:
+    """Result of looking up a name across both registries.
+
+    Exactly one of `userlevel_program` or `skill_metadata` is non-None for
+    a successful lookup.
+    """
+
+    kind: str  # "userlevel" | "skill" | "none"
+    userlevel_program: RegisteredProgram | None = None
+    skill_metadata: object | None = None  # Avoid hard import on skill module.
+
+    @property
+    def found(self) -> bool:
+        return self.kind != "none"
+
+
+def lookup_command(name: str) -> LookupResult:
+    """Look up a name across both the UserLevel registry and the bundled
+    skills registry. Returns the first match.
+
+    Order:
+      1. UserLevel namespaces (e.g. "github-pr") — fast, in-memory.
+      2. UserLevel plugin names (e.g. "github-pr-ops").
+      3. Bundled skill names (loaded from .claude-plugin/skills/).
+
+    Args:
+        name: The command name, namespace, or plugin name to look up.
+
+    Returns:
+        `LookupResult` indicating which registry matched.
+    """
+    ul = get_userlevel_registry()
+
+    program = ul.get_by_namespace(name)
+    if program is not None:
+        return LookupResult(kind="userlevel", userlevel_program=program)
+
+    program = ul.get(name)
+    if program is not None:
+        return LookupResult(kind="userlevel", userlevel_program=program)
+
+    # Skills lookup: import lazily so this module doesn't pull in watchdog
+    # and yaml at import time.
+    try:
+        from ouroboros.plugin.skills.registry import get_registry as _get_skill_registry
+    except ImportError:  # pragma: no cover - defensive
+        return LookupResult(kind="none")
+
+    skill_registry = _get_skill_registry()
+    skill = skill_registry.get_skill(name)
+    if skill is not None:
+        return LookupResult(kind="skill", skill_metadata=skill.metadata)
+
+    return LookupResult(kind="none")
+
+
+__all__ = [
+    "LookupResult",
+    "RegisteredProgram",
+    "RegistryError",
+    "UserLevelProgramRegistry",
+    "get_userlevel_registry",
+    "lookup_command",
+    "reset_userlevel_registry",
+]

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -1,0 +1,381 @@
+"""Tests for the plugin invocation firewall (Q00/ouroboros#729)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ouroboros.plugin.firewall import (
+    InvocationResult,
+    invoke_plugin,
+)
+from ouroboros.plugin.manifest import load_manifest
+from ouroboros.plugin.trust_store import TrustStore
+from ouroboros.plugin.userlevel_registry import (
+    UserLevelProgramRegistry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+            "requires_confirmation": False,
+        },
+        {
+            "namespace": "github-pr",
+            "name": "merge",
+            "summary": "Merge a PR under policy.",
+            "usage": "ooo github-pr merge <url>",
+            "risk": "destructive",
+            "requires_confirmation": True,
+        },
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write"},
+    ],
+    "permissions": [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {"scope": "github:pull_request:write", "risk": "destructive", "required": False},
+    ],
+    "entrypoint": {"type": "command", "command": "python -m fake_plugin"},
+}
+
+
+def _write_manifest(tmp_path: Path, payload: dict) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _make_program(tmp_path: Path, payload: dict | None = None):
+    """Load a manifest and register it into a fresh registry."""
+    payload = payload if payload is not None else REFERENCE_MANIFEST
+    manifest = load_manifest(_write_manifest(tmp_path, payload))
+    registry = UserLevelProgramRegistry()
+    return registry.register(manifest)
+
+
+def _fake_runner(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+    raise_filenotfound: bool = False,
+):
+    """Build a stand-in for subprocess.run that returns canned data."""
+
+    def _run(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        if raise_filenotfound:
+            raise FileNotFoundError(argv[0])
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path) -> None:
+    """Test 1: trusted invocation emits invoked → permission_used → completed."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-1",
+        subprocess_runner=_fake_runner(stdout="ok\n"),
+    )
+    assert result.status == "success"
+    assert result.exit_code == 0
+    assert [e["event_type"] for e in events] == [
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+    ]
+    # plugin.invoked appears BEFORE permission_used (locked invocation order).
+    assert events[1]["permissions_used"] == ["github:read"]
+    assert events[2]["result"]["status"] == "success"
+    # No raw stdout/stderr content in any event payload. The literal
+    # bytes returned from the fake runner ("ok\n") must not leak into
+    # any event.
+    serialized = json.dumps(events)
+    assert "ok\\n" not in serialized
+    # sha256 hash recorded in completed.provenance.
+    assert "stdout_sha256" in events[-1]["provenance"]
+
+
+def test_trust_violation_only_emits_failed_no_invoked(tmp_path: Path) -> None:
+    """Test 2: missing required scope → ONLY plugin.failed (status=blocked).
+
+    Crucially, plugin.invoked must NOT be emitted when the trust check
+    fails (locked Q1 of Q00/ouroboros-plugins#9).
+    """
+    program = _make_program(tmp_path)
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=None,  # not yet trusted
+        event_sink=events.append,
+        correlation_id="corr-2",
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "blocked"
+    assert result.exit_code is None
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    assert "plugin.invoked" not in types  # explicit absence assertion
+    # Message format per locked Q1.
+    assert "github:read" in result.message
+    assert "ooo plugin trust github-pr-ops --scope github:read" in result.message
+    assert events[0]["result"]["status"] == "blocked"
+
+
+def test_subprocess_failure_emits_failed_with_exit_code(tmp_path: Path) -> None:
+    """Test 3: subprocess exits non-zero → invoked, permission_used, failed."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["bad-url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-3",
+        subprocess_runner=_fake_runner(returncode=2, stderr="boom\n"),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 2
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert events[-1]["result"]["status"] == "failed"
+    assert "code 2" in events[-1]["result"]["message"]
+
+
+def test_bounded_payload_records_sha_not_raw(tmp_path: Path) -> None:
+    """Test 4: 1MB stdout — no part of it appears in any event;
+    sha256 hash recorded instead."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    big_payload = "X" * (1024 * 1024)  # 1 MiB
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-4",
+        subprocess_runner=_fake_runner(stdout=big_payload),
+    )
+    assert result.status == "success"
+    assert result.stdout_sha256 is not None
+    # No raw payload in any event (string check).
+    serialized = json.dumps(events)
+    assert "X" * 1000 not in serialized
+    # sha256 hash present in completed event provenance.
+    completed_event = next(e for e in events if e["event_type"] == "plugin.completed")
+    assert completed_event["provenance"]["stdout_sha256"] == result.stdout_sha256
+
+
+def test_confirmation_declined_blocks_with_no_subprocess(tmp_path: Path) -> None:
+    """Test 5: requires_confirmation=true + confirm()=False → blocked.
+
+    No subprocess launched; only plugin.failed (status=blocked) emitted.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    runner_called = False
+
+    def _spy(*args, **kwargs):
+        nonlocal runner_called
+        runner_called = True
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="merge",  # requires_confirmation = True
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-5",
+        confirm=lambda _msg: False,  # user said No
+        subprocess_runner=_spy,
+    )
+    assert result.status == "blocked"
+    assert runner_called is False
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    assert "user declined" in result.message
+
+
+def test_confirmation_accepted_proceeds(tmp_path: Path) -> None:
+    """Test 6: requires_confirmation=true + confirm()=True → normal flow."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="merge",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-6",
+        confirm=lambda _msg: True,
+        subprocess_runner=_fake_runner(returncode=0, stdout="ok"),
+    )
+    assert result.status == "success"
+    types = [e["event_type"] for e in events]
+    # Standard happy-path order; only one permission emitted (github:read,
+    # the required one). github:pull_request:write is required:false so
+    # it's NOT emitted in v0 (Option (a) coarse rule).
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.completed"]
+    assert events[1]["permissions_used"] == ["github:read"]
+
+
+def test_optional_permission_not_emitted(tmp_path: Path) -> None:
+    """Test 7: required:false permission is NOT emitted in v0.
+
+    The reference manifest has 'github:pull_request:write' with
+    required:false. After invocation, no plugin.permission_used event
+    should reference it (locked Option (a) coarse emission rule).
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-7",
+        subprocess_runner=_fake_runner(stdout=""),
+    )
+    permission_events = [e for e in events if e["event_type"] == "plugin.permission_used"]
+    scopes_emitted = {p for e in permission_events for p in e["permissions_used"]}
+    assert scopes_emitted == {"github:read"}
+    assert "github:pull_request:write" not in scopes_emitted
+
+
+def test_first_party_skips_trust_check(tmp_path: Path) -> None:
+    """Test 8: source.type=first_party bypasses trust check (Q00/ouroboros-plugins#8 lock)."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-auto"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []  # first-party with no external scopes
+    fp["commands"] = [
+        {
+            "namespace": "auto",
+            "name": "run",
+            "summary": "Run auto.",
+            "usage": "ooo auto",
+            "risk": "write",
+        }
+    ]
+    program = _make_program(tmp_path, fp)
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="run",
+        argv=["my goal"],
+        trust_record=None,  # no trust at all
+        event_sink=events.append,
+        correlation_id="corr-8",
+        subprocess_runner=_fake_runner(stdout="ok"),
+    )
+    assert result.status == "success"
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.completed"]
+    # trust_state field reports "first_party"
+    assert all(e["trust_state"] == "first_party" for e in events)
+
+
+def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
+    """Test 9: subprocess FileNotFoundError → status=failed, exit_code=127."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-9",
+        subprocess_runner=_fake_runner(raise_filenotfound=True),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 127
+    # invoked + permission_used + failed
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert "not found" in result.message.lower()

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -380,6 +380,63 @@ def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
     assert "not found" in result.message.lower()
 
 
+def test_required_permission_order_matches_manifest_declaration(tmp_path: Path) -> None:
+    """Manifest declaration order must drive both the blocked-scope error
+    message (which names the FIRST missing required scope) and the
+    `plugin.permission_used` event order.
+
+    Pre-fix, `manifest.permissions` was a `frozenset`, so iteration order
+    was undefined and the firewall's UX/audit ordering became
+    process-dependent. Now `permissions` is a tuple preserving the JSON
+    declaration order; both downstream behaviors must follow.
+    """
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    # Three required permissions in a specific JSON order.
+    payload["permissions"] = [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {"scope": "shell:execute", "risk": "destructive", "required": True},
+        {"scope": "github:repo:read", "risk": "read_only", "required": True},
+    ]
+    program = _make_program(tmp_path, payload)
+
+    # Untrusted call -> blocked message names the FIRST declared scope.
+    blocked_events: list[dict] = []
+    blocked = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=None,
+        event_sink=blocked_events.append,
+        correlation_id="corr-order-blocked",
+        subprocess_runner=_fake_runner(),
+    )
+    assert blocked.status == "blocked"
+    assert "github:read" in blocked.message
+    assert blocked.message.index("github:read") < blocked.message.index("github-pr-ops")
+
+    # Fully trust then re-invoke; permission_used events follow declaration order.
+    store = TrustStore(root=tmp_path / "trust")
+    for scope in ("github:read", "shell:execute", "github:repo:read"):
+        store.grant(plugin="github-pr-ops", version="0.1.0", scope=scope, granted_by="u")
+    trust = store.read("github-pr-ops")
+    happy_events: list[dict] = []
+    happy = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=happy_events.append,
+        correlation_id="corr-order-happy",
+        subprocess_runner=_fake_runner(stdout="ok"),
+    )
+    assert happy.status == "success"
+    permission_events = [
+        e for e in happy_events if e["event_type"] == "plugin.permission_used"
+    ]
+    scopes_in_order = [e["permissions_used"][0] for e in permission_events]
+    assert scopes_in_order == ["github:read", "shell:execute", "github:repo:read"]
+
+
 @pytest.mark.parametrize(
     "exc, expected_code, descriptor_substr",
     [

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -430,9 +430,7 @@ def test_required_permission_order_matches_manifest_declaration(tmp_path: Path) 
         subprocess_runner=_fake_runner(stdout="ok"),
     )
     assert happy.status == "success"
-    permission_events = [
-        e for e in happy_events if e["event_type"] == "plugin.permission_used"
-    ]
+    permission_events = [e for e in happy_events if e["event_type"] == "plugin.permission_used"]
     scopes_in_order = [e["permissions_used"][0] for e in permission_events]
     assert scopes_in_order == ["github:read", "shell:execute", "github:repo:read"]
 

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -380,6 +380,85 @@ def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
     assert "not found" in result.message.lower()
 
 
+def test_stale_trust_record_version_is_invalidated_at_invocation(tmp_path: Path) -> None:
+    """A `TrustRecord` whose version does not match the manifest must be
+    treated as if no trust existed.
+
+    Per Q00/ouroboros-plugins#9 Q4, a version bump invalidates trust.
+    `TrustStore` enforces that at write time, but the firewall must
+    also enforce it at INVOCATION time — otherwise a caller holding a
+    stale `TrustRecord` (e.g. read into memory before an upgrade) could
+    authorize the new code under consent given to the old code.
+    """
+    program = _make_program(tmp_path)  # manifest version = 0.1.0
+    # Hand-craft a stale TrustRecord that grants the required scope,
+    # but for a DIFFERENT version. The firewall must reject it.
+    from ouroboros.plugin.trust_store import GrantedScope, TrustRecord
+
+    stale = TrustRecord(
+        plugin="github-pr-ops",
+        version="0.0.9",  # manifest is 0.1.0 -> mismatch
+        granted_scopes=(
+            GrantedScope(
+                scope="github:read",
+                granted_at="2025-01-01T00:00:00Z",
+                granted_by="user:test",
+            ),
+        ),
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=stale,
+        event_sink=events.append,
+        correlation_id="corr-stale-version",
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "blocked"
+    assert "github:read" in result.message
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    # The audit trail records "installed" (no live trust), not "trusted".
+    assert events[0]["trust_state"] == "installed"
+
+
+def test_trust_record_for_different_plugin_is_invalidated(tmp_path: Path) -> None:
+    """A `TrustRecord` whose `plugin` field doesn't match the manifest
+    name must also be treated as no trust.
+
+    Defense-in-depth against a caller passing the wrong record into
+    `invoke_plugin` (e.g. a bug in the CLI dispatch layer).
+    """
+    program = _make_program(tmp_path)  # manifest name = github-pr-ops
+    from ouroboros.plugin.trust_store import GrantedScope, TrustRecord
+
+    wrong_plugin = TrustRecord(
+        plugin="some-other-plugin",
+        version="0.1.0",
+        granted_scopes=(
+            GrantedScope(
+                scope="github:read",
+                granted_at="2025-01-01T00:00:00Z",
+                granted_by="user:test",
+            ),
+        ),
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=wrong_plugin,
+        event_sink=events.append,
+        correlation_id="corr-wrong-plugin",
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "blocked"
+    assert events[0]["trust_state"] == "installed"
+
+
 def test_required_permission_order_matches_manifest_declaration(tmp_path: Path) -> None:
     """Manifest declaration order must drive both the blocked-scope error
     message (which names the FIRST missing required scope) and the

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 import subprocess
 
+import pytest
+
 from ouroboros.plugin.firewall import (
     invoke_plugin,
 )
@@ -74,12 +76,15 @@ def _fake_runner(
     stdout: str = "",
     stderr: str = "",
     raise_filenotfound: bool = False,
+    raise_oserror: BaseException | None = None,
 ):
     """Build a stand-in for subprocess.run that returns canned data."""
 
     def _run(argv, *args, **kwargs) -> subprocess.CompletedProcess:
         if raise_filenotfound:
             raise FileNotFoundError(argv[0])
+        if raise_oserror is not None:
+            raise raise_oserror
         return subprocess.CompletedProcess(
             args=argv,
             returncode=returncode,
@@ -373,3 +378,53 @@ def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
     types = [e["event_type"] for e in events]
     assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
     assert "not found" in result.message.lower()
+
+
+@pytest.mark.parametrize(
+    "exc, expected_code, descriptor_substr",
+    [
+        (PermissionError(13, "Permission denied"), 126, "not executable"),
+        (IsADirectoryError(21, "Is a directory"), 126, "is a directory"),
+        (NotADirectoryError(20, "Not a directory"), 126, "not a directory"),
+        (OSError(5, "I/O error"), 126, "launcher error"),
+    ],
+)
+def test_launcher_oserror_emits_terminal_failed(
+    tmp_path: Path,
+    exc: OSError,
+    expected_code: int,
+    descriptor_substr: str,
+) -> None:
+    """All launcher-side OSErrors must produce a terminal `plugin.failed`.
+
+    Pre-fix the firewall only caught `FileNotFoundError`. Anything else
+    escaped as an exception AFTER `plugin.invoked` and
+    `plugin.permission_used` had already been emitted, leaving an
+    incomplete audit trail and breaking the documented contract that
+    `invoke_plugin` always returns an `InvocationResult`.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-oserror",
+        subprocess_runner=_fake_runner(raise_oserror=exc),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == expected_code
+    assert descriptor_substr in result.message.lower()
+    types = [e["event_type"] for e in events]
+    # Contract: once `plugin.invoked` is emitted, a terminal event MUST
+    # follow. permission_used appears between them per locked order.
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert events[-1]["result"]["status"] == "failed"

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -3,15 +3,10 @@
 from __future__ import annotations
 
 import json
-import subprocess
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
-
-import pytest
+import subprocess
 
 from ouroboros.plugin.firewall import (
-    InvocationResult,
     invoke_plugin,
 )
 from ouroboros.plugin.manifest import load_manifest
@@ -19,7 +14,6 @@ from ouroboros.plugin.trust_store import TrustStore
 from ouroboros.plugin.userlevel_registry import (
     UserLevelProgramRegistry,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/plugin/test_lockfile.py
+++ b/tests/unit/plugin/test_lockfile.py
@@ -1,0 +1,152 @@
+"""Tests for the plugin lockfile (Q00/ouroboros#732)."""
+
+from __future__ import annotations
+
+import multiprocessing
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.lockfile import (
+    LOCKFILE_SCHEMA_VERSION,
+    LockEntry,
+    Lockfile,
+)
+
+
+def _make_entry(name: str = "github-pr-ops", version: str = "0.1.0") -> LockEntry:
+    return LockEntry(
+        name=name,
+        version=version,
+        source_kind="git",
+        repository="https://github.com/Q00/ouroboros-plugins",
+        git_sha="b3a91f2",
+        manifest_checksum="sha256:abc123",
+        installed_at="2026-05-08T03:14:00Z",
+        plugin_home=f"~/.ouroboros/plugins/{name}",
+    )
+
+
+def test_install_then_read(tmp_path: Path) -> None:
+    """Test 1: install → lockfile entry present; round-trip through TOML."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    entry = _make_entry()
+    lock.add(entry)
+
+    fresh = Lockfile(tmp_path / "plugins.lock")
+    entries = fresh.read()
+    assert "github-pr-ops" in entries
+    assert entries["github-pr-ops"] == entry
+
+
+def test_remove_drops_entry(tmp_path: Path) -> None:
+    """Test 2: remove → entry gone."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry())
+    assert lock.remove("github-pr-ops") is True
+    assert lock.read() == {}
+    # Removing again is a no-op.
+    assert lock.remove("github-pr-ops") is False
+
+
+def test_lockfile_is_sorted(tmp_path: Path) -> None:
+    """Test 3: entries are written in deterministic name-sorted order."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry(name="zebra"))
+    lock.add(_make_entry(name="apple"))
+    lock.add(_make_entry(name="middle"))
+
+    text = (tmp_path / "plugins.lock").read_text()
+    apple_idx = text.find('name = "apple"')
+    middle_idx = text.find('name = "middle"')
+    zebra_idx = text.find('name = "zebra"')
+    assert apple_idx < middle_idx < zebra_idx
+
+
+def test_lockfile_schema_version_present(tmp_path: Path) -> None:
+    """Test 4: lockfile carries a schema_version header."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry())
+    text = (tmp_path / "plugins.lock").read_text()
+    assert f'schema_version = "{LOCKFILE_SCHEMA_VERSION}"' in text
+
+
+def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
+    """Test 5: a lockfile with the wrong schema_version raises on read."""
+    path = tmp_path / "plugins.lock"
+    path.write_text('schema_version = "99.0"\n')
+    lock = Lockfile(path)
+    with pytest.raises(ValueError, match="unsupported lockfile schema_version"):
+        lock.read()
+
+
+def test_atomic_write_no_partial_file_on_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test 6: simulated crash mid-write leaves the original file intact."""
+    lock_path = tmp_path / "plugins.lock"
+    lock = Lockfile(lock_path)
+    lock.add(_make_entry(name="initial"))
+
+    original = lock_path.read_text()
+
+    # Patch os.replace to fail, simulating a crash before rename.
+    import os
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated crash during rename")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    with pytest.raises(OSError, match="simulated crash"):
+        lock.add(_make_entry(name="second"))
+
+    # Original lockfile content must be unchanged.
+    assert lock_path.read_text() == original
+    # No leftover .plugins.lock.* temp file in the directory.
+    leftovers = list(tmp_path.glob(".plugins.lock.*"))
+    assert leftovers == []
+
+
+def _concurrent_writer(target_path_str: str, name: str, count: int) -> None:
+    """Worker for concurrent-write test. Adds N entries with distinct names."""
+    from pathlib import Path as _Path
+
+    from ouroboros.plugin.lockfile import LockEntry, Lockfile
+
+    lock = Lockfile(_Path(target_path_str))
+    for i in range(count):
+        lock.add(
+            LockEntry(
+                name=f"{name}-{i}",
+                version="0.1.0",
+                source_kind="local",
+                repository=None,
+                git_sha=None,
+                manifest_checksum="sha256:0",
+                installed_at="2026-05-08T03:14:00Z",
+                plugin_home=f"~/.ouroboros/plugins/{name}-{i}",
+            )
+        )
+
+
+def test_concurrent_writes_do_not_corrupt(tmp_path: Path) -> None:
+    """Test 7: two processes writing concurrently do not corrupt the file
+    or lose entries (POSIX flock holds them serialized)."""
+    lock_path = tmp_path / "plugins.lock"
+    procs = [
+        multiprocessing.Process(target=_concurrent_writer, args=(str(lock_path), "p1", 5)),
+        multiprocessing.Process(target=_concurrent_writer, args=(str(lock_path), "p2", 5)),
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=10)
+        assert p.exitcode == 0, f"writer exited {p.exitcode}"
+
+    # Final lockfile is valid TOML and contains all 10 entries.
+    entries = Lockfile(lock_path).read()
+    assert len(entries) == 10
+    assert {e.name for e in entries.values()} == {
+        f"{prefix}-{i}" for prefix in ("p1", "p2") for i in range(5)
+    }

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -214,6 +214,54 @@ def test_duplicate_command_name_rejected(tmp_path: Path) -> None:
     assert "review" in excinfo.value.args[0]
 
 
+def test_duplicate_permission_scope_rejected(tmp_path: Path) -> None:
+    """Duplicate permission scopes within a plugin must be rejected.
+
+    The firewall treats `scope` as the unique permission identifier:
+    `_required_permissions()` would emit one `plugin.permission_used`
+    event per duplicate, and `_scope_risk_index()` silently lets the
+    last entry win for the blocked-message risk label. Two
+    `github:read` entries with conflicting `risk` or `required` values
+    therefore produce inconsistent UX and audit data instead of being
+    rejected at load time.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["permissions"] = [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {
+            "scope": "github:read",
+            "risk": "destructive",  # same scope, different risk
+            "required": False,  # and different required flag
+            "reason": "would overwrite the first entry's risk label",
+        },
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/permissions/1/scope"
+    assert "duplicate" in excinfo.value.args[0].lower()
+    assert "github:read" in excinfo.value.args[0]
+
+
+def test_duplicate_capability_name_rejected(tmp_path: Path) -> None:
+    """Duplicate capability names within a plugin must be rejected.
+
+    Downstream code keys capability decisions on `name`; a duplicate
+    silently shadows another entry's `access` and `reason`.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["capabilities"] = [
+        {"name": "ledger", "access": "write", "reason": "Record decisions."},
+        # Same name, different access -> would silently shadow.
+        {"name": "ledger", "access": "read", "reason": "Conflicting duplicate."},
+        {"name": "provenance", "access": "write", "reason": "Record context."},
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/capabilities/1/name"
+    assert "duplicate" in excinfo.value.args[0].lower()
+    assert "ledger" in excinfo.value.args[0]
+
+
 def test_invalid_json_decodes_to_useful_error(tmp_path: Path) -> None:
     """Bonus: garbage JSON is reported with a useful message."""
     target = tmp_path / "ouroboros.plugin.json"

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -262,6 +262,52 @@ def test_duplicate_capability_name_rejected(tmp_path: Path) -> None:
     assert "ledger" in excinfo.value.args[0]
 
 
+def test_audit_events_must_include_firewall_events(tmp_path: Path) -> None:
+    """A manifest that drops any firewall-emitted event from
+    `audit.events` must be rejected at load time.
+
+    Pre-fix, `load_manifest` accepted any subset (the JSON Schema
+    permits one-of-seven enum values), but the firewall unconditionally
+    emits the four standard events. A manifest declaring just
+    `[plugin.invoked]` would validate while the runtime still emitted
+    `plugin.permission_used` / `plugin.completed` / `plugin.failed` —
+    breaking any consumer that treats the manifest as authoritative.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    # Drop `plugin.permission_used` from the audit set.
+    bad["audit"] = {
+        "events": [
+            "plugin.invoked",
+            "plugin.completed",
+            "plugin.failed",
+        ]
+    }
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/audit/events"
+    assert "plugin.permission_used" in excinfo.value.args[0]
+
+
+def test_audit_events_may_extend_required_set(tmp_path: Path) -> None:
+    """A manifest may declare extra lifecycle events beyond the four
+    firewall-mandatory ones (e.g. `plugin.installed`, `plugin.trusted`)
+    that other components emit. Those declarations are allowed."""
+    extended = json.loads(json.dumps(REFERENCE_MANIFEST))
+    extended["audit"] = {
+        "events": [
+            "plugin.invoked",
+            "plugin.permission_used",
+            "plugin.completed",
+            "plugin.failed",
+            "plugin.installed",
+            "plugin.trusted",
+        ]
+    }
+    manifest = load_manifest(_write(tmp_path, extended))
+    assert "plugin.installed" in manifest.audit.events
+    assert "plugin.trusted" in manifest.audit.events
+
+
 def test_invalid_json_decodes_to_useful_error(tmp_path: Path) -> None:
     """Bonus: garbage JSON is reported with a useful message."""
     target = tmp_path / "ouroboros.plugin.json"

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -308,6 +308,23 @@ def test_audit_events_may_extend_required_set(tmp_path: Path) -> None:
     assert "plugin.trusted" in manifest.audit.events
 
 
+def test_blank_entrypoint_command_rejected(tmp_path: Path) -> None:
+    """`entrypoint.command` must shlex.split to at least one token.
+
+    Pre-fix the JSON Schema only enforced `minLength: 1`, so a manifest
+    with `"   "` would pass shape validation but `shlex.split` returned
+    `[]` at invocation time. The firewall would then call
+    `subprocess.run([])` which raises `IndexError` AFTER `plugin.invoked`
+    had been emitted, leaving an incomplete audit trail.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["entrypoint"]["command"] = "   "
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/entrypoint/command"
+    assert "non-empty" in excinfo.value.expected.lower()
+
+
 def test_invalid_json_decodes_to_useful_error(tmp_path: Path) -> None:
     """Bonus: garbage JSON is reported with a useful message."""
     target = tmp_path / "ouroboros.plugin.json"

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -1,0 +1,203 @@
+"""Tests for the plugin manifest loader (Q00/ouroboros#728).
+
+Each test asserts BOTH the rejection AND the JSON Pointer to the failing
+field, so a future schema change cannot silently relax constraints.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.manifest import (
+    PluginManifest,
+    PluginManifestError,
+    load_manifest,
+    SUPPORTED_SCHEMA_VERSIONS,
+)
+
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "description": "Reference skeleton for GitHub PR operational workflows.",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness without mutating it.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+            "requires_confirmation": False,
+            "arguments": [
+                {
+                    "name": "pull_request_url",
+                    "type": "url",
+                    "required": True,
+                    "description": "GitHub pull request URL to inspect.",
+                }
+            ],
+        }
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write", "reason": "Record decisions."},
+        {"name": "provenance", "access": "write", "reason": "Record context."},
+    ],
+    "permissions": [
+        {
+            "scope": "github:read",
+            "risk": "read_only",
+            "required": True,
+            "reason": "Read PR status.",
+        }
+    ],
+    "entrypoint": {"type": "command", "command": "python -m github_pr_ops"},
+}
+
+
+def _write(tmp_path: Path, payload: dict | str) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    if isinstance(payload, str):
+        target.write_text(payload)
+    else:
+        target.write_text(json.dumps(payload))
+    return target
+
+
+def test_load_reference_manifest(tmp_path: Path) -> None:
+    """Test 1: github-pr-ops reference manifest loads cleanly."""
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    assert isinstance(manifest, PluginManifest)
+    assert manifest.name == "github-pr-ops"
+    assert manifest.version == "0.1.0"
+    assert manifest.schema_version == "0.1"
+    assert len(manifest.commands) == 1
+    assert manifest.commands[0].name == "review"
+    assert manifest.source.type == "local_path"
+
+
+def test_missing_required_top_level_field(tmp_path: Path) -> None:
+    """Test 2: missing `name` raises with empty json_pointer (root-level)."""
+    bad = {**REFERENCE_MANIFEST}
+    bad.pop("name")
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    err = excinfo.value
+    assert err.json_pointer == ""
+    assert "name" in err.args[0]
+
+
+def test_pattern_violation_on_name(tmp_path: Path) -> None:
+    """Test 3: pattern violation reports json_pointer=/name."""
+    bad = {**REFERENCE_MANIFEST, "name": "Bad Name"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/name"
+    assert "match" in excinfo.value.args[0].lower() or "pattern" in excinfo.value.expected.lower()
+
+
+def test_unknown_capability(tmp_path: Path) -> None:
+    """Test 4: unknown capability name reports nested pointer."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["capabilities"][0]["name"] = "fake_cap"
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/capabilities/0/name"
+
+
+def test_unknown_source_type(tmp_path: Path) -> None:
+    """Test 5: unknown source.type reports /source/type pointer."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "remote"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/source/type"
+
+
+def test_additional_property_rejected(tmp_path: Path) -> None:
+    """Test 6: additionalProperties:false catches unknown top-level keys."""
+    bad = {**REFERENCE_MANIFEST, "weird_key": 1}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert "weird_key" in excinfo.value.args[0]
+
+
+def test_unsupported_schema_version(tmp_path: Path) -> None:
+    """Test 7: schema_version outside support window is rejected."""
+    bad = {**REFERENCE_MANIFEST, "schema_version": "99.0"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/schema_version"
+    assert "99.0" in excinfo.value.got
+    assert str(list(SUPPORTED_SCHEMA_VERSIONS)) in excinfo.value.expected
+
+
+def test_returned_manifest_is_frozen(tmp_path: Path) -> None:
+    """Test 8: PluginManifest dataclass is frozen — attribute mutation raises."""
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        manifest.name = "other"  # type: ignore[misc]
+
+
+def test_optional_fields_omitted(tmp_path: Path) -> None:
+    """Test 9: manifest without description and audit loads with defaults
+    (per Q00/ouroboros-plugins#6 lock — 8 required + 2 optional)."""
+    bare = {k: v for k, v in REFERENCE_MANIFEST.items() if k not in ("description", "audit")}
+    manifest = load_manifest(_write(tmp_path, bare))
+    assert manifest.description == ""
+    assert "plugin.invoked" in manifest.audit.events
+    assert "plugin.completed" in manifest.audit.events
+    assert "plugin.failed" in manifest.audit.events
+
+
+def test_first_party_source_branch(tmp_path: Path) -> None:
+    """Test 10: source.type=first_party loads without requiring path/repository
+    (per Q00/ouroboros-plugins#8 lock)."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-auto"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []
+    fp["commands"] = [
+        {
+            "namespace": "auto",
+            "name": "run",
+            "summary": "Take a goal, run interview, produce Seed, hand off execution.",
+            "usage": "ooo auto <goal-text>",
+            "risk": "write",
+        }
+    ]
+    manifest = load_manifest(_write(tmp_path, fp))
+    assert manifest.source.type == "first_party"
+    assert manifest.source.path is None
+    assert manifest.source.repository is None
+
+
+def test_old_risk_enum_value_rejected(tmp_path: Path) -> None:
+    """Test 11: command.risk='writes_state' rejected by 3-value enum
+    (per Q00/ouroboros-plugins#10 lock)."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["commands"][0]["risk"] = "writes_state"
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/commands/0/risk"
+
+
+def test_invalid_json_decodes_to_useful_error(tmp_path: Path) -> None:
+    """Bonus: garbage JSON is reported with a useful message."""
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text("{invalid json")
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(target)
+    assert "JSON" in excinfo.value.args[0] or "json" in excinfo.value.args[0].lower()
+
+
+def test_missing_file_reports_clean_error(tmp_path: Path) -> None:
+    """Bonus: missing file path reports a clean error, not a stack trace."""
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(tmp_path / "does-not-exist.json")
+    assert "not found" in excinfo.value.args[0]

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -13,12 +13,11 @@ from pathlib import Path
 import pytest
 
 from ouroboros.plugin.manifest import (
+    SUPPORTED_SCHEMA_VERSIONS,
     PluginManifest,
     PluginManifestError,
     load_manifest,
-    SUPPORTED_SCHEMA_VERSIONS,
 )
-
 
 REFERENCE_MANIFEST: dict = {
     "schema_version": "0.1",

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -186,6 +186,34 @@ def test_old_risk_enum_value_rejected(tmp_path: Path) -> None:
     assert excinfo.value.json_pointer == "/commands/0/risk"
 
 
+def test_duplicate_command_name_rejected(tmp_path: Path) -> None:
+    """Duplicate command names within a plugin must be rejected at load.
+
+    `RegisteredProgram.find_command()` returns the FIRST match by name,
+    so a duplicate would silently shadow a different command's risk
+    level / confirmation policy / arguments. Loader-level enforcement
+    keeps the contract honest at the boundary.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["commands"] = [
+        bad["commands"][0],
+        # second command, same name, different risk + confirmation policy
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Different review with destructive risk.",
+            "usage": "ooo github-pr review <url>",
+            "risk": "destructive",
+            "requires_confirmation": True,
+        },
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/commands/1/name"
+    assert "duplicate" in excinfo.value.args[0].lower()
+    assert "review" in excinfo.value.args[0]
+
+
 def test_invalid_json_decodes_to_useful_error(tmp_path: Path) -> None:
     """Bonus: garbage JSON is reported with a useful message."""
     target = tmp_path / "ouroboros.plugin.json"

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -1,0 +1,158 @@
+"""Tests for the per-plugin trust store (Q00/ouroboros#732)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.trust_store import (
+    TRUST_SCHEMA_VERSION,
+    TrustRecord,
+    TrustStore,
+)
+
+
+def test_grant_then_read(tmp_path: Path) -> None:
+    """Test 1: grant a scope, read it back. File at locked Q5 path."""
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:shaun0927",
+    )
+    assert record.has_scope("github:read")
+
+    file_path = tmp_path / "github-pr-ops" / "trust.json"
+    assert file_path.is_file()
+    data = json.loads(file_path.read_text())
+    assert data["schema_version"] == TRUST_SCHEMA_VERSION
+    assert data["plugin"] == "github-pr-ops"
+    assert data["version"] == "0.1.0"
+    assert data["granted_scopes"][0]["scope"] == "github:read"
+    assert data["granted_scopes"][0]["granted_by"] == "user:shaun0927"
+
+
+def test_grant_is_idempotent(tmp_path: Path) -> None:
+    """Test 2: granting the same scope twice does not duplicate."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    record = store.grant(
+        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
+    )
+    assert len(record.granted_scopes) == 1
+
+
+def test_exact_scope_only(tmp_path: Path) -> None:
+    """Test 3: parent scope does NOT imply child (Q3 lock).
+
+    Granting `github:pull_request` does not satisfy `github:pull_request:write`.
+    """
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="X",
+        version="0.1.0",
+        scope="github:pull_request",
+        granted_by="u",
+    )
+    assert record.has_scope("github:pull_request")
+    assert not record.has_scope("github:pull_request:write")
+    assert record.missing(["github:pull_request:write"]) == ["github:pull_request:write"]
+
+
+def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
+    """Test 4: granting against a new version drops the previous grants
+    (Q00/ouroboros-plugins#9 Q4 lock)."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    store.grant(plugin="X", version="0.1.0", scope="github:repo:read", granted_by="u")
+
+    # Now bump to 0.2.0 and grant a different scope.
+    record = store.grant(
+        plugin="X", version="0.2.0", scope="github:read", granted_by="u"
+    )
+    assert record.version == "0.2.0"
+    # Previous github:repo:read grant is invalidated.
+    assert not record.has_scope("github:repo:read")
+    # The newly granted scope on the new version is present.
+    assert record.has_scope("github:read")
+
+
+def test_reset_for_version_bump(tmp_path: Path) -> None:
+    """Test 5: explicit version-bump reset writes an empty grant list."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    store.reset_for_version_bump("X", new_version="0.2.0")
+
+    record = store.read("X")
+    assert isinstance(record, TrustRecord)
+    assert record.version == "0.2.0"
+    assert record.granted_scopes == ()
+
+
+def test_remove_drops_trust_file(tmp_path: Path) -> None:
+    """Test 6: remove() deletes the trust file and prunes the empty dir."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    file_path = tmp_path / "X" / "trust.json"
+    assert file_path.is_file()
+    assert store.remove("X") is True
+    assert not file_path.exists()
+    # Directory pruned.
+    assert not file_path.parent.exists()
+    # Removing again is a no-op.
+    assert store.remove("X") is False
+
+
+def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
+    """Test 7: a trust file with the wrong schema_version raises on read."""
+    plugin_dir = tmp_path / "X"
+    plugin_dir.mkdir()
+    (plugin_dir / "trust.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "99.0",
+                "plugin": "X",
+                "version": "0.1.0",
+                "granted_scopes": [],
+            }
+        )
+    )
+    store = TrustStore(root=tmp_path)
+    with pytest.raises(ValueError, match="unsupported trust file schema_version"):
+        store.read("X")
+
+
+def test_no_raw_token_in_persisted_file(tmp_path: Path) -> None:
+    """Test 8: scope strings and granted_by are persisted, but nothing
+    else. The store offers no API for tokens; this test is a sanity
+    check that future contributors don't add one without notice."""
+    store = TrustStore(root=tmp_path)
+    store.grant(
+        plugin="X",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:shaun0927",
+    )
+    raw = (tmp_path / "X" / "trust.json").read_text()
+    # Keys present
+    assert '"scope"' in raw
+    assert '"granted_by"' in raw
+    assert '"granted_at"' in raw
+    # Nothing token-shaped (no "token", "secret", "auth", "Bearer")
+    for forbidden in ("token", "secret", "auth", "Bearer", "ghp_"):
+        assert forbidden.lower() not in raw.lower(), f"forbidden marker {forbidden!r} in trust file"
+
+
+def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
+    """Test 9: TrustRecord.missing() returns missing required scopes in
+    the input iteration order — useful for predictable error messages."""
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
+    )
+    # `github:read` is granted; the others are missing.
+    missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
+    assert missing == ["github:pull_request:write", "shell:execute"]

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -89,17 +89,25 @@ def test_reset_for_version_bump(tmp_path: Path) -> None:
 
 
 def test_remove_drops_trust_file(tmp_path: Path) -> None:
-    """Test 6: remove() deletes the trust file and prunes the empty dir."""
+    """Test 6: remove() deletes the trust file.
+
+    The lock file (`trust.json.lock`) is intentionally retained — see
+    `TrustStore.remove` docstring for the cross-process race that
+    deleting it would reintroduce. The plugin directory therefore may
+    not be empty after `remove()`, so this test only asserts that the
+    trust record itself is gone.
+    """
     store = TrustStore(root=tmp_path)
     store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     file_path = tmp_path / "X" / "trust.json"
     assert file_path.is_file()
     assert store.remove("X") is True
     assert not file_path.exists()
-    # Directory pruned.
-    assert not file_path.parent.exists()
-    # Removing again is a no-op.
+    # Removing again is a no-op (file already gone).
     assert store.remove("X") is False
+    # Lock file is retained on purpose to keep cross-process flock
+    # synchronization sound.
+    assert (tmp_path / "X" / "trust.json.lock").exists()
 
 
 def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -146,6 +146,56 @@ def test_no_raw_token_in_persisted_file(tmp_path: Path) -> None:
         assert forbidden.lower() not in raw.lower(), f"forbidden marker {forbidden!r} in trust file"
 
 
+def test_concurrent_grants_do_not_lose_data(tmp_path: Path) -> None:
+    """Test 10: concurrent grants on the same plugin must not silently
+    drop scopes via read-modify-write race.
+
+    The pre-fix `grant()` did `self.read()` then `self._write_atomic()`
+    with no inter-thread serialization. Two concurrent grants would both
+    read the same baseline, append different scopes, and the later
+    `os.replace` would silently win — losing the earlier grant.
+
+    This test races N threads granting distinct scopes against a shared
+    trust file and asserts every scope survives. The fix uses an
+    exclusive `fcntl.flock` around the RMW.
+    """
+    import threading
+
+    store = TrustStore(root=tmp_path)
+    n_threads = 12
+    barrier = threading.Barrier(n_threads)
+    scopes = [f"capability:scope_{i:02d}" for i in range(n_threads)]
+    errors: list[BaseException] = []
+
+    def _worker(scope: str) -> None:
+        try:
+            barrier.wait(timeout=5)
+            store.grant(
+                plugin="X",
+                version="0.1.0",
+                scope=scope,
+                granted_by="user:test",
+            )
+        except BaseException as exc:  # noqa: BLE001 - propagate to assertion
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker, args=(s,)) for s in scopes]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"worker errors: {errors!r}"
+
+    final = store.read("X")
+    assert final is not None
+    persisted = {g.scope for g in final.granted_scopes}
+    assert persisted == set(scopes), (
+        f"lost scopes under concurrent grant: missing="
+        f"{set(scopes) - persisted}, extra={persisted - set(scopes)}"
+    )
+
+
 def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
     """Test 9: TrustRecord.missing() returns missing required scopes in
     the input iteration order — useful for predictable error messages."""

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -11,6 +11,7 @@ from ouroboros.plugin.trust_store import (
     TRUST_SCHEMA_VERSION,
     TrustRecord,
     TrustStore,
+    TrustStoreError,
 )
 
 
@@ -38,8 +39,8 @@ def test_grant_then_read(tmp_path: Path) -> None:
 def test_grant_is_idempotent(tmp_path: Path) -> None:
     """Test 2: granting the same scope twice does not duplicate."""
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    record = store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
     assert len(record.granted_scopes) == 1
 
 
@@ -50,7 +51,7 @@ def test_exact_scope_only(tmp_path: Path) -> None:
     """
     store = TrustStore(root=tmp_path)
     record = store.grant(
-        plugin="X",
+        plugin="test-plugin",
         version="0.1.0",
         scope="github:pull_request",
         granted_by="u",
@@ -64,11 +65,11 @@ def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
     """Test 4: granting against a new version drops the previous grants
     (Q00/ouroboros-plugins#9 Q4 lock)."""
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    store.grant(plugin="X", version="0.1.0", scope="github:repo:read", granted_by="u")
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:repo:read", granted_by="u")
 
     # Now bump to 0.2.0 and grant a different scope.
-    record = store.grant(plugin="X", version="0.2.0", scope="github:read", granted_by="u")
+    record = store.grant(plugin="test-plugin", version="0.2.0", scope="github:read", granted_by="u")
     assert record.version == "0.2.0"
     # Previous github:repo:read grant is invalidated.
     assert not record.has_scope("github:repo:read")
@@ -79,10 +80,10 @@ def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
 def test_reset_for_version_bump(tmp_path: Path) -> None:
     """Test 5: explicit version-bump reset writes an empty grant list."""
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    store.reset_for_version_bump("X", new_version="0.2.0")
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    store.reset_for_version_bump("test-plugin", new_version="0.2.0")
 
-    record = store.read("X")
+    record = store.read("test-plugin")
     assert isinstance(record, TrustRecord)
     assert record.version == "0.2.0"
     assert record.granted_scopes == ()
@@ -98,27 +99,27 @@ def test_remove_drops_trust_file(tmp_path: Path) -> None:
     trust record itself is gone.
     """
     store = TrustStore(root=tmp_path)
-    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    file_path = tmp_path / "X" / "trust.json"
+    store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
+    file_path = tmp_path / "test-plugin" / "trust.json"
     assert file_path.is_file()
-    assert store.remove("X") is True
+    assert store.remove("test-plugin") is True
     assert not file_path.exists()
     # Removing again is a no-op (file already gone).
-    assert store.remove("X") is False
+    assert store.remove("test-plugin") is False
     # Lock file is retained on purpose to keep cross-process flock
     # synchronization sound.
-    assert (tmp_path / "X" / "trust.json.lock").exists()
+    assert (tmp_path / "test-plugin" / "trust.json.lock").exists()
 
 
 def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
     """Test 7: a trust file with the wrong schema_version raises on read."""
-    plugin_dir = tmp_path / "X"
+    plugin_dir = tmp_path / "test-plugin"
     plugin_dir.mkdir()
     (plugin_dir / "trust.json").write_text(
         json.dumps(
             {
                 "schema_version": "99.0",
-                "plugin": "X",
+                "plugin": "test-plugin",
                 "version": "0.1.0",
                 "granted_scopes": [],
             }
@@ -126,7 +127,7 @@ def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
     )
     store = TrustStore(root=tmp_path)
     with pytest.raises(ValueError, match="unsupported trust file schema_version"):
-        store.read("X")
+        store.read("test-plugin")
 
 
 def test_no_raw_token_in_persisted_file(tmp_path: Path) -> None:
@@ -135,12 +136,12 @@ def test_no_raw_token_in_persisted_file(tmp_path: Path) -> None:
     check that future contributors don't add one without notice."""
     store = TrustStore(root=tmp_path)
     store.grant(
-        plugin="X",
+        plugin="test-plugin",
         version="0.1.0",
         scope="github:read",
         granted_by="user:shaun0927",
     )
-    raw = (tmp_path / "X" / "trust.json").read_text()
+    raw = (tmp_path / "test-plugin" / "trust.json").read_text()
     # Keys present
     assert '"scope"' in raw
     assert '"granted_by"' in raw
@@ -175,7 +176,7 @@ def test_concurrent_grants_do_not_lose_data(tmp_path: Path) -> None:
         try:
             barrier.wait(timeout=5)
             store.grant(
-                plugin="X",
+                plugin="test-plugin",
                 version="0.1.0",
                 scope=scope,
                 granted_by="user:test",
@@ -191,7 +192,7 @@ def test_concurrent_grants_do_not_lose_data(tmp_path: Path) -> None:
 
     assert not errors, f"worker errors: {errors!r}"
 
-    final = store.read("X")
+    final = store.read("test-plugin")
     assert final is not None
     persisted = {g.scope for g in final.granted_scopes}
     assert persisted == set(scopes), (
@@ -200,11 +201,48 @@ def test_concurrent_grants_do_not_lose_data(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "evil_name",
+    [
+        "../../../etc/passwd",
+        "..",
+        "./relative",
+        "subdir/leak",
+        "absolute\\path",
+        "X",  # uppercase, schema-rejected
+        "",  # empty
+        "name with spaces",
+    ],
+)
+def test_path_traversal_in_plugin_name_is_rejected(tmp_path: Path, evil_name: str) -> None:
+    """Plugin identifiers used as filesystem path segments must not be
+    able to escape the configured trust root.
+
+    Pre-fix `TrustStore` interpolated `plugin` directly into the
+    `<root>/<plugin>/trust.json` path, so a value containing path
+    separators or `..` segments could read, write, or delete arbitrary
+    files reachable by the process. The store now validates the
+    identifier against the manifest-name pattern at every public
+    boundary.
+    """
+    store = TrustStore(root=tmp_path)
+    with pytest.raises(TrustStoreError):
+        store.grant(plugin=evil_name, version="0.1.0", scope="x:read", granted_by="u")
+    with pytest.raises(TrustStoreError):
+        store.read(evil_name)
+    with pytest.raises(TrustStoreError):
+        store.remove(evil_name)
+    with pytest.raises(TrustStoreError):
+        store.reset_for_version_bump(evil_name, new_version="0.2.0")
+    # Filesystem must be untouched: nothing escaped the tmp_path tree.
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
     """Test 9: TrustRecord.missing() returns missing required scopes in
     the input iteration order — useful for predictable error messages."""
     store = TrustStore(root=tmp_path)
-    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    record = store.grant(plugin="test-plugin", version="0.1.0", scope="github:read", granted_by="u")
     # `github:read` is granted; the others are missing.
     missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
     assert missing == ["github:pull_request:write", "shell:execute"]

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -39,9 +39,7 @@ def test_grant_is_idempotent(tmp_path: Path) -> None:
     """Test 2: granting the same scope twice does not duplicate."""
     store = TrustStore(root=tmp_path)
     store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    record = store.grant(
-        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     assert len(record.granted_scopes) == 1
 
 
@@ -70,9 +68,7 @@ def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
     store.grant(plugin="X", version="0.1.0", scope="github:repo:read", granted_by="u")
 
     # Now bump to 0.2.0 and grant a different scope.
-    record = store.grant(
-        plugin="X", version="0.2.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.2.0", scope="github:read", granted_by="u")
     assert record.version == "0.2.0"
     # Previous github:repo:read grant is invalidated.
     assert not record.has_scope("github:repo:read")
@@ -200,9 +196,7 @@ def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
     """Test 9: TrustRecord.missing() returns missing required scopes in
     the input iteration order — useful for predictable error messages."""
     store = TrustStore(root=tmp_path)
-    record = store.grant(
-        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     # `github:read` is granted; the others are missing.
     missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
     assert missing == ["github:pull_request:write", "shell:execute"]

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -1,0 +1,177 @@
+"""Tests for the UserLevel program registry (Q00/ouroboros#730)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.manifest import load_manifest
+from ouroboros.plugin.userlevel_registry import (
+    LookupResult,
+    RegisteredProgram,
+    RegistryError,
+    UserLevelProgramRegistry,
+    get_userlevel_registry,
+    lookup_command,
+    reset_userlevel_registry,
+)
+
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+        }
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write"},
+    ],
+    "permissions": [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+    ],
+    "entrypoint": {"type": "command", "command": "python -m github_pr_ops"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_registry():
+    """Each test starts with a clean global registry."""
+    reset_userlevel_registry()
+    yield
+    reset_userlevel_registry()
+
+
+def _write_manifest(tmp_path: Path, payload: dict) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _load_ref(tmp_path: Path, **overrides) -> "RegisteredProgram":
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload.update(overrides)
+    return load_manifest(_write_manifest(tmp_path, payload))
+
+
+def test_register_and_get(tmp_path: Path) -> None:
+    """Test 1: register a manifest, look it up by name and namespace."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    program = registry.register(manifest)
+
+    assert isinstance(program, RegisteredProgram)
+    assert registry.get("github-pr-ops") == program
+    assert registry.get_by_namespace("github-pr") == program
+    assert registry.get("nonexistent") is None
+    assert registry.get_by_namespace("nonexistent") is None
+
+
+def test_namespace_collision_rejected(tmp_path: Path) -> None:
+    """Test 2: two plugins claiming the same namespace → error."""
+    registry = UserLevelProgramRegistry()
+    a = _load_ref(tmp_path / "a", name="plugin-a")
+    b = _load_ref(tmp_path / "b", name="plugin-b")  # same namespace "github-pr"
+
+    registry.register(a)
+    with pytest.raises(RegistryError, match="already owned"):
+        registry.register(b)
+
+
+def test_duplicate_name_requires_replace(tmp_path: Path) -> None:
+    """Test 3: re-registering the same name without replace=True → error."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    registry.register(manifest)
+    with pytest.raises(RegistryError, match="already registered"):
+        registry.register(manifest)
+    # With replace=True, succeeds.
+    registry.register(manifest, replace=True)
+
+
+def test_unregister(tmp_path: Path) -> None:
+    """Test 4: unregister releases name AND namespace ownership."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    registry.register(manifest)
+    assert registry.unregister("github-pr-ops") is True
+    assert registry.unregister("github-pr-ops") is False
+    # After unregistering, the namespace can be claimed by a different plugin.
+    other = _load_ref(tmp_path / "other", name="plugin-other")
+    registry.register(other)  # must not raise
+
+
+def test_all_programs(tmp_path: Path) -> None:
+    """Test 5: all_programs returns every registered program."""
+    registry = UserLevelProgramRegistry()
+    a = _load_ref(tmp_path / "a", name="plugin-a")
+    # Different namespace for b
+    b_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    b_payload["name"] = "plugin-b"
+    b_payload["commands"][0]["namespace"] = "other-ns"
+    b = load_manifest(_write_manifest(tmp_path / "b", b_payload))
+    registry.register(a)
+    registry.register(b)
+    names = {p.name for p in registry.all_programs()}
+    assert names == {"plugin-a", "plugin-b"}
+
+
+def test_lookup_command_finds_userlevel_by_namespace(tmp_path: Path) -> None:
+    """Test 6: lookup_command finds via namespace first."""
+    manifest = _load_ref(tmp_path)
+    get_userlevel_registry().register(manifest)
+    result = lookup_command("github-pr")
+    assert result.found
+    assert result.kind == "userlevel"
+    assert result.userlevel_program is not None
+    assert result.userlevel_program.name == "github-pr-ops"
+
+
+def test_lookup_command_finds_userlevel_by_name(tmp_path: Path) -> None:
+    """Test 7: lookup_command also finds via plugin name."""
+    manifest = _load_ref(tmp_path)
+    get_userlevel_registry().register(manifest)
+    result = lookup_command("github-pr-ops")
+    assert result.found
+    assert result.kind == "userlevel"
+
+
+def test_lookup_command_returns_none_for_unknown(tmp_path: Path) -> None:
+    """Test 8: lookup_command returns kind='none' for unknown names."""
+    result = lookup_command("totally-unknown-plugin")
+    assert not result.found
+    assert result.kind == "none"
+
+
+def test_global_singleton_persists_within_session(tmp_path: Path) -> None:
+    """Test 9: get_userlevel_registry returns the same instance."""
+    a = get_userlevel_registry()
+    b = get_userlevel_registry()
+    assert a is b
+
+
+def test_skill_registry_unaffected(tmp_path: Path) -> None:
+    """Test 10: existing skill registry tests still work — no state shared.
+
+    This test loads the skill registry module to confirm we can co-exist
+    with it (no import-time conflicts), without depending on its discovery.
+    """
+    from ouroboros.plugin.skills.registry import get_registry as _get_skill_registry
+
+    skill_registry = _get_skill_registry()
+    # The skill registry is independent from our UserLevel registry.
+    ul = get_userlevel_registry()
+    manifest = _load_ref(tmp_path)
+    ul.register(manifest)
+    # Skill registry must remain unchanged by our registration.
+    assert skill_registry.get_skill("github-pr-ops") is None

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -9,7 +9,6 @@ import pytest
 
 from ouroboros.plugin.manifest import load_manifest
 from ouroboros.plugin.userlevel_registry import (
-    LookupResult,
     RegisteredProgram,
     RegistryError,
     UserLevelProgramRegistry,
@@ -17,7 +16,6 @@ from ouroboros.plugin.userlevel_registry import (
     lookup_command,
     reset_userlevel_registry,
 )
-
 
 REFERENCE_MANIFEST: dict = {
     "schema_version": "0.1",
@@ -58,7 +56,7 @@ def _write_manifest(tmp_path: Path, payload: dict) -> Path:
     return target
 
 
-def _load_ref(tmp_path: Path, **overrides) -> "RegisteredProgram":
+def _load_ref(tmp_path: Path, **overrides) -> RegisteredProgram:
     payload = json.loads(json.dumps(REFERENCE_MANIFEST))
     payload.update(overrides)
     return load_manifest(_write_manifest(tmp_path, payload))

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -202,6 +202,51 @@ def test_replace_with_changed_namespace_releases_old_namespace(tmp_path: Path) -
     assert other_found.name == "plugin-other"
 
 
+def test_register_rejects_name_namespace_cross_collision(tmp_path: Path) -> None:
+    """Registering a plugin whose name shadows another plugin's namespace
+    (or vice versa) must be rejected.
+
+    `lookup_command()` resolves namespaces before plugin names, so a
+    cross-collision makes one of the two programs unreachable through a
+    valid identifier. Pre-fix the registry only checked name-vs-name
+    and namespace-vs-namespace; this test pins the new cross-table
+    invariant.
+    """
+    registry = UserLevelProgramRegistry()
+
+    # Plugin A with namespace "shared-id" — claims the namespace.
+    a_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    a_payload["name"] = "plugin-a"
+    a_payload["commands"][0]["namespace"] = "shared-id"
+    a = load_manifest(_write_manifest(tmp_path / "a", a_payload))
+    registry.register(a)
+
+    # Plugin B literally named "shared-id" — the existing namespace
+    # would shadow B from `lookup_command("shared-id")`.
+    b_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    b_payload["name"] = "shared-id"
+    b_payload["commands"][0]["namespace"] = "different-ns"
+    b = load_manifest(_write_manifest(tmp_path / "b", b_payload))
+    with pytest.raises(RegistryError, match="collides with namespace"):
+        registry.register(b)
+
+    # And the reverse direction: a plugin with a namespace that matches
+    # an existing plugin's name must be rejected too.
+    registry2 = UserLevelProgramRegistry()
+    c_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    c_payload["name"] = "shared-id"
+    c_payload["commands"][0]["namespace"] = "c-ns"
+    c = load_manifest(_write_manifest(tmp_path / "c", c_payload))
+    registry2.register(c)
+
+    d_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    d_payload["name"] = "plugin-d"
+    d_payload["commands"][0]["namespace"] = "shared-id"
+    d = load_manifest(_write_manifest(tmp_path / "d", d_payload))
+    with pytest.raises(RegistryError, match="collides with existing plugin name"):
+        registry2.register(d)
+
+
 def test_skill_registry_unaffected(tmp_path: Path) -> None:
     """Test 10: existing skill registry tests still work — no state shared.
 

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -158,6 +158,50 @@ def test_global_singleton_persists_within_session(tmp_path: Path) -> None:
     assert a is b
 
 
+def test_replace_with_changed_namespace_releases_old_namespace(tmp_path: Path) -> None:
+    """`register(replace=True)` on a plugin that changed namespace must
+    free the old namespace mapping.
+
+    Pre-fix, `_namespace_owner` retained both the stale old namespace and
+    the new one pointing at the same plugin name. A later
+    `unregister(name)` only popped the *new* namespace, leaving the old
+    one permanently shadowed and rejecting any other plugin that tried to
+    claim it.
+    """
+    registry = UserLevelProgramRegistry()
+
+    v1 = _load_ref(tmp_path / "v1")  # namespace="github-pr"
+    registry.register(v1)
+
+    # Re-register the same plugin name with a NEW namespace, replace=True.
+    v2_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    v2_payload["version"] = "0.2.0"
+    v2_payload["commands"][0]["namespace"] = "github-pr-v2"
+    v2 = load_manifest(_write_manifest(tmp_path / "v2", v2_payload))
+    registry.register(v2, replace=True)
+
+    # Old namespace must be free again.
+    assert registry.get_by_namespace("github-pr") is None
+    # New namespace owns the program.
+    found = registry.get_by_namespace("github-pr-v2")
+    assert found is not None
+    assert found.manifest.version == "0.2.0"
+
+    # And a different plugin can now claim the old namespace.
+    other_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    other_payload["name"] = "plugin-other"
+    other = load_manifest(_write_manifest(tmp_path / "other", other_payload))
+    registry.register(other)  # must not raise — namespace "github-pr" is free
+
+    # Unregistering the replaced plugin must drop only its current ns.
+    assert registry.unregister("github-pr-ops") is True
+    assert registry.get_by_namespace("github-pr-v2") is None
+    # The other plugin's ownership of "github-pr" is unaffected.
+    other_found = registry.get_by_namespace("github-pr")
+    assert other_found is not None
+    assert other_found.name == "plugin-other"
+
+
 def test_skill_registry_unaffected(tmp_path: Path) -> None:
     """Test 10: existing skill registry tests still work — no state shared.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1494,6 +1494,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "anyio" },
+    { name = "jsonschema" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -1553,6 +1554,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0.0,<5.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'all'", specifier = ">=0.1.0,<1.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'claude'", specifier = ">=0.1.0,<1.0.0" },
+    { name = "jsonschema", specifier = ">=4.21.0,<5.0.0" },
     { name = "litellm", marker = "extra == 'all'", specifier = ">=1.80.0,<=1.82.6" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80.0,<=1.82.6" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.26.0,<2.0.0" },


### PR DESCRIPTION
Closes #729. Sub-issue of #725 (Phase 1).

**Stacked on** #745 (CR-3 manifest loader), #746 (CR-7 lockfile + trust store), #747 (CR-5 UserLevel registry). Branches merged into this one for cross-module integration; review after the three foundation PRs land.

## Module: `src/ouroboros/plugin/firewall.py`

`invoke_plugin(program, command_name, argv, *, trust_record, event_sink, correlation_id, confirm, subprocess_runner)`.

### Behavior, in locked order

1. **Pre-invocation trust check** (Q00/ouroboros-plugins#9 Q1):
   - Every `required: true` permission must be in the trust record (exact-scope match per Q3).
   - On any missing scope: emit **only** `plugin.failed` (status=blocked) with a clean error message; **NO `plugin.invoked` is emitted**. Return `InvocationResult(status="blocked")`.
   - First-party programs (`source.type=first_party`) skip the check (per Q00/ouroboros-plugins#8 lock).

2. **Confirmation gate** (Q00/ouroboros-plugins#9 Q2):
   - If `command.requires_confirmation=true`, call `confirm()` exactly once.
   - On decline: `plugin.failed` (blocked, "user declined confirmation"); subprocess never launched.

3. **Emit `plugin.invoked`** before launching subprocess.

4. **Emit one `plugin.permission_used` per `required: true` permission** (locked Option (a) coarse rule). Optional permissions are NOT emitted in v0.

5. **Run entrypoint** (subprocess.run by default; injectable via `subprocess_runner` for tests).

6. **Emit `plugin.completed`** (success) or `plugin.failed` (failed) with exit code in `result.message`.

### Bounded payloads

- `argv` stored as-is (already user-facing).
- Raw stdout/stderr NOT copied to events; only sha256 hashes in provenance (`stdout_sha256`, `stderr_sha256`).
- Tokens, channel IDs, free-form messages forbidden by contract.

All events conform to `schemas/0.1/audit-event.schema.json` (vendored in #745).

`EventSink` is a callable — the core ledger writer in production, `list.append` in tests. The firewall does not own the audit log.

## Tests — 9/9 firewall, 193 plugin total

```
$ PYTHONPATH=src python3 -m pytest tests/unit/plugin/ -v
======================== 193 passed, 1 skipped in 0.64s ========================
```

| # | Test | Asserts |
|---|---|---|
| 1 | Happy path | `invoked → permission_used → completed` order; no raw stdout; sha256 in provenance |
| 2 | Trust violation | ONLY `plugin.failed (blocked)`; explicitly asserts NO `plugin.invoked`; locked Q1 message format |
| 3 | Subprocess failure | `invoked + permission_used + failed`; exit code in message |
| 4 | Bounded payload | 1MiB stdout — no portion in events |
| 5 | Confirmation declined | blocked, no subprocess launched |
| 6 | Confirmation accepted | normal happy path |
| 7 | Optional permission | NOT emitted (Option (a) coarse rule) |
| 8 | First-party skips trust | `trust_state="first_party"` |
| 9 | Entrypoint not found | `failed, exit_code=127` |

## Cross-repo

- Audit-event schema compatibility (#737) is partly addressed here — emitted events match the v0.1 schema. The downstream task is to ensure the core ledger writer accepts these events without truncation; tracked separately in #737.

## What's next

- CR-10 (#737) — wire firewall events into the core ledger writer; round-trip tests.
- #731 (CLI) — calls `invoke_plugin` from `ooo plugin run` / dispatched commands.
- #733 (E2E) — exercises this firewall against the real `github-pr-ops` plugin.