### PR TITLE
feat(auto): steer interviews toward open ledger gaps

### DIFF
--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -152,6 +152,57 @@ class AutoAnswerer:
                 )
         return answer
 
+    def answer_gap(
+        self,
+        section: str,
+        ledger: SeedDraftLedger,
+        context: AutoAnswerContext | None = None,
+    ) -> AutoAnswer:
+        """Return an answer targeted at an unresolved required ledger section.
+
+        This path is used when the backend keeps asking broad prompts and the
+        normal question-shaped answer would repeat or fail to close any open
+        required gap.  Keep it domain-neutral: it only fills Seed contract
+        sections with conservative, reversible defaults.
+        """
+        context = context or AutoAnswerContext()
+        if section == "goal":
+            blocker = AutoBlocker(reason="goal is unresolved", question="Clarify the primary goal.")
+            return AutoAnswer(
+                text="Cannot safely decide automatically: goal is unresolved",
+                source=AutoAnswerSource.BLOCKER,
+                confidence=1.0,
+                blocker=blocker,
+            )
+        if section in {"actors", "inputs", "outputs"}:
+            return self._io_actor_answer("Who are the actors, inputs, and outputs for this task?")
+        if section in {"constraints", "failure_modes"}:
+            return self._default_answer(
+                "What conservative constraints and failure modes should bound this MVP?", ledger
+            )
+        if section == "non_goals":
+            return self._non_goal_answer(
+                "What non-goals should explicitly remain out of scope?", ledger
+            )
+        if section in {"acceptance_criteria", "verification_plan"}:
+            return self._verification_answer(
+                "Which command output verifies the acceptance criteria?"
+            )
+        if section == "runtime_context":
+            return self._runtime_answer(
+                "Which runtime stack, repo, and project patterns should be used?", context
+            )
+        blocker = AutoBlocker(
+            reason=f"unsupported ledger gap section: {section}",
+            question=f"Clarify {section}.",
+        )
+        return AutoAnswer(
+            text=f"Cannot safely decide automatically: unsupported ledger gap section: {section}",
+            source=AutoAnswerSource.BLOCKER,
+            confidence=1.0,
+            blocker=blocker,
+        )
+
     def apply(self, answer: AutoAnswer, ledger: SeedDraftLedger, *, question: str) -> None:
         """Apply answer updates to ``ledger``."""
         ledger.record_qa(question, answer.prefixed_text)

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -75,6 +75,13 @@ class AutoAnswer:
     assumptions: list[str] = field(default_factory=list)
     non_goals: list[str] = field(default_factory=list)
     blocker: AutoBlocker | None = None
+    # True only when the answer came from the catch-all generic-default route
+    # (``_default_answer``). Feature-specific helpers
+    # (e.g. ``_feature_acceptance_answer``, ``_runtime_answer``) leave this
+    # ``False`` even when their ``source`` is ``CONSERVATIVE_DEFAULT``, so the
+    # interview driver can preserve repeated specific follow-ups instead of
+    # treating them as repeated generic fallbacks.
+    generic_default: bool = False
 
     @property
     def prefixed_text(self) -> str:
@@ -486,7 +493,13 @@ class AutoAnswerer:
                 ),
             ),
         ]
-        return AutoAnswer(value, AutoAnswerSource.CONSERVATIVE_DEFAULT, 0.82, updates)
+        return AutoAnswer(
+            value,
+            AutoAnswerSource.CONSERVATIVE_DEFAULT,
+            0.82,
+            updates,
+            generic_default=True,
+        )
 
 
 def _is_verification_question(lowered: str) -> bool:

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 import inspect
+import re
 from typing import Protocol
 from uuid import uuid4
 
@@ -280,10 +281,11 @@ class AutoInterviewDriver:
             return answer
         gaps = self.gap_detector.detect(ledger)
         first_gap = gaps[0]
-        if first_gap.section == "goal" or first_gap.state in {
-            LedgerStatus.CONFLICTING,
-            LedgerStatus.BLOCKED,
-        }:
+
+        # `goal` can never be filled by an auto-default — it must come from the
+        # user. Block immediately so callers don't send placeholder text to the
+        # backend.
+        if first_gap.section == "goal":
             blocker = AutoBlocker(reason=first_gap.message, question=question)
             return AutoAnswer(
                 text=f"Cannot safely decide automatically: {first_gap.message}",
@@ -291,10 +293,34 @@ class AutoInterviewDriver:
                 confidence=1.0,
                 blocker=blocker,
             )
