### PR TITLE
fix(auto): bound retry on run_handoff_status="unknown" with idempotency-key

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -136,12 +136,15 @@ class HandlerRunStarter:
         self.handler = handler
         self.cwd = cwd
 
-    async def __call__(self, seed: Seed) -> dict[str, object]:
+    async def __call__(self, seed: Seed, *, idempotency_key: str = "") -> dict[str, object]:
         seed_yaml = yaml.dump(
             seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
         )
+        arguments: dict[str, object] = {"seed_content": seed_yaml, "cwd": self.cwd}
+        if idempotency_key:
+            arguments["idempotency_key"] = idempotency_key
         result = _unwrap(
-            await self.handler.handle({"seed_content": seed_yaml, "cwd": self.cwd}),
+            await self.handler.handle(arguments),
             tool_name="ouroboros_start_execute_seed",
         )
         meta = result.meta or {}

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
 import inspect
 import threading
-from typing import Any
+from typing import Any, Protocol
 
 from ouroboros.auto.blocker_attribution import record_authoring_backend
 from ouroboros.auto.grading import GradeGate
@@ -27,9 +27,25 @@ from ouroboros.auto.state import (
 from ouroboros.core.seed import Seed
 
 SeedGenerator = Callable[[str], Awaitable[Seed]]
-RunStarter = Callable[[Seed], Awaitable[dict[str, Any]]]
+
+
+class RunStarter(Protocol):
+    """Protocol for run-starter callables.
+
+    Implementations accept an optional ``idempotency_key`` so the auto
+    pipeline can safely retry a single run-start attempt without enqueuing
+    a duplicate execution server-side. The key is populated from
+    ``state.auto_session_id`` by ``AutoPipeline.run``.
+    """
+
+    async def __call__(self, seed: Seed, *, idempotency_key: str = "") -> dict[str, Any]: ...
+
+
 SeedSaver = Callable[[Seed], str]
 SeedLoader = Callable[[str], Seed]
+
+
+_RETRY_GUIDANCE_PHRASE = "retried once with idempotency key"
 
 
 @dataclass(frozen=True, slots=True)
@@ -381,15 +397,6 @@ class AutoPipeline:
                 )
                 self._save(state)
                 return self._result(state, ledger, review=review)
-            if state.run_start_attempted:
-                _mark_unknown_run_handoff(state)
-                state.mark_blocked(
-                    state.run_handoff_guidance
-                    or "Run start status is unknown; refusing to start a duplicate execution",
-                    tool_name="run_starter",
-                )
-                self._save(state)
-                return self._result(state, ledger, review=review, blocker=state.last_error)
             if not _grade_meets_required(state.last_grade, state.required_grade):
                 state.mark_blocked(
                     f"Cannot start execution without a persisted grade meeting {state.required_grade}",
@@ -426,51 +433,127 @@ class AutoPipeline:
                 f"starting execution for grade {state.last_grade or state.required_grade} Seed",
             )
             self._save(state)
-        state.run_start_attempted = True
-        self._save(state)
-        try:
-            run_meta = await asyncio.wait_for(
-                self.run_starter(seed), timeout=self.run_start_timeout_seconds
-            )
-            if not isinstance(run_meta, dict):
-                msg = f"run starter returned {type(run_meta).__name__}, expected dict"
-                raise TypeError(msg)
-            state.job_id = _optional_str(run_meta.get("job_id"))
-            state.execution_id = _optional_str(run_meta.get("execution_id"))
-        except TimeoutError as exc:
-            _mark_unknown_run_handoff(state, status="unknown_timeout")
-            state.mark_blocked(
-                f"run start timed out after {self.run_start_timeout_seconds:.0f}s",
-                tool_name="run_starter",
-            )
-            self._save(state)
-            return self._result(state, ledger, review=review, blocker=str(exc) or state.last_error)
-        except Exception as exc:
-            state.run_start_attempted = False
-            state.mark_failed(f"run start failed: {exc}", tool_name="run_starter")
-            self._save(state)
-            return self._result(state, ledger, review=review, blocker=state.last_error)
-        state.run_session_id = _optional_str(run_meta.get("session_id"))
-        run_subagent = (
-            run_meta.get("_subagent") if isinstance(run_meta.get("_subagent"), dict) else None
+        # The run starter is invoked at most twice per session lifetime:
+        # once for the initial attempt, and once on retry if the first
+        # attempt timed out or returned no durable tracking handle. Both
+        # calls share the same idempotency_key (state.auto_session_id) so
+        # the server-side handler returns the same execution metadata
+        # rather than enqueuing a duplicate. See Q00/ouroboros#774.
+        #
+        # If a previous pipeline.run() already exhausted the bounded
+        # retry (state.last_error carries the documented retry phrase),
+        # do NOT call the run starter a third time — the in-process
+        # idempotency map cannot rule out a duplicate enqueue past two
+        # attempts on the same session.
+        idempotency_key = state.auto_session_id
+        prior_retry_exhausted = (
+            state.run_handoff_guidance is not None
+            and _RETRY_GUIDANCE_PHRASE in state.run_handoff_guidance
         )
-        state.run_subagent = run_subagent or {}
-        if not any((state.job_id, state.execution_id, state.run_session_id)):
-            _mark_unknown_run_handoff(state)
+        if prior_retry_exhausted:
+            blocker_text = state.last_error or state.run_handoff_guidance
             state.mark_blocked(
-                state.run_handoff_guidance or "Run starter returned no tracking handle",
-                tool_name="run_starter",
+                blocker_text or "run starter retry already exhausted", tool_name="run_starter"
             )
             self._save(state)
             return self._result(state, ledger, review=review, blocker=state.last_error)
-        state.run_handoff_status = "started"
-        state.run_handoff_guidance = None
-        state.transition(
-            AutoPhase.COMPLETE,
-            f"execution started for grade {state.last_grade or state.required_grade} Seed",
-        )
-        self._save(state)
-        return self._result(state, ledger, review=review, run_subagent=run_subagent)
+        # If we resume into RUN with a persisted unknown handoff
+        # (``run_start_attempted=True`` plus an ``unknown_*`` status), the
+        # first iteration of this loop *is* the retry — the prior
+        # pipeline.run() call already used the initial attempt slot.
+        retried = bool(state.run_start_attempted) and state.run_handoff_status in {
+            "unknown_no_handle",
+            "unknown_timeout",
+        }
+        attempted_at_entry = state.run_start_attempted
+        while True:
+            state.run_start_attempted = True
+            self._save(state)
+            run_meta: dict[str, Any] | None = None
+            try:
+                run_meta = await asyncio.wait_for(
+                    self.run_starter(seed, idempotency_key=idempotency_key),
+                    timeout=self.run_start_timeout_seconds,
+                )
+                if not isinstance(run_meta, dict):
+                    msg = f"run starter returned {type(run_meta).__name__}, expected dict"
+                    raise TypeError(msg)
+            except TimeoutError as exc:
+                _mark_unknown_run_handoff(state, status="unknown_timeout")
+                if retried:
+                    state.run_handoff_guidance = (
+                        f"{state.run_handoff_guidance or ''} "
+                        f"{_RETRY_GUIDANCE_PHRASE} {idempotency_key}"
+                    ).strip()
+                    state.mark_blocked(
+                        f"run start timed out after {self.run_start_timeout_seconds:.0f}s; "
+                        f"{_RETRY_GUIDANCE_PHRASE} {idempotency_key}",
+                        tool_name="run_starter",
+                    )
+                    self._save(state)
+                    return self._result(
+                        state,
+                        ledger,
+                        review=review,
+                        blocker=state.last_error or str(exc),
+                    )
+            except Exception as exc:
+                # Non-timeout errors are not retried — the contract is to
+                # bound retries on *unknown* handoffs only. Reset the
+                # attempt flag so the caller can re-invoke after fixing
+                # the underlying error (preserves prior behavior).
+                if not retried:
+                    state.run_start_attempted = attempted_at_entry
+                state.mark_failed(f"run start failed: {exc}", tool_name="run_starter")
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
+
+            if run_meta is not None:
+                state.job_id = _optional_str(run_meta.get("job_id"))
+                state.execution_id = _optional_str(run_meta.get("execution_id"))
+                state.run_session_id = _optional_str(run_meta.get("session_id"))
+                run_subagent = (
+                    run_meta.get("_subagent")
+                    if isinstance(run_meta.get("_subagent"), dict)
+                    else None
+                )
+                state.run_subagent = run_subagent or {}
+                if any((state.job_id, state.execution_id, state.run_session_id)):
+                    state.run_handoff_status = "started"
+                    state.run_handoff_guidance = None
+                    state.transition(
+                        AutoPhase.COMPLETE,
+                        f"execution started for grade "
+                        f"{state.last_grade or state.required_grade} Seed",
+                    )
+                    self._save(state)
+                    return self._result(state, ledger, review=review, run_subagent=run_subagent)
+                # No durable handle surfaced — treat as unknown handoff.
+                _mark_unknown_run_handoff(state)
+
+            if retried:
+                # Retry exhausted on no-handle path (timed_out path returned
+                # earlier). Block with the documented retry phrase and
+                # persist it onto run_handoff_guidance so a later resume
+                # can detect that the bound is already spent.
+                guidance = state.run_handoff_guidance or "Run starter returned no tracking handle"
+                state.run_handoff_guidance = (
+                    f"{guidance} {_RETRY_GUIDANCE_PHRASE} {idempotency_key}"
+                ).strip()
+                state.mark_blocked(
+                    f"{guidance} {_RETRY_GUIDANCE_PHRASE} {idempotency_key}",
+                    tool_name="run_starter",
+                )
+                self._save(state)
+                return self._result(state, ledger, review=review, blocker=state.last_error)
+
+            # First attempt landed in an unknown handoff (timeout or
+            # no-handle). Persist the unknown status, then retry exactly
+            # once with the same idempotency_key so the server-side
+            # handler can short-circuit any duplicate enqueue. Both
+            # timeout and no-handle paths share this same retry slot.
+            self._save(state)
+            retried = True
 
     def _load_seed(self, state: AutoPipelineState, seed_path: str) -> Seed | None:
         if self.seed_loader is None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -449,6 +449,13 @@ class AutoPipeline:
         prior_retry_exhausted = (
             state.run_handoff_guidance is not None
             and _RETRY_GUIDANCE_PHRASE in state.run_handoff_guidance
+        ) or (
+            # Symmetric guard for the non-timeout retry-exception path:
+            # ``unknown_retry_failed`` is set when the retry attempt raised a
+            # non-TimeoutError exception. ``run_start_attempted`` stays True
+            # so a follow-up pipeline.run() must short-circuit here instead
+            # of calling run_starter a third time.
+            bool(state.run_start_attempted) and state.run_handoff_status == "unknown_retry_failed"
         )
         if prior_retry_exhausted:
             blocker_text = state.last_error or state.run_handoff_guidance
@@ -498,12 +505,36 @@ class AutoPipeline:
                         blocker=state.last_error or str(exc),
                     )
             except Exception as exc:
