### PR TITLE
feat(auto): finalize safe default interview gaps

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -453,8 +453,7 @@ class AutoInterviewDriver:
             )
         except TimeoutError as exc:
             blocker = (
-                "safe-default synthesis could not be persisted to the interview "
-                f"transcript: {exc}"
+                f"safe-default synthesis could not be persisted to the interview transcript: {exc}"
             )
             state.mark_blocked(blocker, tool_name="interview.answer")
             record_authoring_backend(state)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -24,7 +24,11 @@ from ouroboros.auto.gap_detector import GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.repo_context import repo_auto_answer_context
-from ouroboros.auto.safe_defaults import finalize_safe_defaultable_gaps
+from ouroboros.auto.safe_defaults import (
+    SafeDefaultFinalization,
+    build_safe_default_synthesis,
+    finalize_safe_defaultable_gaps,
+)
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 
 log = structlog.get_logger(__name__)
@@ -263,6 +267,17 @@ class AutoInterviewDriver:
             )
             state.ledger = ledger.to_dict()
             if finalization.completed and ledger.is_seed_ready():
+                synthesis_blocker = await self._record_safe_default_synthesis(
+                    state, ledger, finalization
+                )
+                if synthesis_blocker is not None:
+                    return AutoInterviewResult(
+                        "blocked",
+                        state.interview_session_id,
+                        ledger,
+                        self.max_rounds,
+                        synthesis_blocker,
+                    )
                 state.pending_question = None
                 state.interview_completed = True
                 state.mark_progress(
@@ -407,6 +422,57 @@ class AutoInterviewDriver:
         record_authoring_backend(state)
         self._save(state)
         return AutoInterviewResult("blocked", state.interview_session_id, ledger, rounds, blocker)
+
+    async def _record_safe_default_synthesis(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        finalization: SafeDefaultFinalization,
+    ) -> str | None:
+        """Persist the safe-default synthesis through the interview backend.
+
+        The downstream seed generator reads from the interview transcript on
+        disk, not from the auto ledger, so a ledger that becomes Seed-ready
+        only via :func:`finalize_safe_defaultable_gaps` would otherwise leave
+        the transcript missing those assumptions (Q00/ouroboros#763 review on
+        ``c072ed94``). Push a one-shot synthesis answer through
+        ``backend.answer`` so the transcript and ledger stay in sync. Returns
+        a blocker string if the synthesis cannot be persisted; ``None`` on
+        success or when there is nothing to synthesize.
+        """
+        synthesis = build_safe_default_synthesis(finalization)
+        if not synthesis or not state.interview_session_id:
+            return None
+        try:
+            synthesis_turn = _validate_turn(
+                await self._with_timeout(
+                    self.backend.answer(state.interview_session_id, synthesis),
+                    state,
+                    tool_name="interview.answer",
+                )
+            )
+        except TimeoutError as exc:
+            blocker = (
+                "safe-default synthesis could not be persisted to the interview "
+                f"transcript: {exc}"
+            )
+            state.mark_blocked(blocker, tool_name="interview.answer")
+            record_authoring_backend(state)
+            self._save(state)
+            return blocker
+        except Exception as exc:
+            blocker = f"safe-default synthesis answer failed: {exc}"
+            state.mark_blocked(blocker, tool_name="interview.answer")
+            record_authoring_backend(state)
+            self._save(state)
+            return blocker
+        state.interview_session_id = synthesis_turn.session_id
+        ledger.record_qa(
+            state.pending_question or "auto safe-default finalization",
+            synthesis,
+        )
+        state.ledger = ledger.to_dict()
+        return None
 
     async def _with_timeout(
         self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -25,6 +25,8 @@ from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.safe_defaults import (
+    AUTO_ANSWER_PREFIX,
+    SAFE_DEFAULT_SYNTHESIS_TAG,
     SafeDefaultFinalization,
     build_safe_default_synthesis,
     finalize_safe_defaultable_gaps,
@@ -423,6 +425,16 @@ class AutoInterviewDriver:
         self._save(state)
         return AutoInterviewResult("blocked", state.interview_session_id, ledger, rounds, blocker)
 
+    # Maximum number of completion-signal turns the driver will send when
+    # closing the interview after safe-default finalization. The production
+    # InterviewHandler requires a stability streak of
+    # ``AUTO_COMPLETE_STREAK_REQUIRED`` (=2) qualifying completion signals
+    # before it actually closes the transcript, so a single synthesis turn
+    # does not always suffice — we send the full synthesis once and then
+    # short follow-up confirmations until the backend confirms or we hit
+    # this cap.
+    _SYNTHESIS_COMPLETION_MAX_ATTEMPTS = 3
+
     async def _record_safe_default_synthesis(
         self,
         state: AutoPipelineState,
@@ -435,60 +447,71 @@ class AutoInterviewDriver:
         disk, not from the auto ledger, so a ledger that becomes Seed-ready
         only via :func:`finalize_safe_defaultable_gaps` would otherwise leave
         the transcript missing those assumptions (Q00/ouroboros#763 review on
-        ``c072ed94``). Push a one-shot synthesis answer through
-        ``backend.answer`` so the transcript and ledger stay in sync. Returns
-        a blocker string if the synthesis cannot be persisted; ``None`` on
-        success or when there is nothing to synthesize.
+        ``c072ed94``). Push the synthesis answer through ``backend.answer``
+        so the transcript and ledger stay in sync, then send up to
+        :pyattr:`_SYNTHESIS_COMPLETION_MAX_ATTEMPTS - 1` short confirmation
+        turns until the backend signals ``seed_ready``/``completed``. The
+        production interview handler requires a streak of two qualifying
+        completion signals before it closes the transcript (review of
+        ``64875869``), so a single synthesis turn does not reliably end the
+        session. Returns ``None`` on success or when there is nothing to
+        synthesize, and a blocker string if the synthesis cannot be
+        persisted within the attempt budget.
         """
         synthesis = build_safe_default_synthesis(finalization)
         if not synthesis or not state.interview_session_id:
             return None
-        try:
-            synthesis_turn = _validate_turn(
-                await self._with_timeout(
-                    self.backend.answer(state.interview_session_id, synthesis),
-                    state,
-                    tool_name="interview.answer",
-                )
-            )
-        except TimeoutError as exc:
-            blocker = (
-                f"safe-default synthesis could not be persisted to the interview transcript: {exc}"
-            )
-            state.mark_blocked(blocker, tool_name="interview.answer")
-            record_authoring_backend(state)
-            self._save(state)
-            return blocker
-        except Exception as exc:
-            blocker = f"safe-default synthesis answer failed: {exc}"
-            state.mark_blocked(blocker, tool_name="interview.answer")
-            record_authoring_backend(state)
-            self._save(state)
-            return blocker
-        state.interview_session_id = synthesis_turn.session_id
-        ledger.record_qa(
-            state.pending_question or "auto safe-default finalization",
-            synthesis,
+        follow_up = (
+            f"{AUTO_ANSWER_PREFIX}{SAFE_DEFAULT_SYNTHESIS_TAG} "
+            "Mark the interview complete and hand off for seed generation. "
+            "No remaining ambiguity for safe-defaultable sections."
         )
-        state.ledger = ledger.to_dict()
-        # The synthesis text contains a completion signal recognised by the
-        # production interview handler ("mark the interview complete / hand
-        # off for seed generation"). If the backend honoured it the turn
-        # comes back with seed_ready/completed and the persisted transcript
-        # is closed. If it did not, the transcript still has a trailing
-        # unanswered question — finalising auto state at that point would
-        # leave seed generation reading a transcript that disagrees with
-        # the auto pipeline, so we block instead.
-        if not (synthesis_turn.seed_ready or synthesis_turn.completed):
-            blocker = (
-                "interview backend did not honour the safe-default completion "
-                "signal; transcript would still contain an unanswered question."
-            )
-            state.mark_blocked(blocker, tool_name="interview.answer")
-            record_authoring_backend(state)
-            self._save(state)
-            return blocker
-        return None
+        for attempt in range(self._SYNTHESIS_COMPLETION_MAX_ATTEMPTS):
+            text = synthesis if attempt == 0 else follow_up
+            try:
+                turn = _validate_turn(
+                    await self._with_timeout(
+                        self.backend.answer(state.interview_session_id, text),
+                        state,
+                        tool_name="interview.answer",
+                    )
+                )
+            except TimeoutError as exc:
+                blocker = (
+                    "safe-default synthesis could not be persisted to the "
+                    f"interview transcript: {exc}"
+                )
+                state.mark_blocked(blocker, tool_name="interview.answer")
+                record_authoring_backend(state)
+                self._save(state)
+                return blocker
+            except Exception as exc:
+                blocker = f"safe-default synthesis answer failed: {exc}"
+                state.mark_blocked(blocker, tool_name="interview.answer")
+                record_authoring_backend(state)
+                self._save(state)
+                return blocker
+            state.interview_session_id = turn.session_id
+            if attempt == 0:
+                ledger.record_qa(
+                    state.pending_question or "auto safe-default finalization",
+                    synthesis,
+                )
+                state.ledger = ledger.to_dict()
+            if turn.seed_ready or turn.completed:
+                return None
+        # The backend still has not honoured the completion signal. Block
+        # rather than declare seed_ready against a transcript that still
+        # contains unanswered turns.
+        blocker = (
+            "interview backend did not honour the safe-default completion "
+            f"signal within {self._SYNTHESIS_COMPLETION_MAX_ATTEMPTS} attempts; "
+            "transcript would still contain an unanswered question."
+        )
+        state.mark_blocked(blocker, tool_name="interview.answer")
+        record_authoring_backend(state)
+        self._save(state)
+        return blocker
 
     async def _with_timeout(
         self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -472,6 +472,23 @@ class AutoInterviewDriver:
             synthesis,
         )
         state.ledger = ledger.to_dict()
+        # The synthesis text contains a completion signal recognised by the
+        # production interview handler ("mark the interview complete / hand
+        # off for seed generation"). If the backend honoured it the turn
+        # comes back with seed_ready/completed and the persisted transcript
+        # is closed. If it did not, the transcript still has a trailing
+        # unanswered question — finalising auto state at that point would
+        # leave seed generation reading a transcript that disagrees with
+        # the auto pipeline, so we block instead.
+        if not (synthesis_turn.seed_ready or synthesis_turn.completed):
+            blocker = (
+                "interview backend did not honour the safe-default completion "
+                "signal; transcript would still contain an unanswered question."
+            )
+            state.mark_blocked(blocker, tool_name="interview.answer")
+            record_authoring_backend(state)
+            self._save(state)
+            return blocker
         return None
 
     async def _with_timeout(

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -468,6 +468,9 @@ class AutoInterviewDriver:
             "Mark the interview complete and hand off for seed generation. "
             "No remaining ambiguity for safe-defaultable sections."
         )
+        # Capture the question that was pending before synthesis started so
+        # the ledger can record the correct Q/A pairing for round 1.
+        prior_pending_question = state.pending_question or "auto safe-default finalization"
         for attempt in range(self._SYNTHESIS_COMPLETION_MAX_ATTEMPTS):
             text = synthesis if attempt == 0 else follow_up
             try:
@@ -479,26 +482,36 @@ class AutoInterviewDriver:
                     )
                 )
             except TimeoutError as exc:
+                # The backend may or may not have processed the call —
+                # invalidate our cached pending_question so a later
+                # ``--resume`` queries live state via ``backend.resume`` and
+                # cannot replay an already-answered prompt.
+                state.pending_question = None
+                self._save(state)
                 return (
                     "safe-default synthesis could not be persisted to the "
                     f"interview transcript: {exc}"
                 )
-                # Caller is responsible for marking the state blocked so the
-                # final blocker message reflects the rolled-back ledger.
             except Exception as exc:
+                state.pending_question = None
+                self._save(state)
                 return f"safe-default synthesis answer failed: {exc}"
             state.interview_session_id = turn.session_id
+            # Sync pending_question with the backend's latest turn so that a
+            # later ``--resume`` after synthesis failure re-enters the
+            # interview at the correct prompt instead of replaying the
+            # pre-synthesis question (review of ``cc128420``).
+            state.pending_question = turn.question or None
             if attempt == 0:
-                ledger.record_qa(
-                    state.pending_question or "auto safe-default finalization",
-                    synthesis,
-                )
+                ledger.record_qa(prior_pending_question, synthesis)
                 state.ledger = ledger.to_dict()
+            self._save(state)
             if turn.seed_ready or turn.completed:
                 return None
         # The backend still has not honoured the completion signal. Caller
         # rolls back the safe-default entries and emits the canonical
-        # "unresolved gaps" blocker; we just signal the failure here.
+        # "unresolved gaps" blocker; we just signal the failure here. The
+        # final ``state.pending_question`` reflects the live backend prompt.
         return (
             "interview backend did not honour the safe-default completion "
             f"signal within {self._SYNTHESIS_COMPLETION_MAX_ATTEMPTS} attempts; "

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -24,6 +24,7 @@ from ouroboros.auto.gap_detector import GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.repo_context import repo_auto_answer_context
+from ouroboros.auto.safe_defaults import finalize_safe_defaultable_gaps
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 
 log = structlog.get_logger(__name__)
@@ -254,7 +255,25 @@ class AutoInterviewDriver:
             self._save(state)
 
         if not ledger.is_seed_ready():
-            gaps = ", ".join(ledger.open_gaps())
+            finalization = finalize_safe_defaultable_gaps(
+                ledger,
+                goal=state.goal,
+                provenance=f"auto interview max rounds {self.max_rounds}",
+                pending_question=state.pending_question,
+            )
+            state.ledger = ledger.to_dict()
+            if finalization.completed and ledger.is_seed_ready():
+                state.pending_question = None
+                state.interview_completed = True
+                state.mark_progress(
+                    "auto interview finalized safe-defaultable gaps at max rounds",
+                    tool_name="interview_driver",
+                )
+                self._save(state)
+                return AutoInterviewResult(
+                    "seed_ready", state.interview_session_id, ledger, self.max_rounds
+                )
+            gaps = ", ".join(finalization.unsafe_gaps or ledger.open_gaps())
             blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
             state.mark_blocked(blocker, tool_name="interview_driver")
             record_authoring_backend(state)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -272,25 +272,27 @@ class AutoInterviewDriver:
                 synthesis_blocker = await self._record_safe_default_synthesis(
                     state, ledger, finalization
                 )
-                if synthesis_blocker is not None:
-                    return AutoInterviewResult(
-                        "blocked",
-                        state.interview_session_id,
-                        ledger,
-                        self.max_rounds,
-                        synthesis_blocker,
+                if synthesis_blocker is None:
+                    state.pending_question = None
+                    state.interview_completed = True
+                    state.mark_progress(
+                        "auto interview finalized safe-defaultable gaps at max rounds",
+                        tool_name="interview_driver",
                     )
-                state.pending_question = None
-                state.interview_completed = True
-                state.mark_progress(
-                    "auto interview finalized safe-defaultable gaps at max rounds",
-                    tool_name="interview_driver",
-                )
-                self._save(state)
-                return AutoInterviewResult(
-                    "seed_ready", state.interview_session_id, ledger, self.max_rounds
-                )
-            gaps = ", ".join(finalization.unsafe_gaps or ledger.open_gaps())
+                    self._save(state)
+                    return AutoInterviewResult(
+                        "seed_ready", state.interview_session_id, ledger, self.max_rounds
+                    )
+                # Synthesis could not be persisted to the interview transcript —
+                # roll back the safe-default entries so ledger.open_gaps() and
+                # the blocker message reflect the genuinely unresolved state.
+                # Without this, downstream consumers of the convergence
+                # contract (interview stalled → name the unresolved sections)
+                # would see an apparently complete ledger paired with a block.
+                _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                state.ledger = ledger.to_dict()
+            gaps_list = finalization.unsafe_gaps or tuple(ledger.open_gaps())
+            gaps = ", ".join(gaps_list)
             blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
             state.mark_blocked(blocker, tool_name="interview_driver")
             record_authoring_backend(state)
@@ -477,20 +479,14 @@ class AutoInterviewDriver:
                     )
                 )
             except TimeoutError as exc:
-                blocker = (
+                return (
                     "safe-default synthesis could not be persisted to the "
                     f"interview transcript: {exc}"
                 )
-                state.mark_blocked(blocker, tool_name="interview.answer")
-                record_authoring_backend(state)
-                self._save(state)
-                return blocker
+                # Caller is responsible for marking the state blocked so the
+                # final blocker message reflects the rolled-back ledger.
             except Exception as exc:
-                blocker = f"safe-default synthesis answer failed: {exc}"
-                state.mark_blocked(blocker, tool_name="interview.answer")
-                record_authoring_backend(state)
-                self._save(state)
-                return blocker
+                return f"safe-default synthesis answer failed: {exc}"
             state.interview_session_id = turn.session_id
             if attempt == 0:
                 ledger.record_qa(
@@ -500,18 +496,14 @@ class AutoInterviewDriver:
                 state.ledger = ledger.to_dict()
             if turn.seed_ready or turn.completed:
                 return None
-        # The backend still has not honoured the completion signal. Block
-        # rather than declare seed_ready against a transcript that still
-        # contains unanswered turns.
-        blocker = (
+        # The backend still has not honoured the completion signal. Caller
+        # rolls back the safe-default entries and emits the canonical
+        # "unresolved gaps" blocker; we just signal the failure here.
+        return (
             "interview backend did not honour the safe-default completion "
             f"signal within {self._SYNTHESIS_COMPLETION_MAX_ATTEMPTS} attempts; "
             "transcript would still contain an unanswered question."
         )
-        state.mark_blocked(blocker, tool_name="interview.answer")
-        record_authoring_backend(state)
-        self._save(state)
-        return blocker
 
     async def _with_timeout(
         self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str
@@ -624,6 +616,28 @@ class FunctionInterviewBackend:
         if self._is_session_persisted is None:
             return False
         return bool(self._is_session_persisted(session_id))
+
+
+def _revert_safe_default_entries(
+    ledger: SeedDraftLedger, defaulted_sections: tuple[str, ...]
+) -> None:
+    """Remove the safe-default policy's entries from the named sections.
+
+    Used when the safe-default synthesis cannot be persisted to the interview
+    transcript: rolling back the policy's own DEFAULTED entries restores the
+    ledger to its pre-finalization state so ``open_gaps()`` and the block
+    message report the genuinely unresolved sections to downstream consumers
+    of the convergence contract.
+    """
+    for section_name in defaulted_sections:
+        section = ledger.sections.get(section_name)
+        if section is None:
+            continue
+        section.entries = [
+            entry
+            for entry in section.entries
+            if not entry.key.endswith(".safe_default_finalization")
+        ]
 
 
 def _generate_interview_id() -> str:

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -237,10 +237,41 @@ def _unsafe_context_reason(
         )
         if value.strip()
     ).lower()
+    context = _strip_negated_clauses(context)
     for reason, pattern in _UNSAFE_CONTEXT_PATTERNS:
         if re.search(pattern, context):
             return reason
     return None
+
+
+_NEGATION_CLAUSE_PATTERN = re.compile(
+    # Negation cue at a word boundary, then the rest of the clause it scopes
+    # up to the next sentence break or contrastive conjunction. This lets
+    # ``No production deployment`` and ``Do not use customer credentials`` be
+    # stripped before the unsafe regex bank runs, while keeping a positively
+    # asserted clause that follows ``but``/``however``/``although`` visible.
+    r"\b(?:no|not|never|don[’']t|do not|do n[’']t|without|none(?:\s+of)?|neither|nor|"
+    r"skip|skips|skipped|avoid|avoids|avoided|exclude|excludes|excluded|forbid|forbids|forbidden)\b"
+    r"(?:(?!\b(?:but|however|although|except)\b)[^.;?!\n])*",
+    re.IGNORECASE,
+)
+
+
+def _strip_negated_clauses(text: str) -> str:
+    """Blank clauses the user has explicitly negated.
+
+    The unsafe-context gate must not trip on phrases like ``No production
+    deployment`` or ``Do not use customer credentials``: those are explicit
+    *exclusions*, not authorizations. We replace the negation cue plus the
+    rest of the clause it scopes (up to the next sentence-break punctuation
+    or contrastive conjunction) with whitespace so the regex bank only sees
+    positively asserted scope. The implementation is deliberately a coarse
+    lexical heuristic — it stops at ``.``, ``;``, ``?``, ``!``, newlines, and
+    contrastive conjunctions (``but``, ``however``, ``although``, ``except``)
+    so a clause like ``no prod deploys, but log credentials`` keeps the
+    second half visible to the unsafe gate.
+    """
+    return _NEGATION_CLAUSE_PATTERN.sub(" ", text)
 
 
 _INACTIVE_LEDGER_STATUSES: frozenset[LedgerStatus] = frozenset(

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -1,0 +1,215 @@
+"""Safe-default finalization for bounded auto interviews."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+from ouroboros.auto.ledger import (
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SafeDefaultFinalization:
+    """Outcome of trying to close required ledger gaps with safe defaults."""
+
+    defaulted_sections: tuple[str, ...]
+    unsafe_gaps: tuple[str, ...]
+
+    @property
+    def completed(self) -> bool:
+        """Return True when all remaining gaps were safely defaulted."""
+        return bool(self.defaulted_sections) and not self.unsafe_gaps
+
+
+@dataclass(frozen=True, slots=True)
+class _DefaultSpec:
+    value: str
+    rationale: str
+
+
+_SAFE_DEFAULTS: dict[str, _DefaultSpec] = {
+    "actors": _DefaultSpec(
+        "Assume the primary actor is the user or automation agent described by the goal; "
+        "do not introduce additional actor classes.",
+        "No explicit actor split remained after the bounded interview.",
+    ),
+    "inputs": _DefaultSpec(
+        "Use only inputs already present in the goal, repository state, or explicit interview "
+        "answers; do not require new external data.",
+        "Unspecified inputs can be safely bounded to existing local context.",
+    ),
+    "outputs": _DefaultSpec(
+        "Produce the smallest observable artifact, state change, or response needed to satisfy "
+        "the goal and make verification possible.",
+        "Unspecified outputs can be safely bounded to observable MVP behavior.",
+    ),
+    "constraints": _DefaultSpec(
+        "Keep scope to a reversible local MVP, preserve existing project patterns, and avoid new "
+        "dependencies unless explicit acceptance criteria require them.",
+        "Conservative local constraints reduce execution risk.",
+    ),
+    "non_goals": _DefaultSpec(
+        "Do not perform credential handling, billing, production deployment, legal or medical "
+        "judgment, security-sensitive authority choices, or ambiguous external side effects.",
+        "Unsafe authority remains out of scope without explicit user direction.",
+    ),
+    "acceptance_criteria": _DefaultSpec(
+        "Completion requires an observable check that demonstrates the requested behavior and a "
+        "negative or edge-path check where the implementation surface supports one.",
+        "A Seed needs testable acceptance criteria before generation.",
+    ),
+    "verification_plan": _DefaultSpec(
+        "Run the narrowest relevant local tests, type checks, or smoke checks for the changed "
+        "behavior; report any verification gap explicitly.",
+        "Verification can be safely scoped to local, non-destructive checks.",
+    ),
+    "failure_modes": _DefaultSpec(
+        "Failure includes unverified behavior, scope expansion, dependency churn, non-reproducible "
+        "output, or external side effects not authorized by the goal.",
+        "Generic failure boundaries keep the Seed auditable without domain assumptions.",
+    ),
+    "runtime_context": _DefaultSpec(
+        "Use the current repository/worktree runtime and established project conventions; do not "
+        "choose a new framework, provider, or deployment target.",
+        "Existing local conventions are the safest runtime default.",
+    ),
+}
+
+_UNSAFE_CONTEXT_PATTERNS: tuple[tuple[str, str], ...] = (
+    (
+        "credentials/secrets",
+        r"\b(credential|credentials|secret|secrets|access token|auth token|private key|api key|password|"
+        r"passphrase)\b",
+    ),
+    (
+        "destructive production action",
+        r"\b(delete|drop|erase|wipe|destroy|remove|truncate)\b.+\b(production|prod|live|database|db|"
+        r"branch|bucket|account)\b|\b(production|prod|live)\b.+\b(delete|drop|erase|wipe|destroy|"
+        r"remove|truncate)\b",
+    ),
+    (
+        "payment/billing",
+        r"\b(payment|billing|paid service|credit card|bank account|invoice|charge|purchase|subscribe|"
+        r"subscription)\b",
+    ),
+    (
+        "legal/medical judgment",
+        r"\b(legal|compliance|license|contract|liability|medical|clinical|diagnosis|treatment|"
+        r"healthcare|patient)\b",
+    ),
+    (
+        "security-sensitive choice",
+        r"\b(security|encryption|authentication|authorization|authz|oauth|sso|access control|"
+        r"permissions|vulnerability|exploit|threat model)\b",
+    ),
+    (
+        "ambiguous external side effect",
+        r"\b(deploy|release|publish|production|prod|live|external|send email|webhook|notify users|"
+        r"create account|delete branch|database migration)\b",
+    ),
+)
+
+
+def finalize_safe_defaultable_gaps(
+    ledger: SeedDraftLedger,
+    *,
+    goal: str,
+    provenance: str,
+    pending_question: str | None = None,
+) -> SafeDefaultFinalization:
+    """Fill safe-defaultable required gaps with auditable assumptions.
+
+    The policy is intentionally general: only missing or weak required Seed
+    sections may be defaulted, and only when the unresolved context does not
+    include unsafe authority, irreversible production actions, payment/billing,
+    legal/medical/security-sensitive decisions, or ambiguous external effects.
+    Conflicting, blocked, or missing-goal gaps remain hard blockers.
+    """
+    gaps = ledger.open_gaps()
+    if not gaps:
+        return SafeDefaultFinalization((), ())
+
+    unsafe_reason = _unsafe_context_reason(ledger, goal=goal, pending_question=pending_question)
+    statuses = ledger.section_statuses()
+    defaulted: list[str] = []
+    unsafe: list[str] = []
+
+    for section in gaps:
+        status = statuses[section]
+        if section == "goal":
+            unsafe.append(f"{section}: primary goal cannot be defaulted")
+            continue
+        if status in {LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}:
+            unsafe.append(f"{section}: {status.value} ledger state cannot be defaulted")
+            continue
+        if unsafe_reason is not None:
+            unsafe.append(f"{section}: unsafe default context ({unsafe_reason})")
+            continue
+        spec = _SAFE_DEFAULTS.get(section)
+        if spec is None:
+            unsafe.append(f"{section}: no safe default policy")
+            continue
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.safe_default_finalization",
+                value=spec.value,
+                source=LedgerSource.ASSUMPTION,
+                confidence=0.68,
+                status=LedgerStatus.DEFAULTED,
+                rationale=f"{spec.rationale} Applied at {provenance}.",
+                evidence=[
+                    provenance,
+                    "safe-default policy: missing/weak required gap, local and reversible, no unsafe context detected",
+                ],
+            ),
+        )
+        defaulted.append(section)
+
+    if not unsafe and ledger.open_gaps():
+        unsafe.extend(
+            f"{section}: still unresolved after safe-default finalization"
+            for section in ledger.open_gaps()
+        )
+
+    return SafeDefaultFinalization(tuple(defaulted), tuple(unsafe))
+
+
+def _unsafe_context_reason(
+    ledger: SeedDraftLedger, *, goal: str, pending_question: str | None
+) -> str | None:
+    context = "\n".join(
+        value
+        for value in (
+            goal,
+            pending_question or "",
+            *_unsafe_ledger_values(ledger),
+            *_interview_questions(ledger),
+        )
+        if value.strip()
+    ).lower()
+    for reason, pattern in _UNSAFE_CONTEXT_PATTERNS:
+        if re.search(pattern, context):
+            return reason
+    return None
+
+
+def _unsafe_ledger_values(ledger: SeedDraftLedger) -> tuple[str, ...]:
+    values: list[str] = []
+    for section in ledger.sections.values():
+        for entry in section.entries:
+            if entry.source == LedgerSource.USER_GOAL:
+                values.append(entry.value)
+    return tuple(values)
+
+
+def _interview_questions(ledger: SeedDraftLedger) -> tuple[str, ...]:
+    values: list[str] = []
+    for item in ledger.question_history:
+        values.append(item.get("question", ""))
+    return tuple(values)

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -121,21 +121,32 @@ _UNSAFE_CONTEXT_PATTERNS: tuple[tuple[str, str], ...] = (
 )
 
 
+# Prefix matching :pyattr:`AutoAnswer.prefixed_text` and tagging this module's
+# safe-default synthesis. ``_interview_answers`` filters on this prefix so the
+# unsafe-context gate never re-feeds policy-emitted answers (auto answers or
+# our own synthesis) back into itself — keeping safe-default finalization
+# idempotent across resume/re-finalize calls.
+_AUTO_ANSWER_PREFIX = "[from-auto]"
+_SAFE_DEFAULT_SYNTHESIS_TAG = "[safe-default-synthesis]"
+
+
 def build_safe_default_synthesis(finalization: SafeDefaultFinalization) -> str:
     """Build a synthesis answer text describing every defaulted section.
 
-    The synthesis is intended to be pushed back into the interview transcript
-    (via ``backend.answer``) so the downstream seed generator — which reads the
+    The synthesis is pushed back into the interview transcript (via
+    ``backend.answer``) so the downstream seed generator — which reads the
     persisted interview rounds, not the in-memory ledger — sees the same
-    assumptions the ledger now records.
+    assumptions the ledger now records. The text is tagged with the same
+    ``[from-auto]`` prefix that :class:`AutoAnswerer` uses so the
+    unsafe-context gate skips it on a later pass.
     """
     if not finalization.defaulted_sections:
         return ""
     lines = [
-        "Auto safe-default synthesis (max interview rounds reached). "
-        "The following conservative assumptions close the remaining required "
-        "Seed sections; treat them as auditable defaults that may be revised "
-        "if a stricter answer is required.",
+        f"{_AUTO_ANSWER_PREFIX}{_SAFE_DEFAULT_SYNTHESIS_TAG} Auto safe-default "
+        "synthesis (max interview rounds reached). The following conservative "
+        "assumptions close the remaining required Seed sections; treat them as "
+        "auditable defaults that may be revised if a stricter answer is required.",
     ]
     for section in finalization.defaulted_sections:
         spec = _SAFE_DEFAULTS.get(section)
@@ -324,11 +335,21 @@ def _interview_answers(ledger: SeedDraftLedger) -> tuple[str, ...]:
 
     Backend-authored questions are deliberately excluded because a clarifying
     question (for example "Does this deploy to production?") does not assert
-    that the deploy will happen — only the answer can.
+    that the deploy will happen — only an answer can.
+
+    Policy-authored answers are also excluded. :class:`AutoAnswerer` records
+    its own answers with a ``[from-auto]`` prefix, and this module's safe-
+    default synthesis is tagged the same way. Re-feeding either of those
+    into the unsafe-context gate would let the gate flag its own boundary
+    text on a subsequent pass and break finalization idempotence (a problem
+    visible on resume/re-finalize flows).
     """
     values: list[str] = []
     for item in ledger.question_history:
         answer = item.get("answer", "")
-        if answer:
-            values.append(answer)
+        if not answer:
+            continue
+        if answer.lstrip().startswith(_AUTO_ANSWER_PREFIX):
+            continue
+        values.append(answer)
     return tuple(values)

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -211,15 +211,29 @@ def finalize_safe_defaultable_gaps(
 
 
 def _unsafe_context_reason(
-    ledger: SeedDraftLedger, *, goal: str, pending_question: str | None
+    ledger: SeedDraftLedger,
+    *,
+    goal: str,
+    pending_question: str | None,  # noqa: ARG001 - kept for backward-compatible call sites
 ) -> str | None:
+    """Detect whether the user-asserted context authorizes any unsafe action.
+
+    The detector inspects only assertions the user (or repo) has actually
+    affirmed: the original goal, active non-NON_GOAL ledger entries, and the
+    interview answers the user gave. It deliberately ignores backend-authored
+    interview questions and the still-open ``pending_question``, because a
+    clarifying question like "should this deploy to production?" does not
+    authorize a deploy — only the answer does. It also ignores ``NON_GOAL``
+    entries because confirmed non-goals are explicit *exclusions*; treating
+    "non-goals are credentials and production deployment" as active unsafe
+    scope would invert the user's intent.
+    """
     context = "\n".join(
         value
         for value in (
             goal,
-            pending_question or "",
             *_unsafe_ledger_values(ledger),
-            *_interview_transcript(ledger),
+            *_interview_answers(ledger),
         )
         if value.strip()
     ).lower()
@@ -235,15 +249,21 @@ _INACTIVE_LEDGER_STATUSES: frozenset[LedgerStatus] = frozenset(
 
 
 def _unsafe_ledger_values(ledger: SeedDraftLedger) -> tuple[str, ...]:
-    """Return active ledger entry values that may carry unsafe interview context.
+    """Return active ledger entry values that may carry unsafe user assertions.
 
-    Includes any source that represents user-supplied, repository-derived, or
-    interview-derived requirements (USER_GOAL, REPO_FACT, EXISTING_CONVENTION,
-    INFERENCE, NON_GOAL, BLOCKER, CONSERVATIVE_DEFAULT). Excludes inactive
-    entries (weak/conflicting/blocked) and the safe-default policy's own
-    DEFAULTED outputs so the gate does not re-flag its own boundary text on a
-    subsequent pass.
+    Includes USER_GOAL, REPO_FACT, EXISTING_CONVENTION, INFERENCE, BLOCKER,
+    and CONSERVATIVE_DEFAULT entries. Excludes:
+
+    * inactive entries (weak/conflicting/blocked) — superseded or rejected,
+    * the safe-default policy's own DEFAULTED outputs — to avoid re-flagging
+      its own boundary text on a subsequent pass,
+    * any ASSUMPTION-source entry — assumptions describe boundary defaults,
+      not user-affirmed scope, and
+    * ``NON_GOAL`` entries — confirmed non-goals are explicit exclusions
+      ("non-goals are auth and production deployment"), and reading them as
+      active unsafe scope would invert the user's intent.
     """
+    skip_sources = {LedgerSource.ASSUMPTION, LedgerSource.NON_GOAL}
     values: list[str] = []
     for section in ledger.sections.values():
         for entry in section.entries:
@@ -251,20 +271,22 @@ def _unsafe_ledger_values(ledger: SeedDraftLedger) -> tuple[str, ...]:
                 continue
             if entry.status == LedgerStatus.DEFAULTED:
                 continue
-            if entry.source == LedgerSource.ASSUMPTION:
+            if entry.source in skip_sources:
                 continue
             values.append(entry.value)
     return tuple(values)
 
 
-def _interview_transcript(ledger: SeedDraftLedger) -> tuple[str, ...]:
-    """Return both questions and answers recorded during the interview."""
+def _interview_answers(ledger: SeedDraftLedger) -> tuple[str, ...]:
+    """Return user-supplied interview answers only.
+
+    Backend-authored questions are deliberately excluded because a clarifying
+    question (for example "Does this deploy to production?") does not assert
+    that the deploy will happen — only the answer can.
+    """
     values: list[str] = []
     for item in ledger.question_history:
-        question = item.get("question", "")
         answer = item.get("answer", "")
-        if question:
-            values.append(question)
         if answer:
             values.append(answer)
     return tuple(values)

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -110,13 +110,21 @@ _UNSAFE_CONTEXT_PATTERNS: tuple[tuple[str, str], ...] = (
     (
         "ambiguous external side effect",
         # Concrete external side effects only: deploy/release/publish flows,
-        # production/prod/live targets, explicit messaging or account/branch
-        # mutations, and database migrations. Earlier revisions matched bare
-        # ``external``, which incorrectly flagged benign phrases such as
-        # "no external dependencies" or "use existing external API schema
-        # files only" — matched phrases must imply an actual side effect.
-        r"\b(deploy|release|publish|production|prod|live|send email|webhook|notify users|"
-        r"create account|delete branch|database migration)\b",
+        # explicit messaging or account/branch mutations, database
+        # migrations, and "go live"/"push live"/"going live" phrasings.
+        # Earlier revisions matched bare ``external``, which flagged benign
+        # phrases such as "no external dependencies"; this revision drops
+        # bare ``production``/``prod``/``live`` for the same reason —
+        # phrases like "reproduce a production bug locally" or "use the
+        # production schema snapshot already in the repo" describe
+        # read-only context, not a side effect. ``deploy``, ``release``,
+        # ``publish`` still catch the production-deploy class of phrasing
+        # ("deploy to production", "production deploy", "release to
+        # production"), and the explicit ``go live``/``push live`` phrases
+        # cover the few remaining production-cutover idioms.
+        r"\b(deploy|release|publish|send email|webhook|notify users|"
+        r"create account|delete branch|database migration|"
+        r"go live|going live|push live)\b",
     ),
 )
 

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -142,11 +142,19 @@ def build_safe_default_synthesis(finalization: SafeDefaultFinalization) -> str:
     """
     if not finalization.defaulted_sections:
         return ""
+    # The leading line is recognised as an interview-completion signal by
+    # ``GenerateSeedHandler`` (matches ``_INTERVIEW_COMPLETION_PHRASES``:
+    # "mark the interview complete" / "ready for seed generation"). That
+    # tells the production interview handler to close the session in the
+    # same turn — so the persisted transcript does not gain a trailing
+    # unanswered question while auto state declares the interview done.
     lines = [
-        f"{_AUTO_ANSWER_PREFIX}{_SAFE_DEFAULT_SYNTHESIS_TAG} Auto safe-default "
-        "synthesis (max interview rounds reached). The following conservative "
-        "assumptions close the remaining required Seed sections; treat them as "
-        "auditable defaults that may be revised if a stricter answer is required.",
+        f"{_AUTO_ANSWER_PREFIX}{_SAFE_DEFAULT_SYNTHESIS_TAG} "
+        "Mark the interview complete and hand off for seed generation. "
+        "Auto safe-default synthesis (max interview rounds reached). "
+        "The following conservative assumptions close the remaining required "
+        "Seed sections; treat them as auditable defaults that may be revised "
+        "if a stricter answer is required.",
     ]
     for section in finalization.defaulted_sections:
         spec = _SAFE_DEFAULTS.get(section)

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -189,7 +189,7 @@ def _unsafe_context_reason(
             goal,
             pending_question or "",
             *_unsafe_ledger_values(ledger),
-            *_interview_questions(ledger),
+            *_interview_transcript(ledger),
         )
         if value.strip()
     ).lower()
@@ -199,17 +199,42 @@ def _unsafe_context_reason(
     return None
 
 
+_INACTIVE_LEDGER_STATUSES: frozenset[LedgerStatus] = frozenset(
+    {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+)
+
+
 def _unsafe_ledger_values(ledger: SeedDraftLedger) -> tuple[str, ...]:
+    """Return active ledger entry values that may carry unsafe interview context.
+
+    Includes any source that represents user-supplied, repository-derived, or
+    interview-derived requirements (USER_GOAL, REPO_FACT, EXISTING_CONVENTION,
+    INFERENCE, NON_GOAL, BLOCKER, CONSERVATIVE_DEFAULT). Excludes inactive
+    entries (weak/conflicting/blocked) and the safe-default policy's own
+    DEFAULTED outputs so the gate does not re-flag its own boundary text on a
+    subsequent pass.
+    """
     values: list[str] = []
     for section in ledger.sections.values():
         for entry in section.entries:
-            if entry.source == LedgerSource.USER_GOAL:
-                values.append(entry.value)
+            if entry.status in _INACTIVE_LEDGER_STATUSES:
+                continue
+            if entry.status == LedgerStatus.DEFAULTED:
+                continue
+            if entry.source == LedgerSource.ASSUMPTION:
+                continue
+            values.append(entry.value)
     return tuple(values)
 
 
-def _interview_questions(ledger: SeedDraftLedger) -> tuple[str, ...]:
+def _interview_transcript(ledger: SeedDraftLedger) -> tuple[str, ...]:
+    """Return both questions and answers recorded during the interview."""
     values: list[str] = []
     for item in ledger.question_history:
-        values.append(item.get("question", ""))
+        question = item.get("question", "")
+        answer = item.get("answer", "")
+        if question:
+            values.append(question)
+        if answer:
+            values.append(answer)
     return tuple(values)

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -263,15 +263,161 @@ def _unsafe_context_reason(
     return None
 
 
+# Imperative verbs that mark a *new* action clause when they follow a comma.
+# Used to break the negation scope on ``,\s*<verb>`` so that mixed clauses
+# like ``No production deploys, use customer credentials`` only blank the
+# negated half — the second half stays visible to the unsafe regex bank.
+_IMPERATIVE_VERBS_AFTER_COMMA = (
+    "use",
+    "uses",
+    "using",
+    "send",
+    "sends",
+    "sending",
+    "log",
+    "logs",
+    "logging",
+    "logged",
+    "deploy",
+    "deploys",
+    "deploying",
+    "deployed",
+    "write",
+    "writes",
+    "writing",
+    "wrote",
+    "call",
+    "calls",
+    "calling",
+    "called",
+    "push",
+    "pushes",
+    "pushing",
+    "pushed",
+    "pull",
+    "pulls",
+    "pulling",
+    "pulled",
+    "store",
+    "stores",
+    "storing",
+    "stored",
+    "configure",
+    "configures",
+    "configuring",
+    "configured",
+    "connect",
+    "connects",
+    "connecting",
+    "connected",
+    "publish",
+    "publishes",
+    "publishing",
+    "published",
+    "run",
+    "runs",
+    "running",
+    "expose",
+    "exposes",
+    "exposing",
+    "exposed",
+    "read",
+    "reads",
+    "reading",
+    "fetch",
+    "fetches",
+    "fetching",
+    "create",
+    "creates",
+    "creating",
+    "created",
+    "delete",
+    "deletes",
+    "deleting",
+    "deleted",
+    "update",
+    "updates",
+    "updating",
+    "updated",
+    "sync",
+    "syncs",
+    "syncing",
+    "synced",
+    "forward",
+    "forwards",
+    "forwarding",
+    "forwarded",
+    "invoke",
+    "invokes",
+    "invoking",
+    "invoked",
+    "provision",
+    "provisions",
+    "provisioning",
+    "provisioned",
+    "grant",
+    "grants",
+    "granting",
+    "granted",
+    "access",
+    "accesses",
+    "accessing",
+    "accessed",
+    "trigger",
+    "triggers",
+    "triggering",
+    "triggered",
+    "load",
+    "loads",
+    "loading",
+    "loaded",
+    "save",
+    "saves",
+    "saving",
+    "saved",
+    "transfer",
+    "transfers",
+    "transferring",
+    "transferred",
+    "charge",
+    "charges",
+    "charging",
+    "charged",
+    "notify",
+    "notifies",
+    "notifying",
+    "notified",
+    "encrypt",
+    "encrypts",
+    "encrypting",
+    "encrypted",
+    "authenticate",
+    "authenticates",
+    "authenticating",
+    "authenticated",
+    "authorize",
+    "authorizes",
+    "authorizing",
+    "authorized",
+)
+
+_IMPERATIVE_VERBS_ALT = "|".join(_IMPERATIVE_VERBS_AFTER_COMMA)
+
 _NEGATION_CLAUSE_PATTERN = re.compile(
     # Negation cue at a word boundary, then the rest of the clause it scopes
-    # up to the next sentence break or contrastive conjunction. This lets
-    # ``No production deployment`` and ``Do not use customer credentials`` be
-    # stripped before the unsafe regex bank runs, while keeping a positively
-    # asserted clause that follows ``but``/``however``/``although`` visible.
+    # up to the next sentence break, contrastive conjunction, or comma that
+    # introduces a fresh imperative clause. This lets ``No production
+    # deployment`` and ``Do not use customer credentials`` be stripped before
+    # the unsafe regex bank runs, while keeping mixed clauses like
+    # ``No production deploys, use customer credentials from Vault`` visible
+    # past the comma so the second clause still flags.
     r"\b(?:no|not|never|don[’']t|do not|do n[’']t|without|none(?:\s+of)?|neither|nor|"
     r"skip|skips|skipped|avoid|avoids|avoided|exclude|excludes|excluded|forbid|forbids|forbidden)\b"
-    r"(?:(?!\b(?:but|however|although|except)\b)[^.;?!\n])*",
+    r"(?:"
+    r"(?!\b(?:but|however|although|except)\b)"
+    rf"(?!,\s*\b(?:{_IMPERATIVE_VERBS_ALT})\b)"
+    r"[^.;?!\n]"
+    r")*",
     re.IGNORECASE,
 )
 
@@ -282,13 +428,19 @@ def _strip_negated_clauses(text: str) -> str:
     The unsafe-context gate must not trip on phrases like ``No production
     deployment`` or ``Do not use customer credentials``: those are explicit
     *exclusions*, not authorizations. We replace the negation cue plus the
-    rest of the clause it scopes (up to the next sentence-break punctuation
-    or contrastive conjunction) with whitespace so the regex bank only sees
-    positively asserted scope. The implementation is deliberately a coarse
-    lexical heuristic — it stops at ``.``, ``;``, ``?``, ``!``, newlines, and
-    contrastive conjunctions (``but``, ``however``, ``although``, ``except``)
-    so a clause like ``no prod deploys, but log credentials`` keeps the
-    second half visible to the unsafe gate.
+    rest of the clause it scopes with whitespace so the regex bank only sees
+    positively asserted scope.
+
+    Scope ends at sentence-break punctuation (``.``, ``;``, ``?``, ``!``,
+    newlines), contrastive conjunctions (``but``, ``however``, ``although``,
+    ``except``), or a comma that is followed by a fresh imperative verb
+    (``use``, ``send``, ``log``, ``deploy``, etc.). The comma + imperative
+    boundary lets mixed clauses such as ``No production deploys, use
+    customer credentials from Vault`` keep the second half visible — the
+    ``credentials`` token is still flagged by the unsafe regex bank — while
+    plain list-style negations such as ``No auth, credentials, and
+    production deployment`` (no imperative verb after the comma) remain
+    fully scoped under the negation.
     """
     return _NEGATION_CLAUSE_PATTERN.sub(" ", text)
 

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -109,7 +109,13 @@ _UNSAFE_CONTEXT_PATTERNS: tuple[tuple[str, str], ...] = (
     ),
     (
         "ambiguous external side effect",
-        r"\b(deploy|release|publish|production|prod|live|external|send email|webhook|notify users|"
+        # Concrete external side effects only: deploy/release/publish flows,
+        # production/prod/live targets, explicit messaging or account/branch
+        # mutations, and database migrations. Earlier revisions matched bare
+        # ``external``, which incorrectly flagged benign phrases such as
+        # "no external dependencies" or "use existing external API schema
+        # files only" — matched phrases must imply an actual side effect.
+        r"\b(deploy|release|publish|production|prod|live|send email|webhook|notify users|"
         r"create account|delete branch|database migration)\b",
     ),
 )

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -115,6 +115,30 @@ _UNSAFE_CONTEXT_PATTERNS: tuple[tuple[str, str], ...] = (
 )
 
 
