### PR TITLE
test(auto): define interview convergence contract

### DIFF
--- a/docs/auto-interview-convergence-contract.md
+++ b/docs/auto-interview-convergence-contract.md
@@ -70,6 +70,11 @@ maximum round count was reached.
 
 `tests/unit/auto/test_interview_pipeline.py` includes contract tests for:
 
-- broad benign goals resolving via safe assumptions and bounded facts;
-- unsafe credential/production-authority questions blocking immediately;
-- stalled generic follow-ups producing actionable unresolved-gap blockers.
+- broad benign goals reaching `seed_ready` with required sections filled by
+  safe auto assumptions (with at least one ``DEFAULTED`` acceptance-criteria
+  entry) when no bounded repo facts are supplied;
+- unsafe credential/production-authority questions blocking immediately on the
+  first turn with a ``credential or secret value required`` reason;
+- stalled generic ``What else?`` follow-up loops producing a round-cap blocker
+  that names the unresolved required sections rather than just reporting that
+  ``max_rounds`` was reached.

--- a/docs/auto-interview-convergence-contract.md
+++ b/docs/auto-interview-convergence-contract.md
@@ -1,0 +1,75 @@
+# Auto-interview convergence contract
+
+`ooo auto` may start from a broad or underspecified goal, but the interview phase
+must not converge by accident.  It has to make every required Seed Draft Ledger
+section auditable before the pipeline proceeds, or it must stop with a precise
+blocker.
+
+This contract is intentionally domain-agnostic.  It describes how the auto
+interview behaves for broad benign work, unsafe work, and stalled loops without
+encoding prompt-specific defaults.
+
+## Required-section outcomes
+
+Every required ledger section must finish in exactly one of these outcome
+classes:
+
+1. **User-provided fact** — the original goal or interview answer directly states
+   the value.  These entries are sourced as user facts and should normally be
+   `confirmed`.
+2. **Bounded repo fact** — the caller supplies already-collected repository
+   context, such as runtime/package information with evidence paths.  The
+   answerer may use these facts but must not perform unbounded repository or
+   network exploration itself.
+3. **Safe auto assumption** — the missing detail is local, reversible, and
+   non-destructive, so auto mode may choose a conservative default.  The entry
+   must be source-tagged as a default/assumption and retain enough rationale for
+   review and later repair.
+4. **Explicit blocker** — the gap requires human authority, secrets, external or
+   destructive side effects, production/billing decisions, regulated-domain
+   judgment, or another unsafe choice.  The session must block instead of
+   inventing a value.
+
+A session is **converged** only when all required sections are resolved by one of
+the first three outcomes and no blocker is present.
+
+## Broad benign goals
+
+For an underspecified but benign goal, such as building a small local tool, auto
+mode should keep the scope conservative and steer toward open ledger gaps.  It
+may proceed with safe assumptions for actors, IO, non-goals, acceptance criteria,
+verification, failure modes, and runtime context when those assumptions are
+local, reversible, and observable.
+
+Proceeding does **not** mean merely avoiding `blocked`: the resulting ledger must
+include auditable assumptions, non-goals, acceptance criteria, and a verification
+plan so seed generation and review can reject weak or untestable work.
+
+## Unsafe or authority-requiring goals
+
+Auto mode must not fill gaps that require human-only authority.  Examples include
+real credential values, production deployment authority, destructive data/schema
+operations, payment/billing choices, or regulated handling policy.  For those
+questions the answerer should emit a blocker and the driver should persist an
+actionable blocked state.
+
+## Stalled gap-reduction loops
+
+The interview backend may keep asking generic follow-up questions (`What else?`,
+`Any additional context?`) even after auto answers become repetitive.  The driver
+must treat unchanged required gaps as a convergence signal:
+
+- steer generic follow-ups toward the highest-priority open gap;
+- recognize repeated generic fallback answers as a stall signal that should trigger gap-directed steering;
+- when the round cap is reached, report the unresolved sections explicitly.
+
+The blocked reason should name the gaps or unsafe decision, not only say that the
+maximum round count was reached.
+
+## Regression coverage
+
+`tests/unit/auto/test_interview_pipeline.py` includes contract tests for:
+
+- broad benign goals resolving via safe assumptions and bounded facts;
+- unsafe credential/production-authority questions blocking immediately;
+- stalled generic follow-ups producing actionable unresolved-gap blockers.

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2852,19 +2852,26 @@ async def test_convergence_contract_unsafe_authority_question_blocks(tmp_path) -
 
 
 @pytest.mark.asyncio
