### PR TITLE
refactor(mcp): max_turns=1 envelope sweep across remaining sites

### DIFF
--- a/.github/workflows/max-turns-envelope.yml
+++ b/.github/workflows/max-turns-envelope.yml
@@ -1,0 +1,24 @@
+name: max-turns-envelope
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-envelope:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enforce max_turns=1 -> allowed_tools=[] pairing (#781)
+        run: python3 scripts/check-max-turns-envelope.py

--- a/scripts/check-max-turns-envelope.py
+++ b/scripts/check-max-turns-envelope.py
@@ -57,17 +57,21 @@ def _is_empty_list(node: ast.expr) -> bool:
 
 
 def _ifexp_resolves_to_empty_list(node: ast.expr) -> bool:
-    """``[] if cond else None`` (or symmetric forms) — at least one branch is ``[]``."""
+    """``[] if cond else None`` only — the supported-backend branch must close."""
     if not isinstance(node, ast.IfExp):
         return False
-    return _is_empty_list(node.body) or _is_empty_list(node.orelse)
+    return (
+        _is_empty_list(node.body)
+        and isinstance(node.orelse, ast.Constant)
+        and node.orelse.value is None
+    )
 
 
 def _value_is_empty_envelope(value: ast.expr) -> bool:
     """Approach A — strict literal-only acceptance (PR #786 review).
 
-    Only a direct ``[]`` literal, or an ``IfExp`` where at least one branch
-    is a direct ``[]`` literal, counts as an empty envelope. Any other form
+    Only a direct ``[]`` literal, or an ``IfExp`` of the canonical
+    ``[] if cond else None`` shape, counts as an empty envelope. Any other form
     (``Name`` reference, function call, attribute access, comprehension,
     starred expansion) is rejected. Resolving ``Name`` bindings via AST
     walk is order- and scope-unsafe — see the rejection notes in this

--- a/scripts/check-max-turns-envelope.py
+++ b/scripts/check-max-turns-envelope.py
@@ -28,8 +28,6 @@ Accepted ``allowed_tools`` value forms (Form A — see issue #781):
     * ``allowed_tools=[]``
     * ``allowed_tools=[] if cond else None``
     * ``allowed_tools=([] if cond else None)``
-    * ``allowed_tools=<Name>`` where the same scope binds the Name
-      to one of the forms above (e.g. ``_shared_allowed_tools``).
 
 This deliberately rejects:
 
@@ -37,6 +35,11 @@ This deliberately rejects:
     * a non-empty list literal (``allowed_tools=["Read", ...]``)
     * an opaque function call (``allowed_tools=_interview_allowed_tools(...)``)
       — those return non-empty envelopes and re-introduce the regression.
+    * a ``Name`` reference (``allowed_tools=_shared_allowed_tools``).
+      Resolving Names via AST walk is order- and scope-unsafe (PR #786
+      review): an assignment after the call, in a sibling/inner function,
+      or in a nested class would be erroneously accepted. Inline the
+      ``[] if cond else None`` literal at every call site instead.
 """
 
 from __future__ import annotations
@@ -61,27 +64,16 @@ def _ifexp_resolves_to_empty_list(node: ast.expr) -> bool:
 
 
 def _value_is_empty_envelope(value: ast.expr) -> bool:
+    """Approach A — strict literal-only acceptance (PR #786 review).
+
+    Only a direct ``[]`` literal, or an ``IfExp`` where at least one branch
+    is a direct ``[]`` literal, counts as an empty envelope. Any other form
+    (``Name`` reference, function call, attribute access, comprehension,
+    starred expansion) is rejected. Resolving ``Name`` bindings via AST
+    walk is order- and scope-unsafe — see the rejection notes in this
+    file's module docstring.
+    """
     return _is_empty_list(value) or _ifexp_resolves_to_empty_list(value)
-
-
-def _scope_bindings_to_empty_envelope(scope: ast.AST, name: str) -> bool:
-    """Return True if ``name`` is assigned an empty-envelope expression in ``scope``."""
-    for node in ast.walk(scope):
-        target_id: str | None = None
-        value: ast.expr | None = None
-        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            target_id = node.target.id
-            value = node.value
-        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
-            t = node.targets[0]
-            if isinstance(t, ast.Name):
-                target_id = t.id
-                value = node.value
-        if target_id != name or value is None:
-            continue
-        if _value_is_empty_envelope(value):
-            return True
-    return False
 
 
 def _find_max_turns_one_calls(tree: ast.AST) -> list[ast.Call]:
@@ -96,36 +88,12 @@ def _find_max_turns_one_calls(tree: ast.AST) -> list[ast.Call]:
     return hits
 
 
-def _enclosing_scopes(tree: ast.AST, target: ast.Call) -> list[ast.AST]:
-    """Return ancestor scopes (Module / FunctionDef / AsyncFunctionDef / ClassDef)
-    of ``target`` from innermost to outermost. Used to resolve ``Name`` bindings
-    for ``allowed_tools=<Name>`` forms.
-    """
-    scopes: list[ast.AST] = []
-
-    def _walk(node: ast.AST, ancestors: list[ast.AST]) -> bool:
-        if node is target:
-            scopes.extend(reversed(ancestors))
-            return True
-        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            ancestors = ancestors + [node]
-        return any(_walk(child, ancestors) for child in ast.iter_child_nodes(node))
-
-    _walk(tree, [])
-    return scopes
-
-
-def _call_has_empty_envelope(tree: ast.AST, call: ast.Call) -> bool:
+def _call_has_empty_envelope(call: ast.Call) -> bool:
     for kw in call.keywords:
         if kw.arg != "allowed_tools":
             continue
-        value = kw.value
-        if _value_is_empty_envelope(value):
+        if _value_is_empty_envelope(kw.value):
             return True
-        if isinstance(value, ast.Name):
-            for scope in _enclosing_scopes(tree, call):
-                if _scope_bindings_to_empty_envelope(scope, value.id):
-                    return True
     return False
 
 
@@ -143,7 +111,7 @@ def _scan_file(path: Path) -> list[tuple[int, str]]:
         return findings
 
     for call in _find_max_turns_one_calls(tree):
-        if _call_has_empty_envelope(tree, call):
+        if _call_has_empty_envelope(call):
             continue
         # Surface the offending call's location.
         line = (

--- a/scripts/check-max-turns-envelope.py
+++ b/scripts/check-max-turns-envelope.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Enforce the ``max_turns=1`` ↔ ``allowed_tools=[]`` pairing at PR time.
+
+Per Q00/ouroboros#781, every adapter call site that passes
+``max_turns=1`` (or ``max_turns = 1``) MUST also pass an empty
+``allowed_tools`` envelope on the *same* call. Otherwise a single
+tool-use block from the model burns the only allowed turn and the
+SDK raises ``Reached maximum number of turns (1)`` before any final
+text response can stream — a latent hang reproduced as
+https://github.com/Q00/ouroboros/issues/765 and swept across the
+remaining sites in #781.
+
+The guard walks the AST of ``src/ouroboros/`` and exits non-zero if
+any keyword call passes ``max_turns=1`` without a co-located empty
+``allowed_tools``. Pure comments containing ``max_turns=1`` are
+ignored (the AST walker only sees real calls).
+
+Run locally::
+
+    python3 scripts/check-max-turns-envelope.py
+
+CI hookup:
+    Add an invocation to ``.github/workflows/`` alongside the
+    existing ``check-auto-boundary.py`` job.
+
+Accepted ``allowed_tools`` value forms (Form A — see issue #781):
+
+    * ``allowed_tools=[]``
+    * ``allowed_tools=[] if cond else None``
+    * ``allowed_tools=([] if cond else None)``
+    * ``allowed_tools=<Name>`` where the same scope binds the Name
+      to one of the forms above (e.g. ``_shared_allowed_tools``).
+
+This deliberately rejects:
+
+    * a missing ``allowed_tools`` kwarg
+    * a non-empty list literal (``allowed_tools=["Read", ...]``)
+    * an opaque function call (``allowed_tools=_interview_allowed_tools(...)``)
+      — those return non-empty envelopes and re-introduce the regression.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_ROOT = REPO_ROOT / "src" / "ouroboros"
+
+
+def _is_empty_list(node: ast.expr) -> bool:
+    return isinstance(node, ast.List) and len(node.elts) == 0
+
+
+def _ifexp_resolves_to_empty_list(node: ast.expr) -> bool:
+    """``[] if cond else None`` (or symmetric forms) — at least one branch is ``[]``."""
+    if not isinstance(node, ast.IfExp):
+        return False
+    return _is_empty_list(node.body) or _is_empty_list(node.orelse)
+
+
+def _value_is_empty_envelope(value: ast.expr) -> bool:
+    return _is_empty_list(value) or _ifexp_resolves_to_empty_list(value)
+
+
+def _scope_bindings_to_empty_envelope(scope: ast.AST, name: str) -> bool:
+    """Return True if ``name`` is assigned an empty-envelope expression in ``scope``."""
+    for node in ast.walk(scope):
+        target_id: str | None = None
+        value: ast.expr | None = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target_id = node.target.id
+            value = node.value
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            t = node.targets[0]
+            if isinstance(t, ast.Name):
+                target_id = t.id
+                value = node.value
+        if target_id != name or value is None:
+            continue
+        if _value_is_empty_envelope(value):
+            return True
+    return False
+
+
+def _find_max_turns_one_calls(tree: ast.AST) -> list[ast.Call]:
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def _enclosing_scopes(tree: ast.AST, target: ast.Call) -> list[ast.AST]:
+    """Return ancestor scopes (Module / FunctionDef / AsyncFunctionDef / ClassDef)
+    of ``target`` from innermost to outermost. Used to resolve ``Name`` bindings
+    for ``allowed_tools=<Name>`` forms.
+    """
+    scopes: list[ast.AST] = []
+
+    def _walk(node: ast.AST, ancestors: list[ast.AST]) -> bool:
+        if node is target:
+            scopes.extend(reversed(ancestors))
+            return True
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            ancestors = ancestors + [node]
+        return any(_walk(child, ancestors) for child in ast.iter_child_nodes(node))
+
+    _walk(tree, [])
+    return scopes
+
+
+def _call_has_empty_envelope(tree: ast.AST, call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if _value_is_empty_envelope(value):
+            return True
+        if isinstance(value, ast.Name):
+            for scope in _enclosing_scopes(tree, call):
+                if _scope_bindings_to_empty_envelope(scope, value.id):
+                    return True
+    return False
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return offending ``(line_no, snippet)`` tuples for ``path``."""
+    findings: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return findings
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
+        # Don't fail the guard on partial/edited files — main test suite catches that.
+        return findings
+
+    for call in _find_max_turns_one_calls(tree):
+        if _call_has_empty_envelope(tree, call):
+            continue
+        # Surface the offending call's location.
+        line = (
+            text.splitlines()[call.lineno - 1] if call.lineno - 1 < len(text.splitlines()) else ""
+        )
+        findings.append((call.lineno, line.rstrip()))
+    return findings
+
+
+def main() -> int:
+    if not SCAN_ROOT.is_dir():
+        sys.stderr.write(
+            f"check-max-turns-envelope: FAILED — scan root {SCAN_ROOT} does not exist.\n"
+        )
+        return 1
+
+    targets = sorted(SCAN_ROOT.rglob("*.py"))
+    all_findings: list[tuple[Path, int, str]] = []
+    for path in targets:
+        for lineno, line in _scan_file(path):
+            all_findings.append((path, lineno, line))
+
+    if not all_findings:
+        print(f"check-max-turns-envelope: OK ({len(targets)} files scanned, 0 findings)")
+        return 0
+
+    sys.stderr.write(
+        "check-max-turns-envelope: FAILED — ``max_turns=1`` call sites without "
+        "``allowed_tools=[]``.\n"
+        "Per Q00/ouroboros#781, every single-shot adapter MUST close its tool "
+        "envelope so a tool-use block cannot consume the only allowed turn.\n\n"
+    )
+    for path, lineno, line in all_findings:
+        try:
+            rel = path.relative_to(REPO_ROOT)
+        except ValueError:
+            rel = path
+        sys.stderr.write(f"  {rel}:{lineno}\n    {line}\n")
+    sys.stderr.write(
+        "\nFix: add ``allowed_tools=[]`` (or the conditional form\n"
+        "``[] if backend_supports_tool_envelope(resolve_llm_backend(backend)) else None``)\n"
+        "to each offending call.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ouroboros/cli/commands/detect.py
+++ b/src/ouroboros/cli/commands/detect.py
@@ -19,6 +19,7 @@ from typing import Annotated
 
 import typer
 
+from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.cli.formatters.panels import (
     print_error,
     print_info,
@@ -30,7 +31,7 @@ from ouroboros.evaluation.detector import (
     has_mechanical_toml,
     toml_path,
 )
-from ouroboros.providers.factory import create_llm_adapter
+from ouroboros.providers.factory import create_llm_adapter, resolve_llm_backend
 
 app = typer.Typer(
     name="detect",
@@ -73,7 +74,14 @@ def detect(
         raise typer.Exit(code=0)
 
     try:
-        adapter = create_llm_adapter(backend=backend, max_turns=1)
+        # ``allowed_tools=[]`` paired with ``max_turns=1``: see issue #781.
+        adapter = create_llm_adapter(
+            backend=backend,
+            max_turns=1,
+            allowed_tools=(
+                [] if backend_supports_tool_envelope(resolve_llm_backend(backend)) else None
+            ),
+        )
     except Exception as exc:  # noqa: BLE001 — surface any factory failure to user
         print_error(f"Could not initialize LLM adapter: {exc}")
         raise typer.Exit(code=1) from exc

--- a/src/ouroboros/evaluation/verification_artifacts.py
+++ b/src/ouroboros/evaluation/verification_artifacts.py
@@ -98,13 +98,22 @@ async def _auto_detect_mechanical_toml(
     adapter = llm_adapter
     if adapter is None:
         try:
-            from ouroboros.providers.factory import create_llm_adapter
+            from ouroboros.backends import backend_supports_tool_envelope
+            from ouroboros.providers.factory import create_llm_adapter, resolve_llm_backend
 
             # Build the default adapter *against the same backend* so the
             # subsequent ``ensure_mechanical_toml(..., backend=...)`` call is
             # not routed through a provider that cannot consume the sentinel
             # model ("default") returned for Codex / OpenCode backends.
-            adapter = create_llm_adapter(backend=llm_backend, max_turns=1)
+            #
+            # ``allowed_tools=[]`` paired with ``max_turns=1``: see issue #781.
+            adapter = create_llm_adapter(
+                backend=llm_backend,
+                max_turns=1,
+                allowed_tools=(
+                    [] if backend_supports_tool_envelope(resolve_llm_backend(llm_backend)) else None
+                ),
+            )
         except Exception:  # noqa: BLE001 — adapter construction must never break QA
             return
     try:

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1224,14 +1224,17 @@ def create_ouroboros_server(
     from ouroboros.backends import backend_supports_tool_envelope
     from ouroboros.providers import resolve_llm_backend
 
-    _shared_allowed_tools: list[str] | None = (
-        [] if backend_supports_tool_envelope(resolve_llm_backend(llm_backend)) else None
-    )
+    # Inlined as a direct ``[] if cond else None`` literal (rather than a
+    # Name binding) so the static guard at scripts/check-max-turns-envelope.py
+    # can verify the envelope without resolving Name references — see PR
+    # #786 review-1: AST-walk Name resolution is order- and scope-unsafe.
     llm_adapter = create_llm_adapter(
         backend=llm_backend,
         max_turns=1,
         cwd=effective_cwd,
-        allowed_tools=_shared_allowed_tools,
+        allowed_tools=(
+            [] if backend_supports_tool_envelope(resolve_llm_backend(llm_backend)) else None
+        ),
     )
 
     # Create or use provided EventStore

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1217,10 +1217,21 @@ def create_ouroboros_server(
     # Create shared LLM adapter for interview/seed paths.
     # Evaluation constructs its own adapter with higher max_turns — see
     # EvaluateHandler.handle in mcp/tools/evaluation_handlers.py.
+    # ``allowed_tools=[]`` paired with ``max_turns=1``: any tool-use block
+    # emitted by the model would consume the only allowed turn and the SDK
+    # then raises ``Reached maximum number of turns (1)`` before a final
+    # text response can stream. See issue #781.
+    from ouroboros.backends import backend_supports_tool_envelope
+    from ouroboros.providers import resolve_llm_backend
+
+    _shared_allowed_tools: list[str] | None = (
+        [] if backend_supports_tool_envelope(resolve_llm_backend(llm_backend)) else None
+    )
     llm_adapter = create_llm_adapter(
         backend=llm_backend,
         max_turns=1,
         cwd=effective_cwd,
+        allowed_tools=_shared_allowed_tools,
     )
 
     # Create or use provided EventStore
@@ -1257,10 +1268,14 @@ def create_ouroboros_server(
     from ouroboros.verification.verifier import SpecVerifier
 
     def fresh_llm_adapter():
+        # ``allowed_tools=[]`` paired with ``max_turns=1``: see issue #781.
         return create_llm_adapter(
             backend=llm_backend if llm_backend is not None else None,
             max_turns=1,
             cwd=effective_cwd,
+            allowed_tools=(
+                [] if backend_supports_tool_envelope(resolve_llm_backend(llm_backend)) else None
+            ),
         )
 
     wonder_engine = WonderEngine(

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -584,10 +584,17 @@ class GenerateSeedHandler:
         # Fall-through: real in-process seed generation (subprocess / non-opencode runtimes).
 
         try:
-            # Use injected or create services
+            # Use injected or create services.
+            # ``allowed_tools=[]`` paired with ``max_turns=1``: any tool-use
+            # block emitted by the model would consume the only allowed turn
+            # and the SDK then raises ``Reached maximum number of turns (1)``
+            # before a final text response can stream. See issue #781.
             llm_adapter = self.llm_adapter or create_llm_adapter(
                 backend=self.llm_backend,
                 max_turns=1,
+                allowed_tools=[]
+                if backend_supports_tool_envelope(resolve_llm_backend(self.llm_backend))
+                else None,
             )
             interview_engine = self.interview_engine or InterviewEngine(
                 llm_adapter=llm_adapter,

--- a/src/ouroboros/mcp/tools/qa.py
+++ b/src/ouroboros/mcp/tools/qa.py
@@ -18,6 +18,7 @@ import uuid
 
 import structlog
 
+from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.config import get_qa_model
 from ouroboros.core.types import Result
 from ouroboros.evaluation.json_utils import extract_json_payload
@@ -37,7 +38,7 @@ from ouroboros.mcp.types import (
     ToolInputType,
 )
 from ouroboros.persistence.event_store import EventStore
-from ouroboros.providers import create_llm_adapter
+from ouroboros.providers import create_llm_adapter, resolve_llm_backend
 from ouroboros.providers.base import LLMAdapter
 
 log = structlog.get_logger(__name__)
@@ -573,9 +574,16 @@ class QAHandler:
                 Message(role=MessageRole.USER, content=user_prompt),
             ]
 
+            # ``allowed_tools=[]`` paired with ``max_turns=1``: any tool-use
+            # block emitted by the model would consume the only allowed turn
+            # and the SDK then raises ``Reached maximum number of turns (1)``
+            # before a final text response can stream. See issue #781.
             llm_adapter = self.llm_adapter or create_llm_adapter(
                 backend=self.llm_backend,
                 max_turns=1,
+                allowed_tools=[]
+                if backend_supports_tool_envelope(resolve_llm_backend(self.llm_backend))
+                else None,
             )
             config = CompletionConfig(
                 model=get_qa_model(self.llm_backend),

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -33,6 +33,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
+from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.core.errors import OuroborosError
 from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.seed_contract_prompt import render_seed_contract_for_execution
@@ -95,7 +96,7 @@ from ouroboros.orchestrator.runtime_message_projection import (
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
 from ouroboros.orchestrator.workflow_state import coerce_ac_marker_update
 from ouroboros.persistence.checkpoint import CheckpointStore
-from ouroboros.providers import create_llm_adapter
+from ouroboros.providers import create_llm_adapter, resolve_llm_backend
 from ouroboros.resilience.lateral import ThinkingPersona
 from ouroboros.resilience.recovery import (
     RecoveryActionKind,
@@ -728,12 +729,16 @@ class OrchestratorRunner:
         cli_path = getattr(self._adapter, "cli_path", None)
         resolved_cli_path = cli_path if isinstance(cli_path, str) and cli_path else None
         try:
+            # ``allowed_tools=[]`` paired with ``max_turns=1``: see issue #781.
             llm_adapter = create_llm_adapter(
                 backend=backend,
                 permission_mode=self._adapter.permission_mode,
                 cli_path=resolved_cli_path,
                 cwd=self._effective_cwd(),
                 max_turns=1,
+                allowed_tools=(
+                    [] if backend_supports_tool_envelope(resolve_llm_backend(backend)) else None
+                ),
             )
         except (RuntimeError, ImportError, ConnectionError, OSError, ValueError) as exc:
             log.warning(

--- a/tests/_envelope_wiring.py
+++ b/tests/_envelope_wiring.py
@@ -5,8 +5,8 @@ These helpers mirror the production guard at
 drift from the canonical CI-enforced semantics.
 
 Per Q00/ouroboros#781, every ``max_turns=1`` adapter call site MUST
-co-locate ``allowed_tools=[]`` (or the conditional ``[] if cond else None``
-form, in either branch). See PR #786 review-2 for the dedup rationale.
+co-locate ``allowed_tools=[]`` (or the canonical conditional ``[] if cond else None``
+form). See PR #786 review-2 for the dedup rationale.
 """
 
 from __future__ import annotations
@@ -39,7 +39,6 @@ def has_empty_allowed_tools(call: ast.Call) -> bool:
 
         * ``allowed_tools=[]``
         * ``allowed_tools=[] if cond else None``  (empty list in body)
-        * ``allowed_tools=None if cond else []``  (empty list in orelse)
         * ``allowed_tools=([] if cond else None)`` (parenthesised IfExp)
 
     Rejects all other forms (``Name`` reference, function call,
@@ -52,8 +51,11 @@ def has_empty_allowed_tools(call: ast.Call) -> bool:
         value = kw.value
         if _is_empty_list(value):
             return True
-        if isinstance(value, ast.IfExp) and (
-            _is_empty_list(value.body) or _is_empty_list(value.orelse)
+        if (
+            isinstance(value, ast.IfExp)
+            and _is_empty_list(value.body)
+            and isinstance(value.orelse, ast.Constant)
+            and value.orelse.value is None
         ):
             return True
     return False

--- a/tests/_envelope_wiring.py
+++ b/tests/_envelope_wiring.py
@@ -1,0 +1,59 @@
+"""Shared AST helpers for ``max_turns=1`` / ``allowed_tools=[]`` wiring tests.
+
+These helpers mirror the production guard at
+``scripts/check-max-turns-envelope.py`` so per-file wiring tests cannot
+drift from the canonical CI-enforced semantics.
+
+Per Q00/ouroboros#781, every ``max_turns=1`` adapter call site MUST
+co-locate ``allowed_tools=[]`` (or the conditional ``[] if cond else None``
+form, in either branch). See PR #786 review-2 for the dedup rationale.
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+def _is_empty_list(node: ast.expr) -> bool:
+    return isinstance(node, ast.List) and len(node.elts) == 0
+
+
+def find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
+    """Return every ``Call`` node passing ``max_turns=1`` as a keyword arg."""
+    tree = ast.parse(source_text)
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def has_empty_allowed_tools(call: ast.Call) -> bool:
+    """``allowed_tools`` kwarg value contains an empty-list literal.
+
+    Mirrors the production guard semantics. Accepts:
+
+        * ``allowed_tools=[]``
+        * ``allowed_tools=[] if cond else None``  (empty list in body)
+        * ``allowed_tools=None if cond else []``  (empty list in orelse)
+        * ``allowed_tools=([] if cond else None)`` (parenthesised IfExp)
+
+    Rejects all other forms (``Name`` reference, function call,
+    non-empty literal, comprehension). Resolving Name bindings via AST
+    walk is order- and scope-unsafe — see PR #786 review-1.
+    """
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if _is_empty_list(value):
+            return True
+        if isinstance(value, ast.IfExp) and (
+            _is_empty_list(value.body) or _is_empty_list(value.orelse)
+        ):
+            return True
+    return False

--- a/tests/unit/cli/test_detect_allowed_tools_wiring.py
+++ b/tests/unit/cli/test_detect_allowed_tools_wiring.py
@@ -1,0 +1,67 @@
+"""Wiring lock for ``ooo detect``'s ``max_turns=1`` adapter.
+
+Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
+MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
+envelope). The detect CLI builds a single-shot adapter for the
+mechanical.toml proposal flow.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import ouroboros.cli.commands.detect as detect_module
+
+DETECT_SOURCE = Path(detect_module.__file__)
+
+
+def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
+    tree = ast.parse(source_text)
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def _has_empty_allowed_tools(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if isinstance(value, ast.List) and len(value.elts) == 0:
+            return True
+        if isinstance(value, ast.IfExp) and (
+            isinstance(value.body, ast.List) and len(value.body.elts) == 0
+        ):
+            return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def detect_source() -> str:
+    return DETECT_SOURCE.read_text(encoding="utf-8")
+
+
+def test_detect_module_has_a_max_turns_one_call(detect_source: str) -> None:
+    calls = _find_max_turns_one_calls(detect_source)
+    assert calls, (
+        "ooo detect must still construct an adapter with max_turns=1 — if this "
+        "test fails the wiring-lock target moved and must be re-pinned."
+    )
+
+
+def test_detect_max_turns_one_call_pins_allowed_tools_empty(detect_source: str) -> None:
+    calls = _find_max_turns_one_calls(detect_source)
+    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    assert not unguarded, (
+        f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
+        f"{DETECT_SOURCE.name} without ``allowed_tools=[]``. See issue #781."
+    )

--- a/tests/unit/cli/test_detect_allowed_tools_wiring.py
+++ b/tests/unit/cli/test_detect_allowed_tools_wiring.py
@@ -4,45 +4,22 @@ Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
 MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
 envelope). The detect CLI builds a single-shot adapter for the
 mechanical.toml proposal flow.
+
+AST helpers are deduplicated in :mod:`tests._envelope_wiring` so this
+file cannot drift from the canonical guard semantics enforced by
+``scripts/check-max-turns-envelope.py`` (PR #786 review-2).
 """
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
 
 import ouroboros.cli.commands.detect as detect_module
+from tests._envelope_wiring import find_max_turns_one_calls, has_empty_allowed_tools
 
 DETECT_SOURCE = Path(detect_module.__file__)
-
-
-def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
-    tree = ast.parse(source_text)
-    hits: list[ast.Call] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
-                hits.append(node)
-                break
-    return hits
-
-
-def _has_empty_allowed_tools(call: ast.Call) -> bool:
-    for kw in call.keywords:
-        if kw.arg != "allowed_tools":
-            continue
-        value = kw.value
-        if isinstance(value, ast.List) and len(value.elts) == 0:
-            return True
-        if isinstance(value, ast.IfExp) and (
-            isinstance(value.body, ast.List) and len(value.body.elts) == 0
-        ):
-            return True
-    return False
 
 
 @pytest.fixture(scope="module")
@@ -51,7 +28,7 @@ def detect_source() -> str:
 
 
 def test_detect_module_has_a_max_turns_one_call(detect_source: str) -> None:
-    calls = _find_max_turns_one_calls(detect_source)
+    calls = find_max_turns_one_calls(detect_source)
     assert calls, (
         "ooo detect must still construct an adapter with max_turns=1 — if this "
         "test fails the wiring-lock target moved and must be re-pinned."
@@ -59,8 +36,8 @@ def test_detect_module_has_a_max_turns_one_call(detect_source: str) -> None:
 
 
 def test_detect_max_turns_one_call_pins_allowed_tools_empty(detect_source: str) -> None:
-    calls = _find_max_turns_one_calls(detect_source)
-    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    calls = find_max_turns_one_calls(detect_source)
+    unguarded = [c for c in calls if not has_empty_allowed_tools(c)]
     assert not unguarded, (
         f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
         f"{DETECT_SOURCE.name} without ``allowed_tools=[]``. See issue #781."

--- a/tests/unit/evaluation/test_verification_artifacts_allowed_tools_wiring.py
+++ b/tests/unit/evaluation/test_verification_artifacts_allowed_tools_wiring.py
@@ -4,45 +4,22 @@ Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
 MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
 envelope). ``verification_artifacts`` builds a default single-shot
 adapter for Stage 1 mechanical.toml fall-through.
+
+AST helpers are deduplicated in :mod:`tests._envelope_wiring` so this
+file cannot drift from the canonical guard semantics enforced by
+``scripts/check-max-turns-envelope.py`` (PR #786 review-2).
 """
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
 
 import ouroboros.evaluation.verification_artifacts as va_module
+from tests._envelope_wiring import find_max_turns_one_calls, has_empty_allowed_tools
 
 VA_SOURCE = Path(va_module.__file__)
-
-
-def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
-    tree = ast.parse(source_text)
-    hits: list[ast.Call] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
-                hits.append(node)
-                break
-    return hits
-
-
-def _has_empty_allowed_tools(call: ast.Call) -> bool:
-    for kw in call.keywords:
-        if kw.arg != "allowed_tools":
-            continue
-        value = kw.value
-        if isinstance(value, ast.List) and len(value.elts) == 0:
-            return True
-        if isinstance(value, ast.IfExp) and (
-            isinstance(value.body, ast.List) and len(value.body.elts) == 0
-        ):
-            return True
-    return False
 
 
 @pytest.fixture(scope="module")
@@ -51,7 +28,7 @@ def va_source() -> str:
 
 
 def test_verification_artifacts_has_a_max_turns_one_call(va_source: str) -> None:
-    calls = _find_max_turns_one_calls(va_source)
+    calls = find_max_turns_one_calls(va_source)
     assert calls, (
         "verification_artifacts must still construct an adapter with max_turns=1 — "
         "if this test fails the wiring-lock target moved and must be re-pinned."
@@ -61,8 +38,8 @@ def test_verification_artifacts_has_a_max_turns_one_call(va_source: str) -> None
 def test_verification_artifacts_max_turns_one_call_pins_allowed_tools_empty(
     va_source: str,
 ) -> None:
-    calls = _find_max_turns_one_calls(va_source)
-    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    calls = find_max_turns_one_calls(va_source)
+    unguarded = [c for c in calls if not has_empty_allowed_tools(c)]
     assert not unguarded, (
         f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
         f"{VA_SOURCE.name} without ``allowed_tools=[]``. See issue #781."

--- a/tests/unit/evaluation/test_verification_artifacts_allowed_tools_wiring.py
+++ b/tests/unit/evaluation/test_verification_artifacts_allowed_tools_wiring.py
@@ -1,0 +1,69 @@
+"""Wiring lock for ``verification_artifacts``'s ``max_turns=1`` adapter.
+
+Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
+MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
+envelope). ``verification_artifacts`` builds a default single-shot
+adapter for Stage 1 mechanical.toml fall-through.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import ouroboros.evaluation.verification_artifacts as va_module
+
+VA_SOURCE = Path(va_module.__file__)
+
+
+def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
+    tree = ast.parse(source_text)
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def _has_empty_allowed_tools(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if isinstance(value, ast.List) and len(value.elts) == 0:
+            return True
+        if isinstance(value, ast.IfExp) and (
+            isinstance(value.body, ast.List) and len(value.body.elts) == 0
+        ):
+            return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def va_source() -> str:
+    return VA_SOURCE.read_text(encoding="utf-8")
+
+
+def test_verification_artifacts_has_a_max_turns_one_call(va_source: str) -> None:
+    calls = _find_max_turns_one_calls(va_source)
+    assert calls, (
+        "verification_artifacts must still construct an adapter with max_turns=1 — "
+        "if this test fails the wiring-lock target moved and must be re-pinned."
+    )
+
+
+def test_verification_artifacts_max_turns_one_call_pins_allowed_tools_empty(
+    va_source: str,
+) -> None:
+    calls = _find_max_turns_one_calls(va_source)
+    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    assert not unguarded, (
+        f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
+        f"{VA_SOURCE.name} without ``allowed_tools=[]``. See issue #781."
+    )

--- a/tests/unit/mcp/server/test_adapter_max_turns_envelope_wiring.py
+++ b/tests/unit/mcp/server/test_adapter_max_turns_envelope_wiring.py
@@ -1,0 +1,121 @@
+"""Wiring lock for ``mcp/server/adapter.py``'s ``max_turns=1`` adapters.
+
+Covers both call sites:
+
+    * The shared composition-root LLM adapter (``llm_adapter = ...``).
+    * The ``fresh_llm_adapter()`` closure used by Wonder/Reflect engines.
+
+Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
+MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
+envelope). Otherwise a single tool-use block from the model burns the
+only allowed turn and the SDK raises 'Reached maximum number of turns (1)'.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import ouroboros.mcp.server.adapter as adapter_module
+
+ADAPTER_SOURCE = Path(adapter_module.__file__)
+
+EXPECTED_MAX_TURNS_ONE_CALLS = 2  # shared adapter + fresh_llm_adapter closure
+
+
+def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
+    tree = ast.parse(source_text)
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def _has_empty_allowed_tools(call: ast.Call) -> bool:
+    """An ``allowed_tools`` kwarg whose value either *is* the empty list
+    literal or *can be* the empty list literal (IfExp), or is a Name that
+    in the same scope is bound to such an expression."""
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if isinstance(value, ast.List) and len(value.elts) == 0:
+            return True
+        if isinstance(value, ast.IfExp) and (
+            isinstance(value.body, ast.List) and len(value.body.elts) == 0
+        ):
+            return True
+        # Name reference — accept if it's our known intermediate variable.
+        # The composition root binds the envelope to ``_shared_allowed_tools``
+        # to share it across the shared adapter and downstream engines.
+        if isinstance(value, ast.Name) and value.id == "_shared_allowed_tools":
+            return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def adapter_source() -> str:
+    return ADAPTER_SOURCE.read_text(encoding="utf-8")
+
+
+def test_adapter_module_has_expected_max_turns_one_calls(adapter_source: str) -> None:
+    calls = _find_max_turns_one_calls(adapter_source)
+    assert len(calls) == EXPECTED_MAX_TURNS_ONE_CALLS, (
+        f"Expected {EXPECTED_MAX_TURNS_ONE_CALLS} ``max_turns=1`` call sites in "
+        f"{ADAPTER_SOURCE.name}; found {len(calls)}. Re-pin EXPECTED if a "
+        "single-shot adapter was added or removed."
+    )
+
+
+def test_adapter_max_turns_one_calls_pin_allowed_tools_empty(adapter_source: str) -> None:
+    calls = _find_max_turns_one_calls(adapter_source)
+    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    assert not unguarded, (
+        f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
+        f"{ADAPTER_SOURCE.name} without ``allowed_tools=[]`` (or a name "
+        "binding equivalent). See issue #781."
+    )
+
+
+def test_shared_allowed_tools_is_bound_to_empty_list_envelope(adapter_source: str) -> None:
+    """``_shared_allowed_tools`` (if used) must resolve to ``[]`` for envelope-aware backends.
+
+    The shared composition-root adapter passes ``allowed_tools=_shared_allowed_tools``
+    to thread the envelope through; this test pins that the variable's binding
+    contains an empty list literal (matching the per-site Form A pattern).
+    """
+    if "_shared_allowed_tools" not in adapter_source:
+        pytest.skip("_shared_allowed_tools intermediate not in use")
+
+    tree = ast.parse(adapter_source)
+    for node in ast.walk(tree):
+        # AnnAssign or Assign of _shared_allowed_tools = ([] if ... else None)
+        target_id: str | None = None
+        value: ast.expr | None = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target_id = node.target.id
+            value = node.value
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            t = node.targets[0]
+            if isinstance(t, ast.Name):
+                target_id = t.id
+                value = node.value
+        if target_id != "_shared_allowed_tools" or value is None:
+            continue
+        if isinstance(value, ast.IfExp) and (
+            isinstance(value.body, ast.List) and len(value.body.elts) == 0
+        ):
+            return
+        if isinstance(value, ast.List) and len(value.elts) == 0:
+            return
+    pytest.fail(
+        "_shared_allowed_tools is referenced but its binding does not resolve "
+        "to an empty list literal — pair with ``allowed_tools=[]`` per #781."
+    )

--- a/tests/unit/mcp/server/test_adapter_max_turns_envelope_wiring.py
+++ b/tests/unit/mcp/server/test_adapter_max_turns_envelope_wiring.py
@@ -9,55 +9,28 @@ Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
 MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
 envelope). Otherwise a single tool-use block from the model burns the
 only allowed turn and the SDK raises 'Reached maximum number of turns (1)'.
+
+AST helpers are deduplicated in :mod:`tests._envelope_wiring` so this
+file cannot drift from the canonical guard semantics enforced by
+``scripts/check-max-turns-envelope.py`` (PR #786 review-2). Both call
+sites use inline ``[] if cond else None`` literals — Name-binding
+acceptance was removed when the shared-intermediate refactor was
+abandoned (PR #786 review-1: AST-walk Name resolution is order- and
+scope-unsafe).
 """
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
 
 import ouroboros.mcp.server.adapter as adapter_module
+from tests._envelope_wiring import find_max_turns_one_calls, has_empty_allowed_tools
 
 ADAPTER_SOURCE = Path(adapter_module.__file__)
 
 EXPECTED_MAX_TURNS_ONE_CALLS = 2  # shared adapter + fresh_llm_adapter closure
-
-
-def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
-    tree = ast.parse(source_text)
-    hits: list[ast.Call] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
-                hits.append(node)
-                break
-    return hits
-
-
-def _has_empty_allowed_tools(call: ast.Call) -> bool:
-    """An ``allowed_tools`` kwarg whose value either *is* the empty list
-    literal or *can be* the empty list literal (IfExp), or is a Name that
-    in the same scope is bound to such an expression."""
-    for kw in call.keywords:
-        if kw.arg != "allowed_tools":
-            continue
-        value = kw.value
-        if isinstance(value, ast.List) and len(value.elts) == 0:
-            return True
-        if isinstance(value, ast.IfExp) and (
-            isinstance(value.body, ast.List) and len(value.body.elts) == 0
-        ):
-            return True
-        # Name reference — accept if it's our known intermediate variable.
-        # The composition root binds the envelope to ``_shared_allowed_tools``
-        # to share it across the shared adapter and downstream engines.
-        if isinstance(value, ast.Name) and value.id == "_shared_allowed_tools":
-            return True
-    return False
 
 
 @pytest.fixture(scope="module")
@@ -66,7 +39,7 @@ def adapter_source() -> str:
 
 
 def test_adapter_module_has_expected_max_turns_one_calls(adapter_source: str) -> None:
-    calls = _find_max_turns_one_calls(adapter_source)
+    calls = find_max_turns_one_calls(adapter_source)
     assert len(calls) == EXPECTED_MAX_TURNS_ONE_CALLS, (
         f"Expected {EXPECTED_MAX_TURNS_ONE_CALLS} ``max_turns=1`` call sites in "
         f"{ADAPTER_SOURCE.name}; found {len(calls)}. Re-pin EXPECTED if a "
@@ -75,47 +48,9 @@ def test_adapter_module_has_expected_max_turns_one_calls(adapter_source: str) ->
 
 
 def test_adapter_max_turns_one_calls_pin_allowed_tools_empty(adapter_source: str) -> None:
-    calls = _find_max_turns_one_calls(adapter_source)
-    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    calls = find_max_turns_one_calls(adapter_source)
+    unguarded = [c for c in calls if not has_empty_allowed_tools(c)]
     assert not unguarded, (
         f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
-        f"{ADAPTER_SOURCE.name} without ``allowed_tools=[]`` (or a name "
-        "binding equivalent). See issue #781."
-    )
-
-
-def test_shared_allowed_tools_is_bound_to_empty_list_envelope(adapter_source: str) -> None:
-    """``_shared_allowed_tools`` (if used) must resolve to ``[]`` for envelope-aware backends.
-
-    The shared composition-root adapter passes ``allowed_tools=_shared_allowed_tools``
-    to thread the envelope through; this test pins that the variable's binding
-    contains an empty list literal (matching the per-site Form A pattern).
-    """
-    if "_shared_allowed_tools" not in adapter_source:
-        pytest.skip("_shared_allowed_tools intermediate not in use")
-
-    tree = ast.parse(adapter_source)
-    for node in ast.walk(tree):
-        # AnnAssign or Assign of _shared_allowed_tools = ([] if ... else None)
-        target_id: str | None = None
-        value: ast.expr | None = None
-        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            target_id = node.target.id
-            value = node.value
-        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
-            t = node.targets[0]
-            if isinstance(t, ast.Name):
-                target_id = t.id
-                value = node.value
-        if target_id != "_shared_allowed_tools" or value is None:
-            continue
-        if isinstance(value, ast.IfExp) and (
-            isinstance(value.body, ast.List) and len(value.body.elts) == 0
-        ):
-            return
-        if isinstance(value, ast.List) and len(value.elts) == 0:
-            return
-    pytest.fail(
-        "_shared_allowed_tools is referenced but its binding does not resolve "
-        "to an empty list literal — pair with ``allowed_tools=[]`` per #781."
+        f"{ADAPTER_SOURCE.name} without ``allowed_tools=[]``. See issue #781."
     )

--- a/tests/unit/mcp/tools/test_authoring_allowed_tools_wiring.py
+++ b/tests/unit/mcp/tools/test_authoring_allowed_tools_wiring.py
@@ -1,0 +1,85 @@
+"""Wiring lock for ``authoring_handlers``' ``max_turns=1`` adapters.
+
+Covers both call sites in ``src/ouroboros/mcp/tools/authoring_handlers.py``:
+
+    * ``GenerateSeedHandler.handle()`` — in-process seed generation.
+    * ``InterviewHandler.handle()``   — nested-MCP question generator
+      (already pinned by ``test_interview_allowed_tools_wiring.py``;
+      this test re-affirms the lock at the module level so a future
+      sweep cannot silently re-open the envelope).
+
+Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
+MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
+envelope). Otherwise a single tool-use block from the model burns the
+only allowed turn and the SDK raises 'Reached maximum number of turns (1)'.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import ouroboros.mcp.tools.authoring_handlers as authoring_module
+
+AUTHORING_SOURCE = Path(authoring_module.__file__)
+
+EXPECTED_MAX_TURNS_ONE_CALLS = 2  # GenerateSeedHandler + InterviewHandler
+
+
+def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
+    tree = ast.parse(source_text)
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def _has_empty_allowed_tools(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if isinstance(value, ast.List) and len(value.elts) == 0:
+            return True
+        if isinstance(value, ast.IfExp) and (
+            isinstance(value.body, ast.List) and len(value.body.elts) == 0
+        ):
+            return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def authoring_source() -> str:
+    return AUTHORING_SOURCE.read_text(encoding="utf-8")
+
+
+def test_authoring_module_has_expected_max_turns_one_calls(authoring_source: str) -> None:
+    """Sanity-pin: the count of ``max_turns=1`` call sites is fixed.
+
+    A drift here is a signal — either a new single-shot adapter was added
+    (extend this lock) or an existing one was removed (re-pin EXPECTED).
+    """
+    calls = _find_max_turns_one_calls(authoring_source)
+    assert len(calls) == EXPECTED_MAX_TURNS_ONE_CALLS, (
+        f"Expected {EXPECTED_MAX_TURNS_ONE_CALLS} ``max_turns=1`` call sites in "
+        f"{AUTHORING_SOURCE.name}; found {len(calls)}. If a new single-shot "
+        "adapter was added, extend this wiring lock alongside the new site."
+    )
+
+
+def test_authoring_max_turns_one_calls_pin_allowed_tools_empty(authoring_source: str) -> None:
+    """Both authoring ``max_turns=1`` adapter calls MUST set ``allowed_tools=[]``."""
+    calls = _find_max_turns_one_calls(authoring_source)
+    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    assert not unguarded, (
+        f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
+        f"{AUTHORING_SOURCE.name} without ``allowed_tools=[]``. Each such site "
+        "is a latent turn-starvation hang — see issue #781."
+    )

--- a/tests/unit/mcp/tools/test_authoring_allowed_tools_wiring.py
+++ b/tests/unit/mcp/tools/test_authoring_allowed_tools_wiring.py
@@ -12,47 +12,24 @@ Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
 MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
 envelope). Otherwise a single tool-use block from the model burns the
 only allowed turn and the SDK raises 'Reached maximum number of turns (1)'.
+
+AST helpers are deduplicated in :mod:`tests._envelope_wiring` so this
+file cannot drift from the canonical guard semantics enforced by
+``scripts/check-max-turns-envelope.py`` (PR #786 review-2).
 """
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
 
 import ouroboros.mcp.tools.authoring_handlers as authoring_module
+from tests._envelope_wiring import find_max_turns_one_calls, has_empty_allowed_tools
 
 AUTHORING_SOURCE = Path(authoring_module.__file__)
 
 EXPECTED_MAX_TURNS_ONE_CALLS = 2  # GenerateSeedHandler + InterviewHandler
-
-
-def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
-    tree = ast.parse(source_text)
-    hits: list[ast.Call] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
-                hits.append(node)
-                break
-    return hits
-
-
-def _has_empty_allowed_tools(call: ast.Call) -> bool:
-    for kw in call.keywords:
-        if kw.arg != "allowed_tools":
-            continue
-        value = kw.value
-        if isinstance(value, ast.List) and len(value.elts) == 0:
-            return True
-        if isinstance(value, ast.IfExp) and (
-            isinstance(value.body, ast.List) and len(value.body.elts) == 0
-        ):
-            return True
-    return False
 
 
 @pytest.fixture(scope="module")
@@ -66,7 +43,7 @@ def test_authoring_module_has_expected_max_turns_one_calls(authoring_source: str
     A drift here is a signal — either a new single-shot adapter was added
     (extend this lock) or an existing one was removed (re-pin EXPECTED).
     """
-    calls = _find_max_turns_one_calls(authoring_source)
+    calls = find_max_turns_one_calls(authoring_source)
     assert len(calls) == EXPECTED_MAX_TURNS_ONE_CALLS, (
         f"Expected {EXPECTED_MAX_TURNS_ONE_CALLS} ``max_turns=1`` call sites in "
         f"{AUTHORING_SOURCE.name}; found {len(calls)}. If a new single-shot "
@@ -76,8 +53,8 @@ def test_authoring_module_has_expected_max_turns_one_calls(authoring_source: str
 
 def test_authoring_max_turns_one_calls_pin_allowed_tools_empty(authoring_source: str) -> None:
     """Both authoring ``max_turns=1`` adapter calls MUST set ``allowed_tools=[]``."""
-    calls = _find_max_turns_one_calls(authoring_source)
-    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    calls = find_max_turns_one_calls(authoring_source)
+    unguarded = [c for c in calls if not has_empty_allowed_tools(c)]
     assert not unguarded, (
         f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
         f"{AUTHORING_SOURCE.name} without ``allowed_tools=[]``. Each such site "

--- a/tests/unit/mcp/tools/test_pm_handler_allowed_tools_wiring.py
+++ b/tests/unit/mcp/tools/test_pm_handler_allowed_tools_wiring.py
@@ -5,45 +5,22 @@ MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
 envelope). ``pm_handler.py`` was the prior-art reference cited by
 PR #770; this test re-affirms the lock at the module level so a
 future sweep cannot silently re-open the envelope.
+
+AST helpers are deduplicated in :mod:`tests._envelope_wiring` so this
+file cannot drift from the canonical guard semantics enforced by
+``scripts/check-max-turns-envelope.py`` (PR #786 review-2).
 """
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
 
 import ouroboros.mcp.tools.pm_handler as pm_module
+from tests._envelope_wiring import find_max_turns_one_calls, has_empty_allowed_tools
 
 PM_SOURCE = Path(pm_module.__file__)
-
-
-def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
-    tree = ast.parse(source_text)
-    hits: list[ast.Call] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
-                hits.append(node)
-                break
-    return hits
-
-
-def _has_empty_allowed_tools(call: ast.Call) -> bool:
-    for kw in call.keywords:
-        if kw.arg != "allowed_tools":
-            continue
-        value = kw.value
-        if isinstance(value, ast.List) and len(value.elts) == 0:
-            return True
-        if isinstance(value, ast.IfExp) and (
-            isinstance(value.body, ast.List) and len(value.body.elts) == 0
-        ):
-            return True
-    return False
 
 
 @pytest.fixture(scope="module")
@@ -52,7 +29,7 @@ def pm_source() -> str:
 
 
 def test_pm_handler_has_a_max_turns_one_call(pm_source: str) -> None:
-    calls = _find_max_turns_one_calls(pm_source)
+    calls = find_max_turns_one_calls(pm_source)
     assert calls, (
         "PMInterviewHandler must still construct an adapter with max_turns=1 — "
         "if this test fails the wiring-lock target moved and must be re-pinned."
@@ -60,8 +37,8 @@ def test_pm_handler_has_a_max_turns_one_call(pm_source: str) -> None:
 
 
 def test_pm_handler_max_turns_one_call_pins_allowed_tools_empty(pm_source: str) -> None:
-    calls = _find_max_turns_one_calls(pm_source)
-    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    calls = find_max_turns_one_calls(pm_source)
+    unguarded = [c for c in calls if not has_empty_allowed_tools(c)]
     assert not unguarded, (
         f"Found {len(unguarded)} ``max_turns=1`` call site(s) in {PM_SOURCE.name} "
         "without ``allowed_tools=[]``. See issue #781."

--- a/tests/unit/mcp/tools/test_pm_handler_allowed_tools_wiring.py
+++ b/tests/unit/mcp/tools/test_pm_handler_allowed_tools_wiring.py
@@ -1,0 +1,68 @@
+"""Wiring lock for ``PMInterviewHandler``'s ``max_turns=1`` adapter.
+
+Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
+MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
+envelope). ``pm_handler.py`` was the prior-art reference cited by
+PR #770; this test re-affirms the lock at the module level so a
+future sweep cannot silently re-open the envelope.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import ouroboros.mcp.tools.pm_handler as pm_module
+
+PM_SOURCE = Path(pm_module.__file__)
+
+
+def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
+    tree = ast.parse(source_text)
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def _has_empty_allowed_tools(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if isinstance(value, ast.List) and len(value.elts) == 0:
+            return True
+        if isinstance(value, ast.IfExp) and (
+            isinstance(value.body, ast.List) and len(value.body.elts) == 0
+        ):
+            return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def pm_source() -> str:
+    return PM_SOURCE.read_text(encoding="utf-8")
+
+
+def test_pm_handler_has_a_max_turns_one_call(pm_source: str) -> None:
+    calls = _find_max_turns_one_calls(pm_source)
+    assert calls, (
+        "PMInterviewHandler must still construct an adapter with max_turns=1 — "
+        "if this test fails the wiring-lock target moved and must be re-pinned."
+    )
+
+
+def test_pm_handler_max_turns_one_call_pins_allowed_tools_empty(pm_source: str) -> None:
+    calls = _find_max_turns_one_calls(pm_source)
+    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    assert not unguarded, (
+        f"Found {len(unguarded)} ``max_turns=1`` call site(s) in {PM_SOURCE.name} "
+        "without ``allowed_tools=[]``. See issue #781."
+    )

--- a/tests/unit/mcp/tools/test_qa_allowed_tools_wiring.py
+++ b/tests/unit/mcp/tools/test_qa_allowed_tools_wiring.py
@@ -1,0 +1,88 @@
+"""Wiring lock for ``QAHandler``'s ``max_turns=1`` adapter.
+
+Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
+MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
+envelope). Otherwise a single tool-use block from the model burns the
+only allowed turn and ``_is_usable_max_turns_partial`` rejects the
+``stop_reason="tool_use"`` partial — yielding a latent hang.
+
+This test asserts the wiring at the AST level: a non-empty allowlist
+or a missing ``allowed_tools`` kwarg on the QA adapter call would
+re-introduce the regression and is statically forbidden here.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import ouroboros.mcp.tools.qa as qa_module
+
+QA_SOURCE = Path(qa_module.__file__)
+
+
+def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
+    """Return every ``Call`` node passing ``max_turns=1`` as a keyword arg."""
+    tree = ast.parse(source_text)
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def _has_empty_allowed_tools(call: ast.Call) -> bool:
+    """``allowed_tools`` kwarg whose value contains an empty list literal.
+
+    Accepts:
+        * ``allowed_tools=[]``
+        * ``allowed_tools=[] if cond else None``  (IfExp with empty list body)
+        * ``allowed_tools=([] if cond else None)``
+    """
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if isinstance(value, ast.List) and len(value.elts) == 0:
+            return True
+        if isinstance(value, ast.IfExp) and (
+            isinstance(value.body, ast.List) and len(value.body.elts) == 0
+        ):
+            return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def qa_source() -> str:
+    return QA_SOURCE.read_text(encoding="utf-8")
+
+
+def test_qa_module_has_a_max_turns_one_call(qa_source: str) -> None:
+    """Sanity: the QA handler still constructs at least one max_turns=1 adapter."""
+    calls = _find_max_turns_one_calls(qa_source)
+    assert calls, (
+        "QAHandler must still construct an adapter with max_turns=1 — if this "
+        "test fails the wiring-lock target moved and the lock must be re-pinned."
+    )
+
+
+def test_qa_max_turns_one_call_pins_allowed_tools_empty(qa_source: str) -> None:
+    """Every ``max_turns=1`` adapter call in qa.py MUST set ``allowed_tools=[]``.
+
+    Regression guard for issue #781 — a non-empty allowlist paired with
+    ``max_turns=1`` lets the model burn the single allowed turn on a
+    tool-use block and the SDK raises 'Reached maximum number of turns (1)'.
+    """
+    calls = _find_max_turns_one_calls(qa_source)
+    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    assert not unguarded, (
+        f"Found {len(unguarded)} ``max_turns=1`` call site(s) in {QA_SOURCE.name} "
+        "without ``allowed_tools=[]``. Each such site is a latent turn-starvation "
+        "hang. See https://github.com/Q00/ouroboros/issues/781."
+    )

--- a/tests/unit/mcp/tools/test_qa_allowed_tools_wiring.py
+++ b/tests/unit/mcp/tools/test_qa_allowed_tools_wiring.py
@@ -9,53 +9,22 @@ only allowed turn and ``_is_usable_max_turns_partial`` rejects the
 This test asserts the wiring at the AST level: a non-empty allowlist
 or a missing ``allowed_tools`` kwarg on the QA adapter call would
 re-introduce the regression and is statically forbidden here.
+
+AST helpers are deduplicated in :mod:`tests._envelope_wiring` so this
+file cannot drift from the canonical guard semantics enforced by
+``scripts/check-max-turns-envelope.py`` (PR #786 review-2).
 """
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
 
 import ouroboros.mcp.tools.qa as qa_module
+from tests._envelope_wiring import find_max_turns_one_calls, has_empty_allowed_tools
 
 QA_SOURCE = Path(qa_module.__file__)
-
-
-def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
-    """Return every ``Call`` node passing ``max_turns=1`` as a keyword arg."""
-    tree = ast.parse(source_text)
-    hits: list[ast.Call] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
-                hits.append(node)
-                break
-    return hits
-
-
-def _has_empty_allowed_tools(call: ast.Call) -> bool:
-    """``allowed_tools`` kwarg whose value contains an empty list literal.
-
-    Accepts:
-        * ``allowed_tools=[]``
-        * ``allowed_tools=[] if cond else None``  (IfExp with empty list body)
-        * ``allowed_tools=([] if cond else None)``
-    """
-    for kw in call.keywords:
-        if kw.arg != "allowed_tools":
-            continue
-        value = kw.value
-        if isinstance(value, ast.List) and len(value.elts) == 0:
-            return True
-        if isinstance(value, ast.IfExp) and (
-            isinstance(value.body, ast.List) and len(value.body.elts) == 0
-        ):
-            return True
-    return False
 
 
 @pytest.fixture(scope="module")
@@ -65,7 +34,7 @@ def qa_source() -> str:
 
 def test_qa_module_has_a_max_turns_one_call(qa_source: str) -> None:
     """Sanity: the QA handler still constructs at least one max_turns=1 adapter."""
-    calls = _find_max_turns_one_calls(qa_source)
+    calls = find_max_turns_one_calls(qa_source)
     assert calls, (
         "QAHandler must still construct an adapter with max_turns=1 — if this "
         "test fails the wiring-lock target moved and the lock must be re-pinned."
@@ -79,8 +48,8 @@ def test_qa_max_turns_one_call_pins_allowed_tools_empty(qa_source: str) -> None:
     ``max_turns=1`` lets the model burn the single allowed turn on a
     tool-use block and the SDK raises 'Reached maximum number of turns (1)'.
     """
-    calls = _find_max_turns_one_calls(qa_source)
-    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    calls = find_max_turns_one_calls(qa_source)
+    unguarded = [c for c in calls if not has_empty_allowed_tools(c)]
     assert not unguarded, (
         f"Found {len(unguarded)} ``max_turns=1`` call site(s) in {QA_SOURCE.name} "
         "without ``allowed_tools=[]``. Each such site is a latent turn-starvation "

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2109,6 +2109,7 @@ class TestOrchestratorRunner:
             cli_path=None,
             cwd="/tmp/project",
             max_turns=1,
+            allowed_tools=[],
         )
         dependency_analyzer_cls.assert_called_once_with(llm_adapter=llm_adapter)
 
@@ -2146,6 +2147,7 @@ class TestOrchestratorRunner:
             cli_path="/tmp/real-codex",
             cwd="/tmp/project",
             max_turns=1,
+            allowed_tools=[],
         )
 
     def test_build_dependency_analyzer_uses_public_llm_backend_property(
@@ -2182,6 +2184,7 @@ class TestOrchestratorRunner:
             cli_path=None,
             cwd="/tmp/project",
             max_turns=1,
+            allowed_tools=[],
         )
 
     def test_build_dependency_analyzer_falls_back_to_runtime_backend_when_llm_backend_none(
@@ -2217,6 +2220,7 @@ class TestOrchestratorRunner:
             cli_path=None,
             cwd="/tmp/project",
             max_turns=1,
+            allowed_tools=[],
         )
 
     def test_build_dependency_analyzer_catches_expected_exceptions(

--- a/tests/unit/orchestrator/test_runner_allowed_tools_wiring.py
+++ b/tests/unit/orchestrator/test_runner_allowed_tools_wiring.py
@@ -4,45 +4,22 @@ Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
 MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
 envelope). The runner builds a single-shot adapter for the dependency
 analyzer fall-through.
+
+AST helpers are deduplicated in :mod:`tests._envelope_wiring` so this
+file cannot drift from the canonical guard semantics enforced by
+``scripts/check-max-turns-envelope.py`` (PR #786 review-2).
 """
 
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
 
 import ouroboros.orchestrator.runner as runner_module
+from tests._envelope_wiring import find_max_turns_one_calls, has_empty_allowed_tools
 
 RUNNER_SOURCE = Path(runner_module.__file__)
-
-
-def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
-    tree = ast.parse(source_text)
-    hits: list[ast.Call] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
-                hits.append(node)
-                break
-    return hits
-
-
-def _has_empty_allowed_tools(call: ast.Call) -> bool:
-    for kw in call.keywords:
-        if kw.arg != "allowed_tools":
-            continue
-        value = kw.value
-        if isinstance(value, ast.List) and len(value.elts) == 0:
-            return True
-        if isinstance(value, ast.IfExp) and (
-            isinstance(value.body, ast.List) and len(value.body.elts) == 0
-        ):
-            return True
-    return False
 
 
 @pytest.fixture(scope="module")
@@ -51,7 +28,7 @@ def runner_source() -> str:
 
 
 def test_runner_has_a_max_turns_one_call(runner_source: str) -> None:
-    calls = _find_max_turns_one_calls(runner_source)
+    calls = find_max_turns_one_calls(runner_source)
     assert calls, (
         "orchestrator.runner must still construct an adapter with max_turns=1 — "
         "if this test fails the wiring-lock target moved and must be re-pinned."
@@ -59,8 +36,8 @@ def test_runner_has_a_max_turns_one_call(runner_source: str) -> None:
 
 
 def test_runner_max_turns_one_call_pins_allowed_tools_empty(runner_source: str) -> None:
-    calls = _find_max_turns_one_calls(runner_source)
-    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    calls = find_max_turns_one_calls(runner_source)
+    unguarded = [c for c in calls if not has_empty_allowed_tools(c)]
     assert not unguarded, (
         f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
         f"{RUNNER_SOURCE.name} without ``allowed_tools=[]``. See issue #781."

--- a/tests/unit/orchestrator/test_runner_allowed_tools_wiring.py
+++ b/tests/unit/orchestrator/test_runner_allowed_tools_wiring.py
@@ -1,0 +1,67 @@
+"""Wiring lock for ``orchestrator.runner``'s ``max_turns=1`` adapter.
+
+Per Q00/ouroboros#781, every adapter constructed with ``max_turns=1``
+MUST also pin ``allowed_tools=[]`` (when the backend supports a tool
+envelope). The runner builds a single-shot adapter for the dependency
+analyzer fall-through.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import ouroboros.orchestrator.runner as runner_module
+
+RUNNER_SOURCE = Path(runner_module.__file__)
+
+
+def _find_max_turns_one_calls(source_text: str) -> list[ast.Call]:
+    tree = ast.parse(source_text)
+    hits: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "max_turns" and isinstance(kw.value, ast.Constant) and kw.value.value == 1:
+                hits.append(node)
+                break
+    return hits
+
+
+def _has_empty_allowed_tools(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg != "allowed_tools":
+            continue
+        value = kw.value
+        if isinstance(value, ast.List) and len(value.elts) == 0:
+            return True
+        if isinstance(value, ast.IfExp) and (
+            isinstance(value.body, ast.List) and len(value.body.elts) == 0
+        ):
+            return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def runner_source() -> str:
+    return RUNNER_SOURCE.read_text(encoding="utf-8")
+
+
+def test_runner_has_a_max_turns_one_call(runner_source: str) -> None:
+    calls = _find_max_turns_one_calls(runner_source)
+    assert calls, (
+        "orchestrator.runner must still construct an adapter with max_turns=1 — "
+        "if this test fails the wiring-lock target moved and must be re-pinned."
+    )
+
+
+def test_runner_max_turns_one_call_pins_allowed_tools_empty(runner_source: str) -> None:
+    calls = _find_max_turns_one_calls(runner_source)
+    unguarded = [c for c in calls if not _has_empty_allowed_tools(c)]
+    assert not unguarded, (
+        f"Found {len(unguarded)} ``max_turns=1`` call site(s) in "
+        f"{RUNNER_SOURCE.name} without ``allowed_tools=[]``. See issue #781."
+    )

--- a/tests/unit/scripts/test_check_max_turns_envelope.py
+++ b/tests/unit/scripts/test_check_max_turns_envelope.py
@@ -1,0 +1,184 @@
+"""Self-tests for ``scripts/check-max-turns-envelope.py`` (PR #786 review-1).
+
+The guard is the enforcement backstop for issue #781: every adapter call
+site that passes ``max_turns=1`` must close its tool envelope on the
+*same* call so a single tool-use block cannot consume the only allowed
+turn.
+
+The original implementation accepted ``allowed_tools=<Name>`` and tried
+to resolve the binding via ``ast.walk`` over an enclosing scope. That is
+order- and scope-unsafe — assignments after the call, in sibling/inner
+functions, or inside nested classes were erroneously accepted, so the
+loophole let through exactly the regression the guard is meant to block.
+
+These tests exercise the strict literal-only rule (Approach A): direct
+``[]`` literal or an ``IfExp`` with a ``[]`` branch, nothing else. They
+cover the three negatives the bot reproduced plus a positive baseline,
+and pin the production-tree scan so the guard keeps reporting OK on
+every existing ``max_turns=1`` site.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "check-max-turns-envelope.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_max_turns_envelope", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+@pytest.fixture()
+def guard():
+    return _load_module()
+
+
+def _scan_source(guard, source: str) -> list[tuple[int, str]]:
+    """Run the guard's per-file scanner against an in-memory source string."""
+    import ast
+
+    tree = ast.parse(source)
+    findings: list[tuple[int, str]] = []
+    lines = source.splitlines()
+    for call in guard._find_max_turns_one_calls(tree):
+        if guard._call_has_empty_envelope(call):
+            continue
+        line = lines[call.lineno - 1] if call.lineno - 1 < len(lines) else ""
+        findings.append((call.lineno, line.rstrip()))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Positives — must be accepted (no findings).
+# ---------------------------------------------------------------------------
+
+
+def test_direct_empty_list_accepted(guard) -> None:
+    src = "create_llm_adapter(max_turns=1, allowed_tools=[])\n"
+    assert _scan_source(guard, src) == []
+
+
+def test_ifexp_with_empty_list_branch_accepted(guard) -> None:
+    src = "create_llm_adapter(\n    max_turns=1,\n    allowed_tools=[] if cond else None,\n)\n"
+    assert _scan_source(guard, src) == []
+
+
+def test_parenthesized_ifexp_with_empty_list_branch_accepted(guard) -> None:
+    src = "create_llm_adapter(\n    max_turns=1,\n    allowed_tools=([] if cond else None),\n)\n"
+    assert _scan_source(guard, src) == []
+
+
+# ---------------------------------------------------------------------------
+# Negatives — the bot's BLOCKING reproductions and friends.
+# Each case asserts the strict guard now rejects the form. Under the
+# previous Name-resolving implementation, every one of these returned 0
+# findings (false negative).
+# ---------------------------------------------------------------------------
+
+
+def test_name_reference_rejected_even_with_correct_binding(guard) -> None:
+    """Even a benign Name binding is rejected under Approach A — the
+    rule is literal-only, no Name resolution. Migrate sites to inline
+    literals."""
+    src = (
+        "def f(cond):\n"
+        "    x = [] if cond else None\n"
+        "    create_llm_adapter(max_turns=1, allowed_tools=x)\n"
+    )
+    findings = _scan_source(guard, src)
+    assert findings, f"expected guard to reject Name reference, got {findings!r}"
+
+
+def test_assignment_after_call_in_same_function_rejected(guard) -> None:
+    """Bot's first reproduction: assignment to the bound name appears
+    *after* the call. The previous AST-walk-the-enclosing-subtree code
+    accepted this; Approach A rejects it (it never inspects Names)."""
+    src = "def f():\n    create_llm_adapter(max_turns=1, allowed_tools=x)\n    x = []\n"
+    findings = _scan_source(guard, src)
+    assert findings, f"expected guard to reject post-call assignment, got {findings!r}"
+
+
+def test_assignment_in_nested_inner_function_rejected(guard) -> None:
+    """Bot's nested-function reproduction: ``x = []`` lives in a
+    sibling/inner ``def g(): ...`` and must not satisfy the outer
+    call's envelope."""
+    src = (
+        "def f():\n"
+        "    create_llm_adapter(max_turns=1, allowed_tools=x)\n"
+        "    def g():\n"
+        "        x = []\n"
+    )
+    findings = _scan_source(guard, src)
+    assert findings, f"expected guard to reject nested-function leak, got {findings!r}"
+
+
+def test_assignment_in_different_outer_function_rejected(guard) -> None:
+    """Bot's cross-function reproduction: ``x = []`` lives in an
+    unrelated module-level function. The previous scope-walk code
+    incorrectly accepted this when the guard re-walked Module."""
+    src = "def g():\n    x = []\ndef f():\n    create_llm_adapter(max_turns=1, allowed_tools=x)\n"
+    findings = _scan_source(guard, src)
+    assert findings, f"expected guard to reject cross-function binding, got {findings!r}"
+
+
+def test_assignment_in_nested_class_rejected(guard) -> None:
+    """Class-body bindings must not satisfy outer call envelopes."""
+    src = (
+        "def f():\n"
+        "    create_llm_adapter(max_turns=1, allowed_tools=x)\n"
+        "    class C:\n"
+        "        x = []\n"
+    )
+    findings = _scan_source(guard, src)
+    assert findings, f"expected guard to reject class-body binding, got {findings!r}"
+
+
+def test_missing_allowed_tools_rejected(guard) -> None:
+    src = "create_llm_adapter(max_turns=1)\n"
+    findings = _scan_source(guard, src)
+    assert findings
+
+
+def test_non_empty_list_rejected(guard) -> None:
+    src = 'create_llm_adapter(max_turns=1, allowed_tools=["Read"])\n'
+    findings = _scan_source(guard, src)
+    assert findings
+
+
+def test_function_call_value_rejected(guard) -> None:
+    src = "create_llm_adapter(max_turns=1, allowed_tools=_interview_allowed_tools(backend))\n"
+    findings = _scan_source(guard, src)
+    assert findings
+
+
+# ---------------------------------------------------------------------------
+# Production-tree regression: every existing ``max_turns=1`` site must
+# continue to satisfy the stricter rule (otherwise it's using a Name
+# reference and needs to be migrated to a direct literal).
+# ---------------------------------------------------------------------------
+
+
+def test_production_scan_passes() -> None:
+    """Run the script as a subprocess against the live ``src/ouroboros``
+    tree. Pinned to the repo's actual scripts entrypoint so a regression
+    in either the guard or any current call site fails loudly here."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"production scan failed under strict guard.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/tests/unit/scripts/test_check_max_turns_envelope.py
+++ b/tests/unit/scripts/test_check_max_turns_envelope.py
@@ -78,6 +78,23 @@ def test_parenthesized_ifexp_with_empty_list_branch_accepted(guard) -> None:
     assert _scan_source(guard, src) == []
 
 
+def test_inverted_ifexp_rejected(guard) -> None:
+    """Do not accept the unsafe orientation for the canonical backend gate.
+
+    ``None if backend_supports_tool_envelope(...) else []`` leaves supported
+    backends without a closed envelope, which is exactly the future
+    regression this guard must prevent.
+    """
+    src = (
+        "create_llm_adapter(\n"
+        "    max_turns=1,\n"
+        "    allowed_tools=None if backend_supports_tool_envelope(backend) else [],\n"
+        ")\n"
+    )
+    findings = _scan_source(guard, src)
+    assert findings, f"expected guard to reject inverted conditional, got {findings!r}"
+
+
 # ---------------------------------------------------------------------------
 # Negatives — the bot's BLOCKING reproductions and friends.
 # Each case asserts the strict guard now rejects the form. Under the


### PR DESCRIPTION
Closes #781.

## Decision: Form A (per-site fix)

This PR adopts **Form A** — passing `allowed_tools=[]` directly at each `create_llm_adapter(..., max_turns=1, ...)` call site. Form B (policy-level auto-narrow in `orchestrator/policy.py`) was explicitly not chosen: Form A carries lower regression risk, is the pattern already established by PR #770 and `PMInterviewHandler._get_engine` (the prior-art reference), and makes the wiring visible at each call site without requiring a policy-layer side-effect.

## Sites patched (8 new + 1 pre-patched)

| # | File | Actual changed line |
|---|------|---------------------|
| 1 | `src/ouroboros/mcp/tools/qa.py` | ~583 |
| 2 | `src/ouroboros/mcp/tools/authoring_handlers.py` | ~594 (GenerateSeedHandler) |
| 3 | `src/ouroboros/mcp/tools/authoring_handlers.py` | ~1280 (InterviewHandler — already patched by #770, lock re-affirmed) |
| 4 | `src/ouroboros/mcp/tools/pm_handler.py` | ~370 (pre-patched prior art, not re-touched) |
| 5 | `src/ouroboros/mcp/server/adapter.py` | ~1232 (shared composition-root adapter) |
| 6 | `src/ouroboros/mcp/server/adapter.py` | ~1274 (`fresh_llm_adapter` closure) |
| 7 | `src/ouroboros/cli/commands/detect.py` | ~80 |
| 8 | `src/ouroboros/evaluation/verification_artifacts.py` | ~111 |
| 9 | `src/ouroboros/orchestrator/runner.py` | ~738 |

Each site uses the same conditional Form A pattern as PR #770:
```python
allowed_tools=[] if backend_supports_tool_envelope(resolve_llm_backend(backend)) else None
```

## New files

- **7 wiring-lock test files** — one per logical site (authoring and adapter each cover two sites), AST-based, pin that `max_turns=1` calls always co-locate `allowed_tools=[]`.
- **`scripts/check-max-turns-envelope.py`** — AST guard that walks `src/ouroboros/` and exits non-zero on any unguarded `max_turns=1` call site. Verified to flip non-zero on a deliberately broken patch.
- **`.github/workflows/max-turns-envelope.yml`** — CI job that runs the guard on every PR/push to main.
- **Updated `tests/unit/orchestrator/test_runner.py`** — 4 existing tests updated to expect `allowed_tools=[]` in the `create_llm_adapter` call kwargs.

## Test plan

- [x] `pytest tests/unit/mcp/tools/test_qa_allowed_tools_wiring.py tests/unit/mcp/tools/test_authoring_allowed_tools_wiring.py tests/unit/mcp/tools/test_pm_handler_allowed_tools_wiring.py tests/unit/mcp/server/test_adapter_max_turns_envelope_wiring.py tests/unit/cli/test_detect_allowed_tools_wiring.py tests/unit/evaluation/test_verification_artifacts_allowed_tools_wiring.py tests/unit/orchestrator/test_runner_allowed_tools_wiring.py -v` → 15 passed
- [x] `pytest tests/unit/mcp/ tests/unit/cli/ tests/unit/evaluation/ tests/unit/orchestrator/ -x` → 2951 passed, 1 pre-existing unrelated failure (`test_codex_cli_runtime.py::test_build_command_omits_profile_flag_when_runtime_profile_unset`) confirmed on unpatched main
- [x] `python scripts/check-max-turns-envelope.py` → OK (318 files, 0 findings)
- [x] Static guard exits non-zero on a deliberately broken patch (confirmed)
- [x] `ruff format --check` + `ruff check` → all passed