### PR TITLE
fix(ralph): per-iteration wall-clock timeout

### DIFF
--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -225,6 +225,7 @@ class RalphHandler:
                 skip_qa=config.skip_qa,
                 project_dir=config.project_dir,
                 max_generations=config.max_generations,
+                per_iteration_timeout_seconds=config.per_iteration_timeout_seconds,
             )
             await self._event_store.initialize()
             await emit_subagent_dispatched_event(

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -7,6 +7,7 @@ longer have to own the multi-generation loop in prompt/skill pseudo-code.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import math
 from typing import Any
 
 from ouroboros.core.types import Result
@@ -181,6 +182,13 @@ class RalphHandler:
             return Result.err(
                 MCPToolError(
                     "per_iteration_timeout_seconds must be a number",
+                    tool_name="ouroboros_ralph",
+                )
+            )
+        if not math.isfinite(per_iteration_timeout_seconds):
+            return Result.err(
+                MCPToolError(
+                    "per_iteration_timeout_seconds must be a finite number",
                     tool_name="ouroboros_ralph",
                 )
             )

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -28,9 +28,16 @@ from ouroboros.mcp.types import (
     ToolInputType,
 )
 from ouroboros.persistence.event_store import EventStore
-from ouroboros.ralph_loop import EvolveStepLike, RalphLoopConfig, RalphLoopRunner
+from ouroboros.ralph_loop import (
+    DEFAULT_PER_ITERATION_TIMEOUT_SECONDS,
+    EvolveStepLike,
+    RalphLoopConfig,
+    RalphLoopRunner,
+)
 
 MAX_RALPH_GENERATIONS = 10
+MIN_PER_ITERATION_TIMEOUT_SECONDS = 30.0
+MAX_PER_ITERATION_TIMEOUT_SECONDS = 7200.0
 
 
 @dataclass
@@ -112,6 +119,17 @@ class RalphHandler:
                     required=False,
                     default=MAX_RALPH_GENERATIONS,
                 ),
+                MCPToolParameter(
+                    name="per_iteration_timeout_seconds",
+                    type=ToolInputType.NUMBER,
+                    description=(
+                        "Per-iteration wall-clock timeout in seconds. If a single "
+                        "evolve_step generation exceeds this, the loop stops with "
+                        "stop_reason='iteration_timeout'. Default: 1800. Range: 30-7200."
+                    ),
+                    required=False,
+                    default=DEFAULT_PER_ITERATION_TIMEOUT_SECONDS,
+                ),
             ),
         )
 
@@ -152,6 +170,33 @@ class RalphHandler:
                 )
             )
 
