### PR TITLE
docs(install): broaden uv install guidance for policy-restricted environments

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,3 +68,37 @@ should be aware of the following security considerations:
 This security policy covers the `ouroboros-ai` Python package and its
 official documentation. Third-party plugins, runtime backends, and
 downstream integrations are outside the scope of this policy.
+
+## Installation Channel
+
+Official installation channels for Ouroboros:
+
+- **PyPI** -- `ouroboros-ai`, installable via `pipx`, `uv tool`, or `pip`.
+- **GitHub repository** -- `https://github.com/Q00/ouroboros`. The
+  `scripts/install.sh` one-liner installer is hosted here and is also
+  advertised in `README.md`. It auto-detects an available CLI runtime and
+  registers the MCP server, which is why it remains the default Quick Start
+  path.
+- **uv** -- when uv is required, prefer package-manager installs
+  (`pipx install uv`, `pip install --user uv`, `brew install uv`) before
+  falling back to the vendor one-liner (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+  Both `scripts/install.sh` and `skills/setup/SKILL.md` surface these
+  alternatives so users in policy-restricted environments are not forced
+  through pipe-to-shell.
+
+If you operate in an environment that prohibits piping remote scripts to
+a shell, use the PyPI path (`pipx install ouroboros-ai` then
+`ouroboros setup`) -- it produces the same final configuration.
+
+## Bulk-Disclosure Scanner Policy
+
+Automated scanners that bulk-file pattern-matched findings (for example,
+`curl | sh` detectors) **should still follow the private reporting
+channel above before opening a public issue**, even for low-confidence
+matches. This gives maintainers a chance to triage, deduplicate, and
+respond before the report becomes externally indexable.
+
+Conventional installer patterns shared with peer tooling (rustup, uv,
+Homebrew, Deno, Bun, etc.) are treated as *Medium / hardening* at most
+under the severity ladder above; they are not classified as *Critical*
+solely because they match a `curl | sh` pattern.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,7 +112,11 @@ if [ "$HAS_UV" = false ]; then
       echo "Error: pipx requires Python >=${MIN_PYTHON} but none was found."
       echo ""
       echo "Install Python ${MIN_PYTHON}+: https://www.python.org/downloads/"
-      echo "Or switch to uv (recommended): curl -LsSf https://astral.sh/uv/install.sh | sh"
+      echo "Or install uv (recommended). Pick whichever fits your environment:"
+      echo "  pipx install uv"
+      echo "  pip install --user uv"
+      echo "  brew install uv          # macOS / Linuxbrew"
+      echo "  curl -LsSf https://astral.sh/uv/install.sh | sh   # vendor one-liner"
       exit 1
     fi
     echo "  Python: $($PYTHON --version)"
@@ -128,7 +132,11 @@ if [ "$HAS_UV" = false ]; then
       echo "Error: No installer found (uv, pipx) and Python >=${MIN_PYTHON} not available."
       echo ""
       echo "Install one of:"
-      echo "  • uv (recommended): curl -LsSf https://astral.sh/uv/install.sh | sh"
+      echo "  • uv (recommended). Pick whichever fits your environment:"
+      echo "      pipx install uv"
+      echo "      pip install --user uv"
+      echo "      brew install uv          # macOS / Linuxbrew"
+      echo "      curl -LsSf https://astral.sh/uv/install.sh | sh   # vendor one-liner"
       echo "  • Python ${MIN_PYTHON}+: https://www.python.org/downloads/"
       exit 1
     fi

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -176,10 +176,15 @@ pipx list 2>/dev/null | grep -q ouroboros && echo "PIPX" || echo "NOT_PIPX"
   ```
   If `DEPS_MISSING`: `python3 -m pip install ouroboros-ai[claude]`
 
-If deps are missing and the user doesn't want to fix manually, recommend uvx:
+If deps are missing and the user doesn't want to fix manually, recommend uv. Prefer
+package-manager paths over the vendor pipe-to-shell when the user's environment supports
+them (pipx > pip > brew > vendor one-liner):
 ```
-Or install uvx (recommended — handles deps automatically):
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+Or install uv (recommended — handles deps automatically). Any one of:
+  pipx install uv
+  pip install --user uv
+  brew install uv          # macOS / Linuxbrew
+  curl -LsSf https://astral.sh/uv/install.sh | sh   # vendor one-liner (last resort)
 Then re-run: ooo setup
 ```
 
@@ -189,8 +194,12 @@ Then re-run: ooo setup
 ```
 Ouroboros requires uvx (recommended) or the ouroboros package installed.
 
-Quick install (< 1 minute):
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+Quick install (< 1 minute) — install uv via any of:
+  pipx install uv
+  pip install --user uv
+  brew install uv          # macOS / Linuxbrew
+  curl -LsSf https://astral.sh/uv/install.sh | sh   # vendor one-liner (last resort)
+Then:
   uv python install 3.12
 
 Then re-run: ooo setup


### PR DESCRIPTION
## Summary
- Surface `pipx install uv` / `pip install --user uv` / `brew install uv` alongside the existing vendor `curl -LsSf https://astral.sh/uv/install.sh | sh` one-liner in both `scripts/install.sh` (pipx-branch and pip-fallback branch) and `skills/setup/SKILL.md` (missing-deps and missing-prereqs prompts), so users and agents in environments that disallow pipe-to-shell have a first-class install path without forking the installer.
- Add an *Installation Channel* section and a *Bulk-Disclosure Scanner Policy* section to `SECURITY.md`. The first documents canonical install paths (PyPI, GitHub, uv) and recommends package-manager paths over pipe-to-shell where the environment supports it; the second sets expectations that pattern-match scanners should still use the private reporting channel (`jqyu.lee@gmail.com`) before opening public issues, and clarifies that conventional installer patterns shared with peer tooling (rustup, uv, Homebrew, Deno, Bun) are at most *Medium / hardening* under the existing severity ladder, not *Critical*.

## Why this is scoped narrowly
This PR intentionally does **not**:
- Demote the `curl ... | bash` one-liner from the README primary CTA — the installer's value is auto-detecting the runtime and registering the MCP server, which alternative install paths skip.
- Pin the installer URL to a release tag — at the current ship cadence this would delay installer fixes by a release cycle for marginal threat-model benefit.
- Add SHA256 verify ceremony — a checksum published alongside the script in the same release is in the same trust domain (security theatre).

We may revisit those once the release cadence stabilises. See the issue thread on #766 for the full rationale.

Refs #766.

## Test plan
- [ ] `bash -n scripts/install.sh` (syntax check)
- [ ] Trigger pipx-branch missing-Python error path on a fresh VM; confirm the four-option block renders correctly
- [ ] Trigger pip-fallback missing-Python error path; confirm the four-option block renders correctly
- [ ] Run `ooo setup` against an environment with neither uv nor uvx; confirm the skill prescribes pipx/pip/brew paths first