-                # Non-timeout errors are not retried — the contract is to
-                # bound retries on *unknown* handoffs only. Reset the
-                # attempt flag so the caller can re-invoke after fixing
-                # the underlying error (preserves prior behavior).
-                if not retried:
-                    state.run_start_attempted = attempted_at_entry
+                if retried:
+                    # Retry attempt itself raised — bound is exhausted. The
+                    # initial attempt may have already enqueued execution on
+                    # the server, so we MUST NOT call run_starter a third
+                    # time on a later resume. Persist an exhausted-retry
+                    # marker so the symmetric guard above re-blocks instead
+                    # of re-entering the run-start branch. ``last_error``
+                    # carries the documented retry phrase so callers can
+                    # detect this specific terminal state.
+                    state.run_handoff_status = "unknown_retry_failed"
+                    state.run_handoff_guidance = (
+                        f"{state.run_handoff_guidance or 'Run starter retry raised an exception'} "
+                        f"{_RETRY_GUIDANCE_PHRASE} {idempotency_key}"
+                    ).strip()
+                    state.mark_blocked(
+                        f"run start failed on retry: {exc}; "
+                        f"{_RETRY_GUIDANCE_PHRASE} {idempotency_key}",
+                        tool_name="run_starter",
+                    )
+                    # Leave state.run_start_attempted=True so the caller's
+                    # next pipeline.run() short-circuits at the symmetric
+                    # guard rather than starting a third attempt.
+                    self._save(state)
+                    return self._result(state, ledger, review=review, blocker=state.last_error)
+                # Initial attempt: non-timeout errors are not retried —
+                # the contract is to bound retries on *unknown* handoffs
+                # only. Reset the attempt flag so the caller can re-invoke
+                # after fixing the underlying error (preserves prior
+                # behavior).
+                state.run_start_attempted = attempted_at_entry
                 state.mark_failed(f"run start failed: {exc}", tool_name="run_starter")
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=state.last_error)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -868,15 +868,19 @@ def _mark_unknown_run_handoff(
     if status == "unknown_timeout":
         state.run_handoff_guidance = (
             "Run starter timed out before a durable tracking handle was captured. "
-            "The runtime may still have created an execution. Resume will not start "
-            "another run automatically or risk duplicate execution; inspect the "
-            "runtime for an existing execution before rerunning manually."
+            "The runtime may still have created an execution. Resume will attempt "
+            "exactly one automatic retry reusing the same idempotency key (state."
+            "auto_session_id) so the server-side handler can short-circuit a "
+            "duplicate enqueue. After that retry budget is exhausted the pipeline "
+            "blocks and any further resume requires manual inspection."
         )
         return
     state.run_handoff_guidance = (
         "Run starter was attempted, but no durable tracking handle was captured. "
-        "Resume will not start another run automatically or risk duplicate execution; "
-        "inspect the runtime for an existing execution before rerunning manually."
+        "Resume will attempt exactly one automatic retry reusing the same "
+        "idempotency key (state.auto_session_id) so the server-side handler can "
+        "short-circuit a duplicate enqueue. After that retry budget is exhausted "
+        "the pipeline blocks and any further resume requires manual inspection."
     )
 
 

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -450,12 +450,22 @@ class AutoPipeline:
             state.run_handoff_guidance is not None
             and _RETRY_GUIDANCE_PHRASE in state.run_handoff_guidance
         ) or (
-            # Symmetric guard for the non-timeout retry-exception path:
-            # ``unknown_retry_failed`` is set when the retry attempt raised a
-            # non-TimeoutError exception. ``run_start_attempted`` stays True
-            # so a follow-up pipeline.run() must short-circuit here instead
-            # of calling run_starter a third time.
-            bool(state.run_start_attempted) and state.run_handoff_status == "unknown_retry_failed"
+            # Conservative non-retryable guard. Covers two cases:
+            #   1. Pre-#787 sessions persisted before ``run_handoff_status``
+            #      existed: ``AutoPipelineState.from_dict`` defaults the
+            #      field to ``None`` on load. Such a session resumed with
+            #      ``run_start_attempted=True`` cannot prove which retry
+            #      slot is still safe, so the conservative pre-#787
+            #      behavior is preserved (block instead of dispatching a
+            #      duplicate enqueue).
+            #   2. Mid-call crash before ``_mark_unknown_run_handoff`` ran
+            #      (loop sets ``run_start_attempted=True`` and saves before
+            #      calling ``run_starter``).
+            #   3. Symmetric guard for the non-timeout retry-exception
+            #      path: ``unknown_retry_failed`` lands here too because
+            #      it's not a retryable status.
+            bool(state.run_start_attempted)
+            and state.run_handoff_status not in {"unknown_no_handle", "unknown_timeout"}
         )
         if prior_retry_exhausted:
             blocker_text = state.last_error or state.run_handoff_guidance

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -930,6 +930,14 @@ class StartExecuteSeedHandler:
         # ``_subagent`` envelope without triggering a second
         # subagent_dispatched event.  Keyed by idempotency_key.
         self._idempotency_plugin_payload: dict[str, dict[str, Any]] = {}