+        try:
+            per_iteration_timeout_seconds = float(
+                arguments.get(
+                    "per_iteration_timeout_seconds",
+                    DEFAULT_PER_ITERATION_TIMEOUT_SECONDS,
+                )
+            )
+        except (TypeError, ValueError):
+            return Result.err(
+                MCPToolError(
+                    "per_iteration_timeout_seconds must be a number",
+                    tool_name="ouroboros_ralph",
+                )
+            )
+        if (
+            per_iteration_timeout_seconds < MIN_PER_ITERATION_TIMEOUT_SECONDS
+            or per_iteration_timeout_seconds > MAX_PER_ITERATION_TIMEOUT_SECONDS
+        ):
+            return Result.err(
+                MCPToolError(
+                    "per_iteration_timeout_seconds must be between "
+                    f"{MIN_PER_ITERATION_TIMEOUT_SECONDS:g} and "
+                    f"{MAX_PER_ITERATION_TIMEOUT_SECONDS:g}",
+                    tool_name="ouroboros_ralph",
+                )
+            )
+
         if arguments.get("delegation_depth", 0):
             return Result.err(
                 MCPToolError(
@@ -168,6 +213,7 @@ class RalphHandler:
             skip_qa=bool(arguments.get("skip_qa", False)),
             project_dir=arguments.get("project_dir"),
             max_generations=max_generations,
+            per_iteration_timeout_seconds=per_iteration_timeout_seconds,
         )
 
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -124,9 +124,16 @@ class RalphHandler:
                     name="per_iteration_timeout_seconds",
                     type=ToolInputType.NUMBER,
                     description=(
-                        "Per-iteration wall-clock timeout in seconds. If a single "
-                        "evolve_step generation exceeds this, the loop stops with "
-                        "stop_reason='iteration_timeout'. Default: 1800. Range: 30-7200."
+                        "Per-iteration wall-clock bound in seconds. In-process "
+                        "runtime: hard-enforced via asyncio.timeout, the loop "
+                        "stops with stop_reason='iteration_timeout' on expiry. "
+                        "OpenCode plugin runtime: advisory bound advertised to "
+                        "the child session via prompt + subagent context — the "
+                        "child is expected to honor it and return "
+                        "stop_reason='iteration_timeout', but the parent MCP "
+                        "process cannot interrupt the child, so a non-conforming "
+                        "child session may still exceed this bound. "
+                        "Default: 1800. Range: 30-7200."
                     ),
                     required=False,
                     default=DEFAULT_PER_ITERATION_TIMEOUT_SECONDS,

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1168,6 +1168,7 @@ def build_ralph_subagent(
     skip_qa: bool = False,
     project_dir: str | None = None,
     max_generations: int = 10,
+    per_iteration_timeout_seconds: float | None = None,
     delegation_depth: int = 1,
     allow_nested_ouroboros_ralph: bool = False,
 ) -> SubagentPayload:
@@ -1177,6 +1178,14 @@ def build_ralph_subagent(
     OpenCode bridge plugin runtime, however, MCP handlers must return a
     ``_subagent`` envelope and let the plugin's Task pane own execution rather
     than enqueueing an unobservable local background job.
+
+    Args:
+        per_iteration_timeout_seconds: Per-iteration wall-clock bound forwarded
+            from the MCP handler. The plugin child session must abort any
+            single ``evolve_step`` invocation that exceeds this many seconds
+            and surface ``stop_reason=iteration_timeout`` to the parent. When
+            ``None``, the field is omitted from prompt and context (legacy
+            shape preserved for callers that don't care about the bound).
     """
     seed_note = ""
     if seed_content is not None:
@@ -1211,6 +1220,16 @@ def build_ralph_subagent(
         )
     )
 
+    timeout_note = ""
+    if per_iteration_timeout_seconds is not None:
+        timeout_note = (
+            "\n## Per-Iteration Timeout\n"
+            f"per_iteration_timeout_seconds: {per_iteration_timeout_seconds:g}\n"
+            "Stop the generation immediately if any single `evolve_step` "
+            f"invocation exceeds {per_iteration_timeout_seconds:g} seconds; "
+            "that satisfies the public contract `stop_reason=iteration_timeout`.\n"
+        )
+
     prompt = f"""## Your Task
 
 Run a Ralph loop for the given lineage inside this OpenCode child session.
@@ -1220,6 +1239,8 @@ Repeat one evolutionary generation at a time until one stop condition is met:
 - action is converged
 - action is failed / interrupted / exhausted / stagnated
 - max_generations is reached
+- a single `evolve_step` invocation exceeds per_iteration_timeout_seconds
+  (when supplied) — return stop_reason=iteration_timeout
 
 ## Lineage ID
 {lineage_id}
@@ -1232,7 +1253,7 @@ Repeat one evolutionary generation at a time until one stop condition is met:
 - allow_nested_ouroboros_ralph: {str(allow_nested_ouroboros_ralph).lower()}
 - Do not call ouroboros_ralph from this child session. Run the loop directly
   by executing/evaluating one generation at a time.
-{seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}
+{seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{timeout_note}
 For generation 1, use the seed content when present. For later generations,
 reconstruct state from the lineage and continue without resending seed_content.
 
@@ -1249,6 +1270,7 @@ do not enqueue another background Ralph job."""
         "skip_qa": skip_qa,
         "project_dir": project_dir,
         "max_generations": max_generations,
+        "per_iteration_timeout_seconds": per_iteration_timeout_seconds,
         "delegation_depth": delegation_depth,
         "allow_nested_ouroboros_ralph": allow_nested_ouroboros_ralph,
     }

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1181,11 +1181,19 @@ def build_ralph_subagent(
 
     Args:
         per_iteration_timeout_seconds: Per-iteration wall-clock bound forwarded
-            from the MCP handler. The plugin child session must abort any
-            single ``evolve_step`` invocation that exceeds this many seconds
-            and surface ``stop_reason=iteration_timeout`` to the parent. When
-            ``None``, the field is omitted from prompt and context (legacy
-            shape preserved for callers that don't care about the bound).
+            from the MCP handler.
+
+            This is an *advisory* bound on the plugin path: the parent Python
+            MCP process cannot interrupt the OpenCode child session, so the
+            value is rendered into the subagent's prompt (with an explicit
+            stop instruction) and context dict, and the child session is
+            expected to honor it and return
+            ``stop_reason=iteration_timeout`` on expiry. A non-conforming
+            child session may still exceed the bound; hard wall-clock
+            enforcement only exists on the in-process runtime path
+            (``RalphLoopRunner``). When ``None``, the field is omitted from
+            both prompt and context (legacy shape preserved for callers that
+            don't care about the bound).
     """
     seed_note = ""
     if seed_content is not None:

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1270,10 +1270,11 @@ do not enqueue another background Ralph job."""
         "skip_qa": skip_qa,
         "project_dir": project_dir,
         "max_generations": max_generations,
-        "per_iteration_timeout_seconds": per_iteration_timeout_seconds,
         "delegation_depth": delegation_depth,
         "allow_nested_ouroboros_ralph": allow_nested_ouroboros_ralph,
     }
+    if per_iteration_timeout_seconds is not None:
+        context["per_iteration_timeout_seconds"] = per_iteration_timeout_seconds
 
     return build_subagent_payload(
         tool_name="ouroboros_ralph",

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -7,6 +7,7 @@ running repeated ``evolve_step`` calls inside one background job.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
@@ -16,6 +17,8 @@ from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
 _TERMINAL_SUCCESS_ACTIONS = frozenset({"converged"})
 _TERMINAL_FAILURE_ACTIONS = frozenset({"failed", "interrupted", "exhausted", "stagnated"})
+
+DEFAULT_PER_ITERATION_TIMEOUT_SECONDS = 1800.0
 
 
 class EvolveStepLike(Protocol):
@@ -35,6 +38,7 @@ class RalphLoopConfig:
     skip_qa: bool = False
     project_dir: str | None = None
     max_generations: int = 10
+    per_iteration_timeout_seconds: float = DEFAULT_PER_ITERATION_TIMEOUT_SECONDS
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,7 +133,43 @@ class RalphLoopRunner:
             if config.project_dir:
                 arguments["project_dir"] = config.project_dir
 
-            result = await self.evolve_handler.handle(arguments)
+            try:
+                result = await asyncio.wait_for(
+                    self.evolve_handler.handle(arguments),
+                    timeout=config.per_iteration_timeout_seconds,
+                )
+            except TimeoutError:
+                iterations.append(
+                    RalphIteration(
+                        generation=None,
+                        action="iteration_timeout",
+                        qa_verdict=None,
+                        is_error=True,
+                    )
+                )
+                status = "failed"
+                stop_reason = "iteration_timeout"
+                if final_result is None:
+                    final_result = MCPToolResult(
+                        content=(
+                            MCPContentItem(
+                                type=ContentType.TEXT,
+                                text=(
+                                    "Ralph iteration "
+                                    f"{iteration_index} exceeded "
+                                    f"{config.per_iteration_timeout_seconds:.0f}s timeout."
+                                ),
+                            ),
+                        ),
+                        is_error=True,
+                        meta={
+                            "lineage_id": config.lineage_id,
+                            "action": "iteration_timeout",
+                            "generation": None,
+                        },
+                    )
+                break
+
             if result.is_err:
                 raise RuntimeError(str(result.error))
 

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -133,12 +133,23 @@ class RalphLoopRunner:
             if config.project_dir:
                 arguments["project_dir"] = config.project_dir
 
+            iteration_timed_out = False
             try:
-                result = await asyncio.wait_for(
-                    self.evolve_handler.handle(arguments),
-                    timeout=config.per_iteration_timeout_seconds,
-                )
+                async with asyncio.timeout(config.per_iteration_timeout_seconds) as iteration_cm:
+                    result = await self.evolve_handler.handle(arguments)
             except TimeoutError:
+                # Distinguish *our* wall-clock timeout from any TimeoutError raised
+                # by ``evolve_handler.handle`` itself (e.g. an inner provider
+                # timeout). Only when ``iteration_cm.expired()`` is True did the
+                # per-iteration deadline actually fire; otherwise the inner
+                # exception is the real failure and must propagate so the outer
+                # caller can surface the underlying cause instead of a misleading
+                # ``stop_reason=iteration_timeout``.
+                if not iteration_cm.expired():
+                    raise
+                iteration_timed_out = True
+
+            if iteration_timed_out:
                 iterations.append(
                     RalphIteration(
                         generation=None,

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -252,10 +252,10 @@ class TestBuildRalphSubagent:
             "skip_qa": True,
             "project_dir": "/repo",
             "max_generations": 4,
-            "per_iteration_timeout_seconds": None,
             "delegation_depth": 1,
             "allow_nested_ouroboros_ralph": False,
         }
+        assert "per_iteration_timeout_seconds" not in payload.context
 
     def test_forwards_per_iteration_timeout_to_prompt_and_context(self) -> None:
         payload = build_ralph_subagent(

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -242,6 +242,8 @@ class TestBuildRalphSubagent:
         assert "delegation_depth: 1" in payload.prompt
         assert "allow_nested_ouroboros_ralph: false" in payload.prompt
         assert "Do not call ouroboros_ralph" in payload.prompt
+        # Without per_iteration_timeout_seconds, the timeout block is omitted.
+        assert "Per-Iteration Timeout" not in payload.prompt
         assert payload.context == {
             "lineage_id": "lin-ralph",
             "seed_content": "goal: ship",
@@ -250,9 +252,23 @@ class TestBuildRalphSubagent:
             "skip_qa": True,
             "project_dir": "/repo",
             "max_generations": 4,
+            "per_iteration_timeout_seconds": None,
             "delegation_depth": 1,
             "allow_nested_ouroboros_ralph": False,
         }
+
+    def test_forwards_per_iteration_timeout_to_prompt_and_context(self) -> None:
+        payload = build_ralph_subagent(
+            lineage_id="lin-timeout",
+            seed_content="goal: ship",
+            max_generations=3,
+            per_iteration_timeout_seconds=900,
+        )
+
+        assert payload.context["per_iteration_timeout_seconds"] == 900
+        assert "per_iteration_timeout_seconds: 900" in payload.prompt
+        assert "stop_reason=iteration_timeout" in payload.prompt
+        assert "exceeds 900 seconds" in payload.prompt
 
     def test_serializes_seed_content_as_json_data(self) -> None:
         payload = build_ralph_subagent(

--- a/tests/unit/test_ralph_loop_timeout.py
+++ b/tests/unit/test_ralph_loop_timeout.py
@@ -1,0 +1,155 @@
+"""Regression tests for the per-iteration wall-clock timeout in Ralph loop.
+
+Covers issue #776: a single hung ``evolve_step`` invocation must not consume
+the entire wall clock. The runner enforces a per-iteration timeout via
+``asyncio.wait_for``; the MCP layer validates the user-supplied bound at
+``30 <= x <= 7200`` seconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.ralph_loop import RalphLoopConfig, RalphLoopRunner
+
+
+@dataclass
+class _SleepingEvolveHandler:
+    """Evolve handler whose ``handle`` blocks past the per-iteration timeout."""
+
+    sleep_seconds: float
+    calls: int = 0
+    started: asyncio.Event = field(default_factory=asyncio.Event)
+
+    async def handle(self, arguments: dict[str, Any]):
+        self.calls += 1
+        self.started.set()
+        await asyncio.sleep(self.sleep_seconds)
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": self.calls,
+                    "action": "continue",
+                },
+            )
+        )
+
+
+@dataclass
+class _ImmediateEvolveHandler:
+    """Trivial evolve handler so RalphHandler validation tests can be wired."""
+
+    async def handle(self, arguments: dict[str, Any]):  # pragma: no cover - unused path
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": 1,
+                    "action": "converged",
+                },
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_ralph_loop_stops_when_iteration_exceeds_timeout() -> None:
+    """A handler that hangs longer than the timeout must abort the loop."""
+    evolve = _SleepingEvolveHandler(sleep_seconds=0.5)
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_timeout",
+            seed_content="goal: timeout",
+            max_generations=5,
+            per_iteration_timeout_seconds=0.05,
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.stop_reason == "iteration_timeout"
+    assert result.iteration_count == 1
+    assert result.iterations[0].action == "iteration_timeout"
+    assert result.iterations[0].is_error is True
+    # The loop must abort after the first iteration; no second handler call.
+    assert evolve.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ralph_loop_timeout_surfaces_in_tool_result_meta() -> None:
+    """``iterations`` end-to-end metadata exposes the timeout cause to clients."""
+    evolve = _SleepingEvolveHandler(sleep_seconds=0.2)
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_timeout_meta",
+            max_generations=3,
+            per_iteration_timeout_seconds=0.05,
+        )
+    )
+
+    tool_result = result.to_tool_result()
+    assert tool_result.is_error is True
+    assert tool_result.meta["status"] == "failed"
+    assert tool_result.meta["stop_reason"] == "iteration_timeout"
+    assert tool_result.meta["actions"] == ["iteration_timeout"]
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_per_iteration_timeout_below_floor() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_floor",
+            "per_iteration_timeout_seconds": 10,
+        }
+    )
+
+    assert result.is_err
+    assert "per_iteration_timeout_seconds" in str(result.error)
+    assert "between 30 and 7200" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_per_iteration_timeout_above_ceiling() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_ceiling",
+            "per_iteration_timeout_seconds": 10000,
+        }
+    )
+
+    assert result.is_err
+    assert "per_iteration_timeout_seconds" in str(result.error)
+    assert "between 30 and 7200" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_non_numeric_per_iteration_timeout() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_bad",
+            "per_iteration_timeout_seconds": "not-a-number",
+        }
+    )
+
+    assert result.is_err
+    assert "per_iteration_timeout_seconds must be a number" in str(result.error)

