### PR TITLE
feat(auto): CI lint guard for ooo auto product boundary

### DIFF
--- a/.github/workflows/auto-boundary.yml
+++ b/.github/workflows/auto-boundary.yml
@@ -1,0 +1,24 @@
+name: ooo-auto-boundary
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-boundary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enforce ooo auto product boundary
+        run: python3 scripts/check-auto-boundary.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,22 @@ The last command enforces that the `ooo auto` core source files do
 not introduce domain-specific keywords (`github`, `pull_request`,
 `jira`, `slack`, …). Domain workflows belong in UserLevel plugins,
 not in `ooo auto`. The CI workflow `ooo-auto-boundary` runs the same
-check on every PR. If a forbidden keyword is genuinely necessary on
-a line (rare), append `# domain-keyword-allowed: <reason>` and
-include rationale in the PR description.
+check on every PR.
+
+Coverage is the union of (a) every `*.py` under `src/ouroboros/auto/`
+and (b) `src/ouroboros/cli/commands/auto.py`, so any new module added
+under the auto package is scanned automatically. Forbidden keywords
+are matched as case-insensitive substrings, which catches realistic
+identifier forms such as `GitHubClient`, `github_client`, `JiraIssue`,
+or `SlackNotifier`. The script also fails loud if a load-bearing
+anchor file (declared in `ANCHOR_FILES` inside the script) is missing,
+so a refactor that renames or removes one of those files cannot
+silently strip enforcement coverage — update `ANCHOR_FILES` in the
+same PR.
+
+If a forbidden keyword is genuinely necessary on a line (rare),
+append `# domain-keyword-allowed: <reason>` and include rationale in
+the PR description.
 
 ### 6. Submit PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,18 @@ uv run ruff format src/ tests/
 
 # Type check
 uv run mypy src/ouroboros
+
+# ooo auto product boundary check (Q00/ouroboros#725)
+python3 scripts/check-auto-boundary.py
 ```
+
+The last command enforces that the `ooo auto` core source files do
+not introduce domain-specific keywords (`github`, `pull_request`,
+`jira`, `slack`, …). Domain workflows belong in UserLevel plugins,
+not in `ooo auto`. The CI workflow `ooo-auto-boundary` runs the same
+check on every PR. If a forbidden keyword is genuinely necessary on
+a line (rare), append `# domain-keyword-allowed: <reason>` and
+include rationale in the PR description.
 
 ### 6. Submit PR
 

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -96,16 +96,27 @@ SCAN_EXTRA_FILES: tuple[str, ...] = ("src/ouroboros/cli/commands/auto.py",)
 # bracket character classes such as ``[A-Z]`` outside that scope stay
 # case-sensitive, which is the exact discrimination needed for
 # PascalCase-composition forms.
