### PR TITLE
feat(auto): classify interview questions by intent

### DIFF
--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -1067,6 +1067,22 @@ _USER_VERIFY_VERB_RE = re.compile(
 )
 
 
+# Meta-verification questions ("Should WE verify users can reset passwords?",
+# "How should WE validate admins can log in?") share the same actor-noun +
+# permission-modal + verify-verb tokens as user-facing feature questions but
+# the OUTER subject is engineering / first-person-plural ("we", "nous",
+# "wir", "我们", "우리", etc.).  When that meta-subject is present the
+# question is asking about QA, not a product feature, so we defer back to
+# VERIFICATION instead of demoting it.
+_FIRST_PERSON_META_RE = re.compile(
+    r"\b(we|us|our|ours|"
+    r"nous|notre|nos|"
+    r"wir|uns|unser|unsere|unseren|unserem|unserer|"
+    r"nosotros|nosotras|nuestro|nuestra|nuestros|nuestras)\b"
+    r"|私たち|私達|我们|我們|우리|저희"
+)
+
+
 def _has_user_verify_feature_shape(lowered: str) -> bool:
     """Detect ``ACTOR + permission-modal + verify-verb`` feature questions.
 
@@ -1077,12 +1093,19 @@ def _has_user_verify_feature_shape(lowered: str) -> bool:
     QA questions like ``"How should we verify the HIPAA worker tests
     pass?"`` continue to route to ``_verification_answer()`` and through
     the existing regulated-data blocker.
+
+    A first-person-plural subject (``we``/``nous``/``wir``/``我们``/``우리``…)
+    is also disqualifying — those questions ask about engineering-side QA
+    even when they mention an actor, e.g. ``"Should we verify users can
+    reset passwords?"``.
     """
-    return bool(
-        _USER_VERIFY_ACTOR_RE.search(lowered)
-        and _USER_VERIFY_MODAL_RE.search(lowered)
-        and _USER_VERIFY_VERB_RE.search(lowered)
-    )
+    if not _USER_VERIFY_ACTOR_RE.search(lowered):
+        return False
+    if not _USER_VERIFY_MODAL_RE.search(lowered):
+        return False
+    if not _USER_VERIFY_VERB_RE.search(lowered):
+        return False
+    return not _FIRST_PERSON_META_RE.search(lowered)
 
 
 def _has_product_behavior_intent(lowered: str) -> bool:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -685,11 +685,9 @@ def _classify_question_intents(question: str) -> frozenset[QuestionIntent]:
         lowered, QuestionIntent.ACCEPTANCE_CRITERIA
     ):
         intents.add(QuestionIntent.ACCEPTANCE_CRITERIA)
-    if _is_actor_or_io_question(lowered) or _contains_actor_io_intent_cue(lowered):
+    if _has_actor_io_intent(lowered):
         intents.add(QuestionIntent.ACTOR_IO)
-    if _is_runtime_context_question(lowered) or _contains_intent_cue(
-        lowered, QuestionIntent.RUNTIME_CONTEXT
-    ):
+    if _has_runtime_context_intent(lowered):
         intents.add(QuestionIntent.RUNTIME_CONTEXT)
     if _is_product_behavior_question(lowered):
         intents.add(QuestionIntent.PRODUCT_BEHAVIOR)
@@ -701,75 +699,199 @@ def _contains_intent_cue(lowered: str, intent: QuestionIntent) -> bool:
     return any(cue in lowered for cue in _INTENT_CUES[intent])
 
 
-def _contains_actor_io_intent_cue(lowered: str) -> bool:
-    io_cues = (
-        "input",
-        "inputs",
-        "output",
-        "outputs",
-        "argument",
-        "arguments",
-        "entrada",
-        "entradas",
-        "salida",
-        "salidas",
-        "entrée",
-        "entree",
-        "sortie",
-        "eingabe",
-        "ausgabe",
-        "입력",
-        "출력",
-        "入力",
-        "出力",
-        "输入",
-        "輸入",
-        "输出",
-        "輸出",
-    )
-    if any(cue in lowered for cue in io_cues):
-        return True
+_IO_NOUN_CUES: tuple[str, ...] = (
+    "input",
+    "inputs",
+    "output",
+    "outputs",
+    "argument",
+    "arguments",
+    "entrada",
+    "entradas",
+    "salida",
+    "salidas",
+    "entrée",
+    "entree",
+    "sortie",
+    "eingabe",
+    "ausgabe",
+    "입력",
+    "출력",
+    "入力",
+    "出力",
+    "输入",
+    "輸入",
+    "输出",
+    "輸出",
+)
 