--- a/tests/unit/test_ralph_loop_timeout.py
+++ b/tests/unit/test_ralph_loop_timeout.py
@@ -156,6 +156,28 @@ async def test_ralph_handler_rejects_non_numeric_per_iteration_timeout() -> None
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+async def test_ralph_handler_rejects_non_finite_per_iteration_timeout(
+    bad_value: float,
+) -> None:
+    """Non-finite values bypass plain range comparisons (`NaN < 30` is False),
+    so the handler must reject them explicitly before they can leak into
+    ``asyncio.wait_for`` or the plugin-path subagent context.
+    """
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_nonfinite",
+            "per_iteration_timeout_seconds": bad_value,
+        }
+    )
+
+    assert result.is_err
+    assert "per_iteration_timeout_seconds must be a finite number" in str(result.error)
+
+
+@pytest.mark.asyncio
 async def test_plugin_dispatch_forwards_per_iteration_timeout_seconds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_ralph_loop_timeout.py
+++ b/tests/unit/test_ralph_loop_timeout.py
@@ -153,3 +153,54 @@ async def test_ralph_handler_rejects_non_numeric_per_iteration_timeout() -> None
 
     assert result.is_err
     assert "per_iteration_timeout_seconds must be a number" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_plugin_dispatch_forwards_per_iteration_timeout_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plugin-mode dispatch must forward per_iteration_timeout_seconds.