+#
+# Every keyword anchors with a left ``(?<![A-Za-z])`` (negative
+# lookbehind: not preceded by a letter) so that benign identifiers
+# that merely *contain* the keyword as a substring --
+# ``collinearPoints``, ``bilinearForm``, ``nonlinear_adapter``,
+# ``mygithub_thing``, ``mypull_request_data`` -- do not false-positive.
+# We deliberately do *not* use ``\b`` here, because ``_`` is a word
+# character: ``\b`` would mean the underscore-adjacent forms
+# ``notify_slack_user``, ``FOO_GITHUB_BASE``, and ``linear_client``
+# stop matching, which loses the legitimate snake_case-composition
+# catches the bot review specifically asked us to keep.
 FORBIDDEN_PATTERNS: tuple[str, ...] = (
-    r"(?i:github)",
-    r"(?i:pull_request)",
+    r"(?<![A-Za-z])(?i:github)",
+    r"(?<![A-Za-z])(?i:pull_request)",
     # Compressed camelCase form ``PullRequestHandler`` / ``pullRequestId``
     # that the snake-case pattern above misses (the underscore prevents
     # the substrings from sharing).
-    r"(?i:pullrequest)",
-    r"(?i:/pulls?/)",
-    r"(?i:jira)",
-    r"(?i:slack)",
+    r"(?<![A-Za-z])(?i:pullrequest)",
+    r"(?i:/pulls?/)",  # `/` is already a non-word boundary
+    r"(?<![A-Za-z])(?i:jira)",
+    r"(?<![A-Za-z])(?i:slack)",
     # Linear (the issue tracker / SaaS) -- tightened to:
     #   * the URL form ``linear.app`` / ``linear.com``, or
     #   * a PascalCase composition (`LinearClient`, `LinearAdapter`,
@@ -115,11 +126,13 @@ FORBIDDEN_PATTERNS: tuple[str, ...] = (
     #   * an explicit integration suffix in snake_case
     #     (`linear_client`, `linear_webhook`, ...).
     # Plain "linear pipeline" / "linear scan" / "linear_time" do NOT
-    # match.
+    # match. Each sub-pattern carries its own ``(?<![A-Za-z])`` anchor
+    # so that embedded forms like ``collinearPoints``, ``bilinearForm``,
+    # ``nonlinearAdapter``, and ``nonlinear_adapter`` also do not match.
     (
-        r"(?i:linear\.(?:app|com))"
-        r"|(?i:linear)[A-Z]"
-        r"|(?i:linear_(?:client|adapter|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
+        r"(?<![A-Za-z])(?i:linear\.(?:app|com))"
+        r"|(?<![A-Za-z])(?i:linear)[A-Z]"
+        r"|(?<![A-Za-z])(?i:linear_(?:client|adapter|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
     ),
 )
 

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -83,12 +83,21 @@ SCAN_EXTRA_FILES: tuple[str, ...] = ("src/ouroboros/cli/commands/auto.py",)
 # the bot review of the original guard).
 FORBIDDEN_PATTERNS: tuple[str, ...] = (
     "github",
+    # Both forms are needed: lowercased lines preserve underscores, so
+    # `pull_request` (snake_case) and `pullrequest` (camelCase compressed
+    # form, e.g. PullRequestHandler/pullRequestId) are distinct
+    # substrings.
     "pull_request",
+    "pullrequest",
     "/pulls/",
     "/pull/",
     "jira",
     "slack",
-    "linear.app",
+    # `linear` (rather than `linear.app`) is required to catch identifier
+    # forms such as `LinearClient` / `LinearAdapter`. The substring also
+    # subsumes the original URL match `linear.app`. Verified zero false
+    # positives on the actual scan target (current main).
+    "linear",
 )
 
 

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -47,6 +47,29 @@ Pattern strategy:
     PascalCase composition (lowercase ``linear`` + an explicit
     uppercase letter), or one of an enumerated set of integration
     suffixes.
+
+    Each keyword carries TWO recognition forms so that compound
+    identifiers across naming conventions are not silent bypasses:
+
+    1. *Token-start* form: anchored by ``(?<![A-Za-z])`` so the keyword
+       starts after a non-letter (start-of-line, whitespace, ``_``,
+       digit, punctuation). This catches ``GitHubClient``,
+       ``GITHUB_TOKEN``, ``github_client``, ``_github_url``, and the
+       SCREAMING_SNAKE form ``FOO_GITHUB_BASE``.
+
+    2. *camelCase-boundary* form: anchored by ``(?<=[a-z])`` (lowercase
+       letter on the left) plus a *case-sensitive* uppercase first
+       character of the keyword. This catches mixed-case compounds like
+       ``openGithubIssue``, ``makePullRequestUrl``, ``sendToSlack``,
+       ``openJiraIssue``, and ``notifyLinearAdapter`` -- the exact
+       bypass class that earlier iterations of this guard missed -- while
+       still rejecting the explicitly-benign embedded-substring forms
+       that only contain the keyword in lowercase (``mygithub_thing``,
+       ``mypull_request_data``, ``collinearPoints``, ``bilinearForm``,
+       ``nonlinearAdapter``, ``nonlinear_adapter``). The discrimination
+       is purely the case of the keyword's first letter at the boundary:
+       lowercase = embedded substring (benign), uppercase = camelCase
+       composition (domain leak).
 """
 
 from __future__ import annotations
@@ -97,26 +120,41 @@ SCAN_EXTRA_FILES: tuple[str, ...] = ("src/ouroboros/cli/commands/auto.py",)
 # case-sensitive, which is the exact discrimination needed for
 # PascalCase-composition forms.
 #
-# Every keyword anchors with a left ``(?<![A-Za-z])`` (negative
-# lookbehind: not preceded by a letter) so that benign identifiers
-# that merely *contain* the keyword as a substring --
-# ``collinearPoints``, ``bilinearForm``, ``nonlinear_adapter``,
-# ``mygithub_thing``, ``mypull_request_data`` -- do not false-positive.
-# We deliberately do *not* use ``\b`` here, because ``_`` is a word
-# character: ``\b`` would mean the underscore-adjacent forms
-# ``notify_slack_user``, ``FOO_GITHUB_BASE``, and ``linear_client``
-# stop matching, which loses the legitimate snake_case-composition
-# catches the bot review specifically asked us to keep.
+# Every keyword has TWO recognition arms (separated by ``|``):
+#
+#   * Token-start arm ``(?<![A-Za-z])(?i:<kw>)``: the keyword sits at
+#     the start of a token (preceded by start-of-line, whitespace,
+#     ``_``, digit, ``/``, ``"``, etc.). Case-insensitive, so it
+#     catches ``GitHubClient``, ``GITHUB_TOKEN``, ``github_client``,
+#     ``_github_url``, and SCREAMING_SNAKE forms like
+#     ``FOO_GITHUB_BASE``. We deliberately do *not* use ``\b`` here,
+#     because ``_`` is a word character and ``\b`` would lose the
+#     underscore-adjacent forms (``notify_slack_user``,
+#     ``FOO_GITHUB_BASE``, ``linear_client``).
+#
+#   * camelCase-boundary arm ``(?<=[a-z])<KW first letter capitalized>(?i:<kw rest>)``:
+#     the keyword sits at a camelCase boundary (lowercase letter on
+#     the left, *uppercase* keyword first letter, case-insensitive
+#     remainder). This catches ``openGithubIssue``,
+#     ``makePullRequestUrl``, ``sendToSlack``, ``openJiraIssue``,
+#     ``notifyLinearAdapter`` -- the bypass class earlier iterations
+#     missed. The case-sensitive uppercase first letter is what
+#     preserves the explicitly-benign embedded-lowercase forms
+#     (``mygithub_thing``, ``mypull_request_data``,
+#     ``collinearPoints``, ``bilinearForm``, ``nonlinearAdapter``,
+#     ``nonlinear_adapter``): in those, the keyword's first letter is
+#     lowercase, so the camelCase arm does not match.
 FORBIDDEN_PATTERNS: tuple[str, ...] = (
-    r"(?<![A-Za-z])(?i:github)",
+    r"(?<![A-Za-z])(?i:github)|(?<=[a-z])G(?i:ithub)",
     r"(?<![A-Za-z])(?i:pull_request)",
-    # Compressed camelCase form ``PullRequestHandler`` / ``pullRequestId``
-    # that the snake-case pattern above misses (the underscore prevents
-    # the substrings from sharing).
-    r"(?<![A-Za-z])(?i:pullrequest)",
+    # Compressed camelCase / no-underscore form ``PullRequestHandler`` /
+    # ``pullRequestId`` / ``makePullRequestUrl`` that the snake-case
+    # pattern above misses (the underscore prevents the substrings from
+    # sharing).
+    r"(?<![A-Za-z])(?i:pullrequest)|(?<=[a-z])P(?i:ullrequest)",
     r"(?i:/pulls?/)",  # `/` is already a non-word boundary
-    r"(?<![A-Za-z])(?i:jira)",
-    r"(?<![A-Za-z])(?i:slack)",
+    r"(?<![A-Za-z])(?i:jira)|(?<=[a-z])J(?i:ira)",
+    r"(?<![A-Za-z])(?i:slack)|(?<=[a-z])S(?i:lack)",
     # Linear (the issue tracker / SaaS) -- tightened to:
     #   * the URL form ``linear.app`` / ``linear.com``, or
     #   * a PascalCase composition (`LinearClient`, `LinearAdapter`,
@@ -124,15 +162,21 @@ FORBIDDEN_PATTERNS: tuple[str, ...] = (
     #     trailing ``[A-Z]`` is case-sensitive, so this distinguishes
     #     ``LinearClient`` from benign ``linearize`` / ``linear_time``,
     #   * an explicit integration suffix in snake_case
-    #     (`linear_client`, `linear_webhook`, ...).
+    #     (`linear_client`, `linear_webhook`, ...),
+    #   * a camelCase composition where ``Linear`` is preceded by a
+    #     lowercase letter (``notifyLinearAdapter``,
+    #     ``maybeLinearClient``).
     # Plain "linear pipeline" / "linear scan" / "linear_time" do NOT
-    # match. Each sub-pattern carries its own ``(?<![A-Za-z])`` anchor
-    # so that embedded forms like ``collinearPoints``, ``bilinearForm``,
+    # match. Each token-start arm carries ``(?<![A-Za-z])`` and each
+    # camelCase arm carries ``(?<=[a-z])L`` (case-sensitive) so that
+    # embedded forms like ``collinearPoints``, ``bilinearForm``,
     # ``nonlinearAdapter``, and ``nonlinear_adapter`` also do not match.
     (
         r"(?<![A-Za-z])(?i:linear\.(?:app|com))"
         r"|(?<![A-Za-z])(?i:linear)[A-Z]"
         r"|(?<![A-Za-z])(?i:linear_(?:client|adapter|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
+        r"|(?<=[a-z])L(?i:inear)[A-Z]"
+        r"|(?<=[a-z])L(?i:inear_(?:client|adapter|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
     ),
 )
 

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -155,28 +155,38 @@ FORBIDDEN_PATTERNS: tuple[str, ...] = (
     r"(?i:/pulls?/)",  # `/` is already a non-word boundary
     r"(?<![A-Za-z])(?i:jira)|(?<=[a-z])J(?i:ira)",
     r"(?<![A-Za-z])(?i:slack)|(?<=[a-z])S(?i:lack)",
-    # Linear (the issue tracker / SaaS) -- tightened to:
-    #   * the URL form ``linear.app`` / ``linear.com``, or
-    #   * a PascalCase composition (`LinearClient`, `LinearAdapter`,
-    #     `LinearAuth`, ...): "(?i:linear)" is case-insensitive but the
-    #     trailing ``[A-Z]`` is case-sensitive, so this distinguishes
-    #     ``LinearClient`` from benign ``linearize`` / ``linear_time``,
-    #   * an explicit integration suffix in snake_case
-    #     (`linear_client`, `linear_webhook`, ...),
-    #   * a camelCase composition where ``Linear`` is preceded by a
-    #     lowercase letter (``notifyLinearAdapter``,
-    #     ``maybeLinearClient``).
-    # Plain "linear pipeline" / "linear scan" / "linear_time" do NOT
-    # match. Each token-start arm carries ``(?<![A-Za-z])`` and each
-    # camelCase arm carries ``(?<=[a-z])L`` (case-sensitive) so that
-    # embedded forms like ``collinearPoints``, ``bilinearForm``,
-    # ``nonlinearAdapter``, and ``nonlinear_adapter`` also do not match.
+    # Linear (the issue tracker / SaaS) -- tightened to require an
+    # explicit *integration suffix* from a closed enumerated list, so
+    # generic English compounds like ``linearTime``,
+    # ``linearTransform``, or ``LinearOperator`` stay benign even
+    # though their first letter is uppercase. Linear-the-product
+    # integrations always carry a recognizable role suffix
+    # (``Client``, ``Adapter``, ``Auth``, ``Webhook``, ...), so
+    # enumerating those suffixes -- rather than accepting any trailing
+    # ``[A-Z]`` -- removes the entire false-positive class without
+    # losing any real-domain catch.
+    #
+    # The arms cover:
+    #   * the URL form ``linear.app`` / ``linear.com``;
+    #   * token-start ``linear<suffix>`` with optional underscore --
+    #     handles PascalCase ``LinearClient``, camelCase
+    #     ``linearClient``, snake_case ``linear_client``,
+    #     SCREAMING_SNAKE ``LINEAR_CLIENT``, and the no-separator
+    #     all-caps ``LINEARCLIENT``;
+    #   * camelCase-boundary form preceded by a lowercase letter
+    #     (``notifyLinearAdapter``, ``maybeLinearClient``) -- the
+    #     literal ``L`` is case-sensitive so embedded-lowercase forms
+    #     (``mylinear_client``, ``collinear_client``) stay benign by
+    #     the same rule the other keywords use.
+    # Plain "linear pipeline", "linear scan", "linear_time",
+    # ``linearize``, ``linearTime``, ``LinearTime``, ``LinearOperator``
+    # do NOT match. Embedded forms like ``collinearPoints``,
+    # ``bilinearForm``, ``nonlinearAdapter``, and ``nonlinear_adapter``
+    # also do not match.
     (
         r"(?<![A-Za-z])(?i:linear\.(?:app|com))"
-        r"|(?<![A-Za-z])(?i:linear)[A-Z]"
-        r"|(?<![A-Za-z])(?i:linear_(?:client|adapter|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
-        r"|(?<=[a-z])L(?i:inear)[A-Z]"
-        r"|(?<=[a-z])L(?i:inear_(?:client|adapter|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
+        r"|(?<![A-Za-z])(?i:linear_?(?:client|adapter|auth|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
+        r"|(?<=[a-z])L(?i:inear_?(?:client|adapter|auth|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
     ),
 )
 

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -2,13 +2,13 @@
 """Enforce the `ooo auto` product boundary at PR time.
 
 Per Q00/ouroboros#725, `ooo auto` has a permanent product boundary:
-`goal → interview → Seed → handoff`. Domain-specific operational
-workflows (GitHub PR ops, Jira, Slack, …) belong in plugins, not in
-core auto.
+`goal -> interview -> Seed -> handoff`. Domain-specific operational
+workflows (GitHub PR ops, Jira, Slack, Linear, ...) belong in plugins,
+not in core auto.
 
-This script greps a watched set of `ooo auto` source files for
-forbidden domain keywords and exits non-zero if any are found. It is
-the mechanical enforcement layer paired with #734's documentary work.
+This script greps the `ooo auto` core source files for forbidden domain
+keywords and exits non-zero if any are found. It is the mechanical
+enforcement layer paired with #734's documentary work.
 
 Run locally:
     python3 scripts/check-auto-boundary.py
@@ -22,24 +22,37 @@ Allowlist:
     `# domain-keyword-allowed: <reason>` to bypass the check. Each
     allowlist usage requires reviewer sign-off.
 
-To extend the watched set, add to `WATCHED_FILES` below; to extend
-the keyword list, add to `FORBIDDEN_PATTERNS`.
+Coverage strategy:
+    The scan target is the *union* of (a) every `*.py` under
+    `src/ouroboros/auto/`, plus (b) explicit extra files such as
+    `src/ouroboros/cli/commands/auto.py`. New files added under the
+    auto package are automatically covered. A small set of ANCHOR_FILES
+    is checked for existence; if any anchor is missing the guard fails
+    loudly so a refactor that renames or removes a load-bearing file
+    cannot silently strip enforcement coverage.
+
+Pattern strategy:
+    Forbidden patterns are matched as case-insensitive *substrings*,
+    not word-boundaried regex. This catches realistic identifier forms
+    (`GitHubClient`, `github_client`, `JiraIssue`, `SlackNotifier`)
+    that a word-boundary regex would miss. Patterns are deliberately
+    chosen with low false-positive risk on the actual `ooo auto`
+    surface (verified against current main).
 """
 
 from __future__ import annotations
 
-import re
-import sys
 from pathlib import Path
-
+import sys
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-# Files that constitute the `ooo auto` core product boundary. New
-# domain branches in any of these is the failure mode this script
-# catches.
-WATCHED_FILES: tuple[str, ...] = (
+# Required-anchor files that constitute the load-bearing core of `ooo
+# auto`. The guard fails loud if any anchor is missing -- silent loss
+# of enforcement coverage during a refactor would defeat the purpose
+# of the guard.
+ANCHOR_FILES: tuple[str, ...] = (
     "src/ouroboros/cli/commands/auto.py",
     "src/ouroboros/auto/pipeline.py",
     "src/ouroboros/auto/interview_driver.py",
@@ -51,72 +64,127 @@ WATCHED_FILES: tuple[str, ...] = (
     "src/ouroboros/auto/progress.py",
 )
 
-# Forbidden domain keywords. Each is a regex; matches are case-insensitive.
-# Keywords are chosen for high precision (low false-positive rate) on the
-# specific domains that drove #689 and the framing in #725.
+
+# Auto-discovered scan roots. All `*.py` files under each directory are
+# scanned (recursively), so newly added auto-package files are covered
+# without an explicit list update.
+SCAN_DIRS: tuple[str, ...] = ("src/ouroboros/auto",)
+
+
+# Extra individual files to include in the scan that live outside the
+# SCAN_DIRS roots.
+SCAN_EXTRA_FILES: tuple[str, ...] = ("src/ouroboros/cli/commands/auto.py",)
+
+
+# Forbidden domain keywords (case-insensitive substrings). Word
+# boundaries are deliberately NOT used: a contributor can otherwise
+# bypass the guard by writing `GitHubClient` or `github_client` and
+# having the regex skip identifier-embedded forms (the gap flagged by
+# the bot review of the original guard).
 FORBIDDEN_PATTERNS: tuple[str, ...] = (
-    r"\bgithub\b",
-    r"\bpull_request\b",
-    r"/pulls?/",
-    r"\bapi\.github\.com\b",
-    r"\bjira\b",
-    r"\bslack\b",
-    r"\blinear\.app\b",
-    # The exact PR-route keyword from #689; precise enough to catch even
-    # if someone uses snake_case identifiers.
-    r"\bgithub_pr\b",
+    "github",
+    "pull_request",
+    "/pulls/",
+    "/pull/",
+    "jira",
+    "slack",
+    "linear.app",
 )
+
 
 # Marker comment that allowlists a single line.
 ALLOWLIST_MARKER = "domain-keyword-allowed:"
 
 
-def _scan_file(path: Path) -> list[tuple[int, str, str]]:
-    """Return offending (line_no, line, matched_pattern) tuples for `path`.
+def _resolve_scan_targets() -> tuple[list[Path], list[str]]:
+    """Return ``(scan_targets, missing_anchors)``.
 
-    Lines carrying the allowlist marker are skipped. Lines inside string
-    literals or comments are still checked — the docstring at the top of
-    auto.py would catch a stray keyword, which is the desired behavior.
+    ``scan_targets`` is the union of every existing ``*.py`` file under
+    SCAN_DIRS plus any SCAN_EXTRA_FILES that exist. ``missing_anchors``
+    is the list of ANCHOR_FILES that do not exist on disk; a non-empty
+    list means the guard must fail loud.
+    """
+    targets: list[Path] = []
+    seen: set[Path] = set()
+
+    for d in SCAN_DIRS:
+        root = REPO_ROOT / d
+        if root.is_dir():
+            for p in sorted(root.rglob("*.py")):
+                rp = p.resolve()
+                if rp not in seen:
+                    seen.add(rp)
+                    targets.append(p)
+
+    for rel in SCAN_EXTRA_FILES:
+        p = REPO_ROOT / rel
+        if p.is_file():
+            rp = p.resolve()
+            if rp not in seen:
+                seen.add(rp)
+                targets.append(p)
+
+    missing = [rel for rel in ANCHOR_FILES if not (REPO_ROOT / rel).is_file()]
+    return targets, missing
+
+
+def _scan_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return offending ``(line_no, line, matched_pattern)`` tuples for ``path``.
+
+    Lines carrying the allowlist marker are skipped. Lines inside
+    string literals or comments are still checked -- a stray keyword
+    in a docstring of a watched file would catch, which is the desired
+    behavior.
     """
     findings: list[tuple[int, str, str]] = []
     if not path.is_file():
-        # Missing watched files are not an error in themselves; this script
-        # is forward-looking.
         return findings
     text = path.read_text(encoding="utf-8")
     for lineno, line in enumerate(text.splitlines(), start=1):
         if ALLOWLIST_MARKER in line:
             continue
+        lowered = line.lower()
         for pattern in FORBIDDEN_PATTERNS:
-            if re.search(pattern, line, flags=re.IGNORECASE):
+            if pattern in lowered:
                 findings.append((lineno, line.rstrip(), pattern))
                 break
     return findings
 
 
 def main() -> int:
+    targets, missing = _resolve_scan_targets()
+
+    if missing:
+        sys.stderr.write(
+            "ooo-auto-boundary: FAILED -- required anchor files are missing.\n"
+            "These files define the `ooo auto` product surface; if you\n"
+            "renamed/moved/deleted them, update ANCHOR_FILES in\n"
+            "scripts/check-auto-boundary.py in the same PR so enforcement\n"
+            "coverage is preserved.\n\n"
+        )
+        for rel in missing:
+            sys.stderr.write(f"  missing anchor: {rel}\n")
+        return 1
+
     all_findings: list[tuple[Path, int, str, str]] = []
-    for rel in WATCHED_FILES:
-        path = REPO_ROOT / rel
+    for path in targets:
         for lineno, line, pattern in _scan_file(path):
             all_findings.append((path, lineno, line, pattern))
 
     if not all_findings:
-        print(
-            "ooo-auto-boundary: OK "
-            f"({len(WATCHED_FILES)} files scanned, 0 findings)"
-        )
+        print(f"ooo-auto-boundary: OK ({len(targets)} files scanned, 0 findings)")
         return 0
 
     sys.stderr.write(
-        "ooo-auto-boundary: FAILED — domain keywords leaked into core auto.\n"
+        "ooo-auto-boundary: FAILED -- domain keywords leaked into core auto.\n"
         "Per Q00/ouroboros#725, these belong in a UserLevel plugin, not in `ooo auto`.\n\n"
     )
     for path, lineno, line, pattern in all_findings:
-        rel = path.relative_to(REPO_ROOT)
-        sys.stderr.write(
-            f"  {rel}:{lineno}: matched {pattern}\n    {line}\n"
-        )
+        try:
+            rel = path.relative_to(REPO_ROOT)
+        except ValueError:
+            rel = path
+        sys.stderr.write(f"  {rel}:{lineno}: matched {pattern!r}\n    {line}\n")
     sys.stderr.write(
         "\n"
         "If a forbidden keyword is genuinely necessary on a line (rare), append\n"

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Enforce the `ooo auto` product boundary at PR time.
+
+Per Q00/ouroboros#725, `ooo auto` has a permanent product boundary:
+`goal → interview → Seed → handoff`. Domain-specific operational
+workflows (GitHub PR ops, Jira, Slack, …) belong in plugins, not in
+core auto.
+
+This script greps a watched set of `ooo auto` source files for
+forbidden domain keywords and exits non-zero if any are found. It is
+the mechanical enforcement layer paired with #734's documentary work.
+
+Run locally:
+    python3 scripts/check-auto-boundary.py
+
+CI:
+    .github/workflows/auto-boundary.yml runs this on every PR.
+
+Allowlist:
+    Lines that genuinely need a forbidden keyword (rare; usually a
+    legacy import) can be marked with the trailing comment
+    `# domain-keyword-allowed: <reason>` to bypass the check. Each
+    allowlist usage requires reviewer sign-off.
+
+To extend the watched set, add to `WATCHED_FILES` below; to extend
+the keyword list, add to `FORBIDDEN_PATTERNS`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# Files that constitute the `ooo auto` core product boundary. New
+# domain branches in any of these is the failure mode this script
+# catches.
+WATCHED_FILES: tuple[str, ...] = (
+    "src/ouroboros/cli/commands/auto.py",
+    "src/ouroboros/auto/pipeline.py",
+    "src/ouroboros/auto/interview_driver.py",
+    "src/ouroboros/auto/state.py",
+    "src/ouroboros/auto/adapters.py",
+    "src/ouroboros/auto/grading.py",
+    "src/ouroboros/auto/seed_repairer.py",
+    "src/ouroboros/auto/seed_reviewer.py",
+    "src/ouroboros/auto/progress.py",
+)
+
+# Forbidden domain keywords. Each is a regex; matches are case-insensitive.
+# Keywords are chosen for high precision (low false-positive rate) on the
+# specific domains that drove #689 and the framing in #725.
+FORBIDDEN_PATTERNS: tuple[str, ...] = (
+    r"\bgithub\b",
+    r"\bpull_request\b",
+    r"/pulls?/",
+    r"\bapi\.github\.com\b",
+    r"\bjira\b",
+    r"\bslack\b",
+    r"\blinear\.app\b",
+    # The exact PR-route keyword from #689; precise enough to catch even
+    # if someone uses snake_case identifiers.
+    r"\bgithub_pr\b",
+)
+
+# Marker comment that allowlists a single line.
+ALLOWLIST_MARKER = "domain-keyword-allowed:"
+
+
+def _scan_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return offending (line_no, line, matched_pattern) tuples for `path`.
+
+    Lines carrying the allowlist marker are skipped. Lines inside string
+    literals or comments are still checked — the docstring at the top of
+    auto.py would catch a stray keyword, which is the desired behavior.
+    """
+    findings: list[tuple[int, str, str]] = []
+    if not path.is_file():
+        # Missing watched files are not an error in themselves; this script
+        # is forward-looking.
+        return findings
+    text = path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if ALLOWLIST_MARKER in line:
+            continue
+        for pattern in FORBIDDEN_PATTERNS:
+            if re.search(pattern, line, flags=re.IGNORECASE):
+                findings.append((lineno, line.rstrip(), pattern))
+                break
+    return findings
+
+
+def main() -> int:
+    all_findings: list[tuple[Path, int, str, str]] = []
+    for rel in WATCHED_FILES:
+        path = REPO_ROOT / rel
+        for lineno, line, pattern in _scan_file(path):
+            all_findings.append((path, lineno, line, pattern))
+
+    if not all_findings:
+        print(
+            "ooo-auto-boundary: OK "
+            f"({len(WATCHED_FILES)} files scanned, 0 findings)"
+        )
+        return 0
+
+    sys.stderr.write(
+        "ooo-auto-boundary: FAILED — domain keywords leaked into core auto.\n"
+        "Per Q00/ouroboros#725, these belong in a UserLevel plugin, not in `ooo auto`.\n\n"
+    )
+    for path, lineno, line, pattern in all_findings:
+        rel = path.relative_to(REPO_ROOT)
+        sys.stderr.write(
+            f"  {rel}:{lineno}: matched {pattern}\n    {line}\n"
+        )
+    sys.stderr.write(
+        "\n"
+        "If a forbidden keyword is genuinely necessary on a line (rare), append\n"
+        f"  # {ALLOWLIST_MARKER} <reason>\n"
+        "and add a brief PR-description rationale.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -19,8 +19,12 @@ CI:
 Allowlist:
     Lines that genuinely need a forbidden keyword (rare; usually a
     legacy import) can be marked with the trailing comment
-    `# domain-keyword-allowed: <reason>` to bypass the check. Each
-    allowlist usage requires reviewer sign-off.
+    `# domain-keyword-allowed: <reason>` to bypass the check. The
+    marker is honored only when it appears inside a real Python
+    comment token (the file is tokenized for this), so a stray
+    "domain-keyword-allowed:" inside a string literal cannot be used
+    to smuggle a forbidden keyword past the guard. Each allowlist
+    usage requires reviewer sign-off.
 
 Coverage strategy:
     The scan target is the *union* of (a) every `*.py` under
@@ -42,8 +46,10 @@ Pattern strategy:
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 import sys
+import tokenize
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -137,20 +143,47 @@ def _resolve_scan_targets() -> tuple[list[Path], list[str]]:
     return targets, missing
 
 
+def _allowlisted_lines(text: str) -> set[int]:
+    """Return the set of line numbers carrying a *real* Python comment
+    that contains the allowlist marker.
+
+    A naive substring check (``ALLOWLIST_MARKER in line``) would also
+    bypass a forbidden keyword when the marker appears inside a string
+    literal -- e.g. ``MSG = "domain-keyword-allowed: github"`` -- which
+    silently undermines the contract documented in CONTRIBUTING.md and
+    the script docstring. Tokenize the file and only honor the marker
+    when it appears in a ``COMMENT`` token.
+
+    On tokenize failure (malformed Python, partial file, etc.), return
+    an empty set: the safer default for a boundary guard is to flag
+    rather than over-allowlist.
+    """
+    allowed: set[int] = set()
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(text).readline):
+            if tok.type == tokenize.COMMENT and ALLOWLIST_MARKER in tok.string:
+                allowed.add(tok.start[0])
+    except (tokenize.TokenizeError, IndentationError, SyntaxError):
+        return set()
+    return allowed
+
+
 def _scan_file(path: Path) -> list[tuple[int, str, str]]:
     """Return offending ``(line_no, line, matched_pattern)`` tuples for ``path``.
 
-    Lines carrying the allowlist marker are skipped. Lines inside
-    string literals or comments are still checked -- a stray keyword
-    in a docstring of a watched file would catch, which is the desired
-    behavior.
+    Lines carrying the allowlist marker *as a real comment* are skipped.
+    Lines inside string literals or docstrings are still checked -- a
+    stray keyword in a docstring of a watched file would catch, which
+    is the desired behavior; and a forbidden keyword on a line whose
+    only marker is inside a string literal is *not* allowlisted.
     """
     findings: list[tuple[int, str, str]] = []
     if not path.is_file():
         return findings
     text = path.read_text(encoding="utf-8")
+    allowed_lines = _allowlisted_lines(text)
     for lineno, line in enumerate(text.splitlines(), start=1):
-        if ALLOWLIST_MARKER in line:
+        if lineno in allowed_lines:
             continue
         lowered = line.lower()
         for pattern in FORBIDDEN_PATTERNS:

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -36,18 +36,24 @@ Coverage strategy:
     cannot silently strip enforcement coverage.
 
 Pattern strategy:
-    Forbidden patterns are matched as case-insensitive *substrings*,
-    not word-boundaried regex. This catches realistic identifier forms
-    (`GitHubClient`, `github_client`, `JiraIssue`, `SlackNotifier`)
-    that a word-boundary regex would miss. Patterns are deliberately
-    chosen with low false-positive risk on the actual `ooo auto`
-    surface (verified against current main).
+    Forbidden patterns are Python regexes scoped with inline
+    case-insensitivity flags (``(?i:...)``) so each pattern can mix
+    case-insensitive and case-sensitive sub-matches as needed. This
+    catches realistic identifier forms (`GitHubClient`,
+    `github_client`, `PullRequestHandler`, `pullRequestId`,
+    `LinearClient`) without false-positiving on benign code such as
+    ``linear_time``, ``linearize``, or "linear pipeline" -- the
+    Linear-the-product pattern requires either the URL form, a
+    PascalCase composition (lowercase ``linear`` + an explicit
+    uppercase letter), or one of an enumerated set of integration
+    suffixes.
 """
 
 from __future__ import annotations
 
 import io
 from pathlib import Path
+import re
 import sys
 import tokenize
 
@@ -82,29 +88,43 @@ SCAN_DIRS: tuple[str, ...] = ("src/ouroboros/auto",)
 SCAN_EXTRA_FILES: tuple[str, ...] = ("src/ouroboros/cli/commands/auto.py",)
 
 
-# Forbidden domain keywords (case-insensitive substrings). Word
-# boundaries are deliberately NOT used: a contributor can otherwise
-# bypass the guard by writing `GitHubClient` or `github_client` and
-# having the regex skip identifier-embedded forms (the gap flagged by
-# the bot review of the original guard).
+# Forbidden domain keywords expressed as Python regexes. Patterns are
+# intentionally precise: a guard whose patterns false-positive on
+# benign code (e.g. ``linear_time``, ``linearize``, "linear pipeline")
+# turns into a CI-noise generator and gets allowlisted into
+# uselessness. ``(?i:...)`` is used for case-insensitive sub-matches;
+# bracket character classes such as ``[A-Z]`` outside that scope stay
+# case-sensitive, which is the exact discrimination needed for
+# PascalCase-composition forms.
 FORBIDDEN_PATTERNS: tuple[str, ...] = (
-    "github",
-    # Both forms are needed: lowercased lines preserve underscores, so
-    # `pull_request` (snake_case) and `pullrequest` (camelCase compressed
-    # form, e.g. PullRequestHandler/pullRequestId) are distinct
-    # substrings.
-    "pull_request",
-    "pullrequest",
-    "/pulls/",
-    "/pull/",
-    "jira",
-    "slack",
-    # `linear` (rather than `linear.app`) is required to catch identifier
-    # forms such as `LinearClient` / `LinearAdapter`. The substring also
-    # subsumes the original URL match `linear.app`. Verified zero false
-    # positives on the actual scan target (current main).
-    "linear",
+    r"(?i:github)",
+    r"(?i:pull_request)",
+    # Compressed camelCase form ``PullRequestHandler`` / ``pullRequestId``
+    # that the snake-case pattern above misses (the underscore prevents
+    # the substrings from sharing).
+    r"(?i:pullrequest)",
+    r"(?i:/pulls?/)",
+    r"(?i:jira)",
+    r"(?i:slack)",
+    # Linear (the issue tracker / SaaS) -- tightened to:
+    #   * the URL form ``linear.app`` / ``linear.com``, or
+    #   * a PascalCase composition (`LinearClient`, `LinearAdapter`,
+    #     `LinearAuth`, ...): "(?i:linear)" is case-insensitive but the
+    #     trailing ``[A-Z]`` is case-sensitive, so this distinguishes
+    #     ``LinearClient`` from benign ``linearize`` / ``linear_time``,
+    #   * an explicit integration suffix in snake_case
+    #     (`linear_client`, `linear_webhook`, ...).
+    # Plain "linear pipeline" / "linear scan" / "linear_time" do NOT
+    # match.
+    (
+        r"(?i:linear\.(?:app|com))"
+        r"|(?i:linear)[A-Z]"
+        r"|(?i:linear_(?:client|adapter|api|webhook|sdk|service|integration|notifier|hook|bot|messenger|action))"
+    ),
 )
+
+
+_COMPILED_PATTERNS: tuple[re.Pattern[str], ...] = tuple(re.compile(p) for p in FORBIDDEN_PATTERNS)
 
 
 # Marker comment that allowlists a single line.
@@ -185,9 +205,8 @@ def _scan_file(path: Path) -> list[tuple[int, str, str]]:
     for lineno, line in enumerate(text.splitlines(), start=1):
         if lineno in allowed_lines:
             continue
-        lowered = line.lower()
-        for pattern in FORBIDDEN_PATTERNS:
-            if pattern in lowered:
+        for pattern, compiled in zip(FORBIDDEN_PATTERNS, _COMPILED_PATTERNS, strict=True):
+            if compiled.search(line):
                 findings.append((lineno, line.rstrip(), pattern))
                 break
     return findings

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -148,11 +148,12 @@ def test_each_forbidden_pattern_independently_caught(
     samples = {
         "github": "host = 'github.com'",
         "pull_request": "if 'pull_request' in payload: ...",
+        "pullrequest": "handler = PullRequestHandler()",
         "/pulls/": "uri = '/pulls/42'",
         "/pull/": "uri = '/pull/42'",
         "jira": "issue = 'JIRA-1'",
         "slack": "channel = '#xchan'  # slack",
-        "linear.app": "url = 'https://linear.app/...'",
+        "linear": "client = LinearClient()",
     }
     import re as _re
 
@@ -178,6 +179,14 @@ def test_each_forbidden_pattern_independently_caught(
         ("def notify_slack_user(): pass", "slack snake_case"),
         ("notifier = SlackNotifier()", "Slack PascalCase"),
         ("FOO_GITHUB_BASE = 'x'", "SCREAMING_SNAKE_CASE"),
+        # Compressed camelCase / no-underscore forms that the original
+        # ``pull_request`` / ``linear.app`` substrings missed.
+        ("handler = PullRequestHandler()", "PullRequest PascalCase"),
+        ("event_id = pullRequestId", "pullRequest camelCase"),
+        ("class PRHandler(PullRequestBase): ...", "PullRequest base class"),
+        ("client = LinearClient()", "Linear PascalCase"),
+        ("adapter = LinearAdapter()", "Linear adapter PascalCase"),
+        ("from foo import linear_client", "linear snake_case"),
     ],
 )
 def test_identifier_forms_are_caught(

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -197,6 +197,17 @@ def test_each_forbidden_pattern_independently_caught(
         ("client = LinearClient()", "Linear PascalCase"),
         ("adapter = LinearAdapter()", "Linear adapter PascalCase"),
         ("from foo import linear_client", "linear snake_case"),
+        # camelCase-compound forms where the keyword sits in the middle
+        # of an identifier preceded by a lowercase letter (the bypass
+        # class flagged by bot review on commit c2b6943).
+        ("issue = openGithubIssue()", "openGithubIssue (Github mid-camelCase)"),
+        ("url = makePullRequestUrl()", "makePullRequestUrl (PullRequest mid-camelCase)"),
+        ("sendToSlack(msg)", "sendToSlack (Slack mid-camelCase)"),
+        ("issue = openJiraIssue()", "openJiraIssue (Jira mid-camelCase)"),
+        ("hook = notifyLinearAdapter()", "notifyLinearAdapter (Linear mid-camelCase)"),
+        ("client = maybeLinearClient()", "maybeLinearClient (Linear mid-camelCase)"),
+        ("notifier = registerSlackNotifier()", "registerSlackNotifier (Slack mid-camelCase)"),
+        ("payload = buildGithubPayload()", "buildGithubPayload (Github mid-camelCase)"),
     ],
 )
 def test_identifier_forms_are_caught(

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -309,6 +309,65 @@ def test_anchor_file_present_but_outside_scan_dir_still_anchored(
     assert rc == 1
 
 
+def test_allowlist_marker_inside_string_literal_does_not_bypass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The allowlist marker is only honored inside a real comment.
+
+    A forbidden keyword on a line whose only marker is embedded in a
+    string literal -- e.g. ``MSG = "domain-keyword-allowed: github"``
+    -- must still be flagged. Substring-only marker detection (the
+    pre-fix behavior) was a real bypass that defeated the guard.
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    (watched_dir / "auto.py").write_text('MSG = "domain-keyword-allowed: docs github"\n')
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1
+
+
+def test_allowlist_marker_in_real_comment_still_bypasses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The allowlist marker still works when it appears in a genuine
+    Python comment (trailing ``#`` form) -- regression guard for the
+    string-literal fix above."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    (watched_dir / "auto.py").write_text(
+        "import legacy_github  # domain-keyword-allowed: legacy plumbing\n"
+    )
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 0
+
+
+def test_allowlist_marker_split_string_and_comment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A line where the marker is in a string AND a separate (non-marker)
+    real comment exists must NOT bypass. Only a marker in a real comment
+    counts."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    (watched_dir / "auto.py").write_text(
+        'MSG = "domain-keyword-allowed: github"  # actual comment without marker\n'
+    )
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1
+
+
 def test_scan_extra_files_are_scanned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A SCAN_EXTRA_FILES entry that lives outside SCAN_DIRS is still
     scanned for forbidden keywords (regression guard for the union

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -1,39 +1,68 @@
-"""Self-tests for `scripts/check-auto-boundary.py`.
+"""Self-tests for ``scripts/check-auto-boundary.py``.
 
 The guard's value is proportional to its precision: it must catch real
-domain-keyword leaks AND must not false-positive on benign code (e.g. a
-docstring referencing `ooo auto`'s product boundary). Both directions
-are exercised here.
+domain-keyword leaks (including realistic Python identifier forms such
+as ``GitHubClient`` and ``github_client``) AND must not false-positive
+on benign code. It must also fail loud when a load-bearing anchor file
+disappears, so a refactor cannot silently strip enforcement coverage.
+Both directions are exercised here.
 """
 
 from __future__ import annotations
 
 import importlib.util
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
-
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = REPO_ROOT / "scripts" / "check-auto-boundary.py"
 
 
 def _load_module():
-    """Load the hyphenated script as a module so we can call `main()`
-    directly with a custom REPO_ROOT."""
+    """Load the hyphenated script as a module so we can call ``main()``
+    directly with custom REPO_ROOT / configuration."""
     spec = importlib.util.spec_from_file_location("check_auto_boundary", SCRIPT)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore[union-attr]
     return module
 
 
+def _make_anchor_layout(repo: Path, anchors: tuple[str, ...]) -> None:
+    """Create empty placeholders for every anchor path so the
+    fail-loud-on-missing branch doesn't fire in unrelated tests."""
+    for rel in anchors:
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if not p.exists():
+            p.write_text("# placeholder\n")
+
+
+def _isolate(
+    module,
+    monkeypatch: pytest.MonkeyPatch,
+    repo: Path,
+    *,
+    scan_dirs: tuple[str, ...] = ("src/ouroboros/auto",),
+    scan_extra_files: tuple[str, ...] = ("src/ouroboros/cli/commands/auto.py",),
+    anchor_files: tuple[str, ...] | None = None,
+) -> None:
+    """Point the module at a fake repo with controlled scan/anchor sets."""
+    if anchor_files is None:
+        anchor_files = scan_extra_files
+    monkeypatch.setattr(module, "REPO_ROOT", repo)
+    monkeypatch.setattr(module, "SCAN_DIRS", scan_dirs)
+    monkeypatch.setattr(module, "SCAN_EXTRA_FILES", scan_extra_files)
+    monkeypatch.setattr(module, "ANCHOR_FILES", anchor_files)
+
+
 def test_clean_repo_passes_via_subprocess() -> None:
     """The current `ooo auto` source must pass the guard.
 
     This is the runtime invariant the guard exists to protect: at any
-    point in main, every watched file is free of forbidden keywords.
+    point in main, every scanned file is free of forbidden keywords.
     """
     result = subprocess.run(
         [sys.executable, str(SCRIPT)],
@@ -46,9 +75,7 @@ def test_clean_repo_passes_via_subprocess() -> None:
     assert "OK" in result.stdout
 
 
-def test_offending_file_is_caught(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_offending_file_is_caught(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A synthetic file containing a forbidden keyword must be caught."""
     module = _load_module()
     fake_repo = tmp_path / "repo"
@@ -56,24 +83,15 @@ def test_offending_file_is_caught(
     watched_dir.mkdir(parents=True)
     offending = watched_dir / "auto.py"
     offending.write_text(
-        "def handle(url: str) -> None:\n"
-        "    if 'github.com' in url:\n"
-        "        do_pr_things(url)\n"
+        "def handle(url: str) -> None:\n    if 'github.com' in url:\n        do_pr_things(url)\n"
     )
 
-    monkeypatch.setattr(module, "REPO_ROOT", fake_repo)
-    monkeypatch.setattr(
-        module,
-        "WATCHED_FILES",
-        ("src/ouroboros/cli/commands/auto.py",),
-    )
+    _isolate(module, monkeypatch, fake_repo)
     rc = module.main()
     assert rc == 1
 
 
-def test_allowlist_marker_bypasses(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_allowlist_marker_bypasses(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A line carrying the allowlist marker is not flagged."""
     module = _load_module()
     fake_repo = tmp_path / "repo"
@@ -81,36 +99,38 @@ def test_allowlist_marker_bypasses(
     watched_dir.mkdir(parents=True)
     offending = watched_dir / "auto.py"
     offending.write_text(
-        "# Routing reuses an unrelated GitHub adapter import. # domain-keyword-allowed: legacy plumbing\n"
+        "# Routing reuses an unrelated GitHub adapter import. "
+        "# domain-keyword-allowed: legacy plumbing\n"
         "x = 1\n"
     )
 
-    monkeypatch.setattr(module, "REPO_ROOT", fake_repo)
-    monkeypatch.setattr(
-        module,
-        "WATCHED_FILES",
-        ("src/ouroboros/cli/commands/auto.py",),
-    )
+    _isolate(module, monkeypatch, fake_repo)
     rc = module.main()
     assert rc == 0
 
 
-def test_missing_watched_file_does_not_error(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """If a watched file is removed (e.g. in a refactor), the guard does
-    NOT crash — it simply has nothing to scan for that path."""
+def test_missing_anchor_file_fails_loud(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a load-bearing anchor file is missing (e.g. removed in a
+    refactor without updating ANCHOR_FILES), the guard MUST fail loud.
+
+    This is the bot-review-flagged silent-failure mode: a hand-maintained
+    file list combined with "missing == clean" turns refactors into
+    accidental coverage strippers.
+    """
     module = _load_module()
     fake_repo = tmp_path / "repo"
     fake_repo.mkdir()
-    monkeypatch.setattr(module, "REPO_ROOT", fake_repo)
-    monkeypatch.setattr(
+
+    _isolate(
         module,
-        "WATCHED_FILES",
-        ("src/ouroboros/cli/commands/auto.py",),  # path that doesn't exist
+        monkeypatch,
+        fake_repo,
+        scan_dirs=(),  # nothing to discover
+        scan_extra_files=(),
+        anchor_files=("src/ouroboros/cli/commands/auto.py",),  # does not exist
     )
     rc = module.main()
-    assert rc == 0
+    assert rc == 1
 
 
 def test_each_forbidden_pattern_independently_caught(
@@ -118,37 +138,180 @@ def test_each_forbidden_pattern_independently_caught(
 ) -> None:
     """For each forbidden pattern, a synthetic offender is caught.
 
-    This is a meta-test: it confirms the pattern list itself is wired
-    into the scan loop, so future additions to FORBIDDEN_PATTERNS take
-    effect without wiring code.
+    Meta-test that the pattern list is wired into the scan loop, so
+    additions to FORBIDDEN_PATTERNS take effect without wiring code.
+    Each sample is chosen to match exactly one pattern so the test
+    survives the first-match-wins ordering of ``_scan_file``.
     """
     module = _load_module()
 
     samples = {
-        r"\bgithub\b": "host = 'github.com'",
-        r"\bpull_request\b": "if 'pull_request' in payload: ...",
-        r"/pulls?/": "uri = '/pulls/42'",
-        r"\bapi\.github\.com\b": "host = 'api.github.com'",
-        r"\bjira\b": "issue = 'jira issue OUR-1'",
-        r"\bslack\b": "channel = 'slack #x'",
-        r"\blinear\.app\b": "url = 'https://linear.app/...'",
-        r"\bgithub_pr\b": "if event == 'github_pr': ...",
+        "github": "host = 'github.com'",
+        "pull_request": "if 'pull_request' in payload: ...",
+        "/pulls/": "uri = '/pulls/42'",
+        "/pull/": "uri = '/pull/42'",
+        "jira": "issue = 'JIRA-1'",
+        "slack": "channel = '#xchan'  # slack",
+        "linear.app": "url = 'https://linear.app/...'",
     }
     import re as _re
+
     for i, pattern in enumerate(module.FORBIDDEN_PATTERNS):
         assert pattern in samples, f"add a sample for {pattern!r}"
-        # Sanitize pattern for use as a directory name (every regex
-        # metachar would otherwise leak into the path).
         safe = _re.sub(r"[^a-zA-Z0-9]", "_", pattern).strip("_")
         fake_repo = tmp_path / f"case-{i}-{safe}"
         watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
         watched_dir.mkdir(parents=True)
         (watched_dir / "auto.py").write_text(samples[pattern] + "\n")
-        monkeypatch.setattr(module, "REPO_ROOT", fake_repo)
-        monkeypatch.setattr(
-            module,
-            "WATCHED_FILES",
-            ("src/ouroboros/cli/commands/auto.py",),
-        )
+        _isolate(module, monkeypatch, fake_repo)
         rc = module.main()
         assert rc == 1, f"pattern {pattern!r} not caught for sample"
+
+
+@pytest.mark.parametrize(
+    "snippet,reason",
+    [
+        ("client = GitHubClient()", "PascalCase identifier"),
+        ("from .ghub import github_client", "snake_case identifier"),
+        ("from foo import GitHubAdapter", "PascalCase import"),
+        ("issue = JiraIssue(id=1)", "Jira PascalCase"),
+        ("def notify_slack_user(): pass", "slack snake_case"),
+        ("notifier = SlackNotifier()", "Slack PascalCase"),
+        ("FOO_GITHUB_BASE = 'x'", "SCREAMING_SNAKE_CASE"),
+    ],
+)
+def test_identifier_forms_are_caught(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    snippet: str,
+    reason: str,
+) -> None:
+    """Realistic Python identifier forms (camelCase, snake_case,
+    PascalCase, SCREAMING_SNAKE_CASE, import-from) must be caught.
+
+    The original word-boundary regex (``\\bgithub\\b`` etc.) silently
+    skipped these. The bot review flagged this as a guard bypass; the
+    relaxed substring matching closes it.
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    (watched_dir / "auto.py").write_text(snippet + "\n")
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1, f"{reason}: {snippet!r} should have been flagged"
+
+
+def test_auto_discovery_picks_up_new_files_in_auto_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A brand-new file dropped under ``src/ouroboros/auto/`` is scanned
+    automatically -- no manual list update required.
+
+    This addresses the bot review design note that a hand-maintained
+    file list weakens the enforcement contract: a contributor adding a
+    new domain-tainted module would otherwise be invisible to the
+    guard until someone remembered to extend the list.
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    # Anchor placeholder so the missing-anchor branch doesn't fire.
+    (fake_repo / "src" / "ouroboros" / "cli" / "commands").mkdir(parents=True)
+    (fake_repo / "src" / "ouroboros" / "cli" / "commands" / "auto.py").write_text("# clean\n")
+    # New file with a forbidden keyword embedded in an identifier.
+    (auto_dir / "new_module.py").write_text("class GitHubAdapter:\n    pass\n")
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1, "auto-discovery missed a new file under src/ouroboros/auto/"
+
+
+def test_clean_auto_dir_with_anchors_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clean auto/ dir containing several files plus all anchors
+    passes the guard."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    (auto_dir / "pipeline.py").write_text("def run() -> None:\n    pass\n")
+    (auto_dir / "extra_module.py").write_text("VALUE = 1\n")
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "auto.py").write_text("# entrypoint\n")
+
+    _isolate(
+        module,
+        monkeypatch,
+        fake_repo,
+        anchor_files=(
+            "src/ouroboros/cli/commands/auto.py",
+            "src/ouroboros/auto/pipeline.py",
+        ),
+    )
+    rc = module.main()
+    assert rc == 0
+
+
+def test_keyword_in_docstring_of_watched_file_is_caught(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Docstrings and comments are part of the watched surface: a
+    docstring example referencing a domain workflow should be caught
+    so that contributors are nudged to put it in a plugin doc instead."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    (watched_dir / "auto.py").write_text(
+        '"""Helpers.\n\n    Example: ``ooo auto --target slack-bot``.\n"""\n'
+    )
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1
+
+
+def test_anchor_file_present_but_outside_scan_dir_still_anchored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An anchor file living outside the SCAN_DIRS roots is still
+    enforced as must-exist (it represents a load-bearing surface even
+    if discovery wouldn't have picked it up)."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    (auto_dir / "pipeline.py").write_text("# clean\n")
+    # cli/commands/auto.py is intentionally NOT created
+    _isolate(
+        module,
+        monkeypatch,
+        fake_repo,
+        anchor_files=(
+            "src/ouroboros/cli/commands/auto.py",
+            "src/ouroboros/auto/pipeline.py",
+        ),
+    )
+    rc = module.main()
+    assert rc == 1
+
+
+def test_scan_extra_files_are_scanned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A SCAN_EXTRA_FILES entry that lives outside SCAN_DIRS is still
+    scanned for forbidden keywords (regression guard for the union
+    discovery logic)."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "auto.py").write_text("import GitHubClient  # noqa\n")
+    # Empty auto package so SCAN_DIRS contributes nothing
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -411,6 +411,19 @@ def test_allowlist_marker_split_string_and_comment(
         ("data = myslack_data", "myslack_data (embedded slack)"),
         ("data = mypull_request_data", "mypull_request_data (embedded pull_request)"),
         ("var = mypullrequest_handler", "mypullrequest (embedded pullrequest)"),
+        # Generic English camelCase / PascalCase compounds that begin
+        # with ``linear`` but are not Linear-the-product integrations
+        # must NOT trigger. The follow-up bot review on commit 293d87c7
+        # flagged that the previous ``(?i:linear)[A-Z]`` arm rejected
+        # this whole class as if it referenced Linear-the-SaaS.
+        ("dt = linearTime", "linearTime (generic camelCase)"),
+        ("class LinearTime: ...", "LinearTime (generic PascalCase)"),
+        ("op = linearTransform()", "linearTransform (generic camelCase)"),
+        ("class LinearTransform: ...", "LinearTransform (generic PascalCase)"),
+        ("op = LinearOperator()", "LinearOperator (generic PascalCase)"),
+        ("class LinearRegressor: ...", "LinearRegressor (generic PascalCase)"),
+        ("y = linearScan(arr)", "linearScan (generic camelCase)"),
+        ("var = LinearProgrammingSolver()", "LinearProgrammingSolver (generic compound)"),
     ],
 )
 def test_linear_word_is_not_a_false_positive(

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -145,28 +145,38 @@ def test_each_forbidden_pattern_independently_caught(
     """
     module = _load_module()
 
-    samples = {
-        "github": "host = 'github.com'",
-        "pull_request": "if 'pull_request' in payload: ...",
-        "pullrequest": "handler = PullRequestHandler()",
-        "/pulls/": "uri = '/pulls/42'",
-        "/pull/": "uri = '/pull/42'",
-        "jira": "issue = 'JIRA-1'",
-        "slack": "channel = '#xchan'  # slack",
-        "linear": "client = LinearClient()",
-    }
+    # Map each declared FORBIDDEN_PATTERNS entry to a single-pattern
+    # sample. The samples are chosen so they match exactly one regex,
+    # surviving the first-match-wins ordering of ``_scan_file``.
+    samples_by_index = [
+        "host = 'github.com'",  # github
+        "if 'pull_request' in payload: ...",  # pull_request (snake)
+        "handler = PullRequestHandler()",  # pullrequest (compressed)
+        "uri = '/pulls/42'",  # /pulls?/
+        "issue = 'JIRA-1'",  # jira
+        "channel = '#xchan'  # slack",  # slack (only in trailing real-Python comment)
+        "client = LinearClient()",  # linear (PascalCase composition)
+    ]
+
+    assert len(samples_by_index) == len(module.FORBIDDEN_PATTERNS), (
+        "samples_by_index must align 1:1 with FORBIDDEN_PATTERNS; "
+        f"got {len(samples_by_index)} samples for "
+        f"{len(module.FORBIDDEN_PATTERNS)} patterns"
+    )
+
     import re as _re
 
-    for i, pattern in enumerate(module.FORBIDDEN_PATTERNS):
-        assert pattern in samples, f"add a sample for {pattern!r}"
-        safe = _re.sub(r"[^a-zA-Z0-9]", "_", pattern).strip("_")
+    for i, (pattern, sample) in enumerate(
+        zip(module.FORBIDDEN_PATTERNS, samples_by_index, strict=True)
+    ):
+        safe = _re.sub(r"[^a-zA-Z0-9]", "_", pattern)[:40].strip("_") or f"p{i}"
         fake_repo = tmp_path / f"case-{i}-{safe}"
         watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
         watched_dir.mkdir(parents=True)
-        (watched_dir / "auto.py").write_text(samples[pattern] + "\n")
+        (watched_dir / "auto.py").write_text(sample + "\n")
         _isolate(module, monkeypatch, fake_repo)
         rc = module.main()
-        assert rc == 1, f"pattern {pattern!r} not caught for sample"
+        assert rc == 1, f"pattern {pattern!r} not caught for sample {sample!r}"
 
 
 @pytest.mark.parametrize(
@@ -366,6 +376,76 @@ def test_allowlist_marker_split_string_and_comment(
     _isolate(module, monkeypatch, fake_repo)
     rc = module.main()
     assert rc == 1
+
+
+@pytest.mark.parametrize(
+    "snippet,reason",
+    [
+        ("def linear_time_search(): pass", "linear_time identifier"),
+        ("# linear pipeline scan", "'linear pipeline' docstring fragment"),
+        ("def linearize(matrix): pass", "linearize identifier"),
+        ("STEP_LINEAR = 1", "SCREAMING_SNAKE LINEAR_ ... only"),
+        ("complexity = 'linear'", "string literal 'linear'"),
+        ("# perform a linear search across the timeline", "linear search comment"),
+    ],
+)
+def test_linear_word_is_not_a_false_positive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    snippet: str,
+    reason: str,
+) -> None:
+    """The bare English word ``linear`` must NOT trigger the guard.
+
+    Bot review on iteration 3 flagged that a naive substring ``linear``
+    rejected legitimate identifiers (``linear_time``, ``linearize``)
+    and docstrings (``"linear pipeline"``). The tightened pattern only
+    matches Linear-the-SaaS forms (URL, PascalCase, integration suffix).
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    (watched_dir / "auto.py").write_text(snippet + "\n")
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 0, f"{reason}: {snippet!r} should NOT have been flagged"
+
+
+@pytest.mark.parametrize(
+    "snippet,reason",
+    [
+        ("client = LinearClient()", "PascalCase composition"),
+        ("adapter = LinearAdapter()", "PascalCase composition (Adapter)"),
+        ("auth = LinearAuth()", "PascalCase composition (Auth)"),
+        ("url = 'https://linear.app/team/x'", "linear.app URL"),
+        ("url = 'https://linear.com/...'", "linear.com URL (case-insensitive)"),
+        ("url = 'https://Linear.App/...'", "Linear.App URL (case-insensitive)"),
+        ("from x import linear_client", "snake_case integration suffix (client)"),
+        ("from x import linear_webhook", "snake_case integration suffix (webhook)"),
+        ("hook = linear_notifier()", "snake_case integration suffix (notifier)"),
+    ],
+)
+def test_linear_saas_forms_are_caught(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    snippet: str,
+    reason: str,
+) -> None:
+    """Linear-the-SaaS identifier and URL forms must be caught.
+
+    Counterpart to ``test_linear_word_is_not_a_false_positive``: ensures
+    the tightened regex still catches what we want, not just rejects
+    what we don't.
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    (watched_dir / "auto.py").write_text(snippet + "\n")
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1, f"{reason}: {snippet!r} should have been flagged"
 
 
 def test_scan_extra_files_are_scanned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -387,6 +387,19 @@ def test_allowlist_marker_split_string_and_comment(
         ("STEP_LINEAR = 1", "SCREAMING_SNAKE LINEAR_ ... only"),
         ("complexity = 'linear'", "string literal 'linear'"),
         ("# perform a linear search across the timeline", "linear search comment"),
+        # Embedded-substring guards: `linear` inside a larger word must
+        # not trigger the linear-the-SaaS pattern.
+        ("pts = collinearPoints()", "collinearPoints (linear inside)"),
+        ("form = bilinearForm()", "bilinearForm (linear inside)"),
+        ("ad = nonlinearAdapter()", "nonlinearAdapter (linear inside)"),
+        ("from x import nonlinear_adapter", "nonlinear_adapter (snake embed)"),
+        # Word-boundary guards for the other keywords too: embedded
+        # substrings should NOT trigger.
+        ("var = mygithub_thing", "mygithub_thing (embedded github)"),
+        ("data = myjira_data", "myjira_data (embedded jira)"),
+        ("data = myslack_data", "myslack_data (embedded slack)"),
+        ("data = mypull_request_data", "mypull_request_data (embedded pull_request)"),
+        ("var = mypullrequest_handler", "mypullrequest (embedded pullrequest)"),
     ],
 )
 def test_linear_word_is_not_a_false_positive(

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -1,0 +1,154 @@
+"""Self-tests for `scripts/check-auto-boundary.py`.
+
+The guard's value is proportional to its precision: it must catch real
+domain-keyword leaks AND must not false-positive on benign code (e.g. a
+docstring referencing `ooo auto`'s product boundary). Both directions
+are exercised here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "check-auto-boundary.py"
+
+
+def _load_module():
+    """Load the hyphenated script as a module so we can call `main()`
+    directly with a custom REPO_ROOT."""
+    spec = importlib.util.spec_from_file_location("check_auto_boundary", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def test_clean_repo_passes_via_subprocess() -> None:
+    """The current `ooo auto` source must pass the guard.
+
+    This is the runtime invariant the guard exists to protect: at any
+    point in main, every watched file is free of forbidden keywords.
+    """
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"guard failed on a presumed-clean main:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_offending_file_is_caught(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A synthetic file containing a forbidden keyword must be caught."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    offending = watched_dir / "auto.py"
+    offending.write_text(
+        "def handle(url: str) -> None:\n"
+        "    if 'github.com' in url:\n"
+        "        do_pr_things(url)\n"
+    )
+
+    monkeypatch.setattr(module, "REPO_ROOT", fake_repo)
+    monkeypatch.setattr(
+        module,
+        "WATCHED_FILES",
+        ("src/ouroboros/cli/commands/auto.py",),
+    )
+    rc = module.main()
+    assert rc == 1
+
+
+def test_allowlist_marker_bypasses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A line carrying the allowlist marker is not flagged."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    watched_dir.mkdir(parents=True)
+    offending = watched_dir / "auto.py"
+    offending.write_text(
+        "# Routing reuses an unrelated GitHub adapter import. # domain-keyword-allowed: legacy plumbing\n"
+        "x = 1\n"
+    )
+
+    monkeypatch.setattr(module, "REPO_ROOT", fake_repo)
+    monkeypatch.setattr(
+        module,
+        "WATCHED_FILES",
+        ("src/ouroboros/cli/commands/auto.py",),
+    )
+    rc = module.main()
+    assert rc == 0
+
+
+def test_missing_watched_file_does_not_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If a watched file is removed (e.g. in a refactor), the guard does
+    NOT crash — it simply has nothing to scan for that path."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    fake_repo.mkdir()
+    monkeypatch.setattr(module, "REPO_ROOT", fake_repo)
+    monkeypatch.setattr(
+        module,
+        "WATCHED_FILES",
+        ("src/ouroboros/cli/commands/auto.py",),  # path that doesn't exist
+    )
+    rc = module.main()
+    assert rc == 0
+
+
+def test_each_forbidden_pattern_independently_caught(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """For each forbidden pattern, a synthetic offender is caught.
+
+    This is a meta-test: it confirms the pattern list itself is wired
+    into the scan loop, so future additions to FORBIDDEN_PATTERNS take
+    effect without wiring code.
+    """
+    module = _load_module()
+
+    samples = {
+        r"\bgithub\b": "host = 'github.com'",
+        r"\bpull_request\b": "if 'pull_request' in payload: ...",
+        r"/pulls?/": "uri = '/pulls/42'",
+        r"\bapi\.github\.com\b": "host = 'api.github.com'",
+        r"\bjira\b": "issue = 'jira issue OUR-1'",
+        r"\bslack\b": "channel = 'slack #x'",
+        r"\blinear\.app\b": "url = 'https://linear.app/...'",
+        r"\bgithub_pr\b": "if event == 'github_pr': ...",
+    }
+    import re as _re
+    for i, pattern in enumerate(module.FORBIDDEN_PATTERNS):
+        assert pattern in samples, f"add a sample for {pattern!r}"
+        # Sanitize pattern for use as a directory name (every regex
+        # metachar would otherwise leak into the path).
+        safe = _re.sub(r"[^a-zA-Z0-9]", "_", pattern).strip("_")
+        fake_repo = tmp_path / f"case-{i}-{safe}"
+        watched_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+        watched_dir.mkdir(parents=True)
+        (watched_dir / "auto.py").write_text(samples[pattern] + "\n")
+        monkeypatch.setattr(module, "REPO_ROOT", fake_repo)
+        monkeypatch.setattr(
+            module,
+            "WATCHED_FILES",
+            ("src/ouroboros/cli/commands/auto.py",),
+        )
+        rc = module.main()
+        assert rc == 1, f"pattern {pattern!r} not caught for sample"


### PR DESCRIPTION
Closes **both** #734 and #735 (consolidated). Sub-issue of #725 (Phase 4).

This PR is **independent of the Sprint 1+2+3 stack** — branched off `main` directly so it can land in any order.

## Pre-flight verification

At the time of this PR, `grep -nE '\bgithub\b|\bpull_request\b|/pulls?/'` on the 9 watched `ooo auto` source files returns **empty**. The boundary #725 protects is intact today. The closed #689 PR stack (`#697`, `#707`, `#712`, `#715`, `#721`) is the de facto evidence; this PR is the de jure mechanical guard.

## `scripts/check-auto-boundary.py`

Greps a watched set of 9 `ooo auto` source files for forbidden domain keywords:

```
github   pull_request   /pulls/   api.github.com   jira
slack    linear.app     github_pr
```

Exits non-zero with a per-finding report:

```
ooo-auto-boundary: FAILED — domain keywords leaked into core auto.
Per Q00/ouroboros#725, these belong in a UserLevel plugin, not in `ooo auto`.

  src/ouroboros/cli/commands/auto.py:42: matched \bgithub\b
    if "github.com" in url:
```

### Allowlist

A line that genuinely needs a forbidden keyword (rare) can opt out via:

```python
# domain-keyword-allowed: <reason>
```

Each usage requires reviewer sign-off via PR description rationale.

## `.github/workflows/auto-boundary.yml`

Runs the script on every `pull_request` to main and on push to main. **Recommend configuring as a required status check in repo settings** (flagged for maintainer).

## Tests — 5/5 self-tests pass

```
$ PYTHONPATH=src python3 -m pytest tests/unit/scripts/test_check_auto_boundary.py -v
============================== 5 passed in 0.23s ===============================
```

| # | Test | What it guards |
|---|---|---|
| 1 | clean main passes via subprocess | the runtime invariant (current main is clean) |
| 2 | synthetic offender caught | the guard actually rejects |
| 3 | allowlist marker bypasses | the escape hatch works |
| 4 | missing watched file does not error | refactors that delete watched files don't crash CI |
| 5 | each forbidden pattern is independently caught | adding a pattern takes effect without wiring code |

## `CONTRIBUTING.md`

Adds the boundary check to the "Lint and Format" workflow step with the allowlist marker syntax explained.

## Cross-repo

Pairs with #743 (CR-1 RFC) — that PR's `ooo auto Boundary` section already cross-links the closed #689 PR stack and points at this guard as the mechanical enforcement layer.

## What this completes

Phase 4 of the #725 work. Combined with PRs #745–#752, the full Sprint 1+2+3 plan is now open as PRs ready for review.