### PR TITLE
fix(mcp,interview): close tool envelope on max_turns=1 to stop turn starvation

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1250,6 +1250,16 @@ class InterviewHandler:
         # max_turns=1: MCP is a pure question generator. No tool use needed.
         # Main session handles codebase exploration and answering.
         #
+        # ``allowed_tools=[]`` is paired with ``max_turns=1``: any tool-use
+        # block emitted by the model would consume the only allowed turn
+        # and the SDK then raises ``Reached maximum number of turns (1)``
+        # before a final text response can stream.  The read-only policy
+        # envelope (``_interview_allowed_tools``) is intentionally bypassed
+        # here — interview is a single-shot question generator, not an
+        # agentic explorer, and matches ``PMInterviewHandler._get_engine``
+        # which closes the envelope the same way (``pm_handler.py``).
+        # See: https://github.com/Q00/ouroboros/issues/765
+        #
         # ``strict_mcp_config=True`` is opt-in here — and ONLY here — so the
         # subprocess spawned for question generation cannot rediscover the
         # plugin-provided ouroboros MCP server when this handler runs as a
@@ -1262,7 +1272,11 @@ class InterviewHandler:
             backend=self.llm_backend,
             max_turns=1,
             use_case="interview",
-            allowed_tools=_interview_allowed_tools(self.llm_backend),
+            allowed_tools=(
+                []
+                if backend_supports_tool_envelope(resolve_llm_backend(self.llm_backend))
+                else None
+            ),
             strict_mcp_config=True,
         )
         engine = self.interview_engine or InterviewEngine(

--- a/tests/unit/mcp/tools/test_interview_allowed_tools_wiring.py
+++ b/tests/unit/mcp/tools/test_interview_allowed_tools_wiring.py
@@ -1,0 +1,165 @@
+"""Wiring lock for the nested-MCP interview ``allowed_tools`` empty envelope.
+
+The nested ``ouroboros_interview`` MCP-tool entrypoint
+(``InterviewHandler.handle()``) MUST construct its question-generation
+adapter with ``allowed_tools=[]`` (when the backend supports a tool
+envelope) so the model cannot consume the single allowed turn on a
+read-only tool-use block.
+
+Background — https://github.com/Q00/ouroboros/issues/765
+``max_turns=1`` was paired with the *read-only* policy envelope
+(``_interview_allowed_tools``) by ``d7bbbf09`` ("Enforce read-only
+policy envelopes for MCP handlers"). On modern Claude (Opus 4.x) the
+model frequently chooses a ``Read``/``Grep``/``Glob`` tool call as its
+first turn, immediately exhausting the budget and surfacing
+``Reached maximum number of turns (1)`` before any final text streams.
+
+This test pins the wiring so a future "policy consistency" sweep
+cannot silently re-open the envelope and re-introduce the regression.
+``PMInterviewHandler._get_engine`` (``pm_handler.py``) closes the
+envelope the same way and is the prior-art reference.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ouroboros.bigbang.interview import InterviewState, InterviewStatus
+from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+
+@dataclass(slots=True)
+class _FakeInterviewEngine:
+    """Minimal injected engine — same shape as ``test_interview_strict_mcp_config_wiring``."""
+
+    state_dir: Path
+    saved_states: list[InterviewState] = field(default_factory=list)
+
+    async def start_interview(
+        self,
+        initial_context: str,
+        cwd: str | None = None,
+        interview_id: str | None = None,
+    ) -> Result[InterviewState, MCPServerError]:
+        sid = interview_id or "interview_allowedtoolswiring001"
+        state = InterviewState(
+            interview_id=sid,
+            initial_context=initial_context,
+            status=InterviewStatus.IN_PROGRESS,
+        )
+        self.saved_states.append(state)
+        return Result.ok(state)
+
+    async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
+        return Result.ok("What is the primary user goal?")
+
+    async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
+        path = self.state_dir / f"interview_{state.interview_id}.json"
+        path.write_text("{}", encoding="utf-8")
+        self.saved_states.append(state)
+        return Result.ok(path)
+
+    async def load_state(
+        self, session_id: str
+    ) -> Result[InterviewState, MCPServerError]:  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_nested_mcp_interview_handler_pins_allowed_tools_to_empty_for_envelope_backends(
+    tmp_path: Path,
+) -> None:
+    """``InterviewHandler.handle()`` MUST close the tool envelope on max_turns=1.
+
+    Regression guard for https://github.com/Q00/ouroboros/issues/765 — a
+    non-empty ``allowed_tools`` paired with ``max_turns=1`` lets the model
+    burn the only allowed turn on a tool-use block.
+    """
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    fake_adapter = MagicMock()
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=fake_adapter,
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+    ):
+        outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert outcome.is_ok, "handler must complete successfully on the happy path"
+    assert mock_factory.called, "handler must construct an LLM adapter via the factory"
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs.get("max_turns") == 1, (
+        "interview adapter is single-shot; this test pairs with the empty envelope below"
+    )
+    assert factory_kwargs.get("allowed_tools") == [], (
+        "interview adapter MUST be wired with allowed_tools=[] when the backend "
+        "supports a tool envelope. A non-empty envelope paired with max_turns=1 "
+        "lets the model spend the only allowed turn on a Read/Grep/Glob tool call "
+        "and the SDK raises 'Reached maximum number of turns (1)' before any "
+        "final text can stream. See issue #765 / commit d7bbbf09 for history."
+    )
+
+
+@pytest.mark.asyncio
+async def test_nested_mcp_interview_handler_passes_none_for_envelope_unaware_backends(
+    tmp_path: Path,
+) -> None:
+    """Backends without a tool-envelope concept (e.g. hermes) must receive ``None``.
+
+    Mirrors ``PMInterviewHandler._get_engine`` so the two handlers stay aligned.
+    """
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    fake_adapter = MagicMock()
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=fake_adapter,
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=False,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "hermes",
+        ),
+    ):
+        outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert outcome.is_ok
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs.get("allowed_tools") is None, (
+        "envelope-unaware backends must receive allowed_tools=None, not [], to "
+        "preserve the pre-policy default behaviour for those runtimes"
+    )


### PR DESCRIPTION
## Summary

- Restores `allowed_tools=[]` (envelope-aware) on `InterviewHandler.handle()`'s question-generation adapter, matching the prior-art pattern already used by `PMInterviewHandler._get_engine`
- Fixes the ~90% failure rate of `ouroboros_interview` reported in #765 — modern Claude (Opus 4.x) was burning the only allowed turn on a `Read` tool-call before any final-text question could stream
- Adds a wiring-lock test so a future "policy consistency" sweep cannot silently re-open the envelope and re-introduce this regression

## Root cause

Commit `d7bbbf09` ("Enforce read-only policy envelopes for MCP handlers", 2026-04-18) intentionally changed the interview adapter from `allowed_tools=[]` to the read-only policy envelope (`Read`/`Glob`/`Grep`/`WebFetch`/`WebSearch`). That change did not account for the existing `max_turns=1` budget — modern Claude often emits a `Read` tool-use block on its first turn, the SDK consumes the only allowed turn, and `_is_usable_max_turns_partial` (`claude_code_adapter.py:1019`) intentionally rejects `stop_reason=\"tool_use\"` partials, so #587's recovery path never fires.

`PMInterviewHandler._get_engine` (`pm_handler.py:368-375`) was deliberately left with `allowed_tools=[]` in the same `d7bbbf09` commit and is therefore unaffected. This PR brings `InterviewHandler` into alignment with that reference.

`8325246` — flagged by the auto-triage bot as the supposed fix — is orthogonal: it migrated the composition-root `mcp/server/adapter.py` to `ClaudeAgentAdapter` and did not touch any per-handler `create_llm_adapter(..., max_turns=1)` call site.

## What this PR does **not** do

- Does **not** modify `_interview_allowed_tools`. The helper is retained because a cleaner long-term solution is a follow-up to teach `orchestrator/policy.py` to honor the adapter's `max_turns` budget so the read-only envelope is automatically narrowed to `[]` whenever the adapter is single-shot. Filed separately so this hotfix can ship as v0.36.1.
- Does **not** sweep the other `max_turns=1` sites (`qa.py:578`, `authoring_handlers.py:590`, `mcp/server/adapter.py:1222,1262`). Each has a distinct use case and is out of scope for the reported regression.

## Test plan

- [x] `pytest tests/unit/mcp/tools/test_interview_allowed_tools_wiring.py` — new wiring lock (2 tests)
- [x] `pytest tests/unit/mcp/tools/test_interview_strict_mcp_config_wiring.py` — sibling wiring lock still passes
- [x] `pytest tests/unit/auto/test_surface.py::test_interview_allowed_tools_omits_unsupported_hermes_envelope` — helper still callable
- [x] `pytest tests/unit/mcp/tools/test_interview_reopen_seed_ready.py tests/unit/mcp/tools/test_handler_subagent_wiring.py` — adjacent interview tests
- [x] Sanity: confirmed the new wiring-lock test fails on the unpatched code and passes on the patched code
- [ ] (Maintainers) Validate against original repro from #765 before tagging v0.36.1

Closes #765