+
+    Wiring lock for #784 review-1: when ``should_dispatch_via_plugin`` returns
+    True, the produced ``_subagent`` payload context must include
+    ``per_iteration_timeout_seconds``. Otherwise the public stop-reason
+    contract (``iteration_timeout``) is silently dropped on the plugin path
+    and the child session can hang indefinitely.
+    """
+    import json as _json
+
+    from ouroboros.mcp.tools import ralph_handlers as _ralph_handlers
+
+    handler = RalphHandler(
+        evolve_handler=_ImmediateEvolveHandler(),  # type: ignore[arg-type]
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    # Make the audit emitter a no-op (handler initializes its own EventStore).
+    async def _noop_emit(event_store, *, session_id, payload):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(
+        _ralph_handlers,
+        "emit_subagent_dispatched_event",
+        _noop_emit,
+    )
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_plugin_timeout",
+            "seed_content": "goal: ship",
+            "max_generations": 3,
+            "per_iteration_timeout_seconds": 1234,
+        }
+    )
+
+    assert result.is_ok
+    tool_result = result.value
+    body = _json.loads(tool_result.content[0].text)
+    sub = body["_subagent"]
+    assert sub["tool_name"] == "ouroboros_ralph"
+    assert sub["context"]["per_iteration_timeout_seconds"] == 1234
+    assert "per_iteration_timeout_seconds: 1234" in sub["prompt"]
+    assert "stop_reason=iteration_timeout" in sub["prompt"]

--- a/tests/unit/test_ralph_loop_timeout.py
+++ b/tests/unit/test_ralph_loop_timeout.py
@@ -2,8 +2,10 @@
 
 Covers issue #776: a single hung ``evolve_step`` invocation must not consume
 the entire wall clock. The runner enforces a per-iteration timeout via
-``asyncio.wait_for``; the MCP layer validates the user-supplied bound at
-``30 <= x <= 7200`` seconds.
+``asyncio.timeout`` and uses ``Timeout.expired()`` to distinguish *its*
+deadline firing from any ``TimeoutError`` raised by the evolve stack itself.
+The MCP layer validates the user-supplied bound at ``30 <= x <= 7200`` seconds
+and rejects non-finite values.
 """
 
 from __future__ import annotations
