### PR TITLE
fix(providers,interview): isolate subprocess from host plugin env

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1710,7 +1710,6 @@ def create_ouroboros_server(
             event_store=event_store,
         ),
         InterviewHandler(
-            interview_engine=interview_engine,
             event_store=event_store,
             llm_adapter=llm_adapter,
             llm_backend=llm_backend,

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1710,6 +1710,7 @@ def create_ouroboros_server(
             event_store=event_store,
         ),
         InterviewHandler(
+            interview_engine=interview_engine,
             event_store=event_store,
             llm_adapter=llm_adapter,
             llm_backend=llm_backend,

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1249,11 +1249,21 @@ class InterviewHandler:
         # Use injected or create interview engine
         # max_turns=1: MCP is a pure question generator. No tool use needed.
         # Main session handles codebase exploration and answering.
+        #
+        # ``strict_mcp_config=True`` is opt-in here — and ONLY here — so the
+        # subprocess spawned for question generation cannot rediscover the
+        # plugin-provided ouroboros MCP server when this handler runs as a
+        # child of Claude Code's MCP host (where ``mcp__plugin_ouroboros_*``
+        # tools are auto-registered).  Without this, the subprocess
+        # recurses on ``ouroboros_interview`` and exits at ``--max-turns 1``.
+        # CLI interview entrypoints (``ooo init`` / ``ooo pm``) do NOT pass
+        # this flag, so they keep plugin/project ``.mcp.json`` servers.
         llm_adapter = self.llm_adapter or create_llm_adapter(
             backend=self.llm_backend,
             max_turns=1,
             use_case="interview",
             allowed_tools=_interview_allowed_tools(self.llm_backend),
+            strict_mcp_config=True,
         )
         engine = self.interview_engine or InterviewEngine(
             llm_adapter=llm_adapter,

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1249,7 +1249,7 @@ class InterviewHandler:
         # Use injected or create interview engine
         # max_turns=1: MCP is a pure question generator. No tool use needed.
         # Main session handles codebase exploration and answering.
-        llm_adapter = self.llm_adapter or create_llm_adapter(
+        llm_adapter = create_llm_adapter(
             backend=self.llm_backend,
             max_turns=1,
             use_case="interview",

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1249,7 +1249,7 @@ class InterviewHandler:
         # Use injected or create interview engine
         # max_turns=1: MCP is a pure question generator. No tool use needed.
         # Main session handles codebase exploration and answering.
-        llm_adapter = create_llm_adapter(
+        llm_adapter = self.llm_adapter or create_llm_adapter(
             backend=self.llm_backend,
             max_turns=1,
             use_case="interview",

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -601,9 +601,10 @@ class ClaudeCodeAdapter:
             "CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK": os.environ.get(
                 "OUROBOROS_SKIP_VERSION_CHECK", "1"
             ),
+            "CLAUDECODE": "",
+            "CLAUDE_PLUGIN_DATA": "",
+            "CLAUDE_PLUGIN_ROOT": "",
         }
-        if claudecode_present:
-            env_overrides["CLAUDECODE"] = ""
 
         stderr_lines: list[str] = []
 

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -30,6 +30,8 @@ import asyncio
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import replace
+from functools import lru_cache
+import inspect
 import json
 import os
 from pathlib import Path
@@ -67,6 +69,26 @@ _RETRYABLE_ERROR_PATTERNS = (
     "need retry",  # explicit retry request
     "startup",
 )
+
+
+@lru_cache(maxsize=1)
+def _claude_options_field_names() -> frozenset[str]:
+    """Return parameter names accepted by ``ClaudeAgentOptions``.
+
+    Used to gate optional kwargs that may not exist across the supported
+    SDK pin range (``claude-agent-sdk>=0.1.0,<1.0.0``).  ``strict-mcp-config``
+    is only available via ``extra_args`` (CLI passthrough) on current SDK
+    versions; older releases may also lack ``extra_args`` itself, so we
+    detect support before forwarding instead of assuming a typed kwarg.
+    """
+    try:
+        from claude_agent_sdk import ClaudeAgentOptions  # noqa: PLC0415
+    except ImportError:
+        return frozenset()
+    try:
+        return frozenset(inspect.signature(ClaudeAgentOptions).parameters)
+    except (TypeError, ValueError):
+        return frozenset()
 
 
 class ClaudeCodeAdapter:
@@ -641,10 +663,33 @@ class ClaudeCodeAdapter:
             # Opt-in MCP isolation: prevents the spawned subprocess from
             # discovering plugin-provided servers (notably ouroboros itself,
             # which would recurse on ouroboros_interview when invoked from
-            # inside Claude Code's MCP context). Scoped to callers that
+            # inside Claude Code's MCP context).  Scoped to callers that
             # explicitly request the policy — generic explicit envelopes
             # keep MCP-tool access intact.
-            options_kwargs["strict_mcp_config"] = True
+            #
+            # ``ClaudeAgentOptions`` does not expose ``strict_mcp_config``
+            # as a typed field across the supported SDK pin range
+            # (``claude-agent-sdk>=0.1.0,<1.0.0``), so we forward it via
+            # ``extra_args`` (the canonical CLI-flag passthrough) when
+            # available.  If neither surface exists on this SDK build, we
+            # log and skip the flag rather than raise ``TypeError`` from
+            # ``ClaudeAgentOptions(**options_kwargs)``.
+            field_names = _claude_options_field_names()
+            if "strict_mcp_config" in field_names:
+                options_kwargs["strict_mcp_config"] = True
+            elif "extra_args" in field_names:
+                extra_args = dict(options_kwargs.get("extra_args") or {})
+                extra_args.setdefault("strict-mcp-config", None)
+                options_kwargs["extra_args"] = extra_args
+            else:
+                log.warning(
+                    "claude_code_adapter.strict_mcp_config_unsupported",
+                    hint=(
+                        "Installed claude-agent-sdk has no surface for "
+                        "--strict-mcp-config; nested-MCP isolation skipped. "
+                        "Upgrade claude-agent-sdk to enable the protection."
+                    ),
+                )
 
         # Pass model from CompletionConfig if specified
         # "default" is not a valid SDK model — treat it as None (use SDK default)

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -669,11 +669,12 @@ class ClaudeCodeAdapter:
             #
             # ``ClaudeAgentOptions`` does not expose ``strict_mcp_config``
             # as a typed field across the supported SDK pin range
-            # (``claude-agent-sdk>=0.1.0,<1.0.0``), so we forward it via
-            # ``extra_args`` (the canonical CLI-flag passthrough) when
-            # available.  If neither surface exists on this SDK build, we
-            # log and skip the flag rather than raise ``TypeError`` from
-            # ``ClaudeAgentOptions(**options_kwargs)``.
+            # (``claude-agent-sdk>=0.1.0,<1.0.0``); current releases accept
+            # the flag only via ``extra_args`` (CLI passthrough).  When a
+            # caller asked for strict isolation we MUST honor it — silently
+            # degrading would re-open the recursion path the caller is
+            # trying to close.  Raise a clear, actionable upgrade error
+            # instead of best-effort no-op.
             field_names = _claude_options_field_names()
             if "strict_mcp_config" in field_names:
                 options_kwargs["strict_mcp_config"] = True
@@ -682,13 +683,26 @@ class ClaudeCodeAdapter:
                 extra_args.setdefault("strict-mcp-config", None)
                 options_kwargs["extra_args"] = extra_args
             else:
-                log.warning(
+                msg = (
+                    "Nested-MCP isolation was requested but the installed "
+                    "claude-agent-sdk exposes neither ``strict_mcp_config`` "
+                    "nor ``extra_args``. Upgrade claude-agent-sdk to a "
+                    "release that supports CLI-flag passthrough (any "
+                    "version with the ``extra_args`` field on "
+                    "``ClaudeAgentOptions``) so ``--strict-mcp-config`` "
+                    "can be applied."
+                )
+                log.error(
                     "claude_code_adapter.strict_mcp_config_unsupported",
-                    hint=(
-                        "Installed claude-agent-sdk has no surface for "
-                        "--strict-mcp-config; nested-MCP isolation skipped. "
-                        "Upgrade claude-agent-sdk to enable the protection."
-                    ),
+                    hint=msg,
+                )
+                raise ProviderError(
+                    message=msg,
+                    details={
+                        "error_type": "ConfigurationError",
+                        "supported_options_fields": sorted(field_names),
+                        "required_options_field": "extra_args or strict_mcp_config",
+                    },
                 )
 
         # Pass model from CompletionConfig if specified

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -102,6 +102,7 @@ class ClaudeCodeAdapter:
         max_turns: int = 1,
         on_message: Callable[[str, str], None] | None = None,
         timeout: float | None = None,
+        strict_mcp_config: bool = False,
     ) -> None:
         """Initialize Claude Code adapter.
 
@@ -124,6 +125,12 @@ class ClaudeCodeAdapter:
             timeout: Optional application-level timeout in seconds for a
                 single completion request. When set, aborts before outer
                 transport timeouts and returns a ProviderError.
+            strict_mcp_config: When ``True``, forwards ``strict_mcp_config=True``
+                to the SDK so the spawned subprocess ignores plugin-provided
+                MCP servers and inherited project ``.mcp.json`` entries. Used
+                exclusively by callers that must avoid recursion into the
+                ouroboros MCP server (notably the interview policy path);
+                generic ``allowed_tools`` envelopes keep MCP-tool access intact.
         """
         self._permission_mode: str = permission_mode
         self._cli_path: Path | None = self._resolve_cli_path(cli_path)
@@ -134,6 +141,7 @@ class ClaudeCodeAdapter:
         self._max_turns: int = max_turns
         self._on_message: Callable[[str, str], None] | None = on_message
         self._timeout: float | None = timeout if timeout and timeout > 0 else None
+        self._strict_mcp_config: bool = bool(strict_mcp_config)
         log.info(
             "claude_code_adapter.initialized",
             permission_mode=permission_mode,
@@ -628,10 +636,14 @@ class ClaudeCodeAdapter:
             # default built-ins like AskUserQuestion/ToolSearch.
             options_kwargs["allowed_tools"] = list(self._allowed_tools)
             options_kwargs["tools"] = list(self._allowed_tools)
-            # When the caller pinned an explicit read-only envelope, also
-            # ignore plugin-provided MCP servers so the subprocess cannot
-            # reach mcp__plugin_* tools (notably ouroboros itself, which
-            # would recurse on ouroboros_interview).
+
+        if self._strict_mcp_config:
+            # Opt-in MCP isolation: prevents the spawned subprocess from
+            # discovering plugin-provided servers (notably ouroboros itself,
+            # which would recurse on ouroboros_interview when invoked from
+            # inside Claude Code's MCP context). Scoped to callers that
+            # explicitly request the policy — generic explicit envelopes
+            # keep MCP-tool access intact.
             options_kwargs["strict_mcp_config"] = True
 
         # Pass model from CompletionConfig if specified

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -670,11 +670,22 @@ class ClaudeCodeAdapter:
             # ``ClaudeAgentOptions`` does not expose ``strict_mcp_config``
             # as a typed field across the supported SDK pin range
             # (``claude-agent-sdk>=0.1.0,<1.0.0``); current releases accept
-            # the flag only via ``extra_args`` (CLI passthrough).  When a
-            # caller asked for strict isolation we MUST honor it — silently
-            # degrading would re-open the recursion path the caller is
-            # trying to close.  Raise a clear, actionable upgrade error
-            # instead of best-effort no-op.
+            # the flag only via ``extra_args`` (CLI passthrough).
+            #
+            # Compatibility invariant (verified against the published
+            # PyPI history): ``extra_args`` has been a field on
+            # ``ClaudeAgentOptions`` since the earliest published release
+            # (``claude-agent-sdk==0.0.23``) and remains present at every
+            # version in the declared support range, so the
+            # ``extra_args`` branch below is the path actually taken on
+            # any pip-installed SDK in that range.  The fail-fast branch
+            # is defense-in-depth against vendored, partial, or
+            # monkey-patched SDK builds where the field has been removed:
+            # we MUST honor the caller's isolation request rather than
+            # silently re-open the recursion path.  ``test_factory.py``
+            # and ``test_claude_code_adapter.py`` lock the live-SDK
+            # invariant so any future upper-bound bump that drops
+            # ``extra_args`` fails CI before reaching production.
             field_names = _claude_options_field_names()
             if "strict_mcp_config" in field_names:
                 options_kwargs["strict_mcp_config"] = True

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -601,10 +601,9 @@ class ClaudeCodeAdapter:
             "CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK": os.environ.get(
                 "OUROBOROS_SKIP_VERSION_CHECK", "1"
             ),
-            "CLAUDECODE": "",
-            "CLAUDE_PLUGIN_DATA": "",
-            "CLAUDE_PLUGIN_ROOT": "",
         }
+        if claudecode_present:
+            env_overrides["CLAUDECODE"] = ""
 
         stderr_lines: list[str] = []
 
@@ -629,6 +628,11 @@ class ClaudeCodeAdapter:
             # default built-ins like AskUserQuestion/ToolSearch.
             options_kwargs["allowed_tools"] = list(self._allowed_tools)
             options_kwargs["tools"] = list(self._allowed_tools)
+            # When the caller pinned an explicit read-only envelope, also
+            # ignore plugin-provided MCP servers so the subprocess cannot
+            # reach mcp__plugin_* tools (notably ouroboros itself, which
+            # would recurse on ouroboros_interview).
+            options_kwargs["strict_mcp_config"] = True
 
         # Pass model from CompletionConfig if specified
         # "default" is not a valid SDK model — treat it as None (use SDK default)

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -120,6 +120,7 @@ def create_llm_adapter(
     timeout: float | None = None,
     max_retries: int = 3,
     io_recorder: IOJournalRecorder | None = None,
+    strict_mcp_config: bool = False,
 ) -> LLMAdapter:
     """Create an LLM adapter from config or explicit options."""
     resolved_backend = resolve_llm_backend(backend)
@@ -162,12 +163,14 @@ def create_llm_adapter(
             max_turns=max_turns,
             on_message=on_message,
             timeout=timeout,
-            # Interview is the only path that must avoid recursing into the
-            # ouroboros MCP server when launched from inside Claude Code's
-            # MCP context. Other callers keep plugin/project MCP servers
-            # reachable so explicit envelopes (e.g. ``mcp__ouroboros__qa``)
-            # remain functional.
-            strict_mcp_config=use_case == "interview",
+            # Forwarded as-is.  The factory does NOT auto-derive
+            # ``strict_mcp_config`` from ``use_case`` because non-MCP
+            # interview entrypoints (CLI ``ooo init`` / ``ooo pm``) need
+            # to keep plugin and project ``.mcp.json`` servers reachable.
+            # Only the nested MCP-tool entrypoint
+            # (``InterviewHandler.handle`` in
+            # ``mcp/tools/authoring_handlers.py``) opts in.
+            strict_mcp_config=strict_mcp_config,
         )
     if resolved_backend == "codex":
         return CodexCliLLMAdapter(

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -162,6 +162,12 @@ def create_llm_adapter(
             max_turns=max_turns,
             on_message=on_message,
             timeout=timeout,
+            # Interview is the only path that must avoid recursing into the
+            # ouroboros MCP server when launched from inside Claude Code's
+            # MCP context. Other callers keep plugin/project MCP servers
+            # reachable so explicit envelopes (e.g. ``mcp__ouroboros__qa``)
+            # remain functional.
+            strict_mcp_config=use_case == "interview",
         )
     if resolved_backend == "codex":
         return CodexCliLLMAdapter(

--- a/tests/unit/mcp/tools/test_interview_strict_mcp_config_wiring.py
+++ b/tests/unit/mcp/tools/test_interview_strict_mcp_config_wiring.py
@@ -1,0 +1,104 @@
+"""Wiring lock for the nested-MCP interview ``strict_mcp_config`` opt-in.
+
+The nested ``ouroboros_interview`` MCP-tool entrypoint
+(``InterviewHandler.handle()``) MUST request ``strict_mcp_config=True``
+when constructing its question-generation adapter — otherwise the
+spawned Claude subprocess can rediscover the plugin-provided ouroboros
+MCP server and recurse on ``ouroboros_interview`` until it hits the
+``--max-turns 1`` boundary.
+
+CLI interview entrypoints (``ooo init`` / ``ooo pm``) are NOT exercised
+here; they are confirmed by ``test_factory.py`` to leave the flag at
+its default ``False`` so they keep plugin/project ``.mcp.json`` servers
+reachable for brownfield repository tooling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ouroboros.bigbang.interview import InterviewState, InterviewStatus
+from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+
+@dataclass(slots=True)
+class _FakeInterviewEngine:
+    """Minimal injected engine that satisfies the handler's contract.
+
+    ``start_interview`` returns a persisted state, ``ask_next_question``
+    returns a deterministic question, ``save_state`` is a no-op probe.
+    The handler is exercised purely for its factory-call wiring.
+    """
+
+    state_dir: Path
+    saved_states: list[InterviewState] = field(default_factory=list)
+
+    async def start_interview(
+        self,
+        initial_context: str,
+        cwd: str | None = None,
+        interview_id: str | None = None,
+    ) -> Result[InterviewState, MCPServerError]:
+        sid = interview_id or "interview_strictwiring001"
+        state = InterviewState(
+            interview_id=sid,
+            initial_context=initial_context,
+            status=InterviewStatus.IN_PROGRESS,
+        )
+        self.saved_states.append(state)
+        return Result.ok(state)
+
+    async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
+        return Result.ok("What is the primary user goal?")
+
+    async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
+        path = self.state_dir / f"interview_{state.interview_id}.json"
+        path.write_text("{}", encoding="utf-8")
+        self.saved_states.append(state)
+        return Result.ok(path)
+
+    async def load_state(
+        self, session_id: str
+    ) -> Result[InterviewState, MCPServerError]:  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_nested_mcp_interview_handler_requests_strict_mcp_config(
+    tmp_path: Path,
+) -> None:
+    """``InterviewHandler.handle()`` MUST opt into strict MCP isolation."""
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    fake_adapter = MagicMock()
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+        return_value=fake_adapter,
+    ) as mock_factory:
+        outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert outcome.is_ok, "handler must complete successfully on the happy path"
+    assert mock_factory.called, "handler must construct an LLM adapter via the factory"
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs.get("use_case") == "interview", (
+        "the question-generation adapter is built with use_case='interview'"
+    )
+    assert factory_kwargs.get("strict_mcp_config") is True, (
+        "the nested MCP interview entrypoint MUST request strict_mcp_config=True "
+        "to prevent the spawned subprocess from rediscovering plugin-provided "
+        "ouroboros and recursing on ouroboros_interview"
+    )

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -687,6 +687,78 @@ class TestJsonSchemaHandling:
         assert "ToolSearch" not in options_call_kwargs["tools"]
         assert "AskUserQuestion" not in options_call_kwargs["tools"]
         assert "Write" in options_call_kwargs["disallowed_tools"]
+        # Generic explicit envelopes must not silently drop plugin/project
+        # MCP servers — only opt-in callers (e.g. the interview policy
+        # path) should set strict_mcp_config. Otherwise envelopes that
+        # include MCP names like ``mcp__ouroboros__qa`` would lose access
+        # to those tools at runtime.
+        assert "strict_mcp_config" not in options_call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_strict_mcp_config_opt_in_forwards_to_sdk(self) -> None:
+        """Opt-in strict_mcp_config flag flows through to the SDK options."""
+        allowed_tools = ["Read", "Grep"]
+        adapter = ClaudeCodeAdapter(
+            allowed_tools=allowed_tools,
+            strict_mcp_config=True,
+        )
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        assert options_call_kwargs["allowed_tools"] == allowed_tools
+        assert options_call_kwargs["tools"] == allowed_tools
+        assert options_call_kwargs.get("strict_mcp_config") is True
+
+    @pytest.mark.asyncio
+    async def test_default_tool_policy_does_not_set_strict_mcp_config(self) -> None:
+        """Default callers (no allowed_tools, no opt-in) keep plugin MCP servers."""
+        adapter = ClaudeCodeAdapter()
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        assert "strict_mcp_config" not in options_call_kwargs
 
 
 class TestErrorDiagnostics:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -688,15 +688,32 @@ class TestJsonSchemaHandling:
         assert "AskUserQuestion" not in options_call_kwargs["tools"]
         assert "Write" in options_call_kwargs["disallowed_tools"]
         # Generic explicit envelopes must not silently drop plugin/project
-        # MCP servers — only opt-in callers (e.g. the interview policy
-        # path) should set strict_mcp_config. Otherwise envelopes that
-        # include MCP names like ``mcp__ouroboros__qa`` would lose access
-        # to those tools at runtime.
+        # MCP servers — only opt-in callers (the nested MCP-tool entrypoint
+        # in ``mcp/tools/authoring_handlers.py``) should request strict
+        # isolation.  Otherwise envelopes that include MCP names like
+        # ``mcp__ouroboros__qa`` would lose access to those tools at runtime.
         assert "strict_mcp_config" not in options_call_kwargs
+        assert "strict-mcp-config" not in (options_call_kwargs.get("extra_args") or {})
 
     @pytest.mark.asyncio
-    async def test_strict_mcp_config_opt_in_forwards_to_sdk(self) -> None:
-        """Opt-in strict_mcp_config flag flows through to the SDK options."""
+    async def test_strict_mcp_config_uses_extra_args_when_options_supports_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Opt-in MCP isolation forwards via ``extra_args`` on SDKs that
+        expose ``extra_args`` but not ``strict_mcp_config`` as a typed field.
+
+        This matches the supported SDK pin range
+        (``claude-agent-sdk>=0.1.0,<1.0.0``) where the latest releases
+        accept the flag only through CLI passthrough.
+        """
+        from ouroboros.providers import claude_code_adapter as adapter_mod
+
+        monkeypatch.setattr(
+            adapter_mod,
+            "_claude_options_field_names",
+            lambda: frozenset({"extra_args", "allowed_tools", "tools"}),
+        )
+
         allowed_tools = ["Read", "Grep"]
         adapter = ClaudeCodeAdapter(
             allowed_tools=allowed_tools,
@@ -728,7 +745,95 @@ class TestJsonSchemaHandling:
         options_call_kwargs = mock_options_cls.call_args.kwargs
         assert options_call_kwargs["allowed_tools"] == allowed_tools
         assert options_call_kwargs["tools"] == allowed_tools
+        # Flag forwarded via CLI passthrough surface, not as a typed kwarg.
+        assert "strict_mcp_config" not in options_call_kwargs
+        assert options_call_kwargs.get("extra_args", {}).get("strict-mcp-config") is None
+        assert "strict-mcp-config" in options_call_kwargs.get("extra_args", {})
+
+    @pytest.mark.asyncio
+    async def test_strict_mcp_config_uses_typed_field_when_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Forward to a typed ``strict_mcp_config`` field if a future SDK
+        adds one, in preference to the CLI passthrough form."""
+        from ouroboros.providers import claude_code_adapter as adapter_mod
+
+        monkeypatch.setattr(
+            adapter_mod,
+            "_claude_options_field_names",
+            lambda: frozenset({"extra_args", "allowed_tools", "tools", "strict_mcp_config"}),
+        )
+
+        adapter = ClaudeCodeAdapter(allowed_tools=["Read"], strict_mcp_config=True)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
         assert options_call_kwargs.get("strict_mcp_config") is True
+        # Should not double-pass via extra_args when the typed field is present.
+        assert "strict-mcp-config" not in (options_call_kwargs.get("extra_args") or {})
+
+    @pytest.mark.asyncio
+    async def test_strict_mcp_config_skipped_when_sdk_lacks_surface(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the SDK exposes neither surface, opt-in degrades silently
+        instead of crashing ``ClaudeAgentOptions(**options_kwargs)``."""
+        from ouroboros.providers import claude_code_adapter as adapter_mod
+
+        monkeypatch.setattr(
+            adapter_mod,
+            "_claude_options_field_names",
+            lambda: frozenset({"allowed_tools", "tools"}),
+        )
+
+        adapter = ClaudeCodeAdapter(allowed_tools=["Read"], strict_mcp_config=True)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        assert "strict_mcp_config" not in options_call_kwargs
+        assert "extra_args" not in options_call_kwargs
 
     @pytest.mark.asyncio
     async def test_default_tool_policy_does_not_set_strict_mcp_config(self) -> None:
@@ -759,6 +864,7 @@ class TestJsonSchemaHandling:
 
         options_call_kwargs = mock_options_cls.call_args.kwargs
         assert "strict_mcp_config" not in options_call_kwargs
+        assert "strict-mcp-config" not in (options_call_kwargs.get("extra_args") or {})
 
 
 class TestErrorDiagnostics:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -794,11 +794,17 @@ class TestJsonSchemaHandling:
         assert "strict-mcp-config" not in (options_call_kwargs.get("extra_args") or {})
 
     @pytest.mark.asyncio
-    async def test_strict_mcp_config_skipped_when_sdk_lacks_surface(
+    async def test_strict_mcp_config_fails_fast_when_sdk_lacks_surface(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """If the SDK exposes neither surface, opt-in degrades silently
-        instead of crashing ``ClaudeAgentOptions(**options_kwargs)``."""
+        """If the SDK exposes neither surface, the opt-in MUST fail fast.
+
+        Silently dropping the flag would re-open the very recursion path
+        ``InterviewHandler.handle()`` is trying to close.  The error must
+        be actionable (telling operators to upgrade ``claude-agent-sdk``)
+        rather than a generic ``TypeError`` from
+        ``ClaudeAgentOptions(**options_kwargs)``.
+        """
         from ouroboros.providers import claude_code_adapter as adapter_mod
 
         monkeypatch.setattr(
@@ -822,18 +828,24 @@ class TestJsonSchemaHandling:
 
         sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
 
-        with patch.dict(
-            "sys.modules",
-            {
-                "claude_agent_sdk": sdk_module,
-                "claude_agent_sdk._errors": sdk_module._errors,
-            },
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "claude_agent_sdk": sdk_module,
+                    "claude_agent_sdk._errors": sdk_module._errors,
+                },
+            ),
+            pytest.raises(ProviderError) as excinfo,
         ):
             await adapter._execute_single_request("test prompt", config)
 
-        options_call_kwargs = mock_options_cls.call_args.kwargs
-        assert "strict_mcp_config" not in options_call_kwargs
-        assert "extra_args" not in options_call_kwargs
+        assert "strict-mcp-config" in str(excinfo.value).lower() or (
+            "strict_mcp_config" in str(excinfo.value).lower()
+        )
+        assert excinfo.value.details.get("error_type") == "ConfigurationError"
+        # Options must NEVER be constructed when isolation cannot be honored.
+        mock_options_cls.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_default_tool_policy_does_not_set_strict_mcp_config(self) -> None:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -706,7 +706,22 @@ class TestJsonSchemaHandling:
         swap that drops the field fails fast at test time, well before
         the adapter's defense-in-depth fail-fast path could fire in
         production.
+
+        Skipped when ``claude-agent-sdk`` is not installed — the SDK is
+        an optional extra (``ouroboros-ai[claude]``) and the rest of
+        this file mocks ``sys.modules['claude_agent_sdk']`` so it does
+        not require the real package.  This particular invariant only
+        matters when the real package IS installed; otherwise there is
+        no ``ClaudeAgentOptions`` to introspect.
         """
+        pytest.importorskip(
+            "claude_agent_sdk",
+            reason=(
+                "claude-agent-sdk is an optional extra; the live-SDK "
+                "invariant only applies when it is installed."
+            ),
+        )
+
         from ouroboros.providers.claude_code_adapter import (
             _claude_options_field_names,
         )

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -695,6 +695,37 @@ class TestJsonSchemaHandling:
         assert "strict_mcp_config" not in options_call_kwargs
         assert "strict-mcp-config" not in (options_call_kwargs.get("extra_args") or {})
 
+    def test_live_claude_agent_sdk_supports_extra_args(self) -> None:
+        """Pin invariant: every ``claude-agent-sdk`` version in the declared
+        support range (``>=0.1.0,<1.0.0``) MUST expose ``extra_args``.
+
+        Verified empirically against the published PyPI history
+        (``extra_args`` is a field on ``ClaudeAgentOptions`` since the
+        earliest public release ``0.0.23``).  This test locks the
+        invariant in CI so a future upper-bound bump or vendored SDK
+        swap that drops the field fails fast at test time, well before
+        the adapter's defense-in-depth fail-fast path could fire in
+        production.
+        """
+        from ouroboros.providers.claude_code_adapter import (
+            _claude_options_field_names,
+        )
+
+        # ``_claude_options_field_names`` is ``lru_cache``-d, so clear it
+        # to make this test independent of any monkeypatching done
+        # elsewhere in the module.
+        _claude_options_field_names.cache_clear()
+        try:
+            field_names = _claude_options_field_names()
+        finally:
+            _claude_options_field_names.cache_clear()
+        assert "extra_args" in field_names, (
+            "claude-agent-sdk lost the ``extra_args`` passthrough field; the "
+            "interview recursion fix relies on it. Either pin the SDK to a "
+            "release that still has it or add a typed ``strict_mcp_config`` "
+            "kwarg to the adapter forwarding."
+        )
+
     @pytest.mark.asyncio
     async def test_strict_mcp_config_uses_extra_args_when_options_supports_it(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/providers/test_factory.py
+++ b/tests/unit/providers/test_factory.py
@@ -90,21 +90,38 @@ class TestCreateLLMAdapter:
         assert isinstance(adapter, ClaudeCodeAdapter)
         assert adapter._cwd == "/tmp/project"
 
-    def test_claude_code_interview_use_case_enables_strict_mcp_config(self) -> None:
-        """Interview is the only path that must avoid recursing into the
-        ouroboros MCP server, so the factory opts into ``strict_mcp_config``
-        for the Claude adapter exclusively on ``use_case="interview"``."""
+    def test_claude_code_interview_use_case_does_not_auto_enable_strict_mcp_config(
+        self,
+    ) -> None:
+        """``use_case="interview"`` MUST NOT auto-enable strict MCP isolation.
+
+        CLI interview entrypoints (``ooo init`` / ``ooo pm``) take this
+        path and rely on plugin/project ``.mcp.json`` servers being
+        reachable for brownfield repository tooling.  Only the nested
+        MCP-tool entrypoint opts in explicitly.
+        """
         adapter = create_llm_adapter(
             backend="claude_code",
             use_case="interview",
             allowed_tools=["Read"],
         )
         assert isinstance(adapter, ClaudeCodeAdapter)
+        assert adapter._strict_mcp_config is False
+
+    def test_claude_code_explicit_strict_mcp_config_is_forwarded(self) -> None:
+        """The MCP nested-interview handler opts in via this explicit flag."""
+        adapter = create_llm_adapter(
+            backend="claude_code",
+            use_case="interview",
+            allowed_tools=["Read"],
+            strict_mcp_config=True,
+        )
+        assert isinstance(adapter, ClaudeCodeAdapter)
         assert adapter._strict_mcp_config is True
 
-    def test_claude_code_default_use_case_keeps_plugin_mcp_servers(self) -> None:
-        """Default callers (non-interview) must keep plugin/project MCP
-        servers reachable, even when an explicit envelope is supplied."""
+    def test_claude_code_default_keeps_plugin_mcp_servers(self) -> None:
+        """Default callers (no opt-in) must keep plugin/project MCP servers
+        reachable, even when an explicit envelope is supplied."""
         adapter = create_llm_adapter(
             backend="claude_code",
             allowed_tools=["Read", "mcp__ouroboros__qa"],

--- a/tests/unit/providers/test_factory.py
+++ b/tests/unit/providers/test_factory.py
@@ -90,6 +90,28 @@ class TestCreateLLMAdapter:
         assert isinstance(adapter, ClaudeCodeAdapter)
         assert adapter._cwd == "/tmp/project"
 
+    def test_claude_code_interview_use_case_enables_strict_mcp_config(self) -> None:
+        """Interview is the only path that must avoid recursing into the
+        ouroboros MCP server, so the factory opts into ``strict_mcp_config``
+        for the Claude adapter exclusively on ``use_case="interview"``."""
+        adapter = create_llm_adapter(
+            backend="claude_code",
+            use_case="interview",
+            allowed_tools=["Read"],
+        )
+        assert isinstance(adapter, ClaudeCodeAdapter)
+        assert adapter._strict_mcp_config is True
+
+    def test_claude_code_default_use_case_keeps_plugin_mcp_servers(self) -> None:
+        """Default callers (non-interview) must keep plugin/project MCP
+        servers reachable, even when an explicit envelope is supplied."""
+        adapter = create_llm_adapter(
+            backend="claude_code",
+            allowed_tools=["Read", "mcp__ouroboros__qa"],
+        )
+        assert isinstance(adapter, ClaudeCodeAdapter)
+        assert adapter._strict_mcp_config is False
+
     def test_creates_litellm_adapter(self) -> None:
         """LiteLLM backend returns LiteLLMAdapter."""
         adapter = create_llm_adapter(backend="litellm")


### PR DESCRIPTION
# fix(providers,interview): pass strict_mcp_config when allowed_tools is pinned

> Updated after [ouroboros-agent[bot] review](#) on c4d3bb7f.
> Replaced the broad approach (CLAUDE_PLUGIN_DATA wipe + wiring change)
> with a single SDK option flip. See d2b2ff62.

## Summary

Calling `mcp__plugin_ouroboros_ouroboros__ouroboros_interview` (and likely
other `ClaudeCodeAdapter`-backed tools) from inside Claude Code consistently
fails with `Command failed with exit code 1` and an empty stderr. The
spawned `claude` subprocess auto-loads plugin-provided MCP servers
(including ouroboros itself), registers `mcp__plugin_ouroboros_*` tools,
and recurses on `ouroboros_interview` until it exits on the
`--max-turns 1` boundary.

This PR fixes the issue by forwarding `strict_mcp_config=True` to the SDK
whenever the caller has pinned an explicit read-only tool envelope. No
changes to plugin env, hook configuration, or composition-root wiring.

## Reproduction

The failure is **specific to Claude Code MCP server context**: the
adapter only fails when its subprocess is spawned from inside an MCP
server that Claude Code itself launched (the path used by
`mcp__plugin_*` tools). Direct CLI invocations of `claude` with the
same flags succeed.

Independently reproduced on two environments running `ouroboros-ai`
v0.35.0:

| Host                                 | Claude Code | Python      | API surface           |
|--------------------------------------|-------------|-------------|-----------------------|
| macOS 15.7.3 (Darwin 24.6, x86_64)   | 2.1.132     | 3.14 (uvx)  | api.anthropic.com     |
| macOS (Darwin 25.2, arm64, internal) | 2.1.119     | 3.12 (pipx) | enterprise gateway    |

Reproducible regardless of `initial_context` length. Symptom:

    Claude Agent SDK request failed: Command failed with exit code 1
    Error output: Check stderr output for details

SDK metadata at the failing call:
`claudecode_present=False, claude_code_entrypoint=cli,
env_override_keys=['CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK']`. The
subprocess emits zero stderr lines.

## Root cause

When `ClaudeCodeAdapter` spawns its SDK subprocess from inside an MCP
server context, the child reads the host's MCP configuration sources
(project `.mcp.json`, user/global settings, **plugin-provided servers**)
and registers every tool they expose. Plugin-provided servers include
ouroboros's own MCP server, which exposes `ouroboros_interview` to the
child as `mcp__plugin_ouroboros_ouroboros__ouroboros_interview`. The
child then invokes that tool, hits `--max-turns 1` immediately, and
exits with code 1. The CLI treats turn-limit termination as non-error,
so the SDK surfaces the exit code with no stderr.

The CLI's `--allowedTools` whitelist is not enough to block the
recursion: plugin-loaded MCP tools are not gated by it.

## Fix

`providers/claude_code_adapter.py` — when the caller has pinned an
explicit tool envelope (`allowed_tools is not None`, e.g. the
interview path's `_interview_allowed_tools()` whitelist), also forward
`strict_mcp_config=True` on the SDK call. This maps to the CLI's
`--strict-mcp-config` flag and, per `ClaudeAgentOptions.strict_mcp_config`
docstring, restricts the subprocess to MCP servers we pass explicitly
while ignoring plugin-provided servers. Plugin hooks and global plugin
env stay intact.

The change is gated on `self._allowed_tools is not None` so existing
permissive callers keep their current behaviour.

## What changed since c4d3bb7f

The original commit broadly cleared `CLAUDECODE` /
`CLAUDE_PLUGIN_DATA` / `CLAUDE_PLUGIN_ROOT` in `env_overrides`, removed
the `interview_engine` injection from `mcp/server/adapter.py`, and
forced a fresh adapter rebuild in `InterviewHandler.handle()`.
ouroboros-agent[bot] correctly flagged the first two as overreach:
clearing the plugin env disables every checked-in hook that references
`${CLAUDE_PLUGIN_ROOT}/...`, and dropping the injection silently
switches `ouroboros_interview` to the default state directory,
splitting persisted sessions in deployments that override `state_dir`.

`d2b2ff62` reverts all three changes and replaces them with a single
SDK option flip in `providers/claude_code_adapter.py`. The previously
modified `mcp/server/adapter.py` and `mcp/tools/authoring_handlers.py`
are now unchanged from `main`. Verified by ablation that the SDK flip
alone closes the recursion path.

## Tests / quality gates

- `uv run ruff check src/` — clean.
- `uv run ruff format --check src/` — clean.
- `uv run mypy src/ouroboros/providers/claude_code_adapter.py` — clean.
- `uv run pytest tests/unit/providers/test_claude_code_adapter.py
  tests/unit/mcp/tools/{test_handler_subagent_wiring,
  test_interview_persists_session_on_failure,
  test_interview_done_streak,test_interview_reopen_seed_ready}.py
  tests/unit/mcp/server/` — 169 passed. No tests modified; existing
  injection contract preserved.

End-to-end smoke: `mcp__plugin_ouroboros_ouroboros__ouroboros_interview`
returns the first round question after `/mcp` reconnect on macOS
15.7.3 / Claude Code 2.1.132. Without the SDK flip, the same call
returns `exit code 1` deterministically.

## Notes

- No new dependencies, no public API changes, no plugin/hook regressions.
- Diff is one hunk (5 lines) in a single file.
- `_interview_allowed_tools()` already expressed the intended read-only
  policy; this PR only ensures the corresponding MCP-server isolation
  is applied alongside it.