### PR TITLE
feat(ledger): plugin audit-event adapter for core EventStore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "aiosqlite>=0.20.0,<1.0.0",
     "anyio>=4.0.0,<5.0.0",
+    "jsonschema>=4.21.0,<5.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "prompt-toolkit>=3.0.0,<4.0.0",
     "pyyaml>=6.0.0,<7.0.0",

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -203,6 +203,19 @@ def invoke_plugin(
             message=f"unknown command {command_name!r} in namespace {namespace!r}",
         )
 
+    # Defense-in-depth: a TrustRecord must positively identify the plugin
+    # and version it was granted for. A record from a previous version (the
+    # locked Q4 says version-bumps invalidate trust) or a record loaded for
+    # a different plugin that happens to grant the same scope strings must
+    # NOT authorize execution. Mismatched records are dropped here so the
+    # downstream check sees no trust and fails the call closed. Per the
+    # documented "single chokepoint" contract, the firewall — not callers —
+    # owns this invariant.
+    if trust_record is not None and (
+        trust_record.plugin != manifest.name or trust_record.version != manifest.version
+    ):
+        trust_record = None
+
     trust_state = _trust_state_label(manifest, trust_record)
     risks = _scope_risk_index(manifest)
     emitted: list[dict] = []

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -30,18 +30,17 @@ ledger writer (#737). Tests pass a list-appender for inspection.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 import hashlib
 import shlex
 import subprocess
-from collections.abc import Callable
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Iterable, Literal
+from typing import Literal
 
 from ouroboros.plugin.manifest import PluginManifest
 from ouroboros.plugin.trust_store import TrustRecord
 from ouroboros.plugin.userlevel_registry import RegisteredProgram
-
 
 SCHEMA_VERSION = "0.1"
 
@@ -60,7 +59,7 @@ class InvocationResult:
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _source_type_for_event(manifest: PluginManifest) -> str:
@@ -292,8 +291,22 @@ def invoke_plugin(
             text=True,
             check=False,
         )
-    except FileNotFoundError as exc:
-        message = f"entrypoint not found: {cmd_argv[0]!r} ({exc})"
+    except OSError as exc:
+        # Cover the full launch-failure surface (FileNotFoundError,
+        # PermissionError, IsADirectoryError, ENOEXEC, etc.). The firewall is
+        # the documented single chokepoint, so every launch failure must emit
+        # a terminal `plugin.failed` event rather than escaping as an
+        # uncaught exception. Exit code uses the conventional shell mapping
+        # (127 = not found, 126 = found-but-not-executable, otherwise 1).
+        if isinstance(exc, FileNotFoundError):
+            message = f"entrypoint not found: {cmd_argv[0]!r} ({exc})"
+            launch_exit_code = 127
+        elif isinstance(exc, PermissionError):
+            message = f"entrypoint not executable: {cmd_argv[0]!r} ({exc})"
+            launch_exit_code = 126
+        else:
+            message = f"entrypoint launch failed: {cmd_argv[0]!r} ({exc})"
+            launch_exit_code = 1
         _emit(
             _event_envelope(
                 event_type="plugin.failed",
@@ -308,7 +321,7 @@ def invoke_plugin(
         )
         return InvocationResult(
             status="failed",
-            exit_code=127,
+            exit_code=launch_exit_code,
             message=message,
             events=tuple(emitted),
         )

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -160,6 +160,31 @@ def _scope_risk_index(manifest: PluginManifest) -> dict[str, str]:
     return {p.scope: p.risk for p in manifest.permissions}
 
 
+def _resolve_plugin_cwd(manifest: PluginManifest) -> str | None:
+    """Compute the working directory the entrypoint subprocess should run in.
+
+    For `local_path` and `plugin_home` sources, the manifest is now
+    required to declare `source.path` (per the schema's conditional
+    required block) — entrypoints typically reference their own
+    installation tree (`./run.sh`, `python -m foo`), so the firewall
+    runs the subprocess with cwd set to the resolved plugin directory.
+    `~`-style expansion is handled here so a manifest like
+    `{"path": "~/.ouroboros/plugins/x"}` works even when the calling
+    process didn't pre-expand it. First-party plugins keep cwd=None
+    (current process cwd) because they are launched from the parent
+    ouroboros runtime and have no installation tree of their own.
+    """
+    if manifest.source.type == "first_party":
+        return None
+    raw = manifest.source.path
+    if not raw:  # pragma: no cover — schema now rejects this at load time
+        return None
+    from os.path import expanduser
+    from pathlib import Path
+
+    return str(Path(expanduser(raw)).resolve())
+
+
 def _deny_confirmation(_msg: str) -> bool:
     """Fail-closed default for `invoke_plugin(confirm=...)`.
 
@@ -351,6 +376,13 @@ def invoke_plugin(
     # 5. Run entrypoint out-of-process.
     cmd_template = manifest.entrypoint.command
     cmd_argv = shlex.split(cmd_template) + [command_name] + list(argv)
+    # Run from the plugin's installation directory so relative
+    # entrypoints (e.g. "./run.sh") resolve against the source path
+    # the manifest declares. The schema now requires `path` for the
+    # non-first-party source types, so this is well-defined for them;
+    # first-party plugins keep the current process cwd because they
+    # are launched from the parent ouroboros runtime.
+    cwd = _resolve_plugin_cwd(manifest)
     runner = subprocess_runner or subprocess.run
     try:
         completed = runner(
@@ -358,6 +390,7 @@ def invoke_plugin(
             capture_output=True,
             text=True,
             check=False,
+            cwd=cwd,
         )
     except OSError as exc:
         # Cover the full launch-failure surface (FileNotFoundError,

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -160,6 +160,20 @@ def _scope_risk_index(manifest: PluginManifest) -> dict[str, str]:
     return {p.scope: p.risk for p in manifest.permissions}
 
 
+def _deny_confirmation(_msg: str) -> bool:
+    """Fail-closed default for `invoke_plugin(confirm=...)`.
+
+    Locked Q2 of Q00/ouroboros-plugins#9 mandates a single, explicit
+    user-confirmation gate for `requires_confirmation: true` commands.
+    The firewall is the documented chokepoint, so a caller that simply
+    forgot to wire a prompt MUST NOT silently execute the destructive
+    command — it must fail closed. CLI callers pass an interactive
+    prompt; tests pass `lambda _: True` only when they intentionally
+    exercise the confirmed path.
+    """
+    return False
+
+
 def invoke_plugin(
     program: RegisteredProgram,
     *,
@@ -168,7 +182,7 @@ def invoke_plugin(
     trust_record: TrustRecord | None,
     event_sink: EventSink,
     correlation_id: str,
-    confirm: ConfirmFn = lambda _msg: True,
+    confirm: ConfirmFn = _deny_confirmation,
     subprocess_runner: Callable[..., subprocess.CompletedProcess] | None = None,
 ) -> InvocationResult:
     """Invoke a UserLevel plugin command through the firewall.
@@ -184,9 +198,13 @@ def invoke_plugin(
             ledger writer (#737) in production; pass `events.append` in
             tests.
         correlation_id: Cross-event correlation id for the ledger.
-        confirm: Optional callable for confirmation prompts. Default is
-            "auto-confirm" (returns True). CLI passes a function that
-            actually prompts.
+        confirm: Callable for the per-command confirmation prompt
+            (locked Q2). The default fails closed (always returns False)
+            so a caller that forgot to wire a real prompt cannot
+            silently execute a `requires_confirmation: true` command.
+            The CLI passes a function that actually prompts the user;
+            tests pass `lambda _: True` only when they intentionally
+            exercise the confirmed path.
         subprocess_runner: Optional override (for tests) of subprocess.run.
 
     Returns:

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -34,6 +34,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import hashlib
+import logging
 import shlex
 import subprocess
 from typing import Literal
@@ -41,6 +42,8 @@ from typing import Literal
 from ouroboros.plugin.manifest import PluginManifest
 from ouroboros.plugin.trust_store import TrustRecord
 from ouroboros.plugin.userlevel_registry import RegisteredProgram
+
+logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = "0.1"
 
@@ -221,7 +224,28 @@ def invoke_plugin(
     emitted: list[dict] = []
 
     def _emit(event: dict) -> None:
-        event_sink(event)
+        # The firewall is the documented chokepoint, so a sink (ledger)
+        # outage MUST NOT turn into an uncaught exception that obscures
+        # the actual invocation outcome. This is most damaging on the
+        # terminal `plugin.completed` / `plugin.failed` emissions: by
+        # then the subprocess has already run, and propagating a sink
+        # exception would leave the caller with no `InvocationResult`
+        # even though the plugin command did execute. We catch broadly,
+        # log, and continue: the result still records the actual exit
+        # state and the events that were successfully observed locally.
+        try:
+            event_sink(event)
+        except Exception as exc:  # noqa: BLE001 — chokepoint isolation
+            logger.warning(
+                "plugin.firewall.event_sink_failed",
+                extra={
+                    "plugin": manifest.name,
+                    "version": manifest.version,
+                    "event_type": event.get("event_type"),
+                    "correlation_id": correlation_id,
+                    "error": repr(exc),
+                },
+            )
         emitted.append(event)
 
     # 1. Pre-invocation trust check (locked Q1).

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -168,11 +168,20 @@ def _resolve_plugin_cwd(manifest: PluginManifest) -> str | None:
     required block) — entrypoints typically reference their own
     installation tree (`./run.sh`, `python -m foo`), so the firewall
     runs the subprocess with cwd set to the resolved plugin directory.
-    `~`-style expansion is handled here so a manifest like
-    `{"path": "~/.ouroboros/plugins/x"}` works even when the calling
-    process didn't pre-expand it. First-party plugins keep cwd=None
-    (current process cwd) because they are launched from the parent
-    ouroboros runtime and have no installation tree of their own.
+
+    Resolution rules:
+      - `~` is expanded so `{"path": "~/.ouroboros/plugins/x"}` works
+        even if the calling process did not pre-expand it.
+      - Absolute paths are honored verbatim.
+      - **Relative** paths are resolved against the *manifest's*
+        directory, NOT the calling process cwd. The manifest carries
+        its own loaded-from location in `manifest_path`, so an
+        installed plugin invoked from any other working directory
+        still resolves the same way.
+
+    First-party plugins keep cwd=None (current process cwd) because
+    they are launched from the parent ouroboros runtime and have no
+    installation tree of their own.
     """
     if manifest.source.type == "first_party":
         return None
@@ -182,7 +191,13 @@ def _resolve_plugin_cwd(manifest: PluginManifest) -> str | None:
     from os.path import expanduser
     from pathlib import Path
 
-    return str(Path(expanduser(raw)).resolve())
+    expanded = Path(expanduser(raw))
+    if expanded.is_absolute():
+        return str(expanded.resolve())
+    if manifest.manifest_path is None:  # pragma: no cover — synthetic manifests in tests
+        return str(expanded.resolve())
+    base = Path(manifest.manifest_path).resolve().parent
+    return str((base / expanded).resolve())
 
 
 def _deny_confirmation(_msg: str) -> bool:

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -111,11 +111,24 @@ def _trust_state_label(
     manifest: PluginManifest,
     trust_record: TrustRecord | None,
 ) -> str:
+    """Compute the audit `trust_state` label.
+
+    The label must agree with the result the firewall is about to record:
+    `trusted` is reserved for invocations that pass the trust check, i.e.
+    every `required: true` permission is covered by a granted scope.
+    Partial trust (some scopes granted, others missing) MUST NOT report
+    `trusted` — that would produce an internally contradictory event when
+    the firewall then emits `plugin.failed` with `result.status=blocked`.
+    """
     if manifest.source.type == "first_party":
         return "first_party"
-    if trust_record is not None and trust_record.granted_scopes:
-        return "trusted"
-    return "installed"
+    required = _required_permissions(manifest)
+    if trust_record is None:
+        return "installed"
+    if trust_record.missing(required):
+        # Some required scopes are still missing — not yet trusted.
+        return "installed"
+    return "trusted"
 
 
 def _missing_required(

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -1,0 +1,380 @@
+"""Plugin invocation firewall.
+
+Every UserLevel plugin command must pass through `invoke_plugin`. The
+firewall is the single chokepoint that:
+
+  1. Pre-invocation trust check (locked Q1 of Q00/ouroboros-plugins#9):
+     refuse + clean error if a `required: true` permission is not trusted;
+     emit only `plugin.failed (status=blocked)`. NO `plugin.invoked` is
+     emitted in this case.
+  2. Single confirmation gate (locked Q2): if the command sets
+     `requires_confirmation: true`, prompt the user once. No second
+     prompt for permission risk.
+  3. Emit `plugin.invoked` before launching the entrypoint subprocess.
+  4. Emit `plugin.permission_used` for each `required: true` permission
+     declared by the manifest. v0 uses Option (a): coarse declared-set
+     emission, not per-call granular tracking.
+  5. Run the entrypoint out-of-process via subprocess.
+  6. Emit `plugin.completed` (status=success) or `plugin.failed`
+     (status=failed) on terminal.
+
+Audit events conform to schemas/0.1/audit-event.schema.json. Bounded
+payloads: argv stored as-is, raw stdout/stderr replaced with a sha256
+hash. Tokens, channel IDs, free-form user messages are forbidden by
+contract.
+
+The firewall does NOT own the audit log. Callers pass an `event_sink`
+(any callable taking a dict) which is typically wired to the core
+ledger writer (#737). Tests pass a list-appender for inspection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Literal
+
+from ouroboros.plugin.manifest import PluginManifest
+from ouroboros.plugin.trust_store import TrustRecord
+from ouroboros.plugin.userlevel_registry import RegisteredProgram
+
+
+SCHEMA_VERSION = "0.1"
+
+EventSink = Callable[[dict], None]
+ConfirmFn = Callable[[str], bool]
+
+
+@dataclass(frozen=True)
+class InvocationResult:
+    status: Literal["success", "blocked", "failed"]
+    exit_code: int | None = None
+    message: str = ""
+    stdout_sha256: str | None = None
+    stderr_sha256: str | None = None
+    events: tuple[dict, ...] = field(default_factory=tuple)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _source_type_for_event(manifest: PluginManifest) -> str:
+    return manifest.source.type
+
+
+def _event_envelope(
+    *,
+    event_type: str,
+    manifest: PluginManifest,
+    namespace: str,
+    command_name: str,
+    argv: list[str] | None,
+    trust_state: str,
+    capabilities_used: Iterable[str] = (),
+    permissions_used: Iterable[str] = (),
+    result: dict | None = None,
+    provenance: dict[str, str] | None = None,
+) -> dict:
+    """Build an event matching schemas/0.1/audit-event.schema.json."""
+    cmd: dict = {"namespace": namespace, "name": command_name}
+    if argv is not None:
+        cmd["argv"] = list(argv)
+    event: dict = {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": event_type,
+        "occurred_at": _utc_now_iso(),
+        "plugin": {
+            "name": manifest.name,
+            "version": manifest.version,
+            "source_type": _source_type_for_event(manifest),
+        },
+        "command": cmd,
+        "trust_state": trust_state,
+        "capabilities_used": list(capabilities_used),
+        "permissions_used": list(permissions_used),
+        "result": result or {"status": "success"},
+    }
+    if provenance is not None:
+        event["provenance"] = dict(provenance)
+    return event
+
+
+def _required_permissions(manifest: PluginManifest) -> list[str]:
+    return [p.scope for p in manifest.permissions if p.required]
+
+
+def _trust_state_label(
+    manifest: PluginManifest,
+    trust_record: TrustRecord | None,
+) -> str:
+    if manifest.source.type == "first_party":
+        return "first_party"
+    if trust_record is not None and trust_record.granted_scopes:
+        return "trusted"
+    return "installed"
+
+
+def _missing_required(
+    manifest: PluginManifest,
+    trust_record: TrustRecord | None,
+) -> list[str]:
+    required = _required_permissions(manifest)
+    if not required:
+        return []
+    if trust_record is None:
+        return list(required)
+    return trust_record.missing(required)
+
+
+def _format_blocked_message(plugin_name: str, missing: list[str], risks: dict[str, str]) -> str:
+    """Per locked Q1: name the missing scope and the exact trust command."""
+    first = missing[0]
+    risk = risks.get(first, "?")
+    return (
+        f"plugin requires `{first}` ({risk}), which is not yet trusted. "
+        f"Run: ooo plugin trust {plugin_name} --scope {first}"
+    )
+
+
+def _scope_risk_index(manifest: PluginManifest) -> dict[str, str]:
+    return {p.scope: p.risk for p in manifest.permissions}
+
+
+def invoke_plugin(
+    program: RegisteredProgram,
+    *,
+    command_name: str,
+    argv: list[str],
+    trust_record: TrustRecord | None,
+    event_sink: EventSink,
+    correlation_id: str,
+    confirm: ConfirmFn = lambda _msg: True,
+    subprocess_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> InvocationResult:
+    """Invoke a UserLevel plugin command through the firewall.
+
+    Args:
+        program: Registered UserLevel program (from `userlevel_registry`).
+        command_name: The name of the command within the plugin's namespace.
+        argv: User-provided argument vector for the command.
+        trust_record: The plugin's TrustRecord (None if not yet trusted).
+            For first-party programs, may be None — the firewall does not
+            consult it for them.
+        event_sink: Callable that receives audit events. Wire to the core
+            ledger writer (#737) in production; pass `events.append` in
+            tests.
+        correlation_id: Cross-event correlation id for the ledger.
+        confirm: Optional callable for confirmation prompts. Default is
+            "auto-confirm" (returns True). CLI passes a function that
+            actually prompts.
+        subprocess_runner: Optional override (for tests) of subprocess.run.
+
+    Returns:
+        `InvocationResult` with status, exit code, sha256 hashes of
+        stdout/stderr, and the events emitted (also pushed to event_sink).
+    """
+    manifest = program.manifest
+    namespace = program.namespace
+    command = program.find_command(command_name)
+    if command is None:
+        # Treat unknown command as a failure that emits no events — the
+        # caller (CLI) is responsible for surfacing this. Returning a
+        # failed result keeps the contract simple.
+        return InvocationResult(
+            status="failed",
+            exit_code=2,
+            message=f"unknown command {command_name!r} in namespace {namespace!r}",
+        )
+
+    trust_state = _trust_state_label(manifest, trust_record)
+    risks = _scope_risk_index(manifest)
+    emitted: list[dict] = []
+
+    def _emit(event: dict) -> None:
+        event_sink(event)
+        emitted.append(event)
+
+    # 1. Pre-invocation trust check (locked Q1).
+    # First-party programs skip the trust check (per Q00/ouroboros-plugins#8).
+    if manifest.source.type != "first_party":
+        missing = _missing_required(manifest, trust_record)
+        if missing:
+            message = _format_blocked_message(manifest.name, missing, risks)
+            _emit(
+                _event_envelope(
+                    event_type="plugin.failed",
+                    manifest=manifest,
+                    namespace=namespace,
+                    command_name=command_name,
+                    argv=argv,
+                    trust_state=trust_state,
+                    result={"status": "blocked", "message": message},
+                    provenance={"correlation_id": correlation_id},
+                )
+            )
+            return InvocationResult(
+                status="blocked",
+                exit_code=None,
+                message=message,
+                events=tuple(emitted),
+            )
+
+    # 2. Confirmation gate (locked Q2 — ONE prompt, command-level).
+    if command.requires_confirmation:
+        prompt = (
+            f"This command is destructive and requires confirmation.\n"
+            f"Plugin: {manifest.name} {manifest.version}\n"
+            f"Action: {command_name} {' '.join(argv)}\n"
+            f"Continue?"
+        )
+        if not confirm(prompt):
+            message = "user declined confirmation"
+            _emit(
+                _event_envelope(
+                    event_type="plugin.failed",
+                    manifest=manifest,
+                    namespace=namespace,
+                    command_name=command_name,
+                    argv=argv,
+                    trust_state=trust_state,
+                    result={"status": "blocked", "message": message},
+                    provenance={"correlation_id": correlation_id},
+                )
+            )
+            return InvocationResult(
+                status="blocked",
+                exit_code=None,
+                message=message,
+                events=tuple(emitted),
+            )
+
+    # 3. Emit `plugin.invoked` before launch.
+    _emit(
+        _event_envelope(
+            event_type="plugin.invoked",
+            manifest=manifest,
+            namespace=namespace,
+            command_name=command_name,
+            argv=argv,
+            trust_state=trust_state,
+            provenance={"correlation_id": correlation_id},
+        )
+    )
+
+    # 4. Emit one `plugin.permission_used` per required permission.
+    for scope in _required_permissions(manifest):
+        _emit(
+            _event_envelope(
+                event_type="plugin.permission_used",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                permissions_used=[scope],
+                provenance={"correlation_id": correlation_id, "scope": scope},
+            )
+        )
+
+    # 5. Run entrypoint out-of-process.
+    cmd_template = manifest.entrypoint.command
+    cmd_argv = shlex.split(cmd_template) + [command_name] + list(argv)
+    runner = subprocess_runner or subprocess.run
+    try:
+        completed = runner(
+            cmd_argv,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        message = f"entrypoint not found: {cmd_argv[0]!r} ({exc})"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={"correlation_id": correlation_id},
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=127,
+            message=message,
+            events=tuple(emitted),
+        )
+
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    stdout_hash = hashlib.sha256(stdout.encode("utf-8")).hexdigest()
+    stderr_hash = hashlib.sha256(stderr.encode("utf-8")).hexdigest()
+
+    # 6. Terminal event: completed or failed.
+    if completed.returncode == 0:
+        _emit(
+            _event_envelope(
+                event_type="plugin.completed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "success"},
+                provenance={
+                    "correlation_id": correlation_id,
+                    "stdout_sha256": stdout_hash,
+                    "stderr_sha256": stderr_hash,
+                },
+            )
+        )
+        return InvocationResult(
+            status="success",
+            exit_code=0,
+            stdout_sha256=stdout_hash,
+            stderr_sha256=stderr_hash,
+            events=tuple(emitted),
+        )
+    else:
+        message = f"entrypoint exited with code {completed.returncode}"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={
+                    "correlation_id": correlation_id,
+                    "stdout_sha256": stdout_hash,
+                    "stderr_sha256": stderr_hash,
+                },
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=completed.returncode,
+            message=message,
+            stdout_sha256=stdout_hash,
+            stderr_sha256=stderr_hash,
+            events=tuple(emitted),
+        )
+
+
+__all__ = [
+    "ConfirmFn",
+    "EventSink",
+    "InvocationResult",
+    "SCHEMA_VERSION",
+    "invoke_plugin",
+]

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -33,7 +33,11 @@ async session and bridges to `append_fn`.
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 import uuid
+
+if TYPE_CHECKING:  # pragma: no cover — type-only; keeps the module import-light
+    from ouroboros.events.base import BaseEvent
 
 PLUGIN_AGGREGATE_TYPE = "plugin"
 
@@ -120,6 +124,65 @@ def unwrap_plugin_event(envelope: dict) -> dict:
     return dict(payload)
 
 
+def envelope_to_base_event(envelope: dict) -> BaseEvent:
+    """Convert a wrapped plugin envelope into a `BaseEvent` for the core
+    event store.
+
+    The PR introducing this adapter intentionally avoids importing the
+    async-SQLAlchemy `EventStore` machinery at module import time, but
+    the production integration path is `EventStore.append`, which only
+    accepts `BaseEvent`. This helper is the documented bridge: the CLI
+    integration point (#731) calls it to translate the dict envelope
+    produced by `wrap_plugin_event` into a `BaseEvent` and then awaits
+    `event_store.append(event)`.
+
+    `BaseEvent` is imported lazily so consumers that only need
+    wrap/unwrap (e.g. tests, schema-shape validation) do not pay the
+    pydantic-import cost.
+
+    Args:
+        envelope: A row envelope produced by `wrap_plugin_event`.
+
+    Returns:
+        A `BaseEvent` whose `to_db_dict()` matches the events_table
+        column shape and whose `data` is the audit-event payload.
+
+    Raises:
+        ValueError: if the envelope is not a plugin envelope.
+    """
+    from datetime import datetime
+
+    from ouroboros.events.base import BaseEvent  # local import — see docstring
+
+    agg = envelope.get("aggregate_type")
+    if agg != PLUGIN_AGGREGATE_TYPE:
+        raise ValueError(
+            f"envelope is not a plugin envelope (aggregate_type={agg!r}); "
+            f"expected {PLUGIN_AGGREGATE_TYPE!r}"
+        )
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        raise ValueError("envelope payload is missing or not a dict")
+
+    raw_ts = envelope.get("timestamp")
+    if not isinstance(raw_ts, str):
+        raise ValueError("envelope timestamp must be an RFC3339 string")
+    # BaseEvent.timestamp is a `datetime`; the audit-event `occurred_at`
+    # is RFC3339 ("YYYY-MM-DDThh:mm:ssZ"). Convert the trailing Z so
+    # `datetime.fromisoformat` accepts it on Python <3.11 too.
+    iso = raw_ts.replace("Z", "+00:00")
+    timestamp = datetime.fromisoformat(iso)
+
+    return BaseEvent(
+        id=envelope["id"],
+        type=envelope["event_type"],
+        timestamp=timestamp,
+        aggregate_type=envelope["aggregate_type"],
+        aggregate_id=envelope["aggregate_id"],
+        data=dict(payload),
+    )
+
+
 def make_event_sink(
     append_fn: Callable[[dict], None],
     *,
@@ -129,10 +192,27 @@ def make_event_sink(
 ) -> Callable[[dict], None]:
     """Build a firewall-compatible `EventSink` that wraps and appends.
 
+    The sink expects an `append_fn` that consumes the **dict envelope**
+    produced by `wrap_plugin_event`, NOT the typed `BaseEvent` that
+    `EventStore.append` requires. Production wiring (#731) pairs this
+    factory with `envelope_to_base_event` to perform the typed
+    translation, e.g.::
+
+        async def _ledger_append(envelope: dict) -> None:
+            await event_store.append(envelope_to_base_event(envelope))
+
+        sink = make_event_sink(
+            lambda env: asyncio.run(_ledger_append(env)),
+            correlation_id=corr,
+        )
+
+    Tests pass `list.append` to inspect the dict-shaped envelopes
+    directly without bringing the async store online.
+
     Args:
         append_fn: Where to append the wrapped envelope. In production,
-            wire to an EventStore.append wrapper. In tests, pass
-            `list.append`.
+            wire through `envelope_to_base_event` to `EventStore.append`.
+            In tests, pass `list.append`.
         correlation_id: Default aggregate id and forwarded to wrap.
         aggregate_id: Override.
         envelope_id_factory: Override for envelope id generation
@@ -157,6 +237,7 @@ def make_event_sink(
 __all__ = [
     "AUDIT_EVENT_TYPES",
     "PLUGIN_AGGREGATE_TYPE",
+    "envelope_to_base_event",
     "make_event_sink",
     "unwrap_plugin_event",
     "wrap_plugin_event",

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -1,0 +1,165 @@
+"""Adapter from firewall audit events to the core event store.
+
+The firewall (`plugin/firewall.py`) emits events that conform to
+`schemas/0.1/audit-event.schema.json`. Those events have
+`additionalProperties: false`, so any wrapping fields the core ledger
+needs (`id`, `aggregate_type`, `aggregate_id`, `timestamp`) MUST live
+in a layer ABOVE the audit-event boundary, not inside it.
+
+This adapter:
+
+  - `wrap_plugin_event(event_dict, *, correlation_id, aggregate_id=None)`
+    returns a row-shaped envelope ready for `persistence.event_store`.
+    The full audit event becomes the `payload`; the envelope adds the
+    fields the core ledger requires.
+
+  - `unwrap_plugin_event(envelope) -> dict`
+    returns the original audit event from a stored envelope. Used by
+    consumers that need to round-trip events back into schema-valid
+    form (e.g. `ooo plugin status` reading the audit trail).
+
+  - `make_event_sink(append_fn, *, correlation_id, ...) -> EventSink`
+    factory that produces a `firewall.EventSink` callable wired to a
+    given append function (signature `append(envelope: dict) -> None`).
+    Production wires it to `EventStore.append`; tests can wire it to a
+    list.
+
+This module deliberately does NOT import `persistence/event_store.py`
+or its async machinery. It speaks the envelope shape, not the store.
+The CLI (#731) is the integration point that takes a real EventStore
+async session and bridges to `append_fn`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+
+PLUGIN_AGGREGATE_TYPE = "plugin"
+
+# Audit event types the firewall may emit. Used by tests + by
+# downstream consumers that want to filter ledger queries.
+AUDIT_EVENT_TYPES: tuple[str, ...] = (
+    "plugin.discovered",
+    "plugin.installed",
+    "plugin.trusted",
+    "plugin.invoked",
+    "plugin.permission_used",
+    "plugin.completed",
+    "plugin.failed",
+)
+
+
+def wrap_plugin_event(
+    audit_event: dict,
+    *,
+    correlation_id: str,
+    aggregate_id: str | None = None,
+    envelope_id: str | None = None,
+) -> dict:
+    """Wrap a plugin audit event in a core-ledger row envelope.
+
+    Args:
+        audit_event: A dict matching schemas/0.1/audit-event.schema.json.
+            This becomes the `payload` field verbatim — the schema's
+            `additionalProperties: false` is preserved by NOT mutating
+            the event in place.
+        correlation_id: Cross-event correlation id (from the firewall).
+            Used as the default `aggregate_id`.
+        aggregate_id: Override for the aggregate id. Defaults to
+            `correlation_id`. Must be a string; the events_table column
+            is `String(36)` so callers should keep it short (UUID-shaped
+            is conventional).
+        envelope_id: Override for the row's UUID. Defaults to a fresh
+            uuid4. Tests pin a specific id for determinism.
+
+    Returns:
+        A dict with the envelope fields (`id`, `aggregate_type`,
+        `aggregate_id`, `event_type`, `payload`, `timestamp`).
+    """
+    if not isinstance(audit_event, dict):
+        raise TypeError(f"audit_event must be dict, got {type(audit_event).__name__}")
+    if "event_type" not in audit_event:
+        raise ValueError("audit_event missing 'event_type'")
+    if "occurred_at" not in audit_event:
+        raise ValueError("audit_event missing 'occurred_at'")
+
+    return {
+        "id": envelope_id or str(uuid.uuid4()),
+        "aggregate_type": PLUGIN_AGGREGATE_TYPE,
+        "aggregate_id": aggregate_id or correlation_id,
+        "event_type": audit_event["event_type"],
+        "payload": dict(audit_event),  # shallow copy so callers can't mutate stored form
+        "timestamp": audit_event["occurred_at"],
+    }
+
+
+def unwrap_plugin_event(envelope: dict) -> dict:
+    """Extract the original audit event from a wrapped envelope.
+
+    Args:
+        envelope: A dict produced by `wrap_plugin_event`, or a row read
+            back from the event store.
+
+    Returns:
+        The original audit event (a dict matching audit-event.schema.json).
+
+    Raises:
+        ValueError: if the envelope is not a plugin envelope or its
+            payload is missing.
+    """
+    agg = envelope.get("aggregate_type")
+    if agg != PLUGIN_AGGREGATE_TYPE:
+        raise ValueError(
+            f"envelope is not a plugin envelope (aggregate_type={agg!r}); "
+            f"expected {PLUGIN_AGGREGATE_TYPE!r}"
+        )
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        raise ValueError("envelope payload is missing or not a dict")
+    return dict(payload)
+
+
+def make_event_sink(
+    append_fn: Callable[[dict], None],
+    *,
+    correlation_id: str,
+    aggregate_id: str | None = None,
+    envelope_id_factory: Callable[[], str] | None = None,
+) -> Callable[[dict], None]:
+    """Build a firewall-compatible `EventSink` that wraps and appends.
+
+    Args:
+        append_fn: Where to append the wrapped envelope. In production,
+            wire to an EventStore.append wrapper. In tests, pass
+            `list.append`.
+        correlation_id: Default aggregate id and forwarded to wrap.
+        aggregate_id: Override.
+        envelope_id_factory: Override for envelope id generation
+            (tests pass a counter).
+
+    Returns:
+        A callable that wraps each audit event and forwards to append_fn.
+    """
+
+    def _sink(audit_event: dict) -> None:
+        envelope = wrap_plugin_event(
+            audit_event,
+            correlation_id=correlation_id,
+            aggregate_id=aggregate_id,
+            envelope_id=envelope_id_factory() if envelope_id_factory else None,
+        )
+        append_fn(envelope)
+
+    return _sink
+
+
+__all__ = [
+    "AUDIT_EVENT_TYPES",
+    "PLUGIN_AGGREGATE_TYPE",
+    "make_event_sink",
+    "unwrap_plugin_event",
+    "wrap_plugin_event",
+]

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -32,10 +32,8 @@ async session and bridges to `append_fn`.
 
 from __future__ import annotations
 
-import uuid
 from collections.abc import Callable
-from typing import Any
-
+import uuid
 
 PLUGIN_AGGREGATE_TYPE = "plugin"
 

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -1,0 +1,193 @@
+"""Plugin lockfile.
+
+Persists records of installed plugins at `~/.ouroboros/plugins.lock` (TOML).
+The lockfile is the source of truth for "what is installed" — the trust store
+(see `trust_store.py`) is the source of truth for "what is trusted."
+
+Per the locked Q00/ouroboros#732 spec:
+  - Atomic writes (temp file + rename).
+  - Concurrent-write safety via a POSIX file lock (fcntl).
+  - Deterministic ordering: entries sorted by `name` so diffs are reviewable.
+  - Schema versioned (`schema_version = "0.1"`).
+  - Removal is atomic (no orphaned entries).
+
+The TOML shape is fixed and small. We hand-roll serialization rather than
+take on a `tomli_w` dependency. Reading uses stdlib `tomllib`.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import tomllib
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+LOCKFILE_SCHEMA_VERSION = "0.1"
+
+# Default location. Overridable via constructor for tests.
+DEFAULT_LOCKFILE_PATH = Path.home() / ".ouroboros" / "plugins.lock"
+
+
+@dataclass(frozen=True)
+class LockEntry:
+    """One installed plugin's lockfile record."""
+
+    name: str
+    version: str
+    source_kind: str  # "git" | "local"
+    repository: str | None  # git URL when source_kind="git"; else None
+    git_sha: str | None
+    manifest_checksum: str  # "sha256:<hex>"
+    installed_at: str  # RFC3339
+    plugin_home: str  # filesystem path
+
+    def to_toml_lines(self) -> list[str]:
+        lines = ["[[plugin]]"]
+        lines.append(f"name = {_toml_str(self.name)}")
+        lines.append(f"version = {_toml_str(self.version)}")
+        lines.append(f"source_kind = {_toml_str(self.source_kind)}")
+        if self.repository is not None:
+            lines.append(f"repository = {_toml_str(self.repository)}")
+        if self.git_sha is not None:
+            lines.append(f"git_sha = {_toml_str(self.git_sha)}")
+        lines.append(f"manifest_checksum = {_toml_str(self.manifest_checksum)}")
+        lines.append(f"installed_at = {_toml_str(self.installed_at)}")
+        lines.append(f"plugin_home = {_toml_str(self.plugin_home)}")
+        return lines
+
+
+def _toml_str(value: str) -> str:
+    """Serialize a string value as TOML basic string. Restricts content to
+    avoid escaping edge cases — the lockfile only stores names, paths, hashes
+    and timestamps, none of which contain control chars or non-ASCII in
+    practice."""
+    if any(ch == "\\" or ch == '"' or ord(ch) < 0x20 for ch in value):
+        # Use TOML's basic string escapes for the small set we actually need.
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+            .replace("\r", "\\r")
+        )
+        return f'"{escaped}"'
+    return f'"{value}"'
+
+
+class Lockfile:
+    """Atomic, file-locked plugins lockfile manager."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or DEFAULT_LOCKFILE_PATH
+
+    def _ensure_dir(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def read(self) -> dict[str, LockEntry]:
+        """Read the lockfile, returning entries keyed by plugin name.
+
+        Returns an empty dict if the file does not exist.
+        Raises ValueError if the schema_version is unsupported.
+        """
+        if not self.path.is_file():
+            return {}
+        with self.path.open("rb") as handle:
+            data = tomllib.load(handle)
+        version = data.get("schema_version")
+        if version != LOCKFILE_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported lockfile schema_version {version!r}; "
+                f"expected {LOCKFILE_SCHEMA_VERSION!r}"
+            )
+        result: dict[str, LockEntry] = {}
+        for raw in data.get("plugin", []):
+            entry = LockEntry(
+                name=raw["name"],
+                version=raw["version"],
+                source_kind=raw["source_kind"],
+                repository=raw.get("repository"),
+                git_sha=raw.get("git_sha"),
+                manifest_checksum=raw["manifest_checksum"],
+                installed_at=raw["installed_at"],
+                plugin_home=raw["plugin_home"],
+            )
+            result[entry.name] = entry
+        return result
+
+    def _write_atomic(self, entries: dict[str, LockEntry]) -> None:
+        """Write the lockfile atomically (temp file + rename)."""
+        self._ensure_dir()
+        ordered = sorted(entries.values(), key=lambda e: e.name)
+        lines = [f'schema_version = "{LOCKFILE_SCHEMA_VERSION}"', ""]
+        for entry in ordered:
+            lines.extend(entry.to_toml_lines())
+            lines.append("")
+        body = "\n".join(lines).rstrip() + "\n"
+
+        # Write to temp file in the same directory, then atomic rename.
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".plugins.lock.", dir=str(self.path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(body)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, self.path)
+        except Exception:
+            # Best-effort cleanup of the temp file on failure.
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    @contextmanager
+    def _file_lock(self) -> Iterator[None]:
+        """Acquire an exclusive flock for concurrent-write safety.
+
+        POSIX-only. Falls through gracefully on platforms without fcntl
+        (the file is still atomically replaced via os.replace, which gives
+        last-writer-wins semantics — acceptable for non-concurrent use).
+        """
+        self._ensure_dir()
+        try:
+            import fcntl
+        except ImportError:  # pragma: no cover — non-POSIX platforms
+            yield
+            return
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        with lock_path.open("w") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def add(self, entry: LockEntry) -> None:
+        """Add or replace an entry. Holds the file lock for the duration."""
+        with self._file_lock():
+            entries = self.read()
+            entries[entry.name] = entry
+            self._write_atomic(entries)
+
+    def remove(self, name: str) -> bool:
+        """Remove an entry by name. Returns True if removed, False if absent."""
+        with self._file_lock():
+            entries = self.read()
+            if name not in entries:
+                return False
+            entries.pop(name)
+            self._write_atomic(entries)
+            return True
+
+
+__all__ = [
+    "DEFAULT_LOCKFILE_PATH",
+    "LOCKFILE_SCHEMA_VERSION",
+    "LockEntry",
+    "Lockfile",
+]

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -17,13 +17,13 @@ take on a `tomli_w` dependency. Reading uses stdlib `tomllib`.
 
 from __future__ import annotations
 
-import os
-import tempfile
-import tomllib
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+import os
 from pathlib import Path
-from typing import Iterator
+import tempfile
+import tomllib
 
 LOCKFILE_SCHEMA_VERSION = "0.1"
 

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -128,9 +128,7 @@ class Lockfile:
         body = "\n".join(lines).rstrip() + "\n"
 
         # Write to temp file in the same directory, then atomic rename.
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=".plugins.lock.", dir=str(self.path.parent)
-        )
+        fd, tmp_path = tempfile.mkstemp(prefix=".plugins.lock.", dir=str(self.path.parent))
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 handle.write(body)

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -285,6 +285,24 @@ def load_manifest(path: str | Path) -> PluginManifest:
         repository=source_raw.get("repository"),
     )
 
+    # Reject duplicate command names within a manifest. `RegisteredProgram
+    # .find_command()` returns the first match by name, so a second command
+    # with the same name would be silently unreachable and its
+    # `risk` / `requires_confirmation` settings would be ignored — an
+    # API-contract ambiguity at the manifest boundary that should fail
+    # loud at load time, mirroring the per-permission/per-capability
+    # uniqueness already enforced below.
+    command_names_seen: set[str] = set()
+    for index, c in enumerate(raw["commands"]):
+        if c["name"] in command_names_seen:
+            raise PluginManifestError(
+                f"duplicate command name {c['name']!r}",
+                path=str(manifest_path),
+                json_pointer=f"/commands/{index}/name",
+                expected="unique command name across the array",
+                got=c["name"],
+            )
+        command_names_seen.add(c["name"])
     commands = tuple(_build_command(c) for c in raw["commands"])
 
     # Capabilities and permissions preserve manifest declaration order so the

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -161,6 +161,12 @@ class PluginManifest:
     entrypoint: Entrypoint
     description: str = ""
     audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
+    # Filesystem path the manifest was loaded from. Used downstream to
+    # resolve relative `source.path` values against the manifest
+    # directory (not the calling process cwd). May be `None` for
+    # synthetic manifests built in tests; production code paths set it
+    # via `load_manifest`.
+    manifest_path: str | None = None
 
 
 def _load_schema(schema_version: str) -> dict[str, Any]:
@@ -369,6 +375,7 @@ def load_manifest(path: str | Path) -> PluginManifest:
         entrypoint=entrypoint,
         description=raw.get("description", ""),
         audit=audit,
+        manifest_path=str(manifest_path.resolve()),
     )
 
 

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -353,9 +353,27 @@ def load_manifest(path: str | Path) -> PluginManifest:
             )
         )
     permissions = tuple(permissions_list)
+    # The schema only enforces `minLength: 1`, which lets a whitespace-only
+    # command like "   " through. At invocation time `shlex.split` of such
+    # a command yields zero tokens; the firewall would then prepend the
+    # subcommand name and try to exec the literal subcommand as the
+    # binary — a misleading runtime failure that escapes after
+    # `plugin.invoked` has already been emitted. Reject here at the
+    # manifest boundary.
+    import shlex
+
+    entrypoint_command_raw = raw["entrypoint"]["command"]
+    if not entrypoint_command_raw.strip() or not shlex.split(entrypoint_command_raw):
+        raise PluginManifestError(
+            "entrypoint.command must contain at least one non-whitespace token",
+            path=str(manifest_path),
+            json_pointer="/entrypoint/command",
+            expected="shell command with >= 1 executable token",
+            got=repr(entrypoint_command_raw),
+        )
     entrypoint = Entrypoint(
         type=raw["entrypoint"]["type"],
-        command=raw["entrypoint"]["command"],
+        command=entrypoint_command_raw,
     )
 
     audit_raw = raw.get("audit")

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -1,0 +1,336 @@
+"""Plugin manifest loader.
+
+Loads UserLevel plugin manifests (`ouroboros.plugin.json`) and validates them
+against the vendored JSON Schema under `src/ouroboros/plugin/schemas/<major>/`.
+
+The locked spec (Q00/ouroboros#728) requires:
+
+  - `PluginManifest` is a frozen dataclass with 8 required + 2 optional fields
+    (per Q00/ouroboros-plugins#6 lock).
+  - `load_manifest(path)` returns a frozen, validated manifest.
+  - On any schema violation, raise `PluginManifestError` with structured
+    fields: `path`, `json_pointer`, `expected`, `got`. A reviewer can match
+    on `json_pointer` rather than parsing message text.
+  - `source.type=first_party` is a real branch; the loader does not require
+    `source.path`/`source.repository` for first-party manifests.
+  - Manifest's `schema_version` selects the matching archived schema.
+    Unsupported versions raise with a clear message naming the support
+    window.
+
+This module is intentionally narrow. It does not load remote URLs (that is
+the manager's job in #731), does not cache (premature), and does not perform
+runtime side effects.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "jsonschema>=4.21 is required. Install it via `pip install jsonschema`."
+    ) from exc
+
+
+# Support window per Q00/ouroboros-plugins#11 lock: current MAJOR + previous MAJOR.
+# Today we only ship 0.1; once 1.0 ships, both "0.1" and "1.0" are accepted, "0.x"
+# below the latest is unsupported.
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1",)
+
+_SCHEMAS_ROOT = Path(__file__).resolve().parent / "schemas"
+
+
+class PluginManifestError(Exception):
+    """Raised when a manifest fails to load or validate.
+
+    Attributes:
+        path: Filesystem path of the manifest that failed.
+        json_pointer: JSON Pointer (RFC 6901) to the failing field, or None
+            for whole-file failures.
+        expected: Human-readable description of what was expected.
+        got: Human-readable description of what was actually present.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: str | Path,
+        json_pointer: str | None = None,
+        expected: str = "",
+        got: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.path = str(path)
+        self.json_pointer = json_pointer
+        self.expected = expected
+        self.got = got
+
+    def __str__(self) -> str:  # pragma: no cover - convenience
+        loc = self.json_pointer if self.json_pointer is not None else "(root)"
+        return f"{self.path}: {loc}: {self.args[0] if self.args else ''}"
+
+
+@dataclass(frozen=True)
+class CommandArgument:
+    name: str
+    type: str
+    required: bool
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    namespace: str
+    name: str
+    summary: str
+    usage: str
+    risk: str
+    requires_confirmation: bool = False
+    arguments: tuple[CommandArgument, ...] = ()
+
+
+@dataclass(frozen=True)
+class Capability:
+    name: str
+    access: str
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class Permission:
+    scope: str
+    risk: str
+    required: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    type: str
+    path: str | None = None
+    repository: str | None = None
+
+
+@dataclass(frozen=True)
+class Entrypoint:
+    type: str
+    command: str
+
+
+@dataclass(frozen=True)
+class AuditSpec:
+    events: tuple[str, ...]
+
+    @staticmethod
+    def standard_four_events() -> "AuditSpec":
+        return AuditSpec(
+            events=(
+                "plugin.invoked",
+                "plugin.permission_used",
+                "plugin.completed",
+                "plugin.failed",
+            )
+        )
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Frozen representation of a validated plugin manifest.
+
+    Field shape matches Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json
+    after the locked Q00/ouroboros-plugins#6 (8 required + 2 optional)
+    decision is applied.
+    """
+
+    schema_version: str
+    name: str
+    version: str
+    source: SourceSpec
+    commands: tuple[CommandSpec, ...]
+    capabilities: frozenset[Capability]
+    permissions: frozenset[Permission]
+    entrypoint: Entrypoint
+    description: str = ""
+    audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
+
+
+def _load_schema(schema_version: str) -> dict[str, Any]:
+    schema_path = _SCHEMAS_ROOT / schema_version / "plugin.schema.json"
+    if not schema_path.is_file():
+        raise PluginManifestError(
+            f"vendored schema for version {schema_version!r} not found",
+            path=str(schema_path),
+            json_pointer="/schema_version",
+            expected=f"one of {list(SUPPORTED_SCHEMA_VERSIONS)}",
+            got=f"{schema_version!r} (no vendored schema)",
+        )
+    with schema_path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _build_command(raw: dict[str, Any]) -> CommandSpec:
+    args = tuple(
+        CommandArgument(
+            name=a["name"],
+            type=a["type"],
+            required=a["required"],
+            description=a.get("description", ""),
+        )
+        for a in raw.get("arguments", [])
+    )
+    return CommandSpec(
+        namespace=raw["namespace"],
+        name=raw["name"],
+        summary=raw["summary"],
+        usage=raw["usage"],
+        risk=raw["risk"],
+        requires_confirmation=raw.get("requires_confirmation", False),
+        arguments=args,
+    )
+
+
+def load_manifest(path: str | Path) -> PluginManifest:
+    """Load and validate a plugin manifest from `path`.
+
+    Args:
+        path: Filesystem path to an `ouroboros.plugin.json` file.
+
+    Returns:
+        A frozen, validated `PluginManifest`.
+
+    Raises:
+        PluginManifestError: on JSON decode failure, schema violation, or
+            unsupported `schema_version`.
+    """
+    manifest_path = Path(path)
+    if not manifest_path.is_file():
+        raise PluginManifestError(
+            f"manifest file not found: {manifest_path}",
+            path=str(manifest_path),
+            json_pointer=None,
+            expected="readable file",
+            got="missing",
+        )
+
+    try:
+        with manifest_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise PluginManifestError(
+            f"manifest is not valid JSON: {exc.msg}",
+            path=str(manifest_path),
+            json_pointer=None,
+            expected="valid JSON object",
+            got=f"JSON decode error at line {exc.lineno}, col {exc.colno}",
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise PluginManifestError(
+            "manifest must be a JSON object",
+            path=str(manifest_path),
+            json_pointer="",
+            expected="object",
+            got=type(raw).__name__,
+        )
+
+    schema_version = raw.get("schema_version")
+    if not isinstance(schema_version, str):
+        raise PluginManifestError(
+            "manifest is missing `schema_version`",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected="string (e.g. '0.1')",
+            got=type(schema_version).__name__,
+        )
+
+    if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+        raise PluginManifestError(
+            f"schema_version {schema_version!r} is not in the support window",
+            path=str(manifest_path),
+            json_pointer="/schema_version",
+            expected=f"schema_version in supported window {list(SUPPORTED_SCHEMA_VERSIONS)}",
+            got=schema_version,
+        )
+
+    schema = _load_schema(schema_version)
+    validator = Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(raw),
+        key=lambda e: list(e.absolute_path),
+    )
+    if errors:
+        err = errors[0]
+        pointer = "/" + "/".join(str(p) for p in err.absolute_path) if err.absolute_path else ""
+        raise PluginManifestError(
+            err.message,
+            path=str(manifest_path),
+            json_pointer=pointer,
+            expected=str(err.schema),
+            got=str(err.instance)[:200],
+        )
+
+    source_raw = raw["source"]
+    source = SourceSpec(
+        type=source_raw["type"],
+        path=source_raw.get("path"),
+        repository=source_raw.get("repository"),
+    )
+
+    commands = tuple(_build_command(c) for c in raw["commands"])
+    capabilities = frozenset(
+        Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
+        for c in raw["capabilities"]
+    )
+    permissions = frozenset(
+        Permission(
+            scope=p["scope"],
+            risk=p["risk"],
+            required=p["required"],
+            reason=p.get("reason", ""),
+        )
+        for p in raw["permissions"]
+    )
+    entrypoint = Entrypoint(
+        type=raw["entrypoint"]["type"],
+        command=raw["entrypoint"]["command"],
+    )
+
+    audit_raw = raw.get("audit")
+    if audit_raw is None:
+        audit = AuditSpec.standard_four_events()
+    else:
+        audit = AuditSpec(events=tuple(audit_raw["events"]))
+
+    return PluginManifest(
+        schema_version=schema_version,
+        name=raw["name"],
+        version=raw["version"],
+        source=source,
+        commands=commands,
+        capabilities=capabilities,
+        permissions=permissions,
+        entrypoint=entrypoint,
+        description=raw.get("description", ""),
+        audit=audit,
+    )
+
+
+__all__ = [
+    "Capability",
+    "CommandArgument",
+    "CommandSpec",
+    "Entrypoint",
+    "Permission",
+    "PluginManifest",
+    "PluginManifestError",
+    "SourceSpec",
+    "AuditSpec",
+    "load_manifest",
+    "SUPPORTED_SCHEMA_VERSIONS",
+]

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -24,8 +24,8 @@ runtime side effects.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
 from typing import Any
 
@@ -128,7 +128,7 @@ class AuditSpec:
     events: tuple[str, ...]
 
     @staticmethod
-    def standard_four_events() -> "AuditSpec":
+    def standard_four_events() -> AuditSpec:
         return AuditSpec(
             events=(
                 "plugin.invoked",
@@ -153,8 +153,11 @@ class PluginManifest:
     version: str
     source: SourceSpec
     commands: tuple[CommandSpec, ...]
-    capabilities: frozenset[Capability]
-    permissions: frozenset[Permission]
+    # Ordered tuples (not frozensets) so the firewall's audit-event/message
+    # iteration order matches manifest declaration order. Uniqueness is
+    # enforced at load time via `_unique_in_order`.
+    capabilities: tuple[Capability, ...]
+    permissions: tuple[Permission, ...]
     entrypoint: Entrypoint
     description: str = ""
     audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
@@ -283,19 +286,49 @@ def load_manifest(path: str | Path) -> PluginManifest:
     )
 
     commands = tuple(_build_command(c) for c in raw["commands"])
-    capabilities = frozenset(
-        Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
-        for c in raw["capabilities"]
-    )
-    permissions = frozenset(
-        Permission(
-            scope=p["scope"],
-            risk=p["risk"],
-            required=p["required"],
-            reason=p.get("reason", ""),
+
+    # Capabilities and permissions preserve manifest declaration order so the
+    # firewall's audit-event emission and "first missing scope" message are
+    # deterministic. Duplicate keys are rejected with a structured pointer
+    # rather than silently deduped, so manifest authors get a clear error.
+    capabilities_seen: set[str] = set()
+    capabilities_list: list[Capability] = []
+    for index, c in enumerate(raw["capabilities"]):
+        if c["name"] in capabilities_seen:
+            raise PluginManifestError(
+                f"duplicate capability name {c['name']!r}",
+                path=str(manifest_path),
+                json_pointer=f"/capabilities/{index}/name",
+                expected="unique capability name across the array",
+                got=c["name"],
+            )
+        capabilities_seen.add(c["name"])
+        capabilities_list.append(
+            Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
         )
-        for p in raw["permissions"]
-    )
+    capabilities = tuple(capabilities_list)
+
+    permissions_seen: set[str] = set()
+    permissions_list: list[Permission] = []
+    for index, p in enumerate(raw["permissions"]):
+        if p["scope"] in permissions_seen:
+            raise PluginManifestError(
+                f"duplicate permission scope {p['scope']!r}",
+                path=str(manifest_path),
+                json_pointer=f"/permissions/{index}/scope",
+                expected="unique permission scope across the array",
+                got=p["scope"],
+            )
+        permissions_seen.add(p["scope"])
+        permissions_list.append(
+            Permission(
+                scope=p["scope"],
+                risk=p["risk"],
+                required=p["required"],
+                reason=p.get("reason", ""),
+            )
+        )
+    permissions = tuple(permissions_list)
     entrypoint = Entrypoint(
         type=raw["entrypoint"]["type"],
         command=raw["entrypoint"]["command"],

--- a/src/ouroboros/plugin/schemas/0.1/_source.json
+++ b/src/ouroboros/plugin/schemas/0.1/_source.json
@@ -1,0 +1,6 @@
+{
+  "repo": "Q00/ouroboros-plugins",
+  "schema_version": "0.1",
+  "vendored_at": "2026-05-07",
+  "note": "These schemas mirror Q00/ouroboros-plugins/schemas/0.1/. They reflect the locked decisions in Q00/ouroboros-plugins #6 (manifest 8+2 fields), #10 (3-value risk enum), #11 (per-major archive). Sync via scripts/sync-plugin-schemas.sh once Q00/ouroboros-plugins#13/#16/#19/#20 land on upstream main."
+}

--- a/src/ouroboros/plugin/schemas/0.1/audit-event.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/audit-event.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros-plugins/schemas/0.1/audit-event.schema.json",
+  "title": "Ouroboros Plugin Audit Event (v0.1)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "occurred_at",
+    "plugin",
+    "command",
+    "trust_state",
+    "capabilities_used",
+    "permissions_used",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "plugin.discovered",
+        "plugin.installed",
+        "plugin.trusted",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed"
+      ]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "plugin": {
+      "type": "object",
+      "required": ["name", "version", "source_type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "source_type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["namespace", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": { "type": "string" },
+        "name": { "type": "string" },
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "trust_state": {
+      "type": "string",
+      "enum": ["discovered", "installed", "trusted", "disabled", "blocked", "first_party"]
+    },
+    "capabilities_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "permissions_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "result": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["success", "blocked", "failed"]
+        },
+        "message": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
@@ -46,7 +46,17 @@
         "repository": {
           "type": "string"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "local_path" } }, "required": ["type"] },
+          "then": { "required": ["path"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "plugin_home" } }, "required": ["type"] },
+          "then": { "required": ["path"] }
+        }
+      ]
     },
     "commands": {
       "type": "array",

--- a/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json",
+  "title": "Ouroboros Plugin Manifest (v0.1)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "version",
+    "source",
+    "commands",
+    "capabilities",
+    "permissions",
+    "entrypoint"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "description": {
+      "type": "string",
+      "default": ""
+    },
+    "source": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        },
+        "path": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        }
+      }
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["namespace", "name", "summary", "usage", "risk"],
+        "additionalProperties": false,
+        "properties": {
+          "namespace": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "usage": {
+            "type": "string",
+            "minLength": 1
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "requires_confirmation": {
+            "type": "boolean",
+            "default": false
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "type", "required"],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_-]*$"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["string", "boolean", "integer", "path", "url"]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "access"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "seed",
+              "ledger",
+              "state",
+              "provenance",
+              "runtime",
+              "mcp",
+              "handoff",
+              "progress"
+            ]
+          },
+          "access": {
+            "type": "string",
+            "enum": ["read", "write", "execute", "attach"]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scope", "risk", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "scope": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "entrypoint": {
+      "type": "object",
+      "required": ["type", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "command"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": ["events"],
+      "additionalProperties": false,
+      "default": {
+        "events": [
+          "plugin.invoked",
+          "plugin.permission_used",
+          "plugin.completed",
+          "plugin.failed"
+        ]
+      },
+      "properties": {
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "plugin.discovered",
+              "plugin.installed",
+              "plugin.trusted",
+              "plugin.invoked",
+              "plugin.permission_used",
+              "plugin.completed",
+              "plugin.failed"
+            ]
+          },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -113,17 +113,18 @@ class TrustStore:
             raise
 
     @contextmanager
-    def _grant_lock(self, plugin: str) -> Iterator[None]:
-        """Hold an exclusive POSIX flock for the duration of a grant().
+    def _trust_lock(self, plugin: str) -> Iterator[None]:
+        """Hold an exclusive POSIX flock for the duration of a mutation.
 
-        The trust file is the source of truth for authorization, so the
-        read-modify-write sequence in `grant()` must be serialised across
-        processes — without this, two concurrent grants for different
-        scopes both read the same prior file and the second `os.replace`
-        wins, silently dropping the other scope. The lock is taken on a
-        sidecar `.lock` file in the plugin's trust directory; on platforms
-        without `fcntl` we degrade to last-writer-wins (no concurrent CLI
-        usage is expected outside POSIX).
+        The trust file is the source of truth for authorization, so every
+        mutating operation (`grant`, `reset_for_version_bump`, `remove`)
+        must be serialised across processes — without this, concurrent
+        writers both read the same prior file and the second `os.replace`
+        wins, silently dropping a previously granted scope or
+        reintroducing stale state. The lock is taken on a sidecar `.lock`
+        file in the plugin's trust directory; on platforms without
+        `fcntl` we degrade to last-writer-wins (no concurrent CLI usage
+        is expected outside POSIX).
         """
         plugin_dir = self.root / plugin
         plugin_dir.mkdir(parents=True, exist_ok=True)
@@ -159,7 +160,7 @@ class TrustStore:
         when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        with self._grant_lock(plugin):
+        with self._trust_lock(plugin):
             existing = self.read(plugin)
             # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
             if existing is not None and existing.version != version:
@@ -185,7 +186,8 @@ class TrustStore:
         """Invalidate trust because the plugin's version changed.
 
         Writes a new trust file with version=new_version and empty grants.
-        Per Q00/ouroboros-plugins#9 Q4 lock.
+        Per Q00/ouroboros-plugins#9 Q4 lock. Held under the per-plugin
+        trust lock so it cannot race a concurrent `grant()`.
         """
         payload = {
             "schema_version": TRUST_SCHEMA_VERSION,
@@ -193,22 +195,33 @@ class TrustStore:
             "version": new_version,
             "granted_scopes": [],
         }
-        self._write_atomic(plugin, payload)
+        with self._trust_lock(plugin):
+            self._write_atomic(plugin, payload)
 
     def remove(self, plugin: str) -> bool:
-        """Remove the trust file for `plugin`. Returns True if removed."""
+        """Remove the trust file for `plugin`. Returns True if removed.
+
+        Held under the per-plugin trust lock so it cannot race a
+        concurrent `grant()` or `reset_for_version_bump()` and re-create
+        a partially written file.
+        """
         path = self._path(plugin)
         if not path.is_file():
             return False
-        path.unlink()
-        # Best-effort: also drop the sidecar lock file so the plugin
-        # directory can be pruned cleanly when it's otherwise empty.
+        with self._trust_lock(plugin):
+            # Re-check under the lock — another writer may have removed
+            # the file between the precheck and acquisition.
+            if not path.is_file():
+                return False
+            path.unlink()
+        # Lock has been released, so the sidecar can now be removed and
+        # the directory pruned without holding the lock open on a file
+        # we are about to delete.
         lock_path = path.with_suffix(path.suffix + ".lock")
         try:
             lock_path.unlink()
         except FileNotFoundError:
             pass
-        # Best-effort: remove the empty plugin dir if it's empty afterwards.
         try:
             path.parent.rmdir()
         except OSError:

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -21,13 +21,13 @@ from this store.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 import json
 import os
-import tempfile
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+import tempfile
 
 TRUST_SCHEMA_VERSION = "0.1"
 
@@ -122,7 +122,7 @@ class TrustStore:
     ) -> TrustRecord:
         """Grant `scope` to `plugin@version`. Idempotent: granting an
         already-granted scope is a no-op (timestamps preserved)."""
-        when = when or datetime.now(tz=timezone.utc)
+        when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         existing = self.read(plugin)

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -204,6 +204,17 @@ class TrustStore:
         Held under the per-plugin trust lock so it cannot race a
         concurrent `grant()` or `reset_for_version_bump()` and re-create
         a partially written file.
+
+        The sidecar lock file is intentionally left in place: unlinking
+        it after releasing the flock would let a concurrent `grant()`
+        racing this remove lock the *old* inode, while the next writer
+        recreates the path and locks a *new* inode — so the two
+        processes would no longer serialise. Keeping the lock file
+        sticky guarantees every future writer locks the same inode that
+        is still held open by any concurrent process. The trade-off is
+        that the plugin directory is not pruned by `remove()` alone;
+        directory cleanup is the caller's job (e.g. `ooo plugin remove`
+        deletes the whole plugin home).
         """
         path = self._path(plugin)
         if not path.is_file():
@@ -214,18 +225,6 @@ class TrustStore:
             if not path.is_file():
                 return False
             path.unlink()
-        # Lock has been released, so the sidecar can now be removed and
-        # the directory pruned without holding the lock open on a file
-        # we are about to delete.
-        lock_path = path.with_suffix(path.suffix + ".lock")
-        try:
-            lock_path.unlink()
-        except FileNotFoundError:
-            pass
-        try:
-            path.parent.rmdir()
-        except OSError:
-            pass
         return True
 
 

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -1,0 +1,183 @@
+"""Per-plugin trust store.
+
+Persists granted trust scopes per plugin at
+`~/.ouroboros/plugins/<name>/trust.json`. Per the locked Q00/ouroboros#732
+spec (which consumes the locked Q00/ouroboros-plugins#9 trust UX answers):
+
+- **Per-user storage** (Q5): one trust file per installed plugin, in the
+  same per-user directory as the plugin home.
+- **Version-bump invalidation** (Q4): when a plugin's version changes,
+  the trust file is reset (granted_scopes emptied). The user must re-grant
+  scopes via `ooo plugin trust` after upgrading.
+- **Exact scope grants** (Q3): each grant records the exact scope string;
+  parent scopes do not imply children.
+- **No raw tokens stored.** Only the scope name, timestamp, and granting
+  user identity are persisted.
+
+The trust store does NOT emit audit events itself; the firewall (#729) and
+CLI (#731) emit `plugin.trusted` when grants happen, sourcing the data
+from this store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+TRUST_SCHEMA_VERSION = "0.1"
+
+# Default location root. Each plugin gets a subdirectory here.
+DEFAULT_TRUST_ROOT = Path.home() / ".ouroboros" / "plugins"
+
+
+@dataclass(frozen=True)
+class GrantedScope:
+    scope: str
+    granted_at: str  # RFC3339
+    granted_by: str  # e.g. "user:<id>"
+
+
+@dataclass(frozen=True)
+class TrustRecord:
+    plugin: str
+    version: str
+    granted_scopes: tuple[GrantedScope, ...] = ()
+
+    def has_scope(self, scope: str) -> bool:
+        """Exact-string scope check (per Q00/ouroboros-plugins#9 Q3 lock —
+        parent scope does NOT imply child)."""
+        return any(g.scope == scope for g in self.granted_scopes)
+
+    def missing(self, required_scopes: Iterable[str]) -> list[str]:
+        """Return required scopes that are not granted, in order."""
+        granted = {g.scope for g in self.granted_scopes}
+        return [s for s in required_scopes if s not in granted]
+
+
+class TrustStore:
+    """Per-plugin trust store at <root>/<plugin-name>/trust.json."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or DEFAULT_TRUST_ROOT
+
+    def _path(self, plugin: str) -> Path:
+        return self.root / plugin / "trust.json"
+
+    def read(self, plugin: str) -> TrustRecord | None:
+        """Read the trust record for `plugin`, or None if not present."""
+        path = self._path(plugin)
+        if not path.is_file():
+            return None
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+        version = data.get("schema_version")
+        if version != TRUST_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported trust file schema_version {version!r}; "
+                f"expected {TRUST_SCHEMA_VERSION!r}"
+            )
+        return TrustRecord(
+            plugin=data["plugin"],
+            version=data["version"],
+            granted_scopes=tuple(
+                GrantedScope(
+                    scope=g["scope"],
+                    granted_at=g["granted_at"],
+                    granted_by=g["granted_by"],
+                )
+                for g in data.get("granted_scopes", [])
+            ),
+        )
+
+    def _write_atomic(self, plugin: str, payload: dict) -> None:
+        path = self._path(plugin)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".trust.", dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def grant(
+        self,
+        *,
+        plugin: str,
+        version: str,
+        scope: str,
+        granted_by: str,
+        when: datetime | None = None,
+    ) -> TrustRecord:
+        """Grant `scope` to `plugin@version`. Idempotent: granting an
+        already-granted scope is a no-op (timestamps preserved)."""
+        when = when or datetime.now(tz=timezone.utc)
+        ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        existing = self.read(plugin)
+        # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
+        if existing is not None and existing.version != version:
+            existing = None  # treat as fresh
+
+        granted = list(existing.granted_scopes) if existing else []
+        if all(g.scope != scope for g in granted):
+            granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
+
+        payload = {
+            "schema_version": TRUST_SCHEMA_VERSION,
+            "plugin": plugin,
+            "version": version,
+            "granted_scopes": [
+                {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
+                for g in granted
+            ],
+        }
+        self._write_atomic(plugin, payload)
+        return TrustRecord(plugin=plugin, version=version, granted_scopes=tuple(granted))
+
+    def reset_for_version_bump(self, plugin: str, new_version: str) -> None:
+        """Invalidate trust because the plugin's version changed.
+
+        Writes a new trust file with version=new_version and empty grants.
+        Per Q00/ouroboros-plugins#9 Q4 lock.
+        """
+        payload = {
+            "schema_version": TRUST_SCHEMA_VERSION,
+            "plugin": plugin,
+            "version": new_version,
+            "granted_scopes": [],
+        }
+        self._write_atomic(plugin, payload)
+
+    def remove(self, plugin: str) -> bool:
+        """Remove the trust file for `plugin`. Returns True if removed."""
+        path = self._path(plugin)
+        if not path.is_file():
+            return False
+        path.unlink()
+        # Best-effort: remove the empty plugin dir if it's empty afterwards.
+        try:
+            path.parent.rmdir()
+        except OSError:
+            pass
+        return True
+
+
+__all__ = [
+    "DEFAULT_TRUST_ROOT",
+    "TRUST_SCHEMA_VERSION",
+    "GrantedScope",
+    "TrustRecord",
+    "TrustStore",
+]

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -21,7 +21,8 @@ from this store.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import json
@@ -111,6 +112,34 @@ class TrustStore:
                 pass
             raise
 
+    @contextmanager
+    def _grant_lock(self, plugin: str) -> Iterator[None]:
+        """Hold an exclusive POSIX flock for the duration of a grant().
+
+        The trust file is the source of truth for authorization, so the
+        read-modify-write sequence in `grant()` must be serialised across
+        processes — without this, two concurrent grants for different
+        scopes both read the same prior file and the second `os.replace`
+        wins, silently dropping the other scope. The lock is taken on a
+        sidecar `.lock` file in the plugin's trust directory; on platforms
+        without `fcntl` we degrade to last-writer-wins (no concurrent CLI
+        usage is expected outside POSIX).
+        """
+        plugin_dir = self.root / plugin
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            import fcntl
+        except ImportError:  # pragma: no cover — non-POSIX platforms
+            yield
+            return
+        lock_path = plugin_dir / "trust.json.lock"
+        with lock_path.open("w") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
     def grant(
         self,
         *,
@@ -121,30 +150,36 @@ class TrustStore:
         when: datetime | None = None,
     ) -> TrustRecord:
         """Grant `scope` to `plugin@version`. Idempotent: granting an
-        already-granted scope is a no-op (timestamps preserved)."""
+        already-granted scope is a no-op (timestamps preserved).
+
+        The read-modify-write is serialised under a per-plugin file lock
+        so that concurrent grants for different scopes do not race and
+        silently drop one of them.
+        """
         when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        existing = self.read(plugin)
-        # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
-        if existing is not None and existing.version != version:
-            existing = None  # treat as fresh
+        with self._grant_lock(plugin):
+            existing = self.read(plugin)
+            # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
+            if existing is not None and existing.version != version:
+                existing = None  # treat as fresh
 
-        granted = list(existing.granted_scopes) if existing else []
-        if all(g.scope != scope for g in granted):
-            granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
+            granted = list(existing.granted_scopes) if existing else []
+            if all(g.scope != scope for g in granted):
+                granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
 
-        payload = {
-            "schema_version": TRUST_SCHEMA_VERSION,
-            "plugin": plugin,
-            "version": version,
-            "granted_scopes": [
-                {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
-                for g in granted
-            ],
-        }
-        self._write_atomic(plugin, payload)
-        return TrustRecord(plugin=plugin, version=version, granted_scopes=tuple(granted))
+            payload = {
+                "schema_version": TRUST_SCHEMA_VERSION,
+                "plugin": plugin,
+                "version": version,
+                "granted_scopes": [
+                    {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
+                    for g in granted
+                ],
+            }
+            self._write_atomic(plugin, payload)
+            return TrustRecord(plugin=plugin, version=version, granted_scopes=tuple(granted))
 
     def reset_for_version_bump(self, plugin: str, new_version: str) -> None:
         """Invalidate trust because the plugin's version changed.
@@ -166,6 +201,13 @@ class TrustStore:
         if not path.is_file():
             return False
         path.unlink()
+        # Best-effort: also drop the sidecar lock file so the plugin
+        # directory can be pruned cleanly when it's otherwise empty.
+        lock_path = path.with_suffix(path.suffix + ".lock")
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
         # Best-effort: remove the empty plugin dir if it's empty afterwards.
         try:
             path.parent.rmdir()

--- a/src/ouroboros/plugin/userlevel_registry.py
+++ b/src/ouroboros/plugin/userlevel_registry.py
@@ -111,6 +111,18 @@ class UserLevelProgramRegistry:
                     f"refusing to register {manifest.name!r}"
                 )
 
+            # When replacing, the new manifest may declare a different namespace
+            # than the prior version. Drop the stale namespace mapping so that
+            # `get_by_namespace(old_ns)` no longer resolves to this plugin and
+            # the old namespace becomes available to other plugins.
+            if existing is not None:
+                old_namespace = existing.namespace
+                if (
+                    old_namespace != namespace
+                    and self._namespace_owner.get(old_namespace) == manifest.name
+                ):
+                    self._namespace_owner.pop(old_namespace)
+
             program = RegisteredProgram(manifest=manifest)
             self._by_name[manifest.name] = program
             self._namespace_owner[namespace] = manifest.name

--- a/src/ouroboros/plugin/userlevel_registry.py
+++ b/src/ouroboros/plugin/userlevel_registry.py
@@ -1,0 +1,237 @@
+"""UserLevel program registry.
+
+Tracks installed UserLevel plugins (and first-party programs) by their
+manifest. Sits alongside the existing `skills/registry.py` SkillRegistry —
+both are queryable via the top-level `lookup_command(...)` helper at the
+bottom of this module.
+
+Per the locked Q00/ouroboros#730 spec:
+  - One in-memory registry shared across the process.
+  - Namespace ownership: the first plugin to register `namespace=foo`
+    owns it; subsequent registrations for the same namespace are
+    rejected with a clear error.
+  - Names ARE used as primary keys (one program per name); re-registering
+    the same name without explicit replace is rejected.
+  - The registry is decoupled from discovery — callers (CLI, firewall,
+    integration tests) build a registry from already-loaded `PluginManifest`
+    instances.
+
+This module deliberately does NOT subsume or modify the SkillRegistry. The
+two cover different artifact shapes (JSON manifest vs SKILL.md frontmatter)
+and have different lifecycle semantics (install/trust vs hot-reload). They
+share only the cross-registry lookup helper at the bottom.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import RLock
+
+from ouroboros.plugin.manifest import CommandSpec, PluginManifest
+
+
+class RegistryError(Exception):
+    """Raised on namespace collision, duplicate registration, etc."""
+
+
+@dataclass(frozen=True)
+class RegisteredProgram:
+    """One entry in the UserLevel program registry.
+
+    The registry stores manifest references rather than copies — the
+    manifest is already frozen and value-equal.
+    """
+
+    manifest: PluginManifest
+
+    @property
+    def name(self) -> str:
+        return self.manifest.name
+
+    @property
+    def namespace(self) -> str:
+        # All commands of one plugin share one namespace per the schema's
+        # pattern + the manager's collision check; pick the first.
+        return self.manifest.commands[0].namespace
+
+    def find_command(self, name: str) -> CommandSpec | None:
+        for command in self.manifest.commands:
+            if command.name == name:
+                return command
+        return None
+
+
+class UserLevelProgramRegistry:
+    """In-memory registry of installed UserLevel programs."""
+
+    def __init__(self) -> None:
+        self._by_name: dict[str, RegisteredProgram] = {}
+        self._namespace_owner: dict[str, str] = {}  # namespace -> plugin name
+        self._lock = RLock()
+
+    def register(self, manifest: PluginManifest, *, replace: bool = False) -> RegisteredProgram:
+        """Register a program from its loaded manifest.
+
+        Args:
+            manifest: The validated `PluginManifest` (from `load_manifest`).
+            replace: If True, replace an existing entry with the same name.
+                Default False — duplicate registrations raise.
+
+        Returns:
+            The registered program.
+
+        Raises:
+            RegistryError: on namespace collision or duplicate name without
+                `replace=True`.
+        """
+        if not manifest.commands:
+            raise RegistryError(f"{manifest.name}: manifest has no commands")
+
+        # All commands must share the same namespace per the schema's pattern.
+        namespaces = {c.namespace for c in manifest.commands}
+        if len(namespaces) != 1:
+            raise RegistryError(
+                f"{manifest.name}: commands declare multiple namespaces "
+                f"{sorted(namespaces)}; one plugin must own one namespace"
+            )
+        namespace = namespaces.pop()
+
+        with self._lock:
+            existing = self._by_name.get(manifest.name)
+            if existing is not None and not replace:
+                raise RegistryError(
+                    f"{manifest.name} is already registered "
+                    f"(version {existing.manifest.version}); pass replace=True to update"
+                )
+
+            owner = self._namespace_owner.get(namespace)
+            if owner is not None and owner != manifest.name:
+                raise RegistryError(
+                    f"namespace {namespace!r} already owned by {owner!r}; "
+                    f"refusing to register {manifest.name!r}"
+                )
+
+            program = RegisteredProgram(manifest=manifest)
+            self._by_name[manifest.name] = program
+            self._namespace_owner[namespace] = manifest.name
+            return program
+
+    def unregister(self, name: str) -> bool:
+        """Remove a program by name. Returns True if removed."""
+        with self._lock:
+            program = self._by_name.pop(name, None)
+            if program is None:
+                return False
+            ns = program.namespace
+            if self._namespace_owner.get(ns) == name:
+                self._namespace_owner.pop(ns)
+            return True
+
+    def get(self, name: str) -> RegisteredProgram | None:
+        with self._lock:
+            return self._by_name.get(name)
+
+    def get_by_namespace(self, namespace: str) -> RegisteredProgram | None:
+        with self._lock:
+            owner = self._namespace_owner.get(namespace)
+            if owner is None:
+                return None
+            return self._by_name.get(owner)
+
+    def all_programs(self) -> list[RegisteredProgram]:
+        with self._lock:
+            return list(self._by_name.values())
+
+
+# Global singleton — modeled after skills/registry.py's pattern.
+_global: UserLevelProgramRegistry | None = None
+_global_lock = RLock()
+
+
+def get_userlevel_registry() -> UserLevelProgramRegistry:
+    """Return the process-wide UserLevel program registry singleton."""
+    global _global
+    with _global_lock:
+        if _global is None:
+            _global = UserLevelProgramRegistry()
+        return _global
+
+
+def reset_userlevel_registry() -> None:
+    """Reset the singleton. Tests use this to isolate state."""
+    global _global
+    with _global_lock:
+        _global = None
+
+
+# ---------------------------------------------------------------------------
+# Cross-registry lookup
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LookupResult:
+    """Result of looking up a name across both registries.
+
+    Exactly one of `userlevel_program` or `skill_metadata` is non-None for
+    a successful lookup.
+    """
+
+    kind: str  # "userlevel" | "skill" | "none"
+    userlevel_program: RegisteredProgram | None = None
+    skill_metadata: object | None = None  # Avoid hard import on skill module.
+
+    @property
+    def found(self) -> bool:
+        return self.kind != "none"
+
+
+def lookup_command(name: str) -> LookupResult:
+    """Look up a name across both the UserLevel registry and the bundled
+    skills registry. Returns the first match.
+
+    Order:
+      1. UserLevel namespaces (e.g. "github-pr") — fast, in-memory.
+      2. UserLevel plugin names (e.g. "github-pr-ops").
+      3. Bundled skill names (loaded from .claude-plugin/skills/).
+
+    Args:
+        name: The command name, namespace, or plugin name to look up.
+
+    Returns:
+        `LookupResult` indicating which registry matched.
+    """
+    ul = get_userlevel_registry()
+
+    program = ul.get_by_namespace(name)
+    if program is not None:
+        return LookupResult(kind="userlevel", userlevel_program=program)
+
+    program = ul.get(name)
+    if program is not None:
+        return LookupResult(kind="userlevel", userlevel_program=program)
+
+    # Skills lookup: import lazily so this module doesn't pull in watchdog
+    # and yaml at import time.
+    try:
+        from ouroboros.plugin.skills.registry import get_registry as _get_skill_registry
+    except ImportError:  # pragma: no cover - defensive
+        return LookupResult(kind="none")
+
+    skill_registry = _get_skill_registry()
+    skill = skill_registry.get_skill(name)
+    if skill is not None:
+        return LookupResult(kind="skill", skill_metadata=skill.metadata)
+
+    return LookupResult(kind="none")
+
+
+__all__ = [
+    "LookupResult",
+    "RegisteredProgram",
+    "RegistryError",
+    "UserLevelProgramRegistry",
+    "get_userlevel_registry",
+    "lookup_command",
+    "reset_userlevel_registry",
+]

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -68,6 +68,17 @@ def _make_program(tmp_path: Path, payload: dict | None = None):
     return registry.register(manifest)
 
 
+def _make_partially_trusted_program(tmp_path: Path):
+    """Variant of _make_program with TWO required scopes, used to exercise
+    the partial-trust audit-event invariant."""
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["permissions"] = [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {"scope": "github:pull_request:write", "risk": "destructive", "required": True},
+    ]
+    return _make_program(tmp_path, payload)
+
+
 def _fake_runner(
     *,
     returncode: int = 0,
@@ -131,6 +142,46 @@ def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path)
     assert "ok\\n" not in serialized
     # sha256 hash recorded in completed.provenance.
     assert "stdout_sha256" in events[-1]["provenance"]
+
+
+def test_partial_trust_reports_installed_not_trusted(tmp_path: Path) -> None:
+    """Partial trust must NOT report trust_state='trusted' on the blocked event.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    39ad604: when one of several required scopes is granted but others are
+    still missing, `_trust_state_label` previously returned `trusted`, so
+    the firewall emitted a `plugin.failed` event with
+    `result.status='blocked'` but `trust_state='trusted'`. That contradicts
+    the audit-event contract (`trusted` is reserved for invocations that
+    actually pass the trust check). The label now reflects coverage of all
+    required scopes.
+    """
+    program = _make_partially_trusted_program(tmp_path)
+    # Grant exactly ONE of the two required scopes — partial trust.
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-partial",
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "blocked"
+    # The single emitted event is plugin.failed (status=blocked).
+    assert [e["event_type"] for e in events] == ["plugin.failed"]
+    failed = events[0]
+    assert failed["result"]["status"] == "blocked"
+    # The contradiction the bot flagged: trust_state must NOT be 'trusted'
+    # while the result is blocked. With the fix it reports 'installed'.
+    assert failed["trust_state"] == "installed"
 
 
 def test_trust_violation_only_emits_failed_no_invoked(tmp_path: Path) -> None:

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -144,6 +144,88 @@ def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path)
     assert "stdout_sha256" in events[-1]["provenance"]
 
 
+def test_subprocess_runs_in_resolved_plugin_cwd(tmp_path: Path) -> None:
+    """The subprocess runs with cwd=resolved manifest.source.path so
+    relative entrypoints (`./run.sh`, `python -m foo`) work.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    7197380: previously `invoke_plugin()` ran the entrypoint in the
+    current process cwd, so a `local_path` / `plugin_home` plugin with
+    a relative entrypoint would emit `plugin.invoked` and then fail
+    `entrypoint not found` even when correctly installed. The firewall
+    now passes `cwd=` derived from `manifest.source.path` (with `~`
+    expansion); first-party plugins still inherit the parent cwd.
+    """
+    plugin_dir = tmp_path / "plugins" / "github-pr-ops"
+    plugin_dir.mkdir(parents=True)
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["source"]["path"] = str(plugin_dir)
+    program = _make_program(tmp_path / "manifest", payload)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+
+    captured: dict[str, object] = {}
+
+    def _capturing_runner(argv, *args, **kwargs):
+        captured["argv"] = argv
+        captured["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
+
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=[].append,
+        correlation_id="corr-cwd",
+        subprocess_runner=_capturing_runner,
+    )
+    assert result.status == "success"
+    # The cwd argument must point to the manifest's resolved source
+    # path — exactly what the bot's reproducer cared about.
+    assert captured["cwd"] == str(plugin_dir.resolve())
+
+
+def test_first_party_subprocess_has_no_cwd_override(tmp_path: Path) -> None:
+    """First-party plugins keep cwd=None (parent ouroboros runtime cwd)."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-auto"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []
+    fp["commands"] = [
+        {
+            "namespace": "auto",
+            "name": "run",
+            "summary": "first-party command",
+            "usage": "ooo auto",
+            "risk": "write",
+        }
+    ]
+    program = _make_program(tmp_path / "fp-manifest", fp)
+
+    captured: dict[str, object] = {}
+
+    def _capturing_runner(argv, *args, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
+
+    result = invoke_plugin(
+        program,
+        command_name="run",
+        argv=[],
+        trust_record=None,  # first-party skips trust check
+        event_sink=[].append,
+        correlation_id="corr-fp-cwd",
+        subprocess_runner=_capturing_runner,
+    )
+    assert result.status == "success"
+    assert captured["cwd"] is None
+
+
 def test_default_confirm_fails_closed_for_destructive_command(tmp_path: Path) -> None:
     """The default `confirm` parameter denies, so a caller that forgot to
     wire a prompt cannot silently execute a destructive command.

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -1,0 +1,381 @@
+"""Tests for the plugin invocation firewall (Q00/ouroboros#729)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ouroboros.plugin.firewall import (
+    InvocationResult,
+    invoke_plugin,
+)
+from ouroboros.plugin.manifest import load_manifest
+from ouroboros.plugin.trust_store import TrustStore
+from ouroboros.plugin.userlevel_registry import (
+    UserLevelProgramRegistry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+            "requires_confirmation": False,
+        },
+        {
+            "namespace": "github-pr",
+            "name": "merge",
+            "summary": "Merge a PR under policy.",
+            "usage": "ooo github-pr merge <url>",
+            "risk": "destructive",
+            "requires_confirmation": True,
+        },
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write"},
+    ],
+    "permissions": [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {"scope": "github:pull_request:write", "risk": "destructive", "required": False},
+    ],
+    "entrypoint": {"type": "command", "command": "python -m fake_plugin"},
+}
+
+
+def _write_manifest(tmp_path: Path, payload: dict) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _make_program(tmp_path: Path, payload: dict | None = None):
+    """Load a manifest and register it into a fresh registry."""
+    payload = payload if payload is not None else REFERENCE_MANIFEST
+    manifest = load_manifest(_write_manifest(tmp_path, payload))
+    registry = UserLevelProgramRegistry()
+    return registry.register(manifest)
+
+
+def _fake_runner(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+    raise_filenotfound: bool = False,
+):
+    """Build a stand-in for subprocess.run that returns canned data."""
+
+    def _run(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        if raise_filenotfound:
+            raise FileNotFoundError(argv[0])
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path) -> None:
+    """Test 1: trusted invocation emits invoked → permission_used → completed."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-1",
+        subprocess_runner=_fake_runner(stdout="ok\n"),
+    )
+    assert result.status == "success"
+    assert result.exit_code == 0
+    assert [e["event_type"] for e in events] == [
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+    ]
+    # plugin.invoked appears BEFORE permission_used (locked invocation order).
+    assert events[1]["permissions_used"] == ["github:read"]
+    assert events[2]["result"]["status"] == "success"
+    # No raw stdout/stderr content in any event payload. The literal
+    # bytes returned from the fake runner ("ok\n") must not leak into
+    # any event.
+    serialized = json.dumps(events)
+    assert "ok\\n" not in serialized
+    # sha256 hash recorded in completed.provenance.
+    assert "stdout_sha256" in events[-1]["provenance"]
+
+
+def test_trust_violation_only_emits_failed_no_invoked(tmp_path: Path) -> None:
+    """Test 2: missing required scope → ONLY plugin.failed (status=blocked).
+
+    Crucially, plugin.invoked must NOT be emitted when the trust check
+    fails (locked Q1 of Q00/ouroboros-plugins#9).
+    """
+    program = _make_program(tmp_path)
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=None,  # not yet trusted
+        event_sink=events.append,
+        correlation_id="corr-2",
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "blocked"
+    assert result.exit_code is None
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    assert "plugin.invoked" not in types  # explicit absence assertion
+    # Message format per locked Q1.
+    assert "github:read" in result.message
+    assert "ooo plugin trust github-pr-ops --scope github:read" in result.message
+    assert events[0]["result"]["status"] == "blocked"
+
+
+def test_subprocess_failure_emits_failed_with_exit_code(tmp_path: Path) -> None:
+    """Test 3: subprocess exits non-zero → invoked, permission_used, failed."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["bad-url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-3",
+        subprocess_runner=_fake_runner(returncode=2, stderr="boom\n"),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 2
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert events[-1]["result"]["status"] == "failed"
+    assert "code 2" in events[-1]["result"]["message"]
+
+
+def test_bounded_payload_records_sha_not_raw(tmp_path: Path) -> None:
+    """Test 4: 1MB stdout — no part of it appears in any event;
+    sha256 hash recorded instead."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    big_payload = "X" * (1024 * 1024)  # 1 MiB
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-4",
+        subprocess_runner=_fake_runner(stdout=big_payload),
+    )
+    assert result.status == "success"
+    assert result.stdout_sha256 is not None
+    # No raw payload in any event (string check).
+    serialized = json.dumps(events)
+    assert "X" * 1000 not in serialized
+    # sha256 hash present in completed event provenance.
+    completed_event = next(e for e in events if e["event_type"] == "plugin.completed")
+    assert completed_event["provenance"]["stdout_sha256"] == result.stdout_sha256
+
+
+def test_confirmation_declined_blocks_with_no_subprocess(tmp_path: Path) -> None:
+    """Test 5: requires_confirmation=true + confirm()=False → blocked.
+
+    No subprocess launched; only plugin.failed (status=blocked) emitted.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    runner_called = False
+
+    def _spy(*args, **kwargs):
+        nonlocal runner_called
+        runner_called = True
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="merge",  # requires_confirmation = True
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-5",
+        confirm=lambda _msg: False,  # user said No
+        subprocess_runner=_spy,
+    )
+    assert result.status == "blocked"
+    assert runner_called is False
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    assert "user declined" in result.message
+
+
+def test_confirmation_accepted_proceeds(tmp_path: Path) -> None:
+    """Test 6: requires_confirmation=true + confirm()=True → normal flow."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="merge",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-6",
+        confirm=lambda _msg: True,
+        subprocess_runner=_fake_runner(returncode=0, stdout="ok"),
+    )
+    assert result.status == "success"
+    types = [e["event_type"] for e in events]
+    # Standard happy-path order; only one permission emitted (github:read,
+    # the required one). github:pull_request:write is required:false so
+    # it's NOT emitted in v0 (Option (a) coarse rule).
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.completed"]
+    assert events[1]["permissions_used"] == ["github:read"]
+
+
+def test_optional_permission_not_emitted(tmp_path: Path) -> None:
+    """Test 7: required:false permission is NOT emitted in v0.
+
+    The reference manifest has 'github:pull_request:write' with
+    required:false. After invocation, no plugin.permission_used event
+    should reference it (locked Option (a) coarse emission rule).
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-7",
+        subprocess_runner=_fake_runner(stdout=""),
+    )
+    permission_events = [e for e in events if e["event_type"] == "plugin.permission_used"]
+    scopes_emitted = {p for e in permission_events for p in e["permissions_used"]}
+    assert scopes_emitted == {"github:read"}
+    assert "github:pull_request:write" not in scopes_emitted
+
+
+def test_first_party_skips_trust_check(tmp_path: Path) -> None:
+    """Test 8: source.type=first_party bypasses trust check (Q00/ouroboros-plugins#8 lock)."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-auto"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []  # first-party with no external scopes
+    fp["commands"] = [
+        {
+            "namespace": "auto",
+            "name": "run",
+            "summary": "Run auto.",
+            "usage": "ooo auto",
+            "risk": "write",
+        }
+    ]
+    program = _make_program(tmp_path, fp)
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="run",
+        argv=["my goal"],
+        trust_record=None,  # no trust at all
+        event_sink=events.append,
+        correlation_id="corr-8",
+        subprocess_runner=_fake_runner(stdout="ok"),
+    )
+    assert result.status == "success"
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.completed"]
+    # trust_state field reports "first_party"
+    assert all(e["trust_state"] == "first_party" for e in events)
+
+
+def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
+    """Test 9: subprocess FileNotFoundError → status=failed, exit_code=127."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-9",
+        subprocess_runner=_fake_runner(raise_filenotfound=True),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 127
+    # invoked + permission_used + failed
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert "not found" in result.message.lower()

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -3,15 +3,10 @@
 from __future__ import annotations
 
 import json
-import subprocess
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
-
-import pytest
+import subprocess
 
 from ouroboros.plugin.firewall import (
-    InvocationResult,
     invoke_plugin,
 )
 from ouroboros.plugin.manifest import load_manifest
@@ -19,7 +14,6 @@ from ouroboros.plugin.trust_store import TrustStore
 from ouroboros.plugin.userlevel_registry import (
     UserLevelProgramRegistry,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -379,3 +373,76 @@ def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
     types = [e["event_type"] for e in events]
     assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
     assert "not found" in result.message.lower()
+
+
+def _raising_runner(exc: BaseException):
+    """Build a stand-in for subprocess.run that always raises `exc`."""
+
+    def _run(argv, *args, **kwargs):
+        raise exc
+
+    return _run
+
+
+def test_entrypoint_permission_error_emits_failed_126(tmp_path: Path) -> None:
+    """PermissionError on launch → terminal plugin.failed, exit_code=126.
+
+    Regression for ouroboros-agent[bot] follow-up finding on PR #749:
+    invoke_plugin previously only caught FileNotFoundError, so other
+    common launch failures (PermissionError, generic OSError) escaped
+    uncaught — leaving the firewall's "single chokepoint" contract broken
+    (plugin.invoked emitted but no terminal plugin.failed).
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-9b",
+        subprocess_runner=_raising_runner(PermissionError("perm denied")),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 126
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert "not executable" in result.message.lower()
+    assert events[-1]["result"]["status"] == "failed"
+
+
+def test_entrypoint_generic_oserror_emits_failed(tmp_path: Path) -> None:
+    """Generic OSError on launch → terminal plugin.failed, exit_code=1.
+
+    Same regression as PermissionError: any OSError variant must produce a
+    clean terminal failure event rather than escaping as an exception.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-9c",
+        subprocess_runner=_raising_runner(OSError("ENOEXEC")),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 1
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert "launch failed" in result.message.lower()

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -10,7 +10,7 @@ from ouroboros.plugin.firewall import (
     invoke_plugin,
 )
 from ouroboros.plugin.manifest import load_manifest
-from ouroboros.plugin.trust_store import TrustStore
+from ouroboros.plugin.trust_store import GrantedScope, TrustRecord, TrustStore
 from ouroboros.plugin.userlevel_registry import (
     UserLevelProgramRegistry,
 )
@@ -142,6 +142,69 @@ def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path)
     assert "ok\\n" not in serialized
     # sha256 hash recorded in completed.provenance.
     assert "stdout_sha256" in events[-1]["provenance"]
+
+
+def test_trust_record_for_wrong_plugin_is_rejected(tmp_path: Path) -> None:
+    """A TrustRecord whose plugin name does not match must NOT authorize.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    78698d0: the firewall is the documented authorization chokepoint, so
+    it must reject mismatched records before any scope check. Previously
+    a record loaded for a different plugin that happened to grant the
+    same scope strings would pass `_missing_required` and authorise the
+    invocation. Now the record is dropped and the call is blocked closed.
+    """
+    program = _make_program(tmp_path)  # plugin name = "github-pr-ops"
+    # A record granting the same scope, but for a *different* plugin.
+    foreign = TrustStore(root=tmp_path / "trust").grant(
+        plugin="some-other-plugin",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=foreign,
+        event_sink=events.append,
+        correlation_id="corr-foreign",
+        subprocess_runner=_fake_runner(),
+    )
+    # The record must be ignored, so the call falls into the missing-
+    # required-scope branch and is blocked closed.
+    assert result.status == "blocked"
+    assert [e["event_type"] for e in events] == ["plugin.failed"]
+    assert events[0]["trust_state"] == "installed"
+
+
+def test_trust_record_for_wrong_version_is_rejected(tmp_path: Path) -> None:
+    """A stale TrustRecord (older version) must NOT authorize the new
+    version. Locked Q4 says version-bumps invalidate trust, and the
+    firewall must defend that even if a caller hands it a stale record.
+    """
+    program = _make_program(tmp_path)  # plugin version = "0.1.0"
+    stale = TrustRecord(
+        plugin="github-pr-ops",
+        version="0.0.9",  # older version
+        granted_scopes=(
+            GrantedScope(scope="github:read", granted_at="2025-01-01T00:00:00Z", granted_by="u"),
+        ),
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=stale,
+        event_sink=events.append,
+        correlation_id="corr-stale",
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "blocked"
+    assert [e["event_type"] for e in events] == ["plugin.failed"]
+    assert events[0]["trust_state"] == "installed"
 
 
 def test_partial_trust_reports_installed_not_trusted(tmp_path: Path) -> None:

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -144,6 +144,46 @@ def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path)
     assert "stdout_sha256" in events[-1]["provenance"]
 
 
+def test_default_confirm_fails_closed_for_destructive_command(tmp_path: Path) -> None:
+    """The default `confirm` parameter denies, so a caller that forgot to
+    wire a prompt cannot silently execute a destructive command.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    7509b0e: previously `confirm` defaulted to `lambda _: True`, which
+    auto-approved every confirmation gate, so a missing caller hook
+    became a silent destructive action instead of failing closed. The
+    default now denies (per the locked Q2 contract); explicit tests
+    that exercise the confirmed path pass `confirm=lambda _: True`.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="merge",  # requires_confirmation = True per fixture
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-default-confirm",
+        # NO confirm= argument — must fall back to the fail-closed default.
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "blocked"
+    assert "user declined confirmation" in result.message
+    # The confirmation gate fires before any subprocess launch, so only
+    # the terminal `plugin.failed` (status=blocked) is emitted — not
+    # `plugin.invoked`. This matches the locked emission ordering for a
+    # blocked-by-confirmation invocation.
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    assert events[-1]["result"]["status"] == "blocked"
+
+
 def test_event_sink_exception_does_not_break_invocation_result(tmp_path: Path) -> None:
     """A failing event_sink (e.g. ledger outage) on the terminal emit
     must NOT propagate; the firewall must still return an InvocationResult.

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 import subprocess
 
+import pytest
+
 from ouroboros.plugin.firewall import (
     invoke_plugin,
 )
@@ -187,6 +189,69 @@ def test_subprocess_runs_in_resolved_plugin_cwd(tmp_path: Path) -> None:
     assert result.status == "success"
     # The cwd argument must point to the manifest's resolved source
     # path — exactly what the bot's reproducer cared about.
+    assert captured["cwd"] == str(plugin_dir.resolve())
+
+
+def test_subprocess_cwd_resolves_relative_path_against_manifest_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Relative `source.path` resolves against the manifest directory,
+    not the calling process cwd.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    093873e: previously `_resolve_plugin_cwd` used
+    `Path(...).resolve()` against the *process* cwd, so an installed
+    plugin with `source.path: "plugins/github-pr-ops"` invoked from
+    any other directory would compute the wrong cwd and break
+    relative entrypoints again. The firewall now resolves relative
+    paths against `manifest.manifest_path`'s directory.
+    """
+    # Layout:
+    #   <root>/install/ouroboros.plugin.json   (manifest path)
+    #   <root>/install/plugins/github-pr-ops/  (target plugin dir)
+    install = tmp_path / "install"
+    install.mkdir()
+    plugin_dir = install / "plugins" / "github-pr-ops"
+    plugin_dir.mkdir(parents=True)
+
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["source"]["path"] = "plugins/github-pr-ops"  # RELATIVE
+    manifest_file = install / "ouroboros.plugin.json"
+    manifest_file.write_text(json.dumps(payload))
+    manifest = load_manifest(manifest_file)
+    program = UserLevelProgramRegistry().register(manifest)
+
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+
+    # Move the calling process into a directory that is NOT the
+    # manifest directory, to prove the firewall does not use proc cwd.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    captured: dict[str, object] = {}
+
+    def _capturing_runner(argv, *args, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
+
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=[].append,
+        correlation_id="corr-rel",
+        subprocess_runner=_capturing_runner,
+    )
+    assert result.status == "success"
+    # cwd MUST be the resolved plugin directory inside <install>, NOT
+    # something derived from `elsewhere/`.
     assert captured["cwd"] == str(plugin_dir.resolve())
 
 

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -144,6 +144,56 @@ def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path)
     assert "stdout_sha256" in events[-1]["provenance"]
 
 
+def test_event_sink_exception_does_not_break_invocation_result(tmp_path: Path) -> None:
+    """A failing event_sink (e.g. ledger outage) on the terminal emit
+    must NOT propagate; the firewall must still return an InvocationResult.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    be5e480: previously `_emit()` called event_sink directly and let
+    exceptions escape, so a ledger append failure during the terminal
+    `plugin.completed`/`plugin.failed` emission left the caller with no
+    structured result even though the plugin command had already
+    executed. The chokepoint now isolates sink failures: invocation
+    outcome is still surfaced as InvocationResult.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+
+    fail_count = {"n": 0}
+
+    def _flaky_sink(event: dict) -> None:
+        # Fail only on terminal events — the most damaging case: the
+        # subprocess has already run and the caller still needs a result.
+        if event["event_type"] in {"plugin.completed", "plugin.failed"}:
+            fail_count["n"] += 1
+            raise RuntimeError("simulated ledger outage")
+
+    # Successful subprocess: the terminal emit is plugin.completed.
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=_flaky_sink,
+        correlation_id="corr-flaky",
+        subprocess_runner=_fake_runner(stdout="ok"),
+    )
+    assert result.status == "success"
+    assert result.exit_code == 0
+    # The sink raised at least once (terminal emit), but the firewall
+    # absorbed it and still produced a structured result.
+    assert fail_count["n"] >= 1
+    # The events tuple still records what the firewall observed locally,
+    # including the terminal event the sink rejected.
+    types = [e["event_type"] for e in result.events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.completed"]
+
+
 def test_trust_record_for_wrong_plugin_is_rejected(tmp_path: Path) -> None:
     """A TrustRecord whose plugin name does not match must NOT authorize.
 

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -1,0 +1,198 @@
+"""Tests for the firewall-to-core-ledger adapter (Q00/ouroboros#737)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ouroboros.plugin.ledger_adapter import (
+    AUDIT_EVENT_TYPES,
+    PLUGIN_AGGREGATE_TYPE,
+    make_event_sink,
+    unwrap_plugin_event,
+    wrap_plugin_event,
+)
+
+
+# Audit-event schema is vendored in CR-3 at this path.
+SCHEMA_PATH = Path(__file__).resolve().parents[3] / (
+    "src/ouroboros/plugin/schemas/0.1/audit-event.schema.json"
+)
+AUDIT_SCHEMA = json.loads(SCHEMA_PATH.read_text())
+AUDIT_VALIDATOR = Draft202012Validator(AUDIT_SCHEMA)
+
+
+def _audit_event(event_type: str, **overrides) -> dict:
+    """Build an audit event matching schemas/0.1/audit-event.schema.json."""
+    base = {
+        "schema_version": "0.1",
+        "event_type": event_type,
+        "occurred_at": "2026-05-07T12:00:00Z",
+        "plugin": {
+            "name": "github-pr-ops",
+            "version": "0.1.0",
+            "source_type": "plugin_home",
+        },
+        "command": {"namespace": "github-pr", "name": "review", "argv": ["url"]},
+        "trust_state": "trusted",
+        "capabilities_used": [],
+        "permissions_used": ["github:read"],
+        "result": {"status": "success"},
+    }
+    base.update(overrides)
+    # Confirm the test fixture itself validates against the schema.
+    errs = list(AUDIT_VALIDATOR.iter_errors(base))
+    assert not errs, f"test fixture invalid: {errs}"
+    return base
+
+
+def test_wrap_basic_envelope() -> None:
+    """Wrapping produces the documented envelope shape."""
+    ev = _audit_event("plugin.invoked")
+    env = wrap_plugin_event(ev, correlation_id="corr-1")
+
+    assert env["aggregate_type"] == PLUGIN_AGGREGATE_TYPE
+    assert env["aggregate_id"] == "corr-1"
+    assert env["event_type"] == "plugin.invoked"
+    assert env["timestamp"] == "2026-05-07T12:00:00Z"
+    assert isinstance(env["id"], str) and len(env["id"]) > 0
+    # payload contains the full audit event
+    assert env["payload"]["schema_version"] == "0.1"
+    assert env["payload"]["plugin"]["name"] == "github-pr-ops"
+
+
+def test_wrap_does_not_mutate_input() -> None:
+    """The audit event passed in must not be mutated by wrap()."""
+    ev = _audit_event("plugin.invoked")
+    snapshot = json.dumps(ev, sort_keys=True)
+    wrap_plugin_event(ev, correlation_id="x")
+    assert json.dumps(ev, sort_keys=True) == snapshot
+
+
+def test_wrap_does_not_inject_fields_into_audit_event() -> None:
+    """Envelope fields stay above the audit event boundary.
+
+    The audit-event schema declares additionalProperties:false. The
+    payload must remain schema-valid after wrapping.
+    """
+    ev = _audit_event("plugin.invoked")
+    env = wrap_plugin_event(ev, correlation_id="x")
+    # payload alone must validate as an audit event.
+    errs = list(AUDIT_VALIDATOR.iter_errors(env["payload"]))
+    assert not errs, f"payload no longer schema-valid: {errs}"
+
+
+def test_unwrap_returns_audit_event() -> None:
+    """unwrap recovers the audit event from an envelope."""
+    ev = _audit_event("plugin.completed")
+    env = wrap_plugin_event(ev, correlation_id="x")
+    unwrapped = unwrap_plugin_event(env)
+    # validate as audit event
+    errs = list(AUDIT_VALIDATOR.iter_errors(unwrapped))
+    assert not errs
+    # equality with original
+    assert unwrapped == ev
+
+
+def test_round_trip_for_all_seven_event_types() -> None:
+    """Round-trip every event type defined in the schema."""
+    for event_type in AUDIT_EVENT_TYPES:
+        ev = _audit_event(event_type)
+        env = wrap_plugin_event(ev, correlation_id=f"corr-{event_type}")
+        recovered = unwrap_plugin_event(env)
+        assert recovered == ev, f"{event_type} did not round-trip"
+        # And the envelope's event_type matches.
+        assert env["event_type"] == event_type
+
+
+def test_unwrap_rejects_non_plugin_envelope() -> None:
+    """Envelope with the wrong aggregate_type is rejected."""
+    fake = {
+        "id": "x",
+        "aggregate_type": "execution",
+        "aggregate_id": "y",
+        "event_type": "execution.something",
+        "payload": {},
+        "timestamp": "2026-05-07T12:00:00Z",
+    }
+    with pytest.raises(ValueError, match="not a plugin envelope"):
+        unwrap_plugin_event(fake)
+
+
+def test_wrap_requires_event_type() -> None:
+    """Wrapping fails fast if the audit event is missing event_type."""
+    with pytest.raises(ValueError, match="event_type"):
+        wrap_plugin_event({"occurred_at": "x"}, correlation_id="c")
+
+
+def test_wrap_requires_occurred_at() -> None:
+    """Wrapping fails fast if the audit event is missing occurred_at."""
+    with pytest.raises(ValueError, match="occurred_at"):
+        wrap_plugin_event({"event_type": "plugin.invoked"}, correlation_id="c")
+
+
+def test_aggregate_id_override() -> None:
+    """aggregate_id parameter overrides the correlation_id default."""
+    ev = _audit_event("plugin.invoked")
+    env = wrap_plugin_event(ev, correlation_id="default", aggregate_id="custom")
+    assert env["aggregate_id"] == "custom"
+    assert env["aggregate_id"] != "default"
+
+
+def test_make_event_sink_appends_envelopes() -> None:
+    """The sink wraps each audit event and forwards to append_fn."""
+    rows: list[dict] = []
+    sink = make_event_sink(rows.append, correlation_id="corr-x")
+    sink(_audit_event("plugin.invoked"))
+    sink(_audit_event("plugin.completed"))
+    assert len(rows) == 2
+    for row in rows:
+        assert row["aggregate_type"] == PLUGIN_AGGREGATE_TYPE
+        assert row["aggregate_id"] == "corr-x"
+
+
+def test_make_event_sink_with_id_factory() -> None:
+    """envelope_id_factory provides deterministic ids for tests."""
+    rows: list[dict] = []
+    counter = iter(["env-1", "env-2"])
+    sink = make_event_sink(
+        rows.append,
+        correlation_id="x",
+        envelope_id_factory=lambda: next(counter),
+    )
+    sink(_audit_event("plugin.invoked"))
+    sink(_audit_event("plugin.completed"))
+    assert [r["id"] for r in rows] == ["env-1", "env-2"]
+
+
+def test_envelope_event_type_matches_payload_event_type() -> None:
+    """The envelope's event_type string mirrors the payload's event_type
+    (so the events_table.event_type column is queryable without parsing
+    the JSON payload)."""
+    for event_type in AUDIT_EVENT_TYPES:
+        ev = _audit_event(event_type)
+        env = wrap_plugin_event(ev, correlation_id="x")
+        assert env["event_type"] == env["payload"]["event_type"] == event_type
+
+
+def test_wrap_rejects_non_dict_input() -> None:
+    """Wrapping a non-dict raises TypeError."""
+    with pytest.raises(TypeError, match="must be dict"):
+        wrap_plugin_event("not a dict", correlation_id="x")  # type: ignore[arg-type]
+
+
+def test_no_raw_token_fields_in_envelope() -> None:
+    """Sanity: the envelope contains no token-shaped keys.
+
+    Plugin events go through the firewall's bounded-payload guard;
+    this test confirms the adapter doesn't accidentally introduce one.
+    """
+    ev = _audit_event("plugin.completed")
+    env = wrap_plugin_event(ev, correlation_id="x")
+    serialized = json.dumps(env).lower()
+    for forbidden in ("ghp_", "bearer ", "x-api-key"):
+        assert forbidden.lower() not in serialized

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -11,6 +11,7 @@ import pytest
 from ouroboros.plugin.ledger_adapter import (
     AUDIT_EVENT_TYPES,
     PLUGIN_AGGREGATE_TYPE,
+    envelope_to_base_event,
     make_event_sink,
     unwrap_plugin_event,
     wrap_plugin_event,
@@ -194,3 +195,51 @@ def test_no_raw_token_fields_in_envelope() -> None:
     serialized = json.dumps(env).lower()
     for forbidden in ("ghp_", "bearer ", "x-api-key"):
         assert forbidden.lower() not in serialized
+
+
+def test_envelope_to_base_event_matches_event_store_db_dict() -> None:
+    """The BaseEvent bridge produces a `to_db_dict()` that lines up with
+    the `events_table` columns the core EventStore inserts.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    be5e480: `make_event_sink()` advertised wiring to `EventStore.append`
+    but only emitted plain dict envelopes, while `EventStore.append`
+    accepts a typed `BaseEvent`. The adapter now exposes
+    `envelope_to_base_event` so the integration layer can do the
+    translation; this test pins the round-trip from envelope to
+    `to_db_dict()` so a future BaseEvent shape change cannot silently
+    break the integration path again.
+    """
+    audit = _audit_event(
+        "plugin.completed",
+        provenance={"correlation_id": "corr-bridge", "stdout_sha256": "deadbeef"},
+    )
+    envelope = wrap_plugin_event(
+        audit, correlation_id="corr-bridge", envelope_id="00000000-0000-4000-8000-000000000001"
+    )
+    event = envelope_to_base_event(envelope)
+    db_dict = event.to_db_dict()
+
+    # Column-by-column alignment with the events_table writes performed
+    # by `EventStore.append`.
+    assert db_dict["id"] == "00000000-0000-4000-8000-000000000001"
+    assert db_dict["event_type"] == "plugin.completed"
+    assert db_dict["aggregate_type"] == PLUGIN_AGGREGATE_TYPE
+    assert db_dict["aggregate_id"] == "corr-bridge"
+    # The full audit event becomes the persisted payload (plus the
+    # event_version sentinel BaseEvent injects).
+    assert db_dict["payload"]["event_type"] == "plugin.completed"
+    assert db_dict["payload"]["plugin"]["name"] == "github-pr-ops"
+    # Timestamp is parsed back into a real datetime.
+    assert db_dict["timestamp"].isoformat().startswith("2026-05-07T12:00:00")
+
+
+def test_envelope_to_base_event_rejects_non_plugin_envelope() -> None:
+    """The bridge refuses envelopes that are not plugin-aggregate rows."""
+    bad = wrap_plugin_event(
+        _audit_event("plugin.invoked"),
+        correlation_id="x",
+    )
+    bad["aggregate_type"] = "session"  # tamper
+    with pytest.raises(ValueError, match="not a plugin envelope"):
+        envelope_to_base_event(bad)

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
 from jsonschema import Draft202012Validator
+import pytest
 
 from ouroboros.plugin.ledger_adapter import (
     AUDIT_EVENT_TYPES,
@@ -16,7 +15,6 @@ from ouroboros.plugin.ledger_adapter import (
     unwrap_plugin_event,
     wrap_plugin_event,
 )
-
 
 # Audit-event schema is vendored in CR-3 at this path.
 SCHEMA_PATH = Path(__file__).resolve().parents[3] / (

--- a/tests/unit/plugin/test_lockfile.py
+++ b/tests/unit/plugin/test_lockfile.py
@@ -1,0 +1,152 @@
+"""Tests for the plugin lockfile (Q00/ouroboros#732)."""
+
+from __future__ import annotations
+
+import multiprocessing
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.lockfile import (
+    LOCKFILE_SCHEMA_VERSION,
+    LockEntry,
+    Lockfile,
+)
+
+
+def _make_entry(name: str = "github-pr-ops", version: str = "0.1.0") -> LockEntry:
+    return LockEntry(
+        name=name,
+        version=version,
+        source_kind="git",
+        repository="https://github.com/Q00/ouroboros-plugins",
+        git_sha="b3a91f2",
+        manifest_checksum="sha256:abc123",
+        installed_at="2026-05-08T03:14:00Z",
+        plugin_home=f"~/.ouroboros/plugins/{name}",
+    )
+
+
+def test_install_then_read(tmp_path: Path) -> None:
+    """Test 1: install → lockfile entry present; round-trip through TOML."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    entry = _make_entry()
+    lock.add(entry)
+
+    fresh = Lockfile(tmp_path / "plugins.lock")
+    entries = fresh.read()
+    assert "github-pr-ops" in entries
+    assert entries["github-pr-ops"] == entry
+
+
+def test_remove_drops_entry(tmp_path: Path) -> None:
+    """Test 2: remove → entry gone."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry())
+    assert lock.remove("github-pr-ops") is True
+    assert lock.read() == {}
+    # Removing again is a no-op.
+    assert lock.remove("github-pr-ops") is False
+
+
+def test_lockfile_is_sorted(tmp_path: Path) -> None:
+    """Test 3: entries are written in deterministic name-sorted order."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry(name="zebra"))
+    lock.add(_make_entry(name="apple"))
+    lock.add(_make_entry(name="middle"))
+
+    text = (tmp_path / "plugins.lock").read_text()
+    apple_idx = text.find('name = "apple"')
+    middle_idx = text.find('name = "middle"')
+    zebra_idx = text.find('name = "zebra"')
+    assert apple_idx < middle_idx < zebra_idx
+
+
+def test_lockfile_schema_version_present(tmp_path: Path) -> None:
+    """Test 4: lockfile carries a schema_version header."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry())
+    text = (tmp_path / "plugins.lock").read_text()
+    assert f'schema_version = "{LOCKFILE_SCHEMA_VERSION}"' in text
+
+
+def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
+    """Test 5: a lockfile with the wrong schema_version raises on read."""
+    path = tmp_path / "plugins.lock"
+    path.write_text('schema_version = "99.0"\n')
+    lock = Lockfile(path)
+    with pytest.raises(ValueError, match="unsupported lockfile schema_version"):
+        lock.read()
+
+
+def test_atomic_write_no_partial_file_on_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test 6: simulated crash mid-write leaves the original file intact."""
+    lock_path = tmp_path / "plugins.lock"
+    lock = Lockfile(lock_path)
+    lock.add(_make_entry(name="initial"))
+
+    original = lock_path.read_text()
+
+    # Patch os.replace to fail, simulating a crash before rename.
+    import os
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated crash during rename")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    with pytest.raises(OSError, match="simulated crash"):
+        lock.add(_make_entry(name="second"))
+
+    # Original lockfile content must be unchanged.
+    assert lock_path.read_text() == original
+    # No leftover .plugins.lock.* temp file in the directory.
+    leftovers = list(tmp_path.glob(".plugins.lock.*"))
+    assert leftovers == []
+
+
+def _concurrent_writer(target_path_str: str, name: str, count: int) -> None:
+    """Worker for concurrent-write test. Adds N entries with distinct names."""
+    from pathlib import Path as _Path
+
+    from ouroboros.plugin.lockfile import LockEntry, Lockfile
+
+    lock = Lockfile(_Path(target_path_str))
+    for i in range(count):
+        lock.add(
+            LockEntry(
+                name=f"{name}-{i}",
+                version="0.1.0",
+                source_kind="local",
+                repository=None,
+                git_sha=None,
+                manifest_checksum="sha256:0",
+                installed_at="2026-05-08T03:14:00Z",
+                plugin_home=f"~/.ouroboros/plugins/{name}-{i}",
+            )
+        )
+
+
+def test_concurrent_writes_do_not_corrupt(tmp_path: Path) -> None:
+    """Test 7: two processes writing concurrently do not corrupt the file
+    or lose entries (POSIX flock holds them serialized)."""
+    lock_path = tmp_path / "plugins.lock"
+    procs = [
+        multiprocessing.Process(target=_concurrent_writer, args=(str(lock_path), "p1", 5)),
+        multiprocessing.Process(target=_concurrent_writer, args=(str(lock_path), "p2", 5)),
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=10)
+        assert p.exitcode == 0, f"writer exited {p.exitcode}"
+
+    # Final lockfile is valid TOML and contains all 10 entries.
+    entries = Lockfile(lock_path).read()
+    assert len(entries) == 10
+    assert {e.name for e in entries.values()} == {
+        f"{prefix}-{i}" for prefix in ("p1", "p2") for i in range(5)
+    }

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -304,6 +304,25 @@ def test_duplicate_permission_scope_rejected(tmp_path: Path) -> None:
     assert "duplicate permission scope" in excinfo.value.args[0]
 
 
+def test_blank_entrypoint_command_rejected(tmp_path: Path) -> None:
+    """A whitespace-only `entrypoint.command` is rejected at load time.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    d86743c: the schema only enforced `minLength: 1`, so a command like
+    "   " loaded fine. At invocation time `shlex.split` yields zero
+    tokens, the firewall would then prepend the subcommand name and try
+    to exec it as the binary — a misleading runtime failure after
+    `plugin.invoked` was already emitted. The loader now rejects this
+    at the manifest boundary so the runtime path is never reached.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["entrypoint"]["command"] = "   "
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/entrypoint/command"
+    assert "non-whitespace token" in excinfo.value.args[0]
+
+
 def test_duplicate_command_name_rejected(tmp_path: Path) -> None:
     """Two commands sharing a name within one manifest are rejected.
 

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -1,0 +1,203 @@
+"""Tests for the plugin manifest loader (Q00/ouroboros#728).
+
+Each test asserts BOTH the rejection AND the JSON Pointer to the failing
+field, so a future schema change cannot silently relax constraints.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.manifest import (
+    PluginManifest,
+    PluginManifestError,
+    load_manifest,
+    SUPPORTED_SCHEMA_VERSIONS,
+)
+
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "description": "Reference skeleton for GitHub PR operational workflows.",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness without mutating it.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+            "requires_confirmation": False,
+            "arguments": [
+                {
+                    "name": "pull_request_url",
+                    "type": "url",
+                    "required": True,
+                    "description": "GitHub pull request URL to inspect.",
+                }
+            ],
+        }
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write", "reason": "Record decisions."},
+        {"name": "provenance", "access": "write", "reason": "Record context."},
+    ],
+    "permissions": [
+        {
+            "scope": "github:read",
+            "risk": "read_only",
+            "required": True,
+            "reason": "Read PR status.",
+        }
+    ],
+    "entrypoint": {"type": "command", "command": "python -m github_pr_ops"},
+}
+
+
+def _write(tmp_path: Path, payload: dict | str) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    if isinstance(payload, str):
+        target.write_text(payload)
+    else:
+        target.write_text(json.dumps(payload))
+    return target
+
+
+def test_load_reference_manifest(tmp_path: Path) -> None:
+    """Test 1: github-pr-ops reference manifest loads cleanly."""
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    assert isinstance(manifest, PluginManifest)
+    assert manifest.name == "github-pr-ops"
+    assert manifest.version == "0.1.0"
+    assert manifest.schema_version == "0.1"
+    assert len(manifest.commands) == 1
+    assert manifest.commands[0].name == "review"
+    assert manifest.source.type == "local_path"
+
+
+def test_missing_required_top_level_field(tmp_path: Path) -> None:
+    """Test 2: missing `name` raises with empty json_pointer (root-level)."""
+    bad = {**REFERENCE_MANIFEST}
+    bad.pop("name")
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    err = excinfo.value
+    assert err.json_pointer == ""
+    assert "name" in err.args[0]
+
+
+def test_pattern_violation_on_name(tmp_path: Path) -> None:
+    """Test 3: pattern violation reports json_pointer=/name."""
+    bad = {**REFERENCE_MANIFEST, "name": "Bad Name"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/name"
+    assert "match" in excinfo.value.args[0].lower() or "pattern" in excinfo.value.expected.lower()
+
+
+def test_unknown_capability(tmp_path: Path) -> None:
+    """Test 4: unknown capability name reports nested pointer."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["capabilities"][0]["name"] = "fake_cap"
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/capabilities/0/name"
+
+
+def test_unknown_source_type(tmp_path: Path) -> None:
+    """Test 5: unknown source.type reports /source/type pointer."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "remote"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/source/type"
+
+
+def test_additional_property_rejected(tmp_path: Path) -> None:
+    """Test 6: additionalProperties:false catches unknown top-level keys."""
+    bad = {**REFERENCE_MANIFEST, "weird_key": 1}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert "weird_key" in excinfo.value.args[0]
+
+
+def test_unsupported_schema_version(tmp_path: Path) -> None:
+    """Test 7: schema_version outside support window is rejected."""
+    bad = {**REFERENCE_MANIFEST, "schema_version": "99.0"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/schema_version"
+    assert "99.0" in excinfo.value.got
+    assert str(list(SUPPORTED_SCHEMA_VERSIONS)) in excinfo.value.expected
+
+
+def test_returned_manifest_is_frozen(tmp_path: Path) -> None:
+    """Test 8: PluginManifest dataclass is frozen — attribute mutation raises."""
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        manifest.name = "other"  # type: ignore[misc]
+
+
+def test_optional_fields_omitted(tmp_path: Path) -> None:
+    """Test 9: manifest without description and audit loads with defaults
+    (per Q00/ouroboros-plugins#6 lock — 8 required + 2 optional)."""
+    bare = {k: v for k, v in REFERENCE_MANIFEST.items() if k not in ("description", "audit")}
+    manifest = load_manifest(_write(tmp_path, bare))
+    assert manifest.description == ""
+    assert "plugin.invoked" in manifest.audit.events
+    assert "plugin.completed" in manifest.audit.events
+    assert "plugin.failed" in manifest.audit.events
+
+
+def test_first_party_source_branch(tmp_path: Path) -> None:
+    """Test 10: source.type=first_party loads without requiring path/repository
+    (per Q00/ouroboros-plugins#8 lock)."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-auto"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []
+    fp["commands"] = [
+        {
+            "namespace": "auto",
+            "name": "run",
+            "summary": "Take a goal, run interview, produce Seed, hand off execution.",
+            "usage": "ooo auto <goal-text>",
+            "risk": "write",
+        }
+    ]
+    manifest = load_manifest(_write(tmp_path, fp))
+    assert manifest.source.type == "first_party"
+    assert manifest.source.path is None
+    assert manifest.source.repository is None
+
+
+def test_old_risk_enum_value_rejected(tmp_path: Path) -> None:
+    """Test 11: command.risk='writes_state' rejected by 3-value enum
+    (per Q00/ouroboros-plugins#10 lock)."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["commands"][0]["risk"] = "writes_state"
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/commands/0/risk"
+
+
+def test_invalid_json_decodes_to_useful_error(tmp_path: Path) -> None:
+    """Bonus: garbage JSON is reported with a useful message."""
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text("{invalid json")
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(target)
+    assert "JSON" in excinfo.value.args[0] or "json" in excinfo.value.args[0].lower()
+
+
+def test_missing_file_reports_clean_error(tmp_path: Path) -> None:
+    """Bonus: missing file path reports a clean error, not a stack trace."""
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(tmp_path / "does-not-exist.json")
+    assert "not found" in excinfo.value.args[0]

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -202,6 +202,57 @@ def test_missing_file_reports_clean_error(tmp_path: Path) -> None:
     assert "not found" in excinfo.value.args[0]
 
 
+def test_local_path_source_requires_path(tmp_path: Path) -> None:
+    """source.type='local_path' without a `path` is rejected.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    39ad604: the schema previously only required `source.type`, so
+    `local_path` (and `plugin_home`) manifests with no `path` validated
+    fine but downstream install/launch had nothing to resolve. The schema
+    now applies an `if/then` constraint to require `path` for those types,
+    and the loader surfaces the violation with a JSON pointer to /source.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "local_path"}  # no `path`
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer.startswith("/source")
+    assert "path" in excinfo.value.args[0].lower()
+
+
+def test_plugin_home_source_requires_path(tmp_path: Path) -> None:
+    """source.type='plugin_home' also requires `path` (parallel to local_path)."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "plugin_home"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer.startswith("/source")
+    assert "path" in excinfo.value.args[0].lower()
+
+
+def test_first_party_source_does_not_require_path(tmp_path: Path) -> None:
+    """source.type='first_party' is the documented exemption — `path` is
+    optional. Belt-and-suspenders check that the `if/then` schema branch
+    targets only `local_path` / `plugin_home` and does not regress the
+    locked first-party behaviour."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-auto"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []
+    fp["commands"] = [
+        {
+            "namespace": "auto",
+            "name": "run",
+            "summary": "Take a goal, run interview, produce Seed.",
+            "usage": "ooo auto <goal-text>",
+            "risk": "write",
+        }
+    ]
+    manifest = load_manifest(_write(tmp_path, fp))
+    assert manifest.source.type == "first_party"
+    assert manifest.source.path is None
+
+
 def test_capabilities_and_permissions_preserve_declaration_order(tmp_path: Path) -> None:
     """Capabilities and permissions are exposed in manifest declaration order.
 

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -13,12 +13,11 @@ from pathlib import Path
 import pytest
 
 from ouroboros.plugin.manifest import (
+    SUPPORTED_SCHEMA_VERSIONS,
     PluginManifest,
     PluginManifestError,
     load_manifest,
-    SUPPORTED_SCHEMA_VERSIONS,
 )
-
 
 REFERENCE_MANIFEST: dict = {
     "schema_version": "0.1",
@@ -201,3 +200,67 @@ def test_missing_file_reports_clean_error(tmp_path: Path) -> None:
     with pytest.raises(PluginManifestError) as excinfo:
         load_manifest(tmp_path / "does-not-exist.json")
     assert "not found" in excinfo.value.args[0]
+
+
+def test_capabilities_and_permissions_preserve_declaration_order(tmp_path: Path) -> None:
+    """Capabilities and permissions are exposed in manifest declaration order.
+
+    Regression for ouroboros-agent[bot] design-note finding on PR #749:
+    `frozenset` storage made multi-permission iteration order
+    nondeterministic, so the firewall's `plugin.permission_used` event
+    sequence and "first missing scope" message varied between runs. The
+    loader now stores both as ordered tuples.
+    """
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["capabilities"] = [
+        {"name": "ledger", "access": "write"},
+        {"name": "provenance", "access": "write"},
+        {"name": "runtime", "access": "read"},
+    ]
+    payload["permissions"] = [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {"scope": "github:write", "risk": "write", "required": True},
+        {"scope": "ledger:append", "risk": "write", "required": False},
+    ]
+    manifest = load_manifest(_write(tmp_path, payload))
+
+    assert isinstance(manifest.capabilities, tuple)
+    assert isinstance(manifest.permissions, tuple)
+    assert [c.name for c in manifest.capabilities] == ["ledger", "provenance", "runtime"]
+    assert [p.scope for p in manifest.permissions] == [
+        "github:read",
+        "github:write",
+        "ledger:append",
+    ]
+
+
+def test_duplicate_permission_scope_rejected(tmp_path: Path) -> None:
+    """Two permissions with the same scope but different `required` are rejected.
+
+    JSON Schema's `uniqueItems` only catches *whole-item* duplicates, so
+    natural-key collisions (same scope, different risk/required) slip
+    past schema validation. The loader rejects them with a structured
+    JSON pointer.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["permissions"] = [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {"scope": "github:read", "risk": "write", "required": False},
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/permissions/1/scope"
+    assert "duplicate permission scope" in excinfo.value.args[0]
+
+
+def test_duplicate_capability_name_rejected(tmp_path: Path) -> None:
+    """Two capabilities sharing a name (with different access) are rejected."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["capabilities"] = [
+        {"name": "ledger", "access": "write"},
+        {"name": "ledger", "access": "read"},
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/capabilities/1/name"
+    assert "duplicate capability name" in excinfo.value.args[0]

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -304,6 +304,40 @@ def test_duplicate_permission_scope_rejected(tmp_path: Path) -> None:
     assert "duplicate permission scope" in excinfo.value.args[0]
 
 
+def test_duplicate_command_name_rejected(tmp_path: Path) -> None:
+    """Two commands sharing a name within one manifest are rejected.
+
+    Regression for ouroboros-agent[bot] follow-up finding on PR #749 commit
+    e0112d3: `RegisteredProgram.find_command()` returns the first match by
+    name, so a second command with the same name is silently unreachable
+    and its risk/requires_confirmation settings are ignored. The loader
+    now rejects this with a structured pointer, mirroring the
+    per-permission and per-capability uniqueness checks.
+    """
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["commands"] = [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Read-only review.",
+            "usage": "ooo github-pr review <url>",
+            "risk": "read_only",
+        },
+        {
+            "namespace": "github-pr",
+            "name": "review",  # duplicate name with destructive risk
+            "summary": "Hidden destructive variant.",
+            "usage": "ooo github-pr review <url>",
+            "risk": "destructive",
+            "requires_confirmation": True,
+        },
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/commands/1/name"
+    assert "duplicate command name" in excinfo.value.args[0]
+
+
 def test_duplicate_capability_name_rejected(tmp_path: Path) -> None:
     """Two capabilities sharing a name (with different access) are rejected."""
     bad = json.loads(json.dumps(REFERENCE_MANIFEST))

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -89,15 +89,20 @@ def test_reset_for_version_bump(tmp_path: Path) -> None:
 
 
 def test_remove_drops_trust_file(tmp_path: Path) -> None:
-    """Test 6: remove() deletes the trust file and prunes the empty dir."""
+    """Test 6: remove() deletes the trust file and is idempotent.
+
+    The sidecar `trust.json.lock` is intentionally left in place
+    (see TrustStore.remove docstring) so the per-plugin flock keeps
+    serialising concurrent writers that might still be racing the
+    removal. Caller-side directory cleanup is `ooo plugin remove`'s
+    job, not the trust store's.
+    """
     store = TrustStore(root=tmp_path)
     store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     file_path = tmp_path / "X" / "trust.json"
     assert file_path.is_file()
     assert store.remove("X") is True
     assert not file_path.exists()
-    # Directory pruned.
-    assert not file_path.parent.exists()
     # Removing again is a no-op.
     assert store.remove("X") is False
 
@@ -169,6 +174,82 @@ def _reset_in_subprocess(root_str: str, plugin: str, new_version: str) -> None:
     from ouroboros.plugin.trust_store import TrustStore
 
     TrustStore(root=Path(root_str)).reset_for_version_bump(plugin, new_version)
+
+
+def _remove_in_subprocess(root_str: str, plugin: str) -> None:
+    from pathlib import Path
+
+    from ouroboros.plugin.trust_store import TrustStore
+
+    TrustStore(root=Path(root_str)).remove(plugin)
+
+
+def test_remove_keeps_lock_file_sticky_for_serialisation(tmp_path: Path) -> None:
+    """`remove()` must NOT unlink the sidecar lock file.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    093873e: previously remove() unlinked `trust.json.lock` after
+    releasing the flock, opening a race in which a concurrent grant()
+    locked the old inode and the next writer locked a different
+    (recreated) inode — so the two processes no longer serialised.
+    The sidecar is now sticky so every future writer locks the same
+    inode that any concurrent process still holds open.
+    """
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    lock_path = tmp_path / "X" / "trust.json.lock"
+    # Force the lock-file path to exist by triggering a second mutation
+    # (grant takes the lock, which creates the sidecar).
+    store.grant(plugin="X", version="0.1.0", scope="github:write", granted_by="u")
+    assert lock_path.is_file(), "lock file should exist after a mutation"
+
+    assert store.remove("X") is True
+    # The trust file is gone, but the lock file remains so future
+    # writers serialise against the same inode.
+    assert not (tmp_path / "X" / "trust.json").exists()
+    assert lock_path.is_file()
+
+
+def test_concurrent_remove_and_grants_keep_state_consistent(tmp_path: Path) -> None:
+    """A `remove()` racing concurrent `grant()`s must not corrupt the
+    trust file or leave it in an inconsistent (plugin, version) state.
+
+    Same regression class as the earlier concurrent-grant test but
+    extended to cover the third mutating path. With the sticky-lock
+    fix, all writers serialise on the same lock inode, so any final
+    state is internally coherent.
+    """
+    import json as _json
+    import multiprocessing as mp
+
+    plugin = "concurrent-remove"
+    ctx = mp.get_context("spawn")
+
+    TrustStore(root=tmp_path).grant(plugin=plugin, version="0.1.0", scope="seed", granted_by="u")
+
+    workers = [
+        ctx.Process(target=_grant_in_subprocess, args=(str(tmp_path), plugin, "0.1.0", "alpha")),
+        ctx.Process(target=_remove_in_subprocess, args=(str(tmp_path), plugin)),
+        ctx.Process(target=_grant_in_subprocess, args=(str(tmp_path), plugin, "0.1.0", "beta")),
+    ]
+    for w in workers:
+        w.start()
+    for w in workers:
+        w.join(timeout=30)
+        assert w.exitcode == 0, f"worker failed: pid={w.pid} exit={w.exitcode}"
+
+    trust_file = tmp_path / plugin / "trust.json"
+    if trust_file.is_file():
+        # If a grant won the race, the file must be a coherent JSON
+        # document with the expected schema_version and plugin name.
+        payload = _json.loads(trust_file.read_text())
+        assert payload["plugin"] == plugin
+        assert payload["schema_version"] == "0.1"
+        assert payload["version"] == "0.1.0"
+        # And the public reader must succeed without raising.
+        assert TrustStore(root=tmp_path).read(plugin) is not None
+    # Sidecar lock file persists either way, so future serialisation works.
+    assert (tmp_path / plugin / "trust.json.lock").is_file()
 
 
 def test_concurrent_reset_and_grant_produce_valid_file(tmp_path: Path) -> None:

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -150,3 +150,50 @@ def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
     # `github:read` is granted; the others are missing.
     missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
     assert missing == ["github:pull_request:write", "shell:execute"]
+
+
+def _grant_in_subprocess(root_str: str, plugin: str, version: str, scope: str) -> None:
+    """Module-level worker so multiprocessing.spawn can pickle it on macOS."""
+    from pathlib import Path
+
+    from ouroboros.plugin.trust_store import TrustStore
+
+    TrustStore(root=Path(root_str)).grant(
+        plugin=plugin, version=version, scope=scope, granted_by="user:test"
+    )
+
+
+def test_grant_concurrent_writes_do_not_lose_scopes(tmp_path: Path) -> None:
+    """Concurrent grant() calls for different scopes must all persist.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    78698d0: the read-modify-write in `grant()` was previously unguarded,
+    so two processes granting different scopes in parallel could both
+    read the same prior file and the second `os.replace()` would silently
+    drop the other writer's scope. The store now holds an exclusive
+    POSIX flock around the sequence; this test exercises the protection
+    by spawning several processes concurrently and asserting all scopes
+    survive in the final trust file.
+    """
+    import multiprocessing as mp
+
+    scopes = [f"github:scope-{i}" for i in range(6)]
+    ctx = mp.get_context("spawn")  # cross-platform; matches macOS default
+    procs = [
+        ctx.Process(
+            target=_grant_in_subprocess,
+            args=(str(tmp_path), "concurrent-plugin", "0.1.0", scope),
+        )
+        for scope in scopes
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert p.exitcode == 0, f"worker failed: pid={p.pid} exit={p.exitcode}"
+
+    record = TrustStore(root=tmp_path).read("concurrent-plugin")
+    assert record is not None
+    persisted = {g.scope for g in record.granted_scopes}
+    missing = set(scopes) - persisted
+    assert not missing, f"concurrent grants dropped scopes: {sorted(missing)}"

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -1,0 +1,158 @@
+"""Tests for the per-plugin trust store (Q00/ouroboros#732)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.trust_store import (
+    TRUST_SCHEMA_VERSION,
+    TrustRecord,
+    TrustStore,
+)
+
+
+def test_grant_then_read(tmp_path: Path) -> None:
+    """Test 1: grant a scope, read it back. File at locked Q5 path."""
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:shaun0927",
+    )
+    assert record.has_scope("github:read")
+
+    file_path = tmp_path / "github-pr-ops" / "trust.json"
+    assert file_path.is_file()
+    data = json.loads(file_path.read_text())
+    assert data["schema_version"] == TRUST_SCHEMA_VERSION
+    assert data["plugin"] == "github-pr-ops"
+    assert data["version"] == "0.1.0"
+    assert data["granted_scopes"][0]["scope"] == "github:read"
+    assert data["granted_scopes"][0]["granted_by"] == "user:shaun0927"
+
+
+def test_grant_is_idempotent(tmp_path: Path) -> None:
+    """Test 2: granting the same scope twice does not duplicate."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    record = store.grant(
+        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
+    )
+    assert len(record.granted_scopes) == 1
+
+
+def test_exact_scope_only(tmp_path: Path) -> None:
+    """Test 3: parent scope does NOT imply child (Q3 lock).
+
+    Granting `github:pull_request` does not satisfy `github:pull_request:write`.
+    """
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="X",
+        version="0.1.0",
+        scope="github:pull_request",
+        granted_by="u",
+    )
+    assert record.has_scope("github:pull_request")
+    assert not record.has_scope("github:pull_request:write")
+    assert record.missing(["github:pull_request:write"]) == ["github:pull_request:write"]
+
+
+def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
+    """Test 4: granting against a new version drops the previous grants
+    (Q00/ouroboros-plugins#9 Q4 lock)."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    store.grant(plugin="X", version="0.1.0", scope="github:repo:read", granted_by="u")
+
+    # Now bump to 0.2.0 and grant a different scope.
+    record = store.grant(
+        plugin="X", version="0.2.0", scope="github:read", granted_by="u"
+    )
+    assert record.version == "0.2.0"
+    # Previous github:repo:read grant is invalidated.
+    assert not record.has_scope("github:repo:read")
+    # The newly granted scope on the new version is present.
+    assert record.has_scope("github:read")
+
+
+def test_reset_for_version_bump(tmp_path: Path) -> None:
+    """Test 5: explicit version-bump reset writes an empty grant list."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    store.reset_for_version_bump("X", new_version="0.2.0")
+
+    record = store.read("X")
+    assert isinstance(record, TrustRecord)
+    assert record.version == "0.2.0"
+    assert record.granted_scopes == ()
+
+
+def test_remove_drops_trust_file(tmp_path: Path) -> None:
+    """Test 6: remove() deletes the trust file and prunes the empty dir."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    file_path = tmp_path / "X" / "trust.json"
+    assert file_path.is_file()
+    assert store.remove("X") is True
+    assert not file_path.exists()
+    # Directory pruned.
+    assert not file_path.parent.exists()
+    # Removing again is a no-op.
+    assert store.remove("X") is False
+
+
+def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
+    """Test 7: a trust file with the wrong schema_version raises on read."""
+    plugin_dir = tmp_path / "X"
+    plugin_dir.mkdir()
+    (plugin_dir / "trust.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "99.0",
+                "plugin": "X",
+                "version": "0.1.0",
+                "granted_scopes": [],
+            }
+        )
+    )
+    store = TrustStore(root=tmp_path)
+    with pytest.raises(ValueError, match="unsupported trust file schema_version"):
+        store.read("X")
+
+
+def test_no_raw_token_in_persisted_file(tmp_path: Path) -> None:
+    """Test 8: scope strings and granted_by are persisted, but nothing
+    else. The store offers no API for tokens; this test is a sanity
+    check that future contributors don't add one without notice."""
+    store = TrustStore(root=tmp_path)
+    store.grant(
+        plugin="X",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:shaun0927",
+    )
+    raw = (tmp_path / "X" / "trust.json").read_text()
+    # Keys present
+    assert '"scope"' in raw
+    assert '"granted_by"' in raw
+    assert '"granted_at"' in raw
+    # Nothing token-shaped (no "token", "secret", "auth", "Bearer")
+    for forbidden in ("token", "secret", "auth", "Bearer", "ghp_"):
+        assert forbidden.lower() not in raw.lower(), f"forbidden marker {forbidden!r} in trust file"
+
+
+def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
+    """Test 9: TrustRecord.missing() returns missing required scopes in
+    the input iteration order — useful for predictable error messages."""
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
+    )
+    # `github:read` is granted; the others are missing.
+    missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
+    assert missing == ["github:pull_request:write", "shell:execute"]

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -39,9 +39,7 @@ def test_grant_is_idempotent(tmp_path: Path) -> None:
     """Test 2: granting the same scope twice does not duplicate."""
     store = TrustStore(root=tmp_path)
     store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    record = store.grant(
-        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     assert len(record.granted_scopes) == 1
 
 
@@ -70,9 +68,7 @@ def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
     store.grant(plugin="X", version="0.1.0", scope="github:repo:read", granted_by="u")
 
     # Now bump to 0.2.0 and grant a different scope.
-    record = store.grant(
-        plugin="X", version="0.2.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.2.0", scope="github:read", granted_by="u")
     assert record.version == "0.2.0"
     # Previous github:repo:read grant is invalidated.
     assert not record.has_scope("github:repo:read")
@@ -150,9 +146,7 @@ def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
     """Test 9: TrustRecord.missing() returns missing required scopes in
     the input iteration order — useful for predictable error messages."""
     store = TrustStore(root=tmp_path)
-    record = store.grant(
-        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     # `github:read` is granted; the others are missing.
     missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
     assert missing == ["github:pull_request:write", "shell:execute"]

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -163,6 +163,62 @@ def _grant_in_subprocess(root_str: str, plugin: str, version: str, scope: str) -
     )
 
 
+def _reset_in_subprocess(root_str: str, plugin: str, new_version: str) -> None:
+    from pathlib import Path
+
+    from ouroboros.plugin.trust_store import TrustStore
+
+    TrustStore(root=Path(root_str)).reset_for_version_bump(plugin, new_version)
+
+
+def test_concurrent_reset_and_grant_produce_valid_file(tmp_path: Path) -> None:
+    """`reset_for_version_bump` racing with concurrent `grant()` calls
+    must not corrupt the trust file or partially write across writers.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749 commit
+    e0112d3: previously `reset_for_version_bump()` and `remove()` did not
+    take the same per-plugin flock that `grant()` did, so an upgrade/reset
+    racing with `ooo plugin trust` could clobber state in either direction.
+    All three mutating operations now share the lock; under contention the
+    file must remain a well-formed JSON document with the correct
+    schema_version and a coherent (plugin, version) pair.
+    """
+    import json as _json
+    import multiprocessing as mp
+
+    plugin = "concurrent-reset"
+    ctx = mp.get_context("spawn")
+
+    # Seed the file at v1 with a starting scope so all three mutators
+    # operate on an existing record.
+    TrustStore(root=tmp_path).grant(
+        plugin=plugin, version="0.1.0", scope="github:read", granted_by="u"
+    )
+
+    workers = [
+        ctx.Process(target=_grant_in_subprocess, args=(str(tmp_path), plugin, "0.1.0", "a")),
+        ctx.Process(target=_reset_in_subprocess, args=(str(tmp_path), plugin, "0.2.0")),
+        ctx.Process(target=_grant_in_subprocess, args=(str(tmp_path), plugin, "0.1.0", "b")),
+        ctx.Process(target=_grant_in_subprocess, args=(str(tmp_path), plugin, "0.2.0", "c")),
+    ]
+    for w in workers:
+        w.start()
+    for w in workers:
+        w.join(timeout=30)
+        assert w.exitcode == 0, f"worker failed: pid={w.pid} exit={w.exitcode}"
+
+    # The file must still be a syntactically valid JSON object with the
+    # expected top-level fields. Race-corrupted partial writes would fail
+    # here.
+    raw = (tmp_path / plugin / "trust.json").read_text()
+    payload = _json.loads(raw)
+    assert payload["plugin"] == plugin
+    assert payload["schema_version"] == "0.1"
+    assert payload["version"] in {"0.1.0", "0.2.0"}
+    # Read through the public API: it must succeed without raising.
+    assert TrustStore(root=tmp_path).read(plugin) is not None
+
+
 def test_grant_concurrent_writes_do_not_lose_scopes(tmp_path: Path) -> None:
     """Concurrent grant() calls for different scopes must all persist.
 

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -1,0 +1,177 @@
+"""Tests for the UserLevel program registry (Q00/ouroboros#730)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.manifest import load_manifest
+from ouroboros.plugin.userlevel_registry import (
+    LookupResult,
+    RegisteredProgram,
+    RegistryError,
+    UserLevelProgramRegistry,
+    get_userlevel_registry,
+    lookup_command,
+    reset_userlevel_registry,
+)
+
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+        }
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write"},
+    ],
+    "permissions": [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+    ],
+    "entrypoint": {"type": "command", "command": "python -m github_pr_ops"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_registry():
+    """Each test starts with a clean global registry."""
+    reset_userlevel_registry()
+    yield
+    reset_userlevel_registry()
+
+
+def _write_manifest(tmp_path: Path, payload: dict) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _load_ref(tmp_path: Path, **overrides) -> "RegisteredProgram":
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload.update(overrides)
+    return load_manifest(_write_manifest(tmp_path, payload))
+
+
+def test_register_and_get(tmp_path: Path) -> None:
+    """Test 1: register a manifest, look it up by name and namespace."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    program = registry.register(manifest)
+
+    assert isinstance(program, RegisteredProgram)
+    assert registry.get("github-pr-ops") == program
+    assert registry.get_by_namespace("github-pr") == program
+    assert registry.get("nonexistent") is None
+    assert registry.get_by_namespace("nonexistent") is None
+
+
+def test_namespace_collision_rejected(tmp_path: Path) -> None:
+    """Test 2: two plugins claiming the same namespace → error."""
+    registry = UserLevelProgramRegistry()
+    a = _load_ref(tmp_path / "a", name="plugin-a")
+    b = _load_ref(tmp_path / "b", name="plugin-b")  # same namespace "github-pr"
+
+    registry.register(a)
+    with pytest.raises(RegistryError, match="already owned"):
+        registry.register(b)
+
+
+def test_duplicate_name_requires_replace(tmp_path: Path) -> None:
+    """Test 3: re-registering the same name without replace=True → error."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    registry.register(manifest)
+    with pytest.raises(RegistryError, match="already registered"):
+        registry.register(manifest)
+    # With replace=True, succeeds.
+    registry.register(manifest, replace=True)
+
+
+def test_unregister(tmp_path: Path) -> None:
+    """Test 4: unregister releases name AND namespace ownership."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    registry.register(manifest)
+    assert registry.unregister("github-pr-ops") is True
+    assert registry.unregister("github-pr-ops") is False
+    # After unregistering, the namespace can be claimed by a different plugin.
+    other = _load_ref(tmp_path / "other", name="plugin-other")
+    registry.register(other)  # must not raise
+
+
+def test_all_programs(tmp_path: Path) -> None:
+    """Test 5: all_programs returns every registered program."""
+    registry = UserLevelProgramRegistry()
+    a = _load_ref(tmp_path / "a", name="plugin-a")
+    # Different namespace for b
+    b_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    b_payload["name"] = "plugin-b"
+    b_payload["commands"][0]["namespace"] = "other-ns"
+    b = load_manifest(_write_manifest(tmp_path / "b", b_payload))
+    registry.register(a)
+    registry.register(b)
+    names = {p.name for p in registry.all_programs()}
+    assert names == {"plugin-a", "plugin-b"}
+
+
+def test_lookup_command_finds_userlevel_by_namespace(tmp_path: Path) -> None:
+    """Test 6: lookup_command finds via namespace first."""
+    manifest = _load_ref(tmp_path)
+    get_userlevel_registry().register(manifest)
+    result = lookup_command("github-pr")
+    assert result.found
+    assert result.kind == "userlevel"
+    assert result.userlevel_program is not None
+    assert result.userlevel_program.name == "github-pr-ops"
+
+
+def test_lookup_command_finds_userlevel_by_name(tmp_path: Path) -> None:
+    """Test 7: lookup_command also finds via plugin name."""
+    manifest = _load_ref(tmp_path)
+    get_userlevel_registry().register(manifest)
+    result = lookup_command("github-pr-ops")
+    assert result.found
+    assert result.kind == "userlevel"
+
+
+def test_lookup_command_returns_none_for_unknown(tmp_path: Path) -> None:
+    """Test 8: lookup_command returns kind='none' for unknown names."""
+    result = lookup_command("totally-unknown-plugin")
+    assert not result.found
+    assert result.kind == "none"
+
+
+def test_global_singleton_persists_within_session(tmp_path: Path) -> None:
+    """Test 9: get_userlevel_registry returns the same instance."""
+    a = get_userlevel_registry()
+    b = get_userlevel_registry()
+    assert a is b
+
+
+def test_skill_registry_unaffected(tmp_path: Path) -> None:
+    """Test 10: existing skill registry tests still work — no state shared.
+
+    This test loads the skill registry module to confirm we can co-exist
+    with it (no import-time conflicts), without depending on its discovery.
+    """
+    from ouroboros.plugin.skills.registry import get_registry as _get_skill_registry
+
+    skill_registry = _get_skill_registry()
+    # The skill registry is independent from our UserLevel registry.
+    ul = get_userlevel_registry()
+    manifest = _load_ref(tmp_path)
+    ul.register(manifest)
+    # Skill registry must remain unchanged by our registration.
+    assert skill_registry.get_skill("github-pr-ops") is None

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -9,7 +9,6 @@ import pytest
 
 from ouroboros.plugin.manifest import load_manifest
 from ouroboros.plugin.userlevel_registry import (
-    LookupResult,
     RegisteredProgram,
     RegistryError,
     UserLevelProgramRegistry,
@@ -17,7 +16,6 @@ from ouroboros.plugin.userlevel_registry import (
     lookup_command,
     reset_userlevel_registry,
 )
-
 
 REFERENCE_MANIFEST: dict = {
     "schema_version": "0.1",
@@ -58,7 +56,7 @@ def _write_manifest(tmp_path: Path, payload: dict) -> Path:
     return target
 
 
-def _load_ref(tmp_path: Path, **overrides) -> "RegisteredProgram":
+def _load_ref(tmp_path: Path, **overrides) -> RegisteredProgram:
     payload = json.loads(json.dumps(REFERENCE_MANIFEST))
     payload.update(overrides)
     return load_manifest(_write_manifest(tmp_path, payload))
@@ -97,6 +95,39 @@ def test_duplicate_name_requires_replace(tmp_path: Path) -> None:
         registry.register(manifest)
     # With replace=True, succeeds.
     registry.register(manifest, replace=True)
+
+
+def test_replace_with_changed_namespace_releases_old_namespace(tmp_path: Path) -> None:
+    """Re-registering the same name with a NEW namespace must release the old.
+
+    Regression for ouroboros-agent[bot] BLOCKING finding on PR #749:
+    `register(replace=True)` previously left the prior namespace pointing at
+    the same plugin name, so `get_by_namespace(old_ns)` resolved to the new
+    program and other plugins could never claim the old namespace.
+    """
+    registry = UserLevelProgramRegistry()
+    v1 = _load_ref(tmp_path / "v1")
+    registry.register(v1)
+    assert registry.get_by_namespace("github-pr") is not None
+
+    v2_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    v2_payload["version"] = "0.2.0"
+    v2_payload["commands"][0]["namespace"] = "github-pr-v2"
+    v2 = load_manifest(_write_manifest(tmp_path / "v2", v2_payload))
+    program = registry.register(v2, replace=True)
+
+    # New namespace resolves to the new program.
+    assert registry.get_by_namespace("github-pr-v2") is program
+    # Old namespace is released — get_by_namespace returns None, NOT the new
+    # program (the bug previously surfaced as a stale alias).
+    assert registry.get_by_namespace("github-pr") is None
+
+    # And the released namespace becomes claimable by a different plugin.
+    other_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    other_payload["name"] = "plugin-other"
+    other = load_manifest(_write_manifest(tmp_path / "other", other_payload))
+    registry.register(other)
+    assert registry.get_by_namespace("github-pr").name == "plugin-other"
 
 
 def test_unregister(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1494,6 +1494,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "anyio" },
+    { name = "jsonschema" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -1553,6 +1554,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0.0,<5.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'all'", specifier = ">=0.1.0,<1.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'claude'", specifier = ">=0.1.0,<1.0.0" },
+    { name = "jsonschema", specifier = ">=4.21.0,<5.0.0" },
     { name = "litellm", marker = "extra == 'all'", specifier = ">=1.80.0,<=1.82.6" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80.0,<=1.82.6" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.26.0,<2.0.0" },


### PR DESCRIPTION
Closes #737. Sub-issue of #725 (Phase 1). **Stacked on #748 (CR-4 firewall)**.

## Investigation finding

The core `EventStore` (`src/ouroboros/persistence/event_store.py`) stores rows shaped as `(id, aggregate_type, aggregate_id, event_type, payload, timestamp)` — a row envelope around an opaque JSON payload.

The plugin audit-event schema (`schemas/0.1/audit-event.schema.json`) declares `additionalProperties: false`, so wrapping fields the core ledger needs **must** live above the audit-event boundary. The shapes are compatible without modifying the audit-event schema.

## Module: `src/ouroboros/plugin/ledger_adapter.py`

### `wrap_plugin_event(audit_event, *, correlation_id, aggregate_id=None, envelope_id=None) -> dict`

Wraps a firewall-emitted audit event in a core-ledger row envelope:

| Envelope field | Source |
|---|---|
| `id` | `uuid4()` (override-able for deterministic tests) |
| `aggregate_type` | `"plugin"` (constant) |
| `aggregate_id` | `correlation_id` (override-able) |
| `event_type` | `audit_event["event_type"]` (mirrored so `events_table.event_type` is queryable without parsing JSON) |
| `payload` | the full audit event (shallow copy — caller cannot mutate stored form) |
| `timestamp` | `audit_event["occurred_at"]` |

The audit event itself is **not** mutated; the payload remains schema-valid for downstream consumers that read it back.

### `unwrap_plugin_event(envelope) -> dict`

Recovers the original audit event from a stored row. Rejects envelopes whose `aggregate_type != "plugin"` so other event categories cannot accidentally pass through plugin-only consumers.

### `make_event_sink(append_fn, *, correlation_id, ...) -> EventSink`

Factory producing a firewall-compatible `EventSink` callable. Production wires `append_fn` to a real `EventStore.append` adapter; tests pass `list.append`.

## Why this module does NOT import `event_store`

The async-SQLAlchemy machinery in `event_store.py` is a heavy dependency. Keeping the adapter pure-Python lets:

- The firewall stay synchronous (no async leakage from a logging concern).
- Tests stay fast (no async event loop or SQLite setup).
- The CLI (#731) be the integration point that takes a real async session and bridges to `append_fn`.

This matches the `Invocation Contract` framing in `docs/rfc/userlevel-plugins.md` (#743).

## Tests — 14/14 pass; full plugin suite 207/207

```
$ PYTHONPATH=src python3 -m pytest tests/unit/plugin/test_ledger_adapter.py -v
============================== 14 passed in 0.28s ==============================

$ PYTHONPATH=src python3 -m pytest tests/unit/plugin/ --tb=no -q
207 passed, 1 skipped in 0.71s
```

| # | Test | Asserts |
|---|---|---|
| 1 | basic wrap envelope shape | aggregate_type, aggregate_id, event_type, timestamp, id |
| 2 | wrap does not mutate input | input dict unchanged after wrap |
| 3 | payload stays schema-valid | `additionalProperties:false` honored |
| 4 | unwrap returns audit event | round-trip equality |
| 5 | **round-trip for all 7 event types** | the locked spec's main AC |
| 6 | unwrap rejects non-plugin envelope | safety guard |
| 7 | wrap requires event_type | fails fast |
| 8 | wrap requires occurred_at | fails fast |
| 9 | aggregate_id override | overrides correlation_id default |
| 10 | make_event_sink integration | rows appended with envelope shape |
| 11 | id factory for deterministic tests | id sequence preserved |
| 12 | envelope.event_type == payload.event_type | mirrored consistently |
| 13 | wrap rejects non-dict input | TypeError |
| 14 | no token-shaped keys in envelope | sanity guard |

## Cross-repo

- The locked Q00/ouroboros-plugins#9 Q6 trust event shape (with `granted_by`/`granted_scope` in provenance) is exercised by the round-trip test.
- `docs/rfc/userlevel-plugins.md` Section 6 (added in #743) documents this compatibility contract; this PR is the implementation.

## What's next

- #731 (CLI) — bridges `append_fn` to a real `EventStore.append` async session.
- #733 (E2E) — exercises the full firewall → adapter → ledger flow against the `github-pr-ops` plugin.