+        # Per-key serialization lock so two concurrent handle() calls with
+        # the same idempotency_key dedupe correctly. Without this, both
+        # callers can miss the cache (entries are written *after* dispatch)
+        # and each enqueues a fresh execution. ``dict.setdefault`` is
+        # atomic in single-threaded asyncio so the lock-creation path is
+        # race-free; the lock is held across the cache check + dispatch +
+        # cache write so the second caller observes a populated cache.
+        self._idempotency_locks: dict[str, asyncio.Lock] = {}
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -962,6 +970,25 @@ class StartExecuteSeedHandler:
         )
 
     async def handle(
+        self,
+        arguments: dict[str, Any],
+    ) -> Result[MCPToolResult, MCPServerError]:
+        # Serialize concurrent calls with the same idempotency_key so the
+        # check-cache / dispatch / write-cache sequence is atomic per key.
+        # Without this, two in-flight requests can both miss the cache and
+        # each enqueue a fresh execution, breaking the "second call with
+        # the same key does not enqueue" contract. ``setdefault`` is
+        # atomic in single-threaded asyncio (no ``await`` between the
+        # ``in`` check and insert), so lock-creation is race-free.
+        raw_key_outer = arguments.get("idempotency_key")
+        idem_key_outer = raw_key_outer.strip() if isinstance(raw_key_outer, str) else ""
+        if idem_key_outer:
+            lock = self._idempotency_locks.setdefault(idem_key_outer, asyncio.Lock())
+            async with lock:
+                return await self._handle_inner(arguments)
+        return await self._handle_inner(arguments)
+
+    async def _handle_inner(
         self,
         arguments: dict[str, Any],
     ) -> Result[MCPToolResult, MCPServerError]:

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -889,7 +889,23 @@ class ExecuteSeedHandler(BridgeAwareMixin):
 
 @dataclass
 class StartExecuteSeedHandler:
-    """Start a seed execution asynchronously and return a job ID immediately."""
+    """Start a seed execution asynchronously and return a job ID immediately.
+
+    Idempotency contract (Q00/ouroboros#774):
+
+    Callers may pass an ``idempotency_key`` argument. The handler maintains
+    an in-memory ``dict[str, ExecutionMeta]`` keyed by ``idempotency_key``.
+    On a second call with the same key, the handler returns the original
+    execution metadata (``job_id`` / ``session_id`` / ``execution_id``) and
+    does NOT enqueue a new background execution. Different keys produce
+    independent executions.
+
+    **Non-goal**: persistence across server restarts. The map TTL is the
+    process lifetime; on restart the key map is empty and a duplicate
+    request *can* enqueue a new execution. This is an intentional scope
+    bound — auto-side state recovery on the same restart will surface
+    the duplicate. See the issue for the full rationale.
+    """
 
     execute_handler: ExecuteSeedHandler | None = field(default=None, repr=False)
     event_store: EventStore | None = field(default=None, repr=False)
@@ -905,6 +921,10 @@ class StartExecuteSeedHandler:
             agent_runtime_backend=self.agent_runtime_backend,
             opencode_mode=self.opencode_mode,
         )
+        # Process-lifetime idempotency map: idempotency_key -> tool result
+        # meta dict. Entries are added once on first call and reused on
+        # subsequent calls with the same key.
+        self._idempotency_meta: dict[str, dict[str, Any]] = {}
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -920,13 +940,48 @@ class StartExecuteSeedHandler:
                 "This is the handler for 'ooo run' commands — "
                 "do NOT run 'ooo' in the shell; call this MCP tool instead."
             ),
-            parameters=ExecuteSeedHandler().definition.parameters,
+            parameters=(
+                *ExecuteSeedHandler().definition.parameters,
+                MCPToolParameter(
+                    name="idempotency_key",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "Optional process-local idempotency key. A second call with the same "
+                        "key returns the same execution metadata and does NOT enqueue a new "
+                        "execution. Map TTL is process lifetime — not persistent across "
+                        "server restarts."
+                    ),
+                    required=False,
+                ),
+            ),
         )
 
     async def handle(
         self,
         arguments: dict[str, Any],
     ) -> Result[MCPToolResult, MCPServerError]:
+        # Idempotency short-circuit: if this exact key was previously
+        # served, return the same metadata without enqueuing another
+        # execution. The map is process-local; see class docstring.
+        raw_key = arguments.get("idempotency_key")
+        idempotency_key = raw_key.strip() if isinstance(raw_key, str) else ""
+        if idempotency_key and idempotency_key in self._idempotency_meta:
+            cached_meta = dict(self._idempotency_meta[idempotency_key])
+            text = (
+                "Replayed prior background execution via idempotency key.\n\n"
+                f"Idempotency Key: {idempotency_key}\n"
+                f"Job ID: {cached_meta.get('job_id') or 'pending'}\n"
+                f"Session ID: {cached_meta.get('session_id') or 'pending'}\n"
+                f"Execution ID: {cached_meta.get('execution_id') or 'pending'}\n"
+            )
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text=text),),
+                    is_error=False,
+                    meta=cached_meta,
+                )
+            )
+
         cwd_result = ExecuteSeedHandler._resolve_dispatch_cwd_result(
             arguments.get("cwd"), tool_name="ouroboros_start_execute_seed"
         )
@@ -1098,18 +1153,21 @@ class StartExecuteSeedHandler:
             "Use ouroboros_ac_tree_hud(session_id, cursor) for live progress and "
             "ouroboros_job_result(job_id) for the final output."
         )
+        meta: dict[str, Any] = {
+            "job_id": snapshot.job_id,
+            "session_id": snapshot.links.session_id,
+            "execution_id": snapshot.links.execution_id,
+            "status": snapshot.status.value,
+            "cursor": snapshot.cursor,
+            "runtime_backend": runtime_backend,
+            "llm_backend": llm_backend,
+        }
+        if idempotency_key:
+            self._idempotency_meta[idempotency_key] = dict(meta)
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
                 is_error=False,