-async def test_convergence_contract_stalled_unsafe_loop_reports_actionable_gaps(tmp_path) -> None:
-    """Unsafe round-cap blockers must name unresolved sections, not just max rounds."""
+async def test_convergence_contract_stalled_generic_followups_report_actionable_gaps(
+    tmp_path,
+) -> None:
+    """Generic ``What else?`` follow-up loops must blocker on unresolved sections.
+
+    This pins the documented stall pattern from
+    ``docs/auto-interview-convergence-contract.md``: when the backend keeps asking
+    ``What else?`` / ``Any additional context?``-style questions and required
+    sections never resolve, the round-cap blocker has to name the unresolved
+    gaps, not just say that ``max_rounds`` was reached.
+    """
 
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn(
-            "What production credentials should be configured?", "interview_contract"
-        )
+        return InterviewTurn("What else should we know?", "interview_contract")
 
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn("What production credentials should be configured?", session_id)
+        return InterviewTurn("What else should we know?", session_id)
 
     state = AutoPipelineState(
-        goal="Deploy the service to production and configure required credentials",
+        goal="Build a small note-taking CLI",
         cwd=str(tmp_path),
     )
     ledger = SeedDraftLedger.from_goal(state.goal)
@@ -2879,6 +2886,10 @@ async def test_convergence_contract_stalled_unsafe_loop_reports_actionable_gaps(
 
     blocker = result.blocker or ""
     assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
     assert "unresolved gaps" in blocker
-    assert "actors" in blocker
-    assert "runtime_context" in blocker
+    open_gaps = ledger.open_gaps()
+    assert open_gaps, "stalled generic loop must leave at least one open required gap"
+    # The blocker must name at least one specific unresolved section, not just
+    # report that max_rounds was reached.
+    assert any(section in blocker for section in open_gaps)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2765,3 +2765,120 @@ def test_interview_start_timeout_state_routes_to_interview_on_resume_with_retry_
     assert state.pending_question is None
     assert _recoverable_phase_for_tool("interview.start") is AutoPhase.INTERVIEW
     assert state.resume_capability() is AutoResumeCapability.RETRY
+
+
+@pytest.mark.asyncio
+async def test_convergence_contract_broad_benign_goal_resolves_with_safe_assumptions(
+    tmp_path,
+) -> None:
+    """Broad benign goals may proceed only with auditable required sections."""
+
+    rounds = 0
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_contract")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        nonlocal rounds
+        rounds += 1
+        return InterviewTurn(
+            "What else should we know?",
+            session_id,
+            seed_ready=rounds >= 5,
+            completed=rounds >= 5,
+        )
+
+    state = AutoPipelineState(goal="Build a local note taking CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=6,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert ledger.is_seed_ready()
+    assert ledger.open_gaps() == []
+    for required in (
+        "actors",
+        "inputs",
+        "outputs",
+        "non_goals",
+        "acceptance_criteria",
+        "verification_plan",
+        "runtime_context",
+    ):
+        assert ledger.sections[required].entries, required
+    assert {entry.source for entry in ledger.sections["actors"].entries} <= {
+        LedgerSource.ASSUMPTION,
+        LedgerSource.USER_GOAL,
+    }
+    assert any(
+        entry.status == LedgerStatus.DEFAULTED
+        for entry in ledger.sections["acceptance_criteria"].entries
+    )
+
+
+@pytest.mark.asyncio
+async def test_convergence_contract_unsafe_authority_question_blocks(tmp_path) -> None:
+    """Unsafe authority gaps are blockers, not auto-filled defaults."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "Which production access token should auto configure?",
+            "interview_contract",
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("unsafe blocker should stop before backend.answer")
+
+    state = AutoPipelineState(goal="Deploy a service", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=3,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert "credential or secret value required" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_convergence_contract_stalled_unsafe_loop_reports_actionable_gaps(tmp_path) -> None:
+    """Unsafe round-cap blockers must name unresolved sections, not just max rounds."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "What production credentials should be configured?", "interview_contract"
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What production credentials should be configured?", session_id)
+
+    state = AutoPipelineState(
+        goal="Deploy the service to production and configure required credentials",
+        cwd=str(tmp_path),
+    )
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    blocker = result.blocker or ""
+    assert result.status == "blocked"
+    assert "unresolved gaps" in blocker
+    assert "actors" in blocker
+    assert "runtime_context" in blocker


### PR DESCRIPTION
## Summary
- Documents the auto-interview convergence contract for broad benign goals, unsafe goals, stalled gap-reduction loops, and blocked output quality.
- Adds near-end-to-end regression tests that encode the expected convergence behavior without overfitting to a specific application domain.
- Establishes that required ledger sections must be satisfied by user facts, safe auto assumptions, or explicit unsafe blocker reasons.

## Discussion / implementation notes
- This PR defines the contract first so follow-up implementation PRs do not become case-specific patches.
- The contract distinguishes avoiding `blocked` from true success: success requires a seed-ready ledger with auditable assumptions and verification criteria.

## Validation
- [x] `git diff --check`
- [x] `PYTHONPATH=src /opt/hermes/.venv/bin/python -m pytest tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_interview_pipeline.py -q` — 163 passed

Closes #759