@@ -106,6 +108,47 @@ async def test_ralph_loop_timeout_surfaces_in_tool_result_meta() -> None:
     assert tool_result.meta["status"] == "failed"
     assert tool_result.meta["stop_reason"] == "iteration_timeout"
     assert tool_result.meta["actions"] == ["iteration_timeout"]
+
+
+@dataclass
+class _InnerTimeoutEvolveHandler:
+    """Handler that raises ``TimeoutError`` itself, *before* the wall clock fires.
+
+    Models an inner provider/network timeout from inside ``evolve_step``: the
+    runtime per-iteration deadline must not silently rebrand this as
+    ``stop_reason=iteration_timeout`` — the original failure must propagate.
+    """
+
+    calls: int = 0
+
+    async def handle(self, arguments: dict[str, Any]):
+        self.calls += 1
+        raise TimeoutError("inner provider timeout")
+
+
+@pytest.mark.asyncio
+async def test_inner_timeout_error_is_not_swallowed_as_iteration_timeout() -> None:
+    """An inner ``TimeoutError`` must propagate, not be relabeled as our timeout.
+
+    Regression for #784 review-3: catching bare ``TimeoutError`` around
+    ``asyncio.wait_for(...)`` swallowed inner timeouts (provider/IO) and
+    misreported them with ``stop_reason=iteration_timeout``. The runner now
+    distinguishes the two by checking ``asyncio.timeout(...).expired()``.
+    """
+    evolve = _InnerTimeoutEvolveHandler()
+    runner = RalphLoopRunner(evolve)
+
+    with pytest.raises(TimeoutError, match="inner provider timeout"):
+        await runner.run(
+            RalphLoopConfig(
+                lineage_id="lin_inner_timeout",
+                max_generations=3,
+                # Generous budget so the wall-clock deadline cannot fire first.
+                per_iteration_timeout_seconds=30.0,
+            )
+        )
+
+    assert evolve.calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #776.