-                meta={
-                    "job_id": snapshot.job_id,
-                    "session_id": snapshot.links.session_id,
-                    "execution_id": snapshot.links.execution_id,
-                    "status": snapshot.status.value,
-                    "cursor": snapshot.cursor,
-                    "runtime_backend": runtime_backend,
-                    "llm_backend": llm_backend,
-                },
+                meta=meta,
             )
         )

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -925,6 +925,11 @@ class StartExecuteSeedHandler:
         # meta dict. Entries are added once on first call and reused on
         # subsequent calls with the same key.
         self._idempotency_meta: dict[str, dict[str, Any]] = {}
+        # Parallel cache for plugin-dispatch entries — stores the original
+        # SubagentPayload + response_shape so a retry re-emits an identical
+        # ``_subagent`` envelope without triggering a second
+        # subagent_dispatched event.  Keyed by idempotency_key.
+        self._idempotency_plugin_payload: dict[str, dict[str, Any]] = {}
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -965,6 +970,17 @@ class StartExecuteSeedHandler:
         # execution. The map is process-local; see class docstring.
         raw_key = arguments.get("idempotency_key")
         idempotency_key = raw_key.strip() if isinstance(raw_key, str) else ""
+        if idempotency_key and idempotency_key in self._idempotency_plugin_payload:
+            # Plugin-dispatch replay: re-emit an identical ``_subagent``
+            # envelope using the cached payload + response_shape, but do NOT
+            # emit another subagent_dispatched event (the original first call
+            # already recorded it).  This preserves the public response_shape
+            # contract on retries with the same idempotency_key.
+            cached = self._idempotency_plugin_payload[idempotency_key]
+            return build_subagent_result(
+                cached["payload"],
+                response_shape=dict(cached["response_shape"]),
+            )
         if idempotency_key and idempotency_key in self._idempotency_meta:
             cached_meta = dict(self._idempotency_meta[idempotency_key])
             text = (
@@ -1048,17 +1064,24 @@ class StartExecuteSeedHandler:
             # callers would see "completed" while the child is still running.
             # Instead we return job_id=None with an explicit status so no one
             # accidentally polls a non-existent job.
-            return build_subagent_result(
-                payload,
-                response_shape={
-                    "job_id": None,
-                    "session_id": plugin_session_id,
-                    "execution_id": None,
-                    "status": "delegated_to_plugin",
-                    "dispatch_mode": "plugin",
-                    "runtime_backend": self.agent_runtime_backend,
-                },
-            )
+            response_shape: dict[str, Any] = {
+                "job_id": None,
+                "session_id": plugin_session_id,
+                "execution_id": None,
+                "status": "delegated_to_plugin",
+                "dispatch_mode": "plugin",
+                "runtime_backend": self.agent_runtime_backend,
+            }
+            # Cache for idempotent replay: a second handle() with the same
+            # key must NOT re-dispatch (no second subagent_dispatched event)
+            # but MUST return an identical response_shape — same contract as
+            # the non-plugin path's ``_idempotency_meta`` short-circuit.
+            if idempotency_key:
+                self._idempotency_plugin_payload[idempotency_key] = {
+                    "payload": payload,
+                    "response_shape": dict(response_shape),
+                }
+            return build_subagent_result(payload, response_shape=response_shape)
 
         # Fall-through: real background job path — build payload here where
         # session_id may still be None (background path generates its own).

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1088,7 +1088,7 @@ async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed(ac=("The CLI should be easy and user-friendly",))
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         return {"job_id": "job_1", "execution_id": "exec_1", "session_id": "session_1"}
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -1408,7 +1408,7 @@ async def test_pipeline_run_starter_error_marks_failed(tmp_path) -> None:
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed()
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise RuntimeError("runner exploded")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -1562,7 +1562,9 @@ async def test_pipeline_resumes_completed_interview_without_reanswering(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_pipeline_refuses_duplicate_unknown_run_resume(tmp_path) -> None:
+async def test_pipeline_resume_retries_unknown_run_handoff_once(tmp_path) -> None:
+    """Resuming a session with an unknown handoff retries the run starter exactly once."""
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("run resume should not restart interview")
 
@@ -1572,26 +1574,32 @@ async def test_pipeline_refuses_duplicate_unknown_run_resume(tmp_path) -> None:
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("run resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
-        raise AssertionError("unknown run resume should not start another run")
+    keys: list[str] = []
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        keys.append(idempotency_key)
+        return {"job_id": "job_after_retry", "execution_id": "exec_after_retry"}
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
     state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
     state.transition(AutoPhase.INTERVIEW, "interview")
     state.transition(AutoPhase.SEED_GENERATION, "seed")
     state.transition(AutoPhase.REVIEW, "review")
     state.transition(AutoPhase.RUN, "run")
     state.run_start_attempted = True
+    state.run_handoff_status = "unknown_no_handle"
     driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
     pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
 
     result = await pipeline.run(state)
 
-    assert result.status == "blocked"
-    assert result.run_handoff_status == "unknown_no_handle"
-    assert "duplicate execution" in (result.blocker or "")
-    assert "will not start another run automatically" in (result.run_handoff_guidance or "")
-    assert state.run_handoff_status == "unknown_no_handle"
+    assert result.status == "complete"
+    assert result.job_id == "job_after_retry"
+    assert keys == [state.auto_session_id]
 
 
 @pytest.mark.asyncio
@@ -1605,7 +1613,7 @@ async def test_pipeline_blocks_run_start_without_tracking_handle(tmp_path) -> No
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed()
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         return {"job_id": None, "execution_id": None}
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -1621,6 +1629,8 @@ async def test_pipeline_blocks_run_start_without_tracking_handle(tmp_path) -> No
 
     assert result.status == "blocked"
     assert "tracking handle" in (result.blocker or "")
+    # Both attempts returned no handle -> the documented retry phrase is on the blocker.
+    assert "retried once with idempotency key" in (result.blocker or "")
     assert state.phase == AutoPhase.BLOCKED
 
 
@@ -1635,7 +1645,7 @@ async def test_pipeline_resumes_run_with_persisted_handle_without_restarting(tmp
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("run resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise AssertionError("persisted run handle should not start another run")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -2011,7 +2021,7 @@ async def test_pipeline_marks_malformed_run_starter_result_failed(tmp_path) -> N
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed()
 
-    async def run_seed(seed: Seed):  # noqa: ANN202, ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = ""):  # noqa: ANN202, ARG001
         return ["not", "metadata"]
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -2031,7 +2041,9 @@ async def test_pipeline_marks_malformed_run_starter_result_failed(tmp_path) -> N
 
 
 @pytest.mark.asyncio
-async def test_pipeline_blocks_duplicate_run_after_start_timeout(tmp_path) -> None:
+async def test_pipeline_resume_completes_after_first_run_timeout(tmp_path) -> None:
+    """First call times out; resume retries once with the same idempotency key."""
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("resume should not restart interview")
 
@@ -2042,10 +2054,12 @@ async def test_pipeline_blocks_duplicate_run_after_start_timeout(tmp_path) -> No
         raise AssertionError("resume should not regenerate seed")
 
     calls = 0
+    keys: list[str] = []
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         nonlocal calls
         calls += 1
+        keys.append(idempotency_key)
         await asyncio.sleep(0.05)
         return {"job_id": "job_after_timeout", "execution_id": "exec_after_timeout"}
 
@@ -2072,18 +2086,26 @@ async def test_pipeline_blocks_duplicate_run_after_start_timeout(tmp_path) -> No
     pipeline.run_start_timeout_seconds = 1
     second = await pipeline.run(state)
 
+    # First pipeline.run() invokes the run starter twice (initial + the
+    # bounded retry); both time out under the 1ms budget so it blocks
+    # with the documented retry guidance phrase.
     assert first.status == "blocked"
     assert first.run_handoff_status == "unknown_timeout"
-    assert "may still have created an execution" in (first.run_handoff_guidance or "")
+    assert "retried once with idempotency key" in (first.blocker or "")
     assert state.run_start_attempted is True
+    # Resume after the bounded retry has already been exhausted must
+    # NOT call the run starter again — the in-process idempotency map
+    # cannot rule out a duplicate enqueue past two attempts.
     assert second.status == "blocked"
-    assert second.run_handoff_status == "unknown_timeout"
-    assert "duplicate execution" in (second.blocker or "")
-    assert calls == 1
+    assert "retried once with idempotency key" in (second.blocker or "")
+    assert calls == 2
+    assert all(key == state.auto_session_id for key in keys)
 
 
 @pytest.mark.asyncio
-async def test_pipeline_refuses_retry_after_malformed_run_starter_metadata(tmp_path) -> None:
+async def test_pipeline_retries_after_no_handle_on_first_attempt(tmp_path) -> None:
+    """First run-starter call returns no handle; bounded retry succeeds."""
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("resume should not restart interview")
 
@@ -2094,10 +2116,12 @@ async def test_pipeline_refuses_retry_after_malformed_run_starter_metadata(tmp_p
         raise AssertionError("resume should not regenerate seed")
 
     calls = 0
+    keys: list[str] = []
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         nonlocal calls
         calls += 1
+        keys.append(idempotency_key)
         if calls == 1:
             return {}
         return {"job_id": "job_after_retry", "execution_id": "exec_after_retry"}
@@ -2116,16 +2140,13 @@ async def test_pipeline_refuses_retry_after_malformed_run_starter_metadata(tmp_p
     pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=AutoStore(tmp_path))
 
     first = await pipeline.run(state)
-    second = await pipeline.run(state)
 
-    assert first.status == "blocked"
-    assert first.run_handoff_status == "unknown_no_handle"
-    assert "will not start another run automatically" in (first.run_handoff_guidance or "")
+    # The bounded retry resolved the no-handle outcome inside a single run().
+    assert first.status == "complete"
+    assert first.execution_id == "exec_after_retry"
     assert state.run_start_attempted is True
-    assert second.status == "blocked"
-    assert second.run_handoff_status == "unknown_no_handle"
-    assert second.job_id is None
-    assert calls == 1
+    assert calls == 2
+    assert keys == [state.auto_session_id, state.auto_session_id]
 
 
 @pytest.mark.asyncio
@@ -2239,7 +2260,7 @@ async def test_pipeline_resumes_prepared_run_before_first_attempt(tmp_path) -> N
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("run resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         return {"job_id": "job_after_resume", "execution_id": "exec_after_resume"}
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -2338,7 +2359,7 @@ async def test_pipeline_run_resume_rechecks_persisted_ledger_before_execution(tm
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("run resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise AssertionError("unresolved ledger must not start execution")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -2369,7 +2390,7 @@ async def test_pipeline_refuses_run_resume_without_a_grade(tmp_path) -> None:
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("run resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise AssertionError("non-A run resume must not start execution")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -2417,7 +2438,9 @@ async def test_pipeline_seed_generation_resume_requires_interview_session_id(tmp
 
 
 @pytest.mark.asyncio
-async def test_pipeline_refuses_blocked_run_start_replay_from_seed_path(tmp_path) -> None:
+async def test_pipeline_retry_after_blocked_run_start_replay_from_seed_path(tmp_path) -> None:
+    """Resuming a blocked run-start session retries the run starter once."""
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("resume should not restart interview")
 
@@ -2427,8 +2450,11 @@ async def test_pipeline_refuses_blocked_run_start_replay_from_seed_path(tmp_path
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("unknown run resume should not generate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
-        raise AssertionError("ambiguous run start resume should not start another run")
+    keys: list[str] = []
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        keys.append(idempotency_key)
+        return {"job_id": "job_after_replay", "execution_id": "exec_after_replay"}
 
     seed = _seed()
     seed_path = str(tmp_path / "seed.yaml")
@@ -2442,6 +2468,7 @@ async def test_pipeline_refuses_blocked_run_start_replay_from_seed_path(tmp_path
     state.transition(AutoPhase.SEED_GENERATION, "seed")
     state.transition(AutoPhase.REVIEW, "review")
     state.transition(AutoPhase.RUN, "run")
+    state.run_handoff_status = "unknown_timeout"
     state.mark_blocked("run start timed out", tool_name="run_starter")
     state.run_start_attempted = True
     driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
@@ -2457,9 +2484,9 @@ async def test_pipeline_refuses_blocked_run_start_replay_from_seed_path(tmp_path
 
     result = await pipeline.run(state)
 
-    assert result.status == "blocked"
-    assert "duplicate execution" in (result.blocker or "")
-    assert result.job_id is None
+    assert result.status == "complete"
+    assert result.job_id == "job_after_replay"
+    assert keys == [state.auto_session_id]
 
 
 @pytest.mark.asyncio
@@ -2506,7 +2533,7 @@ async def test_pipeline_replays_persisted_run_subagent_after_complete_resume(tmp
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed()
 
-    async def run_seed(seed: Seed) -> dict[str, object]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, object]:  # noqa: ARG001
         return {
             "session_id": "session_1",
             "_subagent": {"tool_name": "ouroboros_execute_seed", "context": {"seed": "x"}},
@@ -2799,7 +2826,7 @@ async def test_pipeline_run_resume_requires_may_run_even_when_required_grade_is_
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("run resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise AssertionError("B-grade Seed with may_run=false must not start execution")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -2830,7 +2857,7 @@ async def test_pipeline_run_resume_rejects_grade_b_when_required_grade_a(tmp_pat
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("run resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise AssertionError("grade B must not run when required grade is A")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -2978,7 +3005,7 @@ async def test_resume_after_interview_max_rounds_can_continue_when_bound_raised(
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed()
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         return {"job_id": "job_resume", "execution_id": "exec_resume", "session_id": "ses_resume"}
 
     pipeline = AutoPipeline(
@@ -3006,7 +3033,7 @@ async def test_pipeline_attaches_run_handle_after_unknown_handoff_without_restar
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise AssertionError("attach-only resume must not start another run")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -3094,7 +3121,7 @@ async def test_pipeline_records_unsupported_reconciliation_without_restart(tmp_p
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise AssertionError("reconcile-only resume must not start another run")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -3268,7 +3295,7 @@ async def test_pipeline_attach_clears_stale_reconciliation_metadata(tmp_path) ->
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         raise AssertionError("resume should not regenerate seed")
 
-    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
         raise AssertionError("attach must not start another run")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))

--- a/tests/unit/auto/test_run_starter_idempotency.py
+++ b/tests/unit/auto/test_run_starter_idempotency.py
@@ -176,6 +176,58 @@ async def test_first_call_returns_no_handle_retry_returns_handle_completes(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_retry_raises_non_timeout_marks_exhausted_and_blocks_resume(tmp_path) -> None:
+    """Scenario 4: first call timeouts; retry raises RuntimeError -> BLOCKED with the
+    documented retry phrase, AND a follow-up pipeline.run() must NOT call
+    run_starter a third time (Q00/ouroboros#787 review-1 BLOCKING-2).
+    """
+
+    calls: list[str] = []
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        calls.append(idempotency_key)
+        if len(calls) == 1:
+            await asyncio.sleep(1.0)  # forces wait_for to TimeoutError
+            raise AssertionError("first call should have been cancelled by wait_for")
+        # Second (retry) call raises a non-timeout exception.
+        raise RuntimeError("retry-side dispatch failure")
+
+    state = _primed_run_state(tmp_path)
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(_unused_start, _unused_answer),
+        store=store,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        _unused_seed_generator,
+        run_starter=run_seed,
+        store=store,
+        run_start_timeout_seconds=0.01,
+    )
+
+    result = await pipeline.run(state)
+
+    # Pipeline blocked with the documented retry phrase.
+    assert result.status == "blocked"
+    assert "retried once with idempotency key" in (state.last_error or "")
+    assert "retried once with idempotency key" in (result.blocker or "")
+    # Exactly two run_starter calls so far (initial + one retry).
+    assert calls == [state.auto_session_id, state.auto_session_id]
+    # State markers persist so the symmetric guard short-circuits next run().
+    assert state.run_start_attempted is True
+    assert state.run_handoff_status == "unknown_retry_failed"
+
+    # Resume: the next pipeline.run() must NOT call run_starter again.
+    result2 = await pipeline.run(state)
+    assert result2.status == "blocked"
+    assert calls == [state.auto_session_id, state.auto_session_id], (
+        f"run_starter called {len(calls)} times; symmetric guard failed to "
+        "short-circuit on resume after exhausted-retry"
+    )
+
+
+@pytest.mark.asyncio
 async def test_both_calls_fail_pipeline_blocks_with_documented_phrase(tmp_path) -> None:
     """Scenario 3: both attempts fail -> BLOCKED with the documented retry phrase."""
 

--- a/tests/unit/auto/test_run_starter_idempotency.py
+++ b/tests/unit/auto/test_run_starter_idempotency.py
@@ -228,6 +228,52 @@ async def test_retry_raises_non_timeout_marks_exhausted_and_blocks_resume(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_resume_legacy_session_with_run_start_attempted_does_not_dispatch(
+    tmp_path,
+) -> None:
+    """Pre-#787 sessions persisted with ``run_start_attempted=True`` and
+    no ``run_handoff_status`` field (defaults to ``None`` on load) must
+    NOT call ``run_starter`` on resume. The new bounded retry replaces a
+    pre-PR duplicate-prevention guard; a legacy session has no recorded
+    handoff status, so the only safe behavior is to block conservatively
+    instead of dispatching a fresh attempt that could duplicate a server-
+    side enqueue (Q00/ouroboros#787 review-2 BLOCKING-1).
+    """
+
+    calls: list[str] = []
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        calls.append(idempotency_key)
+        return {"job_id": "should_not_be_called", "execution_id": "should_not_be_called"}
+
+    state = _primed_run_state(tmp_path)
+    # Simulate a pre-#787 session: an attempt was made but the new status
+    # field was never persisted (load defaults it to None).
+    state.run_start_attempted = True
+    state.run_handoff_status = None
+    state.run_handoff_guidance = None
+
+    pipeline = AutoPipeline(
+        AutoInterviewDriver(
+            FunctionInterviewBackend(_unused_start, _unused_answer),
+            store=AutoStore(tmp_path),
+        ),
+        _unused_seed_generator,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "run_starter"
+    assert calls == [], (
+        f"legacy resume must not invoke run_starter; got {len(calls)} call(s) "
+        "(pre-#787 sessions cannot prove which retry slot is still safe)"
+    )
+
+
+@pytest.mark.asyncio
 async def test_both_calls_fail_pipeline_blocks_with_documented_phrase(tmp_path) -> None:
     """Scenario 3: both attempts fail -> BLOCKED with the documented retry phrase."""
 

--- a/tests/unit/auto/test_run_starter_idempotency.py
+++ b/tests/unit/auto/test_run_starter_idempotency.py
@@ -1,0 +1,206 @@
+"""Auto-pipeline bounded-retry contract for unknown run handoffs.
+
+Regression suite for Q00/ouroboros#774. Each scenario exercises the
+inline retry that ``AutoPipeline.run`` performs when the run starter
+either times out or returns no durable tracking handle. The retry uses
+the same ``idempotency_key`` (``state.auto_session_id``) so the
+server-side handler can short-circuit a duplicate enqueue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _fill_ready(ledger: SeedDraftLedger) -> None:
+    for section, value in {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }.items():
+        source = (
+            LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        )
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=source,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+
+def _seed() -> Seed:
+    return Seed(
+        goal="Build a local CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior"),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.12),
+    )
+
+
+def _primed_run_state(tmp_path) -> AutoPipelineState:
+    """Build an auto state already at the RUN phase with a passing seed."""
+    state = AutoPipelineState(goal="Build a local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    return state
+
+
+async def _unused_start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+    raise AssertionError("run-phase resume must not restart the interview")
+
+
+async def _unused_answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+    raise AssertionError("run-phase resume must not answer the interview")
+
+
+async def _unused_seed_generator(_session_id: str) -> Seed:
+    raise AssertionError("run-phase resume must not regenerate the Seed")
+
+
+@pytest.mark.asyncio
+async def test_first_call_times_out_retry_returns_handle_completes(tmp_path) -> None:
+    """Scenario 1: first call raises TimeoutError; retry returns a handle -> COMPLETE."""
+
+    calls: list[str] = []
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        calls.append(idempotency_key)
+        if len(calls) == 1:
+            await asyncio.sleep(1.0)  # forces wait_for to TimeoutError
+            raise AssertionError("first call should have been cancelled by wait_for")
+        return {"job_id": "job_after_retry", "execution_id": "exec_after_retry"}
+
+    state = _primed_run_state(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(_unused_start, _unused_answer),
+        store=AutoStore(tmp_path),
+    )
+    pipeline = AutoPipeline(
+        driver,
+        _unused_seed_generator,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        run_start_timeout_seconds=0.01,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.execution_id == "exec_after_retry"
+    assert result.job_id == "job_after_retry"
+    # Retry MUST reuse the same idempotency key on both attempts.
+    assert calls == [state.auto_session_id, state.auto_session_id]
+
+
+@pytest.mark.asyncio
+async def test_first_call_returns_no_handle_retry_returns_handle_completes(tmp_path) -> None:
+    """Scenario 2: first call returns ``{}``; retry returns a handle -> COMPLETE."""
+
+    calls: list[str] = []
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        calls.append(idempotency_key)
+        if len(calls) == 1:
+            return {}
+        return {"job_id": "job_after_retry", "execution_id": "exec_after_retry"}
+
+    state = _primed_run_state(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(_unused_start, _unused_answer),
+        store=AutoStore(tmp_path),
+    )
+    pipeline = AutoPipeline(
+        driver,
+        _unused_seed_generator,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.execution_id == "exec_after_retry"
+    assert calls == [state.auto_session_id, state.auto_session_id]
+
+
+@pytest.mark.asyncio
+async def test_both_calls_fail_pipeline_blocks_with_documented_phrase(tmp_path) -> None:
+    """Scenario 3: both attempts fail -> BLOCKED with the documented retry phrase."""
+
+    calls: list[str] = []
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        calls.append(idempotency_key)
+        return {}
+
+    state = _primed_run_state(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(_unused_start, _unused_answer),
+        store=AutoStore(tmp_path),
+    )
+    pipeline = AutoPipeline(
+        driver,
+        _unused_seed_generator,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "run_starter"
+    assert "retried once with idempotency key" in (state.last_error or "")
+    assert "retried once with idempotency key" in (result.blocker or "")
+    assert calls == [state.auto_session_id, state.auto_session_id]

--- a/tests/unit/mcp/tools/test_start_execute_seed_idempotency.py
+++ b/tests/unit/mcp/tools/test_start_execute_seed_idempotency.py
@@ -1,0 +1,182 @@
+"""Server-side idempotency contract for ``StartExecuteSeedHandler``.
+
+Regression suite for Q00/ouroboros#774. The handler maintains an
+in-memory ``dict[str, ExecutionMeta]`` keyed by ``idempotency_key``. A
+second call with the same key short-circuits and returns the original
+metadata; different keys produce independent executions; a fresh
+handler instance has no memory of prior keys (process-restart bound).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobSnapshot, JobStatus
+from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
+from ouroboros.persistence.event_store import EventStore
+
+
+@pytest.fixture
+async def event_store():
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    yield store
+    await store.close()
+
+
+def _make_job_manager_stub(start_calls: list[dict]) -> JobManager:
+    """Return a JobManager-shaped mock that records ``start_job`` invocations.
+
+    Each call appends ``{"job_type", "links", "runner"}`` to ``start_calls``
+    and resolves the runner so the synchronous ExecuteSeedHandler awaitable
+    is consumed exactly the way the real JobManager would (preventing
+    "coroutine was never awaited" warnings while keeping test isolation).
+    """
+
+    job_manager = MagicMock(spec=JobManager)
+
+    counter = {"n": 0}
+
+    async def _start_job(*, job_type, initial_message, runner, links=None):  # noqa: ARG001
+        counter["n"] += 1
+        job_id = f"job_{counter['n']:012d}"
+        start_calls.append(
+            {
+                "job_type": job_type,
+                "links": links,
+                "job_id": job_id,
+            }
+        )
+        # Drain the runner coroutine so it doesn't leak as never-awaited.
+        try:
+            runner.close()
+        except AttributeError:
+            pass
+        now = datetime.now(UTC)
+        snapshot = JobSnapshot(
+            job_id=job_id,
+            job_type=job_type,
+            status=JobStatus.QUEUED,
+            cursor=0,
+            message=initial_message,
+            links=links or JobLinks(),
+            created_at=now,
+            updated_at=now,
+        )
+        return snapshot
+
+    job_manager.start_job = _start_job
+    return job_manager
+
+
+def _make_handler(event_store: EventStore, start_calls: list[dict]) -> StartExecuteSeedHandler:
+    """Build a handler whose JobManager is the stub recording start_job calls.
+
+    ``execute_handler`` is mocked because the server-side idempotency
+    contract is tested at the boundary of ``handle()``; the inner
+    ExecuteSeedHandler is only invoked through the runner coroutine,
+    which the JobManager stub closes without awaiting.
+    """
+
+    return StartExecuteSeedHandler(
+        execute_handler=MagicMock(),
+        event_store=event_store,
+        job_manager=_make_job_manager_stub(start_calls),
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_idempotency_key_replays_metadata_and_skips_enqueue(
+    event_store, tmp_path
+) -> None:
+    """A second call with the same key returns the same meta and does not re-enqueue."""
+    start_calls: list[dict] = []
+    handler = _make_handler(event_store, start_calls)
+
+    arguments = {
+        "seed_content": "goal: idempotent\n",
+        "cwd": str(tmp_path),
+        "idempotency_key": "auto_session_abc",
+    }
+    first = await handler.handle(arguments)
+    second = await handler.handle(arguments)
+
+    assert first.is_ok
+    assert second.is_ok
+    first_meta = first.value.meta
+    second_meta = second.value.meta
+    assert first_meta["execution_id"] == second_meta["execution_id"]
+    assert first_meta["session_id"] == second_meta["session_id"]
+    assert first_meta["job_id"] == second_meta["job_id"]
+    # Exactly one execution was enqueued: the JobManager stub recorded
+    # one start_job call, even though handle() ran twice.
+    assert len(start_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_different_idempotency_keys_produce_independent_executions(
+    event_store, tmp_path
+) -> None:
+    """Distinct keys must lead to distinct enqueue events."""
+    start_calls: list[dict] = []
+    handler = _make_handler(event_store, start_calls)
+
+    first = await handler.handle(
+        {
+            "seed_content": "goal: a\n",
+            "cwd": str(tmp_path),
+            "idempotency_key": "auto_session_a",
+        }
+    )
+    second = await handler.handle(
+        {
+            "seed_content": "goal: b\n",
+            "cwd": str(tmp_path),
+            "idempotency_key": "auto_session_b",
+        }
+    )
+
+    assert first.is_ok and second.is_ok
+    assert first.value.meta["execution_id"] != second.value.meta["execution_id"]
+    assert len(start_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_process_restart_resets_idempotency_map(event_store, tmp_path) -> None:
+    """A fresh handler instance simulates a process restart — keys are forgotten."""
+    start_calls_first: list[dict] = []
+    handler_first = _make_handler(event_store, start_calls_first)
+
+    arguments = {
+        "seed_content": "goal: restart\n",
+        "cwd": str(tmp_path),
+        "idempotency_key": "auto_session_restart",
+    }
+    await handler_first.handle(arguments)
+    assert len(start_calls_first) == 1
+
+    # Simulate process restart: discard the handler instance and rebuild.
+    start_calls_second: list[dict] = []
+    handler_second = _make_handler(event_store, start_calls_second)
+
+    await handler_second.handle(arguments)
+    # Documented non-goal: persistence across restarts. The new handler
+    # has no memory of the prior idempotency key, so the request enqueues
+    # a fresh execution.
+    assert len(start_calls_second) == 1
+
+
+@pytest.mark.asyncio
+async def test_call_without_idempotency_key_always_enqueues(event_store, tmp_path) -> None:
+    """Omitting the key keeps the legacy behavior — every call enqueues."""
+    start_calls: list[dict] = []
+    handler = _make_handler(event_store, start_calls)
+
+    arguments = {"seed_content": "goal: legacy\n", "cwd": str(tmp_path)}
+    await handler.handle(arguments)
+    await handler.handle(arguments)
+
+    assert len(start_calls) == 2

--- a/tests/unit/mcp/tools/test_start_execute_seed_idempotency.py
+++ b/tests/unit/mcp/tools/test_start_execute_seed_idempotency.py
@@ -9,6 +9,7 @@ handler instance has no memory of prior keys (process-restart bound).
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
@@ -227,4 +228,113 @@ async def test_plugin_dispatch_replays_response_shape_and_skips_dispatch(
     assert len(dispatched_events) == 1, (
         f"expected exactly 1 subagent.dispatched event on the first call, "
         f"got {len(dispatched_events)} (replay must not re-dispatch)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_with_same_key_dedupe(event_store, tmp_path) -> None:
+    """Two concurrent handle() calls with the same idempotency_key must not
+    both enqueue (Q00/ouroboros#787 review-2 BLOCKING-2). Without the
+    per-key serialization lock, each in-flight call would miss the cache
+    (the entry is written *after* dispatch) and call ``start_job`` again.
+    """
+    start_calls: list[dict] = []
+
+    # The job manager stub awaits a per-test event so the first handle()
+    # is held mid-dispatch while the second handle() arrives. This is the
+    # exact race the per-key lock has to defeat.
+    release = asyncio.Event()
+
+    job_manager = MagicMock()
+    counter = {"n": 0}
+
+    async def _slow_start_job(*, job_type, initial_message, runner, links=None):  # noqa: ARG001
+        counter["n"] += 1
+        job_id = f"job_{counter['n']:012d}"
+        start_calls.append({"job_id": job_id})
+        try:
+            runner.close()
+        except AttributeError:
+            pass
+        # Hold the first dispatch open so the second handle() races us.
+        await release.wait()
+        now = datetime.now(UTC)
+        return JobSnapshot(
+            job_id=job_id,
+            job_type=job_type,
+            status=JobStatus.QUEUED,
+            cursor=0,
+            message=initial_message,
+            links=links or JobLinks(),
+            created_at=now,
+            updated_at=now,
+        )
+
+    job_manager.start_job = _slow_start_job
+
+    handler = StartExecuteSeedHandler(
+        execute_handler=MagicMock(),
+        event_store=event_store,
+        job_manager=job_manager,
+    )
+
+    arguments = {
+        "seed_content": "goal: concurrent\n",
+        "cwd": str(tmp_path),
+        "idempotency_key": "auto_session_concurrent",
+    }
+
+    first_task = asyncio.create_task(handler.handle(arguments))
+    second_task = asyncio.create_task(handler.handle(arguments))
+    # Yield so both tasks are admitted; first acquires the lock, second
+    # parks on lock acquisition. Without the lock the second would race
+    # past the cache check and trigger a duplicate start_job call.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    release.set()
+
+    first, second = await asyncio.gather(first_task, second_task)
+
+    assert first.is_ok and second.is_ok
+    assert len(start_calls) == 1, (
+        f"expected exactly 1 start_job call across two concurrent handle() "
+        f"calls with the same idempotency_key; got {len(start_calls)}"
+    )
+    assert first.value.meta["execution_id"] == second.value.meta["execution_id"]
+    assert first.value.meta["job_id"] == second.value.meta["job_id"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_plugin_calls_with_same_key_dedupe(event_store, tmp_path) -> None:
+    """Concurrent plugin-dispatch calls with the same key must emit exactly
+    one ``subagent.dispatched`` event (Q00/ouroboros#787 review-2 BLOCKING-2).
+    """
+    handler = StartExecuteSeedHandler(
+        execute_handler=MagicMock(),
+        event_store=event_store,
+        job_manager=_make_job_manager_stub([]),
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    arguments = {
+        "seed_content": "goal: concurrent-plugin\n",
+        "cwd": str(tmp_path),
+        "idempotency_key": "auto_plugin_concurrent",
+    }
+
+    first_task = asyncio.create_task(handler.handle(arguments))
+    second_task = asyncio.create_task(handler.handle(arguments))
+    first, second = await asyncio.gather(first_task, second_task)
+
+    assert first.is_ok and second.is_ok
+    assert first.value.meta["session_id"] == second.value.meta["session_id"]
+    assert first.value.meta["_subagent"] == second.value.meta["_subagent"]
+
+    aggregate_id = first.value.meta["session_id"]
+    events, _ = await event_store.get_events_after("subagent", aggregate_id)
+    dispatched = [e for e in events if e.type == "subagent.dispatched"]
+    assert len(dispatched) == 1, (
+        f"expected exactly 1 subagent.dispatched event under concurrent "
+        f"plugin dispatch with the same key; got {len(dispatched)}"
     )

--- a/tests/unit/mcp/tools/test_start_execute_seed_idempotency.py
+++ b/tests/unit/mcp/tools/test_start_execute_seed_idempotency.py
@@ -180,3 +180,51 @@ async def test_call_without_idempotency_key_always_enqueues(event_store, tmp_pat
     await handler.handle(arguments)
 
     assert len(start_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_plugin_dispatch_replays_response_shape_and_skips_dispatch(
+    event_store, tmp_path
+) -> None:
+    """Plugin-dispatch path: same idempotency_key returns identical response_shape
+    and emits no second subagent_dispatched event (Q00/ouroboros#787 review-1).
+    """
+    handler = StartExecuteSeedHandler(
+        execute_handler=MagicMock(),
+        event_store=event_store,
+        job_manager=_make_job_manager_stub([]),
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    arguments = {
+        "seed_content": "goal: plugin-idempotent\n",
+        "cwd": str(tmp_path),
+        "idempotency_key": "auto_plugin_session",
+    }
+
+    first = await handler.handle(arguments)
+    second = await handler.handle(arguments)
+
+    assert first.is_ok
+    assert second.is_ok
+
+    first_meta = first.value.meta
+    second_meta = second.value.meta
+    # Identical response_shape — same session_id, status, dispatch_mode.
+    assert first_meta["session_id"] == second_meta["session_id"]
+    assert first_meta["status"] == "delegated_to_plugin"
+    assert second_meta["status"] == "delegated_to_plugin"
+    assert first_meta["dispatch_mode"] == second_meta["dispatch_mode"] == "plugin"
+    assert first_meta["runtime_backend"] == second_meta["runtime_backend"]
+    # Identical _subagent envelope (replay re-emits the cached payload).
+    assert first_meta["_subagent"] == second_meta["_subagent"]
+
+    # No second subagent.dispatched event was emitted on retry.
+    aggregate_id = first_meta["session_id"]
+    events, _ = await event_store.get_events_after("subagent", aggregate_id)
+    dispatched_events = [e for e in events if e.type == "subagent.dispatched"]
+    assert len(dispatched_events) == 1, (
+        f"expected exactly 1 subagent.dispatched event on the first call, "
+        f"got {len(dispatched_events)} (replay must not re-dispatch)"
+    )


### PR DESCRIPTION
Closes #774.

## Summary
- `RunStarter` is now a `Protocol` whose `__call__` accepts an `idempotency_key` keyword. `HandlerRunStarter` forwards it as a tool argument so server-side handlers can de-duplicate retries.
- `AutoPipeline.run()` retries the run starter exactly once on `unknown_timeout` / no-handle outcomes using `state.auto_session_id` as the idempotency key. The duplicate-prevention guard at `pipeline.py:355-356` is replaced by this bounded retry path; both attempts share the same `run_start_timeout_seconds` budget.
- On retry exhaustion the pipeline transitions to `BLOCKED` with `tool_name="run_starter"` and the literal phrase `retried once with idempotency key` in both `state.last_error` and `state.run_handoff_guidance`, so a later resume cannot escalate to a third call.
- `StartExecuteSeedHandler` maintains a process-local `dict[str, ExecutionMeta]` keyed by `idempotency_key`. Repeated calls with the same key replay the original metadata without enqueuing a new execution; persistence across server restarts is documented as a non-goal.
- Existing tests that asserted the old "block on duplicate" behavior were updated to reflect the new retry contract.

## Test plan
- [x] `pytest tests/unit/auto/test_run_starter_idempotency.py -v` (3 scenarios: timeout-then-handle, no-handle-then-handle, both-fail-blocks-with-phrase)
- [x] `pytest tests/unit/mcp/tools/test_start_execute_seed_idempotency.py -v` (same key replays / different keys diverge / restart resets / no key keeps legacy behavior)
- [x] Local regression: `pytest tests/unit/auto/ tests/unit/mcp/tools/ -x` — 975 passed
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)