-    actor_cues = (
-        "actor",
-        "actors",
-        "persona",
-        "stakeholder",
-        "usuario",
-        "usuarios",
-        "utilisateur",
-        "utilisateurs",
-        "benutzer",
-        "사용자",
-        "利用者",
-        "ユーザー",
-        "用户",
-        "使用者",
+
+# Cross-lingual flow-verb / interrogative anchors that indicate the question is
+# really asking about the IO contract (what flows in/out, what is produced or
+# returned, what schema/structure to expect).  English shape coverage lives in
+# ``_is_actor_or_io_question``; the patterns below add multilingual signals so
+# that broad nouns like "input" or "output" alone never authoritatively classify
+# a question — there must also be an action-/contract-asking shape.  This is a
+# direct response to ouroboros-agent's design note that broad noun substrings
+# were being treated as authoritative intent without question-shape validation.
+_IO_FLOW_SHAPE_PATTERNS: tuple[str, ...] = (
+    # Spanish flow verbs
+    r"\b(produce|produzca|produzcan|devuelve|devuelven|devolver|emite|emitir|"
+    r"escribe|escribir|recibe|recibir|genera|generan|generar|retorna|retornar)\b",
+    # Spanish interrogative shape: qué/cuál/cuáles + entradas/salidas
+    r"\b(qu[éeè]|cu[áa]l(?:es)?)\b.+\b(entradas?|salidas?)\b",
+    # French flow verbs
+    r"\b(produire|produit|produits|retourner|retourne|[ée]mettre|renvoyer|"
+    r"renvoie|[ée]crire|recevoir|re[çc]oit|g[ée]n[ée]rer|g[ée]n[ée]re)\b",
+    # French interrogative shape
+    r"\b(quels?|quelles?|que)\b.+\b(entr[ée]es?|sorties?)\b",
+    # German flow verbs
+    r"\b(produzieren|produziert|zur[üu]ckgeben|emittieren|schreiben|"
+    r"empfangen|erzeugen|generieren)\b",
+    # German interrogative shape
+    r"\bwelche\b.+\b(eingaben?|ausgaben?)\b",
+    # Korean: 입력/출력 followed by an action/asking particle, or asking words
+    # paired with 입력/출력.
+    r"(입력|출력)(?:은|는|을|를|이|가|에)?[^\?]*?(무엇|뭐|어떤|어떻게|어떠|"
+    r"반환|생성|내보|쓰|받|보내|만들|돌려)",
+    r"(어떤|무엇|뭐|어떠|어떠한)[^\?]*?(입력|출력)",
+    # Japanese: 入力/出力 paired with 何/どの or generation/return verbs.
+    r"(入力|出力)[^\?]*?(何|どの|どんな|生成|返|書|出す|出力|作)",
+    r"(何|どの|どんな)[^\?]*?(入力|出力)",
+    # Chinese (simplified + traditional)
+    r"(输入|输出|輸入|輸出)[^\?]*?(是什么|是甚麼|有哪些|有什么|生成|返回|"
+    r"产生|產生|寫|写|输出|輸出)",
+    r"(什么|甚麼|哪些|哪個|哪个)[^\?]*?(输入|输出|輸入|輸出)",
+)
+
+
+_ACTOR_NOUN_CUES: tuple[str, ...] = (
+    "actor",
+    "actors",
+    "persona",
+    "stakeholder",
+    "usuario",
+    "usuarios",
+    "utilisateur",
+    "utilisateurs",
+    "benutzer",
+    "사용자",
+    "유저",
+    "利用者",
+    "ユーザー",
+    "ユーザ",
+    "用户",
+    "使用者",
+)
+
+
+_ACTOR_QUESTION_CUES: tuple[str, ...] = (
+    "who",
+    "which user",
+    "what user",
+    "primary user",
+    "end user",
+    "quién",
+    "quien",
+    "quiénes",
+    "quienes",
+    "qui ",
+    "quel utilisateur",
+    "quels utilisateurs",
+    "welche benutzer",
+    "wer ",
+    "누구",
+    "어떤 사용자",
+    "어떤 유저",
+    "誰",
+    "どのユーザー",
+    "どのユーザ",
+    "谁",
+    "哪些用户",
+    "哪个用户",
+    "哪些使用者",
+    "哪個使用者",
+)
+
+
+def _has_io_cue_with_flow_shape(lowered: str) -> bool:
+    if not any(cue in lowered for cue in _IO_NOUN_CUES):
+        return False
+    return any(re.search(pattern, lowered) for pattern in _IO_FLOW_SHAPE_PATTERNS)
+
+
+def _has_actor_cue_with_question_shape(lowered: str) -> bool:
+    return any(cue in lowered for cue in _ACTOR_NOUN_CUES) and any(
+        cue in lowered for cue in _ACTOR_QUESTION_CUES
     )
-    actor_question_cues = (
-        "who",
-        "which user",
-        "what user",
-        "primary user",
-        "end user",
-        "quién",
-        "quien",
-        "quiénes",
-        "quienes",
-        "qui ",
-        "quel utilisateur",
-        "welche benutzer",
-        "wer ",
-        "누구",
-        "어떤 사용자",
-        "誰",
-        "どのユーザー",
-        "谁",
-        "哪些用户",
-    )
-    return any(cue in lowered for cue in actor_cues) and any(
-        cue in lowered for cue in actor_question_cues
-    )
+
+
+def _contains_actor_io_intent_cue(lowered: str) -> bool:
+    """Cue-based actor/IO classifier with question-shape validation.
+
+    The previous implementation triggered ``True`` for *any* string containing
+    broad nouns like ``"input"`` or ``"output"``, which silently misrouted
+    questions such as ``"What is the output directory?"`` (a property lookup,
+    not an IO contract question) to the actor/IO answerer.  IO cues now require
+    a flow-verb or interrogative shape; actor cues continue to require an
+    interrogative subject paired with the actor noun.
+    """
+    return _has_io_cue_with_flow_shape(lowered) or _has_actor_cue_with_question_shape(lowered)
+
+
+def _has_actor_io_intent(lowered: str) -> bool:
+    return _is_actor_or_io_question(lowered) or _contains_actor_io_intent_cue(lowered)
+
+
+# Cross-lingual selection/decision shape for runtime questions.  Cue words like
+# ``"runtime"``, ``"repo"``, or ``"architecture"`` are concept anchors but
+# product/property questions can mention them too ("What is the repository
+# status?", "What architecture decisions are documented?").  We require a
+# selection/decision verb in addition to the cue before the runtime intent is
+# inferred.  English shape selection is also handled by the stricter
+# ``_is_runtime_context_question`` regex.
+_RUNTIME_SELECTION_SHAPE_PATTERNS: tuple[str, ...] = (
+    # English selection/decision verbs not always covered by the strict shape regex
+    r"\b(use|using|uses|used|choose|chose|chosen|select|selected|adopt|adopted|"
+    r"configure|configured|set up|setup|target|targets|run on|run in|deploy on|"
+    r"build on|switch to|migrate to|standardize on|standardise on)\b",
+    # Spanish
+    r"\b(usar|usamos|usa|usan|elegir|elegimos|elegido|seleccionar|seleccionamos|"
+    r"configurar|configuramos|adoptar|adoptamos|migrar|escoger)\b",
+    # French
+    r"\b(utiliser|utilise|utilisons|utilis[ée]|choisir|choisissons|choisi|"
+    r"s[ée]lectionner|configurer|adopter|adopt[ée]|migrer)\b",
+    # German
+    r"\b(verwenden|verwendet|nutzen|nutzt|w[äa]hlen|ausw[äa]hlen|"
+    r"konfigurieren|konfiguriert|adoptieren|migrieren|einrichten)\b",
+    # Korean: 사용/선택/구성/설정/채택/도입
+    r"사용|선택|구성|설정|채택|도입",
+    # Japanese: 使う/使い/使用/選ぶ/選択/構成/設定/採用/導入
+    r"使う|使い|使用|選ぶ|選択|構成|設定|採用|導入",
+    # Chinese (simplified + traditional): 使用/选择/选用/配置/采用/設定/設置
+    r"使用|选择|選擇|选用|選用|采用|採用|配置|設定|设定|設置|设置|採納|采纳",
+)
+
+
+def _has_runtime_selection_shape(lowered: str) -> bool:
+    return any(re.search(pattern, lowered) for pattern in _RUNTIME_SELECTION_SHAPE_PATTERNS)
+
+
+def _has_runtime_context_intent(lowered: str) -> bool:
+    """Classify runtime intent with question-shape validation for cue matches.
+
+    The previous implementation accepted *any* string containing broad nouns
+    like ``"repository"`` or ``"architecture"`` as runtime intent, which
+    silently misrouted property/status questions ("What is the repository
+    status?") into ``_runtime_answer()``.  We keep the strict English shape
+    selector as the authoritative trigger and only let cross-lingual cues add
+    the intent when paired with a selection/decision verb.
+    """
+    if _is_runtime_context_question(lowered):
+        return True
+    if not _contains_intent_cue(lowered, QuestionIntent.RUNTIME_CONTEXT):
+        return False
+    return _has_runtime_selection_shape(lowered)
 
 
 def _is_verification_question(lowered: str) -> bool:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -128,9 +128,17 @@ class AutoAnswerer:
 
         if QuestionIntent.NON_GOALS in intents:
             return self._non_goal_answer(question, ledger)
-        if QuestionIntent.VERIFICATION in intents:
+        # When PRODUCT_BEHAVIOR is also inferred, prefer it over VERIFICATION
+        # and ACCEPTANCE_CRITERIA so feature questions like
+        # ``"Can users verify their email?"`` (and the multilingual siblings
+        # ``"Les utilisateurs peuvent-ils vérifier leur e-mail ?"``,
+        # ``"用户可以验证他们的电子邮件吗？"``, ``"사용자가 이메일을
+        # 확인할 수 있나요?"``) preserve the product feature contract instead
+        # of being collapsed into a generic verification-plan template.
+        product_present = QuestionIntent.PRODUCT_BEHAVIOR in intents
+        if QuestionIntent.VERIFICATION in intents and not product_present:
             return self._verification_answer(question)
-        if QuestionIntent.ACCEPTANCE_CRITERIA in intents:
+        if QuestionIntent.ACCEPTANCE_CRITERIA in intents and not product_present:
             return self._feature_acceptance_answer(question)
         if QuestionIntent.RUNTIME_CONTEXT in intents and _should_preserve_runtime_route(lowered):
             answer = self._runtime_answer(question, context)
@@ -905,12 +913,19 @@ _RUNTIME_SELECTION_SHAPE_PATTERNS: tuple[str, ...] = (
     # German
     r"\b(verwenden|verwendet|nutzen|nutzt|w[äa]hlen|ausw[äa]hlen|"
     r"konfigurieren|konfiguriert|adoptieren|migrieren|einrichten)\b",
-    # Korean: 사용/선택/구성/설정/채택/도입
-    r"사용|선택|구성|설정|채택|도입",
-    # Japanese: 使う/使い/使用/選ぶ/選択/構成/設定/採用/導入
-    r"使う|使い|使用|選ぶ|選択|構成|設定|採用|導入",
-    # Chinese (simplified + traditional): 使用/选择/选用/配置/采用/設定/設置
-    r"使用|选择|選擇|选用|選用|采用|採用|配置|設定|设定|設置|设置|採納|采纳",
+    # Korean: only verb-distinctive selection cues.  ``구성`` (composition)
+    # and ``설정`` (settings) are dropped because they also appear in
+    # ordinary status / display questions like ``런타임 설정은 어디에
+    # 표시되나요?`` and would silently misroute property lookups into
+    # ``_runtime_answer()``.
+    r"사용|선택|채택|도입",
+    # Japanese: same rule — drop ``構成`` and ``設定`` (which surface in
+    # ``ランタイム設定はどこに表示されますか?``-style status questions).
+    r"使う|使い|使用|選ぶ|選択|採用|導入",
+    # Chinese (simplified + traditional): drop ``配置`` / ``設定`` /
+    # ``设定`` / ``設置`` / ``设置`` for the same reason — those surface
+    # in display/status questions like ``运行时配置显示在哪里？``.
+    r"使用|选择|選擇|选用|選用|采用|採用|採納|采纳",
 )
 
 
@@ -1014,6 +1029,62 @@ _MULTILINGUAL_PRODUCT_BEHAVIOR_PATTERNS: tuple[str, ...] = (
 )
 
 
+# Cross-lingual "user-verifies-X" feature shape.  The bare verbs
+# ``verify`` / ``vérifier`` / ``verificar`` / ``验证`` / ``확인`` / ``検証``
+# are also classified as VERIFICATION cues; the routing layer prefers
+# PRODUCT_BEHAVIOR when both are inferred so feature questions like
+# ``"Can users verify their email?"`` (and the multilingual siblings) are
+# not collapsed into a generic verification-plan template.
+#
+# We require an explicit actor noun (users / usuarios / utilisateurs /
+# 사용자 / 用户 / ユーザー / etc.) PLUS a permission modal PLUS a verify-style
+# verb.  Without the actor requirement, engineering-side questions like
+# ``"How should we verify the HIPAA worker tests pass?"`` would also match
+# and get demoted from VERIFICATION (which is wrong — those are not product
+# feature questions).
+_USER_VERIFY_ACTOR_RE = re.compile(
+    r"\b(users?|usuarios?|utilisateurs?|benutzer|"
+    r"clients?|kunden?|persons?|accounts?|admins?|owners?|members?|recipients?)\b"
+    r"|사용자|유저|用户|使用者|ユーザー|ユーザ|利用者"
+)
+_USER_VERIFY_MODAL_RE = re.compile(
+    r"\b(can|should|must|will|do|does|may|might|able to|allowed to|"
+    r"pueden|puede|podr[áa]n?|deben|debe|"
+    r"peuvent|peut|peut[- ]on|doivent|doit|pourra|pourront|"
+    r"k(?:[öo]|oe)nnen|kann|d(?:[üu]|ue)rfen|sollen|soll)\b"
+    r"|수\s*있|수\s*없|해야|가능|허용|허락"
+    r"|できる|できます|してもよい|可能|していい|してください"
+    r"|可以|应该|應該|必须|必須|能否|是否"
+)
+_USER_VERIFY_VERB_RE = re.compile(
+    r"\b(verify|verifies|validate|validates|confirm|confirms|approve|approves|"
+    r"verificar|validar|confirmar|aprobar|"
+    r"v[ée]rifier|valider|confirmer|approuver|"
+    r"verifizieren|validieren|best[äa]tigen|bestaetigen|genehmigen)\b"
+    r"|확인|검증|승인"
+    r"|確認|検証|承認"
+    r"|验证|驗證|确认|確認|核实|核實|审核|審核|批准"
+)
+
+
+def _has_user_verify_feature_shape(lowered: str) -> bool:
+    """Detect ``ACTOR + permission-modal + verify-verb`` feature questions.
+
+    Required for routing precedence: when this pattern matches the question
+    is asking about a user-facing verification feature (e.g. ``"Can users
+    verify their email?"``) and PRODUCT_BEHAVIOR should win over the
+    VERIFICATION cue path.  An actor noun is mandatory so engineering-side
+    QA questions like ``"How should we verify the HIPAA worker tests
+    pass?"`` continue to route to ``_verification_answer()`` and through
+    the existing regulated-data blocker.
+    """
+    return bool(
+        _USER_VERIFY_ACTOR_RE.search(lowered)
+        and _USER_VERIFY_MODAL_RE.search(lowered)
+        and _USER_VERIFY_VERB_RE.search(lowered)
+    )
+
+
 def _has_product_behavior_intent(lowered: str) -> bool:
     """Classify product-behavior intent across English and other languages.
 
@@ -1025,6 +1096,8 @@ def _has_product_behavior_intent(lowered: str) -> bool:
     authorization behavior).  This helper restores symmetry.
     """
     if _is_product_behavior_question(lowered):
+        return True
+    if _has_user_verify_feature_shape(lowered):
         return True
     return any(re.search(pattern, lowered) for pattern in _MULTILINGUAL_PRODUCT_BEHAVIOR_PATTERNS)
 

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -22,6 +22,17 @@ class AutoAnswerSource(StrEnum):
     BLOCKER = "blocker"
 
 
+class QuestionIntent(StrEnum):
+    """Ledger-level intent inferred from an interview question."""
+
+    NON_GOALS = "non_goals"
+    VERIFICATION = "verification"
+    ACCEPTANCE_CRITERIA = "acceptance_criteria"
+    ACTOR_IO = "actor_io"
+    RUNTIME_CONTEXT = "runtime_context"
+    PRODUCT_BEHAVIOR = "product_behavior"
+
+
 @dataclass(frozen=True, slots=True)
 class AutoAnswerContext:
     """Bounded facts supplied by a caller before answering interview questions.
@@ -104,7 +115,8 @@ class AutoAnswerer:
     ) -> AutoAnswer:
         """Answer ``question`` using a conservative policy and optional bounded facts."""
         context = context or AutoAnswerContext()
-        lowered = question.lower()
+        lowered = _normalize_question(question)
+        intents = _classify_question_intents(question)
         blocker = _blocker_for(question)
         if blocker is not None:
             return AutoAnswer(
@@ -114,20 +126,20 @@ class AutoAnswerer:
                 blocker=blocker,
             )
 
-        if _matches_any(
-            lowered, (r"\bnon-goals?\b", r"\bout of scope\b", r"\bexclude\b", r"\bnot do\b")
-        ):
+        if QuestionIntent.NON_GOALS in intents:
             return self._non_goal_answer(question, ledger)
-        if _is_verification_question(lowered):
+        if QuestionIntent.VERIFICATION in intents:
             return self._verification_answer(question)
-        if _is_feature_acceptance_question(lowered):
+        if QuestionIntent.ACCEPTANCE_CRITERIA in intents:
             return self._feature_acceptance_answer(question)
-        if _is_actor_or_io_question(lowered):
-            answer = self._io_actor_answer(question)
-        elif _is_runtime_context_question(lowered):
+        if QuestionIntent.RUNTIME_CONTEXT in intents and _should_preserve_runtime_route(lowered):
             answer = self._runtime_answer(question, context)
-        elif _is_product_behavior_question(lowered):
+        elif QuestionIntent.PRODUCT_BEHAVIOR in intents:
             answer = self._product_behavior_answer(question)
+        elif QuestionIntent.ACTOR_IO in intents:
+            answer = self._io_actor_answer(question)
+        elif QuestionIntent.RUNTIME_CONTEXT in intents:
+            answer = self._runtime_answer(question, context)
         else:
             answer = self._default_answer(question, ledger)
 
@@ -502,6 +514,264 @@ class AutoAnswerer:
         )
 
 
+_INTENT_CUES: Mapping[QuestionIntent, tuple[str, ...]] = {
+    QuestionIntent.NON_GOALS: (
+        "non-goal",
+        "non goal",
+        "out of scope",
+        "scope boundary",
+        "exclude",
+        "not do",
+        "won't do",
+        "will not do",
+        "no hacer",
+        "fuera de alcance",
+        "hors périmètre",
+        "hors perimetre",
+        "nicht ziel",
+        "fuera del alcance",
+        "범위 제외",
+        "하지 않을",
+        "비목표",
+        "対象外",
+        "不在范围",
+        "范围外",
+        "不做",
+        "非目标",
+    ),
+    QuestionIntent.VERIFICATION: (
+        "verify",
+        "verification",
+        "validate",
+        "validation",
+        "test",
+        "definition of done",
+        "done criteria",
+        "how know it works",
+        "cómo verific",
+        "como verific",
+        "validar",
+        "vérifier",
+        "verifier",
+        "vérification",
+        "verifikation",
+        "검증",
+        "테스트",
+        "확인",
+        "検証",
+        "测试",
+        "驗證",
+        "验证",
+    ),
+    QuestionIntent.ACCEPTANCE_CRITERIA: (
+        "acceptance criteria",
+        "acceptance criterion",
+        "acceptance",
+        "success criteria",
+        "completion criteria",
+        "criterios de aceptación",
+        "criterios de aceptacion",
+        "critères d'acceptation",
+        "criteres d'acceptation",
+        "akzeptanzkriterien",
+        "인수 조건",
+        "수락 기준",
+        "허용 기준",
+        "受け入れ基準",
+        "验收标准",
+        "驗收標準",
+    ),
+    QuestionIntent.ACTOR_IO: (
+        "actor",
+        "actors",
+        "user",
+        "users",
+        "persona",
+        "stakeholder",
+        "input",
+        "inputs",
+        "output",
+        "outputs",
+        "argument",
+        "arguments",
+        "usuario",
+        "usuarios",
+        "entrada",
+        "entradas",
+        "salida",
+        "salidas",
+        "utilisateur",
+        "utilisateurs",
+        "entrée",
+        "entree",
+        "sortie",
+        "benutzer",
+        "eingabe",
+        "ausgabe",
+        "사용자",
+        "입력",
+        "출력",
+        "利用者",
+        "ユーザー",
+        "入力",
+        "出力",
+        "用户",
+        "使用者",
+        "输入",
+        "輸入",
+        "输出",
+        "輸出",
+    ),
+    QuestionIntent.RUNTIME_CONTEXT: (
+        "runtime",
+        "stack",
+        "repo",
+        "repository",
+        "framework",
+        "package manager",
+        "project structure",
+        "project runtime",
+        "architecture",
+        "estructura del proyecto",
+        "repositorio",
+        "estructura",
+        "référentiel",
+        "referentiel",
+        "cadre",
+        "gestionnaire de paquets",
+        "projektstruktur",
+        "laufzeit",
+        "저장소",
+        "레포",
+        "런타임",
+        "프레임워크",
+        "패키지 매니저",
+        "프로젝트 구조",
+        "リポジトリ",
+        "ランタイム",
+        "フレームワーク",
+        "项目结构",
+        "專案結構",
+        "运行时",
+        "執行環境",
+        "框架",
+    ),
+}
+
+
+def _normalize_question(question: str) -> str:
+    return re.sub(r"\s+", " ", question.casefold()).strip()
+
+
+def _classify_question_intents(question: str) -> frozenset[QuestionIntent]:
+    """Classify interview text by ledger intent, not only English phrasing.
+
+    The classifier intentionally maps broad concept cues to ledger sections and
+    then lets the existing handlers produce conservative answers.  Unknown
+    questions return no intent and keep the existing default fallback.
+    """
+    lowered = _normalize_question(question)
+    intents: set[QuestionIntent] = set()
+
+    if _matches_any(
+        lowered, (r"\bnon-goals?\b", r"\bout of scope\b", r"\bexclude\b", r"\bnot do\b")
+    ) or _contains_intent_cue(lowered, QuestionIntent.NON_GOALS):
+        intents.add(QuestionIntent.NON_GOALS)
+    if _is_verification_question(lowered) or _contains_intent_cue(
+        lowered, QuestionIntent.VERIFICATION
+    ):
+        intents.add(QuestionIntent.VERIFICATION)
+    if _is_feature_acceptance_question(lowered) or _contains_intent_cue(
+        lowered, QuestionIntent.ACCEPTANCE_CRITERIA
+    ):
+        intents.add(QuestionIntent.ACCEPTANCE_CRITERIA)
+    if _is_actor_or_io_question(lowered) or _contains_actor_io_intent_cue(lowered):
+        intents.add(QuestionIntent.ACTOR_IO)
+    if _is_runtime_context_question(lowered) or _contains_intent_cue(
+        lowered, QuestionIntent.RUNTIME_CONTEXT
+    ):
+        intents.add(QuestionIntent.RUNTIME_CONTEXT)
+    if _is_product_behavior_question(lowered):
+        intents.add(QuestionIntent.PRODUCT_BEHAVIOR)
+
+    return frozenset(intents)
+
+
+def _contains_intent_cue(lowered: str, intent: QuestionIntent) -> bool:
+    return any(cue in lowered for cue in _INTENT_CUES[intent])
+
+
+def _contains_actor_io_intent_cue(lowered: str) -> bool:
+    io_cues = (
+        "input",
+        "inputs",
+        "output",
+        "outputs",
+        "argument",
+        "arguments",
+        "entrada",
+        "entradas",
+        "salida",
+        "salidas",
+        "entrée",
+        "entree",
+        "sortie",
+        "eingabe",
+        "ausgabe",
+        "입력",
+        "출력",
+        "入力",
+        "出力",
+        "输入",
+        "輸入",
+        "输出",
+        "輸出",
+    )
+    if any(cue in lowered for cue in io_cues):
+        return True
+
+    actor_cues = (
+        "actor",
+        "actors",
+        "persona",
+        "stakeholder",
+        "usuario",
+        "usuarios",
+        "utilisateur",
+        "utilisateurs",
+        "benutzer",
+        "사용자",
+        "利用者",
+        "ユーザー",
+        "用户",
+        "使用者",
+    )
+    actor_question_cues = (
+        "who",
+        "which user",
+        "what user",
+        "primary user",
+        "end user",
+        "quién",
+        "quien",
+        "quiénes",
+        "quienes",
+        "qui ",
+        "quel utilisateur",
+        "welche benutzer",
+        "wer ",
+        "누구",
+        "어떤 사용자",
+        "誰",
+        "どのユーザー",
+        "谁",
+        "哪些用户",
+    )
+    return any(cue in lowered for cue in actor_cues) and any(
+        cue in lowered for cue in actor_question_cues
+    )
+
+
 def _is_verification_question(lowered: str) -> bool:
     return bool(
         _matches_any(
@@ -579,6 +849,21 @@ def _is_runtime_context_question(lowered: str) -> bool:
         or re.search(rf"\b(which|what)\b.+\b{runtime_term}\b.+\b{selection_verbs}\b", lowered)
         or re.search(rf"\b{runtime_term}\b.+\b{selection_verbs}\b", lowered)
         or re.search(rf"\b{selection_verbs}\b.+\b{runtime_term}\b", lowered)
+    )
+
+
+def _should_preserve_runtime_route(lowered: str) -> bool:
+    """Prefer runtime context only for stack/repo selection questions.
+
+    Broad intent cues intentionally recognise words like "runtime" and "repo"
+    across languages.  Product questions can also contain those words ("runtime
+    status", "repo integration"), so preserve the runtime route only when the
+    established English selector recognises an actual stack/repository choice.
+    Regulated runtime fallback questions still pass through the later safe
+    product reroute unless a grounded repo fact was supplied.
+    """
+    return _is_runtime_context_question(lowered) and not re.search(
+        r"\bruntime\s+status\b|\bstatus\b.+\bruntime\b", lowered
     )
 
 

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -979,9 +979,7 @@ def _has_product_behavior_intent(lowered: str) -> bool:
     """
     if _is_product_behavior_question(lowered):
         return True
-    return any(
-        re.search(pattern, lowered) for pattern in _MULTILINGUAL_PRODUCT_BEHAVIOR_PATTERNS
-    )
+    return any(re.search(pattern, lowered) for pattern in _MULTILINGUAL_PRODUCT_BEHAVIOR_PATTERNS)
 
 
 def _is_verification_question(lowered: str) -> bool:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -1152,14 +1152,23 @@ _USER_VERIFY_VERB_RE = re.compile(
 # "How should WE validate admins can log in?") share the same actor-noun +
 # permission-modal + verify-verb tokens as user-facing feature questions but
 # the OUTER subject is engineering / first-person-plural ("we", "nous",
-# "wir", "我们", "우리", etc.).  When that meta-subject is present the
-# question is asking about QA, not a product feature, so we defer back to
-# VERIFICATION instead of demoting it.
+# "wir", "我们", etc.).  When that meta-subject is present the question is
+# asking about QA, not a product feature, so we defer back to VERIFICATION
+# instead of demoting it.
+#
+# Possessive determiners (``our``/``ours``/``notre``/``nos``/``unser*``/
+# ``nuestro*``) are intentionally excluded: they routinely modify the actor
+# noun in product-behavior questions (``Can our users verify their email?``)
+# and treating them as engineering meta-subjects silently misroutes
+# user-facing feature questions to the verification handler.  The CJK
+# pronoun forms (``우리``/``我们``) are similarly ambiguous between possessive
+# and subject usage in unanchored matching, so they are matched only with a
+# trailing topic/subject particle that disambiguates an outer 1pp subject.
 _FIRST_PERSON_META_RE = re.compile(
-    r"\b(we|us|our|ours|"
-    r"nous|notre|nos|"
-    r"wir|uns|unser|unsere|unseren|unserem|unserer|"
-    r"nosotros|nosotras|nuestro|nuestra|nuestros|nuestras|"
+    r"\b(we|us|"
+    r"nous|"
+    r"wir|uns|"
+    r"nosotros|nosotras|"
     # Spanish first-person plural verb forms.  ``-mos`` is unambiguously
     # 1pp in standard usage, so these are safe meta signals.  Listing the
     # specific common verbs keeps the matcher precise.
@@ -1172,7 +1181,13 @@ _FIRST_PERSON_META_RE = re.compile(
     r"pourrions|pouvons|pouvions|"
     r"v[ée]rifions|v[ée]rifierions|validons|confirmons|approuvons|"
     r"voulons|voudrions)\b"
-    r"|私たち|私達|我们|我們|우리|저희"
+    # Japanese 1pp pronouns are unambiguously subject (no possessive overlap
+    # without an explicit ``の`` particle).
+    r"|私たち|私達"
+    # Chinese / Korean 1pp pronouns require a topic/subject particle so a
+    # possessive use ("我们的产品", "우리 사용자") does not trip the meta path.
+    r"|我们(?:是|应|应当|是否|要|可|可以)|我們(?:是|應|應當|是否|要|可|可以)"
+    r"|우리(?:는|가|들이|들은)|저희(?:는|가|들이|들은)"
 )
 
 
@@ -1603,22 +1618,45 @@ _COMPLIANCE_POLICY_ACTIVE_VERBS_RE = re.compile(
 # to download …" are captured even when ``download`` is not in that helper's verb list.
 _PRODUCT_QUESTION_MODAL_RE = re.compile(r"\b(should|must|can|will|do|does|is|are)\b")
 # Reject "compliance-scope-as-feature-flag" phrasings: a wide-coverage
-# enablement verb (``support`` / ``enable`` / ``allow``) directly followed by a
-# bare regulated noun with no further qualifying noun. Such prompts
-# ("Should the platform support HIPAA?", "Should the app enable GDPR?",
-# "Should the system allow PII?") are treating the entire compliance regime as
-# a feature toggle, which is a regulated-policy decision rather than a bounded
-# product-behavior question. The trailing negative lookahead ``(?!\s+[a-z])``
-# fires when the regulated noun is the last lexical token of the clause; if any
-# qualifying noun follows ("HIPAA audit logs", "GDPR consent banners", "PII
-# redaction in exports", "GDPR data") the question describes a concrete
-# product feature and is not rejected here.
+# enablement verb (``support`` / ``enable`` / ``allow``) followed by a
+# regulated noun used as a policy scope rather than a concrete feature.
+# Two shapes are rejected:
+#
+#   1. Bare regulated noun with no further qualifying noun
+#      (``Should the platform support HIPAA?``, ``Should the app enable GDPR?``).
+#      The trailing negative lookahead ``(?!\s+[a-z])`` fires when the
+#      regulated noun is the last lexical token of the clause.
+#
+#   2. Regulated noun followed (optionally bridged by ``data``) by a
+#      compliance-policy noun that names the policy regime itself —
+#      ``retention``, ``storage``, ``encryption``, ``handling``, ``processing``,
+#      ``collection``, ``disclosure``, ``governance``, ``compliance``,
+#      ``transmission``, ``redaction``.  Phrasings such as
+#      ``support HIPAA data retention`` and ``enable GDPR data storage`` frame
+#      the entire compliance policy as a toggle and are still
+#      regulated-policy decisions, not bounded product behaviour, so they
+#      remain blocked.  A trailing word boundary keeps concrete-feature
+#      variants ("support HIPAA retention reports", "enable GDPR consent
+#      banners") off this path because the policy noun is then followed by a
+#      qualifying feature noun rather than ending the clause.
+#
+# Concrete-feature qualifiers that follow the regulated noun directly
+# ("HIPAA audit logs", "GDPR consent banners", "PII redaction in exports",
+# "GDPR data exports") still describe bounded product features and are not
+# rejected.
 _BARE_COMPLIANCE_SCOPE_RE = re.compile(
     r"\b(?:support|supports|supporting|supported|"
     r"enable|enables|enabling|enabled|"
     r"allow|allows|allowing|allowed)\s+"
     r"(?:pii|personally identifiable information|gdpr|hipaa|sox|pci[- ]?dss)\b"
+    r"(?:"
     r"(?!\s+[a-z])"
+    r"|"
+    r"(?:\s+data)?\s+"
+    r"(?:retention|storage|encryption|handling|processing|collection|"
+    r"disclosure|governance|compliance|transmission|redaction)"
+    r"(?!\s+[a-z])"
+    r")"
 )
 
 

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -628,6 +628,14 @@ _INTENT_CUES: Mapping[QuestionIntent, tuple[str, ...]] = {
         "输出",
         "輸出",
     ),
+    # Runtime cues must be repository-/runtime-specific.  Broad design
+    # nouns like ``architecture`` / ``estructura`` / ``cadre`` were removed
+    # because they leak into product/design questions
+    # (e.g. ``¿Qué estructura usamos para los datos?``) once paired with a
+    # generic selection verb and silently mutate ``runtime_context`` /
+    # ``constraints`` ledger entries.  Phrase-level variants like
+    # ``estructura del proyecto`` and ``project structure`` stay because
+    # the phrase itself is anchored to the project's runtime contract.
     QuestionIntent.RUNTIME_CONTEXT: (
         "runtime",
         "stack",
@@ -637,13 +645,10 @@ _INTENT_CUES: Mapping[QuestionIntent, tuple[str, ...]] = {
         "package manager",
         "project structure",
         "project runtime",
-        "architecture",
         "estructura del proyecto",
         "repositorio",
-        "estructura",
         "référentiel",
         "referentiel",
-        "cadre",
         "gestionnaire de paquets",
         "projektstruktur",
         "laufzeit",

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -941,6 +941,48 @@ def _has_runtime_selection_shape(lowered: str) -> bool:
     return any(re.search(pattern, lowered) for pattern in _RUNTIME_SELECTION_SHAPE_PATTERNS)
 
 
+# Bare direct-lookup runtime shapes for non-English languages.  English
+# direct-lookup ("What runtime?", "Which framework?") is already handled by
+# ``_is_runtime_context_question``; without an equivalent multilingual layer
+# bare lookups like ``"¿Qué framework?"``, ``"Quel framework ?"``,
+# ``"Welches Framework?"``, ``"ランタイムは何ですか?"``, ``"框架是什么？"``,
+# and ``"런타임은 무엇인가요?"`` would fall through to ``_default_answer()``.
+# Each pattern is anchored on a runtime cue plus a direct-lookup
+# interrogative ("what is X" / "which X" / "X 무엇" / "X は何" / "X 是什么")
+# so design / property questions like ``"¿Qué estructura usamos para los
+# datos?"`` (which we already drop ``estructura`` from runtime cues for) and
+# ``"What is the repository status?"`` (English, doesn't match the
+# multilingual interrogatives) keep their conservative-default routing.
+_RUNTIME_DIRECT_LOOKUP_PATTERNS: tuple[str, ...] = (
+    # Spanish / French / German: interrogative + optional copula/article +
+    # runtime cue.  The pattern is anchored to the start of the question
+    # and ends shortly after the cue (only ``?`` and whitespace allowed
+    # at the tail), so longer status questions don't match.
+    r"^\s*¿?\s*(qu[éeè]|cu[áa]l(?:es)?|quel(?:le|s|les)?|welche[ar]?|welches)\b"
+    r"\s*(es|son|ist|sind)?\s*"
+    r"(el|la|los|las|das|der|die|den|le|les|un|une|una)?\s*"
+    r"(runtime|stack|repo|repository|framework|package\s+manager|"
+    r"project\s+structure|project\s+runtime|repositorio|"
+    r"r[ée]f[ée]rentiel|gestionnaire\s+de\s+paquets|projektstruktur|laufzeit|"
+    r"estructura\s+del\s+proyecto)"
+    r"\s*\??\s*$",
+    # Korean: cue + optional topic/subject particle + 무엇/뭐/어떠한.
+    r"(런타임|저장소|레포|프레임워크|패키지\s*매니저|프로젝트\s*구조|스택)"
+    r"(?:은|는|이|가)?\s*(무엇|뭐|어떠한)",
+    # Japanese: cue + は/の + 何/どの/どんな/なに.
+    r"(ランタイム|リポジトリ|レポ|フレームワーク|パッケージマネージャ|"
+    r"プロジェクト構造|スタック)"
+    r"(?:は|の)?\s*(何|どの|どんな|なに)",
+    # Chinese (simplified + traditional): cue + (是|有)? + 什么/什麼/哪个/哪個/哪些/啥.
+    r"(运行时|執行環境|栈|堆栈|仓库|倉庫|框架|包管理器|项目结构|專案結構)"
+    r"\s*(是|有)?\s*(什么|什麼|哪个|哪個|哪些|啥)",
+)
+
+
+def _has_runtime_direct_lookup_shape(lowered: str) -> bool:
+    return any(re.search(pattern, lowered) for pattern in _RUNTIME_DIRECT_LOOKUP_PATTERNS)
+
+
 def _has_runtime_context_intent(lowered: str) -> bool:
     """Classify runtime intent with question-shape validation for cue matches.
 
@@ -948,14 +990,16 @@ def _has_runtime_context_intent(lowered: str) -> bool:
     like ``"repository"`` or ``"architecture"`` as runtime intent, which
     silently misrouted property/status questions ("What is the repository
     status?") into ``_runtime_answer()``.  We keep the strict English shape
-    selector as the authoritative trigger and only let cross-lingual cues add
-    the intent when paired with a selection/decision verb.
+    selector as the authoritative trigger and let cross-lingual cues add the
+    intent only when paired with either a selection/decision verb (``사용`` /
+    ``使う`` / ``adopter`` / etc.) or a direct-lookup interrogative
+    (``¿Qué …?`` / ``X は何ですか?`` / ``X 是什么?`` / ``X 무엇?``).
     """
     if _is_runtime_context_question(lowered):
         return True
     if not _contains_intent_cue(lowered, QuestionIntent.RUNTIME_CONTEXT):
         return False
-    return _has_runtime_selection_shape(lowered)
+    return _has_runtime_selection_shape(lowered) or _has_runtime_direct_lookup_shape(lowered)
 
 
 # Cross-lingual permission/action shape for product-behavior questions.  The

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -868,8 +868,13 @@ _ACTOR_NOUN_CUES: tuple[str, ...] = (
 
 _ACTOR_QUESTION_CUES: tuple[str, ...] = (
     "who",
-    "which user",
-    "what user",
+    # NB: bare ``"which user"`` and ``"what user"`` are intentionally NOT
+    # in this list — combined with the ``user`` / ``users`` actor noun
+    # cues they would silently misroute product-behavior questions like
+    # ``"What user settings should be displayed?"`` and ``"Which user
+    # fields should be editable?"`` into ``_io_actor_answer()``.  Specific
+    # actor phrases (``"primary user"`` / ``"end user"``) stay because
+    # they are unambiguous "who is the user" questions.
     "primary user",
     "end user",
     "quién",
@@ -1342,7 +1347,16 @@ def _is_product_behavior_question(lowered: str) -> bool:
         )
         or re.search(
             r"\b(should|must|can|will|do|does|is|are)\b.+\b(be|become)\s+"
-            r"(editable|edited|deleted|removed|trackable|tracked|enforced|configurable|visible|searchable|exportable|importable)\b",
+            r"(editable|edited|deleted|removed|trackable|tracked|enforced|"
+            r"configurable|visible|searchable|exportable|importable|"
+            # Past-participle forms of common product/UI verbs so questions
+            # like ``"What user settings should be displayed?"`` and
+            # ``"Which fields should be shown?"`` route to PRODUCT_BEHAVIOR
+            # instead of falling through to ``_default_answer`` once the
+            # actor cue path is no longer matched.
+            r"displayed|shown|rendered|hidden|stored|saved|sent|received|"
+            r"returned|generated|created|updated|imported|exported|"
+            r"validated|verified|confirmed|approved|notified)\b",
             lowered,
         )
         or re.search(

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -544,7 +544,13 @@ _INTENT_CUES: Mapping[QuestionIntent, tuple[str, ...]] = {
         "verification",
         "validate",
         "validation",
-        "test",
+        # NB: ``"test"`` is intentionally NOT in this list — bare substring
+        # matching of ``"test"`` would silently route unrelated questions
+        # like ``"Should users contest charges?"`` or ``"What is the latest
+        # output path?"`` into ``_verification_answer()``.  ``\btests?\b``
+        # already lives in ``_is_verification_question`` and uses regex
+        # word boundaries, so the verification path keeps full coverage of
+        # genuine "test"/"tests" questions without the false-positive risk.
         "definition of done",
         "done criteria",
         "how know it works",
@@ -695,8 +701,31 @@ def _classify_question_intents(question: str) -> frozenset[QuestionIntent]:
     return frozenset(intents)
 
 
+# Regex for cues composed only of plain ASCII letters (a–z), spaces, hyphens,
+# or apostrophes.  ASCII-letter cues are matched with regex word boundaries so
+# that broad nouns/verbs like ``"test"`` or ``"verify"`` cannot silently
+# substring-match unrelated words like ``"contest"``, ``"latest"``,
+# ``"protest"``, ``"attestations"``, or ``"overify"``.  Cues that contain
+# accented Latin or CJK characters fall through to plain substring matching
+# because Python's ``\b`` is undefined around CJK characters and the
+# multilingual cues we use are distinctive enough phrases (e.g. ``"cómo
+# verific"``, ``"검증"``).
+_ASCII_LATIN_CUE_RE = re.compile(r"^[a-z'\- ]+$")
+
+
+def _cue_matches(cue: str, lowered: str) -> bool:
+    if not _ASCII_LATIN_CUE_RE.match(cue):
+        return cue in lowered
+    if " " in cue or "-" in cue:
+        # Multi-word / hyphenated phrases: substring is safe because the
+        # phrase shape itself acts as the boundary (e.g. ``"out of scope"``,
+        # ``"definition of done"``).
+        return cue in lowered
+    return bool(re.search(rf"\b{re.escape(cue)}\b", lowered))
+
+
 def _contains_intent_cue(lowered: str, intent: QuestionIntent) -> bool:
-    return any(cue in lowered for cue in _INTENT_CUES[intent])
+    return any(_cue_matches(cue, lowered) for cue in _INTENT_CUES[intent])
 
 
 _IO_NOUN_CUES: tuple[str, ...] = (
@@ -711,10 +740,15 @@ _IO_NOUN_CUES: tuple[str, ...] = (
     "salida",
     "salidas",
     "entrée",
+    "entrées",
     "entree",
+    "entrees",
     "sortie",
+    "sorties",
     "eingabe",
+    "eingaben",
     "ausgabe",
+    "ausgaben",
     "입력",
     "출력",
     "入力",
@@ -769,7 +803,9 @@ _ACTOR_NOUN_CUES: tuple[str, ...] = (
     "actor",
     "actors",
     "persona",
+    "personas",
     "stakeholder",
+    "stakeholders",
     "usuario",
     "usuarios",
     "utilisateur",
@@ -815,14 +851,14 @@ _ACTOR_QUESTION_CUES: tuple[str, ...] = (
 
 
 def _has_io_cue_with_flow_shape(lowered: str) -> bool:
-    if not any(cue in lowered for cue in _IO_NOUN_CUES):
+    if not any(_cue_matches(cue, lowered) for cue in _IO_NOUN_CUES):
         return False
     return any(re.search(pattern, lowered) for pattern in _IO_FLOW_SHAPE_PATTERNS)
 
 
 def _has_actor_cue_with_question_shape(lowered: str) -> bool:
-    return any(cue in lowered for cue in _ACTOR_NOUN_CUES) and any(
-        cue in lowered for cue in _ACTOR_QUESTION_CUES
+    return any(_cue_matches(cue, lowered) for cue in _ACTOR_NOUN_CUES) and any(
+        _cue_matches(cue, lowered) for cue in _ACTOR_QUESTION_CUES
     )
 
 
@@ -921,13 +957,19 @@ _MULTILINGUAL_PRODUCT_BEHAVIOR_PATTERNS: tuple[str, ...] = (
     r"envoyer|exporter|t[ée]l[ée]charger|voir|consulter|acc[ée]der|approuver|"
     r"rejeter|annuler|assigner|notifier|configurer|afficher|stocker|enregistrer|"
     r"lire)\b",
-    # German: können/kann/dürfen/darf/sollen/soll/müssen/muss + mutation verb
-    r"\b(k[öo]nnen|kann|d[üu]rfen|darf|sollen|soll|sollte|sollten|m[üu]ssen|"
-    r"muss|m[üu]sste|m[üu]ssten)\b"
-    r"[^?]*?\b(l[öo]schen|entfernen|erstellen|anlegen|bearbeiten|aktualisieren|"
-    r"senden|exportieren|herunterladen|anzeigen|sehen|zugreifen|genehmigen|"
-    r"ablehnen|stornieren|zuweisen|benachrichtigen|konfigurieren|generieren|"
-    r"speichern|lesen)\b",
+    # German: können/kann/dürfen/darf/sollen/soll/müssen/muss + mutation verb.
+    # Accepts both umlauted (``dürfen``, ``löschen``) and the conventional
+    # ASCII transliterations (``duerfen``, ``loeschen``) so questions written
+    # without umlauts (common when typed on non-DE keyboards) still classify
+    # as product behavior.  Without the ASCII alternates,
+    # ``"Welche Benutzer duerfen Branches loeschen?"`` would silently fall to
+    # ACTOR_IO and inject ``actors``/``inputs``/``outputs``.
+    r"\b(k(?:[öo]|oe)nnen|kann|d(?:[üu]|ue)rfen|darf|sollen|soll|sollte|sollten|"
+    r"m(?:[üu]|ue)ssen|muss|m(?:[üu]|ue)sste|m(?:[üu]|ue)ssten)\b"
+    r"[^?]*?\b(l(?:[öo]|oe)schen|entfernen|erstellen|anlegen|bearbeiten|"
+    r"aktualisieren|senden|exportieren|herunterladen|anzeigen|sehen|zugreifen|"
+    r"genehmigen|ablehnen|stornieren|zuweisen|benachrichtigen|konfigurieren|"
+    r"generieren|speichern|lesen)\b",
     # Korean: action noun + Korean verb-formation morpheme (하|할|되|돼|됨|
     # 됩|됐|할까|하나|하지|되나|되어야) + (later) a permission/modal cue.
     # Anchoring on the verb morpheme prevents noun substrings like ``저장``

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -689,7 +689,7 @@ def _classify_question_intents(question: str) -> frozenset[QuestionIntent]:
         intents.add(QuestionIntent.ACTOR_IO)
     if _has_runtime_context_intent(lowered):
         intents.add(QuestionIntent.RUNTIME_CONTEXT)
-    if _is_product_behavior_question(lowered):
+    if _has_product_behavior_intent(lowered):
         intents.add(QuestionIntent.PRODUCT_BEHAVIOR)
 
     return frozenset(intents)
@@ -892,6 +892,96 @@ def _has_runtime_context_intent(lowered: str) -> bool:
     if not _contains_intent_cue(lowered, QuestionIntent.RUNTIME_CONTEXT):
         return False
     return _has_runtime_selection_shape(lowered)
+
+
+# Cross-lingual permission/action shape for product-behavior questions.  The
+# strict English ``_is_product_behavior_question()`` covers
+# ``can|should|must|...`` paired with mutation/visibility verbs.  Without an
+# equivalent multilingual layer, non-English permission questions like
+# ``Quels utilisateurs peuvent supprimer des branches?`` or
+# ``哪些用户可以删除分支?`` collide with the new actor cues — they get the
+# ACTOR_IO intent only, and the answerer injects ``actors``/``inputs``/
+# ``outputs`` assumptions instead of preserving the requested authorization
+# behavior in the ledger contract.  These patterns add the missing
+# multilingual coverage so PRODUCT_BEHAVIOR wins routing precedence as
+# intended.  This is a direct response to ouroboros-agent's design note that
+# the classifier and the route recognizers were asymmetric.
+_MULTILINGUAL_PRODUCT_BEHAVIOR_PATTERNS: tuple[str, ...] = (
+    # Spanish: pueden/puede/deben/debe/podrán/podrían + mutation/visibility verb
+    r"\b(pueden|puede|podr[áa]n?|podr[íi]an|deben|debe|deber[áa]n?|deber[íi]an?)\b"
+    r"[^?]*?\b(eliminar|borrar|crear|editar|modificar|actualizar|enviar|generar|"
+    r"exportar|descargar|ver|acceder|aprobar|rechazar|cancelar|asignar|notificar|"
+    r"configurar|mostrar|guardar|almacenar|leer)\b",
+    # French: peut/peuvent/doit/doivent/pourra/devraient + mutation/visibility verb.
+    # Hyphenated subject pronouns ("doit-il", "peut-on") are split by the
+    # ``\b`` word boundary.
+    r"\b(peut|peuvent|doit|doivent|pourra|pourront|pourraient|"
+    r"devrait|devraient|peut[- ]on)\b"
+    r"[^?]*?\b(supprimer|effacer|cr[ée]er|modifier|mettre[- ]?[àa][- ]?jour|"
+    r"envoyer|exporter|t[ée]l[ée]charger|voir|consulter|acc[ée]der|approuver|"
+    r"rejeter|annuler|assigner|notifier|configurer|afficher|stocker|enregistrer|"
+    r"lire)\b",
+    # German: können/kann/dürfen/darf/sollen/soll/müssen/muss + mutation verb
+    r"\b(k[öo]nnen|kann|d[üu]rfen|darf|sollen|soll|sollte|sollten|m[üu]ssen|"
+    r"muss|m[üu]sste|m[üu]ssten)\b"
+    r"[^?]*?\b(l[öo]schen|entfernen|erstellen|anlegen|bearbeiten|aktualisieren|"
+    r"senden|exportieren|herunterladen|anzeigen|sehen|zugreifen|genehmigen|"
+    r"ablehnen|stornieren|zuweisen|benachrichtigen|konfigurieren|generieren|"
+    r"speichern|lesen)\b",
+    # Korean: action noun + Korean verb-formation morpheme (하|할|되|돼|됨|
+    # 됩|됐|할까|하나|하지|되나|되어야) + (later) a permission/modal cue.
+    # Anchoring on the verb morpheme prevents noun substrings like ``저장``
+    # inside ``저장소`` (repository) or ``읽`` inside ``읽기`` from falsely
+    # triggering the pattern on runtime/IO questions.
+    r"(삭제|제거|생성|편집|수정|업데이트|전송|다운로드|표시|보기|접근|"
+    r"승인|거부|취소|할당|알림|구성|설정|저장|읽기|보내기|만들기|받기|"
+    r"내보내기|내려받기|로그인|로그아웃|업로드)"
+    r"(?:하|할|함|되|됨|돼|됩|됐|할까|하나|하지|되나|되어야)"
+    r"[^?]*?(수\s*있|수\s*없|해야|해도|가능|있나|있을까|할까|허용|허락)",
+    r"(수\s*있|수\s*없|해야|해도|가능|있나|있을까|할까|허용|허락)"
+    r"[^?]*?(삭제|제거|생성|편집|수정|업데이트|전송|다운로드|표시|보기|"
+    r"접근|승인|거부|취소|할당|알림|구성|설정|저장|읽기|보내기|만들기|"
+    r"받기|내보내기|내려받기|로그인|로그아웃|업로드)"
+    r"(?:하|할|함|되|됨|돼|됩|됐)",
+    # Japanese: action verb + できる/できます/してもよい/可能/していい (or reverse).
+    r"(削除|消去|作成|作る|追加|編集|更新|送信|送る|エクスポート|表示|見|"
+    r"アクセス|承認|却下|キャンセル|割り当て|通知|設定|構成|生成|"
+    r"ダウンロード|保存|読)"
+    r"[^?]*?(できる|できます|できますか|してもよい|してよい|可能|していい|"
+    r"してください|すべき|すべきか)",
+    r"(できる|できます|できますか|してもよい|してよい|可能|していい|"
+    r"すべき|すべきか)"
+    r"[^?]*?(削除|消去|作成|作る|追加|編集|更新|送信|送る|エクスポート|"
+    r"表示|見|アクセス|承認|却下|キャンセル|割り当て|通知|設定|構成|"
+    r"生成|ダウンロード|保存|読)",
+    # Chinese (simplified + traditional): permission modal + mutation verb,
+    # or mutation verb + permission modal.
+    r"(可以|可|应该|應該|必须|必須|能|能否|应當|應當|該|应|须|須)"
+    r"[^?]*?(删除|刪除|创建|建立|创|建|添加|编辑|編輯|更新|修改|发送|"
+    r"發送|发|導出|导出|匯出|下载|下載|查看|访问|訪問|批准|拒绝|拒絕|"
+    r"取消|分配|通知|配置|生成|存储|存儲|读取|讀取|显示|顯示)",
+    r"(删除|刪除|创建|建立|创|建|添加|编辑|編輯|更新|修改|发送|發送|发|"
+    r"導出|导出|匯出|下载|下載|查看|访问|訪問|批准|拒绝|拒絕|取消|分配|"
+    r"通知|配置|生成|存储|存儲|读取|讀取|显示|顯示)"
+    r"[^?]*?(可以|可|应该|應該|必须|必須|能|能否|应當|應當|該|应|须|須)",
+)
+
+
+def _has_product_behavior_intent(lowered: str) -> bool:
+    """Classify product-behavior intent across English and other languages.
+
+    Without multilingual coverage the classifier becomes asymmetric: actor and
+    runtime cues recognise non-English wording but PRODUCT_BEHAVIOR does not,
+    so non-English permission / behavior questions get misrouted to ACTOR_IO
+    or RUNTIME_CONTEXT (e.g. ``"哪些用户可以删除分支?"`` writing
+    ``actors``/``inputs``/``outputs`` instead of preserving the requested
+    authorization behavior).  This helper restores symmetry.
+    """
+    if _is_product_behavior_question(lowered):
+        return True
+    return any(
+        re.search(pattern, lowered) for pattern in _MULTILINGUAL_PRODUCT_BEHAVIOR_PATTERNS
+    )
 
 
 def _is_verification_question(lowered: str) -> bool:

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -580,7 +580,13 @@ _INTENT_CUES: Mapping[QuestionIntent, tuple[str, ...]] = {
     QuestionIntent.ACCEPTANCE_CRITERIA: (
         "acceptance criteria",
         "acceptance criterion",
-        "acceptance",
+        # NB: bare ``"acceptance"`` is intentionally NOT a cue — it would
+        # silently match property/status questions like ``"What is the
+        # acceptance status?"`` and route them through
+        # ``_feature_acceptance_answer()``.  ``_is_feature_acceptance_question``
+        # already covers genuine English acceptance-criteria questions via a
+        # ``\b(acceptance|criteria)\b`` pre-filter combined with stronger
+        # shape checks, so we don't need a bare cue for English coverage.
         "success criteria",
         "completion criteria",
         "criterios de aceptación",
@@ -815,6 +821,8 @@ _IO_FLOW_SHAPE_PATTERNS: tuple[str, ...] = (
 _ACTOR_NOUN_CUES: tuple[str, ...] = (
     "actor",
     "actors",
+    "user",
+    "users",
     "persona",
     "personas",
     "stakeholder",

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -135,10 +135,21 @@ class AutoAnswerer:
         # ``"用户可以验证他们的电子邮件吗？"``, ``"사용자가 이메일을
         # 확인할 수 있나요?"``) preserve the product feature contract instead
         # of being collapsed into a generic verification-plan template.
-        product_present = QuestionIntent.PRODUCT_BEHAVIOR in intents
-        if QuestionIntent.VERIFICATION in intents and not product_present:
+        # Demote VERIFICATION / ACCEPTANCE_CRITERIA in favour of
+        # PRODUCT_BEHAVIOR ONLY when the question is a user-facing
+        # verification feature (actor + permission modal + verify-verb,
+        # without a first-person-plural meta subject).  Other
+        # product-behavior matchers (English ``should…delete``, Spanish
+        # ``pueden…eliminar``, etc.) match the INNER permission clause of
+        # meta-verify questions like ``"Should we verify users can delete
+        # branches?"`` — those should still route to ``_verification_answer``,
+        # not ``_product_behavior_answer``.
+        demote_for_user_verify = (
+            QuestionIntent.PRODUCT_BEHAVIOR in intents and _has_user_verify_feature_shape(lowered)
+        )
+        if QuestionIntent.VERIFICATION in intents and not demote_for_user_verify:
             return self._verification_answer(question)
-        if QuestionIntent.ACCEPTANCE_CRITERIA in intents and not product_present:
+        if QuestionIntent.ACCEPTANCE_CRITERIA in intents and not demote_for_user_verify:
             return self._feature_acceptance_answer(question)
         if QuestionIntent.RUNTIME_CONTEXT in intents and _should_preserve_runtime_route(lowered):
             answer = self._runtime_answer(question, context)
@@ -552,6 +563,19 @@ _INTENT_CUES: Mapping[QuestionIntent, tuple[str, ...]] = {
         "verification",
         "validate",
         "validation",
+        # Spanish / German verify-verb infinitives so meta-verify questions
+        # like ``"¿Deberíamos verificar que los usuarios pueden eliminar
+        # ramas?"`` and ``"Sollten wir verifizieren, ob Benutzer Branches
+        # löschen können?"`` still classify as VERIFICATION (the routing
+        # layer then preserves the verification path because the question
+        # has a first-person-plural meta subject).
+        "verificar",
+        "comprobar",
+        "confirmar",
+        "verifizieren",
+        "validieren",
+        "bestätigen",
+        "bestaetigen",
         # NB: ``"test"`` is intentionally NOT in this list — bare substring
         # matching of ``"test"`` would silently route unrelated questions
         # like ``"Should users contest charges?"`` or ``"What is the latest
@@ -1130,7 +1154,19 @@ _FIRST_PERSON_META_RE = re.compile(
     r"\b(we|us|our|ours|"
     r"nous|notre|nos|"
     r"wir|uns|unser|unsere|unseren|unserem|unserer|"
-    r"nosotros|nosotras|nuestro|nuestra|nuestros|nuestras)\b"
+    r"nosotros|nosotras|nuestro|nuestra|nuestros|nuestras|"
+    # Spanish first-person plural verb forms.  ``-mos`` is unambiguously
+    # 1pp in standard usage, so these are safe meta signals.  Listing the
+    # specific common verbs keeps the matcher precise.
+    r"deber[íi]amos|debemos|deb[íi]amos|"
+    r"podr[íi]amos|podemos|pod[íi]amos|"
+    r"verificamos|verificar[íi]amos|validamos|comprobamos|confirmamos|"
+    r"necesitamos|necesitar[íi]amos|hacemos|haremos|queremos|"
+    # French first-person plural ``-ons`` verb forms.
+    r"devrions|devons|devions|"
+    r"pourrions|pouvons|pouvions|"
+    r"v[ée]rifions|v[ée]rifierions|validons|confirmons|approuvons|"
+    r"voulons|voudrions)\b"
     r"|私たち|私達|我们|我們|우리|저희"
 )
 

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -1184,7 +1184,17 @@ def _acceptance_subject(question: str) -> str:
 
 
 def _slug_key(value: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    """Build a stable, language-aware ledger key fragment from arbitrary text.
+
+    Earlier this stripped everything outside ``[a-z0-9]``, which meant CJK
+    questions like ``"哪些用户可以删除分支?"`` and
+    ``"用户可以验证他们的电子邮件吗？"`` both collapsed to the
+    ``requested_behavior`` fallback and silently merged into the same
+    ledger slot.  Now we keep Unicode letters / digits (``\\w`` is
+    Unicode-aware in Python 3 by default) so non-English questions each
+    produce a distinct, descriptive key.
+    """
+    slug = re.sub(r"[^\w]+", "_", value.casefold(), flags=re.UNICODE).strip("_")
     return slug[:64] or "requested_behavior"
 
 

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -700,6 +700,36 @@ def test_auto_answerer_cjk_property_lookup_does_not_misroute_to_runtime() -> Non
         assert "runtime_context" not in updated_sections, (question, updated_sections)
 
 
+def test_auto_answerer_user_settings_questions_route_to_product_behavior() -> None:
+    """``"What user settings should be displayed?"`` and ``"Which user fields
+    should be editable?"`` are product-behavior questions about a user-facing
+    feature, not actor / IO contract questions.  Flagged by ouroboros-agent
+    on commit 8e0d789 — the bare ``"what user"`` / ``"which user"`` actor
+    cues caused these to misroute to ``_io_actor_answer``.  Routing now
+    drops those cues and ``_is_product_behavior_question`` recognises
+    past-participle forms (``displayed`` / ``shown`` / ``stored`` / etc.).
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "What user settings should be displayed?",
+        "Which user settings should be displayed?",
+        "Which user fields should be shown?",
+    )
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        # Must NOT inject actor / IO assumptions for a settings/fields question.
+        assert "actors" not in updated_sections, (question, updated_sections)
+        assert "inputs" not in updated_sections, (question, updated_sections)
+        assert "outputs" not in updated_sections, (question, updated_sections)
+        # Should preserve the requested behavior in constraints + acceptance.
+        assert {"constraints", "acceptance_criteria"} <= updated_sections, (
+            question,
+            updated_sections,
+        )
+
+
 def test_auto_answerer_english_user_actor_questions_route_to_actor_io() -> None:
     """Common English actor questions like ``"Who is the primary user?"`` and
     ``"Which user is the primary user?"`` must populate ``actors`` /

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -797,14 +797,24 @@ def test_auto_answerer_meta_verify_questions_stay_on_verification_route() -> Non
     the same actor-noun + permission-modal + verify-verb tokens as user
     feature questions, but the OUTER subject is engineering / first-person
     plural — they ask about QA, not a product feature.  Flagged by
-    ouroboros-agent on commit 4ae40d4.  ``_has_user_verify_feature_shape``
-    now requires the absence of a first-person-plural meta subject.
+    ouroboros-agent on commit 4ae40d4 (English/French) and again on commit
+    5e60302 for cases where other product-behavior matchers (English
+    ``should…delete`` or Spanish ``pueden…eliminar``) match the inner
+    permission clause.  Routing now demotes VERIFICATION only when the
+    user-verify shape itself matches, not whenever any product-behavior
+    matcher fires.
     """
     answerer = AutoAnswerer()
     questions = (
         "Should we verify users can reset passwords?",
         "How should we validate admins can log in?",
         "Devrions-nous vérifier que les utilisateurs peuvent se connecter?",
+        # Bot's commit-5e60302 reproductions (inner permission clause
+        # triggers other product-behavior matchers too).
+        "Should we verify users can delete branches?",
+        "Devrions-nous vérifier que les utilisateurs peuvent supprimer des branches?",
+        "¿Deberíamos verificar que los usuarios pueden eliminar ramas?",
+        "我们是否应该验证用户可以删除分支？",
     )
     for question in questions:
         answer = answerer.answer(question, SeedDraftLedger.from_goal("Build an auth service"))

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -645,6 +645,35 @@ def test_auto_answerer_routes_multilingual_questions_by_ledger_intent() -> None:
         assert expected_sections <= updated_sections, question
 
 
+def test_auto_answerer_property_lookup_cues_do_not_misroute_to_intent_handlers() -> None:
+    """Broad cue substrings (``input``, ``output``, ``repository``, ``architecture``)
+    must not by themselves trigger ACTOR_IO or RUNTIME_CONTEXT routing.  These
+    questions are property/status lookups, not contract or selection questions,
+    and would otherwise mutate ledger state with the wrong contract — the exact
+    silent misrouting flagged by ouroboros-agent on commit 9ab5ae1.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "What is the output directory?",
+        "What is the input schema?",
+        "What is the repository status?",
+        "What architecture decisions are documented?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+
+        assert answer.blocker is None, question
+        assert answer.source == AutoAnswerSource.CONSERVATIVE_DEFAULT, question
+        # Routing must not write actor/IO or runtime ledger entries for these
+        # property-shaped questions — the safe default is the only outcome.
+        assert "actors" not in updated_sections, question
+        assert "inputs" not in updated_sections, question
+        assert "outputs" not in updated_sections, question
+        assert "runtime_context" not in updated_sections, question
+
+
 def test_auto_answerer_unknown_multilingual_question_uses_safe_default() -> None:
     answer = AutoAnswerer().answer(
         "¿Cuál es el color favorito del tablero?",

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -719,6 +719,29 @@ def test_auto_answerer_english_user_actor_questions_route_to_actor_io() -> None:
         assert {"actors", "inputs", "outputs"} <= updated_sections, (question, updated_sections)
 
 
+def test_auto_answerer_multilingual_direct_lookup_routes_to_runtime() -> None:
+    """Bare direct-lookup runtime questions in non-English languages must
+    populate ``runtime_context``.  Flagged by ouroboros-agent on commit
+    6a939bf — without a multilingual direct-lookup shape, examples like
+    ``"¿Qué framework?"``, ``"ランタイムは何ですか?"``, and ``"框架是什么？"``
+    fell through to ``_default_answer()``.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "¿Qué framework?",
+        "Quel framework ?",
+        "Welches Framework?",
+        "ランタイムは何ですか?",
+        "框架是什么？",
+        "런타임은 무엇인가요?",
+    )
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        assert "runtime_context" in updated_sections, (question, updated_sections)
+
+
 def test_auto_answerer_cjk_questions_produce_distinct_ledger_keys() -> None:
     """``_slug_key()`` must keep Unicode letters so different CJK questions
     produce different ledger keys instead of all collapsing onto the

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -719,6 +719,35 @@ def test_auto_answerer_english_user_actor_questions_route_to_actor_io() -> None:
         assert {"actors", "inputs", "outputs"} <= updated_sections, (question, updated_sections)
 
 
+def test_auto_answerer_cjk_questions_produce_distinct_ledger_keys() -> None:
+    """``_slug_key()`` must keep Unicode letters so different CJK questions
+    produce different ledger keys instead of all collapsing onto the
+    fallback ``"requested_behavior"``.  Flagged by ouroboros-agent on
+    commit 1581a7b — the contract boundary regression where multilingual
+    routing landed correctly but ledger keys silently merged unrelated
+    requirements together.
+    """
+    answerer = AutoAnswerer()
+    question_a = "哪些用户可以删除分支?"
+    question_b = "用户可以验证他们的电子邮件吗？"
+
+    answer_a = answerer.answer(question_a, SeedDraftLedger.from_goal("Build a CLI"))
+    answer_b = answerer.answer(question_b, SeedDraftLedger.from_goal("Build an auth service"))
+
+    keys_a = sorted({entry.key for _section, entry in answer_a.ledger_updates})
+    keys_b = sorted({entry.key for _section, entry in answer_b.ledger_updates})
+
+    # Both questions must produce ``constraints.behavior.<subject>`` keys
+    # (or ``acceptance.<subject>`` keys for acceptance routes).
+    assert any(".behavior." in k or k.startswith("acceptance.") for k in keys_a), keys_a
+    assert any(".behavior." in k or k.startswith("acceptance.") for k in keys_b), keys_b
+    # Keys must NOT collapse onto the language-blind fallback.
+    assert not any(k.endswith(".requested_behavior") for k in keys_a), keys_a
+    assert not any(k.endswith(".requested_behavior") for k in keys_b), keys_b
+    # Keys for two distinct questions must differ.
+    assert keys_a != keys_b, (keys_a, keys_b)
+
+
 def test_auto_answerer_acceptance_status_does_not_misroute_to_acceptance_route() -> None:
     """Bare ``"acceptance"`` substring must not classify property/status
     questions like ``"What is the acceptance status?"`` as

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -680,6 +680,28 @@ def test_auto_answerer_multilingual_permission_questions_route_to_product_behavi
         assert "outputs" not in updated_sections, question
 
 
+def test_auto_answerer_broad_design_cues_do_not_misroute_to_runtime() -> None:
+    """Broad design nouns (``architecture``, ``estructura``, ``cadre``) plus a
+    generic selection verb must NOT be classified as runtime intent.  The
+    previous cue list paired ``estructura`` with selection verbs like
+    ``usamos`` and silently routed design questions such as
+    ``¿Qué estructura usamos para los datos?`` into ``_runtime_answer()``.
+    Flagged by ouroboros-agent on commit 0230bab.  Cues are now anchored to
+    repository-/runtime-specific phrases only.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "¿Qué estructura usamos para los datos?",
+        "Quelle architecture utilisons-nous pour le rapport?",
+        "What architecture should the report use?",
+    )
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        assert "runtime_context" not in updated_sections, (question, updated_sections)
+
+
 def test_auto_answerer_substring_cues_do_not_misroute_unrelated_words() -> None:
     """Bare ASCII substring cues (e.g. ``"test"``) must not match unrelated
     words (``"contest"``, ``"latest"``, ``"protest"``, ``"attestations"``).

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -700,6 +700,45 @@ def test_auto_answerer_cjk_property_lookup_does_not_misroute_to_runtime() -> Non
         assert "runtime_context" not in updated_sections, (question, updated_sections)
 
 
+def test_auto_answerer_english_user_actor_questions_route_to_actor_io() -> None:
+    """Common English actor questions like ``"Who is the primary user?"`` and
+    ``"Which user is the primary user?"`` must populate ``actors`` /
+    ``inputs`` / ``outputs``.  Flagged by ouroboros-agent on commit f59d4e7
+    after the actor cue list previously omitted ``user``/``users``.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "Who is the primary user?",
+        "Which user is the primary user?",
+        "Who is the end user?",
+    )
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        assert {"actors", "inputs", "outputs"} <= updated_sections, (question, updated_sections)
+
+
+def test_auto_answerer_acceptance_status_does_not_misroute_to_acceptance_route() -> None:
+    """Bare ``"acceptance"`` substring must not classify property/status
+    questions like ``"What is the acceptance status?"`` as
+    ``ACCEPTANCE_CRITERIA``.  Flagged by ouroboros-agent on commit f59d4e7 —
+    same false-positive class as ``output`` / ``repository`` substring
+    matches.
+    """
+    answerer = AutoAnswerer()
+    answer = answerer.answer(
+        "What is the acceptance status?",
+        SeedDraftLedger.from_goal("Build a CLI"),
+    )
+    updated_sections = {section for section, _entry in answer.ledger_updates}
+    assert answer.blocker is None
+    # Must fall through to the conservative default — no acceptance /
+    # verification ledger sections written, no actor/IO injection.
+    assert "acceptance_criteria" not in updated_sections, updated_sections
+    assert "verification_plan" not in updated_sections, updated_sections
+
+
 def test_auto_answerer_meta_verify_questions_stay_on_verification_route() -> None:
     """Meta-verification questions like ``"Should we verify users can reset
     passwords?"`` and ``"How should we validate admins can log in?"`` share

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -622,6 +622,43 @@ def test_auto_answerer_routes_common_input_output_prompts_to_io_ledger() -> None
         assert not {"constraints", "failure_modes"} >= updated_sections
 
 
+def test_auto_answerer_routes_multilingual_questions_by_ledger_intent() -> None:
+    answerer = AutoAnswerer()
+    cases = (
+        ("¿Quién es el usuario principal?", {"actors", "inputs", "outputs"}),
+        ("Quelles sorties le CLI doit-il produire?", {"actors", "inputs", "outputs"}),
+        (
+            "Quels critères d'acceptation le rapport doit-il satisfaire?",
+            {"acceptance_criteria", "verification_plan"},
+        ),
+        ("¿Cómo verificamos que funciona?", {"verification_plan", "acceptance_criteria"}),
+        ("어떤 런타임과 저장소 구조를 사용해야 하나요?", {"runtime_context", "constraints"}),
+        ("哪些功能不在范围内?", {"non_goals"}),
+        ("リポジトリのランタイムは何を使いますか?", {"runtime_context", "constraints"}),
+    )
+
+    for question, expected_sections in cases:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+
+        assert answer.blocker is None, question
+        assert expected_sections <= updated_sections, question
+
+
+def test_auto_answerer_unknown_multilingual_question_uses_safe_default() -> None:
+    answer = AutoAnswerer().answer(
+        "¿Cuál es el color favorito del tablero?",
+        SeedDraftLedger.from_goal("Build a dashboard"),
+    )
+
+    assert answer.blocker is None
+    assert answer.source == AutoAnswerSource.CONSERVATIVE_DEFAULT
+    assert [entry.key for _section, entry in answer.ledger_updates] == [
+        "constraints.conservative_mvp",
+        "failure_modes.unverified_or_scope_creep",
+    ]
+
+
 def test_auto_answerer_blocks_production_environment_selection_variants() -> None:
     questions = (
         "Which production environment should we deploy to?",

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -671,7 +671,10 @@ def test_auto_answerer_multilingual_permission_questions_route_to_product_behavi
         assert answer.blocker is None, question
         # Product-behavior contract is preserved (constraints + acceptance) and
         # actor/IO assumptions are NOT injected.
-        assert {"constraints", "acceptance_criteria"} <= updated_sections, (question, updated_sections)
+        assert {"constraints", "acceptance_criteria"} <= updated_sections, (
+            question,
+            updated_sections,
+        )
         assert "actors" not in updated_sections, question
         assert "inputs" not in updated_sections, question
         assert "outputs" not in updated_sections, question

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -680,6 +680,58 @@ def test_auto_answerer_multilingual_permission_questions_route_to_product_behavi
         assert "outputs" not in updated_sections, question
 
 
+def test_auto_answerer_cjk_property_lookup_does_not_misroute_to_runtime() -> None:
+    """CJK runtime cues paired with bare noun-style "selection shape" tokens
+    (``설정`` / ``設定`` / ``配置``) used to misroute property/status lookups
+    like ``런타임 설정은 어디에 표시되나요?`` into ``_runtime_answer()``.
+    Flagged by ouroboros-agent on commit 4c1ee42.  Selection shape now
+    requires a verb-distinctive cue (``사용``/``선택``/``채택``/``도입`` etc.).
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "런타임 설정은 어디에 표시되나요?",
+        "ランタイム設定はどこに表示されますか?",
+        "运行时配置显示在哪里？",
+    )
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        assert "runtime_context" not in updated_sections, (question, updated_sections)
+
+
+def test_auto_answerer_user_verify_feature_routes_to_product_behavior() -> None:
+    """User-verify feature questions like ``Can users verify their email?``
+    must route to PRODUCT_BEHAVIOR instead of being collapsed into a generic
+    verification-plan template.  Flagged by ouroboros-agent on commit
+    4c1ee42 in English / French / Chinese / Korean variants.  Routing
+    precedence now prefers PRODUCT_BEHAVIOR over VERIFICATION when both are
+    inferred, and verify-style verbs are recognised as product actions.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "Can users verify their email?",
+        "Les utilisateurs peuvent-ils vérifier leur e-mail ?",
+        "用户可以验证他们的电子邮件吗？",
+        "사용자가 이메일을 확인할 수 있나요?",
+    )
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build an auth service"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        assert {"constraints", "acceptance_criteria"} <= updated_sections, (
+            question,
+            updated_sections,
+        )
+        # The product behavior subject must be surfaced in the constraint key.
+        constraint_keys = [
+            entry.key
+            for section, entry in answer.ledger_updates
+            if section == "constraints" and entry.key.startswith("constraints.behavior.")
+        ]
+        assert constraint_keys, (question, [k for _s, e in answer.ledger_updates for k in [e.key]])
+
+
 def test_auto_answerer_broad_design_cues_do_not_misroute_to_runtime() -> None:
     """Broad design nouns (``architecture``, ``estructura``, ``cadre``) plus a
     generic selection verb must NOT be classified as runtime intent.  The

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -680,6 +680,45 @@ def test_auto_answerer_multilingual_permission_questions_route_to_product_behavi
         assert "outputs" not in updated_sections, question
 
 
+def test_auto_answerer_substring_cues_do_not_misroute_unrelated_words() -> None:
+    """Bare ASCII substring cues (e.g. ``"test"``) must not match unrelated
+    words (``"contest"``, ``"latest"``, ``"protest"``, ``"attestations"``).
+    Flagged by ouroboros-agent on commit 52a9ee7 as a silent verification
+    misrouting regression.  Cue matching now uses regex word boundaries for
+    ASCII Latin cues.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "Should users contest charges?",
+        "What is the latest output path?",
+        "How are protest votes counted?",
+    )
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        assert "verification_plan" not in updated_sections, (question, updated_sections)
+
+
+def test_auto_answerer_german_ascii_transliteration_routes_to_product_behavior() -> None:
+    """German ASCII transliterations (``duerfen``/``loeschen``) must be treated
+    the same as their umlauted forms.  Flagged by ouroboros-agent on commit
+    52a9ee7 as a realistic silent-misrouting gap because most German keyboards
+    on dev workstations type ``ue``/``ae``/``oe`` rather than ``ü``/``ä``/``ö``.
+    """
+    answerer = AutoAnswerer()
+    answer = answerer.answer(
+        "Welche Benutzer duerfen Branches loeschen?",
+        SeedDraftLedger.from_goal("Build a CLI"),
+    )
+    updated_sections = {section for section, _entry in answer.ledger_updates}
+    assert answer.blocker is None
+    assert {"constraints", "acceptance_criteria"} <= updated_sections
+    assert "actors" not in updated_sections
+    assert "inputs" not in updated_sections
+    assert "outputs" not in updated_sections
+
+
 def test_auto_answerer_property_lookup_cues_do_not_misroute_to_intent_handlers() -> None:
     """Broad cue substrings (``input``, ``output``, ``repository``, ``architecture``)
     must not by themselves trigger ACTOR_IO or RUNTIME_CONTEXT routing.  These

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -2114,3 +2114,132 @@ def test_ledger_summary_treats_inference_only_sections_as_assumption_only() -> N
     assert "actors" in summary["provenance"].get("inference", [])
     assert "actors" not in summary["evidence_backed_sections"]
     assert "actors" in summary["assumption_only_sections"]
+
+
+def test_auto_answerer_possessive_actor_routes_to_product_behavior() -> None:
+    """Possessive determiners modifying the actor noun must NOT trip the
+    first-person-plural meta filter.
+
+    ``Can our users verify their email?`` is a user-facing feature question:
+    the actor is ``users`` and ``our`` is just a possessive modifier.  An
+    earlier revision treated any occurrence of ``our``/``ours`` (and the
+    French/German/Spanish possessive equivalents ``notre``/``nos``/
+    ``unser*``/``nuestro*``) as an engineering meta subject, which silently
+    demoted user-feature verification questions to
+    ``_verification_answer()`` and corrupted the ledger contract.
+
+    Ref: ouroboros-agent[bot] BLOCKING on commit a447fc1 — answerer.py:1094.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "Can our users verify their email?",
+        "Can ours users verify their email?",
+        "Les utilisateurs de notre plateforme peuvent-ils vérifier leur e-mail ?",
+        "¿Pueden nuestros usuarios verificar su correo electrónico?",
+        "Können unsere Benutzer ihre E-Mail verifizieren?",
+    )
+    ledger = SeedDraftLedger.from_goal("Build an auth service")
+    for question in questions:
+        answer = answerer.answer(question, ledger)
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        assert {"constraints", "acceptance_criteria"} <= updated_sections, (
+            question,
+            updated_sections,
+        )
+        constraint_keys = [
+            entry.key
+            for section, entry in answer.ledger_updates
+            if section == "constraints" and entry.key.startswith("constraints.behavior.")
+        ]
+        assert constraint_keys, (
+            question,
+            [entry.key for _section, entry in answer.ledger_updates],
+        )
+
+
+def test_auto_answerer_meta_first_person_subject_still_routes_to_verification() -> None:
+    """Meta-QA questions whose OUTER subject is engineering ("we"/"nous"/
+    "wir"/"deberíamos"/"devrions"/"我们是否"…) must keep routing to the
+    verification handler so the meta path tightening from the previous
+    review remains intact.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "Should we verify users can reset passwords?",
+        "Devrions-nous vérifier que les utilisateurs peuvent supprimer des branches?",
+        "¿Deberíamos verificar que los usuarios pueden eliminar ramas?",
+        "Sollten wir verifizieren, dass Benutzer Branches löschen können?",
+        "我们是否应该验证用户可以删除分支？",
+    )
+    ledger = SeedDraftLedger.from_goal("Build a CLI")
+    for question in questions:
+        answer = answerer.answer(question, ledger)
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        # Meta-QA questions must populate verification_plan / acceptance_criteria,
+        # NOT the product-behavior constraints path.
+        assert "verification_plan" in updated_sections, (question, updated_sections)
+        behavior_keys = [
+            entry.key
+            for section, entry in answer.ledger_updates
+            if section == "constraints" and entry.key.startswith("constraints.behavior.")
+        ]
+        assert not behavior_keys, (question, behavior_keys)
+
+
+def test_auto_answerer_blocks_compliance_policy_noun_questions() -> None:
+    """``support|enable|allow + regulated noun + (data) + policy noun`` must
+    remain blocked even when no active-form compliance verb is used.
+
+    Phrasings such as ``Should the app support HIPAA data retention?`` or
+    ``Should the platform enable GDPR data storage?`` skip the
+    ``_COMPLIANCE_POLICY_ACTIVE_VERBS_RE`` check (no active verb), and the
+    original ``_BARE_COMPLIANCE_SCOPE_RE`` only fired when the regulated
+    noun ended the clause.  That left the policy-as-toggle wording
+    incorrectly classified as safe product behaviour.
+
+    Ref: ouroboros-agent[bot] BLOCKING on commit a447fc1 — answerer.py:1561.
+    """
+    answerer = AutoAnswerer()
+    blocked_questions = (
+        ("Should the app support HIPAA data retention?", "regulated data handling"),
+        ("Should the platform enable GDPR data storage?", "regulated data handling"),
+        ("Should the system allow PII encryption?", "regulated personal data handling"),
+        ("Should the service support SOX data governance?", "regulated data handling"),
+        ("Should the platform support GDPR data processing?", "regulated data handling"),
+        ("Should the app enable HIPAA disclosure?", "regulated data handling"),
+        ("Should the system allow PII collection?", "regulated personal data handling"),
+    )
+
+    ledger = SeedDraftLedger.from_goal("Build a regulated data app")
+    for question, reason in blocked_questions:
+        answer = answerer.answer(question, ledger)
+        assert answer.source == AutoAnswerSource.BLOCKER, question
+        assert answer.blocker is not None, question
+        assert answer.blocker.reason == reason, question
+
+
+def test_auto_answerer_allows_qualified_compliance_policy_features() -> None:
+    """Concrete product features whose name happens to contain a compliance
+    policy noun must NOT be over-blocked by the new policy-noun rejector.
+
+    When the policy noun is followed by a qualifying feature noun
+    (``HIPAA retention reports``, ``GDPR storage dashboards``,
+    ``PII redaction in exports``) the question is asking about a bounded
+    product feature, not setting compliance policy.  These must continue to
+    pass through.
+    """
+    answerer = AutoAnswerer()
+    allowed_questions = (
+        "Should the platform support HIPAA retention reports?",
+        "Should the app enable GDPR storage dashboards?",
+        "Should the system allow PII redaction in exports?",
+        "Should the service support SOX compliance reporting?",
+    )
+
+    ledger = SeedDraftLedger.from_goal("Build a regulated data app")
+    for question in allowed_questions:
+        answer = answerer.answer(question, ledger)
+        assert answer.blocker is None, question
+        assert answer.source != AutoAnswerSource.BLOCKER, question

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -645,6 +645,38 @@ def test_auto_answerer_routes_multilingual_questions_by_ledger_intent() -> None:
         assert expected_sections <= updated_sections, question
 
 
+def test_auto_answerer_multilingual_permission_questions_route_to_product_behavior() -> None:
+    """Multilingual permission/product-behavior questions must NOT misroute to
+    actor/IO just because they contain an actor noun + interrogative.  Without
+    multilingual product-behavior detection the classifier was asymmetric:
+    actor cues recognised non-English wording but PRODUCT_BEHAVIOR did not, so
+    questions like ``Quels utilisateurs peuvent supprimer des branches?`` and
+    ``哪些用户可以删除分支?`` silently injected ``actors``/``inputs``/``outputs``
+    assumptions instead of preserving the requested authorization behavior.
+    Flagged by ouroboros-agent on commit 4694da0.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "Quels utilisateurs peuvent supprimer des branches?",
+        "哪些用户可以删除分支?",
+        "어떤 사용자가 브랜치를 삭제할 수 있나요?",
+        "Welche Benutzer dürfen Branches löschen?",
+        "¿Qué usuarios pueden eliminar ramas?",
+    )
+
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+
+        assert answer.blocker is None, question
+        # Product-behavior contract is preserved (constraints + acceptance) and
+        # actor/IO assumptions are NOT injected.
+        assert {"constraints", "acceptance_criteria"} <= updated_sections, (question, updated_sections)
+        assert "actors" not in updated_sections, question
+        assert "inputs" not in updated_sections, question
+        assert "outputs" not in updated_sections, question
+
+
 def test_auto_answerer_property_lookup_cues_do_not_misroute_to_intent_handlers() -> None:
     """Broad cue substrings (``input``, ``output``, ``repository``, ``architecture``)
     must not by themselves trigger ACTOR_IO or RUNTIME_CONTEXT routing.  These

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -700,6 +700,36 @@ def test_auto_answerer_cjk_property_lookup_does_not_misroute_to_runtime() -> Non
         assert "runtime_context" not in updated_sections, (question, updated_sections)
 
 
+def test_auto_answerer_meta_verify_questions_stay_on_verification_route() -> None:
+    """Meta-verification questions like ``"Should we verify users can reset
+    passwords?"`` and ``"How should we validate admins can log in?"`` share
+    the same actor-noun + permission-modal + verify-verb tokens as user
+    feature questions, but the OUTER subject is engineering / first-person
+    plural — they ask about QA, not a product feature.  Flagged by
+    ouroboros-agent on commit 4ae40d4.  ``_has_user_verify_feature_shape``
+    now requires the absence of a first-person-plural meta subject.
+    """
+    answerer = AutoAnswerer()
+    questions = (
+        "Should we verify users can reset passwords?",
+        "How should we validate admins can log in?",
+        "Devrions-nous vérifier que les utilisateurs peuvent se connecter?",
+    )
+    for question in questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build an auth service"))
+        updated_sections = {section for section, _entry in answer.ledger_updates}
+        assert answer.blocker is None, question
+        # Verification route writes verification_plan + acceptance_criteria;
+        # the product-behavior route would write constraints with a
+        # ``constraints.behavior.<subject>`` key, which must NOT appear here.
+        assert "verification_plan" in updated_sections, (question, updated_sections)
+        for _section, entry in answer.ledger_updates:
+            assert not entry.key.startswith("constraints.behavior."), (
+                question,
+                entry.key,
+            )
+
+
 def test_auto_answerer_user_verify_feature_routes_to_product_behavior() -> None:
     """User-verify feature questions like ``Can users verify their email?``
     must route to PRODUCT_BEHAVIOR instead of being collapsed into a generic


### PR DESCRIPTION
## Summary
- Refactors auto-answer question routing around intent/ledger targets rather than narrow exact English regex matches.
- Adds multilingual/paraphrase-aware matching for actor/user, input/output, acceptance, verification, runtime context, and non-goal/scope boundary questions.
- Adds regression coverage for non-English and paraphrased interview questions while preserving safe fallback behavior for unknown questions.

## Discussion / implementation notes
- This is a general routing improvement, not a domain-specific fix for any particular prompt.
- Unknown or low-confidence questions still fall back conservatively rather than filling unrelated ledger sections.

## Validation
- [x] `git diff --check`
- [x] `PYTHONPATH=src /opt/hermes/.venv/bin/python -m pytest tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_interview_pipeline.py -q` — 162 passed

Closes #756