## Summary

- Wrap `evolve_handler.handle()` in `asyncio.wait_for(timeout=config.per_iteration_timeout_seconds)` inside `RalphLoopRunner.run` so a single hung iteration cannot consume the entire wall-clock budget. On timeout, append the iteration with `action="iteration_timeout"`, `is_error=True`, and break the loop with `status="failed"`, `stop_reason="iteration_timeout"`.
- Add `RalphLoopConfig.per_iteration_timeout_seconds: float = 1800.0` (30 min default — typical `evolve_step` lands in 5–15 min, this gives ~2× headroom; calibratable in the #783 E2E run).
- Wire `per_iteration_timeout_seconds` as an optional `ouroboros_ralph` MCP argument with validation `30 <= x <= 7200` (raise `MCPToolError` outside that range).
- Surface the timeout in the synthesized `MCPToolResult.meta` (`action="iteration_timeout"`) so `ouroboros_job_result` makes the cause visible to clients.

## Test plan

- [x] `tests/unit/test_ralph_loop_timeout.py` (new, 5 tests): runner stops on timeout; result meta carries `action="iteration_timeout"`; handler rejects values below 30s, above 7200s, and non-numeric.
- [x] Ralph regression: `pytest tests/unit -k ralph` → 49 passed.
- [x] Lint: `ruff format --check` and `ruff check` clean over the touched files.

Pre-existing upstream/main failure (`tests/unit/orchestrator/test_codex_cli_runtime.py::test_build_command_omits_profile_flag_when_runtime_profile_unset`) is unrelated to this PR (verified by stashing the diff and re-running on the parent commit).