-        if self._answer_reduces_open_gaps(question, answer, ledger, open_before) and not (
-            self._is_repeated_default_answer(answer, ledger)
+
+        # Steering only kicks in when the answer is a repeated generic fallback
+        # or the prompt is broad enough that gap-targeted steering is helpful.
+        # Backend-specific answers (e.g. an acceptance follow-up) are preserved
+        # even if they don't reduce the required-gap set this turn.
+        is_repeated_default = self._is_repeated_default_answer(answer, ledger)
+        is_broad_prompt = _can_steer_with_gap_prompt(question)
+        if not (is_repeated_default or is_broad_prompt):
+            return answer
+
+        # Same-turn repair: a current answer that actually reduces required
+        # gaps — including a CONFLICTING/BLOCKED one — is allowed through
+        # before we raise a hard blocker. This lets the driver recover from
+        # persisted ledger conflicts when the next prompt yields a correcting
+        # answer.
+        if not is_repeated_default and self._answer_reduces_open_gaps(
+            question, answer, ledger, open_before
         ):
             return answer
+
+        if first_gap.state in {LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}:
+            blocker = AutoBlocker(reason=first_gap.message, question=question)
+            return AutoAnswer(
+                text=f"Cannot safely decide automatically: {first_gap.message}",
+                source=AutoAnswerSource.BLOCKER,
+                confidence=1.0,
+                blocker=blocker,
+            )
 
         gap_answer = self.answerer.answer_gap(first_gap.section, ledger, context)
         if gap_answer.blocker is not None:
@@ -477,6 +503,17 @@ class FunctionInterviewBackend:
 def _generate_interview_id() -> str:
     """Return a unique interview id matching the engine's plugin format."""
     return f"interview_{uuid4().hex[:16]}"
+
+
+_BROAD_PROMPT_RE = re.compile(
+    r"\b(what else|anything else|additional context|more context|"
+    r"what should we know|clarify further)\b"
+)
+
+
+def _can_steer_with_gap_prompt(question: str) -> bool:
+    """Return True when ``question`` is broad enough to benefit from gap-targeted steering."""
+    return bool(_BROAD_PROMPT_RE.search(question.lower()))
 
 
 _AUTO_ANSWER_LOG_LIMIT = 25

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -359,11 +359,13 @@ class AutoInterviewDriver:
         return len(open_after) < len(open_before) and set(open_after).issubset(open_before)
 
     def _is_repeated_default_answer(self, answer: AutoAnswer, ledger: SeedDraftLedger) -> bool:
-        if answer.source not in {
-            AutoAnswerSource.CONSERVATIVE_DEFAULT,
-            AutoAnswerSource.ASSUMPTION,
-            AutoAnswerSource.EXISTING_CONVENTION,
-        }:
+        # Only the catch-all generic-default route counts as a "repeated
+        # generic fallback". Feature-specific helpers (acceptance, runtime,
+        # IO/actor, verification, non-goal, product behavior) may also use
+        # ``CONSERVATIVE_DEFAULT`` as their answer source but should not be
+        # treated as fallback answers — repeated specific follow-ups stay
+        # preserved instead of being swapped for an unrelated gap fill.
+        if not answer.generic_default:
             return False
         proposed = _normalize_answer_text(answer.prefixed_text)
         return any(

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -6,7 +6,6 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 import inspect
-import re
 from typing import Protocol
 from uuid import uuid4
 
@@ -20,7 +19,7 @@ from ouroboros.auto.answerer import (
     AutoBlocker,
 )
 from ouroboros.auto.blocker_attribution import record_authoring_backend
-from ouroboros.auto.gap_detector import Gap, GapDetector
+from ouroboros.auto.gap_detector import GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.repo_context import repo_auto_answer_context
@@ -276,27 +275,75 @@ class AutoInterviewDriver:
         answer = self.answerer.answer(question, ledger, context)
         if answer.blocker is not None:
             return answer
+        open_before = tuple(ledger.open_gaps())
+        if not open_before:
+            return answer
         gaps = self.gap_detector.detect(ledger)
-        if not gaps:
-            return answer
-        updated_sections = {section for section, _entry in answer.ledger_updates}
-        if any(gap.section in updated_sections for gap in gaps):
-            return answer
-        next_gap = gaps[0]
-        if not _can_steer_with_gap_prompt(question):
-            return answer
-        if next_gap.section == "goal" or next_gap.state in {
+        first_gap = gaps[0]
+        if first_gap.section == "goal" or first_gap.state in {
             LedgerStatus.CONFLICTING,
             LedgerStatus.BLOCKED,
         }:
-            blocker = AutoBlocker(reason=next_gap.message, question=question)
+            blocker = AutoBlocker(reason=first_gap.message, question=question)
             return AutoAnswer(
-                text=f"Cannot safely decide automatically: {next_gap.message}",
+                text=f"Cannot safely decide automatically: {first_gap.message}",
                 source=AutoAnswerSource.BLOCKER,
                 confidence=1.0,
                 blocker=blocker,
             )
-        return self.answerer.answer(_gap_prompt(next_gap), ledger, context)
+        if self._answer_reduces_open_gaps(question, answer, ledger, open_before) and not (
+            self._is_repeated_default_answer(answer, ledger)
+        ):
+            return answer
+
+        gap_answer = self.answerer.answer_gap(first_gap.section, ledger, context)
+        if gap_answer.blocker is not None:
+            return gap_answer
+        if self._answer_reduces_open_gaps(question, gap_answer, ledger, open_before):
+            return gap_answer
+
+        blocker = AutoBlocker(
+            reason=(
+                f"auto answer did not reduce open required ledger gaps: {', '.join(open_before)}"
+            ),
+            question=question,
+        )
+        return AutoAnswer(
+            text=(
+                "Cannot safely decide automatically: auto answer did not reduce open "
+                f"required ledger gaps: {', '.join(open_before)}"
+            ),
+            source=AutoAnswerSource.BLOCKER,
+            confidence=1.0,
+            blocker=blocker,
+        )
+
+    def _answer_reduces_open_gaps(
+        self,
+        question: str,
+        answer: AutoAnswer,
+        ledger: SeedDraftLedger,
+        open_before: tuple[str, ...],
+    ) -> bool:
+        if answer.blocker is not None:
+            return False
+        simulated = SeedDraftLedger.from_dict(ledger.to_dict())
+        self.answerer.apply(answer, simulated, question=question)
+        open_after = tuple(simulated.open_gaps())
+        return len(open_after) < len(open_before) and set(open_after).issubset(open_before)
+
+    def _is_repeated_default_answer(self, answer: AutoAnswer, ledger: SeedDraftLedger) -> bool:
+        if answer.source not in {
+            AutoAnswerSource.CONSERVATIVE_DEFAULT,
+            AutoAnswerSource.ASSUMPTION,
+            AutoAnswerSource.EXISTING_CONVENTION,
+        }:
+            return False
+        proposed = _normalize_answer_text(answer.prefixed_text)
+        return any(
+            _normalize_answer_text(item.get("answer", "")) == proposed
+            for item in ledger.question_history
+        )
 
     def _handle_completed_turn(
         self, state: AutoPipelineState, ledger: SeedDraftLedger, turn: InterviewTurn, rounds: int
@@ -432,32 +479,6 @@ def _generate_interview_id() -> str:
     return f"interview_{uuid4().hex[:16]}"
 
 
-def _can_steer_with_gap_prompt(question: str) -> bool:
-    lowered = question.lower()
-    return bool(
-        re.search(
-            r"\b(what else|anything else|additional context|more context|what should we know|clarify further)\b",
-            lowered,
-        )
-    )
-
-
-def _gap_prompt(gap: Gap) -> str:
-    prompts = {
-        "goal": "Clarify the primary user goal for the Seed.",
-        "actors": "Who are the actors, inputs, and outputs for this task?",
-        "inputs": "Who are the actors, inputs, and outputs for this task?",
-        "outputs": "Who are the actors, inputs, and outputs for this task?",
-        "constraints": "What conservative constraints and failure modes should bound this MVP?",
-        "failure_modes": "What conservative constraints and failure modes should bound this MVP?",
-        "non_goals": "What non-goals should explicitly remain out of scope?",
-        "acceptance_criteria": "Which command output verifies the acceptance criteria?",
-        "verification_plan": "Which command output verifies the acceptance criteria?",
-        "runtime_context": "Which runtime stack, repo, and project patterns should be used?",
-    }
-    return prompts.get(gap.section, gap.message)
-
-
 _AUTO_ANSWER_LOG_LIMIT = 25
 _AUTO_ANSWER_LOG_TEXT_LIMIT = 200
 
@@ -494,6 +515,10 @@ def _truncate(text: str, limit: int) -> str:
     if len(flat) <= limit:
         return flat
     return f"{flat[: limit - 3]}..."
+
+
+def _normalize_answer_text(text: str) -> str:
+    return " ".join(str(text).casefold().split())
 
 
 def _validate_turn(value: object) -> InterviewTurn:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1131,6 +1131,46 @@ async def test_interview_driver_uses_gap_answers_when_generic_defaults_repeat(tm
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_preserves_specific_acceptance_answers_with_open_gaps(
+    tmp_path,
+) -> None:
+    answers: list[str] = []
+    questions = iter(
+        [
+            "What acceptance criteria should the search feature satisfy?",
+            "What acceptance criteria should the export feature satisfy?",
+        ]
+    )
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(next(questions), "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        try:
+            next_q = next(questions)
+        except StopIteration:
+            return InterviewTurn("Anything else?", session_id, completed=True)
+        return InterviewTurn(next_q, session_id)
+
+    state = AutoPipelineState(goal="Build a local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=4
+    )
+
+    await driver.run(state, ledger)
+
+    # Both specific feature/acceptance prompts should produce feature-specific
+    # answers even though other required ledger sections (e.g. actors,
+    # runtime_context) remain open. The driver must not replace them with
+    # gap-targeted fallbacks.
+    assert len(answers) >= 2, answers
+    assert "search feature" in answers[0].lower()
+    assert "export feature" in answers[1].lower()
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_blocks_blank_goal_before_gap_defaults(tmp_path) -> None:
     answers: list[str] = []
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1171,6 +1171,41 @@ async def test_interview_driver_preserves_specific_acceptance_answers_with_open_
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_preserves_repeated_specific_acceptance_answer(
+    tmp_path,
+) -> None:
+    """A specific feature/acceptance prompt asked twice while other sections are
+    still open should still be answered specifically each time, not silently
+    replaced by a gap-targeted fallback.
+    """
+    answers: list[str] = []
+    repeated_question = "What acceptance criteria should the search feature satisfy?"
+    rounds = {"n": 0}
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(repeated_question, "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        rounds["n"] += 1
+        if rounds["n"] >= 2:
+            return InterviewTurn("Anything else?", session_id, completed=True)
+        return InterviewTurn(repeated_question, session_id)
+
+    state = AutoPipelineState(goal="Build a local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=4
+    )
+
+    await driver.run(state, ledger)
+
+    assert len(answers) >= 2, answers
+    assert "search feature" in answers[0].lower()
+    assert "search feature" in answers[1].lower()
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_blocks_blank_goal_before_gap_defaults(tmp_path) -> None:
     answers: list[str] = []
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1102,6 +1102,58 @@ async def test_interview_driver_steers_generic_questions_to_open_gaps(tmp_path) 
     assert any("runtime" in item.lower() for item in answers)
 
 
+@pytest.mark.asyncio
+async def test_interview_driver_uses_gap_answers_when_generic_defaults_repeat(tmp_path) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("Anything else?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        completed = len(answers) >= 5
+        return InterviewTurn("Anything else?", session_id, completed=completed)
+
+    state = AutoPipelineState(goal="Build a local report generator", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=6
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert ledger.open_gaps() == []
+    assert sum("conservative mvp" in item.lower() for item in answers) == 1
+    assert any("single local user" in item.lower() for item in answers)
+    assert any("non-goals" in item.lower() or "non-goal" in item.lower() for item in answers)
+    assert any("runtime" in item.lower() for item in answers)
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_blank_goal_before_gap_defaults(tmp_path) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("Anything else?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        return InterviewTurn("Anything else?", session_id)
+
+    state = AutoPipelineState(goal="Build a local tool", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal("")
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=3
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "goal is weak" in (result.blocker or "")
+    assert answers == []
+
+
 def test_auto_state_rejects_malformed_resume_optional_fields() -> None:
     base = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project").to_dict()
     base["pending_question"] = []


### PR DESCRIPTION
## Summary
- Adds gap-progress tracking in the auto-interview loop.
- Falls back to gap-directed answer generation when an auto answer does not reduce required ledger gaps.
- Adds repeated/default-answer detection so broad interviews cannot keep consuming rounds without ledger progress.
- Adds focused regression coverage for stalled generic fallback behavior.

## Discussion / implementation notes
- This PR keeps the fix general: it steers toward missing required ledger sections rather than adding domain-specific defaults.
- Unsafe/unresolved gaps are still allowed to block when they cannot be safely inferred.

## Validation
- [x] `git diff --check`
- [x] `PYTHONPATH=src /opt/hermes/.venv/bin/python -m pytest tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_interview_pipeline.py -q` — 162 passed

Closes #757
