### PR TITLE
fix(auto): SeedRepairer.converge() add max_iterations + outer wait_for

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -294,7 +294,19 @@ class AutoPipeline:
         if state.phase == AutoPhase.REVIEW:
             reviewer = self.reviewer or SeedReviewer(self.grade_gate)
             repairer = self.repairer or SeedRepairer(reviewer=reviewer)
-            seed, review, repairs = repairer.converge(seed, ledger=ledger)
+            repair_timeout = state.phase_timeout_seconds(AutoPhase.REPAIR)
+            try:
+                seed, review, repairs = await asyncio.wait_for(
+                    asyncio.to_thread(repairer.converge, seed, ledger=ledger),
+                    timeout=repair_timeout,
+                )
+            except TimeoutError:
+                state.mark_blocked(
+                    f"repair phase exceeded {repair_timeout:.0f}s",
+                    tool_name="seed_repairer",
+                )
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
             state.seed_artifact = seed.to_dict()
             state.repair_round = len(repairs)
             state.last_grade = review.grade_result.grade.value

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
+import inspect
+import threading
 from typing import Any
 
 from ouroboros.auto.blocker_attribution import record_authoring_backend
@@ -295,12 +297,27 @@ class AutoPipeline:
             reviewer = self.reviewer or SeedReviewer(self.grade_gate)
             repairer = self.repairer or SeedRepairer(reviewer=reviewer)
             repair_timeout = state.phase_timeout_seconds(AutoPhase.REPAIR)
+            # ``asyncio.wait_for`` only releases the awaiting coroutine; it
+            # cannot interrupt synchronous reviewer work running in the
+            # ``to_thread`` worker. Pass an explicit cancel signal so the
+            # repairer exits at the next iteration boundary instead of
+            # continuing to consume LLM calls after the budget expired
+            # (PR #785 review-3).
+            cancel_event = threading.Event()
+            converge_kwargs: dict[str, Any] = {"ledger": ledger}
+            # Older test stubs / external implementations of ``converge`` may
+            # not accept ``cancel_event``; only pass it when the callable
+            # actually declares it (or accepts ``**kwargs``). Real
+            # ``SeedRepairer.converge`` does declare it.
+            if _accepts_keyword(repairer.converge, "cancel_event"):
+                converge_kwargs["cancel_event"] = cancel_event
             try:
                 seed, review, repairs = await asyncio.wait_for(
-                    asyncio.to_thread(repairer.converge, seed, ledger=ledger),
+                    asyncio.to_thread(repairer.converge, seed, **converge_kwargs),
                     timeout=repair_timeout,
                 )
             except TimeoutError:
+                cancel_event.set()
                 state.mark_blocked(
                     f"repair phase exceeded {repair_timeout:.0f}s",
                     tool_name="seed_repairer",
@@ -744,6 +761,25 @@ def _grade_meets_required(actual: str | None, required: str) -> bool:
     if actual not in rank or required not in rank:
         return False
     return rank[actual] <= rank[required]
+
+
+def _accepts_keyword(func: Callable[..., Any], name: str) -> bool:
+    """Return True iff ``func`` declares ``name`` or accepts ``**kwargs``.
+
+    Used to decide whether the repair-phase cancel signal can be threaded
+    into a ``converge``-shaped callable without breaking older test stubs
+    that only declare ``(seed, *, ledger)``.
+    """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+    for param in sig.parameters.values():
+        if param.name == name:
+            return True
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
 
 
 def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -757,7 +757,12 @@ def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
         return AutoPhase.INTERVIEW
     if tool_name == "seed_generator":
         return AutoPhase.SEED_GENERATION
-    if tool_name in {"seed_saver", "grade_gate", "seed_loader"}:
+    if tool_name in {"seed_saver", "grade_gate", "seed_loader", "seed_repairer"}:
+        # ``seed_repairer`` joins this set so a repair-phase timeout (the
+        # outer ``asyncio.wait_for`` around ``repairer.converge`` inside
+        # AutoPipeline.run) is recoverable on ``--resume``: the only sensible
+        # restart is the REVIEW phase, which re-invokes the bounded repairer.
+        # Without this entry a transient timeout becomes a permanent dead end.
         return AutoPhase.REVIEW
     if tool_name == "run_starter":
         return AutoPhase.RUN

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -5,12 +5,26 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import re
+import threading
 from uuid import uuid4
 
 from ouroboros.auto.grading import VAGUE_TERMS, SeedGrade
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.core.seed import Seed
+
+
+class RepairCancelled(Exception):
+    """Raised when the converge loop observes a set cancel signal.
+
+    The repair phase timeout in ``AutoPipeline.run`` cannot interrupt a
+    synchronous ``reviewer.review()`` call mid-execution, but it can stop the
+    loop from launching *another* review/repair iteration once the in-flight
+    call returns. This sentinel travels back through ``asyncio.to_thread``
+    and is intentionally distinct from ``TimeoutError`` (which the awaiter
+    already raised) so log analysis can tell "stopped at iteration boundary"
+    apart from "still hung in reviewer.review()".
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,7 +150,11 @@ class SeedRepairer:
         )
 
     def converge(
-        self, seed: Seed, *, ledger: SeedDraftLedger | None = None
+        self,
+        seed: Seed,
+        *,
+        ledger: SeedDraftLedger | None = None,
+        cancel_event: threading.Event | None = None,
     ) -> tuple[Seed, SeedReview, list[RepairResult]]:
         """Review/repair until A-grade or bounded stop.
 
@@ -153,12 +171,31 @@ class SeedRepairer:
         ``state.last_grade`` / ``state.findings`` from this review, so a stale
         review here would block a seed that the final allowed repair actually
         fixed (PR #785 review-1).
+
+        ``cancel_event`` enables cooperative cancellation by the pipeline's
+        repair-phase ``asyncio.wait_for``. ``wait_for`` only releases the
+        awaiting coroutine; it cannot interrupt a synchronous reviewer call
+        running in the worker thread. If the event is set, this method
+        raises :class:`RepairCancelled` at the next iteration boundary so no
+        *further* ``reviewer.review`` calls run after the budget expires.
+        The currently in-flight reviewer call still finishes naturally — that
+        is a non-cancellable C/IO boundary in CPython — but the loop will not
+        consume another review's worth of LLM time/cost (PR #785 review-3).
         """
         history: list[RepairResult] = []
         previous_high_fingerprints: set[str] = set()
         current = seed
+
+        def _check_cancelled() -> None:
+            if cancel_event is not None and cancel_event.is_set():
+                raise RepairCancelled(
+                    "repair phase cancelled by pipeline timeout before next reviewer call"
+                )
+
+        _check_cancelled()
         review = self.reviewer.review(current, ledger=ledger)
         for _ in range(self.max_iterations):
+            _check_cancelled()
             if review.grade_result.grade == SeedGrade.A and review.may_run:
                 return current, review, history
             high = {
@@ -173,12 +210,15 @@ class SeedRepairer:
                 # Bound hit *after* a successful repair: the cached ``review``
                 # still describes the previous (pre-repair) seed. Re-review
                 # ``current`` once so the returned pair is consistent.
+                _check_cancelled()
                 review = self.reviewer.review(current, ledger=ledger)
                 return current, review, history
             if high and high == previous_high_fingerprints:
+                _check_cancelled()
                 review = self.reviewer.review(current, ledger=ledger)
                 return current, review, history
             previous_high_fingerprints = high
+            _check_cancelled()
             review = self.reviewer.review(current, ledger=ledger)
         return current, review, history
 

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -142,10 +142,17 @@ class SeedRepairer:
 
         ``max_iterations`` caps the number of recorded repair attempts. Once
         ``len(history) >= self.max_iterations`` the loop returns the most
-        recent reviewed ``(seed, review, history)`` without invoking the
-        reviewer again — this is the upper bound the pipeline relies on to
-        prevent unbounded LLM cost when the reviewer keeps producing the
-        same finding.
+        recent reviewed ``(seed, review, history)`` — this is the upper bound
+        the pipeline relies on to prevent unbounded LLM cost when the reviewer
+        keeps producing the same finding.
+
+        When the bound is reached *immediately after* applying a repair, the
+        last cached ``review`` still describes the *pre-repair* seed; in that
+        case we perform exactly one final reconciliation review so the
+        returned ``(seed, review)`` pair is consistent. The pipeline persists
+        ``state.last_grade`` / ``state.findings`` from this review, so a stale
+        review here would block a seed that the final allowed repair actually
+        fixed (PR #785 review-1).
         """
         history: list[RepairResult] = []
         previous_high_fingerprints: set[str] = set()
@@ -163,8 +170,10 @@ class SeedRepairer:
                 return current, review, history
             current = repair.seed
             if len(history) >= self.max_iterations:
-                # Bound hit: return the last known review without spending
-                # another reviewer call.
+                # Bound hit *after* a successful repair: the cached ``review``
+                # still describes the previous (pre-repair) seed. Re-review
+                # ``current`` once so the returned pair is consistent.
+                review = self.reviewer.review(current, ledger=ledger)
                 return current, review, history
             if high and high == previous_high_fingerprints:
                 review = self.reviewer.review(current, ledger=ledger)

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -29,7 +29,26 @@ class SeedRepairer:
     """Deterministically repair common A-grade failures."""
 
     reviewer: SeedReviewer = field(default_factory=SeedReviewer)
-    max_repair_rounds: int = 5
+    # Canonical iteration bound. ``max_repair_rounds`` is preserved as a
+    # backward-compatible alias for existing callers (CLI, MCP, persisted
+    # state). The default mirrors ``AutoPipelineState.max_repair_rounds`` at
+    # ``state.py:228`` so the repairer-layer bound matches the pipeline-layer
+    # bound the rest of the codebase already advertises.
+    max_iterations: int = 5
+    max_repair_rounds: int = field(default=5, repr=False)
+
+    def __post_init__(self) -> None:
+        # Resolve ``max_iterations`` and ``max_repair_rounds`` to a single
+        # bound so callers can use either name without surprise. When a caller
+        # passes only ``max_repair_rounds`` (legacy callsites in CLI / MCP /
+        # tests), mirror it onto ``max_iterations``. When a caller passes
+        # ``max_iterations`` (new contract), mirror it back onto
+        # ``max_repair_rounds`` so existing introspection (e.g. progress
+        # surfaces reading ``repairer.max_repair_rounds``) keeps working.
+        if self.max_iterations == 5 and self.max_repair_rounds != 5:
+            self.max_iterations = self.max_repair_rounds
+        else:
+            self.max_repair_rounds = self.max_iterations
 
     def repair_once(
         self,
@@ -119,12 +138,20 @@ class SeedRepairer:
     def converge(
         self, seed: Seed, *, ledger: SeedDraftLedger | None = None
     ) -> tuple[Seed, SeedReview, list[RepairResult]]:
-        """Review/repair until A-grade or bounded stop."""
+        """Review/repair until A-grade or bounded stop.
+
+        ``max_iterations`` caps the number of recorded repair attempts. Once
+        ``len(history) >= self.max_iterations`` the loop returns the most
+        recent reviewed ``(seed, review, history)`` without invoking the
+        reviewer again — this is the upper bound the pipeline relies on to
+        prevent unbounded LLM cost when the reviewer keeps producing the
+        same finding.
+        """
         history: list[RepairResult] = []
         previous_high_fingerprints: set[str] = set()
         current = seed
         review = self.reviewer.review(current, ledger=ledger)
-        for _ in range(self.max_repair_rounds):
+        for _ in range(self.max_iterations):
             if review.grade_result.grade == SeedGrade.A and review.may_run:
                 return current, review, history
             high = {
@@ -135,6 +162,10 @@ class SeedRepairer:
             if repair.blocker or not repair.changed:
                 return current, review, history
             current = repair.seed
+            if len(history) >= self.max_iterations:
+                # Bound hit: return the last known review without spending
+                # another reviewer call.
+                return current, review, history
             if high and high == previous_high_fingerprints:
                 review = self.reviewer.review(current, ledger=ledger)
                 return current, review, history

--- a/tests/unit/auto/test_seed_repairer_bounded.py
+++ b/tests/unit/auto/test_seed_repairer_bounded.py
@@ -169,19 +169,163 @@ def test_converge_respects_custom_max_iterations() -> None:
     assert len(history) == 2
 
 
-def test_converge_does_not_review_again_after_bound_hit() -> None:
-    """Once ``len(history) >= max_iterations`` the loop must NOT call reviewer again."""
+def test_converge_reviews_once_more_to_reconcile_after_bound_hit() -> None:
+    """Once ``len(history) >= max_iterations`` the loop must NOT keep repairing.
+
+    The original AC was "don't keep repairing past the bound" — we still honor
+    that. But when the bound is reached *immediately after* a successful
+    repair, the cached review still describes the pre-repair seed. PR #785
+    review-1 requires exactly one final reconciliation review so the returned
+    ``(seed, review)`` pair is consistent (the pipeline persists
+    ``state.last_grade`` / ``state.findings`` from this review).
+    """
     reviewer = _AlwaysVagueReviewer()
     repairer = SeedRepairer(reviewer=reviewer, max_iterations=3)
     seed = _seed()
 
     _, _, history = repairer.converge(seed)
 
-    # 1 initial review + 1 review after each repair (skipping the trailing
-    # post-bound call). Without the bound-skip the reviewer would be called
-    # max_iterations + 1 == 4 times.
+    # 1 initial review + 1 review after each non-final repair (2)
+    # + 1 final reconciliation review at the bound = 4. No further repair
+    # attempts run, so ``history`` is still exactly ``max_iterations``.
     assert len(history) == 3
-    assert reviewer.calls == 3
+    assert reviewer.calls == 4
+
+
+def test_converge_returned_seed_and_review_are_consistent_at_bound() -> None:
+    """At the bound the returned ``(seed, review)`` pair must be consistent.
+
+    Regression test for PR #785 review-1: previously when the loop hit
+    ``max_iterations`` immediately after applying a repair, the returned
+    ``review`` still described the *pre-repair* seed. Re-running the reviewer
+    on the returned seed produced a different review than the one returned —
+    that drove ``AutoPipeline.run`` to persist a stale ``last_grade`` /
+    ``findings`` and could block a seed that the final allowed repair fixed.
+    """
+
+    class _SwitchOnReconcileReviewer:
+        """Returns vague findings until the reconciliation review at the bound.
+
+        With ``max_iterations=2`` the converge loop calls reviewer 3 times:
+          - call 1 (initial review)            → vague
+          - call 2 (post first repair)         → vague (drives second repair)
+          - call 3 (reconciliation at bound)   → clean A-grade
+
+        The pre-fix code skipped call 3 and returned the call-2 vague review
+        describing the *pre-second-repair* seed. Re-running the reviewer on
+        the returned seed produced the clean call-3 review — i.e., the pair
+        was inconsistent.
+        """
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002 — protocol shape
+            self.calls += 1
+            if self.calls < 3:
+                return _vague_review(message=f"Still vague pass {self.calls}")
+            return SeedReview(
+                grade_result=GradeResult(
+                    grade=SeedGrade.A,
+                    scores={
+                        "coverage": 0.95,
+                        "ambiguity": 0.95,
+                        "testability": 0.95,
+                        "execution_feasibility": 0.95,
+                        "risk": 0.05,
+                    },
+                    findings=[],
+                    blockers=[],
+                    may_run=True,
+                ),
+                findings=(),
+            )
+
+    reviewer = _SwitchOnReconcileReviewer()
+    repairer = SeedRepairer(reviewer=reviewer, max_iterations=2)
+    seed = _seed()
+
+    returned_seed, returned_review, history = repairer.converge(seed)
+
+    # The bound was reached after a repair was applied, so the loop ran one
+    # final reconciliation review. The returned review describes the returned
+    # seed (clean A) — not the stale pre-repair vague review.
+    assert len(history) == 2
+    assert returned_review.grade_result.grade == SeedGrade.A
+    assert returned_review.findings == ()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_last_grade_reflects_returned_seed_at_bound(tmp_path) -> None:
+    """``AutoPipeline.run`` must persist a grade consistent with the returned seed.
+
+    Regression for PR #785 review-1: with the pre-fix code, hitting the
+    repair bound immediately after a fix would persist the pre-repair grade
+    onto ``state.last_grade``, blocking a seed that was actually fixed.
+    """
+
+    class _SwitchOnReconcileReviewer:
+        """Vague until the reconciliation review at the bound, then A-grade."""
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002 — protocol shape
+            self.calls += 1
+            if self.calls < 3:
+                return _vague_review(message=f"pass {self.calls}")
+            return SeedReview(
+                grade_result=GradeResult(
+                    grade=SeedGrade.A,
+                    scores={
+                        "coverage": 0.95,
+                        "ambiguity": 0.95,
+                        "testability": 0.95,
+                        "execution_feasibility": 0.95,
+                        "risk": 0.05,
+                    },
+                    findings=[],
+                    blockers=[],
+                    may_run=True,
+                ),
+                findings=(),
+            )
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_1", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not need another answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    reviewer = _SwitchOnReconcileReviewer()
+    repairer = SeedRepairer(reviewer=reviewer, max_iterations=2)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        repairer=repairer,
+        skip_run=True,
+    )
+
+    await pipeline.run(state)
+
+    # The repair at the bound produced a clean seed: the persisted grade and
+    # findings must reflect the post-repair review, not the stale pre-repair
+    # one. With the pre-fix code ``state.last_grade`` would be "B".
+    assert state.last_grade == "A"
+    assert state.findings == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/auto/test_seed_repairer_bounded.py
+++ b/tests/unit/auto/test_seed_repairer_bounded.py
@@ -22,7 +22,7 @@ from ouroboros.auto.interview_driver import (
 )
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipeline
-from ouroboros.auto.seed_repairer import SeedRepairer
+from ouroboros.auto.seed_repairer import RepairCancelled, SeedRepairer
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.core.seed import (
@@ -404,6 +404,22 @@ async def test_pipeline_blocks_when_repair_phase_exceeds_timeout(tmp_path) -> No
     assert sleepy.thread_finished.wait(timeout=timeout * 4), (
         "sleepy reviewer thread never finished — orphan thread leak"
     )
+
+    # Cooperative cancellation: after the timeout fires the pipeline sets a
+    # cancel signal on the repairer, so when the in-flight reviewer call
+    # returns, the loop must NOT launch another ``reviewer.review`` (which
+    # would sleep another ``timeout * 2`` seconds and burn another LLM call's
+    # worth of budget — the exact failure called out in PR #785 review-3).
+    # Give the worker thread a beat to reach the next iteration boundary.
+    deadline_no_extra_calls = time.monotonic() + 1.0
+    while time.monotonic() < deadline_no_extra_calls:
+        if sleepy.calls > 1:
+            break
+        time.sleep(0.05)
+    assert sleepy.calls == 1, (
+        f"reviewer was called {sleepy.calls} times after wait_for timed out; "
+        "cooperative cancellation did not stop the loop at the iteration boundary"
+    )
     # Allow the asyncio default executor a beat to mark the worker idle, then
     # confirm the thread count did not balloon past the post-return baseline.
     deadline = time.monotonic() + 2.0
@@ -515,3 +531,58 @@ async def test_resume_recovers_session_blocked_by_repair_timeout(tmp_path) -> No
     assert state.last_grade == "A"
     assert state.findings == []
     assert resumed.status == AutoPhase.COMPLETE.value
+
+
+# ---------------------------------------------------------------------------
+# AC: ``converge`` honors a cancel signal at iteration boundaries.
+# Regression for PR #785 review-3: the repair-phase ``asyncio.wait_for`` only
+# releases the awaiter; without a cooperative signal, the loop kept calling
+# ``reviewer.review`` after the timeout, burning more LLM cost than the
+# advertised budget. ``cancel_event`` makes the loop exit at the next
+# checkpoint instead of starting another review/repair iteration.
+# ---------------------------------------------------------------------------
+
+
+def test_converge_raises_when_cancel_event_set_before_call() -> None:
+    reviewer = _AlwaysVagueReviewer()
+    repairer = SeedRepairer(reviewer=reviewer)
+    seed = _seed()
+
+    cancel = threading.Event()
+    cancel.set()
+
+    with pytest.raises(RepairCancelled):
+        repairer.converge(seed, cancel_event=cancel)
+    # Reviewer never invoked: the very first checkpoint fires before any
+    # reviewer call so no LLM cost is spent on a pre-cancelled run.
+    assert reviewer.calls == 0
+
+
+def test_converge_stops_at_iteration_boundary_when_cancelled_mid_loop() -> None:
+    """Setting the cancel event between iterations stops the loop at the next boundary.
+
+    The reviewer is wrapped to set the cancel signal after its first call.
+    Without cooperative cancellation the loop would keep iterating up to
+    ``max_iterations``; with it, the loop must exit before the second
+    ``reviewer.review`` invocation.
+    """
+    cancel = threading.Event()
+
+    class _CancelOnFirstCallReviewer:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002 — protocol shape
+            self.calls += 1
+            cancel.set()
+            return _vague_review(message=f"cancel-on-first {self.calls}")
+
+    reviewer = _CancelOnFirstCallReviewer()
+    repairer = SeedRepairer(reviewer=reviewer, max_iterations=5)
+    seed = _seed()
+
+    with pytest.raises(RepairCancelled):
+        repairer.converge(seed, cancel_event=cancel)
+    # Exactly one reviewer call: the initial review, after which the cancel
+    # checkpoint at the top of the loop body fires before the second call.
+    assert reviewer.calls == 1

--- a/tests/unit/auto/test_seed_repairer_bounded.py
+++ b/tests/unit/auto/test_seed_repairer_bounded.py
@@ -1,0 +1,271 @@
+"""Bounded-iteration regression tests for SeedRepairer.converge.
+
+Issue #775 introduces an explicit ``max_iterations`` cap on the convergence
+loop and an outer ``asyncio.wait_for`` budget around the synchronous
+``repairer.converge`` call inside ``AutoPipeline.run``. These tests pin both
+guarantees so a future regression cannot reintroduce an unbounded LLM-spend
+hang.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from ouroboros.auto.grading import GradeResult, SeedGrade
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.seed_repairer import SeedRepairer
+from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers (mirrors of the small fixtures used in test_interview_pipeline.py
+# kept local so this regression file can be read in isolation by reviewers).
+# ---------------------------------------------------------------------------
+
+
+def _fill_ready(ledger: SeedDraftLedger) -> None:
+    for section, value in {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }.items():
+        source = (
+            LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        )
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=source,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+
+def _seed(
+    ac: tuple[str, ...] = ("The CLI should be easy and user-friendly",),
+) -> Seed:
+    return Seed(
+        goal="Build a local CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=ac,
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior"),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+def _vague_review(message: str = "Still vague") -> SeedReview:
+    """Build a SeedReview that reports a single high-severity vague AC.
+
+    The exact ``message`` is rolled into the finding fingerprint, so callers
+    can vary it across iterations to defeat the existing dedup short-circuit
+    (``high == previous_high_fingerprints``) and exercise the
+    ``max_iterations`` bound directly.
+    """
+    finding = ReviewFinding.from_parts(
+        code="vague_acceptance_criteria",
+        target="acceptance_criteria[0]",
+        severity="high",
+        message=message,
+        repair_instruction="Make it observable.",
+    )
+    return SeedReview(
+        grade_result=GradeResult(
+            grade=SeedGrade.B,
+            scores={
+                "coverage": 0.5,
+                "ambiguity": 0.5,
+                "testability": 0.5,
+                "execution_feasibility": 0.8,
+                "risk": 0.1,
+            },
+            findings=[],
+            blockers=[],
+            may_run=False,
+        ),
+        findings=(finding,),
+    )
+
+
+class _AlwaysVagueReviewer:
+    """Reviewer that always returns a vague-AC finding.
+
+    Each call rotates the finding message to produce a fresh fingerprint, so
+    the convergence loop's dedup short-circuit does not fire and the only
+    remaining bound is ``max_iterations``.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002 — protocol shape
+        self.calls += 1
+        return _vague_review(message=f"Still vague pass {self.calls}")
+
+
+# ---------------------------------------------------------------------------
+# AC: max_iterations caps the repair attempt count.
+# ---------------------------------------------------------------------------
+
+
+def test_converge_stops_after_default_max_iterations() -> None:
+    reviewer = _AlwaysVagueReviewer()
+    repairer = SeedRepairer(reviewer=reviewer)
+    seed = _seed()
+
+    _, _, history = repairer.converge(seed)
+
+    # Default max_iterations is 5 (mirrors AutoPipelineState.max_repair_rounds).
+    assert repairer.max_iterations == 5
+    assert len(history) == 5
+
+
+def test_converge_respects_custom_max_iterations() -> None:
+    reviewer = _AlwaysVagueReviewer()
+    repairer = SeedRepairer(reviewer=reviewer, max_iterations=2)
+    seed = _seed()
+
+    _, _, history = repairer.converge(seed)
+
+    assert len(history) == 2
+
+
+def test_converge_does_not_review_again_after_bound_hit() -> None:
+    """Once ``len(history) >= max_iterations`` the loop must NOT call reviewer again."""
+    reviewer = _AlwaysVagueReviewer()
+    repairer = SeedRepairer(reviewer=reviewer, max_iterations=3)
+    seed = _seed()
+
+    _, _, history = repairer.converge(seed)
+
+    # 1 initial review + 1 review after each repair (skipping the trailing
+    # post-bound call). Without the bound-skip the reviewer would be called
+    # max_iterations + 1 == 4 times.
+    assert len(history) == 3
+    assert reviewer.calls == 3
+
+
+# ---------------------------------------------------------------------------
+# AC: outer asyncio.wait_for inside AutoPipeline.run blocks runaway converge
+# without leaking the worker thread (no orphan threads after timeout).
+# ---------------------------------------------------------------------------
+
+
+class _SleepyReviewer:
+    """Reviewer whose first call sleeps long enough to trip wait_for."""
+
+    def __init__(self, sleep_seconds: float) -> None:
+        self.sleep_seconds = sleep_seconds
+        self.calls = 0
+        self.thread_finished = threading.Event()
+
+    def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002 — protocol shape
+        self.calls += 1
+        try:
+            time.sleep(self.sleep_seconds)
+        finally:
+            self.thread_finished.set()
+        return _vague_review()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_when_repair_phase_exceeds_timeout(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_1", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not need another answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    timeout = 1  # whole seconds — phase_timeout_seconds rejects non-positive ints
+    sleepy = _SleepyReviewer(sleep_seconds=timeout * 2)
+    repairer = SeedRepairer(reviewer=sleepy)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.timeout_seconds_by_phase[AutoPhase.REPAIR.value] = timeout
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        repairer=repairer,
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+    threads_after_return = threading.active_count()
+
+    # Pipeline reaches BLOCKED, attribution points at the repairer, and the
+    # error message contains the literal phrase the issue requires.
+    assert state.phase == AutoPhase.BLOCKED
+    assert state.last_tool_name == "seed_repairer"
+    assert state.last_error is not None
+    assert f"repair phase exceeded {timeout}s" in state.last_error
+    assert result.status == "blocked"
+    assert result.blocker is not None and "repair phase exceeded" in result.blocker
+
+    # Wait for the daemon worker thread to unwind on its own. ``wait_for``
+    # cannot cancel a synchronous ``time.sleep`` mid-call, so the worker
+    # keeps running until its bounded sleep completes. The guarantee we want
+    # is "no orphan thread leak" — i.e. once the sleep is over, no new
+    # thread spun up under the rug, and ``active_count`` does not grow
+    # beyond what the pipeline was already keeping alive.
+    assert sleepy.thread_finished.wait(timeout=timeout * 4), (
+        "sleepy reviewer thread never finished — orphan thread leak"
+    )
+    # Allow the asyncio default executor a beat to mark the worker idle, then
+    # confirm the thread count did not balloon past the post-return baseline.
+    deadline = time.monotonic() + 2.0
+    while threading.active_count() > threads_after_return and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert threading.active_count() <= threads_after_return, (
+        f"orphan threads: before-return={threads_after_return}, "
+        f"after-sleep={threading.active_count()}"
+    )

--- a/tests/unit/auto/test_seed_repairer_bounded.py
+++ b/tests/unit/auto/test_seed_repairer_bounded.py
@@ -413,3 +413,105 @@ async def test_pipeline_blocks_when_repair_phase_exceeds_timeout(tmp_path) -> No
         f"orphan threads: before-return={threads_after_return}, "
         f"after-sleep={threading.active_count()}"
     )
+
+
+# ---------------------------------------------------------------------------
+# AC: a session blocked by a repair-phase timeout must be resumable.
+# Regression for PR #785 review-2: ``tool_name="seed_repairer"`` was missing
+# from the recoverable-phase mapping, so ``--resume`` after a transient
+# timeout would refuse to recover and turn the timeout into a permanent dead
+# end. Resume must restart the REVIEW phase, which re-invokes the bounded
+# repairer.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resume_recovers_session_blocked_by_repair_timeout(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_1", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not need another answer")
+
+    seed_calls = {"count": 0}
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        seed_calls["count"] += 1
+        return _seed()
+
+    # First run: sleepy reviewer trips wait_for and blocks the session.
+    timeout = 1
+    sleepy = _SleepyReviewer(sleep_seconds=timeout * 2)
+    blocking_repairer = SeedRepairer(reviewer=sleepy)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.timeout_seconds_by_phase[AutoPhase.REPAIR.value] = timeout
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=store, max_rounds=1)
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=store,
+        repairer=blocking_repairer,
+        skip_run=True,
+    )
+
+    first_result = await pipeline.run(state)
+    assert first_result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    assert state.last_tool_name == "seed_repairer"
+    # Wait for the sleepy reviewer thread so it doesn't bleed into the resume run.
+    assert sleepy.thread_finished.wait(timeout=timeout * 4)
+
+    # Second run: clean reviewer should let the resumed session converge to A
+    # and reach COMPLETE. Without the recoverable-phase mapping for
+    # ``seed_repairer`` the pipeline would short-circuit at the BLOCKED check
+    # and return the prior blocker untouched (no repairer call, last_grade
+    # stays None).
+    class _CleanReviewer:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:  # noqa: ARG002 — protocol shape
+            self.calls += 1
+            return SeedReview(
+                grade_result=GradeResult(
+                    grade=SeedGrade.A,
+                    scores={
+                        "coverage": 0.95,
+                        "ambiguity": 0.95,
+                        "testability": 0.95,
+                        "execution_feasibility": 0.95,
+                        "risk": 0.05,
+                    },
+                    findings=[],
+                    blockers=[],
+                    may_run=True,
+                ),
+                findings=(),
+            )
+
+    clean_reviewer = _CleanReviewer()
+    resume_repairer = SeedRepairer(reviewer=clean_reviewer)
+    resume_pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=store,
+        repairer=resume_repairer,
+        skip_run=True,
+    )
+
+    resumed = await resume_pipeline.run(state)
+
+    # Pipeline recovered: REVIEW re-ran, persisted a clean grade, and reached
+    # COMPLETE. The resumed reviewer was actually invoked (proving the
+    # repair phase resumed, not that we returned the prior blocker untouched).
+    assert clean_reviewer.calls >= 1
+    assert state.phase == AutoPhase.COMPLETE
+    assert state.last_grade == "A"
+    assert state.findings == []
+    assert resumed.status == AutoPhase.COMPLETE.value


### PR DESCRIPTION
Closes #775.

## Summary

- Add `max_iterations: int = 5` to `SeedRepairer.__init__` (mirrors the existing `AutoPipelineState.max_repair_rounds` default at `state.py:228`). `max_repair_rounds` is preserved as a backward-compatible alias for existing CLI / MCP / test callsites that already pass it by keyword.
- `SeedRepairer.converge` now returns the last reviewed `(seed, review, repairs)` tuple as soon as `len(history) >= max_iterations`, without invoking the reviewer again — this is the bound that prevents unbounded LLM cost when the reviewer keeps producing findings.
- `AutoPipeline.run` wraps the synchronous `repairer.converge(seed, ledger=ledger)` call in `await asyncio.wait_for(asyncio.to_thread(...), timeout=state.phase_timeout_seconds(AutoPhase.REPAIR))`. On `TimeoutError` the pipeline transitions to `BLOCKED` with `tool_name="seed_repairer"` and `state.last_error` containing the literal phrase `"repair phase exceeded {N}s"`.

> Note: the issue body refers to `state.timeout_seconds_for_phase(...)` but the actual accessor in `state.py:271` is `state.phase_timeout_seconds(...)`. The PR uses the real method name; behavior is identical to what the issue describes.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/auto/test_seed_repairer_bounded.py -v` — 4 new tests:
  - `test_converge_stops_after_default_max_iterations` — default bound (5) caps history.
  - `test_converge_respects_custom_max_iterations` — `max_iterations=2` caps history at 2.
  - `test_converge_does_not_review_again_after_bound_hit` — reviewer is NOT called after the bound is reached.
  - `test_pipeline_blocks_when_repair_phase_exceeds_timeout` — `time.sleep(timeout * 2)` reviewer trips `wait_for`; pipeline reaches `BLOCKED`, `tool_name="seed_repairer"`, error contains `"repair phase exceeded 1s"`, and `threading.active_count()` does not grow past the post-return baseline (no orphan threads).
- [x] `PYTHONPATH=src python -m pytest tests/unit/auto/ -x` — 442 passed (regression safety).
- [x] `ruff format --check src/ tests/` — clean.
- [x] `ruff check src/ tests/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)