+def build_safe_default_synthesis(finalization: SafeDefaultFinalization) -> str:
+    """Build a synthesis answer text describing every defaulted section.
+
+    The synthesis is intended to be pushed back into the interview transcript
+    (via ``backend.answer``) so the downstream seed generator — which reads the
+    persisted interview rounds, not the in-memory ledger — sees the same
+    assumptions the ledger now records.
+    """
+    if not finalization.defaulted_sections:
+        return ""
+    lines = [
+        "Auto safe-default synthesis (max interview rounds reached). "
+        "The following conservative assumptions close the remaining required "
+        "Seed sections; treat them as auditable defaults that may be revised "
+        "if a stricter answer is required.",
+    ]
+    for section in finalization.defaulted_sections:
+        spec = _SAFE_DEFAULTS.get(section)
+        if spec is None:
+            continue
+        lines.append(f"- {section}: {spec.value} ({spec.rationale})")
+    return "\n".join(lines)
+
+
 def finalize_safe_defaultable_gaps(
     ledger: SeedDraftLedger,
     *,

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -278,6 +278,15 @@ _INACTIVE_LEDGER_STATUSES: frozenset[LedgerStatus] = frozenset(
     {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
 )
 
+# Sources whose entries describe boundary defaults or explicit exclusions
+# rather than user-asserted scope. Filtering on source (not status) keeps
+# CONSERVATIVE_DEFAULT entries — which can land with status DEFAULTED but
+# may still carry production/auth/billing scope that needs to flag — visible
+# to the unsafe-context gate.
+_SKIP_SOURCES_FOR_UNSAFE_GATE: frozenset[LedgerSource] = frozenset(
+    {LedgerSource.ASSUMPTION, LedgerSource.NON_GOAL}
+)
+
 
 def _unsafe_ledger_values(ledger: SeedDraftLedger) -> tuple[str, ...]:
     """Return active ledger entry values that may carry unsafe user assertions.
@@ -286,23 +295,25 @@ def _unsafe_ledger_values(ledger: SeedDraftLedger) -> tuple[str, ...]:
     and CONSERVATIVE_DEFAULT entries. Excludes:
 
     * inactive entries (weak/conflicting/blocked) — superseded or rejected,
-    * the safe-default policy's own DEFAULTED outputs — to avoid re-flagging
-      its own boundary text on a subsequent pass,
-    * any ASSUMPTION-source entry — assumptions describe boundary defaults,
-      not user-affirmed scope, and
+    * any ASSUMPTION-source entry — assumptions describe boundary defaults
+      (including the safe-default policy's own outputs), not user-affirmed
+      scope, so re-feeding them would re-flag the gate's own boundary text
+      on a subsequent pass, and
     * ``NON_GOAL`` entries — confirmed non-goals are explicit exclusions
       ("non-goals are auth and production deployment"), and reading them as
       active unsafe scope would invert the user's intent.
+
+    DEFAULTED-status entries from other sources (notably
+    ``CONSERVATIVE_DEFAULT``) remain visible because they can still encode
+    user-derived unsafe scope — for example, a prior round may have recorded
+    a conservative default that nonetheless authorizes a production deploy.
     """
-    skip_sources = {LedgerSource.ASSUMPTION, LedgerSource.NON_GOAL}
     values: list[str] = []
     for section in ledger.sections.values():
         for entry in section.entries:
             if entry.status in _INACTIVE_LEDGER_STATUSES:
                 continue
-            if entry.status == LedgerStatus.DEFAULTED:
-                continue
-            if entry.source in skip_sources:
+            if entry.source in _SKIP_SOURCES_FOR_UNSAFE_GATE:
                 continue
             values.append(entry.value)
     return tuple(values)

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -126,8 +126,16 @@ _UNSAFE_CONTEXT_PATTERNS: tuple[tuple[str, str], ...] = (
 # unsafe-context gate never re-feeds policy-emitted answers (auto answers or
 # our own synthesis) back into itself — keeping safe-default finalization
 # idempotent across resume/re-finalize calls.
-_AUTO_ANSWER_PREFIX = "[from-auto]"
-_SAFE_DEFAULT_SYNTHESIS_TAG = "[safe-default-synthesis]"
+#
+# These constants are public because the interview driver also needs to build
+# follow-up completion signals tagged the same way (see
+# :meth:`AutoInterviewDriver._record_safe_default_synthesis`).
+AUTO_ANSWER_PREFIX = "[from-auto]"
+SAFE_DEFAULT_SYNTHESIS_TAG = "[safe-default-synthesis]"
+# Backwards-compatible aliases (kept underscore-private for the local helpers
+# below that already reference them inline).
+_AUTO_ANSWER_PREFIX = AUTO_ANSWER_PREFIX
+_SAFE_DEFAULT_SYNTHESIS_TAG = SAFE_DEFAULT_SYNTHESIS_TAG
 
 
 def build_safe_default_synthesis(finalization: SafeDefaultFinalization) -> str:

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -411,21 +411,48 @@ _IMPERATIVE_VERBS_AFTER_COMMA = (
 
 _IMPERATIVE_VERBS_ALT = "|".join(_IMPERATIVE_VERBS_AFTER_COMMA)
 
-_NEGATION_CLAUSE_PATTERN = re.compile(
-    # Negation cue at a word boundary, then the rest of the clause it scopes
-    # up to the next sentence break, contrastive conjunction, or comma that
-    # introduces a fresh imperative clause. This lets ``No production
-    # deployment`` and ``Do not use customer credentials`` be stripped before
-    # the unsafe regex bank runs, while keeping mixed clauses like
-    # ``No production deploys, use customer credentials from Vault`` visible
-    # past the comma so the second clause still flags.
+_NEGATION_CUES = (
     r"\b(?:no|not|never|don[’']t|do not|do n[’']t|without|none(?:\s+of)?|neither|nor|"
-    r"skip|skips|skipped|avoid|avoids|avoided|exclude|excludes|excluded|forbid|forbids|forbidden)\b"
+    r"skip|skips|skipped|avoid|avoids|avoided|exclude|excludes|excluded|"
+    r"forbid|forbids|forbidden)\b"
+)
+
+# Negation pattern with two scope modes:
+#
+# * List mode (lookahead succeeds): the same sentence contains "and"/"or"/"nor"
+#   somewhere before the next sentence break. Scope extends through commas so
+#   list-style negations like "No auth, credentials, and production deployment"
+#   stay fully scoped. A comma followed by an imperative verb still ends the
+#   scope, and the first contrastive conjunction (but/however/although/except)
+#   ends it too.
+#
+# * Non-list mode: no list connector ahead. Scope ends at the FIRST comma in
+#   addition to the usual sentence breaks and contrastive conjunctions.
+#   This is what catches mixed clauses like
+#   "No production deploys, customer credentials from Vault are still required"
+#   or "Without billing integration, send email notifications" — the second
+#   clause stays visible to the unsafe regex bank because the negation only
+#   covers up to the first comma.
+_NEGATION_CLAUSE_PATTERN = re.compile(
+    rf"{_NEGATION_CUES}"
+    r"(?:"
+    # ----- Alt 1: list-mode (scope continues past commas) -----
+    r"(?="
+    r"(?:(?!\b(?:but|however|although|except)\b)[^.;?!\n])*?"
+    r"\b(?:and|or|nor)\b"
+    r")"
     r"(?:"
     r"(?!\b(?:but|however|although|except)\b)"
     rf"(?!,\s*\b(?:{_IMPERATIVE_VERBS_ALT})\b)"
     r"[^.;?!\n]"
-    r")*",
+    r")*"
+    r"|"
+    # ----- Alt 2: non-list mode (scope ends at first comma too) -----
+    r"(?:"
+    r"(?!\b(?:but|however|although|except)\b)"
+    r"[^.;?!\n,]"
+    r")*"
+    r")",
     re.IGNORECASE,
 )
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -224,6 +224,11 @@ async def test_interview_driver_finalizes_safe_defaults_after_max_rounds(tmp_pat
 
     async def answer(session_id: str, text: str) -> InterviewTurn:
         answer_calls.append((session_id, text))
+        # Mirror the production interview handler: a synthesis answer that
+        # carries the "mark the interview complete" completion signal
+        # closes the transcript on the same turn.
+        if "mark the interview complete" in text.lower():
+            return InterviewTurn("", session_id, seed_ready=True, completed=True)
         return InterviewTurn("What else?", session_id, seed_ready=False)
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -249,12 +254,10 @@ async def test_interview_driver_finalizes_safe_defaults_after_max_rounds(tmp_pat
     # Synthesis must be persisted to the interview transcript so the seed
     # generator (which reads the transcript) sees the same assumptions the
     # ledger now records — guards against the ledger/transcript split-brain.
-    assert any(
-        "safe-default synthesis" in text.lower() for _sid, text in answer_calls
-    ), "expected safe-default synthesis to be pushed through backend.answer"
     synthesis_text = next(
         text for _sid, text in answer_calls if "safe-default synthesis" in text.lower()
     )
+    assert "mark the interview complete" in synthesis_text.lower()
     assert "actors" in synthesis_text
     assert any(
         "safe-default" in item.get("answer", "").lower() for item in ledger.question_history
@@ -290,6 +293,40 @@ async def test_interview_driver_blocks_when_safe_default_synthesis_rejected(tmp_
     assert result.status == "blocked"
     assert state.phase == AutoPhase.BLOCKED
     assert "safe-default synthesis" in (result.blocker or "").lower()
+    assert state.interview_completed is False
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_when_backend_ignores_synthesis_completion_signal(
+    tmp_path,
+) -> None:
+    # The synthesis text carries a "mark the interview complete" signal; if
+    # a backend ignores it and keeps asking questions, the persisted
+    # transcript would diverge from auto state. The driver must block
+    # rather than declaring seed_ready against a still-open transcript.
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        # Always return another question with seed_ready=False, regardless
+        # of the answer text — simulating a backend that does not honour
+        # the completion signal.
+        return InterviewTurn("Anything else?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert "completion signal" in (result.blocker or "").lower()
     assert state.interview_completed is False
 
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -484,7 +484,7 @@ def test_safe_default_blocks_when_conservative_default_entry_authorizes_unsafe_s
         "runtime_context",
         LedgerEntry(
             key="runtime_context.conservative_default",
-            value="Production database connection is the conservative default for this CLI.",
+            value="Deploys to production with customer credentials as the conservative default.",
             source=LedgerSource.CONSERVATIVE_DEFAULT,
             confidence=0.6,
             status=LedgerStatus.DEFAULTED,
@@ -525,6 +525,58 @@ def test_safe_default_blocks_when_non_user_goal_entry_introduces_unsafe_context(
 
     assert not result.completed
     assert any("unsafe default context" in gap for gap in result.unsafe_gaps)
+    assert not ledger.is_seed_ready()
+
+
+@pytest.mark.parametrize(
+    "goal",
+    [
+        "Reproduce a production bug locally with the existing test fixtures",
+        "Use the production schema snapshot already in the repo",
+        "Replay a captured production trace against the local server",
+        "Document the prod logging format in the developer guide",
+        "Compile the live preview build for local QA",
+    ],
+)
+def test_safe_default_allows_benign_production_mentions(goal: str) -> None:
+    ledger = SeedDraftLedger.from_goal(goal)
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert result.completed, (
+        f"goal {goal!r} only describes local read-only context; "
+        "finalization must not block on bare production/prod/live mentions"
+    )
+    assert result.unsafe_gaps == ()
+    assert ledger.is_seed_ready()
+
+
+@pytest.mark.parametrize(
+    "goal",
+    [
+        "Deploy the new service to production for the launch event",
+        "Release version 2 to prod after the freeze",
+        "Push live the cutover migration on Friday",
+        "Going live with the rebuilt checkout flow next week",
+    ],
+)
+def test_safe_default_blocks_genuine_production_actions(goal: str) -> None:
+    ledger = SeedDraftLedger.from_goal(goal)
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert not result.completed, (
+        f"goal {goal!r} authorizes a production-class action; finalization must block"
+    )
+    assert any("external side effect" in gap.lower() for gap in result.unsafe_gaps)
     assert not ledger.is_seed_ready()
 
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -312,6 +312,35 @@ def test_safe_default_blocks_when_interview_answer_introduces_unsafe_context() -
     assert not ledger.is_seed_ready()
 
 
+def test_safe_default_blocks_when_conservative_default_entry_authorizes_unsafe_scope() -> None:
+    # CONSERVATIVE_DEFAULT entries land with status DEFAULTED but still carry
+    # user-derived scope — the unsafe gate must not silently treat them as
+    # safe just because their status is DEFAULTED.
+    goal = "Build a small local CLI"
+    ledger = SeedDraftLedger.from_goal(goal)
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime_context.conservative_default",
+            value="Production database connection is the conservative default for this CLI.",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.6,
+            status=LedgerStatus.DEFAULTED,
+            rationale="Recorded by an earlier auto round.",
+        ),
+    )
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert not result.completed
+    assert any("unsafe default context" in gap for gap in result.unsafe_gaps)
+    assert not ledger.is_seed_ready()
+
+
 def test_safe_default_blocks_when_non_user_goal_entry_introduces_unsafe_context() -> None:
     ledger = SeedDraftLedger.from_goal("Build a small local CLI")
     ledger.add_entry(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -312,6 +312,62 @@ def test_safe_default_blocks_when_interview_answer_introduces_unsafe_context() -
     assert not ledger.is_seed_ready()
 
 
+def test_safe_default_ignores_from_auto_answers_in_question_history() -> None:
+    # AutoAnswerer prefixes every policy-emitted answer with "[from-auto]".
+    # Those answers routinely mention auth/credentials/production as
+    # exclusions; the unsafe gate must skip them so its own outputs do not
+    # block subsequent finalization passes.
+    goal = "Build a small local CLI"
+    ledger = SeedDraftLedger.from_goal(goal)
+    ledger.record_qa(
+        "What boundary should we keep?",
+        "[from-auto][conservative_default] Avoid authentication, credentials, "
+        "and production deployment per the conservative default.",
+    )
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert result.completed
+    assert result.unsafe_gaps == ()
+    assert ledger.is_seed_ready()
+
+
+def test_safe_default_finalization_is_idempotent_against_its_own_synthesis() -> None:
+    # Pushing the safe-default synthesis back through the interview transcript
+    # records it as an answer in question_history. A second finalize call on
+    # the same ledger must still succeed — the gate must recognize its own
+    # synthesis (tagged with the [from-auto] prefix) as policy output, not
+    # as new user-asserted unsafe context.
+    goal = "Build a small local CLI"
+    ledger = SeedDraftLedger.from_goal(goal)
+
+    first = finalize_safe_defaultable_gaps(
+        ledger, goal=goal, provenance="unit test pass 1"
+    )
+    assert first.completed
+    assert ledger.is_seed_ready()
+
+    # Simulate the interview driver appending the synthesis back into
+    # question_history (what _record_safe_default_synthesis does).
+    from ouroboros.auto.safe_defaults import build_safe_default_synthesis
+
+    synthesis = build_safe_default_synthesis(first)
+    assert synthesis  # sanity
+    ledger.record_qa("auto safe-default finalization", synthesis)
+
+    second = finalize_safe_defaultable_gaps(
+        ledger, goal=goal, provenance="unit test pass 2"
+    )
+    # Nothing left to default on pass 2, and the synthesis must not have
+    # poisoned the gate.
+    assert second.unsafe_gaps == ()
+    assert ledger.is_seed_ready()
+
+
 def test_safe_default_blocks_when_conservative_default_entry_authorizes_unsafe_scope() -> None:
     # CONSERVATIVE_DEFAULT entries land with status DEFAULTED but still carry
     # user-derived scope — the unsafe gate must not silently treat them as

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -259,9 +259,7 @@ async def test_interview_driver_finalizes_safe_defaults_after_max_rounds(tmp_pat
     )
     assert "mark the interview complete" in synthesis_text.lower()
     assert "actors" in synthesis_text
-    assert any(
-        "safe-default" in item.get("answer", "").lower() for item in ledger.question_history
-    )
+    assert any("safe-default" in item.get("answer", "").lower() for item in ledger.question_history)
 
 
 @pytest.mark.asyncio
@@ -382,9 +380,7 @@ def test_safe_default_finalization_is_idempotent_against_its_own_synthesis() -> 
     goal = "Build a small local CLI"
     ledger = SeedDraftLedger.from_goal(goal)
 
-    first = finalize_safe_defaultable_gaps(
-        ledger, goal=goal, provenance="unit test pass 1"
-    )
+    first = finalize_safe_defaultable_gaps(ledger, goal=goal, provenance="unit test pass 1")
     assert first.completed
     assert ledger.is_seed_ready()
 
@@ -396,9 +392,7 @@ def test_safe_default_finalization_is_idempotent_against_its_own_synthesis() -> 
     assert synthesis  # sanity
     ledger.record_qa("auto safe-default finalization", synthesis)
 
-    second = finalize_safe_defaultable_gaps(
-        ledger, goal=goal, provenance="unit test pass 2"
-    )
+    second = finalize_safe_defaultable_gaps(ledger, goal=goal, provenance="unit test pass 2")
     # Nothing left to default on pass 2, and the synthesis must not have
     # poisoned the gate.
     assert second.unsafe_gaps == ()

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -295,6 +295,54 @@ async def test_interview_driver_blocks_when_safe_default_synthesis_rejected(tmp_
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_finalizes_when_backend_requires_two_completion_signals(
+    tmp_path,
+) -> None:
+    # The production interview handler closes the transcript only after a
+    # streak of two qualifying completion signals. The driver must follow up
+    # with additional confirmation turns until the backend confirms.
+    completion_streak = 0
+    answer_calls: list[tuple[str, str]] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:
+        nonlocal completion_streak
+        answer_calls.append((session_id, text))
+        if "mark the interview complete" in text.lower():
+            completion_streak += 1
+            if completion_streak >= 2:
+                return InterviewTurn("", session_id, seed_ready=True, completed=True)
+            # Streak shortfall — backend asks the user to confirm again.
+            return InterviewTurn("Type done once more", session_id, seed_ready=False)
+        return InterviewTurn("What else?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.interview_completed is True
+    assert ledger.is_seed_ready()
+    # Round-1 user answer + synthesis (turn 1) + confirmation (turn 2) = 3.
+    completion_signal_calls = [
+        text for _sid, text in answer_calls if "mark the interview complete" in text.lower()
+    ]
+    assert len(completion_signal_calls) >= 2, (
+        "expected the driver to send at least two completion signals to satisfy "
+        f"the streak contract; got {completion_signal_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_blocks_when_backend_ignores_synthesis_completion_signal(
     tmp_path,
 ) -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -584,6 +584,13 @@ def test_safe_default_still_blocks_when_negation_does_not_cover_unsafe_term() ->
             "Without billing integration, send email notifications to customers.",
             "external side effect",
         ),
+        # Comma + noun-led counter-clause (no imperative verb) also breaks
+        # the scope when the sentence has no list connector — the second
+        # clause is a positive assertion that must still flag.
+        (
+            "No production deploys, customer credentials from Vault are still required.",
+            "credentials",
+        ),
         # Semicolon also breaks the scope.
         (
             "No external API; deploy to production for the first launch.",

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -217,10 +217,13 @@ def test_seed_draft_ledger_uses_later_repeated_non_goal_as_correction() -> None:
 
 @pytest.mark.asyncio
 async def test_interview_driver_finalizes_safe_defaults_after_max_rounds(tmp_path) -> None:
+    answer_calls: list[tuple[str, str]] = []
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What should we verify?", "interview_1")
 
-    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+    async def answer(session_id: str, text: str) -> InterviewTurn:
+        answer_calls.append((session_id, text))
         return InterviewTurn("What else?", session_id, seed_ready=False)
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -243,6 +246,51 @@ async def test_interview_driver_finalizes_safe_defaults_after_max_rounds(tmp_pat
     assert final_actor.status == LedgerStatus.DEFAULTED
     assert final_actor.source == LedgerSource.ASSUMPTION
     assert any("safe-default policy" in item for item in final_actor.evidence)
+    # Synthesis must be persisted to the interview transcript so the seed
+    # generator (which reads the transcript) sees the same assumptions the
+    # ledger now records — guards against the ledger/transcript split-brain.
+    assert any(
+        "safe-default synthesis" in text.lower() for _sid, text in answer_calls
+    ), "expected safe-default synthesis to be pushed through backend.answer"
+    synthesis_text = next(
+        text for _sid, text in answer_calls if "safe-default synthesis" in text.lower()
+    )
+    assert "actors" in synthesis_text
+    assert any(
+        "safe-default" in item.get("answer", "").lower() for item in ledger.question_history
+    )
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_when_safe_default_synthesis_rejected(tmp_path) -> None:
+    call_count = 0
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return InterviewTurn("What else?", session_id, seed_ready=False)
+        msg = "interview backend refuses post-bound synthesis"
+        raise RuntimeError(msg)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert "safe-default synthesis" in (result.blocker or "").lower()
+    assert state.interview_completed is False
 
 
 def test_safe_default_blocks_when_interview_answer_introduces_unsafe_context() -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -290,8 +290,20 @@ async def test_interview_driver_blocks_when_safe_default_synthesis_rejected(tmp_
 
     assert result.status == "blocked"
     assert state.phase == AutoPhase.BLOCKED
-    assert "safe-default synthesis" in (result.blocker or "").lower()
+    # Synthesis failure rolls back the safe-default entries so the canonical
+    # "unresolved gaps" blocker is reported and the ledger reflects the
+    # genuinely unresolved sections — preserving the convergence contract.
+    assert "unresolved gaps" in (result.blocker or "")
     assert state.interview_completed is False
+    assert ledger.open_gaps(), (
+        "rolled-back ledger must expose at least one unresolved gap so the "
+        "convergence contract still names actionable sections"
+    )
+    assert not any(
+        entry.key.endswith(".safe_default_finalization")
+        for section in ledger.sections.values()
+        for entry in section.entries
+    ), "safe-default policy entries must be reverted on synthesis failure"
 
 
 @pytest.mark.asyncio
@@ -372,8 +384,11 @@ async def test_interview_driver_blocks_when_backend_ignores_synthesis_completion
 
     assert result.status == "blocked"
     assert state.phase == AutoPhase.BLOCKED
-    assert "completion signal" in (result.blocker or "").lower()
+    # Backend ignored the completion signal → synthesis failed → ledger is
+    # rolled back and the canonical "unresolved gaps" blocker is emitted.
+    assert "unresolved gaps" in (result.blocker or "")
     assert state.interview_completed is False
+    assert ledger.open_gaps()
 
 
 def test_safe_default_blocks_when_interview_answer_introduces_unsafe_context() -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -523,6 +523,51 @@ def test_safe_default_still_blocks_when_negation_does_not_cover_unsafe_term() ->
     assert any("unsafe default context" in gap for gap in result.unsafe_gaps)
 
 
+@pytest.mark.parametrize(
+    ("answer", "expected_reason_substring"),
+    [
+        # Comma + imperative verb breaks the negation scope, leaving the
+        # second clause visible to the unsafe regex bank.
+        (
+            "No production deploys, use customer credentials from Vault.",
+            "credentials",
+        ),
+        (
+            "Without billing integration, send email notifications to customers.",
+            "external side effect",
+        ),
+        # Semicolon also breaks the scope.
+        (
+            "No external API; deploy to production for the first launch.",
+            "external side effect",
+        ),
+    ],
+)
+def test_safe_default_blocks_when_negation_does_not_cover_subsequent_clause(
+    answer: str, expected_reason_substring: str
+) -> None:
+    goal = "Build a small local CLI"
+    ledger = SeedDraftLedger.from_goal(goal)
+    ledger.record_qa("How should this work?", answer)
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert not result.completed, (
+        f"answer {answer!r} contains a positively asserted clause; "
+        "finalization must not auto-default"
+    )
+    joined = "\n".join(result.unsafe_gaps).lower()
+    assert expected_reason_substring.lower() in joined, (
+        f"expected unsafe reason matching {expected_reason_substring!r} for {answer!r}, "
+        f"got {result.unsafe_gaps!r}"
+    )
+    assert not ledger.is_seed_ready()
+
+
 def test_safe_default_treats_confirmed_non_goals_as_exclusions_not_unsafe_scope() -> None:
     goal = "Build a small local CLI"
     ledger = SeedDraftLedger.from_goal(goal)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -14,6 +14,7 @@ from ouroboros.auto.interview_driver import (
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipeline
 from ouroboros.auto.repo_context import repo_auto_answer_context
+from ouroboros.auto.safe_defaults import finalize_safe_defaultable_gaps
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
@@ -215,7 +216,7 @@ def test_seed_draft_ledger_uses_later_repeated_non_goal_as_correction() -> None:
 
 
 @pytest.mark.asyncio
-async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path) -> None:
+async def test_interview_driver_finalizes_safe_defaults_after_max_rounds(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What should we verify?", "interview_1")
 
@@ -233,9 +234,68 @@ async def test_interview_driver_blocks_after_max_rounds_with_open_gaps(tmp_path)
 
     result = await driver.run(state, ledger)
 
+    assert result.status == "seed_ready"
+    assert state.phase == AutoPhase.INTERVIEW
+    assert state.interview_completed is True
+    assert ledger.is_seed_ready()
+    assert ledger.summary()["open_gaps"] == []
+    final_actor = ledger.sections["actors"].entries[-1]
+    assert final_actor.status == LedgerStatus.DEFAULTED
+    assert final_actor.source == LedgerSource.ASSUMPTION
+    assert any("safe-default policy" in item for item in final_actor.evidence)
+
+
+def test_safe_default_non_goals_do_not_make_later_finalization_unsafe() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a small local CLI")
+    ledger.add_entry(
+        "non_goals",
+        LedgerEntry(
+            key="non_goals.safe_boundary",
+            value="Do not perform credential handling, billing, or production deployment.",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.7,
+            status=LedgerStatus.DEFAULTED,
+            rationale="Conservative scope boundary recorded by auto policy.",
+        ),
+    )
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a small local CLI",
+        provenance="unit test",
+    )
+
+    assert result.unsafe_gaps == ()
+    assert ledger.is_seed_ready()
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_keeps_unsafe_gaps_blocking_after_max_rounds(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(
+        goal="Deploy the service to production and configure the required credentials",
+        cwd=str(tmp_path),
+    )
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
     assert result.status == "blocked"
     assert state.phase == AutoPhase.BLOCKED
     assert "unresolved gaps" in (result.blocker or "")
+    assert "unsafe default context" in (result.blocker or "")
+    assert not ledger.is_seed_ready()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -304,6 +304,11 @@ async def test_interview_driver_blocks_when_safe_default_synthesis_rejected(tmp_
         for section in ledger.sections.values()
         for entry in section.entries
     ), "safe-default policy entries must be reverted on synthesis failure"
+    # Backend.answer raised after the first synthesis turn — the driver
+    # cannot trust the cached pending_question because the backend may have
+    # processed (or partially processed) the call. Force ``--resume`` to
+    # query live state via ``backend.resume()`` instead of replaying.
+    assert state.pending_question is None
 
 
 @pytest.mark.asyncio
@@ -389,6 +394,13 @@ async def test_interview_driver_blocks_when_backend_ignores_synthesis_completion
     assert "unresolved gaps" in (result.blocker or "")
     assert state.interview_completed is False
     assert ledger.open_gaps()
+    # After synthesis failure the driver must leave pending_question pointing
+    # at the backend's latest live prompt (or cleared) — never the stale
+    # pre-synthesis question. A later ``--resume`` would otherwise replay an
+    # already-answered prompt against an advanced session. The fake backend
+    # always returns "Anything else?" after the synthesis turns, so that's
+    # what the auto state should now hold.
+    assert state.pending_question == "Anything else?"
 
 
 def test_safe_default_blocks_when_interview_answer_introduces_unsafe_context() -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -359,6 +359,54 @@ def test_safe_default_allows_benign_external_mentions(goal: str) -> None:
     assert ledger.is_seed_ready()
 
 
+@pytest.mark.parametrize(
+    "answer",
+    [
+        "No production deployment.",
+        "No authentication required.",
+        "Do not use customer credentials.",
+        "Never deploy to production.",
+        "We avoid OAuth and skip billing.",
+        "No auth, credentials, and production deployment.",
+        "Without payment processing or webhook callbacks.",
+    ],
+)
+def test_safe_default_respects_negated_unsafe_terms(answer: str) -> None:
+    goal = "Build a small local CLI"
+    ledger = SeedDraftLedger.from_goal(goal)
+    ledger.record_qa("How should this work?", answer)
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert result.completed, f"negated answer {answer!r} should not block finalization"
+    assert result.unsafe_gaps == ()
+    assert ledger.is_seed_ready()
+
+
+def test_safe_default_still_blocks_when_negation_does_not_cover_unsafe_term() -> None:
+    goal = "Build a small local CLI"
+    ledger = SeedDraftLedger.from_goal(goal)
+    # Contrastive conjunctions cancel the negation scope — the second half is
+    # a positive assertion and must still flag.
+    ledger.record_qa(
+        "Walk me through the auth model.",
+        "No prod deploys, but log credentials in env so the daemon can read them.",
+    )
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert not result.completed
+    assert any("unsafe default context" in gap for gap in result.unsafe_gaps)
+
+
 def test_safe_default_treats_confirmed_non_goals_as_exclusions_not_unsafe_scope() -> None:
     goal = "Build a small local CLI"
     ledger = SeedDraftLedger.from_goal(goal)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -359,6 +359,55 @@ def test_safe_default_allows_benign_external_mentions(goal: str) -> None:
     assert ledger.is_seed_ready()
 
 
+def test_safe_default_treats_confirmed_non_goals_as_exclusions_not_unsafe_scope() -> None:
+    goal = "Build a small local CLI"
+    ledger = SeedDraftLedger.from_goal(goal)
+    ledger.add_entry(
+        "non_goals",
+        LedgerEntry(
+            key="non_goals.user_excludes",
+            value="auth, credentials, and production deployment",
+            source=LedgerSource.NON_GOAL,
+            confidence=0.95,
+            status=LedgerStatus.CONFIRMED,
+            rationale="User explicitly ruled these out during the interview.",
+        ),
+    )
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert result.completed
+    assert result.unsafe_gaps == ()
+    assert ledger.is_seed_ready()
+
+
+def test_safe_default_ignores_unsafe_terms_in_interview_questions() -> None:
+    goal = "Build a small local CLI"
+    ledger = SeedDraftLedger.from_goal(goal)
+    # The backend asked about authentication and production deployment, but
+    # the user explicitly answered no. Only answers carry user intent — the
+    # question alone must not poison finalization.
+    ledger.record_qa(
+        "How should this authenticate? Does it deploy to production?",
+        "No auth and local-only execution; nothing leaves the machine.",
+    )
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+        pending_question="Does this require any production credentials?",
+    )
+
+    assert result.completed
+    assert result.unsafe_gaps == ()
+    assert ledger.is_seed_ready()
+
+
 def test_safe_default_non_goals_do_not_make_later_finalization_unsafe() -> None:
     ledger = SeedDraftLedger.from_goal("Build a small local CLI")
     ledger.add_entry(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -245,6 +245,50 @@ async def test_interview_driver_finalizes_safe_defaults_after_max_rounds(tmp_pat
     assert any("safe-default policy" in item for item in final_actor.evidence)
 
 
+def test_safe_default_blocks_when_interview_answer_introduces_unsafe_context() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a small local CLI")
+    ledger.record_qa(
+        "How should the CLI authenticate?",
+        "It needs to call the production OAuth provider with the customer access token.",
+    )
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a small local CLI",
+        provenance="unit test",
+    )
+
+    assert not result.completed
+    assert result.unsafe_gaps  # at least one gap stays unsafe
+    assert any("unsafe default context" in gap for gap in result.unsafe_gaps)
+    assert not ledger.is_seed_ready()
+
+
+def test_safe_default_blocks_when_non_user_goal_entry_introduces_unsafe_context() -> None:
+    ledger = SeedDraftLedger.from_goal("Build a small local CLI")
+    ledger.add_entry(
+        "inputs",
+        LedgerEntry(
+            key="inputs.repo_fact",
+            value="Reads the production database credentials file from disk.",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.9,
+            status=LedgerStatus.CONFIRMED,
+            rationale="Surfaced from repo scan during interview.",
+        ),
+    )
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a small local CLI",
+        provenance="unit test",
+    )
+
+    assert not result.completed
+    assert any("unsafe default context" in gap for gap in result.unsafe_gaps)
+    assert not ledger.is_seed_ready()
+
+
 def test_safe_default_non_goals_do_not_make_later_finalization_unsafe() -> None:
     ledger = SeedDraftLedger.from_goal("Build a small local CLI")
     ledger.add_entry(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -337,6 +337,28 @@ def test_safe_default_blocks_when_non_user_goal_entry_introduces_unsafe_context(
     assert not ledger.is_seed_ready()
 
 
+@pytest.mark.parametrize(
+    "goal",
+    [
+        "Build a CLI with no external dependencies",
+        "Use existing external API schema files only",
+        "Sync against external integration documentation already vendored in the repo",
+    ],
+)
+def test_safe_default_allows_benign_external_mentions(goal: str) -> None:
+    ledger = SeedDraftLedger.from_goal(goal)
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert result.completed
+    assert result.unsafe_gaps == ()
+    assert ledger.is_seed_ready()
+
+
 def test_safe_default_non_goals_do_not_make_later_finalization_unsafe() -> None:
     ledger = SeedDraftLedger.from_goal("Build a small local CLI")
     ledger.add_entry(


### PR DESCRIPTION
## Summary
- Adds a general safe-default finalization policy for auto-interview sessions before they are marked blocked.
- Fills safe-defaultable required ledger gaps with explicit auditable assumptions/provenance.
- Keeps unsafe contexts blocking, including credentials/secrets, destructive production actions, payment/billing, regulated/security-sensitive decisions, and ambiguous external side effects.
- Adds regression tests for benign finalization and unsafe blocking.

## Discussion / implementation notes
- This PR intentionally avoids domain-specific templates such as game/frontend defaults.
- Finalization is the last-resort path after normal interview rounds, not a replacement for gap-driven steering.

## Validation
- [x] `git diff --check`
- [x] `PYTHONPATH=src /opt/hermes/.venv/bin/python -m pytest tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_interview_pipeline.py -q` — 161 passed

Closes #758
