### PR TITLE
feat(cli): ooo plugin {discover,inspect,list} (read-only)

### DIFF
--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -29,7 +29,11 @@ from ouroboros.plugin.manifest import (
     PluginManifestError,
     load_manifest,
 )
-from ouroboros.plugin.trust_store import DEFAULT_TRUST_ROOT, TrustStore
+from ouroboros.plugin.trust_store import (
+    DEFAULT_TRUST_ROOT,
+    TrustRecord,
+    TrustStore,
+)
 
 app = typer.Typer(
     name="plugin",
@@ -65,14 +69,52 @@ def _load_with_friendly_error(target: str) -> PluginManifest:
         raise typer.Exit(code=1) from exc
 
 
+def _required_scopes(manifest: PluginManifest) -> list[str]:
+    return [p.scope for p in manifest.permissions if p.required]
+
+
+def _missing_required(
+    manifest: PluginManifest,
+    record: TrustRecord | None,
+) -> list[str]:
+    """Required scopes that are not currently satisfied.
+
+    Mirrors `ouroboros.plugin.firewall._missing_required` so the CLI's
+    trust-state report cannot drift away from the firewall's actual
+    invocation gate. A version-bumped trust file is treated as if no
+    scopes were granted (locked Q4: version bump invalidates trust).
+    """
+    required = _required_scopes(manifest)
+    if not required:
+        return []
+    if record is None:
+        return list(required)
+    if record.version != manifest.version:
+        return list(required)
+    return record.missing(required)
+
+
 def _trust_state_label(
     manifest: PluginManifest,
-    trust_store: TrustStore,
+    record: TrustRecord | None,
 ) -> str:
+    """Compute the trust state shown in `inspect`/`list`.
+
+    "trusted" must mean "the firewall will let this run without further
+    user action" — i.e. the trust file matches the manifest version AND
+    every required scope is granted. Anything short of that is reported
+    as "installed" so the CLI cannot lie to operators about whether
+    invocation will be blocked.
+    """
     if manifest.source.type == "first_party":
         return "first_party"
-    record = trust_store.read(manifest.name)
-    if record is not None and record.granted_scopes:
+    if record is None:
+        return "installed"
+    if record.version != manifest.version:
+        return "installed"
+    if _missing_required(manifest, record):
+        return "installed"
+    if record.granted_scopes:
         return "trusted"
     return "installed"
 
@@ -158,12 +200,19 @@ def inspect_command(
         console.print(f"  repository:     {entry.repository}")
     if entry.git_sha:
         console.print(f"  git_sha:        {entry.git_sha}")
-    console.print(f"  trust_state:    {_trust_state_label(manifest, trust)}")
+    console.print(f"  trust_state:    {_trust_state_label(manifest, record)}")
     console.print(
         f"  granted_scopes: {', '.join(granted) if granted else '(none)'}"
     )
-    required_perms = [p.scope for p in manifest.permissions if p.required]
-    missing = [s for s in required_perms if s not in granted]
+    if record is not None and record.version != manifest.version:
+        # Loud signal so users understand why "trust_state" flipped back
+        # to installed even though the trust file still lists grants.
+        console.print(
+            f"  trust_version:  recorded {record.version!r} but installed "
+            f"{manifest.version!r} — version bump invalidated trust; "
+            f"re-grant scopes via `ooo plugin trust`."
+        )
+    missing = _missing_required(manifest, record)
     if missing:
         console.print(
             f"  missing scopes: {', '.join(missing)} "
@@ -203,13 +252,31 @@ def list_command(
     for entry in sorted(entries.values(), key=lambda e: e.name):
         record = trust.read(entry.name)
         scopes = [g.scope for g in record.granted_scopes] if record else []
+        # Re-load the manifest so trust_state reflects the same gate the
+        # firewall enforces (required-scope set + version match), not
+        # just "did the user grant any scope at all".
+        manifest_path = (
+            Path(entry.plugin_home).expanduser() / "ouroboros.plugin.json"
+        )
+        try:
+            manifest = load_manifest(manifest_path)
+            trust_state = _trust_state_label(manifest, record)
+            missing = _missing_required(manifest, record)
+        except PluginManifestError:
+            # Lockfile entry exists but the on-disk manifest is broken.
+            # We cannot prove "trusted" without the manifest, so report
+            # "installed" — the safer default — and surface the missing
+            # required-scope set as unknown.
+            trust_state = "installed"
+            missing = []
         rows.append(
             {
                 "name": entry.name,
                 "version": entry.version,
                 "source_kind": entry.source_kind,
-                "trust_state": "trusted" if scopes else "installed",
+                "trust_state": trust_state,
                 "granted_scopes": scopes,
+                "missing_required_scopes": missing,
             }
         )
 
@@ -219,7 +286,7 @@ def list_command(
         return
 
     table = create_table(title="Installed UserLevel plugins")
-    for column in ("name", "version", "source", "trust", "scopes"):
+    for column in ("name", "version", "source", "trust", "scopes", "missing"):
         table.add_column(column)
     for row in rows:
         table.add_row(
@@ -228,6 +295,7 @@ def list_command(
             row["source_kind"],
             row["trust_state"],
             ", ".join(row["granted_scopes"]) or "(none)",
+            ", ".join(row["missing_required_scopes"]) or "(none)",
         )
     print_table(table)
 

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import tomllib
 from typing import Annotated
 
 import typer
@@ -65,6 +66,45 @@ def _load_with_friendly_error(target: str) -> PluginManifest:
         loc = exc.json_pointer if exc.json_pointer else "(root)"
         print_error(
             f"manifest invalid:\n  path: {exc.path}\n  at: {loc}\n  expected: {exc.expected}\n  got: {exc.got}"
+        )
+        raise typer.Exit(code=1) from exc
+
+
+_STATE_FILE_ERRORS: tuple[type[Exception], ...] = (
+    ValueError,  # schema_version mismatch raised by Lockfile.read / TrustStore.read
+    tomllib.TOMLDecodeError,
+    json.JSONDecodeError,
+    OSError,  # permission/IO errors on the state files themselves
+)
+
+
+def _read_lockfile_or_exit(lock: Lockfile) -> dict:
+    """Read the lockfile, surfacing a friendly error if it's malformed.
+
+    `inspect` and `list` are diagnostic commands — if the very state
+    file they introspect is broken, they should print a useful error
+    and exit cleanly rather than dump a raw traceback to the operator.
+    """
+    try:
+        return lock.read()
+    except _STATE_FILE_ERRORS as exc:
+        print_error(
+            f"plugins lockfile is unreadable: {lock.path}: {exc}\n"
+            f"  Inspect the file by hand or restore from backup; "
+            f"`ooo plugin` cannot proceed until it parses cleanly."
+        )
+        raise typer.Exit(code=1) from exc
+
+
+def _read_trust_or_exit(trust: TrustStore, plugin: str) -> TrustRecord | None:
+    """Read a trust record, surfacing a friendly error if it's malformed."""
+    try:
+        return trust.read(plugin)
+    except _STATE_FILE_ERRORS as exc:
+        print_error(
+            f"trust file for {plugin!r} is unreadable: {exc}\n"
+            f"  Inspect or remove ~/.ouroboros/plugins/{plugin}/trust.json; "
+            f"`ooo plugin` cannot proceed until it parses cleanly."
         )
         raise typer.Exit(code=1) from exc
 
@@ -178,7 +218,7 @@ def inspect_command(
     lock = Lockfile(lockfile_path or DEFAULT_LOCKFILE_PATH)
     trust = TrustStore(root=trust_root or DEFAULT_TRUST_ROOT)
 
-    entries = lock.read()
+    entries = _read_lockfile_or_exit(lock)
     entry = entries.get(name)
     if entry is None:
         print_error(f"{name!r} is not installed (no entry in {lock.path})")
@@ -194,7 +234,7 @@ def inspect_command(
         )
         raise typer.Exit(code=1) from exc
 
-    record = trust.read(name)
+    record = _read_trust_or_exit(trust, name)
     granted = [g.scope for g in record.granted_scopes] if record else []
 
     print_info(f"{manifest.name} {manifest.version} ({entry.source_kind})")
@@ -244,7 +284,7 @@ def list_command(
     lock = Lockfile(lockfile_path or DEFAULT_LOCKFILE_PATH)
     trust = TrustStore(root=trust_root or DEFAULT_TRUST_ROOT)
 
-    entries = lock.read()
+    entries = _read_lockfile_or_exit(lock)
     if not entries:
         if json_output:
             # Plain stdout (no Rich highlighting) so consumers can pipe to jq.
@@ -255,7 +295,7 @@ def list_command(
 
     rows = []
     for entry in sorted(entries.values(), key=lambda e: e.name):
-        record = trust.read(entry.name)
+        record = _read_trust_or_exit(trust, entry.name)
         scopes = [g.scope for g in record.granted_scopes] if record else []
         # Re-load the manifest so trust_state reflects the same gate the
         # firewall enforces (required-scope set + version match), not

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -138,11 +138,26 @@ def _missing_required(
 ) -> list[str]:
     """Required scopes that are not currently satisfied.
 
-    Mirrors `ouroboros.plugin.firewall._missing_required` so the CLI's
-    trust-state report cannot drift away from the firewall's actual
-    invocation gate. A version-bumped trust file is treated as if no
-    scopes were granted (locked Q4: version bump invalidates trust).
+    Mirrors `ouroboros.plugin.firewall._missing_required` (and its
+    first-party bypass at `invoke_plugin`) so the CLI's trust-state
+    report cannot drift away from the firewall's actual invocation
+    gate.
+
+    First-party plugins ship inside the binary; the firewall
+    explicitly skips the trust gate for `source.type == "first_party"`
+    (`invoke_plugin` only calls `_missing_required` when the source is
+    not first-party). The schema still permits first-party manifests
+    to declare `required: true` permissions, but those declarations
+    are advisory only — invocation will not be blocked. Reporting
+    them here as "missing" would lie to operators about what the
+    firewall would accept and contradict the design notes for the
+    first-party shortcut.
+
+    A version-bumped trust file is treated as if no scopes were
+    granted (locked Q4: version bump invalidates trust).
     """
+    if manifest.source.type == "first_party":
+        return []
     required = _required_scopes(manifest)
     if not required:
         return []
@@ -208,7 +223,18 @@ def discover_command(
     console.print(f"  permissions:    {len(manifest.permissions)}")
     required_perms = [p for p in manifest.permissions if p.required]
     if required_perms:
-        console.print("  required scopes (must be trusted before invocation):")
+        # First-party plugins ship inside the binary and the firewall
+        # explicitly bypasses trust for them (see
+        # `firewall._missing_required`). Telling operators that
+        # required scopes "must be trusted before invocation" for
+        # first-party plugins would contradict that gate. Surface the
+        # declarations, but be honest that they are advisory.
+        if manifest.source.type == "first_party":
+            console.print(
+                "  declared required scopes (advisory; first-party plugins bypass the trust gate):"
+            )
+        else:
+            console.print("  required scopes (must be trusted before invocation):")
         for perm in required_perms:
             console.print(f"    - {perm.scope} ({perm.risk})")
 

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -68,6 +68,17 @@ def _load_with_friendly_error(target: str) -> PluginManifest:
             f"manifest invalid:\n  path: {exc.path}\n  at: {loc}\n  expected: {exc.expected}\n  got: {exc.got}"
         )
         raise typer.Exit(code=1) from exc
+    except OSError as exc:
+        # Mirror the inspect/list error path: `discover` is also a
+        # diagnostic command, so an unreadable manifest (broken
+        # symlink, wrong permissions, transient I/O) must surface as a
+        # clean message instead of bubbling a raw OSError.
+        print_error(
+            f"manifest is unreadable: {path}: {exc}\n"
+            f"  Check the path and file permissions; "
+            f"`ooo plugin discover` cannot proceed without it."
+        )
+        raise typer.Exit(code=1) from exc
 
 
 _STATE_FILE_ERRORS: tuple[type[Exception], ...] = (

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1,0 +1,240 @@
+"""`ooo plugin` command group.
+
+UserLevel plugin manager CLI. Implements Q00/ouroboros#731 (locked spec).
+
+This file contains the **read-only** subcommands (`discover`, `inspect`,
+`list`). State-mutating subcommands (`add`, `install`, `trust`, `disable`,
+`remove`) are added in a follow-up PR; the module structure is laid out
+here so the follow-up plugs in cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from ouroboros.cli.formatters import console
+from ouroboros.cli.formatters.panels import (
+    print_error,
+    print_info,
+    print_success,
+)
+from ouroboros.cli.formatters.tables import create_table, print_table
+from ouroboros.plugin.lockfile import DEFAULT_LOCKFILE_PATH, Lockfile
+from ouroboros.plugin.manifest import (
+    PluginManifest,
+    PluginManifestError,
+    load_manifest,
+)
+from ouroboros.plugin.trust_store import DEFAULT_TRUST_ROOT, TrustStore
+
+app = typer.Typer(
+    name="plugin",
+    help="Manage UserLevel plugins (#725).",
+    no_args_is_help=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_manifest_path(target: str) -> Path:
+    """Accept either a directory containing ouroboros.plugin.json or the
+    file itself; return the file path."""
+    p = Path(target).expanduser()
+    if p.is_dir():
+        return p / "ouroboros.plugin.json"
+    return p
+
+
+def _load_with_friendly_error(target: str) -> PluginManifest:
+    """Load a manifest, printing a nicely-formatted error on failure."""
+    path = _resolve_manifest_path(target)
+    try:
+        return load_manifest(path)
+    except PluginManifestError as exc:
+        loc = exc.json_pointer if exc.json_pointer else "(root)"
+        print_error(
+            f"manifest invalid:\n  path: {exc.path}\n  at: {loc}\n  expected: {exc.expected}\n  got: {exc.got}"
+        )
+        raise typer.Exit(code=1) from exc
+
+
+def _trust_state_label(
+    manifest: PluginManifest,
+    trust_store: TrustStore,
+) -> str:
+    if manifest.source.type == "first_party":
+        return "first_party"
+    record = trust_store.read(manifest.name)
+    if record is not None and record.granted_scopes:
+        return "trusted"
+    return "installed"
+
+
+# ---------------------------------------------------------------------------
+# Read-only subcommands
+# ---------------------------------------------------------------------------
+
+
+@app.command("discover")
+def discover_command(
+    target: Annotated[
+        str,
+        typer.Argument(help="Path to a plugin directory or its ouroboros.plugin.json file."),
+    ],
+) -> None:
+    """Inspect a manifest without registering or granting trust.
+
+    `discover` is the safest command in the manager — it neither writes to
+    the lockfile nor reads the trust store.
+    """
+    manifest = _load_with_friendly_error(target)
+    print_success(f"manifest valid: {manifest.name} {manifest.version}")
+    console.print(f"  schema_version: {manifest.schema_version}")
+    console.print(f"  source.type:    {manifest.source.type}")
+    console.print(f"  description:    {manifest.description or '(none)'}")
+    console.print(
+        f"  commands:       {len(manifest.commands)} "
+        f"in namespace {manifest.commands[0].namespace!r}"
+    )
+    console.print(f"  capabilities:   {len(manifest.capabilities)}")
+    console.print(f"  permissions:    {len(manifest.permissions)}")
+    required_perms = [p for p in manifest.permissions if p.required]
+    if required_perms:
+        console.print("  required scopes (must be trusted before invocation):")
+        for perm in required_perms:
+            console.print(f"    - {perm.scope} ({perm.risk})")
+
+
+@app.command("inspect")
+def inspect_command(
+    name: Annotated[str, typer.Argument(help="Installed plugin name.")],
+    lockfile_path: Annotated[
+        Path | None,
+        typer.Option("--lockfile", help="Override the lockfile path (default: ~/.ouroboros/plugins.lock)."),
+    ] = None,
+    trust_root: Annotated[
+        Path | None,
+        typer.Option("--trust-root", help="Override the trust root (default: ~/.ouroboros/plugins)."),
+    ] = None,
+) -> None:
+    """Show installed plugin metadata + trust state.
+
+    Unlike `discover`, this reads the lockfile and trust store. It still
+    does not mutate any state.
+    """
+    lock = Lockfile(lockfile_path or DEFAULT_LOCKFILE_PATH)
+    trust = TrustStore(root=trust_root or DEFAULT_TRUST_ROOT)
+
+    entries = lock.read()
+    entry = entries.get(name)
+    if entry is None:
+        print_error(f"{name!r} is not installed (no entry in {lock.path})")
+        raise typer.Exit(code=1)
+
+    manifest_path = Path(entry.plugin_home).expanduser() / "ouroboros.plugin.json"
+    try:
+        manifest = load_manifest(manifest_path)
+    except PluginManifestError as exc:
+        print_error(
+            f"installed manifest is invalid: {exc.path}: "
+            f"{exc.json_pointer or '(root)'}: {exc.args[0] if exc.args else ''}"
+        )
+        raise typer.Exit(code=1) from exc
+
+    record = trust.read(name)
+    granted = [g.scope for g in record.granted_scopes] if record else []
+
+    print_info(f"{manifest.name} {manifest.version} ({entry.source_kind})")
+    console.print(f"  installed_at:   {entry.installed_at}")
+    console.print(f"  plugin_home:    {entry.plugin_home}")
+    if entry.repository:
+        console.print(f"  repository:     {entry.repository}")
+    if entry.git_sha:
+        console.print(f"  git_sha:        {entry.git_sha}")
+    console.print(f"  trust_state:    {_trust_state_label(manifest, trust)}")
+    console.print(
+        f"  granted_scopes: {', '.join(granted) if granted else '(none)'}"
+    )
+    required_perms = [p.scope for p in manifest.permissions if p.required]
+    missing = [s for s in required_perms if s not in granted]
+    if missing:
+        console.print(
+            f"  missing scopes: {', '.join(missing)} "
+            f"(invocation will be blocked until granted)"
+        )
+
+
+@app.command("list")
+def list_command(
+    lockfile_path: Annotated[
+        Path | None,
+        typer.Option("--lockfile", help="Override the lockfile path (default: ~/.ouroboros/plugins.lock)."),
+    ] = None,
+    trust_root: Annotated[
+        Path | None,
+        typer.Option("--trust-root", help="Override the trust root (default: ~/.ouroboros/plugins)."),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit JSON for piping; suppresses table formatting."),
+    ] = False,
+) -> None:
+    """List installed plugins with their trust state."""
+    lock = Lockfile(lockfile_path or DEFAULT_LOCKFILE_PATH)
+    trust = TrustStore(root=trust_root or DEFAULT_TRUST_ROOT)
+
+    entries = lock.read()
+    if not entries:
+        if json_output:
+            # Plain stdout (no Rich highlighting) so consumers can pipe to jq.
+            typer.echo(json.dumps([]))
+        else:
+            print_info("no plugins installed")
+        return
+
+    rows = []
+    for entry in sorted(entries.values(), key=lambda e: e.name):
+        record = trust.read(entry.name)
+        scopes = [g.scope for g in record.granted_scopes] if record else []
+        rows.append(
+            {
+                "name": entry.name,
+                "version": entry.version,
+                "source_kind": entry.source_kind,
+                "trust_state": "trusted" if scopes else "installed",
+                "granted_scopes": scopes,
+            }
+        )
+
+    if json_output:
+        # Plain stdout (no Rich highlighting) so consumers can pipe to jq.
+        typer.echo(json.dumps(rows, indent=2))
+        return
+
+    table = create_table(title="Installed UserLevel plugins")
+    for column in ("name", "version", "source", "trust", "scopes"):
+        table.add_column(column)
+    for row in rows:
+        table.add_row(
+            row["name"],
+            row["version"],
+            row["source_kind"],
+            row["trust_state"],
+            ", ".join(row["granted_scopes"]) or "(none)",
+        )
+    print_table(table)
+
+
+__all__ = [
+    "app",
+    "discover_command",
+    "inspect_command",
+    "list_command",
+]

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -58,25 +58,37 @@ def _resolve_manifest_path(target: str) -> Path:
 
 
 def _load_with_friendly_error(target: str) -> PluginManifest:
-    """Load a manifest, printing a nicely-formatted error on failure."""
+    """Load a manifest, printing a nicely-formatted error on failure.
+
+    `load_manifest` already converts every load-time failure
+    (permission denied, JSON decode, schema violation, unsupported
+    schema_version) into a structured `PluginManifestError` with the
+    user-facing message in `args[0]`. The CLI surfaces that message as
+    the leading line so operators can tell "manifest is unreadable"
+    apart from "manifest invalid" without us re-deriving the
+    classification from `expected`/`got`.
+    """
     path = _resolve_manifest_path(target)
     try:
         return load_manifest(path)
     except PluginManifestError as exc:
         loc = exc.json_pointer if exc.json_pointer else "(root)"
+        message = exc.args[0] if exc.args else ""
+        # Most paths inside `load_manifest` already produce a self-
+        # describing message ("manifest is unreadable: …", "manifest is
+        # not valid JSON: …"). The jsonschema-driven validation path
+        # surfaces a raw schema error string (e.g. "'Bad Name' does
+        # not match '^[a-z…'"), which on its own does not say *what*
+        # is wrong. Add the "manifest invalid:" prefix only in that
+        # case so unreadable / decode-failure messages stay precise.
+        if not message.startswith("manifest"):
+            message = f"manifest invalid: {message}"
         print_error(
-            f"manifest invalid:\n  path: {exc.path}\n  at: {loc}\n  expected: {exc.expected}\n  got: {exc.got}"
-        )
-        raise typer.Exit(code=1) from exc
-    except OSError as exc:
-        # Mirror the inspect/list error path: `discover` is also a
-        # diagnostic command, so an unreadable manifest (broken
-        # symlink, wrong permissions, transient I/O) must surface as a
-        # clean message instead of bubbling a raw OSError.
-        print_error(
-            f"manifest is unreadable: {path}: {exc}\n"
-            f"  Check the path and file permissions; "
-            f"`ooo plugin discover` cannot proceed without it."
+            f"{message}\n"
+            f"  path: {exc.path}\n"
+            f"  at: {loc}\n"
+            f"  expected: {exc.expected}\n"
+            f"  got: {exc.got}"
         )
         raise typer.Exit(code=1) from exc
 

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -74,6 +74,14 @@ _STATE_FILE_ERRORS: tuple[type[Exception], ...] = (
     ValueError,  # schema_version mismatch raised by Lockfile.read / TrustStore.read
     tomllib.TOMLDecodeError,
     json.JSONDecodeError,
+    # Lockfile.read / TrustStore.read build dataclasses via unchecked
+    # `raw["field"]` lookups. A parseable-but-structurally-corrupt state
+    # file (missing `name`, wrong field type) therefore raises KeyError
+    # / TypeError. These commands are diagnostic — every shape of
+    # damaged state file must surface a friendly error, not a raw
+    # traceback.
+    KeyError,
+    TypeError,
     OSError,  # permission/IO errors on the state files themselves
 )
 
@@ -233,6 +241,16 @@ def inspect_command(
             f"{exc.json_pointer or '(root)'}: {exc.args[0] if exc.args else ''}"
         )
         raise typer.Exit(code=1) from exc
+    except OSError as exc:
+        # `load_manifest` opens the file directly; an unreadable manifest
+        # (wrong permissions, broken symlink, vanished plugin_home) bubbles
+        # raw OSError. Diagnostic CLI must convert that to a clean message.
+        print_error(
+            f"installed manifest is unreadable: {manifest_path}: {exc}\n"
+            f"  Check the plugin_home path and permissions; "
+            f"`ooo plugin inspect` cannot proceed without it."
+        )
+        raise typer.Exit(code=1) from exc
 
     record = _read_trust_or_exit(trust, name)
     granted = [g.scope for g in record.granted_scopes] if record else []
@@ -305,11 +323,12 @@ def list_command(
             manifest = load_manifest(manifest_path)
             trust_state = _trust_state_label(manifest, record)
             missing = _missing_required(manifest, record)
-        except PluginManifestError:
-            # Lockfile entry exists but the on-disk manifest is broken.
-            # We cannot prove "trusted" without the manifest, so report
-            # "installed" — the safer default — and surface the missing
-            # required-scope set as unknown.
+        except (PluginManifestError, OSError):
+            # Lockfile entry exists but the on-disk manifest is broken
+            # (schema-invalid) or unreadable (vanished/permissions). We
+            # cannot prove "trusted" without it, so report "installed"
+            # — the safer default — and surface the missing
+            # required-scope set as unknown rather than crash the row.
             trust_state = "installed"
             missing = []
         rows.append(

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -263,7 +263,15 @@ def inspect_command(
         )
         raise typer.Exit(code=1) from exc
 
-    record = _read_trust_or_exit(trust, name)
+    # First-party plugins ship inside the binary and the firewall
+    # ignores their trust file by design (Q00/ouroboros-plugins#8). A
+    # leftover/corrupt `trust.json` for such a plugin must not make
+    # `inspect` fail — the correct authoritative state for first-party
+    # is "first_party with no scopes", read straight from the manifest.
+    if manifest.source.type == "first_party":
+        record = None
+    else:
+        record = _read_trust_or_exit(trust, name)
     granted = [g.scope for g in record.granted_scopes] if record else []
 
     print_info(f"{manifest.name} {manifest.version} ({entry.source_kind})")
@@ -324,14 +332,52 @@ def list_command(
 
     rows = []
     for entry in sorted(entries.values(), key=lambda e: e.name):
-        record = _read_trust_or_exit(trust, entry.name)
-        scopes = [g.scope for g in record.granted_scopes] if record else []
         # Re-load the manifest so trust_state reflects the same gate the
         # firewall enforces (required-scope set + version match), not
-        # just "did the user grant any scope at all".
+        # just "did the user grant any scope at all". Reading the
+        # manifest first also lets us skip the trust.json read for
+        # first-party plugins, which the firewall ignores by design —
+        # a leftover trust file there must not make `list` fail.
         manifest_path = Path(entry.plugin_home).expanduser() / "ouroboros.plugin.json"
+        manifest: PluginManifest | None
         try:
             manifest = load_manifest(manifest_path)
+        except (PluginManifestError, OSError):
+            manifest = None
+
+        if manifest is not None and manifest.source.type == "first_party":
+            record = None
+        elif manifest is not None:
+            record = _read_trust_or_exit(trust, entry.name)
+        else:
+            # Manifest unreadable — fall through to the
+            # safe-default branch below; reading trust here would still
+            # require an exit_or path, but we don't yet know the
+            # source.type, so skip and report stale-but-known state.
+            record = _read_trust_or_exit(trust, entry.name)
+
+        # Stale-version trust files: the firewall treats them as
+        # invalidated, so the JSON view should not echo grants that
+        # are no longer effective. Mirror the `inspect` warning by
+        # zero-ing out scopes when the record's version no longer
+        # matches the manifest, and surface a `trust_version_stale`
+        # flag so consumers can branch deterministically.
+        stale_version = bool(
+            manifest is not None and record is not None and record.version != manifest.version
+        )
+        if stale_version:
+            scopes: list[str] = []
+        else:
+            scopes = [g.scope for g in record.granted_scopes] if record else []
+        try:
+            if manifest is None:
+                raise PluginManifestError(
+                    "manifest unreadable",
+                    path=str(manifest_path),
+                    json_pointer=None,
+                    expected="readable",
+                    got="missing",
+                )
             trust_state = _trust_state_label(manifest, record)
             missing = _missing_required(manifest, record)
         except (PluginManifestError, OSError):
@@ -350,6 +396,10 @@ def list_command(
                 "trust_state": trust_state,
                 "granted_scopes": scopes,
                 "missing_required_scopes": missing,
+                # Explicit signal so JSON consumers don't have to compare
+                # versions themselves to know the grants in `trust.json`
+                # were already invalidated by a version bump.
+                "trust_version_stale": stale_version,
             }
         )
 

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -350,11 +350,17 @@ def list_command(
         elif manifest is not None:
             record = _read_trust_or_exit(trust, entry.name)
         else:
-            # Manifest unreadable — fall through to the
-            # safe-default branch below; reading trust here would still
-            # require an exit_or path, but we don't yet know the
-            # source.type, so skip and report stale-but-known state.
-            record = _read_trust_or_exit(trust, entry.name)
+            # Manifest unreadable: we can't tell whether this is a
+            # first-party plugin (trust ignored) or a third-party one
+            # whose grants need showing, and the row is already going
+            # to fall through to the safe-default "installed" branch
+            # below. Reading trust.json here would only add a second
+            # crash path — a corrupt trust.json on top of an
+            # unreadable manifest would abort the entire `list`
+            # output, which defeats the diagnostic purpose of the
+            # command. Skip the trust read and report the row as
+            # safely degraded.
+            record = None
 
         # Stale-version trust files: the firewall treats them as
         # invalidated, so the JSON view should not echo grants that

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -159,11 +159,15 @@ def inspect_command(
     name: Annotated[str, typer.Argument(help="Installed plugin name.")],
     lockfile_path: Annotated[
         Path | None,
-        typer.Option("--lockfile", help="Override the lockfile path (default: ~/.ouroboros/plugins.lock)."),
+        typer.Option(
+            "--lockfile", help="Override the lockfile path (default: ~/.ouroboros/plugins.lock)."
+        ),
     ] = None,
     trust_root: Annotated[
         Path | None,
-        typer.Option("--trust-root", help="Override the trust root (default: ~/.ouroboros/plugins)."),
+        typer.Option(
+            "--trust-root", help="Override the trust root (default: ~/.ouroboros/plugins)."
+        ),
     ] = None,
 ) -> None:
     """Show installed plugin metadata + trust state.
@@ -201,9 +205,7 @@ def inspect_command(
     if entry.git_sha:
         console.print(f"  git_sha:        {entry.git_sha}")
     console.print(f"  trust_state:    {_trust_state_label(manifest, record)}")
-    console.print(
-        f"  granted_scopes: {', '.join(granted) if granted else '(none)'}"
-    )
+    console.print(f"  granted_scopes: {', '.join(granted) if granted else '(none)'}")
     if record is not None and record.version != manifest.version:
         # Loud signal so users understand why "trust_state" flipped back
         # to installed even though the trust file still lists grants.
@@ -215,8 +217,7 @@ def inspect_command(
     missing = _missing_required(manifest, record)
     if missing:
         console.print(
-            f"  missing scopes: {', '.join(missing)} "
-            f"(invocation will be blocked until granted)"
+            f"  missing scopes: {', '.join(missing)} (invocation will be blocked until granted)"
         )
 
 
@@ -224,11 +225,15 @@ def inspect_command(
 def list_command(
     lockfile_path: Annotated[
         Path | None,
-        typer.Option("--lockfile", help="Override the lockfile path (default: ~/.ouroboros/plugins.lock)."),
+        typer.Option(
+            "--lockfile", help="Override the lockfile path (default: ~/.ouroboros/plugins.lock)."
+        ),
     ] = None,
     trust_root: Annotated[
         Path | None,
-        typer.Option("--trust-root", help="Override the trust root (default: ~/.ouroboros/plugins)."),
+        typer.Option(
+            "--trust-root", help="Override the trust root (default: ~/.ouroboros/plugins)."
+        ),
     ] = None,
     json_output: Annotated[
         bool,
@@ -255,9 +260,7 @@ def list_command(
         # Re-load the manifest so trust_state reflects the same gate the
         # firewall enforces (required-scope set + version match), not
         # just "did the user grant any scope at all".
-        manifest_path = (
-            Path(entry.plugin_home).expanduser() / "ouroboros.plugin.json"
-        )
+        manifest_path = Path(entry.plugin_home).expanduser() / "ouroboros.plugin.json"
         try:
             manifest = load_manifest(manifest_path)
             trust_state = _trust_state_label(manifest, record)

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -22,6 +22,7 @@ from ouroboros.cli.commands import (
     detect,
     init,
     mcp,
+    plugin,
     pm,
     resume,
     run,
@@ -53,6 +54,7 @@ app.add_typer(setup.app, name="setup")
 app.add_typer(detect.app, name="detect")
 app.add_typer(tui.app, name="tui")
 app.add_typer(pm.app, name="pm")
+app.add_typer(plugin.app, name="plugin")
 app.add_typer(resume.app, name="resume")
 app.add_typer(uninstall.app, name="uninstall")
 

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -172,6 +172,16 @@ def _resolve_plugin_cwd(manifest: PluginManifest) -> str | None:
     first-party plugins (which ship inside the binary) and any source
     type without a usable path, returns None and the subprocess
     inherits the caller's cwd.
+
+    A missing `source.path` directory does NOT fall back to the
+    caller's cwd — that fallback would silently execute a relative
+    entrypoint like `./run.sh` against whatever directory the
+    operator happened to start `ooo` in, potentially running the
+    wrong program or reading unrelated files. The firewall instead
+    returns the (non-existent) candidate path so `subprocess.run`
+    raises `OSError(ENOENT)`, which `invoke_plugin` already converts
+    into a clean terminal `plugin.failed` event with the missing-dir
+    reason in the message.
     """
     src = manifest.source
     if src.type not in {"local_path", "plugin_home"}:
@@ -179,15 +189,8 @@ def _resolve_plugin_cwd(manifest: PluginManifest) -> str | None:
     if not src.path:
         return None
     candidate = Path(src.path).expanduser()
-    # Only anchor when the directory actually exists. The firewall
-    # already converts spawn-time OSError to `plugin.failed`, so a
-    # missing dir would surface there with a clean message; we just
-    # don't want subprocess.run to raise FileNotFoundError before we
-    # even get to record the launch event.
-    if not candidate.is_dir():
-        return None
     try:
-        return str(candidate.resolve())
+        return str(candidate.resolve(strict=False))
     except OSError:  # pragma: no cover — unresolvable symlink on weird FS
         return str(candidate)
 

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -333,7 +333,35 @@ def invoke_plugin(
 
     # 5. Run entrypoint out-of-process.
     cmd_template = manifest.entrypoint.command
-    cmd_template_parts = shlex.split(cmd_template)
+    try:
+        cmd_template_parts = shlex.split(cmd_template)
+    except ValueError as exc:
+        # Malformed shell quoting (e.g. an unterminated quote like
+        # `"unterminated`) passes the schema's `\\S` pattern check
+        # but explodes inside `shlex.split()`. The firewall's
+        # contract is to surface every launch failure as a terminal
+        # `plugin.failed` event with audit output, never to raise
+        # out of `invoke_plugin`. Treat malformed quoting the same
+        # way as the empty-command case below.
+        message = f"entrypoint command has malformed quoting: {exc}"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={"correlation_id": correlation_id},
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=126,
+            message=message,
+            events=tuple(emitted),
+        )
     if not cmd_template_parts:
         # The schema rejects an empty `command`, but a whitespace-only
         # value historically slipped through and `shlex.split(" ")` returns

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -30,18 +30,17 @@ ledger writer (#737). Tests pass a list-appender for inspection.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 import hashlib
 import shlex
 import subprocess
-from collections.abc import Callable
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Iterable, Literal
+from typing import Literal
 
 from ouroboros.plugin.manifest import PluginManifest
 from ouroboros.plugin.trust_store import TrustRecord
 from ouroboros.plugin.userlevel_registry import RegisteredProgram
-
 
 SCHEMA_VERSION = "0.1"
 
@@ -60,7 +59,7 @@ class InvocationResult:
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _source_type_for_event(manifest: PluginManifest) -> str:
@@ -108,17 +107,6 @@ def _required_permissions(manifest: PluginManifest) -> list[str]:
     return [p.scope for p in manifest.permissions if p.required]
 
 
-def _trust_state_label(
-    manifest: PluginManifest,
-    trust_record: TrustRecord | None,
-) -> str:
-    if manifest.source.type == "first_party":
-        return "first_party"
-    if trust_record is not None and trust_record.granted_scopes:
-        return "trusted"
-    return "installed"
-
-
 def _missing_required(
     manifest: PluginManifest,
     trust_record: TrustRecord | None,
@@ -128,7 +116,36 @@ def _missing_required(
         return []
     if trust_record is None:
         return list(required)
+    # Per Q00/ouroboros-plugins#9 Q4: a version bump invalidates prior
+    # trust. If the trust file's recorded version no longer matches the
+    # manifest, treat the record as if no scopes were granted — the user
+    # must re-trust after upgrading. Without this guard a stale trust
+    # file from an older release would still satisfy the firewall and
+    # silently bypass the version-bump invalidation contract.
+    if trust_record.version != manifest.version:
+        return list(required)
     return trust_record.missing(required)
+
+
+def _trust_state_label(
+    manifest: PluginManifest,
+    trust_record: TrustRecord | None,
+) -> str:
+    if manifest.source.type == "first_party":
+        return "first_party"
+    if trust_record is None:
+        return "installed"
+    # Stale-version trust counts as not yet trusted (locked Q4).
+    if trust_record.version != manifest.version:
+        return "installed"
+    # Required scopes still missing → CLI/firewall will block invocation,
+    # so reporting "trusted" here would lie to operators. Only mark the
+    # plugin trusted once the required-scope set is fully satisfied.
+    if _missing_required(manifest, trust_record):
+        return "installed"
+    if trust_record.granted_scopes:
+        return "trusted"
+    return "installed"
 
 
 def _format_blocked_message(plugin_name: str, missing: list[str], risks: dict[str, str]) -> str:
@@ -292,8 +309,23 @@ def invoke_plugin(
             text=True,
             check=False,
         )
-    except FileNotFoundError as exc:
-        message = f"entrypoint not found: {cmd_argv[0]!r} ({exc})"
+    except OSError as exc:
+        # Broader than FileNotFoundError so the firewall always reaches
+        # a terminal `plugin.failed` event instead of crashing the
+        # caller. Covers PermissionError (exec bit not set) and other
+        # OSError subclasses such as `[Errno 8] Exec format error`
+        # (ENOEXEC) on platforms where subprocess surfaces them at
+        # spawn-time. Conventional shell exit codes: 127 for
+        # "command not found", 126 for "found but not executable".
+        if isinstance(exc, FileNotFoundError):
+            message = f"entrypoint not found: {cmd_argv[0]!r} ({exc})"
+            exit_code = 127
+        elif isinstance(exc, PermissionError):
+            message = f"entrypoint not executable: {cmd_argv[0]!r} ({exc})"
+            exit_code = 126
+        else:
+            message = f"entrypoint failed to launch: {cmd_argv[0]!r} ({exc})"
+            exit_code = 126
         _emit(
             _event_envelope(
                 event_type="plugin.failed",
@@ -308,7 +340,7 @@ def invoke_plugin(
         )
         return InvocationResult(
             status="failed",
-            exit_code=127,
+            exit_code=exit_code,
             message=message,
             events=tuple(emitted),
         )

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -34,6 +34,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import hashlib
+from pathlib import Path
 import shlex
 import subprocess
 from typing import Literal
@@ -160,6 +161,35 @@ def _format_blocked_message(plugin_name: str, missing: list[str], risks: dict[st
 
 def _scope_risk_index(manifest: PluginManifest) -> dict[str, str]:
     return {p.scope: p.risk for p in manifest.permissions}
+
+
+def _resolve_plugin_cwd(manifest: PluginManifest) -> str | None:
+    """Working directory the firewall should anchor the subprocess in.
+
+    Returns the manifest's source path (resolved to absolute) for
+    `local_path` / `plugin_home` plugins so relative entrypoints and
+    file accesses don't depend on where `ooo` was invoked from. For
+    first-party plugins (which ship inside the binary) and any source
+    type without a usable path, returns None and the subprocess
+    inherits the caller's cwd.
+    """
+    src = manifest.source
+    if src.type not in {"local_path", "plugin_home"}:
+        return None
+    if not src.path:
+        return None
+    candidate = Path(src.path).expanduser()
+    # Only anchor when the directory actually exists. The firewall
+    # already converts spawn-time OSError to `plugin.failed`, so a
+    # missing dir would surface there with a clean message; we just
+    # don't want subprocess.run to raise FileNotFoundError before we
+    # even get to record the launch event.
+    if not candidate.is_dir():
+        return None
+    try:
+        return str(candidate.resolve())
+    except OSError:  # pragma: no cover — unresolvable symlink on weird FS
+        return str(candidate)
 
 
 def invoke_plugin(
@@ -300,7 +330,41 @@ def invoke_plugin(
 
     # 5. Run entrypoint out-of-process.
     cmd_template = manifest.entrypoint.command
-    cmd_argv = shlex.split(cmd_template) + [command_name] + list(argv)
+    cmd_template_parts = shlex.split(cmd_template)
+    if not cmd_template_parts:
+        # The schema rejects an empty `command`, but a whitespace-only
+        # value historically slipped through and `shlex.split(" ")` returns
+        # `[]`. The firewall contract is to fail cleanly with a terminal
+        # `plugin.failed` event on any launch error — never raise out of
+        # `invoke_plugin`. Treat this as an unbuildable entrypoint.
+        message = f"entrypoint command is empty or whitespace: {cmd_template!r}"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={"correlation_id": correlation_id},
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=126,
+            message=message,
+            events=tuple(emitted),
+        )
+    cmd_argv = cmd_template_parts + [command_name] + list(argv)
+
+    # Compute the working directory the entrypoint should run in.
+    # `local_path` / `plugin_home` manifests carry their own location;
+    # relative entrypoints like `./run.sh` and commands that read files
+    # from the plugin directory only work when the subprocess is anchored
+    # there. `first_party` plugins ship inside the binary and have no
+    # plugin-local directory, so we let them inherit the caller's cwd.
+    cwd = _resolve_plugin_cwd(manifest)
     runner = subprocess_runner or subprocess.run
     try:
         completed = runner(
@@ -308,6 +372,7 @@ def invoke_plugin(
             capture_output=True,
             text=True,
             check=False,
+            cwd=cwd,
         )
     except OSError as exc:
         # Broader than FileNotFoundError so the firewall always reaches

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -1,0 +1,380 @@
+"""Plugin invocation firewall.
+
+Every UserLevel plugin command must pass through `invoke_plugin`. The
+firewall is the single chokepoint that:
+
+  1. Pre-invocation trust check (locked Q1 of Q00/ouroboros-plugins#9):
+     refuse + clean error if a `required: true` permission is not trusted;
+     emit only `plugin.failed (status=blocked)`. NO `plugin.invoked` is
+     emitted in this case.
+  2. Single confirmation gate (locked Q2): if the command sets
+     `requires_confirmation: true`, prompt the user once. No second
+     prompt for permission risk.
+  3. Emit `plugin.invoked` before launching the entrypoint subprocess.
+  4. Emit `plugin.permission_used` for each `required: true` permission
+     declared by the manifest. v0 uses Option (a): coarse declared-set
+     emission, not per-call granular tracking.
+  5. Run the entrypoint out-of-process via subprocess.
+  6. Emit `plugin.completed` (status=success) or `plugin.failed`
+     (status=failed) on terminal.
+
+Audit events conform to schemas/0.1/audit-event.schema.json. Bounded
+payloads: argv stored as-is, raw stdout/stderr replaced with a sha256
+hash. Tokens, channel IDs, free-form user messages are forbidden by
+contract.
+
+The firewall does NOT own the audit log. Callers pass an `event_sink`
+(any callable taking a dict) which is typically wired to the core
+ledger writer (#737). Tests pass a list-appender for inspection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Literal
+
+from ouroboros.plugin.manifest import PluginManifest
+from ouroboros.plugin.trust_store import TrustRecord
+from ouroboros.plugin.userlevel_registry import RegisteredProgram
+
+
+SCHEMA_VERSION = "0.1"
+
+EventSink = Callable[[dict], None]
+ConfirmFn = Callable[[str], bool]
+
+
+@dataclass(frozen=True)
+class InvocationResult:
+    status: Literal["success", "blocked", "failed"]
+    exit_code: int | None = None
+    message: str = ""
+    stdout_sha256: str | None = None
+    stderr_sha256: str | None = None
+    events: tuple[dict, ...] = field(default_factory=tuple)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _source_type_for_event(manifest: PluginManifest) -> str:
+    return manifest.source.type
+
+
+def _event_envelope(
+    *,
+    event_type: str,
+    manifest: PluginManifest,
+    namespace: str,
+    command_name: str,
+    argv: list[str] | None,
+    trust_state: str,
+    capabilities_used: Iterable[str] = (),
+    permissions_used: Iterable[str] = (),
+    result: dict | None = None,
+    provenance: dict[str, str] | None = None,
+) -> dict:
+    """Build an event matching schemas/0.1/audit-event.schema.json."""
+    cmd: dict = {"namespace": namespace, "name": command_name}
+    if argv is not None:
+        cmd["argv"] = list(argv)
+    event: dict = {
+        "schema_version": SCHEMA_VERSION,
+        "event_type": event_type,
+        "occurred_at": _utc_now_iso(),
+        "plugin": {
+            "name": manifest.name,
+            "version": manifest.version,
+            "source_type": _source_type_for_event(manifest),
+        },
+        "command": cmd,
+        "trust_state": trust_state,
+        "capabilities_used": list(capabilities_used),
+        "permissions_used": list(permissions_used),
+        "result": result or {"status": "success"},
+    }
+    if provenance is not None:
+        event["provenance"] = dict(provenance)
+    return event
+
+
+def _required_permissions(manifest: PluginManifest) -> list[str]:
+    return [p.scope for p in manifest.permissions if p.required]
+
+
+def _trust_state_label(
+    manifest: PluginManifest,
+    trust_record: TrustRecord | None,
+) -> str:
+    if manifest.source.type == "first_party":
+        return "first_party"
+    if trust_record is not None and trust_record.granted_scopes:
+        return "trusted"
+    return "installed"
+
+
+def _missing_required(
+    manifest: PluginManifest,
+    trust_record: TrustRecord | None,
+) -> list[str]:
+    required = _required_permissions(manifest)
+    if not required:
+        return []
+    if trust_record is None:
+        return list(required)
+    return trust_record.missing(required)
+
+
+def _format_blocked_message(plugin_name: str, missing: list[str], risks: dict[str, str]) -> str:
+    """Per locked Q1: name the missing scope and the exact trust command."""
+    first = missing[0]
+    risk = risks.get(first, "?")
+    return (
+        f"plugin requires `{first}` ({risk}), which is not yet trusted. "
+        f"Run: ooo plugin trust {plugin_name} --scope {first}"
+    )
+
+
+def _scope_risk_index(manifest: PluginManifest) -> dict[str, str]:
+    return {p.scope: p.risk for p in manifest.permissions}
+
+
+def invoke_plugin(
+    program: RegisteredProgram,
+    *,
+    command_name: str,
+    argv: list[str],
+    trust_record: TrustRecord | None,
+    event_sink: EventSink,
+    correlation_id: str,
+    confirm: ConfirmFn = lambda _msg: True,
+    subprocess_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> InvocationResult:
+    """Invoke a UserLevel plugin command through the firewall.
+
+    Args:
+        program: Registered UserLevel program (from `userlevel_registry`).
+        command_name: The name of the command within the plugin's namespace.
+        argv: User-provided argument vector for the command.
+        trust_record: The plugin's TrustRecord (None if not yet trusted).
+            For first-party programs, may be None — the firewall does not
+            consult it for them.
+        event_sink: Callable that receives audit events. Wire to the core
+            ledger writer (#737) in production; pass `events.append` in
+            tests.
+        correlation_id: Cross-event correlation id for the ledger.
+        confirm: Optional callable for confirmation prompts. Default is
+            "auto-confirm" (returns True). CLI passes a function that
+            actually prompts.
+        subprocess_runner: Optional override (for tests) of subprocess.run.
+
+    Returns:
+        `InvocationResult` with status, exit code, sha256 hashes of
+        stdout/stderr, and the events emitted (also pushed to event_sink).
+    """
+    manifest = program.manifest
+    namespace = program.namespace
+    command = program.find_command(command_name)
+    if command is None:
+        # Treat unknown command as a failure that emits no events — the
+        # caller (CLI) is responsible for surfacing this. Returning a
+        # failed result keeps the contract simple.
+        return InvocationResult(
+            status="failed",
+            exit_code=2,
+            message=f"unknown command {command_name!r} in namespace {namespace!r}",
+        )
+
+    trust_state = _trust_state_label(manifest, trust_record)
+    risks = _scope_risk_index(manifest)
+    emitted: list[dict] = []
+
+    def _emit(event: dict) -> None:
+        event_sink(event)
+        emitted.append(event)
+
+    # 1. Pre-invocation trust check (locked Q1).
+    # First-party programs skip the trust check (per Q00/ouroboros-plugins#8).
+    if manifest.source.type != "first_party":
+        missing = _missing_required(manifest, trust_record)
+        if missing:
+            message = _format_blocked_message(manifest.name, missing, risks)
+            _emit(
+                _event_envelope(
+                    event_type="plugin.failed",
+                    manifest=manifest,
+                    namespace=namespace,
+                    command_name=command_name,
+                    argv=argv,
+                    trust_state=trust_state,
+                    result={"status": "blocked", "message": message},
+                    provenance={"correlation_id": correlation_id},
+                )
+            )
+            return InvocationResult(
+                status="blocked",
+                exit_code=None,
+                message=message,
+                events=tuple(emitted),
+            )
+
+    # 2. Confirmation gate (locked Q2 — ONE prompt, command-level).
+    if command.requires_confirmation:
+        prompt = (
+            f"This command is destructive and requires confirmation.\n"
+            f"Plugin: {manifest.name} {manifest.version}\n"
+            f"Action: {command_name} {' '.join(argv)}\n"
+            f"Continue?"
+        )
+        if not confirm(prompt):
+            message = "user declined confirmation"
+            _emit(
+                _event_envelope(
+                    event_type="plugin.failed",
+                    manifest=manifest,
+                    namespace=namespace,
+                    command_name=command_name,
+                    argv=argv,
+                    trust_state=trust_state,
+                    result={"status": "blocked", "message": message},
+                    provenance={"correlation_id": correlation_id},
+                )
+            )
+            return InvocationResult(
+                status="blocked",
+                exit_code=None,
+                message=message,
+                events=tuple(emitted),
+            )
+
+    # 3. Emit `plugin.invoked` before launch.
+    _emit(
+        _event_envelope(
+            event_type="plugin.invoked",
+            manifest=manifest,
+            namespace=namespace,
+            command_name=command_name,
+            argv=argv,
+            trust_state=trust_state,
+            provenance={"correlation_id": correlation_id},
+        )
+    )
+
+    # 4. Emit one `plugin.permission_used` per required permission.
+    for scope in _required_permissions(manifest):
+        _emit(
+            _event_envelope(
+                event_type="plugin.permission_used",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                permissions_used=[scope],
+                provenance={"correlation_id": correlation_id, "scope": scope},
+            )
+        )
+
+    # 5. Run entrypoint out-of-process.
+    cmd_template = manifest.entrypoint.command
+    cmd_argv = shlex.split(cmd_template) + [command_name] + list(argv)
+    runner = subprocess_runner or subprocess.run
+    try:
+        completed = runner(
+            cmd_argv,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        message = f"entrypoint not found: {cmd_argv[0]!r} ({exc})"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={"correlation_id": correlation_id},
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=127,
+            message=message,
+            events=tuple(emitted),
+        )
+
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    stdout_hash = hashlib.sha256(stdout.encode("utf-8")).hexdigest()
+    stderr_hash = hashlib.sha256(stderr.encode("utf-8")).hexdigest()
+
+    # 6. Terminal event: completed or failed.
+    if completed.returncode == 0:
+        _emit(
+            _event_envelope(
+                event_type="plugin.completed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "success"},
+                provenance={
+                    "correlation_id": correlation_id,
+                    "stdout_sha256": stdout_hash,
+                    "stderr_sha256": stderr_hash,
+                },
+            )
+        )
+        return InvocationResult(
+            status="success",
+            exit_code=0,
+            stdout_sha256=stdout_hash,
+            stderr_sha256=stderr_hash,
+            events=tuple(emitted),
+        )
+    else:
+        message = f"entrypoint exited with code {completed.returncode}"
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={
+                    "correlation_id": correlation_id,
+                    "stdout_sha256": stdout_hash,
+                    "stderr_sha256": stderr_hash,
+                },
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=completed.returncode,
+            message=message,
+            stdout_sha256=stdout_hash,
+            stderr_sha256=stderr_hash,
+            events=tuple(emitted),
+        )
+
+
+__all__ = [
+    "ConfirmFn",
+    "EventSink",
+    "InvocationResult",
+    "SCHEMA_VERSION",
+    "invoke_plugin",
+]

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -52,6 +52,7 @@ never persist (tests, schema validators) keep the import surface small.
 from __future__ import annotations
 
 from collections.abc import Callable
+import copy
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 import uuid
@@ -114,7 +115,14 @@ def wrap_plugin_event(
         "aggregate_type": PLUGIN_AGGREGATE_TYPE,
         "aggregate_id": aggregate_id or correlation_id,
         "event_type": audit_event["event_type"],
-        "payload": dict(audit_event),  # shallow copy so callers can't mutate stored form
+        # Deep-copy because audit events carry nested dicts (`plugin`,
+        # `command`, `result`, `provenance`). A shallow `dict(...)` would
+        # share those nested objects, so a caller mutating
+        # `audit_event["plugin"]["name"]` after wrap would silently
+        # corrupt the persisted envelope payload. The dicts are tiny
+        # by contract (no raw stdout/stderr — see firewall bounds), so
+        # the deep copy is cheap and removes the foot-gun entirely.
+        "payload": copy.deepcopy(audit_event),
         "timestamp": audit_event["occurred_at"],
     }
 
@@ -255,7 +263,10 @@ def envelope_to_base_event(
         timestamp=timestamp,
         aggregate_type=PLUGIN_AGGREGATE_TYPE,
         aggregate_id=envelope["aggregate_id"],
-        data=dict(payload),  # frozen BaseEvent: defensive shallow copy
+        # Deep copy for the same reason as `wrap_plugin_event`: payload
+        # has nested dicts (plugin/command/result), and we don't want
+        # later mutation of the envelope to leak into the BaseEvent.
+        data=copy.deepcopy(payload),
     )
 
 

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -52,6 +52,7 @@ never persist (tests, schema validators) keep the import surface small.
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 import uuid
 
@@ -232,13 +233,55 @@ def envelope_to_base_event(
     if not isinstance(payload, dict):
         raise ValueError("envelope payload is missing or not a dict")
 
+    # Carry the original audit time through to BaseEvent.timestamp so
+    # the persisted row reflects when the firewall observed the event,
+    # not when the bridge ran. Without this the EventStore's "now"
+    # default silently rewrites event ordering and recency for plugin
+    # rows. Prefer the envelope's `timestamp` (set by `wrap_plugin_event`
+    # from `audit_event.occurred_at`); fall back to the payload's
+    # `occurred_at` defensively in case a third-party builder skipped
+    # the envelope helper.
+    timestamp_str = envelope.get("timestamp") or payload.get("occurred_at")
+    if not isinstance(timestamp_str, str):
+        raise ValueError(
+            "envelope is missing a string 'timestamp' / payload.occurred_at; "
+            "cannot bridge to BaseEvent without preserving audit time"
+        )
+    timestamp = _parse_audit_timestamp(timestamp_str)
+
     return cls(
         id=envelope["id"],
         type=envelope["event_type"],
+        timestamp=timestamp,
         aggregate_type=PLUGIN_AGGREGATE_TYPE,
         aggregate_id=envelope["aggregate_id"],
         data=dict(payload),  # frozen BaseEvent: defensive shallow copy
     )
+
+
+def _parse_audit_timestamp(value: str) -> datetime:
+    """Parse a firewall audit timestamp into a tz-aware UTC datetime.
+
+    The audit-event schema fixes the wire format at
+    `"%Y-%m-%dT%H:%M:%SZ"` (RFC 3339, second precision, explicit Z).
+    `datetime.fromisoformat` accepts the trailing `Z` from Python 3.11
+    onward, but we normalize defensively for older callers and to
+    surface a clean ValueError with the offending string.
+    """
+    candidate = value.strip()
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise ValueError(
+            f"audit timestamp {value!r} is not RFC 3339; expected 'YYYY-MM-DDTHH:MM:SSZ'"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    else:
+        parsed = parsed.astimezone(UTC)
+    return parsed
 
 
 async def append_envelope_to_event_store(

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -1,0 +1,165 @@
+"""Adapter from firewall audit events to the core event store.
+
+The firewall (`plugin/firewall.py`) emits events that conform to
+`schemas/0.1/audit-event.schema.json`. Those events have
+`additionalProperties: false`, so any wrapping fields the core ledger
+needs (`id`, `aggregate_type`, `aggregate_id`, `timestamp`) MUST live
+in a layer ABOVE the audit-event boundary, not inside it.
+
+This adapter:
+
+  - `wrap_plugin_event(event_dict, *, correlation_id, aggregate_id=None)`
+    returns a row-shaped envelope ready for `persistence.event_store`.
+    The full audit event becomes the `payload`; the envelope adds the
+    fields the core ledger requires.
+
+  - `unwrap_plugin_event(envelope) -> dict`
+    returns the original audit event from a stored envelope. Used by
+    consumers that need to round-trip events back into schema-valid
+    form (e.g. `ooo plugin status` reading the audit trail).
+
+  - `make_event_sink(append_fn, *, correlation_id, ...) -> EventSink`
+    factory that produces a `firewall.EventSink` callable wired to a
+    given append function (signature `append(envelope: dict) -> None`).
+    Production wires it to `EventStore.append`; tests can wire it to a
+    list.
+
+This module deliberately does NOT import `persistence/event_store.py`
+or its async machinery. It speaks the envelope shape, not the store.
+The CLI (#731) is the integration point that takes a real EventStore
+async session and bridges to `append_fn`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+
+PLUGIN_AGGREGATE_TYPE = "plugin"
+
+# Audit event types the firewall may emit. Used by tests + by
+# downstream consumers that want to filter ledger queries.
+AUDIT_EVENT_TYPES: tuple[str, ...] = (
+    "plugin.discovered",
+    "plugin.installed",
+    "plugin.trusted",
+    "plugin.invoked",
+    "plugin.permission_used",
+    "plugin.completed",
+    "plugin.failed",
+)
+
+
+def wrap_plugin_event(
+    audit_event: dict,
+    *,
+    correlation_id: str,
+    aggregate_id: str | None = None,
+    envelope_id: str | None = None,
+) -> dict:
+    """Wrap a plugin audit event in a core-ledger row envelope.
+
+    Args:
+        audit_event: A dict matching schemas/0.1/audit-event.schema.json.
+            This becomes the `payload` field verbatim — the schema's
+            `additionalProperties: false` is preserved by NOT mutating
+            the event in place.
+        correlation_id: Cross-event correlation id (from the firewall).
+            Used as the default `aggregate_id`.
+        aggregate_id: Override for the aggregate id. Defaults to
+            `correlation_id`. Must be a string; the events_table column
+            is `String(36)` so callers should keep it short (UUID-shaped
+            is conventional).
+        envelope_id: Override for the row's UUID. Defaults to a fresh
+            uuid4. Tests pin a specific id for determinism.
+
+    Returns:
+        A dict with the envelope fields (`id`, `aggregate_type`,
+        `aggregate_id`, `event_type`, `payload`, `timestamp`).
+    """
+    if not isinstance(audit_event, dict):
+        raise TypeError(f"audit_event must be dict, got {type(audit_event).__name__}")
+    if "event_type" not in audit_event:
+        raise ValueError("audit_event missing 'event_type'")
+    if "occurred_at" not in audit_event:
+        raise ValueError("audit_event missing 'occurred_at'")
+
+    return {
+        "id": envelope_id or str(uuid.uuid4()),
+        "aggregate_type": PLUGIN_AGGREGATE_TYPE,
+        "aggregate_id": aggregate_id or correlation_id,
+        "event_type": audit_event["event_type"],
+        "payload": dict(audit_event),  # shallow copy so callers can't mutate stored form
+        "timestamp": audit_event["occurred_at"],
+    }
+
+
+def unwrap_plugin_event(envelope: dict) -> dict:
+    """Extract the original audit event from a wrapped envelope.
+
+    Args:
+        envelope: A dict produced by `wrap_plugin_event`, or a row read
+            back from the event store.
+
+    Returns:
+        The original audit event (a dict matching audit-event.schema.json).
+
+    Raises:
+        ValueError: if the envelope is not a plugin envelope or its
+            payload is missing.
+    """
+    agg = envelope.get("aggregate_type")
+    if agg != PLUGIN_AGGREGATE_TYPE:
+        raise ValueError(
+            f"envelope is not a plugin envelope (aggregate_type={agg!r}); "
+            f"expected {PLUGIN_AGGREGATE_TYPE!r}"
+        )
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        raise ValueError("envelope payload is missing or not a dict")
+    return dict(payload)
+
+
+def make_event_sink(
+    append_fn: Callable[[dict], None],
+    *,
+    correlation_id: str,
+    aggregate_id: str | None = None,
+    envelope_id_factory: Callable[[], str] | None = None,
+) -> Callable[[dict], None]:
+    """Build a firewall-compatible `EventSink` that wraps and appends.
+
+    Args:
+        append_fn: Where to append the wrapped envelope. In production,
+            wire to an EventStore.append wrapper. In tests, pass
+            `list.append`.
+        correlation_id: Default aggregate id and forwarded to wrap.
+        aggregate_id: Override.
+        envelope_id_factory: Override for envelope id generation
+            (tests pass a counter).
+
+    Returns:
+        A callable that wraps each audit event and forwards to append_fn.
+    """
+
+    def _sink(audit_event: dict) -> None:
+        envelope = wrap_plugin_event(
+            audit_event,
+            correlation_id=correlation_id,
+            aggregate_id=aggregate_id,
+            envelope_id=envelope_id_factory() if envelope_id_factory else None,
+        )
+        append_fn(envelope)
+
+    return _sink
+
+
+__all__ = [
+    "AUDIT_EVENT_TYPES",
+    "PLUGIN_AGGREGATE_TYPE",
+    "make_event_sink",
+    "unwrap_plugin_event",
+    "wrap_plugin_event",
+]

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -20,20 +20,44 @@ This adapter:
 
   - `make_event_sink(append_fn, *, correlation_id, ...) -> EventSink`
     factory that produces a `firewall.EventSink` callable wired to a
-    given append function (signature `append(envelope: dict) -> None`).
-    Production wires it to `EventStore.append`; tests can wire it to a
-    list.
+    sync `append_fn` whose signature is `(envelope: dict) -> None`.
+    Tests pass `list.append`. Production callers compose this with the
+    bridge helpers below — `EventStore.append` is async and rejects
+    anything that is not a `BaseEvent`, so it MUST NOT be passed to
+    `make_event_sink` directly. The bridge from the dict-shaped
+    envelope to a real EventStore lives in `envelope_to_base_event`
+    and `append_envelope_to_event_store` (the async helper).
+
+  - `envelope_to_base_event(envelope) -> BaseEvent`
+    pure converter from the envelope dict produced by
+    `wrap_plugin_event` to a `BaseEvent` instance the core ledger
+    accepts. Lazy-imports `BaseEvent` so this module stays cheap to
+    import in non-persistence contexts (tests, schema validation).
+
+  - `async append_envelope_to_event_store(envelope, *, store) -> None`
+    awaits `store.append(...)` after converting the envelope. This is
+    the canonical async bridge; firewall integrations running on an
+    asyncio loop should call it directly. For sync stacks (the
+    firewall is sync) the integration layer must hop to the loop —
+    e.g. `asyncio.run_coroutine_threadsafe(...)` — and pass the
+    resulting `Callable[[dict], None]` to `make_event_sink`.
 
 This module deliberately does NOT import `persistence/event_store.py`
-or its async machinery. It speaks the envelope shape, not the store.
-The CLI (#731) is the integration point that takes a real EventStore
-async session and bridges to `append_fn`.
+or its async machinery at module scope. It speaks the envelope shape,
+not the store. The bridge helpers above lazily pull in `BaseEvent` and
+`EventStore` only when they are actually invoked, so callers that
+never persist (tests, schema validators) keep the import surface small.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 import uuid
+
+if TYPE_CHECKING:  # pragma: no cover — typing-only import to avoid cycles
+    from ouroboros.events.base import BaseEvent
+    from ouroboros.persistence.event_store import EventStore
 
 PLUGIN_AGGREGATE_TYPE = "plugin"
 
@@ -130,9 +154,16 @@ def make_event_sink(
     """Build a firewall-compatible `EventSink` that wraps and appends.
 
     Args:
-        append_fn: Where to append the wrapped envelope. In production,
-            wire to an EventStore.append wrapper. In tests, pass
-            `list.append`.
+        append_fn: A SYNC callable accepting the wrapped envelope dict.
+            Tests pass `list.append`. Production callers MUST NOT pass
+            `EventStore.append` directly — that method is async and
+            rejects non-`BaseEvent` payloads. Compose with the bridge
+            helpers in this module: convert to a `BaseEvent` via
+            `envelope_to_base_event` and persist via
+            `append_envelope_to_event_store`, then schedule the
+            coroutine onto the running loop (e.g. with
+            `asyncio.run_coroutine_threadsafe`) to obtain the sync
+            callable this parameter expects.
         correlation_id: Default aggregate id and forwarded to wrap.
         aggregate_id: Override.
         envelope_id_factory: Override for envelope id generation
@@ -154,9 +185,113 @@ def make_event_sink(
     return _sink
 
 
+# ---------------------------------------------------------------------------
+# Bridge to the core EventStore. Lazy imports keep this module cheap.
+# ---------------------------------------------------------------------------
+
+
+# Audit-event types that are still authoritative as `BaseEvent.type` strings
+# for plugin events when persisted in the core ledger. Mirrors the
+# audit-event schema's `event_type` enum.
+def envelope_to_base_event(
+    envelope: dict,
+    *,
+    event_class: type[BaseEvent] | None = None,
+) -> BaseEvent:
+    """Convert a wrapped plugin envelope into a `BaseEvent`.
+
+    Bridges the dict-shaped contract this module speaks into the
+    `BaseEvent` shape `EventStore.append` requires. The audit event
+    payload (the inner schema-validated dict) is preserved verbatim
+    under `data` so consumers can still round-trip it back to
+    schema-valid form via `unwrap_plugin_event`.
+
+    Args:
+        envelope: Output of `wrap_plugin_event`.
+        event_class: Optional `BaseEvent` subclass override. Defaults
+            to a minimal in-module subclass that pins
+            `aggregate_type='plugin'` and uses the envelope's
+            `event_type` as `BaseEvent.type`.
+
+    Returns:
+        A frozen `BaseEvent` instance ready for `EventStore.append`.
+
+    Raises:
+        ValueError: if the envelope is not a plugin envelope produced
+            by `wrap_plugin_event`.
+    """
+    if envelope.get("aggregate_type") != PLUGIN_AGGREGATE_TYPE:
+        raise ValueError(
+            f"envelope is not a plugin envelope (aggregate_type="
+            f"{envelope.get('aggregate_type')!r}); expected "
+            f"{PLUGIN_AGGREGATE_TYPE!r}"
+        )
+
+    cls = event_class or _default_plugin_event_class()
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        raise ValueError("envelope payload is missing or not a dict")
+
+    return cls(
+        id=envelope["id"],
+        type=envelope["event_type"],
+        aggregate_type=PLUGIN_AGGREGATE_TYPE,
+        aggregate_id=envelope["aggregate_id"],
+        data=dict(payload),  # frozen BaseEvent: defensive shallow copy
+    )
+
+
+async def append_envelope_to_event_store(
+    envelope: dict,
+    *,
+    store: EventStore,
+    event_class: type[BaseEvent] | None = None,
+) -> None:
+    """Persist a wrapped plugin envelope to the core EventStore.
+
+    The canonical async bridge from this module's dict-shaped contract
+    to the live ledger. Convert with `envelope_to_base_event`, then
+    `await store.append(...)`. Use directly from async code; for the
+    sync firewall, schedule onto the running loop and wrap the result
+    in `make_event_sink`'s `append_fn`.
+    """
+    event = envelope_to_base_event(envelope, event_class=event_class)
+    await store.append(event)
+
+
+def _default_plugin_event_class() -> type[BaseEvent]:
+    """Lazy-construct the default `BaseEvent` subclass for plugin events.
+
+    Defined as a function so importing this module never pulls in
+    `events.base` (which transitively touches Pydantic) for callers
+    that only need the dict-shaped helpers.
+    """
+    global _DEFAULT_PLUGIN_EVENT_CLASS
+    if _DEFAULT_PLUGIN_EVENT_CLASS is not None:
+        return _DEFAULT_PLUGIN_EVENT_CLASS
+
+    from ouroboros.events.base import BaseEvent as _BaseEvent
+
+    class PluginAuditEvent(_BaseEvent):
+        """Generic plugin audit event for the core ledger.
+
+        Concrete subclasses can override `event_version` / type if a
+        firewall feature needs richer typing; the default is intended
+        for v0 dict-shaped persistence.
+        """
+
+    _DEFAULT_PLUGIN_EVENT_CLASS = PluginAuditEvent
+    return PluginAuditEvent
+
+
+_DEFAULT_PLUGIN_EVENT_CLASS: type[Any] | None = None
+
+
 __all__ = [
     "AUDIT_EVENT_TYPES",
     "PLUGIN_AGGREGATE_TYPE",
+    "append_envelope_to_event_store",
+    "envelope_to_base_event",
     "make_event_sink",
     "unwrap_plugin_event",
     "wrap_plugin_event",

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -32,10 +32,8 @@ async session and bridges to `append_fn`.
 
 from __future__ import annotations
 
-import uuid
 from collections.abc import Callable
-from typing import Any
-
+import uuid
 
 PLUGIN_AGGREGATE_TYPE = "plugin"
 

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -1,0 +1,193 @@
+"""Plugin lockfile.
+
+Persists records of installed plugins at `~/.ouroboros/plugins.lock` (TOML).
+The lockfile is the source of truth for "what is installed" — the trust store
+(see `trust_store.py`) is the source of truth for "what is trusted."
+
+Per the locked Q00/ouroboros#732 spec:
+  - Atomic writes (temp file + rename).
+  - Concurrent-write safety via a POSIX file lock (fcntl).
+  - Deterministic ordering: entries sorted by `name` so diffs are reviewable.
+  - Schema versioned (`schema_version = "0.1"`).
+  - Removal is atomic (no orphaned entries).
+
+The TOML shape is fixed and small. We hand-roll serialization rather than
+take on a `tomli_w` dependency. Reading uses stdlib `tomllib`.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import tomllib
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+LOCKFILE_SCHEMA_VERSION = "0.1"
+
+# Default location. Overridable via constructor for tests.
+DEFAULT_LOCKFILE_PATH = Path.home() / ".ouroboros" / "plugins.lock"
+
+
+@dataclass(frozen=True)
+class LockEntry:
+    """One installed plugin's lockfile record."""
+
+    name: str
+    version: str
+    source_kind: str  # "git" | "local"
+    repository: str | None  # git URL when source_kind="git"; else None
+    git_sha: str | None
+    manifest_checksum: str  # "sha256:<hex>"
+    installed_at: str  # RFC3339
+    plugin_home: str  # filesystem path
+
+    def to_toml_lines(self) -> list[str]:
+        lines = ["[[plugin]]"]
+        lines.append(f"name = {_toml_str(self.name)}")
+        lines.append(f"version = {_toml_str(self.version)}")
+        lines.append(f"source_kind = {_toml_str(self.source_kind)}")
+        if self.repository is not None:
+            lines.append(f"repository = {_toml_str(self.repository)}")
+        if self.git_sha is not None:
+            lines.append(f"git_sha = {_toml_str(self.git_sha)}")
+        lines.append(f"manifest_checksum = {_toml_str(self.manifest_checksum)}")
+        lines.append(f"installed_at = {_toml_str(self.installed_at)}")
+        lines.append(f"plugin_home = {_toml_str(self.plugin_home)}")
+        return lines
+
+
+def _toml_str(value: str) -> str:
+    """Serialize a string value as TOML basic string. Restricts content to
+    avoid escaping edge cases — the lockfile only stores names, paths, hashes
+    and timestamps, none of which contain control chars or non-ASCII in
+    practice."""
+    if any(ch == "\\" or ch == '"' or ord(ch) < 0x20 for ch in value):
+        # Use TOML's basic string escapes for the small set we actually need.
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+            .replace("\r", "\\r")
+        )
+        return f'"{escaped}"'
+    return f'"{value}"'
+
+
+class Lockfile:
+    """Atomic, file-locked plugins lockfile manager."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or DEFAULT_LOCKFILE_PATH
+
+    def _ensure_dir(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def read(self) -> dict[str, LockEntry]:
+        """Read the lockfile, returning entries keyed by plugin name.
+
+        Returns an empty dict if the file does not exist.
+        Raises ValueError if the schema_version is unsupported.
+        """
+        if not self.path.is_file():
+            return {}
+        with self.path.open("rb") as handle:
+            data = tomllib.load(handle)
+        version = data.get("schema_version")
+        if version != LOCKFILE_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported lockfile schema_version {version!r}; "
+                f"expected {LOCKFILE_SCHEMA_VERSION!r}"
+            )
+        result: dict[str, LockEntry] = {}
+        for raw in data.get("plugin", []):
+            entry = LockEntry(
+                name=raw["name"],
+                version=raw["version"],
+                source_kind=raw["source_kind"],
+                repository=raw.get("repository"),
+                git_sha=raw.get("git_sha"),
+                manifest_checksum=raw["manifest_checksum"],
+                installed_at=raw["installed_at"],
+                plugin_home=raw["plugin_home"],
+            )
+            result[entry.name] = entry
+        return result
+
+    def _write_atomic(self, entries: dict[str, LockEntry]) -> None:
+        """Write the lockfile atomically (temp file + rename)."""
+        self._ensure_dir()
+        ordered = sorted(entries.values(), key=lambda e: e.name)
+        lines = [f'schema_version = "{LOCKFILE_SCHEMA_VERSION}"', ""]
+        for entry in ordered:
+            lines.extend(entry.to_toml_lines())
+            lines.append("")
+        body = "\n".join(lines).rstrip() + "\n"
+
+        # Write to temp file in the same directory, then atomic rename.
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".plugins.lock.", dir=str(self.path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(body)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, self.path)
+        except Exception:
+            # Best-effort cleanup of the temp file on failure.
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    @contextmanager
+    def _file_lock(self) -> Iterator[None]:
+        """Acquire an exclusive flock for concurrent-write safety.
+
+        POSIX-only. Falls through gracefully on platforms without fcntl
+        (the file is still atomically replaced via os.replace, which gives
+        last-writer-wins semantics — acceptable for non-concurrent use).
+        """
+        self._ensure_dir()
+        try:
+            import fcntl
+        except ImportError:  # pragma: no cover — non-POSIX platforms
+            yield
+            return
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        with lock_path.open("w") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def add(self, entry: LockEntry) -> None:
+        """Add or replace an entry. Holds the file lock for the duration."""
+        with self._file_lock():
+            entries = self.read()
+            entries[entry.name] = entry
+            self._write_atomic(entries)
+
+    def remove(self, name: str) -> bool:
+        """Remove an entry by name. Returns True if removed, False if absent."""
+        with self._file_lock():
+            entries = self.read()
+            if name not in entries:
+                return False
+            entries.pop(name)
+            self._write_atomic(entries)
+            return True
+
+
+__all__ = [
+    "DEFAULT_LOCKFILE_PATH",
+    "LOCKFILE_SCHEMA_VERSION",
+    "LockEntry",
+    "Lockfile",
+]

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -17,13 +17,13 @@ take on a `tomli_w` dependency. Reading uses stdlib `tomllib`.
 
 from __future__ import annotations
 
-import os
-import tempfile
-import tomllib
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+import os
 from pathlib import Path
-from typing import Iterator
+import tempfile
+import tomllib
 
 LOCKFILE_SCHEMA_VERSION = "0.1"
 

--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -128,9 +128,7 @@ class Lockfile:
         body = "\n".join(lines).rstrip() + "\n"
 
         # Write to temp file in the same directory, then atomic rename.
-        fd, tmp_path = tempfile.mkstemp(
-            prefix=".plugins.lock.", dir=str(self.path.parent)
-        )
+        fd, tmp_path = tempfile.mkstemp(prefix=".plugins.lock.", dir=str(self.path.parent))
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 handle.write(body)

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -159,8 +159,16 @@ class PluginManifest:
     version: str
     source: SourceSpec
     commands: tuple[CommandSpec, ...]
-    capabilities: frozenset[Capability]
-    permissions: frozenset[Permission]
+    # `capabilities` and `permissions` were `frozenset`s, but iteration
+    # order in a frozenset is unstable across hash seeds and Python
+    # versions. That instability leaks into `discover`/`inspect`/
+    # `list --json` CLI output and into the firewall's
+    # `plugin.permission_used` event ordering for multi-scope plugins,
+    # making replay/diffs non-deterministic. The schema enforces
+    # `uniqueItems: true` for both arrays, so a tuple preserves manifest
+    # order while still rejecting duplicates at validation time.
+    capabilities: tuple[Capability, ...]
+    permissions: tuple[Permission, ...]
     entrypoint: Entrypoint
     description: str = ""
     audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
@@ -441,11 +449,11 @@ def load_manifest(path: str | Path) -> PluginManifest:
     )
 
     commands = tuple(_build_command(c) for c in raw["commands"])
-    capabilities = frozenset(
+    capabilities = tuple(
         Capability(name=c["name"], access=c["access"], reason=c.get("reason", ""))
         for c in raw["capabilities"]
     )
-    permissions = frozenset(
+    permissions = tuple(
         Permission(
             scope=p["scope"],
             risk=p["risk"],

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -452,10 +452,26 @@ def load_manifest(path: str | Path) -> PluginManifest:
         # relative slug (no traversal, no absolute, no Windows drive
         # prefix). Now anchor it to the manifest's directory so the
         # firewall's subprocess `cwd` doesn't depend on where the
-        # operator ran `ooo` from. The two steps are complementary:
-        # sandbox validates the on-disk text, this resolves it to a
-        # stable absolute filesystem location for runtime consumers.
+        # operator ran `ooo` from. The textual + resolved checks are
+        # complementary: sandbox validates the on-disk text, this
+        # resolves it and verifies the kernel-level result still
+        # lives under the manifest's directory. Without the second
+        # check, a manifest can point at an in-tree symlink such as
+        # `plugins/link -> /outside/path` and the loader would
+        # silently accept a sandbox escape — `Path.resolve()` follows
+        # symlinks, so the syntactic slug check alone is insufficient.
+        anchor = manifest_path.parent.resolve()
         candidate = (manifest_path.parent / source_path).resolve()
+        try:
+            candidate.relative_to(anchor)
+        except ValueError as exc:
+            raise PluginManifestError(
+                f"source.path for {source_type!r} resolves outside the manifest's directory",
+                path=str(manifest_path),
+                json_pointer="/source/path",
+                expected=f"path resolving under {anchor}",
+                got=str(candidate),
+            ) from exc
         source_path = str(candidate)
     source = SourceSpec(
         type=source_type,

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -44,10 +44,16 @@ except ImportError as exc:  # pragma: no cover
 SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1",)
 
 # Source types whose `path` must be a sandboxed relative slug — no absolute
-# paths and no parent-directory traversal. `local_path` resolves relative to
-# the manifest's directory; `plugin_home` resolves relative to the user's
-# plugin home. Either one becoming an absolute or escaping path is a real
-# trust-boundary leak, not a cosmetic issue.
+# paths and no parent-directory traversal. Both `local_path` and `plugin_home`
+# are resolved against the manifest file's parent directory at load time so
+# downstream consumers (firewall cwd, CLI inspect output) see a stable
+# absolute filesystem location regardless of the operator's current working
+# directory. `local_path` is the user-authored case; `plugin_home` is the
+# install-managed case, and the install/manager layer is responsible for
+# placing the manifest in the correct user plugin home before this loader
+# runs — at which point both source types share the same anchoring rule.
+# An absolute or escaping path here is a real trust-boundary leak, not a
+# cosmetic issue.
 _PATH_SANDBOXED_SOURCE_TYPES: frozenset[str] = frozenset({"local_path", "plugin_home"})
 
 

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -442,6 +442,15 @@ def load_manifest(path: str | Path) -> PluginManifest:
     source_path = source_raw.get("path")
     if source_type in _PATH_SANDBOXED_SOURCE_TYPES and isinstance(source_path, str):
         _validate_sandboxed_path(source_path, source_type=source_type, manifest_path=manifest_path)
+        # Sandbox check guarantees the user-authored path is a safe
+        # relative slug (no traversal, no absolute, no Windows drive
+        # prefix). Now anchor it to the manifest's directory so the
+        # firewall's subprocess `cwd` doesn't depend on where the
+        # operator ran `ooo` from. The two steps are complementary:
+        # sandbox validates the on-disk text, this resolves it to a
+        # stable absolute filesystem location for runtime consumers.
+        candidate = (manifest_path.parent / source_path).resolve()
+        source_path = str(candidate)
     source = SourceSpec(
         type=source_type,
         path=source_path,

--- a/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
@@ -196,7 +196,8 @@
         },
         "command": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "pattern": "\\S"
         }
       }
     },

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -21,13 +21,13 @@ from this store.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 import json
 import os
-import tempfile
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+import tempfile
 
 TRUST_SCHEMA_VERSION = "0.1"
 
@@ -122,7 +122,7 @@ class TrustStore:
     ) -> TrustRecord:
         """Grant `scope` to `plugin@version`. Idempotent: granting an
         already-granted scope is a no-op (timestamps preserved)."""
-        when = when or datetime.now(tz=timezone.utc)
+        when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         existing = self.read(plugin)

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -198,24 +198,37 @@ class TrustStore:
             self._write_atomic(plugin, payload)
 
     def remove(self, plugin: str) -> bool:
-        """Remove the trust file for `plugin`. Returns True if removed."""
+        """Remove the trust file for `plugin`. Returns True if removed.
+
+        Bracketed by the same per-plugin lock as `grant()` /
+        `reset_for_version_bump()`. Without the lock, a concurrent
+        `grant()` could win a race against `remove()` and recreate
+        `trust.json` after this method reported success — leaving a
+        supposedly-removed plugin still trusted, or non-deterministically
+        dropping grants. The lock makes the unlink/prune sequence
+        observable as a single critical section.
+        """
         path = self._path(plugin)
-        if not path.is_file():
-            return False
-        path.unlink()
-        # The grant lock-file lives next to trust.json; clear it too so
-        # the per-plugin directory can collapse cleanly.
-        lock_path = path.with_suffix(path.suffix + ".lock")
-        try:
-            lock_path.unlink()
-        except FileNotFoundError:
-            pass
-        # Best-effort: remove the empty plugin dir if it's empty afterwards.
-        try:
-            path.parent.rmdir()
-        except OSError:
-            pass
-        return True
+        with self._grant_lock(plugin):
+            if not path.is_file():
+                return False
+            path.unlink()
+            # The grant lock-file lives next to trust.json; clear it too so
+            # the per-plugin directory can collapse cleanly. Note: the
+            # lock fd is still held above us by `_grant_lock`'s context
+            # manager, so the unlink only removes the dirent — fcntl
+            # mutual exclusion is unaffected.
+            lock_path = path.with_suffix(path.suffix + ".lock")
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
+            # Best-effort: remove the empty plugin dir if it's empty afterwards.
+            try:
+                path.parent.rmdir()
+            except OSError:
+                pass
+            return True
 
 
 __all__ = [

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -21,7 +21,8 @@ from this store.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import json
@@ -111,6 +112,33 @@ class TrustStore:
                 pass
             raise
 
+    @contextmanager
+    def _grant_lock(self, plugin: str) -> Iterator[None]:
+        """Serialize `grant` / `reset` updates for one plugin.
+
+        Without this guard, two concurrent `grant()` calls for the
+        same plugin can both observe the same prior file and each
+        write back a one-scope payload, so the last writer silently
+        deletes the other grant — a real trust-state data-loss bug.
+        Lockfile uses the same `fcntl.flock` pattern; this mirrors it
+        per-plugin so cross-plugin grants don't serialize against
+        each other.
+        """
+        path = self._path(plugin)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            import fcntl
+        except ImportError:  # pragma: no cover — non-POSIX platforms
+            yield
+            return
+        lock_path = path.with_suffix(path.suffix + ".lock")
+        with lock_path.open("w") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
     def grant(
         self,
         *,
@@ -121,36 +149,44 @@ class TrustStore:
         when: datetime | None = None,
     ) -> TrustRecord:
         """Grant `scope` to `plugin@version`. Idempotent: granting an
-        already-granted scope is a no-op (timestamps preserved)."""
+        already-granted scope is a no-op (timestamps preserved).
+
+        Concurrency-safe: the read-modify-write cycle is bracketed by
+        a per-plugin POSIX file lock so two concurrent `grant()` calls
+        cannot drop one another's scope.
+        """
         when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        existing = self.read(plugin)
-        # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
-        if existing is not None and existing.version != version:
-            existing = None  # treat as fresh
+        with self._grant_lock(plugin):
+            existing = self.read(plugin)
+            # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
+            if existing is not None and existing.version != version:
+                existing = None  # treat as fresh
 
-        granted = list(existing.granted_scopes) if existing else []
-        if all(g.scope != scope for g in granted):
-            granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
+            granted = list(existing.granted_scopes) if existing else []
+            if all(g.scope != scope for g in granted):
+                granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
 
-        payload = {
-            "schema_version": TRUST_SCHEMA_VERSION,
-            "plugin": plugin,
-            "version": version,
-            "granted_scopes": [
-                {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
-                for g in granted
-            ],
-        }
-        self._write_atomic(plugin, payload)
+            payload = {
+                "schema_version": TRUST_SCHEMA_VERSION,
+                "plugin": plugin,
+                "version": version,
+                "granted_scopes": [
+                    {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
+                    for g in granted
+                ],
+            }
+            self._write_atomic(plugin, payload)
         return TrustRecord(plugin=plugin, version=version, granted_scopes=tuple(granted))
 
     def reset_for_version_bump(self, plugin: str, new_version: str) -> None:
         """Invalidate trust because the plugin's version changed.
 
         Writes a new trust file with version=new_version and empty grants.
-        Per Q00/ouroboros-plugins#9 Q4 lock.
+        Per Q00/ouroboros-plugins#9 Q4 lock. Bracketed by the same
+        per-plugin lock as `grant()` so a reset cannot race with a
+        concurrent grant for the prior version.
         """
         payload = {
             "schema_version": TRUST_SCHEMA_VERSION,
@@ -158,7 +194,8 @@ class TrustStore:
             "version": new_version,
             "granted_scopes": [],
         }
-        self._write_atomic(plugin, payload)
+        with self._grant_lock(plugin):
+            self._write_atomic(plugin, payload)
 
     def remove(self, plugin: str) -> bool:
         """Remove the trust file for `plugin`. Returns True if removed."""
@@ -166,6 +203,13 @@ class TrustStore:
         if not path.is_file():
             return False
         path.unlink()
+        # The grant lock-file lives next to trust.json; clear it too so
+        # the per-plugin directory can collapse cleanly.
+        lock_path = path.with_suffix(path.suffix + ".lock")
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
         # Best-effort: remove the empty plugin dir if it's empty afterwards.
         try:
             path.parent.rmdir()

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -1,0 +1,183 @@
+"""Per-plugin trust store.
+
+Persists granted trust scopes per plugin at
+`~/.ouroboros/plugins/<name>/trust.json`. Per the locked Q00/ouroboros#732
+spec (which consumes the locked Q00/ouroboros-plugins#9 trust UX answers):
+
+- **Per-user storage** (Q5): one trust file per installed plugin, in the
+  same per-user directory as the plugin home.
+- **Version-bump invalidation** (Q4): when a plugin's version changes,
+  the trust file is reset (granted_scopes emptied). The user must re-grant
+  scopes via `ooo plugin trust` after upgrading.
+- **Exact scope grants** (Q3): each grant records the exact scope string;
+  parent scopes do not imply children.
+- **No raw tokens stored.** Only the scope name, timestamp, and granting
+  user identity are persisted.
+
+The trust store does NOT emit audit events itself; the firewall (#729) and
+CLI (#731) emit `plugin.trusted` when grants happen, sourcing the data
+from this store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+TRUST_SCHEMA_VERSION = "0.1"
+
+# Default location root. Each plugin gets a subdirectory here.
+DEFAULT_TRUST_ROOT = Path.home() / ".ouroboros" / "plugins"
+
+
+@dataclass(frozen=True)
+class GrantedScope:
+    scope: str
+    granted_at: str  # RFC3339
+    granted_by: str  # e.g. "user:<id>"
+
+
+@dataclass(frozen=True)
+class TrustRecord:
+    plugin: str
+    version: str
+    granted_scopes: tuple[GrantedScope, ...] = ()
+
+    def has_scope(self, scope: str) -> bool:
+        """Exact-string scope check (per Q00/ouroboros-plugins#9 Q3 lock —
+        parent scope does NOT imply child)."""
+        return any(g.scope == scope for g in self.granted_scopes)
+
+    def missing(self, required_scopes: Iterable[str]) -> list[str]:
+        """Return required scopes that are not granted, in order."""
+        granted = {g.scope for g in self.granted_scopes}
+        return [s for s in required_scopes if s not in granted]
+
+
+class TrustStore:
+    """Per-plugin trust store at <root>/<plugin-name>/trust.json."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or DEFAULT_TRUST_ROOT
+
+    def _path(self, plugin: str) -> Path:
+        return self.root / plugin / "trust.json"
+
+    def read(self, plugin: str) -> TrustRecord | None:
+        """Read the trust record for `plugin`, or None if not present."""
+        path = self._path(plugin)
+        if not path.is_file():
+            return None
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+        version = data.get("schema_version")
+        if version != TRUST_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported trust file schema_version {version!r}; "
+                f"expected {TRUST_SCHEMA_VERSION!r}"
+            )
+        return TrustRecord(
+            plugin=data["plugin"],
+            version=data["version"],
+            granted_scopes=tuple(
+                GrantedScope(
+                    scope=g["scope"],
+                    granted_at=g["granted_at"],
+                    granted_by=g["granted_by"],
+                )
+                for g in data.get("granted_scopes", [])
+            ),
+        )
+
+    def _write_atomic(self, plugin: str, payload: dict) -> None:
+        path = self._path(plugin)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".trust.", dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def grant(
+        self,
+        *,
+        plugin: str,
+        version: str,
+        scope: str,
+        granted_by: str,
+        when: datetime | None = None,
+    ) -> TrustRecord:
+        """Grant `scope` to `plugin@version`. Idempotent: granting an
+        already-granted scope is a no-op (timestamps preserved)."""
+        when = when or datetime.now(tz=timezone.utc)
+        ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        existing = self.read(plugin)
+        # Per Q00/ouroboros-plugins#9 Q4: version bump invalidates trust.
+        if existing is not None and existing.version != version:
+            existing = None  # treat as fresh
+
+        granted = list(existing.granted_scopes) if existing else []
+        if all(g.scope != scope for g in granted):
+            granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
+
+        payload = {
+            "schema_version": TRUST_SCHEMA_VERSION,
+            "plugin": plugin,
+            "version": version,
+            "granted_scopes": [
+                {"scope": g.scope, "granted_at": g.granted_at, "granted_by": g.granted_by}
+                for g in granted
+            ],
+        }
+        self._write_atomic(plugin, payload)
+        return TrustRecord(plugin=plugin, version=version, granted_scopes=tuple(granted))
+
+    def reset_for_version_bump(self, plugin: str, new_version: str) -> None:
+        """Invalidate trust because the plugin's version changed.
+
+        Writes a new trust file with version=new_version and empty grants.
+        Per Q00/ouroboros-plugins#9 Q4 lock.
+        """
+        payload = {
+            "schema_version": TRUST_SCHEMA_VERSION,
+            "plugin": plugin,
+            "version": new_version,
+            "granted_scopes": [],
+        }
+        self._write_atomic(plugin, payload)
+
+    def remove(self, plugin: str) -> bool:
+        """Remove the trust file for `plugin`. Returns True if removed."""
+        path = self._path(plugin)
+        if not path.is_file():
+            return False
+        path.unlink()
+        # Best-effort: remove the empty plugin dir if it's empty afterwards.
+        try:
+            path.parent.rmdir()
+        except OSError:
+            pass
+        return True
+
+
+__all__ = [
+    "DEFAULT_TRUST_ROOT",
+    "TRUST_SCHEMA_VERSION",
+    "GrantedScope",
+    "TrustRecord",
+    "TrustStore",
+]

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -213,17 +213,21 @@ class TrustStore:
             if not path.is_file():
                 return False
             path.unlink()
-            # The grant lock-file lives next to trust.json; clear it too so
-            # the per-plugin directory can collapse cleanly. Note: the
-            # lock fd is still held above us by `_grant_lock`'s context
-            # manager, so the unlink only removes the dirent — fcntl
-            # mutual exclusion is unaffected.
-            lock_path = path.with_suffix(path.suffix + ".lock")
-            try:
-                lock_path.unlink()
-            except FileNotFoundError:
-                pass
-            # Best-effort: remove the empty plugin dir if it's empty afterwards.
+            # Deliberately do NOT unlink `trust.json.lock` here. POSIX
+            # `flock` is attached to the inode behind the lock-file
+            # path, so unlinking the lock-file (while we still hold
+            # the lock above us) only removes the dirent: a concurrent
+            # `grant()` would `open(lock_path, "w")` against a brand-
+            # new inode, `flock` *that* exclusively, and run in
+            # parallel with this `remove()`. By the time we release
+            # our `flock` on the now-orphan inode, the concurrent
+            # writer has already recreated `trust.json` — reopening
+            # the very race the per-plugin lock was added to close.
+            # The lock-file is a synchronization primitive, not
+            # operation-scoped state; leaving it on disk is correct.
+            # Best-effort dir cleanup still tolerates the leftover
+            # because `rmdir` raises `OSError(ENOTEMPTY)` and we swallow
+            # it below.
             try:
                 path.parent.rmdir()
             except OSError:

--- a/src/ouroboros/plugin/userlevel_registry.py
+++ b/src/ouroboros/plugin/userlevel_registry.py
@@ -111,6 +111,15 @@ class UserLevelProgramRegistry:
                     f"refusing to register {manifest.name!r}"
                 )
 
+            # On replace, release the previous namespace mapping if the new
+            # manifest moved to a different namespace under the same plugin
+            # name. Otherwise the old namespace stays permanently owned by
+            # this plugin: lookup_command(old_ns) still resolves to the new
+            # program (wrong target), and other plugins are blocked from
+            # claiming that namespace forever.
+            if existing is not None and existing.namespace != namespace:
+                self._namespace_owner.pop(existing.namespace, None)
+
             program = RegisteredProgram(manifest=manifest)
             self._by_name[manifest.name] = program
             self._namespace_owner[namespace] = manifest.name

--- a/src/ouroboros/plugin/userlevel_registry.py
+++ b/src/ouroboros/plugin/userlevel_registry.py
@@ -1,0 +1,237 @@
+"""UserLevel program registry.
+
+Tracks installed UserLevel plugins (and first-party programs) by their
+manifest. Sits alongside the existing `skills/registry.py` SkillRegistry —
+both are queryable via the top-level `lookup_command(...)` helper at the
+bottom of this module.
+
+Per the locked Q00/ouroboros#730 spec:
+  - One in-memory registry shared across the process.
+  - Namespace ownership: the first plugin to register `namespace=foo`
+    owns it; subsequent registrations for the same namespace are
+    rejected with a clear error.
+  - Names ARE used as primary keys (one program per name); re-registering
+    the same name without explicit replace is rejected.
+  - The registry is decoupled from discovery — callers (CLI, firewall,
+    integration tests) build a registry from already-loaded `PluginManifest`
+    instances.
+
+This module deliberately does NOT subsume or modify the SkillRegistry. The
+two cover different artifact shapes (JSON manifest vs SKILL.md frontmatter)
+and have different lifecycle semantics (install/trust vs hot-reload). They
+share only the cross-registry lookup helper at the bottom.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import RLock
+
+from ouroboros.plugin.manifest import CommandSpec, PluginManifest
+
+
+class RegistryError(Exception):
+    """Raised on namespace collision, duplicate registration, etc."""
+
+
+@dataclass(frozen=True)
+class RegisteredProgram:
+    """One entry in the UserLevel program registry.
+
+    The registry stores manifest references rather than copies — the
+    manifest is already frozen and value-equal.
+    """
+
+    manifest: PluginManifest
+
+    @property
+    def name(self) -> str:
+        return self.manifest.name
+
+    @property
+    def namespace(self) -> str:
+        # All commands of one plugin share one namespace per the schema's
+        # pattern + the manager's collision check; pick the first.
+        return self.manifest.commands[0].namespace
+
+    def find_command(self, name: str) -> CommandSpec | None:
+        for command in self.manifest.commands:
+            if command.name == name:
+                return command
+        return None
+
+
+class UserLevelProgramRegistry:
+    """In-memory registry of installed UserLevel programs."""
+
+    def __init__(self) -> None:
+        self._by_name: dict[str, RegisteredProgram] = {}
+        self._namespace_owner: dict[str, str] = {}  # namespace -> plugin name
+        self._lock = RLock()
+
+    def register(self, manifest: PluginManifest, *, replace: bool = False) -> RegisteredProgram:
+        """Register a program from its loaded manifest.
+
+        Args:
+            manifest: The validated `PluginManifest` (from `load_manifest`).
+            replace: If True, replace an existing entry with the same name.
+                Default False — duplicate registrations raise.
+
+        Returns:
+            The registered program.
+
+        Raises:
+            RegistryError: on namespace collision or duplicate name without
+                `replace=True`.
+        """
+        if not manifest.commands:
+            raise RegistryError(f"{manifest.name}: manifest has no commands")
+
+        # All commands must share the same namespace per the schema's pattern.
+        namespaces = {c.namespace for c in manifest.commands}
+        if len(namespaces) != 1:
+            raise RegistryError(
+                f"{manifest.name}: commands declare multiple namespaces "
+                f"{sorted(namespaces)}; one plugin must own one namespace"
+            )
+        namespace = namespaces.pop()
+
+        with self._lock:
+            existing = self._by_name.get(manifest.name)
+            if existing is not None and not replace:
+                raise RegistryError(
+                    f"{manifest.name} is already registered "
+                    f"(version {existing.manifest.version}); pass replace=True to update"
+                )
+
+            owner = self._namespace_owner.get(namespace)
+            if owner is not None and owner != manifest.name:
+                raise RegistryError(
+                    f"namespace {namespace!r} already owned by {owner!r}; "
+                    f"refusing to register {manifest.name!r}"
+                )
+
+            program = RegisteredProgram(manifest=manifest)
+            self._by_name[manifest.name] = program
+            self._namespace_owner[namespace] = manifest.name
+            return program
+
+    def unregister(self, name: str) -> bool:
+        """Remove a program by name. Returns True if removed."""
+        with self._lock:
+            program = self._by_name.pop(name, None)
+            if program is None:
+                return False
+            ns = program.namespace
+            if self._namespace_owner.get(ns) == name:
+                self._namespace_owner.pop(ns)
+            return True
+
+    def get(self, name: str) -> RegisteredProgram | None:
+        with self._lock:
+            return self._by_name.get(name)
+
+    def get_by_namespace(self, namespace: str) -> RegisteredProgram | None:
+        with self._lock:
+            owner = self._namespace_owner.get(namespace)
+            if owner is None:
+                return None
+            return self._by_name.get(owner)
+
+    def all_programs(self) -> list[RegisteredProgram]:
+        with self._lock:
+            return list(self._by_name.values())
+
+
+# Global singleton — modeled after skills/registry.py's pattern.
+_global: UserLevelProgramRegistry | None = None
+_global_lock = RLock()
+
+
+def get_userlevel_registry() -> UserLevelProgramRegistry:
+    """Return the process-wide UserLevel program registry singleton."""
+    global _global
+    with _global_lock:
+        if _global is None:
+            _global = UserLevelProgramRegistry()
+        return _global
+
+
+def reset_userlevel_registry() -> None:
+    """Reset the singleton. Tests use this to isolate state."""
+    global _global
+    with _global_lock:
+        _global = None
+
+
+# ---------------------------------------------------------------------------
+# Cross-registry lookup
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LookupResult:
+    """Result of looking up a name across both registries.
+
+    Exactly one of `userlevel_program` or `skill_metadata` is non-None for
+    a successful lookup.
+    """
+
+    kind: str  # "userlevel" | "skill" | "none"
+    userlevel_program: RegisteredProgram | None = None
+    skill_metadata: object | None = None  # Avoid hard import on skill module.
+
+    @property
+    def found(self) -> bool:
+        return self.kind != "none"
+
+
+def lookup_command(name: str) -> LookupResult:
+    """Look up a name across both the UserLevel registry and the bundled
+    skills registry. Returns the first match.
+
+    Order:
+      1. UserLevel namespaces (e.g. "github-pr") — fast, in-memory.
+      2. UserLevel plugin names (e.g. "github-pr-ops").
+      3. Bundled skill names (loaded from .claude-plugin/skills/).
+
+    Args:
+        name: The command name, namespace, or plugin name to look up.
+
+    Returns:
+        `LookupResult` indicating which registry matched.
+    """
+    ul = get_userlevel_registry()
+
+    program = ul.get_by_namespace(name)
+    if program is not None:
+        return LookupResult(kind="userlevel", userlevel_program=program)
+
+    program = ul.get(name)
+    if program is not None:
+        return LookupResult(kind="userlevel", userlevel_program=program)
+
+    # Skills lookup: import lazily so this module doesn't pull in watchdog
+    # and yaml at import time.
+    try:
+        from ouroboros.plugin.skills.registry import get_registry as _get_skill_registry
+    except ImportError:  # pragma: no cover - defensive
+        return LookupResult(kind="none")
+
+    skill_registry = _get_skill_registry()
+    skill = skill_registry.get_skill(name)
+    if skill is not None:
+        return LookupResult(kind="skill", skill_metadata=skill.metadata)
+
+    return LookupResult(kind="none")
+
+
+__all__ = [
+    "LookupResult",
+    "RegisteredProgram",
+    "RegistryError",
+    "UserLevelProgramRegistry",
+    "get_userlevel_registry",
+    "lookup_command",
+    "reset_userlevel_registry",
+]

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -800,3 +800,114 @@ def test_list_survives_doubly_corrupt_row(runner: CliRunner, tmp_path: Path) -> 
     # the same invariant `list_json_zeroes_stale_grants...` enforces.
     assert row["granted_scopes"] == []
     assert row["trust_version_stale"] is False
+
+
+FIRST_PARTY_REQUIRED_MANIFEST: dict = {
+    **REFERENCE_MANIFEST,
+    "name": "ouroboros-builtin",
+    "source": {"type": "first_party"},
+    # Schema still permits first-party manifests to declare permissions;
+    # the firewall just bypasses the trust gate for them.
+    "permissions": [
+        {"scope": "fs:read", "risk": "read_only", "required": True},
+        {"scope": "ledger:write", "risk": "write", "required": True},
+    ],
+}
+
+
+def test_discover_first_party_marks_required_scopes_advisory(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """`discover` must not tell operators that first-party plugins
+    need their `required: true` scopes "trusted before invocation" —
+    the firewall skips trust checks for `source.type == "first_party"`,
+    so the CLI's instruction would directly contradict the gate.
+    """
+    plugin_dir = tmp_path / "ob-builtin"
+    _write_manifest(plugin_dir, FIRST_PARTY_REQUIRED_MANIFEST)
+    result = runner.invoke(plugin_app, ["discover", str(plugin_dir)])
+    assert result.exit_code == 0, result.output
+    # Both scopes still surface so operators can see what the plugin
+    # *declares*, but they are explicitly labeled advisory.
+    assert "fs:read" in result.output
+    assert "ledger:write" in result.output
+    assert "advisory" in result.output
+    assert "first-party" in result.output
+    assert "must be trusted before invocation" not in result.output
+
+
+def test_inspect_first_party_does_not_report_missing_scopes(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """`inspect` for first-party plugins must not flag required scopes
+    as "missing" — the firewall bypasses trust for them, so reporting
+    a blocked invocation contradicts the actual enforcement path."""
+    plugin_home = tmp_path / "ph"
+    _write_manifest(plugin_home, FIRST_PARTY_REQUIRED_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="ouroboros-builtin",
+            version="0.1.0",
+            source_kind="first_party",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "ouroboros-builtin",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(tmp_path / "trust"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "trust_state:    first_party" in result.output
+    assert "missing scopes" not in result.output
+
+
+def test_list_first_party_json_has_no_missing_required_scopes(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """`list --json` must mirror inspect: first-party rows surface
+    `missing_required_scopes: []`, not the manifest's declared set."""
+    plugin_home = tmp_path / "ph"
+    _write_manifest(plugin_home, FIRST_PARTY_REQUIRED_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="ouroboros-builtin",
+            version="0.1.0",
+            source_kind="first_party",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "list",
+            "--json",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(tmp_path / "trust"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert isinstance(data, list) and len(data) == 1
+    row = data[0]
+    assert row["trust_state"] == "first_party"
+    assert row["missing_required_scopes"] == []
+    assert row["granted_scopes"] == []

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -732,3 +732,71 @@ def test_list_json_partial_trust_reports_installed_not_trusted(
     # And the row exposes the firewall-blocking scopes as structured
     # output so consumers can pipe to jq for an automated re-trust step.
     assert row["missing_required_scopes"] == ["github:pull_request:write"]
+
+
+def test_list_survives_doubly_corrupt_row(runner: CliRunner, tmp_path: Path) -> None:
+    """Regression: when a row's on-disk manifest is unreadable, `list`
+    must NOT also try to read its trust.json — a second corrupt file
+    on the same row would otherwise abort the entire `list` output and
+    defeat the diagnostic purpose of the command. The unreadable-
+    manifest branch reports the row as "installed" with empty scopes
+    and falls through cleanly.
+    """
+    import os
+    import sys
+
+    if sys.platform.startswith("win"):
+        pytest.skip("POSIX permission semantics required")
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses POSIX file permissions")
+
+    plugin_home = tmp_path / "ph"
+    manifest_path = _write_manifest(plugin_home, REFERENCE_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    # Corrupt the trust file (parses as JSON, but missing required keys)
+    # AND make the manifest unreadable. With the prior behavior the
+    # corrupt trust read would crash `list` even though the row was
+    # already lost to the unreadable manifest.
+    trust_path = trust_root / "github-pr-ops" / "trust.json"
+    trust_path.parent.mkdir(parents=True, exist_ok=True)
+    trust_path.write_text(json.dumps({"schema_version": "0.1"}))
+    original_mode = manifest_path.stat().st_mode
+    manifest_path.chmod(0o000)
+    try:
+        result = runner.invoke(
+            plugin_app,
+            [
+                "list",
+                "--json",
+                "--lockfile",
+                str(lock_path),
+                "--trust-root",
+                str(trust_root),
+            ],
+        )
+    finally:
+        manifest_path.chmod(original_mode)
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert isinstance(data, list) and len(data) == 1
+    row = data[0]
+    assert row["trust_state"] == "installed"
+    # No grants are echoed because we couldn't verify them against a
+    # readable manifest — refusing to "lie about effective grants" is
+    # the same invariant `list_json_zeroes_stale_grants...` enforces.
+    assert row["granted_scopes"] == []
+    assert row["trust_version_stale"] is False

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -44,7 +44,11 @@ REFERENCE_MANIFEST: dict = {
 
 @pytest.fixture
 def runner() -> CliRunner:
-    return CliRunner(mix_stderr=False) if "mix_stderr" in CliRunner.__init__.__code__.co_varnames else CliRunner()
+    return (
+        CliRunner(mix_stderr=False)
+        if "mix_stderr" in CliRunner.__init__.__code__.co_varnames
+        else CliRunner()
+    )
 
 
 def _write_manifest(dir_: Path, payload: dict) -> Path:
@@ -66,9 +70,7 @@ def test_discover_valid_manifest(runner: CliRunner, tmp_path: Path) -> None:
     assert "github:read" in result.output  # required scope listed
 
 
-def test_discover_invalid_manifest_exits_nonzero(
-    runner: CliRunner, tmp_path: Path
-) -> None:
+def test_discover_invalid_manifest_exits_nonzero(runner: CliRunner, tmp_path: Path) -> None:
     """A schema-violating manifest produces a friendly error and exit 1."""
     bad = {**REFERENCE_MANIFEST, "name": "Bad Name"}  # whitespace breaks pattern
     plugin_dir = tmp_path / "bad"
@@ -98,9 +100,7 @@ def test_inspect_uninstalled_plugin_errors(runner: CliRunner, tmp_path: Path) ->
     assert "is not installed" in result.output
 
 
-def test_inspect_installed_untrusted(
-    runner: CliRunner, tmp_path: Path
-) -> None:
+def test_inspect_installed_untrusted(runner: CliRunner, tmp_path: Path) -> None:
     """An installed-but-untrusted plugin reports trust_state=installed and
     flags the missing required scope."""
     plugin_home = tmp_path / "plugin_home"
@@ -316,9 +316,7 @@ def test_inspect_partial_trust_reports_installed_not_trusted(
     assert "github:pull_request:write" in result.output
 
 
-def test_inspect_stale_version_reports_installed(
-    runner: CliRunner, tmp_path: Path
-) -> None:
+def test_inspect_stale_version_reports_installed(runner: CliRunner, tmp_path: Path) -> None:
     """Regression: a trust file recorded for an older plugin version
     must NOT make `inspect` say "trusted" — the firewall treats it as
     invalidated, and the CLI must agree.

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -367,6 +367,99 @@ def test_inspect_stale_version_reports_installed(runner: CliRunner, tmp_path: Pa
     assert "github:read" in result.output
 
 
+def test_inspect_structurally_corrupt_lockfile_reports_friendly_error(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression: a parseable-but-structurally-corrupt plugins.lock
+    (TOML parses fine, but the [[plugin]] block is missing a required
+    field like `name`) used to raise a raw KeyError straight through
+    `inspect`/`list`. The friendly-error guard now covers KeyError /
+    TypeError too, since `Lockfile.read()` builds dataclasses via
+    unchecked `raw[...]` lookups."""
+    lock_path = tmp_path / "plugins.lock"
+    # Valid TOML, valid schema_version, but plugin block has no `name`.
+    lock_path.write_text(
+        'schema_version = "0.1"\n\n'
+        "[[plugin]]\n"
+        'version = "0.1.0"\n'
+        'source_kind = "local"\n'
+        'manifest_checksum = "sha256:0"\n'
+        'installed_at = "2026-05-08T00:00:00Z"\n'
+        'plugin_home = "/tmp/x"\n'
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "github-pr-ops",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(tmp_path / "trust"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "lockfile is unreadable" in result.output
+    assert "Traceback" not in result.output
+    # KeyError prints as the missing key — the operator needs to see it.
+    assert "name" in result.output
+
+
+def test_inspect_unreadable_manifest_reports_friendly_error(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression: an unreadable on-disk manifest (e.g. wrong perms)
+    used to escape `load_manifest` as a raw `OSError`. `inspect` is
+    a diagnostic command and must surface a clean message instead of
+    a raw traceback. We exercise the path with chmod 000.
+    """
+    import os
+    import sys
+
+    if sys.platform.startswith("win"):
+        pytest.skip("POSIX permission semantics required")
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses POSIX file permissions")
+
+    plugin_home = tmp_path / "plugin_home"
+    manifest_path = _write_manifest(plugin_home, REFERENCE_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    # Strip read perms so `path.open()` raises PermissionError without
+    # tripping the `is_file()` early-exit check inside `load_manifest`.
+    original_mode = manifest_path.stat().st_mode
+    manifest_path.chmod(0o000)
+    try:
+        result = runner.invoke(
+            plugin_app,
+            [
+                "inspect",
+                "github-pr-ops",
+                "--lockfile",
+                str(lock_path),
+                "--trust-root",
+                str(tmp_path / "trust"),
+            ],
+        )
+    finally:
+        manifest_path.chmod(original_mode)
+
+    assert result.exit_code == 1
+    assert "manifest is unreadable" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_inspect_malformed_lockfile_reports_friendly_error(
     runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -367,6 +367,111 @@ def test_inspect_stale_version_reports_installed(runner: CliRunner, tmp_path: Pa
     assert "github:read" in result.output
 
 
+def test_inspect_first_party_ignores_corrupt_trust_file(runner: CliRunner, tmp_path: Path) -> None:
+    """Regression: a leftover/corrupt `trust.json` for a first-party
+    plugin must NOT make `inspect` fail. The firewall ignores the
+    trust store for `source.type == 'first_party'` by design, so the
+    CLI's read-only commands need to do the same instead of treating
+    that file as authoritative."""
+    plugin_home = tmp_path / "plugin_home"
+    fp_manifest = {
+        **REFERENCE_MANIFEST,
+        "name": "ooo-builtin",
+        "source": {"type": "first_party"},
+        "permissions": [],
+    }
+    _write_manifest(plugin_home, fp_manifest)
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="ooo-builtin",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    # Plant a corrupt trust file for the same plugin name. A pre-fix
+    # build would crash on `_read_trust_or_exit`; the new path skips
+    # the read entirely for first_party.
+    trust_dir = trust_root / "ooo-builtin"
+    trust_dir.mkdir(parents=True)
+    (trust_dir / "trust.json").write_text("{garbage")
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "ooo-builtin",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "first_party" in result.output
+
+
+def test_list_json_zeroes_stale_grants_and_flags_version_drift(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression for the `list --json` reporting suggestion: a trust
+    file recorded against an older plugin version must NOT echo its
+    grants in the JSON view, because those grants are no longer
+    effective. The row also exposes `trust_version_stale: true` so
+    consumers can branch deterministically."""
+    plugin_home = tmp_path / "ph"
+    _write_manifest(plugin_home, REFERENCE_MANIFEST)  # version 0.1.0
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    # Trust granted against an older version of the same plugin.
+    TrustStore(root=trust_root).grant(
+        plugin="github-pr-ops",
+        version="0.0.9",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "list",
+            "--json",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert isinstance(data, list) and len(data) == 1
+    row = data[0]
+    assert row["trust_state"] == "installed"
+    assert row["trust_version_stale"] is True
+    # No effective grants remain — don't lie to JSON consumers about
+    # what the firewall would actually accept.
+    assert row["granted_scopes"] == []
+    # Required scope still surfaces as missing.
+    assert row["missing_required_scopes"] == ["github:read"]
+
+
 def test_discover_unreadable_manifest_reports_friendly_error(
     runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -16,7 +16,6 @@ from ouroboros.cli.commands.plugin import app as plugin_app
 from ouroboros.plugin.lockfile import LockEntry, Lockfile
 from ouroboros.plugin.trust_store import TrustStore
 
-
 REFERENCE_MANIFEST: dict = {
     "schema_version": "0.1",
     "name": "github-pr-ops",
@@ -247,3 +246,176 @@ def test_no_args_shows_help(runner: CliRunner) -> None:
     assert "discover" in result.output
     assert "inspect" in result.output
     assert "list" in result.output
+
+
+# Manifest with TWO required scopes — used to exercise partial-trust
+# regression cases that the single-required-scope fixture cannot reach.
+TWO_REQUIRED_MANIFEST: dict = {
+    **REFERENCE_MANIFEST,
+    "permissions": [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {
+            "scope": "github:pull_request:write",
+            "risk": "destructive",
+            "required": True,
+        },
+    ],
+}
+
+
+def test_inspect_partial_trust_reports_installed_not_trusted(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression for the trust_state misreport: when at least one of
+    the manifest's required scopes is missing, `inspect` must NOT call
+    the plugin "trusted" — the firewall would still block invocation.
+    """
+    plugin_home = tmp_path / "plugin_home"
+    _write_manifest(plugin_home, TWO_REQUIRED_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    # Grant only ONE of the two required scopes.
+    TrustStore(root=trust_root).grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "github-pr-ops",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # The display must say "installed" on the trust_state line. We assert
+    # the row text instead of substring matches to avoid the prior false
+    # positive where "trusted" leaked in via a different field.
+    assert "trust_state:    installed" in result.output
+    # The granted scope is still listed truthfully.
+    assert "github:read" in result.output
+    # And the missing required scope is surfaced.
+    assert "missing scopes" in result.output
+    assert "github:pull_request:write" in result.output
+
+
+def test_inspect_stale_version_reports_installed(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression: a trust file recorded for an older plugin version
+    must NOT make `inspect` say "trusted" — the firewall treats it as
+    invalidated, and the CLI must agree.
+    """
+    plugin_home = tmp_path / "plugin_home"
+    _write_manifest(plugin_home, REFERENCE_MANIFEST)  # version 0.1.0
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    # Trust granted against an older version of the same plugin.
+    TrustStore(root=trust_root).grant(
+        plugin="github-pr-ops",
+        version="0.0.9",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "github-pr-ops",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "trust_state:    installed" in result.output
+    # User must see WHY trust flipped back to installed, otherwise the
+    # report is just contradictory. Rich may soft-wrap the line, so we
+    # assert the words separately.
+    assert "trust_version" in result.output
+    assert "version bump" in result.output
+    assert "invalidated trust" in result.output
+    assert "missing scopes" in result.output
+    assert "github:read" in result.output
+
+
+def test_list_json_partial_trust_reports_installed_not_trusted(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression: `list --json` must mirror the firewall's gate. With
+    at least one required scope missing, the row's trust_state cannot
+    say "trusted".
+    """
+    plugin_home = tmp_path / "ph"
+    _write_manifest(plugin_home, TWO_REQUIRED_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    TrustStore(root=trust_root).grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "list",
+            "--json",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert isinstance(data, list) and len(data) == 1
+    row = data[0]
+    assert row["name"] == "github-pr-ops"
+    assert row["trust_state"] == "installed", row
+    assert row["granted_scopes"] == ["github:read"]
+    # And the row exposes the firewall-blocking scopes as structured
+    # output so consumers can pipe to jq for an automated re-trust step.
+    assert row["missing_required_scopes"] == ["github:pull_request:write"]

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -367,6 +367,94 @@ def test_inspect_stale_version_reports_installed(runner: CliRunner, tmp_path: Pa
     assert "github:read" in result.output
 
 
+def test_inspect_malformed_lockfile_reports_friendly_error(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression: a malformed plugins.lock must produce a friendly
+    error and exit code 1, NOT a raw TOMLDecodeError traceback."""
+    lock_path = tmp_path / "plugins.lock"
+    lock_path.write_text("this = is = not valid TOML\n")  # parser bait
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "github-pr-ops",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(tmp_path / "trust"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "lockfile is unreadable" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_list_malformed_lockfile_reports_friendly_error(runner: CliRunner, tmp_path: Path) -> None:
+    """Same as above for `list`, which also reads the lockfile."""
+    lock_path = tmp_path / "plugins.lock"
+    # Wrong schema_version triggers Lockfile.read's ValueError path —
+    # a separate failure mode from raw TOML decode errors.
+    lock_path.write_text('schema_version = "9.9"\n')
+    result = runner.invoke(
+        plugin_app,
+        [
+            "list",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(tmp_path / "trust"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "lockfile is unreadable" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_inspect_malformed_trust_file_reports_friendly_error(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression: a corrupt trust.json must surface a friendly error,
+    not a JSONDecodeError traceback. `inspect` is meant to diagnose
+    plugin state, so the diagnostic itself can't crash on bad state."""
+    plugin_home = tmp_path / "plugin_home"
+    _write_manifest(plugin_home, REFERENCE_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    # Write a malformed trust.json under the trust root.
+    trust_dir = trust_root / "github-pr-ops"
+    trust_dir.mkdir(parents=True)
+    (trust_dir / "trust.json").write_text("{not valid json")
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "github-pr-ops",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "trust file" in result.output
+    assert "unreadable" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_list_json_partial_trust_reports_installed_not_trusted(
     runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -1,0 +1,249 @@
+"""Tests for the read-only `ooo plugin` CLI subcommands.
+
+State-mutating subcommands (add, install, trust, disable, remove) live
+in the follow-up PR.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.cli.commands.plugin import app as plugin_app
+from ouroboros.plugin.lockfile import LockEntry, Lockfile
+from ouroboros.plugin.trust_store import TrustStore
+
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "description": "Reference plugin for PR operational workflows.",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+            "requires_confirmation": False,
+        }
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write"},
+    ],
+    "permissions": [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+    ],
+    "entrypoint": {"type": "command", "command": "python -m github_pr_ops"},
+}
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(mix_stderr=False) if "mix_stderr" in CliRunner.__init__.__code__.co_varnames else CliRunner()
+
+
+def _write_manifest(dir_: Path, payload: dict) -> Path:
+    dir_.mkdir(parents=True, exist_ok=True)
+    target = dir_ / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def test_discover_valid_manifest(runner: CliRunner, tmp_path: Path) -> None:
+    """`ooo plugin discover <dir>` accepts a directory argument and prints
+    the manifest summary on success."""
+    plugin_dir = tmp_path / "github-pr-ops"
+    _write_manifest(plugin_dir, REFERENCE_MANIFEST)
+    result = runner.invoke(plugin_app, ["discover", str(plugin_dir)])
+    assert result.exit_code == 0, result.output
+    assert "github-pr-ops" in result.output
+    assert "0.1.0" in result.output
+    assert "github:read" in result.output  # required scope listed
+
+
+def test_discover_invalid_manifest_exits_nonzero(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """A schema-violating manifest produces a friendly error and exit 1."""
+    bad = {**REFERENCE_MANIFEST, "name": "Bad Name"}  # whitespace breaks pattern
+    plugin_dir = tmp_path / "bad"
+    _write_manifest(plugin_dir, bad)
+    result = runner.invoke(plugin_app, ["discover", str(plugin_dir)])
+    assert result.exit_code == 1
+    assert "manifest invalid" in result.output
+    assert "/name" in result.output  # JSON Pointer surfaced
+
+
+def test_inspect_uninstalled_plugin_errors(runner: CliRunner, tmp_path: Path) -> None:
+    """`inspect <name>` errors when the plugin is not in the lockfile."""
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "github-pr-ops",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "is not installed" in result.output
+
+
+def test_inspect_installed_untrusted(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """An installed-but-untrusted plugin reports trust_state=installed and
+    flags the missing required scope."""
+    plugin_home = tmp_path / "plugin_home"
+    _write_manifest(plugin_home, REFERENCE_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "github-pr-ops",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(tmp_path / "trust"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "github-pr-ops 0.1.0" in result.output
+    assert "trust_state" in result.output
+    assert "installed" in result.output
+    assert "missing scopes" in result.output
+    assert "github:read" in result.output
+
+
+def test_inspect_installed_trusted(runner: CliRunner, tmp_path: Path) -> None:
+    """A plugin with all required scopes granted reports trust_state=trusted
+    and no missing scopes."""
+    plugin_home = tmp_path / "plugin_home"
+    _write_manifest(plugin_home, REFERENCE_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    TrustStore(root=trust_root).grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "inspect",
+            "github-pr-ops",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "trusted" in result.output
+    assert "missing scopes" not in result.output
+
+
+def test_list_empty(runner: CliRunner, tmp_path: Path) -> None:
+    """`list` on an empty lockfile prints the no-plugins notice."""
+    lock_path = tmp_path / "plugins.lock"
+    result = runner.invoke(
+        plugin_app,
+        [
+            "list",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(tmp_path / "trust"),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "no plugins installed" in result.output
+
+
+def test_list_json_output(runner: CliRunner, tmp_path: Path) -> None:
+    """`list --json` emits a parseable JSON array."""
+    plugin_home = tmp_path / "ph"
+    _write_manifest(plugin_home, REFERENCE_MANIFEST)
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    Lockfile(lock_path).add(
+        LockEntry(
+            name="github-pr-ops",
+            version="0.1.0",
+            source_kind="local",
+            repository=None,
+            git_sha=None,
+            manifest_checksum="sha256:0",
+            installed_at="2026-05-08T00:00:00Z",
+            plugin_home=str(plugin_home),
+        )
+    )
+    TrustStore(root=trust_root).grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    result = runner.invoke(
+        plugin_app,
+        [
+            "list",
+            "--json",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output.strip())
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["name"] == "github-pr-ops"
+    assert data[0]["trust_state"] == "trusted"
+    assert data[0]["granted_scopes"] == ["github:read"]
+
+
+def test_no_args_shows_help(runner: CliRunner) -> None:
+    """`ooo plugin` with no subcommand prints help (Typer no_args_is_help)."""
+    result = runner.invoke(plugin_app, [])
+    # With no_args_is_help=True, Typer emits help and exit code 0 or 2.
+    assert "discover" in result.output
+    assert "inspect" in result.output
+    assert "list" in result.output

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -367,6 +367,35 @@ def test_inspect_stale_version_reports_installed(runner: CliRunner, tmp_path: Pa
     assert "github:read" in result.output
 
 
+def test_discover_unreadable_manifest_reports_friendly_error(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Regression: `discover` is also a diagnostic command — an
+    unreadable manifest (chmod 000, broken symlink, transient I/O)
+    must surface as a friendly error rather than a raw OSError
+    traceback. Mirrors the same guarantee `inspect`/`list` make."""
+    import os
+    import sys
+
+    if sys.platform.startswith("win"):
+        pytest.skip("POSIX permission semantics required")
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses POSIX file permissions")
+
+    plugin_dir = tmp_path / "github-pr-ops"
+    manifest_path = _write_manifest(plugin_dir, REFERENCE_MANIFEST)
+    original_mode = manifest_path.stat().st_mode
+    manifest_path.chmod(0o000)
+    try:
+        result = runner.invoke(plugin_app, ["discover", str(plugin_dir)])
+    finally:
+        manifest_path.chmod(original_mode)
+
+    assert result.exit_code == 1
+    assert "manifest is unreadable" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_inspect_structurally_corrupt_lockfile_reports_friendly_error(
     runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -1,0 +1,381 @@
+"""Tests for the plugin invocation firewall (Q00/ouroboros#729)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ouroboros.plugin.firewall import (
+    InvocationResult,
+    invoke_plugin,
+)
+from ouroboros.plugin.manifest import load_manifest
+from ouroboros.plugin.trust_store import TrustStore
+from ouroboros.plugin.userlevel_registry import (
+    UserLevelProgramRegistry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+            "requires_confirmation": False,
+        },
+        {
+            "namespace": "github-pr",
+            "name": "merge",
+            "summary": "Merge a PR under policy.",
+            "usage": "ooo github-pr merge <url>",
+            "risk": "destructive",
+            "requires_confirmation": True,
+        },
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write"},
+    ],
+    "permissions": [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {"scope": "github:pull_request:write", "risk": "destructive", "required": False},
+    ],
+    "entrypoint": {"type": "command", "command": "python -m fake_plugin"},
+}
+
+
+def _write_manifest(tmp_path: Path, payload: dict) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _make_program(tmp_path: Path, payload: dict | None = None):
+    """Load a manifest and register it into a fresh registry."""
+    payload = payload if payload is not None else REFERENCE_MANIFEST
+    manifest = load_manifest(_write_manifest(tmp_path, payload))
+    registry = UserLevelProgramRegistry()
+    return registry.register(manifest)
+
+
+def _fake_runner(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+    raise_filenotfound: bool = False,
+):
+    """Build a stand-in for subprocess.run that returns canned data."""
+
+    def _run(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        if raise_filenotfound:
+            raise FileNotFoundError(argv[0])
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path) -> None:
+    """Test 1: trusted invocation emits invoked → permission_used → completed."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-1",
+        subprocess_runner=_fake_runner(stdout="ok\n"),
+    )
+    assert result.status == "success"
+    assert result.exit_code == 0
+    assert [e["event_type"] for e in events] == [
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+    ]
+    # plugin.invoked appears BEFORE permission_used (locked invocation order).
+    assert events[1]["permissions_used"] == ["github:read"]
+    assert events[2]["result"]["status"] == "success"
+    # No raw stdout/stderr content in any event payload. The literal
+    # bytes returned from the fake runner ("ok\n") must not leak into
+    # any event.
+    serialized = json.dumps(events)
+    assert "ok\\n" not in serialized
+    # sha256 hash recorded in completed.provenance.
+    assert "stdout_sha256" in events[-1]["provenance"]
+
+
+def test_trust_violation_only_emits_failed_no_invoked(tmp_path: Path) -> None:
+    """Test 2: missing required scope → ONLY plugin.failed (status=blocked).
+
+    Crucially, plugin.invoked must NOT be emitted when the trust check
+    fails (locked Q1 of Q00/ouroboros-plugins#9).
+    """
+    program = _make_program(tmp_path)
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=None,  # not yet trusted
+        event_sink=events.append,
+        correlation_id="corr-2",
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "blocked"
+    assert result.exit_code is None
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    assert "plugin.invoked" not in types  # explicit absence assertion
+    # Message format per locked Q1.
+    assert "github:read" in result.message
+    assert "ooo plugin trust github-pr-ops --scope github:read" in result.message
+    assert events[0]["result"]["status"] == "blocked"
+
+
+def test_subprocess_failure_emits_failed_with_exit_code(tmp_path: Path) -> None:
+    """Test 3: subprocess exits non-zero → invoked, permission_used, failed."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["bad-url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-3",
+        subprocess_runner=_fake_runner(returncode=2, stderr="boom\n"),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 2
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert events[-1]["result"]["status"] == "failed"
+    assert "code 2" in events[-1]["result"]["message"]
+
+
+def test_bounded_payload_records_sha_not_raw(tmp_path: Path) -> None:
+    """Test 4: 1MB stdout — no part of it appears in any event;
+    sha256 hash recorded instead."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    big_payload = "X" * (1024 * 1024)  # 1 MiB
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-4",
+        subprocess_runner=_fake_runner(stdout=big_payload),
+    )
+    assert result.status == "success"
+    assert result.stdout_sha256 is not None
+    # No raw payload in any event (string check).
+    serialized = json.dumps(events)
+    assert "X" * 1000 not in serialized
+    # sha256 hash present in completed event provenance.
+    completed_event = next(e for e in events if e["event_type"] == "plugin.completed")
+    assert completed_event["provenance"]["stdout_sha256"] == result.stdout_sha256
+
+
+def test_confirmation_declined_blocks_with_no_subprocess(tmp_path: Path) -> None:
+    """Test 5: requires_confirmation=true + confirm()=False → blocked.
+
+    No subprocess launched; only plugin.failed (status=blocked) emitted.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    runner_called = False
+
+    def _spy(*args, **kwargs):
+        nonlocal runner_called
+        runner_called = True
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="merge",  # requires_confirmation = True
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-5",
+        confirm=lambda _msg: False,  # user said No
+        subprocess_runner=_spy,
+    )
+    assert result.status == "blocked"
+    assert runner_called is False
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    assert "user declined" in result.message
+
+
+def test_confirmation_accepted_proceeds(tmp_path: Path) -> None:
+    """Test 6: requires_confirmation=true + confirm()=True → normal flow."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="merge",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-6",
+        confirm=lambda _msg: True,
+        subprocess_runner=_fake_runner(returncode=0, stdout="ok"),
+    )
+    assert result.status == "success"
+    types = [e["event_type"] for e in events]
+    # Standard happy-path order; only one permission emitted (github:read,
+    # the required one). github:pull_request:write is required:false so
+    # it's NOT emitted in v0 (Option (a) coarse rule).
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.completed"]
+    assert events[1]["permissions_used"] == ["github:read"]
+
+
+def test_optional_permission_not_emitted(tmp_path: Path) -> None:
+    """Test 7: required:false permission is NOT emitted in v0.
+
+    The reference manifest has 'github:pull_request:write' with
+    required:false. After invocation, no plugin.permission_used event
+    should reference it (locked Option (a) coarse emission rule).
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-7",
+        subprocess_runner=_fake_runner(stdout=""),
+    )
+    permission_events = [e for e in events if e["event_type"] == "plugin.permission_used"]
+    scopes_emitted = {p for e in permission_events for p in e["permissions_used"]}
+    assert scopes_emitted == {"github:read"}
+    assert "github:pull_request:write" not in scopes_emitted
+
+
+def test_first_party_skips_trust_check(tmp_path: Path) -> None:
+    """Test 8: source.type=first_party bypasses trust check (Q00/ouroboros-plugins#8 lock)."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-auto"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []  # first-party with no external scopes
+    fp["commands"] = [
+        {
+            "namespace": "auto",
+            "name": "run",
+            "summary": "Run auto.",
+            "usage": "ooo auto",
+            "risk": "write",
+        }
+    ]
+    program = _make_program(tmp_path, fp)
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="run",
+        argv=["my goal"],
+        trust_record=None,  # no trust at all
+        event_sink=events.append,
+        correlation_id="corr-8",
+        subprocess_runner=_fake_runner(stdout="ok"),
+    )
+    assert result.status == "success"
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.completed"]
+    # trust_state field reports "first_party"
+    assert all(e["trust_state"] == "first_party" for e in events)
+
+
+def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
+    """Test 9: subprocess FileNotFoundError → status=failed, exit_code=127."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-9",
+        subprocess_runner=_fake_runner(raise_filenotfound=True),
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 127
+    # invoked + permission_used + failed
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert "not found" in result.message.lower()

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -548,6 +548,102 @@ def test_subprocess_inherits_cwd_for_first_party_manifest(tmp_path: Path) -> Non
     )
 
 
+def test_missing_plugin_cwd_does_not_inherit_callers_cwd(tmp_path: Path) -> None:
+    """Regression: when a `local_path` / `plugin_home` plugin's
+    `source.path` does not exist on disk, the firewall must NOT
+    fall back to `cwd=None` (which silently inherits the operator's
+    current working directory). With a relative entrypoint like
+    `./run.sh` or any command that reads plugin-local files, that
+    fallback can execute the wrong program or the wrong inputs.
+
+    The firewall now passes the (non-existent) candidate path to
+    `subprocess.run`, where the kernel's `chdir` call raises
+    `OSError(ENOENT)`. `invoke_plugin` already wraps that into a
+    terminal `plugin.failed` event with exit 126 and the missing-dir
+    reason in the message, which is the correct surface for this
+    failure mode.
+    """
+    from ouroboros.plugin.manifest import (
+        Capability,
+        CommandSpec,
+        Entrypoint,
+        Permission,
+        PluginManifest,
+        SourceSpec,
+    )
+    from ouroboros.plugin.userlevel_registry import UserLevelProgramRegistry
+
+    # Construct the manifest with a guaranteed-missing absolute path.
+    # We build it in-memory rather than going through `load_manifest`
+    # because the sandbox check rejects absolute paths from on-disk
+    # manifests; here we're testing the firewall's own behavior when
+    # the resolved path no longer exists at launch time.
+    missing_dir = tmp_path / "vanished_plugin_home"
+    assert not missing_dir.exists()
+    manifest = PluginManifest(
+        schema_version="0.1",
+        name="github-pr-ops",
+        version="0.1.0",
+        source=SourceSpec(type="local_path", path=str(missing_dir)),
+        commands=(
+            CommandSpec(
+                namespace="github-pr",
+                name="review",
+                summary="x",
+                usage="x",
+                risk="read_only",
+                requires_confirmation=False,
+                arguments=(),
+            ),
+        ),
+        capabilities=(Capability(name="ledger", access="write", reason="x"),),
+        permissions=(Permission(scope="github:read", risk="read_only", required=True),),
+        entrypoint=Entrypoint(type="command", command="python -m github_pr_ops"),
+        description="",
+    )
+    registry = UserLevelProgramRegistry()
+    program = registry.register(manifest)
+
+    captured: dict = {}
+
+    def _runner(argv, *args, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        # Real `subprocess.run` raises FileNotFoundError when cwd
+        # doesn't exist; emulate that so the firewall's OSError
+        # branch runs and we observe the documented `plugin.failed`.
+        raise FileNotFoundError(2, "No such file or directory", str(kwargs.get("cwd")))
+
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-missing",
+        subprocess_runner=_runner,
+    )
+
+    # The firewall pinned `cwd` to the resolved (non-existent) path,
+    # NOT to None — this is what made the kernel raise ENOENT.
+    assert captured["cwd"] is not None, (
+        "missing-dir must not fall back to caller's cwd; the firewall "
+        "should pass the non-existent path so subprocess.run raises ENOENT"
+    )
+    assert Path(captured["cwd"]).resolve() == missing_dir.resolve()
+    # And the failure surfaces as a terminal plugin.failed (the
+    # OSError-wrapping path established in round 7).
+    assert result.status == "failed"
+    types = [e["event_type"] for e in events]
+    assert types[-1] == "plugin.failed"
+
+
 def test_whitespace_entrypoint_emits_failed_not_crash(tmp_path: Path) -> None:
     """Regression: an entrypoint command that's only whitespace passed
     `minLength: 1` schema validation in earlier revisions and made

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -470,10 +470,12 @@ def test_subprocess_runs_with_cwd_for_local_path_manifest(tmp_path: Path) -> Non
     subprocess is anchored there. The firewall must pass `cwd=...`
     to subprocess.run, not silently inherit the caller's cwd.
     """
-    # Use a real existing directory so the firewall's existence check
-    # accepts the path. tmp_path is the cleanest such directory.
+    # Use a sandboxed relative path that resolves into tmp_path. The
+    # manifest loader rejects absolute paths for `local_path` /
+    # `plugin_home` (#745 sandbox), and then anchors the relative slug
+    # to the manifest's directory — which is `tmp_path` for this test.
     payload = json.loads(json.dumps(REFERENCE_MANIFEST))
-    payload["source"] = {"type": "local_path", "path": str(tmp_path)}
+    payload["source"] = {"type": "local_path", "path": "."}
     program = _make_program(tmp_path, payload)
 
     captured: dict = {}

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -3,15 +3,10 @@
 from __future__ import annotations
 
 import json
-import subprocess
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
-
-import pytest
+import subprocess
 
 from ouroboros.plugin.firewall import (
-    InvocationResult,
     invoke_plugin,
 )
 from ouroboros.plugin.manifest import load_manifest
@@ -19,7 +14,6 @@ from ouroboros.plugin.trust_store import TrustStore
 from ouroboros.plugin.userlevel_registry import (
     UserLevelProgramRegistry,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -379,3 +373,124 @@ def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
     types = [e["event_type"] for e in events]
     assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
     assert "not found" in result.message.lower()
+
+
+def test_stale_trust_version_blocks_invocation(tmp_path: Path) -> None:
+    """Regression: a trust file from an older version of the plugin must
+    not satisfy the firewall after the plugin is upgraded.
+
+    Locked Q00/ouroboros-plugins#9 Q4 makes a version bump invalidate
+    trust. The firewall enforces this by treating a TrustRecord whose
+    `version` differs from the manifest as if no scopes were granted —
+    otherwise an upgrade-without-reset would silently bypass the gate.
+    """
+    program = _make_program(tmp_path)  # manifest version = "0.1.0"
+    # Trust file claims grants for an older release of the same plugin.
+    stale_trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.0.9",  # stale: predates the installed manifest
+        scope="github:read",
+        granted_by="user:test",
+    )
+    runner_called = False
+
+    def _spy(*args, **kwargs):
+        nonlocal runner_called
+        runner_called = True
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=stale_trust,
+        event_sink=events.append,
+        correlation_id="corr-stale",
+        subprocess_runner=_spy,
+    )
+    # The firewall must refuse the call and never reach the runner.
+    assert result.status == "blocked"
+    assert runner_called is False, "stale trust must not let the entrypoint launch"
+    # Only `plugin.failed` (status=blocked); no `plugin.invoked` slipped through.
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.failed"]
+    assert events[0]["result"]["status"] == "blocked"
+    # Blocked-message must guide the user to re-trust the same scope.
+    assert "github:read" in result.message
+    # And the emitted event must NOT label the plugin "trusted" while it
+    # is in fact being blocked — that was the consistency bug.
+    assert events[0]["trust_state"] != "trusted"
+
+
+def test_entrypoint_permission_error_emits_failed_126(tmp_path: Path) -> None:
+    """Regression: PermissionError at subprocess launch must reach a
+    terminal `plugin.failed` event instead of escaping the firewall.
+
+    Previously only FileNotFoundError was caught, so an entrypoint that
+    existed but lacked the exec bit (or any other OSError surfaced at
+    spawn-time) crashed the caller with no audit trail. The firewall
+    now widens the catch to OSError and uses conventional shell exit
+    codes (126 = found-but-not-executable).
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+
+    def _runner(argv, *args, **kwargs):
+        raise PermissionError(13, "Permission denied", argv[0])
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-perm",
+        subprocess_runner=_runner,
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 126
+    # invoked + permission_used + failed (does not raise).
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert events[-1]["result"]["status"] == "failed"
+    assert "not executable" in result.message
+
+
+def test_entrypoint_generic_oserror_emits_failed_126(tmp_path: Path) -> None:
+    """Regression: a generic OSError (e.g. ENOEXEC) must also land on a
+    `plugin.failed` event with a 126-class exit code rather than
+    propagating up and crashing the caller.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+
+    def _runner(argv, *args, **kwargs):
+        raise OSError(8, "Exec format error", argv[0])
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-enoexec",
+        subprocess_runner=_runner,
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 126
+    types = [e["event_type"] for e in events]
+    assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
+    assert "failed to launch" in result.message

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -644,6 +644,88 @@ def test_missing_plugin_cwd_does_not_inherit_callers_cwd(tmp_path: Path) -> None
     assert types[-1] == "plugin.failed"
 
 
+def test_malformed_entrypoint_quoting_emits_failed_not_crash(tmp_path: Path) -> None:
+    """Regression: an `entrypoint.command` with malformed shell
+    quoting (unterminated quote) passes the schema's `\\S` pattern
+    check and `load_manifest()`, but `shlex.split()` raises
+    `ValueError` — so the firewall used to crash *after* having
+    emitted `plugin.invoked` and friends, leaving the audit log
+    partially written and bubbling the exception up to the caller.
+
+    The firewall contract is to convert every launch failure into
+    a terminal `plugin.failed` event with a clean audit trail and
+    a structured `InvocationResult`. This test asserts that the
+    `shlex.split` path now obeys that contract for malformed
+    quoting too.
+    """
+    from ouroboros.plugin.manifest import (
+        Capability,
+        CommandSpec,
+        Entrypoint,
+        PluginManifest,
+        SourceSpec,
+    )
+    from ouroboros.plugin.userlevel_registry import UserLevelProgramRegistry
+
+    # Build the manifest in-memory so the malformed `command` survives
+    # — the schema would reject a manifest with truly nonsense quoting,
+    # but a future schema relaxation, a fixture, or a mistake in the
+    # manager pipeline could still produce one. The firewall must
+    # tolerate it.
+    bad = PluginManifest(
+        schema_version="0.1",
+        name="github-pr-ops",
+        version="0.1.0",
+        source=SourceSpec(type="first_party"),  # no cwd anchoring needed
+        commands=(
+            CommandSpec(
+                namespace="github-pr",
+                name="review",
+                summary="x",
+                usage="x",
+                risk="read_only",
+                requires_confirmation=False,
+                arguments=(),
+            ),
+        ),
+        capabilities=(Capability(name="ledger", access="write", reason="x"),),
+        permissions=(),
+        entrypoint=Entrypoint(type="command", command='"unterminated'),
+    )
+    registry = UserLevelProgramRegistry()
+    program = registry.register(bad)
+
+    captured: dict = {"called": False}
+
+    def _runner(argv, *args, **kwargs):
+        # If the firewall reaches this, the shlex error wasn't caught
+        # and the runner is being invoked with garbage argv. Fail
+        # the test loudly rather than letting it pass silently.
+        captured["called"] = True
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=[],
+        trust_record=None,
+        event_sink=events.append,
+        correlation_id="corr-bad-quote",
+        subprocess_runner=_runner,
+    )
+
+    # The firewall short-circuited before launching the subprocess,
+    # so the runner must NOT have been called.
+    assert captured["called"] is False
+    # Terminal event sequence is invoked → permission_used* → failed.
+    types = [e["event_type"] for e in events]
+    assert types[-1] == "plugin.failed"
+    assert result.status == "failed"
+    assert result.exit_code == 126
+    assert "malformed" in result.message or "quoting" in result.message
+
+
 def test_whitespace_entrypoint_emits_failed_not_crash(tmp_path: Path) -> None:
     """Regression: an entrypoint command that's only whitespace passed
     `minLength: 1` schema validation in earlier revisions and made

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -463,6 +463,165 @@ def test_entrypoint_permission_error_emits_failed_126(tmp_path: Path) -> None:
     assert "not executable" in result.message
 
 
+def test_subprocess_runs_with_cwd_for_local_path_manifest(tmp_path: Path) -> None:
+    """Regression: `local_path` / `plugin_home` manifests carry their
+    own location, and relative entrypoints (`./run.sh`) or commands
+    that read files from the plugin directory only work when the
+    subprocess is anchored there. The firewall must pass `cwd=...`
+    to subprocess.run, not silently inherit the caller's cwd.
+    """
+    # Use a real existing directory so the firewall's existence check
+    # accepts the path. tmp_path is the cleanest such directory.
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["source"] = {"type": "local_path", "path": str(tmp_path)}
+    program = _make_program(tmp_path, payload)
+
+    captured: dict = {}
+
+    def _runner(argv, *args, **kwargs):
+        captured["argv"] = argv
+        captured["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-cwd",
+        subprocess_runner=_runner,
+    )
+    assert result.status == "success"
+    # subprocess was invoked with cwd anchored to the plugin's source.path,
+    # not to wherever the caller happened to be.
+    assert captured["cwd"] is not None
+    assert Path(captured["cwd"]).resolve() == tmp_path.resolve()
+
+
+def test_subprocess_inherits_cwd_for_first_party_manifest(tmp_path: Path) -> None:
+    """First-party plugins ship inside the binary and have no plugin-
+    local directory, so the firewall must NOT pin a `cwd`."""
+    fp = json.loads(json.dumps(REFERENCE_MANIFEST))
+    fp["name"] = "ooo-builtin"
+    fp["source"] = {"type": "first_party"}
+    fp["permissions"] = []
+    fp["commands"] = [
+        {
+            "namespace": "builtin",
+            "name": "run",
+            "summary": "Run.",
+            "usage": "ooo builtin run",
+            "risk": "write",
+        }
+    ]
+    program = _make_program(tmp_path, fp)
+
+    captured: dict = {}
+
+    def _runner(argv, *args, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    invoke_plugin(
+        program,
+        command_name="run",
+        argv=[],
+        trust_record=None,
+        event_sink=events.append,
+        correlation_id="corr-fp",
+        subprocess_runner=_runner,
+    )
+    assert captured["cwd"] is None, (
+        "first-party plugins must inherit the caller's cwd; "
+        "the firewall has no plugin-local directory to pin"
+    )
+
+
+def test_whitespace_entrypoint_emits_failed_not_crash(tmp_path: Path) -> None:
+    """Regression: an entrypoint command that's only whitespace passed
+    `minLength: 1` schema validation in earlier revisions and made
+    `shlex.split(" ")` return `[]`. The firewall must still emit a
+    terminal `plugin.failed` event with a clear message rather than
+    crash the caller.
+
+    The schema now also rejects whitespace-only commands, but the
+    firewall keeps a defense-in-depth runtime guard so a constructed
+    manifest (e.g. via a fixture or a future lax schema) cannot bypass
+    the audit-output contract.
+    """
+    # Build the manifest manually so it bypasses the schema's tightened
+    # `\\S` pattern — we're testing the firewall's runtime guard, not
+    # the schema.
+    from ouroboros.plugin.manifest import (
+        CommandSpec,
+        Entrypoint,
+        Permission,
+        PluginManifest,
+        SourceSpec,
+    )
+    from ouroboros.plugin.userlevel_registry import UserLevelProgramRegistry
+
+    bad_manifest = PluginManifest(
+        schema_version="0.1",
+        name="github-pr-ops",
+        version="0.1.0",
+        source=SourceSpec(type="local_path", path=str(tmp_path)),
+        commands=(
+            CommandSpec(
+                namespace="github-pr",
+                name="review",
+                summary="x",
+                usage="x",
+                risk="read_only",
+                requires_confirmation=False,
+                arguments=(),
+            ),
+        ),
+        capabilities=(),
+        permissions=(Permission(scope="github:read", risk="read_only", required=True),),
+        entrypoint=Entrypoint(type="command", command="   "),
+    )
+    program = UserLevelProgramRegistry().register(bad_manifest)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    runner_called = False
+
+    def _spy(*args, **kwargs):
+        nonlocal runner_called
+        runner_called = True
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-empty-cmd",
+        subprocess_runner=_spy,
+    )
+    assert result.status == "failed"
+    assert result.exit_code == 126
+    assert runner_called is False, "must not even attempt subprocess.run([...])"
+    types = [e["event_type"] for e in events]
+    assert types[-1] == "plugin.failed"
+    assert "empty or whitespace" in result.message
+
+
 def test_entrypoint_generic_oserror_emits_failed_126(tmp_path: Path) -> None:
     """Regression: a generic OSError (e.g. ENOEXEC) must also land on a
     `plugin.failed` event with a 126-class exit code rather than

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -1,0 +1,198 @@
+"""Tests for the firewall-to-core-ledger adapter (Q00/ouroboros#737)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from ouroboros.plugin.ledger_adapter import (
+    AUDIT_EVENT_TYPES,
+    PLUGIN_AGGREGATE_TYPE,
+    make_event_sink,
+    unwrap_plugin_event,
+    wrap_plugin_event,
+)
+
+
+# Audit-event schema is vendored in CR-3 at this path.
+SCHEMA_PATH = Path(__file__).resolve().parents[3] / (
+    "src/ouroboros/plugin/schemas/0.1/audit-event.schema.json"
+)
+AUDIT_SCHEMA = json.loads(SCHEMA_PATH.read_text())
+AUDIT_VALIDATOR = Draft202012Validator(AUDIT_SCHEMA)
+
+
+def _audit_event(event_type: str, **overrides) -> dict:
+    """Build an audit event matching schemas/0.1/audit-event.schema.json."""
+    base = {
+        "schema_version": "0.1",
+        "event_type": event_type,
+        "occurred_at": "2026-05-07T12:00:00Z",
+        "plugin": {
+            "name": "github-pr-ops",
+            "version": "0.1.0",
+            "source_type": "plugin_home",
+        },
+        "command": {"namespace": "github-pr", "name": "review", "argv": ["url"]},
+        "trust_state": "trusted",
+        "capabilities_used": [],
+        "permissions_used": ["github:read"],
+        "result": {"status": "success"},
+    }
+    base.update(overrides)
+    # Confirm the test fixture itself validates against the schema.
+    errs = list(AUDIT_VALIDATOR.iter_errors(base))
+    assert not errs, f"test fixture invalid: {errs}"
+    return base
+
+
+def test_wrap_basic_envelope() -> None:
+    """Wrapping produces the documented envelope shape."""
+    ev = _audit_event("plugin.invoked")
+    env = wrap_plugin_event(ev, correlation_id="corr-1")
+
+    assert env["aggregate_type"] == PLUGIN_AGGREGATE_TYPE
+    assert env["aggregate_id"] == "corr-1"
+    assert env["event_type"] == "plugin.invoked"
+    assert env["timestamp"] == "2026-05-07T12:00:00Z"
+    assert isinstance(env["id"], str) and len(env["id"]) > 0
+    # payload contains the full audit event
+    assert env["payload"]["schema_version"] == "0.1"
+    assert env["payload"]["plugin"]["name"] == "github-pr-ops"
+
+
+def test_wrap_does_not_mutate_input() -> None:
+    """The audit event passed in must not be mutated by wrap()."""
+    ev = _audit_event("plugin.invoked")
+    snapshot = json.dumps(ev, sort_keys=True)
+    wrap_plugin_event(ev, correlation_id="x")
+    assert json.dumps(ev, sort_keys=True) == snapshot
+
+
+def test_wrap_does_not_inject_fields_into_audit_event() -> None:
+    """Envelope fields stay above the audit event boundary.
+
+    The audit-event schema declares additionalProperties:false. The
+    payload must remain schema-valid after wrapping.
+    """
+    ev = _audit_event("plugin.invoked")
+    env = wrap_plugin_event(ev, correlation_id="x")
+    # payload alone must validate as an audit event.
+    errs = list(AUDIT_VALIDATOR.iter_errors(env["payload"]))
+    assert not errs, f"payload no longer schema-valid: {errs}"
+
+
+def test_unwrap_returns_audit_event() -> None:
+    """unwrap recovers the audit event from an envelope."""
+    ev = _audit_event("plugin.completed")
+    env = wrap_plugin_event(ev, correlation_id="x")
+    unwrapped = unwrap_plugin_event(env)
+    # validate as audit event
+    errs = list(AUDIT_VALIDATOR.iter_errors(unwrapped))
+    assert not errs
+    # equality with original
+    assert unwrapped == ev
+
+
+def test_round_trip_for_all_seven_event_types() -> None:
+    """Round-trip every event type defined in the schema."""
+    for event_type in AUDIT_EVENT_TYPES:
+        ev = _audit_event(event_type)
+        env = wrap_plugin_event(ev, correlation_id=f"corr-{event_type}")
+        recovered = unwrap_plugin_event(env)
+        assert recovered == ev, f"{event_type} did not round-trip"
+        # And the envelope's event_type matches.
+        assert env["event_type"] == event_type
+
+
+def test_unwrap_rejects_non_plugin_envelope() -> None:
+    """Envelope with the wrong aggregate_type is rejected."""
+    fake = {
+        "id": "x",
+        "aggregate_type": "execution",
+        "aggregate_id": "y",
+        "event_type": "execution.something",
+        "payload": {},
+        "timestamp": "2026-05-07T12:00:00Z",
+    }
+    with pytest.raises(ValueError, match="not a plugin envelope"):
+        unwrap_plugin_event(fake)
+
+
+def test_wrap_requires_event_type() -> None:
+    """Wrapping fails fast if the audit event is missing event_type."""
+    with pytest.raises(ValueError, match="event_type"):
+        wrap_plugin_event({"occurred_at": "x"}, correlation_id="c")
+
+
+def test_wrap_requires_occurred_at() -> None:
+    """Wrapping fails fast if the audit event is missing occurred_at."""
+    with pytest.raises(ValueError, match="occurred_at"):
+        wrap_plugin_event({"event_type": "plugin.invoked"}, correlation_id="c")
+
+
+def test_aggregate_id_override() -> None:
+    """aggregate_id parameter overrides the correlation_id default."""
+    ev = _audit_event("plugin.invoked")
+    env = wrap_plugin_event(ev, correlation_id="default", aggregate_id="custom")
+    assert env["aggregate_id"] == "custom"
+    assert env["aggregate_id"] != "default"
+
+
+def test_make_event_sink_appends_envelopes() -> None:
+    """The sink wraps each audit event and forwards to append_fn."""
+    rows: list[dict] = []
+    sink = make_event_sink(rows.append, correlation_id="corr-x")
+    sink(_audit_event("plugin.invoked"))
+    sink(_audit_event("plugin.completed"))
+    assert len(rows) == 2
+    for row in rows:
+        assert row["aggregate_type"] == PLUGIN_AGGREGATE_TYPE
+        assert row["aggregate_id"] == "corr-x"
+
+
+def test_make_event_sink_with_id_factory() -> None:
+    """envelope_id_factory provides deterministic ids for tests."""
+    rows: list[dict] = []
+    counter = iter(["env-1", "env-2"])
+    sink = make_event_sink(
+        rows.append,
+        correlation_id="x",
+        envelope_id_factory=lambda: next(counter),
+    )
+    sink(_audit_event("plugin.invoked"))
+    sink(_audit_event("plugin.completed"))
+    assert [r["id"] for r in rows] == ["env-1", "env-2"]
+
+
+def test_envelope_event_type_matches_payload_event_type() -> None:
+    """The envelope's event_type string mirrors the payload's event_type
+    (so the events_table.event_type column is queryable without parsing
+    the JSON payload)."""
+    for event_type in AUDIT_EVENT_TYPES:
+        ev = _audit_event(event_type)
+        env = wrap_plugin_event(ev, correlation_id="x")
+        assert env["event_type"] == env["payload"]["event_type"] == event_type
+
+
+def test_wrap_rejects_non_dict_input() -> None:
+    """Wrapping a non-dict raises TypeError."""
+    with pytest.raises(TypeError, match="must be dict"):
+        wrap_plugin_event("not a dict", correlation_id="x")  # type: ignore[arg-type]
+
+
+def test_no_raw_token_fields_in_envelope() -> None:
+    """Sanity: the envelope contains no token-shaped keys.
+
+    Plugin events go through the firewall's bounded-payload guard;
+    this test confirms the adapter doesn't accidentally introduce one.
+    """
+    ev = _audit_event("plugin.completed")
+    env = wrap_plugin_event(ev, correlation_id="x")
+    serialized = json.dumps(env).lower()
+    for forbidden in ("ghp_", "bearer ", "x-api-key"):
+        assert forbidden.lower() not in serialized

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
 from jsonschema import Draft202012Validator
+import pytest
 
 from ouroboros.plugin.ledger_adapter import (
     AUDIT_EVENT_TYPES,
@@ -16,7 +15,6 @@ from ouroboros.plugin.ledger_adapter import (
     unwrap_plugin_event,
     wrap_plugin_event,
 )
-
 
 # Audit-event schema is vendored in CR-3 at this path.
 SCHEMA_PATH = Path(__file__).resolve().parents[3] / (

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -194,3 +194,83 @@ def test_no_raw_token_fields_in_envelope() -> None:
     serialized = json.dumps(env).lower()
     for forbidden in ("ghp_", "bearer ", "x-api-key"):
         assert forbidden.lower() not in serialized
+
+
+def test_envelope_to_base_event_round_trips_through_real_event_store() -> None:
+    """Regression: the bridge from a wrapped envelope to a `BaseEvent`
+    that `EventStore.append` accepts is real, not aspirational.
+
+    The previous adapter docstring claimed `make_event_sink` could be
+    wired to `EventStore.append` directly, but that method is async
+    and rejects non-`BaseEvent` payloads. The new
+    `envelope_to_base_event` + `append_envelope_to_event_store`
+    helpers actually bridge the contract. This test exercises the
+    full path against an in-memory EventStore and asserts the
+    persisted row reproduces the original audit event.
+    """
+    pytest.importorskip("aiosqlite")  # safety on slim CI images
+
+    import asyncio
+
+    from ouroboros.persistence.event_store import EventStore
+    from ouroboros.plugin.ledger_adapter import (
+        append_envelope_to_event_store,
+        envelope_to_base_event,
+    )
+
+    audit = _audit_event("plugin.completed")
+    envelope = wrap_plugin_event(audit, correlation_id="corr-bridge", envelope_id="env-bridge")
+
+    base_event = envelope_to_base_event(envelope)
+    # The bridge speaks BaseEvent's contract: aggregate_type pinned,
+    # event_type matches the audit payload, payload preserved verbatim.
+    assert base_event.aggregate_type == "plugin"
+    assert base_event.aggregate_id == "corr-bridge"
+    assert base_event.type == "plugin.completed"
+    assert base_event.data["event_type"] == "plugin.completed"
+    assert base_event.data["plugin"]["name"] == "github-pr-ops"
+
+    async def _persist_and_replay() -> list:
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+        # The async bridge is what production code is expected to use.
+        await append_envelope_to_event_store(envelope, store=store)
+        return await store.replay("plugin", "corr-bridge")
+
+    rows = asyncio.run(_persist_and_replay())
+    assert len(rows) == 1
+    persisted = rows[0]
+    assert persisted.type == "plugin.completed"
+    assert persisted.aggregate_type == "plugin"
+    assert persisted.aggregate_id == "corr-bridge"
+    # The original audit event survives a full round-trip — `unwrap_plugin_event`
+    # reconstructs the schema-valid form from the persisted row's data.
+    rebuilt_envelope = {
+        "id": persisted.id,
+        "aggregate_type": persisted.aggregate_type,
+        "aggregate_id": persisted.aggregate_id,
+        "event_type": persisted.type,
+        "payload": persisted.data,
+        "timestamp": persisted.timestamp,
+    }
+    rebuilt_audit = unwrap_plugin_event(rebuilt_envelope)
+    assert rebuilt_audit["event_type"] == audit["event_type"]
+    assert rebuilt_audit["plugin"] == audit["plugin"]
+    assert rebuilt_audit["command"] == audit["command"]
+
+
+def test_envelope_to_base_event_rejects_non_plugin_envelope() -> None:
+    """The bridge refuses envelopes for other aggregates, so a misrouted
+    payload cannot end up persisted under aggregate_type='plugin'."""
+    from ouroboros.plugin.ledger_adapter import envelope_to_base_event
+
+    bogus = {
+        "id": "x",
+        "aggregate_type": "session",
+        "aggregate_id": "y",
+        "event_type": "plugin.completed",
+        "payload": {"event_type": "plugin.completed", "occurred_at": "2026-05-07T12:00:00Z"},
+        "timestamp": "2026-05-07T12:00:00Z",
+    }
+    with pytest.raises(ValueError, match="not a plugin envelope"):
+        envelope_to_base_event(bogus)

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -259,6 +259,47 @@ def test_envelope_to_base_event_round_trips_through_real_event_store() -> None:
     assert rebuilt_audit["command"] == audit["command"]
 
 
+def test_wrap_payload_is_deep_copied() -> None:
+    """Regression: `wrap_plugin_event` must defend against later
+    mutation of nested dicts in the original audit event.
+
+    The previous shallow `dict(audit_event)` copy still shared
+    `audit_event["plugin"]`, `["command"]`, `["result"]`, etc., so a
+    caller mutating `audit_event["plugin"]["name"]` after wrap would
+    silently corrupt the persisted envelope. The contract says the
+    payload is owned by the envelope; deep-copy enforces it.
+    """
+    audit = _audit_event("plugin.invoked")
+    env = wrap_plugin_event(audit, correlation_id="x")
+
+    # Mutate the nested dicts on the SOURCE — none of these mutations
+    # may leak into the envelope payload.
+    audit["plugin"]["name"] = "tampered"
+    audit["command"]["argv"].append("evil")
+    audit["result"]["status"] = "tampered"
+
+    assert env["payload"]["plugin"]["name"] == "github-pr-ops"
+    assert env["payload"]["command"]["argv"] == ["url"]
+    assert env["payload"]["result"]["status"] == "success"
+
+
+def test_envelope_to_base_event_data_is_deep_copied() -> None:
+    """Regression: `BaseEvent.data` must not alias the envelope's
+    payload. Mutating the envelope after the bridge runs must not
+    reach into the persisted event."""
+    from ouroboros.plugin.ledger_adapter import envelope_to_base_event
+
+    audit = _audit_event("plugin.completed")
+    env = wrap_plugin_event(audit, correlation_id="x")
+    base = envelope_to_base_event(env)
+
+    env["payload"]["plugin"]["name"] = "tampered"
+    env["payload"]["command"]["argv"].append("evil")
+
+    assert base.data["plugin"]["name"] == "github-pr-ops"
+    assert base.data["command"]["argv"] == ["url"]
+
+
 def test_envelope_to_base_event_preserves_audit_timestamp() -> None:
     """Regression: the bridge MUST carry the original audit time over to
     `BaseEvent.timestamp`. Without that, persisted rows inherit

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -259,6 +259,90 @@ def test_envelope_to_base_event_round_trips_through_real_event_store() -> None:
     assert rebuilt_audit["command"] == audit["command"]
 
 
+def test_envelope_to_base_event_preserves_audit_timestamp() -> None:
+    """Regression: the bridge MUST carry the original audit time over to
+    `BaseEvent.timestamp`. Without that, persisted rows inherit
+    `BaseEvent`'s "now" default and the events_table.timestamp column
+    no longer reflects when the firewall observed the event — silently
+    breaking ordering, recency, and replay for plugin events.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from ouroboros.plugin.ledger_adapter import envelope_to_base_event
+
+    # An audit event from clearly in the past: any "now"-default would
+    # be wrong by a wide enough margin that the assert can't false-pass
+    # on a slow test machine.
+    audit = _audit_event("plugin.invoked", occurred_at="2020-01-15T08:30:45Z")
+    envelope = wrap_plugin_event(audit, correlation_id="corr-time")
+
+    before = datetime.now(UTC)
+    base_event = envelope_to_base_event(envelope)
+    after = datetime.now(UTC)
+
+    expected = datetime(2020, 1, 15, 8, 30, 45, tzinfo=UTC)
+    assert base_event.timestamp == expected
+    # Sanity: the persisted timestamp is the audit time, not anything
+    # close to "now". Any drift wider than a year proves we did not
+    # accidentally fall through to the default factory.
+    assert before - base_event.timestamp > timedelta(days=365)
+    assert after - base_event.timestamp > timedelta(days=365)
+
+
+def test_envelope_to_base_event_round_trips_timestamp_through_real_store() -> None:
+    """End-to-end check: persist, replay, and confirm the timestamp on
+    the row coming out of EventStore matches the audit's occurred_at
+    rather than wall-clock-now."""
+    pytest.importorskip("aiosqlite")
+
+    import asyncio
+    from datetime import UTC, datetime
+
+    from ouroboros.persistence.event_store import EventStore
+    from ouroboros.plugin.ledger_adapter import append_envelope_to_event_store
+
+    audit = _audit_event("plugin.completed", occurred_at="2024-12-31T23:59:59Z")
+    envelope = wrap_plugin_event(
+        audit, correlation_id="corr-roundtrip", envelope_id="env-roundtrip"
+    )
+    expected = datetime(2024, 12, 31, 23, 59, 59, tzinfo=UTC)
+
+    async def _persist_and_replay() -> list:
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+        await append_envelope_to_event_store(envelope, store=store)
+        return await store.replay("plugin", "corr-roundtrip")
+
+    rows = asyncio.run(_persist_and_replay())
+    assert len(rows) == 1
+    persisted = rows[0]
+    persisted_ts = persisted.timestamp
+    if persisted_ts.tzinfo is None:
+        # Some SQLAlchemy/sqlite combinations strip tzinfo on read; the
+        # timestamp value itself must still be UTC-equivalent.
+        persisted_ts = persisted_ts.replace(tzinfo=UTC)
+    assert persisted_ts == expected, (
+        f"persisted timestamp {persisted_ts!r} drifted from audit occurred_at {expected!r}"
+    )
+
+
+def test_envelope_to_base_event_rejects_missing_timestamp() -> None:
+    """If neither the envelope nor the payload exposes a timestamp the
+    bridge MUST refuse rather than silently default to "now"."""
+    from ouroboros.plugin.ledger_adapter import envelope_to_base_event
+
+    bogus = {
+        "id": "x",
+        "aggregate_type": "plugin",
+        "aggregate_id": "y",
+        "event_type": "plugin.completed",
+        "payload": {"event_type": "plugin.completed"},  # no occurred_at
+        # no top-level timestamp
+    }
+    with pytest.raises(ValueError, match="timestamp"):
+        envelope_to_base_event(bogus)
+
+
 def test_envelope_to_base_event_rejects_non_plugin_envelope() -> None:
     """The bridge refuses envelopes for other aggregates, so a misrouted
     payload cannot end up persisted under aggregate_type='plugin'."""

--- a/tests/unit/plugin/test_lockfile.py
+++ b/tests/unit/plugin/test_lockfile.py
@@ -1,0 +1,152 @@
+"""Tests for the plugin lockfile (Q00/ouroboros#732)."""
+
+from __future__ import annotations
+
+import multiprocessing
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.lockfile import (
+    LOCKFILE_SCHEMA_VERSION,
+    LockEntry,
+    Lockfile,
+)
+
+
+def _make_entry(name: str = "github-pr-ops", version: str = "0.1.0") -> LockEntry:
+    return LockEntry(
+        name=name,
+        version=version,
+        source_kind="git",
+        repository="https://github.com/Q00/ouroboros-plugins",
+        git_sha="b3a91f2",
+        manifest_checksum="sha256:abc123",
+        installed_at="2026-05-08T03:14:00Z",
+        plugin_home=f"~/.ouroboros/plugins/{name}",
+    )
+
+
+def test_install_then_read(tmp_path: Path) -> None:
+    """Test 1: install → lockfile entry present; round-trip through TOML."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    entry = _make_entry()
+    lock.add(entry)
+
+    fresh = Lockfile(tmp_path / "plugins.lock")
+    entries = fresh.read()
+    assert "github-pr-ops" in entries
+    assert entries["github-pr-ops"] == entry
+
+
+def test_remove_drops_entry(tmp_path: Path) -> None:
+    """Test 2: remove → entry gone."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry())
+    assert lock.remove("github-pr-ops") is True
+    assert lock.read() == {}
+    # Removing again is a no-op.
+    assert lock.remove("github-pr-ops") is False
+
+
+def test_lockfile_is_sorted(tmp_path: Path) -> None:
+    """Test 3: entries are written in deterministic name-sorted order."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry(name="zebra"))
+    lock.add(_make_entry(name="apple"))
+    lock.add(_make_entry(name="middle"))
+
+    text = (tmp_path / "plugins.lock").read_text()
+    apple_idx = text.find('name = "apple"')
+    middle_idx = text.find('name = "middle"')
+    zebra_idx = text.find('name = "zebra"')
+    assert apple_idx < middle_idx < zebra_idx
+
+
+def test_lockfile_schema_version_present(tmp_path: Path) -> None:
+    """Test 4: lockfile carries a schema_version header."""
+    lock = Lockfile(tmp_path / "plugins.lock")
+    lock.add(_make_entry())
+    text = (tmp_path / "plugins.lock").read_text()
+    assert f'schema_version = "{LOCKFILE_SCHEMA_VERSION}"' in text
+
+
+def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
+    """Test 5: a lockfile with the wrong schema_version raises on read."""
+    path = tmp_path / "plugins.lock"
+    path.write_text('schema_version = "99.0"\n')
+    lock = Lockfile(path)
+    with pytest.raises(ValueError, match="unsupported lockfile schema_version"):
+        lock.read()
+
+
+def test_atomic_write_no_partial_file_on_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test 6: simulated crash mid-write leaves the original file intact."""
+    lock_path = tmp_path / "plugins.lock"
+    lock = Lockfile(lock_path)
+    lock.add(_make_entry(name="initial"))
+
+    original = lock_path.read_text()
+
+    # Patch os.replace to fail, simulating a crash before rename.
+    import os
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated crash during rename")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    with pytest.raises(OSError, match="simulated crash"):
+        lock.add(_make_entry(name="second"))
+
+    # Original lockfile content must be unchanged.
+    assert lock_path.read_text() == original
+    # No leftover .plugins.lock.* temp file in the directory.
+    leftovers = list(tmp_path.glob(".plugins.lock.*"))
+    assert leftovers == []
+
+
+def _concurrent_writer(target_path_str: str, name: str, count: int) -> None:
+    """Worker for concurrent-write test. Adds N entries with distinct names."""
+    from pathlib import Path as _Path
+
+    from ouroboros.plugin.lockfile import LockEntry, Lockfile
+
+    lock = Lockfile(_Path(target_path_str))
+    for i in range(count):
+        lock.add(
+            LockEntry(
+                name=f"{name}-{i}",
+                version="0.1.0",
+                source_kind="local",
+                repository=None,
+                git_sha=None,
+                manifest_checksum="sha256:0",
+                installed_at="2026-05-08T03:14:00Z",
+                plugin_home=f"~/.ouroboros/plugins/{name}-{i}",
+            )
+        )
+
+
+def test_concurrent_writes_do_not_corrupt(tmp_path: Path) -> None:
+    """Test 7: two processes writing concurrently do not corrupt the file
+    or lose entries (POSIX flock holds them serialized)."""
+    lock_path = tmp_path / "plugins.lock"
+    procs = [
+        multiprocessing.Process(target=_concurrent_writer, args=(str(lock_path), "p1", 5)),
+        multiprocessing.Process(target=_concurrent_writer, args=(str(lock_path), "p2", 5)),
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=10)
+        assert p.exitcode == 0, f"writer exited {p.exitcode}"
+
+    # Final lockfile is valid TOML and contains all 10 entries.
+    entries = Lockfile(lock_path).read()
+    assert len(entries) == 10
+    assert {e.name for e in entries.values()} == {
+        f"{prefix}-{i}" for prefix in ("p1", "p2") for i in range(5)
+    }

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -213,12 +213,16 @@ def test_plugin_home_source_requires_path(tmp_path: Path) -> None:
 
 
 def test_local_path_source_with_path_loads(tmp_path: Path) -> None:
-    """Positive control: source.type=local_path with `path` loads cleanly."""
+    """Positive control: source.type=local_path with `path` loads cleanly
+    and is normalized against the manifest's directory at load time."""
     fp = json.loads(json.dumps(REFERENCE_MANIFEST))
     fp["source"] = {"type": "local_path", "path": "plugins/whatever"}
     manifest = load_manifest(_write(tmp_path, fp))
     assert manifest.source.type == "local_path"
-    assert manifest.source.path == "plugins/whatever"
+    assert manifest.source.path is not None
+    resolved = Path(manifest.source.path)
+    assert resolved.is_absolute()
+    assert resolved == (tmp_path / "plugins" / "whatever").resolve()
 
 
 def test_old_risk_enum_value_rejected(tmp_path: Path) -> None:
@@ -304,12 +308,44 @@ def test_sandboxed_source_path_rejects_traversal(
 
 
 def test_plugin_home_with_relative_path_loads(tmp_path: Path) -> None:
-    """Positive control: a sandboxed relative `plugin_home` path loads."""
+    """Positive control: a sandboxed relative `plugin_home` path loads
+    and is normalized against the manifest's directory so downstream
+    consumers (firewall cwd, CLI inspect output) see a stable absolute
+    location regardless of the operator's current working directory.
+    """
     fp = json.loads(json.dumps(REFERENCE_MANIFEST))
     fp["source"] = {"type": "plugin_home", "path": "vendor/ooo-pr-ops"}
     manifest = load_manifest(_write(tmp_path, fp))
     assert manifest.source.type == "plugin_home"
-    assert manifest.source.path == "vendor/ooo-pr-ops"
+    assert manifest.source.path is not None
+    resolved = Path(manifest.source.path)
+    assert resolved.is_absolute()
+    assert resolved == (tmp_path / "vendor" / "ooo-pr-ops").resolve()
+
+
+def test_relative_source_path_resolves_to_absolute(tmp_path: Path) -> None:
+    """Regression for the d1511607 fix: a `source.path` like `"."` or
+    `"plugins/foo"` used to be passed through to the firewall verbatim,
+    so the subprocess `cwd` depended on where the operator ran `ooo`
+    from. The loader now anchors relative `source.path` to the manifest
+    file's directory at load time. Layered with the sandbox check from
+    #745, the input is validated as a safe relative slug *and* the
+    output is a stable absolute path for runtime consumers.
+    """
+    plugin_home = tmp_path / "plugins" / "github-pr-ops"
+    plugin_home.mkdir(parents=True)
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["source"] = {"type": "local_path", "path": "."}
+    manifest_path = _write(plugin_home, payload)
+
+    manifest = load_manifest(manifest_path)
+
+    assert manifest.source.path is not None
+    resolved = Path(manifest.source.path)
+    assert resolved.is_absolute(), "source.path must be normalized to absolute"
+    assert resolved == plugin_home.resolve(), (
+        f"source.path={resolved!r} did not resolve relative to manifest dir {plugin_home!r}"
+    )
 
 
 def test_vendored_schemas_are_packaged_resources() -> None:

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -391,6 +391,17 @@ def test_source_first_party_path_optional(tmp_path: Path) -> None:
     assert manifest.source.path is None
 
 
+def test_first_party_source_path_stays_none(tmp_path: Path) -> None:
+    """First-party plugins still produce `source.path is None`."""
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["name"] = "ooo-builtin"
+    payload["source"] = {"type": "first_party"}
+    payload["permissions"] = []
+    manifest = load_manifest(_write(tmp_path, payload))
+    assert manifest.source.type == "first_party"
+    assert manifest.source.path is None
+
+
 def test_capabilities_and_permissions_preserve_manifest_order(tmp_path: Path) -> None:
     """Regression: `capabilities` and `permissions` used to be
     `frozenset`s, so iteration order varied across hash seeds and

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -352,3 +352,79 @@ def test_unreadable_manifest_reports_structured_error(tmp_path: Path) -> None:
         assert excinfo.value.path == str(target)
     finally:
         target.chmod(0o644)
+
+
+def test_source_local_path_requires_path(tmp_path: Path) -> None:
+    """Regression: a `local_path` source manifest with no `path` is
+    invalid. The schema previously required only `type`, so the
+    location metadata could be omitted and the rest of the plugin
+    system would only fail later at install/runtime."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "local_path"}  # path missing
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    # The pointer lands on the source object — that's where the
+    # `required: ["type", "path"]` clause attaches.
+    assert excinfo.value.json_pointer.startswith("/source")
+
+
+def test_source_plugin_home_requires_path(tmp_path: Path) -> None:
+    """Regression: same gate for `plugin_home` source type. The
+    location is still mandatory metadata for the plugin system."""
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "plugin_home"}
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer.startswith("/source")
+
+
+def test_source_first_party_path_optional(tmp_path: Path) -> None:
+    """First-party plugins ship with the binary, so they have no
+    on-disk path of their own. The conditional schema must NOT
+    require `path` when `type=first_party`."""
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["name"] = "ooo-builtin"
+    payload["source"] = {"type": "first_party"}
+    payload["permissions"] = []  # built-ins don't need external scopes
+    manifest = load_manifest(_write(tmp_path, payload))  # MUST NOT raise
+    assert manifest.source.type == "first_party"
+    assert manifest.source.path is None
+
+
+def test_capabilities_and_permissions_preserve_manifest_order(tmp_path: Path) -> None:
+    """Regression: `capabilities` and `permissions` used to be
+    `frozenset`s, so iteration order varied across hash seeds and
+    Python versions. That instability leaks into `discover`,
+    `inspect`, `list --json`, and the firewall's
+    `plugin.permission_used` event ordering for multi-scope plugins.
+    A tuple preserves the order the operator wrote in the manifest.
+    """
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    # Order chosen so an alphabetic sort or hash-keyed iteration would
+    # rearrange them, exposing any silent re-ordering in the loader.
+    payload["capabilities"] = [
+        {"name": "state", "access": "read"},
+        {"name": "ledger", "access": "write"},
+        {"name": "provenance", "access": "write"},
+        {"name": "seed", "access": "read"},
+    ]
+    payload["permissions"] = [
+        {"scope": "github:write", "risk": "destructive", "required": False},
+        {"scope": "github:read", "risk": "read_only", "required": True},
+        {"scope": "fs:read", "risk": "read_only", "required": True},
+    ]
+    manifest = load_manifest(_write(tmp_path, payload))
+
+    assert isinstance(manifest.capabilities, tuple)
+    assert isinstance(manifest.permissions, tuple)
+    assert [c.name for c in manifest.capabilities] == [
+        "state",
+        "ledger",
+        "provenance",
+        "seed",
+    ]
+    assert [p.scope for p in manifest.permissions] == [
+        "github:write",
+        "github:read",
+        "fs:read",
+    ]

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -427,6 +427,37 @@ def test_source_first_party_path_optional(tmp_path: Path) -> None:
     assert manifest.source.path is None
 
 
+def test_sandbox_rejects_symlink_escape(tmp_path: Path) -> None:
+    """Regression for the symlink-escape sandbox bypass: the textual
+    sandbox check rejects `..` segments and absolute paths, but a
+    relative slug like `plugins/link` where the on-disk
+    `link -> /outside/path` symlink follows out of the plugin root
+    used to slip through, since `Path.resolve()` honors symlinks.
+    The loader must verify that the *resolved* filesystem target
+    still lives under the manifest's directory, not just that the
+    user-authored text was syntactically safe.
+    """
+    manifest_dir = tmp_path / "plugin_home"
+    manifest_dir.mkdir()
+    outside = tmp_path / "outside_target"
+    outside.mkdir()
+    link_path = manifest_dir / "link"
+    link_path.symlink_to(outside)
+
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["source"] = {"type": "local_path", "path": "link"}
+    target = manifest_dir / "ouroboros.plugin.json"
+    target.write_text(json.dumps(bad))
+
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(target)
+    err = excinfo.value
+    assert err.json_pointer == "/source/path"
+    assert "outside" in err.args[0] or "outside" in err.expected
+    # The escape target should not appear as the loaded path.
+    assert str(outside) in err.got
+
+
 def test_first_party_source_path_stays_none(tmp_path: Path) -> None:
     """First-party plugins still produce `source.path is None`."""
     payload = json.loads(json.dumps(REFERENCE_MANIFEST))

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -89,17 +89,42 @@ def test_reset_for_version_bump(tmp_path: Path) -> None:
 
 
 def test_remove_drops_trust_file(tmp_path: Path) -> None:
-    """Test 6: remove() deletes the trust file and prunes the empty dir."""
+    """remove() deletes the trust file. The per-plugin `*.lock` file
+    is intentionally preserved (see `test_remove_keeps_lock_file_to_avoid_inode_race`),
+    so the directory is only pruned when the lock file isn't there
+    (e.g. on platforms without flock support)."""
     store = TrustStore(root=tmp_path)
     store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     file_path = tmp_path / "X" / "trust.json"
     assert file_path.is_file()
     assert store.remove("X") is True
     assert not file_path.exists()
-    # Directory pruned.
-    assert not file_path.parent.exists()
     # Removing again is a no-op.
     assert store.remove("X") is False
+
+
+def test_remove_keeps_lock_file_to_avoid_inode_race(tmp_path: Path) -> None:
+    """Regression: `remove()` used to also unlink `trust.json.lock`
+    inside its critical section, but POSIX `flock` is attached to
+    the inode behind the lock-file path. Removing the lock-file
+    while still holding the flock orphans the inode: a concurrent
+    `grant()` would `open(lock_path, "w")` against a brand-new
+    inode, `flock` *that* exclusively, and run in parallel with
+    the still-active `remove()` — reopening the very race the
+    per-plugin lock was added to close. The lock-file is a
+    synchronization primitive that must outlive individual
+    operations, so `remove()` now leaves it in place.
+    """
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    lock_path = tmp_path / "X" / "trust.json.lock"
+    assert lock_path.exists(), "fixture sanity: lock file must have been created"
+    assert store.remove("X") is True
+    # The trust.json itself is gone, but the lock file is preserved
+    # so subsequent grant/remove operations on the same plugin name
+    # share the same inode-stable synchronization primitive.
+    assert not (tmp_path / "X" / "trust.json").exists()
+    assert lock_path.exists(), "lock file must persist across remove() to keep flock semantics safe"
 
 
 def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -1,0 +1,158 @@
+"""Tests for the per-plugin trust store (Q00/ouroboros#732)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.trust_store import (
+    TRUST_SCHEMA_VERSION,
+    TrustRecord,
+    TrustStore,
+)
+
+
+def test_grant_then_read(tmp_path: Path) -> None:
+    """Test 1: grant a scope, read it back. File at locked Q5 path."""
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:shaun0927",
+    )
+    assert record.has_scope("github:read")
+
+    file_path = tmp_path / "github-pr-ops" / "trust.json"
+    assert file_path.is_file()
+    data = json.loads(file_path.read_text())
+    assert data["schema_version"] == TRUST_SCHEMA_VERSION
+    assert data["plugin"] == "github-pr-ops"
+    assert data["version"] == "0.1.0"
+    assert data["granted_scopes"][0]["scope"] == "github:read"
+    assert data["granted_scopes"][0]["granted_by"] == "user:shaun0927"
+
+
+def test_grant_is_idempotent(tmp_path: Path) -> None:
+    """Test 2: granting the same scope twice does not duplicate."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    record = store.grant(
+        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
+    )
+    assert len(record.granted_scopes) == 1
+
+
+def test_exact_scope_only(tmp_path: Path) -> None:
+    """Test 3: parent scope does NOT imply child (Q3 lock).
+
+    Granting `github:pull_request` does not satisfy `github:pull_request:write`.
+    """
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="X",
+        version="0.1.0",
+        scope="github:pull_request",
+        granted_by="u",
+    )
+    assert record.has_scope("github:pull_request")
+    assert not record.has_scope("github:pull_request:write")
+    assert record.missing(["github:pull_request:write"]) == ["github:pull_request:write"]
+
+
+def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
+    """Test 4: granting against a new version drops the previous grants
+    (Q00/ouroboros-plugins#9 Q4 lock)."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    store.grant(plugin="X", version="0.1.0", scope="github:repo:read", granted_by="u")
+
+    # Now bump to 0.2.0 and grant a different scope.
+    record = store.grant(
+        plugin="X", version="0.2.0", scope="github:read", granted_by="u"
+    )
+    assert record.version == "0.2.0"
+    # Previous github:repo:read grant is invalidated.
+    assert not record.has_scope("github:repo:read")
+    # The newly granted scope on the new version is present.
+    assert record.has_scope("github:read")
+
+
+def test_reset_for_version_bump(tmp_path: Path) -> None:
+    """Test 5: explicit version-bump reset writes an empty grant list."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    store.reset_for_version_bump("X", new_version="0.2.0")
+
+    record = store.read("X")
+    assert isinstance(record, TrustRecord)
+    assert record.version == "0.2.0"
+    assert record.granted_scopes == ()
+
+
+def test_remove_drops_trust_file(tmp_path: Path) -> None:
+    """Test 6: remove() deletes the trust file and prunes the empty dir."""
+    store = TrustStore(root=tmp_path)
+    store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
+    file_path = tmp_path / "X" / "trust.json"
+    assert file_path.is_file()
+    assert store.remove("X") is True
+    assert not file_path.exists()
+    # Directory pruned.
+    assert not file_path.parent.exists()
+    # Removing again is a no-op.
+    assert store.remove("X") is False
+
+
+def test_unsupported_schema_version_rejected(tmp_path: Path) -> None:
+    """Test 7: a trust file with the wrong schema_version raises on read."""
+    plugin_dir = tmp_path / "X"
+    plugin_dir.mkdir()
+    (plugin_dir / "trust.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "99.0",
+                "plugin": "X",
+                "version": "0.1.0",
+                "granted_scopes": [],
+            }
+        )
+    )
+    store = TrustStore(root=tmp_path)
+    with pytest.raises(ValueError, match="unsupported trust file schema_version"):
+        store.read("X")
+
+
+def test_no_raw_token_in_persisted_file(tmp_path: Path) -> None:
+    """Test 8: scope strings and granted_by are persisted, but nothing
+    else. The store offers no API for tokens; this test is a sanity
+    check that future contributors don't add one without notice."""
+    store = TrustStore(root=tmp_path)
+    store.grant(
+        plugin="X",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:shaun0927",
+    )
+    raw = (tmp_path / "X" / "trust.json").read_text()
+    # Keys present
+    assert '"scope"' in raw
+    assert '"granted_by"' in raw
+    assert '"granted_at"' in raw
+    # Nothing token-shaped (no "token", "secret", "auth", "Bearer")
+    for forbidden in ("token", "secret", "auth", "Bearer", "ghp_"):
+        assert forbidden.lower() not in raw.lower(), f"forbidden marker {forbidden!r} in trust file"
+
+
+def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
+    """Test 9: TrustRecord.missing() returns missing required scopes in
+    the input iteration order — useful for predictable error messages."""
+    store = TrustStore(root=tmp_path)
+    record = store.grant(
+        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
+    )
+    # `github:read` is granted; the others are missing.
+    missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
+    assert missing == ["github:pull_request:write", "shell:execute"]

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -150,3 +150,45 @@ def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
     # `github:read` is granted; the others are missing.
     missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
     assert missing == ["github:pull_request:write", "shell:execute"]
+
+
+def test_concurrent_grants_do_not_lose_scopes(tmp_path: Path) -> None:
+    """Regression: `TrustStore.grant()` was an unlocked
+    read-modify-write. Two concurrent grants for different scopes
+    on the same plugin could both observe the same prior file and
+    each overwrite it with a one-scope payload, so the last writer
+    silently deleted the other grant — real trust-state data loss.
+
+    The store now brackets the cycle in a per-plugin POSIX file lock.
+    This test fans out enough concurrent grants for distinct scopes
+    that the prior racy implementation would lose at least one with
+    high probability; under the new lock all scopes must survive.
+    """
+    import threading
+
+    store = TrustStore(root=tmp_path)
+    scopes = [f"scope:{i}" for i in range(20)]
+    barrier = threading.Barrier(len(scopes))
+
+    def _grant(scope: str) -> None:
+        # Hit the lock at roughly the same instant from every thread.
+        barrier.wait()
+        store.grant(
+            plugin="concurrent-plugin",
+            version="0.1.0",
+            scope=scope,
+            granted_by="user:test",
+        )
+
+    threads = [threading.Thread(target=_grant, args=(s,)) for s in scopes]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    record = store.read("concurrent-plugin")
+    assert record is not None
+    persisted = {g.scope for g in record.granted_scopes}
+    assert persisted == set(scopes), (
+        f"trust store lost {set(scopes) - persisted} under concurrent grants"
+    )

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -39,9 +39,7 @@ def test_grant_is_idempotent(tmp_path: Path) -> None:
     """Test 2: granting the same scope twice does not duplicate."""
     store = TrustStore(root=tmp_path)
     store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
-    record = store.grant(
-        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     assert len(record.granted_scopes) == 1
 
 
@@ -70,9 +68,7 @@ def test_version_bump_invalidates_trust(tmp_path: Path) -> None:
     store.grant(plugin="X", version="0.1.0", scope="github:repo:read", granted_by="u")
 
     # Now bump to 0.2.0 and grant a different scope.
-    record = store.grant(
-        plugin="X", version="0.2.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.2.0", scope="github:read", granted_by="u")
     assert record.version == "0.2.0"
     # Previous github:repo:read grant is invalidated.
     assert not record.has_scope("github:repo:read")
@@ -150,9 +146,7 @@ def test_missing_returns_required_in_input_order(tmp_path: Path) -> None:
     """Test 9: TrustRecord.missing() returns missing required scopes in
     the input iteration order — useful for predictable error messages."""
     store = TrustStore(root=tmp_path)
-    record = store.grant(
-        plugin="X", version="0.1.0", scope="github:read", granted_by="u"
-    )
+    record = store.grant(plugin="X", version="0.1.0", scope="github:read", granted_by="u")
     # `github:read` is granted; the others are missing.
     missing = record.missing(["github:pull_request:write", "github:read", "shell:execute"])
     assert missing == ["github:pull_request:write", "shell:execute"]

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -1,0 +1,177 @@
+"""Tests for the UserLevel program registry (Q00/ouroboros#730)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.manifest import load_manifest
+from ouroboros.plugin.userlevel_registry import (
+    LookupResult,
+    RegisteredProgram,
+    RegistryError,
+    UserLevelProgramRegistry,
+    get_userlevel_registry,
+    lookup_command,
+    reset_userlevel_registry,
+)
+
+
+REFERENCE_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "github-pr-ops",
+    "version": "0.1.0",
+    "source": {"type": "local_path", "path": "plugins/github-pr-ops"},
+    "commands": [
+        {
+            "namespace": "github-pr",
+            "name": "review",
+            "summary": "Review a pull request and summarize readiness.",
+            "usage": "ooo github-pr review <pull-request-url>",
+            "risk": "read_only",
+        }
+    ],
+    "capabilities": [
+        {"name": "ledger", "access": "write"},
+    ],
+    "permissions": [
+        {"scope": "github:read", "risk": "read_only", "required": True},
+    ],
+    "entrypoint": {"type": "command", "command": "python -m github_pr_ops"},
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_registry():
+    """Each test starts with a clean global registry."""
+    reset_userlevel_registry()
+    yield
+    reset_userlevel_registry()
+
+
+def _write_manifest(tmp_path: Path, payload: dict) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _load_ref(tmp_path: Path, **overrides) -> "RegisteredProgram":
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload.update(overrides)
+    return load_manifest(_write_manifest(tmp_path, payload))
+
+
+def test_register_and_get(tmp_path: Path) -> None:
+    """Test 1: register a manifest, look it up by name and namespace."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    program = registry.register(manifest)
+
+    assert isinstance(program, RegisteredProgram)
+    assert registry.get("github-pr-ops") == program
+    assert registry.get_by_namespace("github-pr") == program
+    assert registry.get("nonexistent") is None
+    assert registry.get_by_namespace("nonexistent") is None
+
+
+def test_namespace_collision_rejected(tmp_path: Path) -> None:
+    """Test 2: two plugins claiming the same namespace → error."""
+    registry = UserLevelProgramRegistry()
+    a = _load_ref(tmp_path / "a", name="plugin-a")
+    b = _load_ref(tmp_path / "b", name="plugin-b")  # same namespace "github-pr"
+
+    registry.register(a)
+    with pytest.raises(RegistryError, match="already owned"):
+        registry.register(b)
+
+
+def test_duplicate_name_requires_replace(tmp_path: Path) -> None:
+    """Test 3: re-registering the same name without replace=True → error."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    registry.register(manifest)
+    with pytest.raises(RegistryError, match="already registered"):
+        registry.register(manifest)
+    # With replace=True, succeeds.
+    registry.register(manifest, replace=True)
+
+
+def test_unregister(tmp_path: Path) -> None:
+    """Test 4: unregister releases name AND namespace ownership."""
+    registry = UserLevelProgramRegistry()
+    manifest = _load_ref(tmp_path)
+    registry.register(manifest)
+    assert registry.unregister("github-pr-ops") is True
+    assert registry.unregister("github-pr-ops") is False
+    # After unregistering, the namespace can be claimed by a different plugin.
+    other = _load_ref(tmp_path / "other", name="plugin-other")
+    registry.register(other)  # must not raise
+
+
+def test_all_programs(tmp_path: Path) -> None:
+    """Test 5: all_programs returns every registered program."""
+    registry = UserLevelProgramRegistry()
+    a = _load_ref(tmp_path / "a", name="plugin-a")
+    # Different namespace for b
+    b_payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    b_payload["name"] = "plugin-b"
+    b_payload["commands"][0]["namespace"] = "other-ns"
+    b = load_manifest(_write_manifest(tmp_path / "b", b_payload))
+    registry.register(a)
+    registry.register(b)
+    names = {p.name for p in registry.all_programs()}
+    assert names == {"plugin-a", "plugin-b"}
+
+
+def test_lookup_command_finds_userlevel_by_namespace(tmp_path: Path) -> None:
+    """Test 6: lookup_command finds via namespace first."""
+    manifest = _load_ref(tmp_path)
+    get_userlevel_registry().register(manifest)
+    result = lookup_command("github-pr")
+    assert result.found
+    assert result.kind == "userlevel"
+    assert result.userlevel_program is not None
+    assert result.userlevel_program.name == "github-pr-ops"
+
+
+def test_lookup_command_finds_userlevel_by_name(tmp_path: Path) -> None:
+    """Test 7: lookup_command also finds via plugin name."""
+    manifest = _load_ref(tmp_path)
+    get_userlevel_registry().register(manifest)
+    result = lookup_command("github-pr-ops")
+    assert result.found
+    assert result.kind == "userlevel"
+
+
+def test_lookup_command_returns_none_for_unknown(tmp_path: Path) -> None:
+    """Test 8: lookup_command returns kind='none' for unknown names."""
+    result = lookup_command("totally-unknown-plugin")
+    assert not result.found
+    assert result.kind == "none"
+
+
+def test_global_singleton_persists_within_session(tmp_path: Path) -> None:
+    """Test 9: get_userlevel_registry returns the same instance."""
+    a = get_userlevel_registry()
+    b = get_userlevel_registry()
+    assert a is b
+
+
+def test_skill_registry_unaffected(tmp_path: Path) -> None:
+    """Test 10: existing skill registry tests still work — no state shared.
+
+    This test loads the skill registry module to confirm we can co-exist
+    with it (no import-time conflicts), without depending on its discovery.
+    """
+    from ouroboros.plugin.skills.registry import get_registry as _get_skill_registry
+
+    skill_registry = _get_skill_registry()
+    # The skill registry is independent from our UserLevel registry.
+    ul = get_userlevel_registry()
+    manifest = _load_ref(tmp_path)
+    ul.register(manifest)
+    # Skill registry must remain unchanged by our registration.
+    assert skill_registry.get_skill("github-pr-ops") is None

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -158,6 +158,49 @@ def test_global_singleton_persists_within_session(tmp_path: Path) -> None:
     assert a is b
 
 
+def test_replace_releases_old_namespace(tmp_path: Path) -> None:
+    """Regression: register(replace=True) with a different namespace must
+    free the old namespace so other plugins can claim it AND so
+    `get_by_namespace(old_ns)` no longer returns the new program.
+
+    Previously the old namespace mapping persisted, leaving the
+    registry in an inconsistent state where the old namespace was
+    permanently owned by a plugin whose commands no longer used it.
+    """
+    registry = UserLevelProgramRegistry()
+
+    # Initial registration owns "github-pr".
+    initial = _load_ref(tmp_path / "v0")
+    registry.register(initial)
+    assert registry.get_by_namespace("github-pr") is not None
+
+    # Same plugin name, but the new manifest moved to "github-issue".
+    moved = json.loads(json.dumps(REFERENCE_MANIFEST))
+    moved["version"] = "0.2.0"
+    moved["commands"][0]["namespace"] = "github-issue"
+    moved_manifest = load_manifest(_write_manifest(tmp_path / "v1", moved))
+    registry.register(moved_manifest, replace=True)
+
+    # The old namespace is now free.
+    assert registry.get_by_namespace("github-pr") is None, (
+        "old namespace must be released so lookups don't resolve to a "
+        "plugin that no longer claims it"
+    )
+    # The new namespace resolves to the replaced program.
+    moved_program = registry.get_by_namespace("github-issue")
+    assert moved_program is not None
+    assert moved_program.manifest.version == "0.2.0"
+
+    # And another plugin can now legitimately claim the old namespace.
+    other = json.loads(json.dumps(REFERENCE_MANIFEST))
+    other["name"] = "other-plugin"
+    other["commands"][0]["namespace"] = "github-pr"
+    other_manifest = load_manifest(_write_manifest(tmp_path / "other", other))
+    registry.register(other_manifest)  # MUST NOT raise
+    assert registry.get_by_namespace("github-pr") is not None
+    assert registry.get_by_namespace("github-pr").name == "other-plugin"
+
+
 def test_skill_registry_unaffected(tmp_path: Path) -> None:
     """Test 10: existing skill registry tests still work — no state shared.
 

--- a/tests/unit/plugin/test_userlevel_registry.py
+++ b/tests/unit/plugin/test_userlevel_registry.py
@@ -9,7 +9,6 @@ import pytest
 
 from ouroboros.plugin.manifest import load_manifest
 from ouroboros.plugin.userlevel_registry import (
-    LookupResult,
     RegisteredProgram,
     RegistryError,
     UserLevelProgramRegistry,
@@ -17,7 +16,6 @@ from ouroboros.plugin.userlevel_registry import (
     lookup_command,
     reset_userlevel_registry,
 )
-
 
 REFERENCE_MANIFEST: dict = {
     "schema_version": "0.1",
@@ -58,7 +56,7 @@ def _write_manifest(tmp_path: Path, payload: dict) -> Path:
     return target
 
 
-def _load_ref(tmp_path: Path, **overrides) -> "RegisteredProgram":
+def _load_ref(tmp_path: Path, **overrides) -> RegisteredProgram:
     payload = json.loads(json.dumps(REFERENCE_MANIFEST))
     payload.update(overrides)
     return load_manifest(_write_manifest(tmp_path, payload))


### PR DESCRIPTION
Partial implementation of #731 (read-only half). Sub-issue of #725 (Phase 2). **Stacked on Sprint 2 stack** (#745, #746, #747, #748, #749).

## Module: `src/ouroboros/cli/commands/plugin.py`

Typer app registered as `ooo plugin <subcommand>`.

### Subcommands

- **`ooo plugin discover <path>`** — load and validate a manifest without registering or granting trust. On schema violation, prints a friendly error including the JSON Pointer to the failing field. Lists required scopes the user will need to grant later.
- **`ooo plugin inspect <name>`** — read the lockfile + trust store; print installed metadata, trust state, granted scopes, and any missing required scopes. Both stores are overrideable via `--lockfile` / `--trust-root` so tests don't touch `~/.ouroboros`.
- **`ooo plugin list [--json]`** — enumerate installed plugins. Default Rich table; `--json` emits plain stdout (`typer.echo`) for piping to `jq`.

### Integration

`src/ouroboros/cli/main.py` imports the module and adds the typer via `app.add_typer(plugin.app, name="plugin")`.

### Tests — 8/8 pass

```
$ PYTHONPATH=src python3 -m pytest tests/unit/cli/test_plugin_command.py -v
============================== 8 passed in 0.53s ===============================
```

| # | Test | Asserts |
|---|---|---|
| 1 | discover valid manifest | exit 0, name + version + required scope listed |
| 2 | discover invalid manifest | exit 1, error mentions JSON Pointer (`/name`) |
| 3 | inspect uninstalled | exit 1, "is not installed" |
| 4 | inspect installed/untrusted | trust_state=installed, missing-scopes line |
| 5 | inspect installed/trusted | trust_state=trusted, no missing-scopes line |
| 6 | list empty | "no plugins installed" |
| 7 | list --json | parseable JSON, correct shape |
| 8 | no-args shows help | discover/inspect/list listed |

## What's next

CR-6b stacks on this branch and adds the state-mutating subcommands (`add`, `install`, `trust`, `disable`, `remove`) with the agreed `questionary` multi-select prompt and the rejected-anti-pattern install-string handling.