### PR TITLE
feat(ralph): oscillation / no-progress detection

### DIFF
--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -307,6 +307,8 @@ class RalphHandler:
                 project_dir=config.project_dir,
                 max_generations=config.max_generations,
                 per_iteration_timeout_seconds=config.per_iteration_timeout_seconds,
+                oscillation_window=config.oscillation_window,
+                grade_regression_window=config.grade_regression_window,
             )
             await self._event_store.initialize()
             await emit_subagent_dispatched_event(

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -209,13 +209,12 @@ class RalphHandler:
                 )
             )
 
+        raw_timeout = arguments.get(
+            "per_iteration_timeout_seconds",
+            DEFAULT_PER_ITERATION_TIMEOUT_SECONDS,
+        )
         try:
-            per_iteration_timeout_seconds = float(
-                arguments.get(
-                    "per_iteration_timeout_seconds",
-                    DEFAULT_PER_ITERATION_TIMEOUT_SECONDS,
-                )
-            )
+            per_iteration_timeout_seconds = float(raw_timeout)
         except (TypeError, ValueError):
             return Result.err(
                 MCPToolError(
@@ -224,6 +223,9 @@ class RalphHandler:
                 )
             )
         if not math.isfinite(per_iteration_timeout_seconds):
+            # Reject NaN / +inf / -inf: range comparisons are always False for
+            # NaN and asyncio.wait_for(timeout=inf) defeats the bounded-loop
+            # contract the public API advertises.
             return Result.err(
                 MCPToolError(
                     "per_iteration_timeout_seconds must be a finite number",
@@ -243,17 +245,13 @@ class RalphHandler:
                 )
             )
 
-        try:
-            oscillation_window = int(
-                arguments.get("oscillation_window", DEFAULT_OSCILLATION_WINDOW)
-            )
-        except (TypeError, ValueError):
-            return Result.err(
-                MCPToolError(
-                    "oscillation_window must be an integer",
-                    tool_name="ouroboros_ralph",
-                )
-            )
+        oscillation_window_result = _coerce_window(
+            arguments.get("oscillation_window", DEFAULT_OSCILLATION_WINDOW),
+            field_name="oscillation_window",
+        )
+        if isinstance(oscillation_window_result, MCPToolError):
+            return Result.err(oscillation_window_result)
+        oscillation_window = oscillation_window_result
         if oscillation_window < MIN_PROGRESS_WINDOW or oscillation_window > MAX_RALPH_GENERATIONS:
             return Result.err(
                 MCPToolError(
@@ -263,17 +261,13 @@ class RalphHandler:
                 )
             )
 
-        try:
-            grade_regression_window = int(
-                arguments.get("grade_regression_window", DEFAULT_GRADE_REGRESSION_WINDOW)
-            )
-        except (TypeError, ValueError):
-            return Result.err(
-                MCPToolError(
-                    "grade_regression_window must be an integer",
-                    tool_name="ouroboros_ralph",
-                )
-            )
+        grade_regression_window_result = _coerce_window(
+            arguments.get("grade_regression_window", DEFAULT_GRADE_REGRESSION_WINDOW),
+            field_name="grade_regression_window",
+        )
+        if isinstance(grade_regression_window_result, MCPToolError):
+            return Result.err(grade_regression_window_result)
+        grade_regression_window = grade_regression_window_result
         if (
             grade_regression_window < MIN_PROGRESS_WINDOW
             or grade_regression_window > MAX_RALPH_GENERATIONS
@@ -376,3 +370,28 @@ class RalphHandler:
 def _normalize_lineage_id(value: Any) -> str:
     """Normalize user-provided lineage IDs before starting a mutating Ralph loop."""
     return value.strip() if isinstance(value, str) else ""
+
+
+def _coerce_window(value: Any, *, field_name: str) -> int | MCPToolError:
+    """Strictly coerce an MCP integer field, refusing fractional float truncation.
+
+    The MCP parameter is declared ``INTEGER``. ``int(2.9)`` would silently
+    truncate to ``2``, changing loop-stop semantics behind the caller's back,
+    so reject any float whose value is not exactly integral. Booleans flow
+    through ``int(True) == 1`` and remain handled by the downstream range
+    check (``True``/``False`` end up as 1/0, both below the floor).
+    """
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return MCPToolError(
+            f"{field_name} must be an integer",
+            tool_name="ouroboros_ralph",
+        )
+    # ``isinstance(bool, int)`` is True, but bool truncation is harmless here.
+    if isinstance(value, float) and coerced != value:
+        return MCPToolError(
+            f"{field_name} must be an integer (got fractional value)",
+            tool_name="ouroboros_ralph",
+        )
+    return coerced

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -30,6 +30,8 @@ from ouroboros.mcp.types import (
 )
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.ralph_loop import (
+    DEFAULT_GRADE_REGRESSION_WINDOW,
+    DEFAULT_OSCILLATION_WINDOW,
     DEFAULT_PER_ITERATION_TIMEOUT_SECONDS,
     EvolveStepLike,
     RalphLoopConfig,
@@ -138,6 +140,30 @@ class RalphHandler:
                     required=False,
                     default=DEFAULT_PER_ITERATION_TIMEOUT_SECONDS,
                 ),
+                MCPToolParameter(
+                    name="oscillation_window",
+                    type=ToolInputType.INTEGER,
+                    description=(
+                        "Number of trailing iterations whose findings_hash must "
+                        "match (and QA must not have passed) to stop with "
+                        "stop_reason='oscillation_detected'. Default: 3. "
+                        f"Range: 1-{MAX_RALPH_GENERATIONS}."
+                    ),
+                    required=False,
+                    default=DEFAULT_OSCILLATION_WINDOW,
+                ),
+                MCPToolParameter(
+                    name="grade_regression_window",
+                    type=ToolInputType.INTEGER,
+                    description=(
+                        "Number of trailing iterations whose non-None grades must "
+                        "strictly decrease to stop with "
+                        "stop_reason='grade_regressing'. Default: 2. "
+                        f"Range: 1-{MAX_RALPH_GENERATIONS}."
+                    ),
+                    required=False,
+                    default=DEFAULT_GRADE_REGRESSION_WINDOW,
+                ),
             ),
         )
 
@@ -212,6 +238,44 @@ class RalphHandler:
                 )
             )
 
+        try:
+            oscillation_window = int(
+                arguments.get("oscillation_window", DEFAULT_OSCILLATION_WINDOW)
+            )
+        except (TypeError, ValueError):
+            return Result.err(
+                MCPToolError(
+                    "oscillation_window must be an integer",
+                    tool_name="ouroboros_ralph",
+                )
+            )
+        if oscillation_window < 1 or oscillation_window > MAX_RALPH_GENERATIONS:
+            return Result.err(
+                MCPToolError(
+                    f"oscillation_window must be between 1 and {MAX_RALPH_GENERATIONS}",
+                    tool_name="ouroboros_ralph",
+                )
+            )
+
+        try:
+            grade_regression_window = int(
+                arguments.get("grade_regression_window", DEFAULT_GRADE_REGRESSION_WINDOW)
+            )
+        except (TypeError, ValueError):
+            return Result.err(
+                MCPToolError(
+                    "grade_regression_window must be an integer",
+                    tool_name="ouroboros_ralph",
+                )
+            )
+        if grade_regression_window < 1 or grade_regression_window > MAX_RALPH_GENERATIONS:
+            return Result.err(
+                MCPToolError(
+                    f"grade_regression_window must be between 1 and {MAX_RALPH_GENERATIONS}",
+                    tool_name="ouroboros_ralph",
+                )
+            )
+
         if arguments.get("delegation_depth", 0):
             return Result.err(
                 MCPToolError(
@@ -229,6 +293,8 @@ class RalphHandler:
             project_dir=arguments.get("project_dir"),
             max_generations=max_generations,
             per_iteration_timeout_seconds=per_iteration_timeout_seconds,
+            oscillation_window=oscillation_window,
+            grade_regression_window=grade_regression_window,
         )
 
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -41,6 +41,7 @@ from ouroboros.ralph_loop import (
 MAX_RALPH_GENERATIONS = 10
 MIN_PER_ITERATION_TIMEOUT_SECONDS = 30.0
 MAX_PER_ITERATION_TIMEOUT_SECONDS = 7200.0
+MIN_PROGRESS_WINDOW = 2  # smallest window where strict-decrease / repeat checks are meaningful
 
 
 @dataclass
@@ -147,7 +148,9 @@ class RalphHandler:
                         "Number of trailing iterations whose findings_hash must "
                         "match (and QA must not have passed) to stop with "
                         "stop_reason='oscillation_detected'. Default: 3. "
-                        f"Range: 1-{MAX_RALPH_GENERATIONS}."
+                        f"Range: {MIN_PROGRESS_WINDOW}-{MAX_RALPH_GENERATIONS}. "
+                        "Values < 2 are rejected because a single iteration "
+                        "cannot oscillate with itself."
                     ),
                     required=False,
                     default=DEFAULT_OSCILLATION_WINDOW,
@@ -159,7 +162,9 @@ class RalphHandler:
                         "Number of trailing iterations whose non-None grades must "
                         "strictly decrease to stop with "
                         "stop_reason='grade_regressing'. Default: 2. "
-                        f"Range: 1-{MAX_RALPH_GENERATIONS}."
+                        f"Range: {MIN_PROGRESS_WINDOW}-{MAX_RALPH_GENERATIONS}. "
+                        "Values < 2 are rejected because strict-decrease "
+                        "requires at least two grades to compare."
                     ),
                     required=False,
                     default=DEFAULT_GRADE_REGRESSION_WINDOW,
@@ -249,10 +254,11 @@ class RalphHandler:
                     tool_name="ouroboros_ralph",
                 )
             )
-        if oscillation_window < 1 or oscillation_window > MAX_RALPH_GENERATIONS:
+        if oscillation_window < MIN_PROGRESS_WINDOW or oscillation_window > MAX_RALPH_GENERATIONS:
             return Result.err(
                 MCPToolError(
-                    f"oscillation_window must be between 1 and {MAX_RALPH_GENERATIONS}",
+                    "oscillation_window must be between "
+                    f"{MIN_PROGRESS_WINDOW} and {MAX_RALPH_GENERATIONS}",
                     tool_name="ouroboros_ralph",
                 )
             )
@@ -268,10 +274,14 @@ class RalphHandler:
                     tool_name="ouroboros_ralph",
                 )
             )
-        if grade_regression_window < 1 or grade_regression_window > MAX_RALPH_GENERATIONS:
+        if (
+            grade_regression_window < MIN_PROGRESS_WINDOW
+            or grade_regression_window > MAX_RALPH_GENERATIONS
+        ):
             return Result.err(
                 MCPToolError(
-                    f"grade_regression_window must be between 1 and {MAX_RALPH_GENERATIONS}",
+                    "grade_regression_window must be between "
+                    f"{MIN_PROGRESS_WINDOW} and {MAX_RALPH_GENERATIONS}",
                     tool_name="ouroboros_ralph",
                 )
             )

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1169,6 +1169,8 @@ def build_ralph_subagent(
     project_dir: str | None = None,
     max_generations: int = 10,
     per_iteration_timeout_seconds: float | None = None,
+    oscillation_window: int | None = None,
+    grade_regression_window: int | None = None,
     delegation_depth: int = 1,
     allow_nested_ouroboros_ralph: bool = False,
 ) -> SubagentPayload:
@@ -1194,6 +1196,14 @@ def build_ralph_subagent(
             (``RalphLoopRunner``). When ``None``, the field is omitted from
             both prompt and context (legacy shape preserved for callers that
             don't care about the bound).
+        oscillation_window: Number of trailing iterations whose ``findings_hash``
+            must be identical (and QA still failing) before the plugin child
+            session must stop with ``stop_reason=oscillation_detected``. When
+            ``None``, the block is omitted from the prompt and context.
+        grade_regression_window: Number of trailing iterations whose non-None
+            ``grade`` values must be strictly decreasing before the plugin
+            child session must stop with ``stop_reason=grade_regressing``. When
+            ``None``, the block is omitted from the prompt and context.
     """
     seed_note = ""
     if seed_content is not None:
@@ -1238,6 +1248,26 @@ def build_ralph_subagent(
             "that satisfies the public contract `stop_reason=iteration_timeout`.\n"
         )
 
+    progress_stop_lines: list[str] = []
+    if oscillation_window is not None:
+        progress_stop_lines.append(
+            f"- oscillation_window: {oscillation_window}. Stop with "
+            "`stop_reason=oscillation_detected` when the last "
+            f"{oscillation_window} iterations all carry an identical non-None "
+            "`findings_hash` and QA has not passed."
+        )
+    if grade_regression_window is not None:
+        progress_stop_lines.append(
+            f"- grade_regression_window: {grade_regression_window}. Stop with "
+            "`stop_reason=grade_regressing` when the last "
+            f"{grade_regression_window} iterations all have non-None grades and "
+            "the sequence is strictly decreasing; iterations with `grade=None` "
+            "reset the streak as a neutral observation."
+        )
+    progress_note = ""
+    if progress_stop_lines:
+        progress_note = "\n## Progress Stop Conditions\n" + "\n".join(progress_stop_lines) + "\n"
+
     prompt = f"""## Your Task
 
 Run a Ralph loop for the given lineage inside this OpenCode child session.
@@ -1249,6 +1279,10 @@ Repeat one evolutionary generation at a time until one stop condition is met:
 - max_generations is reached
 - a single `evolve_step` invocation exceeds per_iteration_timeout_seconds
   (when supplied) — return stop_reason=iteration_timeout
+- the last `oscillation_window` iterations share one `findings_hash` with QA
+  not yet passed (when supplied) — return stop_reason=oscillation_detected
+- the last `grade_regression_window` non-None grades are strictly decreasing
+  (when supplied) — return stop_reason=grade_regressing
 
 ## Lineage ID
 {lineage_id}
@@ -1261,7 +1295,7 @@ Repeat one evolutionary generation at a time until one stop condition is met:
 - allow_nested_ouroboros_ralph: {str(allow_nested_ouroboros_ralph).lower()}
 - Do not call ouroboros_ralph from this child session. Run the loop directly
   by executing/evaluating one generation at a time.
-{seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{timeout_note}
+{seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{timeout_note}{progress_note}
 For generation 1, use the seed content when present. For later generations,
 reconstruct state from the lineage and continue without resending seed_content.
 
@@ -1283,6 +1317,10 @@ do not enqueue another background Ralph job."""
     }
     if per_iteration_timeout_seconds is not None:
         context["per_iteration_timeout_seconds"] = per_iteration_timeout_seconds
+    if oscillation_window is not None:
+        context["oscillation_window"] = oscillation_window
+    if grade_regression_window is not None:
+        context["grade_regression_window"] = grade_regression_window
 
     return build_subagent_payload(
         tool_name="ouroboros_ralph",

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+import hashlib
+import json
 from typing import Any, Protocol
 
 from ouroboros.core.types import Result
@@ -19,6 +21,16 @@ _TERMINAL_SUCCESS_ACTIONS = frozenset({"converged"})
 _TERMINAL_FAILURE_ACTIONS = frozenset({"failed", "interrupted", "exhausted", "stagnated"})
 
 DEFAULT_PER_ITERATION_TIMEOUT_SECONDS = 1800.0
+DEFAULT_OSCILLATION_WINDOW = 3
+DEFAULT_GRADE_REGRESSION_WINDOW = 2
+
+_LETTER_GRADE_MAP: dict[str, float] = {
+    "A": 1.0,
+    "B": 0.75,
+    "C": 0.5,
+    "D": 0.25,
+    "F": 0.0,
+}
 
 
 class EvolveStepLike(Protocol):
@@ -39,6 +51,8 @@ class RalphLoopConfig:
     project_dir: str | None = None
     max_generations: int = 10
     per_iteration_timeout_seconds: float = DEFAULT_PER_ITERATION_TIMEOUT_SECONDS
+    oscillation_window: int = DEFAULT_OSCILLATION_WINDOW
+    grade_regression_window: int = DEFAULT_GRADE_REGRESSION_WINDOW
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,6 +63,8 @@ class RalphIteration:
     action: str
     qa_verdict: str | None = None
     is_error: bool = False
+    findings_hash: str | None = None
+    grade: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -188,12 +204,16 @@ class RalphLoopRunner:
             action = str(final_result.meta.get("action", "unknown"))
             generation = _coerce_int(final_result.meta.get("generation"))
             qa_verdict = _extract_qa_verdict(final_result.meta)
+            findings_hash = _extract_findings_hash(final_result.meta)
+            grade = _extract_grade(final_result.meta)
             iterations.append(
                 RalphIteration(
                     generation=generation,
                     action=action,
                     qa_verdict=qa_verdict,
                     is_error=final_result.is_error,
+                    findings_hash=findings_hash,
+                    grade=grade,
                 )
             )
 
@@ -211,6 +231,15 @@ class RalphLoopRunner:
             if action in _TERMINAL_FAILURE_ACTIONS or final_result.is_error:
                 status = "failed"
                 stop_reason = action
+                break
+
+            if _is_oscillating(iterations, config.oscillation_window):
+                status = "failed"
+                stop_reason = "oscillation_detected"
+                break
+            if _is_grade_regressing(iterations, config.grade_regression_window):
+                status = "failed"
+                stop_reason = "grade_regressing"
                 break
 
             # Gen 2+ reconstructs state from EventStore by lineage_id.
@@ -251,3 +280,66 @@ def _extract_qa_verdict(meta: dict[str, Any]) -> str | None:
 def _qa_passed(meta: dict[str, Any]) -> bool:
     verdict = _extract_qa_verdict(meta)
     return verdict in {"pass", "passed"}
+
+
+def _extract_findings_hash(meta: dict[str, Any]) -> str | None:
+    """Compute (or pass through) a deterministic hash of evolve_step findings."""
+    findings = meta.get("findings")
+    if isinstance(findings, list):
+        try:
+            serialized = json.dumps(
+                findings,
+                sort_keys=True,
+                default=str,
+                ensure_ascii=False,
+            )
+        except (TypeError, ValueError):
+            return None
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    precomputed = meta.get("findings_hash")
+    if isinstance(precomputed, str) and precomputed:
+        return precomputed
+    return None
+
+
+def _extract_grade(meta: dict[str, Any]) -> float | None:
+    """Extract a numeric grade in [0.0, 1.0] from QA meta."""
+    qa = meta.get("qa")
+    if not isinstance(qa, dict):
+        return None
+    score = qa.get("score")
+    if isinstance(score, bool):
+        # Guard against bool subclass of int.
+        score = None
+    if isinstance(score, (int, float)):
+        score_value = float(score)
+        if 0.0 <= score_value <= 1.0:
+            return score_value
+    letter = qa.get("grade")
+    if isinstance(letter, str):
+        mapped = _LETTER_GRADE_MAP.get(letter.strip().upper())
+        if mapped is not None:
+            return mapped
+    return None
+
+
+def _is_oscillating(iterations: list[RalphIteration], window: int) -> bool:
+    """Return True when the last ``window`` iterations share one findings_hash."""
+    if window < 1 or len(iterations) < window:
+        return False
+    recent = iterations[-window:]
+    first_hash = recent[0].findings_hash
+    if first_hash is None:
+        return False
+    return all(item.findings_hash == first_hash for item in recent[1:])
+
+
+def _is_grade_regressing(iterations: list[RalphIteration], window: int) -> bool:
+    """Return True when the last ``window`` non-None grades strictly decrease."""
+    if window < 2 or len(iterations) < window:
+        return False
+    recent = iterations[-window:]
+    grades = [item.grade for item in recent]
+    if any(grade is None for grade in grades):
+        return False
+    return all(grades[i] > grades[i + 1] for i in range(len(grades) - 1))

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -283,23 +283,50 @@ def _qa_passed(meta: dict[str, Any]) -> bool:
 
 
 def _extract_findings_hash(meta: dict[str, Any]) -> str | None:
-    """Compute (or pass through) a deterministic hash of evolve_step findings."""
+    """Compute (or pass through) a deterministic hash of evolve_step findings.
+
+    Source priority:
+
+    1. ``meta["findings"]`` (a list) is hashed verbatim. Synthetic test
+       harnesses use this path.
+    2. ``meta["findings_hash"]`` (a non-empty string) passes through unchanged.
+       Producers can supply a precomputed hash to avoid re-serialization.
+    3. ``meta["qa"]["differences"]`` and ``meta["qa"]["suggestions"]`` (lists)
+       are combined into a stable mapping and hashed. The default
+       ``EvolveStepHandler`` does not synthesize a top-level ``findings``
+       field, so deriving the fingerprint from the QA verdict body is the
+       only way oscillation detection can fire on the real in-process loop
+       (issue #788 review-2).
+    """
     findings = meta.get("findings")
     if isinstance(findings, list):
-        try:
-            serialized = json.dumps(
-                findings,
-                sort_keys=True,
-                default=str,
-                ensure_ascii=False,
-            )
-        except (TypeError, ValueError):
-            return None
-        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+        return _hash_findings_payload(findings)
     precomputed = meta.get("findings_hash")
     if isinstance(precomputed, str) and precomputed:
         return precomputed
+    qa = meta.get("qa")
+    if isinstance(qa, dict):
+        diffs = qa.get("differences")
+        suggestions = qa.get("suggestions")
+        diffs_list = diffs if isinstance(diffs, list) else None
+        suggestions_list = suggestions if isinstance(suggestions, list) else None
+        if diffs_list is not None or suggestions_list is not None:
+            return _hash_findings_payload(
+                {
+                    "differences": diffs_list or [],
+                    "suggestions": suggestions_list or [],
+                }
+            )
     return None
+
+
+def _hash_findings_payload(payload: Any) -> str | None:
+    """Stable JSON-then-sha256 hash for a findings payload."""
+    try:
+        serialized = json.dumps(payload, sort_keys=True, default=str, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return None
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def _extract_grade(meta: dict[str, Any]) -> float | None:

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -244,6 +244,8 @@ class TestBuildRalphSubagent:
         assert "Do not call ouroboros_ralph" in payload.prompt
         # Without per_iteration_timeout_seconds, the timeout block is omitted.
         assert "Per-Iteration Timeout" not in payload.prompt
+        # Likewise the progress-stop block is omitted when no windows supplied.
+        assert "Progress Stop Conditions" not in payload.prompt
         assert payload.context == {
             "lineage_id": "lin-ralph",
             "seed_content": "goal: ship",
@@ -269,6 +271,31 @@ class TestBuildRalphSubagent:
         assert "per_iteration_timeout_seconds: 900" in payload.prompt
         assert "stop_reason=iteration_timeout" in payload.prompt
         assert "exceeds 900 seconds" in payload.prompt
+
+    def test_forwards_progress_windows_to_prompt_and_context(self) -> None:
+        """oscillation_window and grade_regression_window must reach the child.
+
+        Wiring lock for #788 review-1: validating the windows in
+        ``RalphLoopConfig`` while dropping them from the plugin dispatch
+        payload silently breaks the public ``stop_reason=oscillation_detected``
+        and ``stop_reason=grade_regressing`` contracts on the OpenCode plugin
+        path.
+        """
+        payload = build_ralph_subagent(
+            lineage_id="lin-progress",
+            seed_content="goal: ship",
+            max_generations=5,
+            oscillation_window=4,
+            grade_regression_window=3,
+        )
+
+        assert payload.context["oscillation_window"] == 4
+        assert payload.context["grade_regression_window"] == 3
+        assert "Progress Stop Conditions" in payload.prompt
+        assert "oscillation_window: 4" in payload.prompt
+        assert "grade_regression_window: 3" in payload.prompt
+        assert "stop_reason=oscillation_detected" in payload.prompt
+        assert "stop_reason=grade_regressing" in payload.prompt
 
     def test_serializes_seed_content_as_json_data(self) -> None:
         payload = build_ralph_subagent(

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -1,0 +1,302 @@
+"""Regression tests for the no-progress / oscillation guards in Ralph loop.
+
+Covers issue #778: stop early when ``evolve_step`` produces the same finding
+set across iterations or when the QA grade strictly regresses, instead of
+burning the entire ``max_generations`` wall-clock budget.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.ralph_loop import RalphLoopConfig, RalphLoopRunner
+
+
+@dataclass
+class _ScriptedEvolveHandler:
+    """Evolve handler that returns a fixed sequence of meta payloads."""
+
+    metas: list[dict[str, Any]]
+    calls: int = 0
+    seen_arguments: list[dict[str, Any]] = field(default_factory=list)
+
+    async def handle(self, arguments: dict[str, Any]):
+        self.seen_arguments.append(arguments)
+        index = min(self.calls, len(self.metas) - 1)
+        meta = dict(self.metas[index])
+        meta.setdefault("lineage_id", arguments["lineage_id"])
+        meta.setdefault("generation", self.calls + 1)
+        meta.setdefault("action", "continue")
+        self.calls += 1
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="step"),),
+                is_error=False,
+                meta=meta,
+            )
+        )
+
+
+@dataclass
+class _ImmediateEvolveHandler:
+    """Trivial evolve handler used only by RalphHandler validation tests."""
+
+    async def handle(self, arguments: dict[str, Any]):  # pragma: no cover - unused path
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": 1,
+                    "action": "converged",
+                },
+            )
+        )
+
+
+def _findings(*labels: str) -> list[dict[str, Any]]:
+    return [{"id": label, "msg": f"finding-{label}"} for label in labels]
+
+
+@pytest.mark.asyncio
+async def test_oscillation_detected_after_window_of_identical_findings_hashes() -> None:
+    """3 iterations sharing one findings_hash with no QA pass must stop early."""
+    repeated = _findings("a", "b")
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "findings": repeated},
+            {"action": "continue", "findings": repeated},
+            {"action": "continue", "findings": repeated},
+            {"action": "continue", "findings": repeated},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_osc",
+            max_generations=5,
+            oscillation_window=3,
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.stop_reason == "oscillation_detected"
+    assert result.iteration_count == 3
+    # All three iterations carry the same hash.
+    hashes = {item.findings_hash for item in result.iterations}
+    assert len(hashes) == 1
+    assert next(iter(hashes)) is not None
+    # The handler must not have been invoked a fourth time.
+    assert evolve.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_grade_regressing_two_iterations_strictly_decreasing() -> None:
+    """[0.8, 0.5] over the default window of 2 must stop with grade_regressing."""
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "qa": {"score": 0.8, "verdict": "fail"}},
+            {"action": "continue", "qa": {"score": 0.5, "verdict": "fail"}},
+            {"action": "continue", "qa": {"score": 0.4, "verdict": "fail"}},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_regress",
+            max_generations=5,
+            grade_regression_window=2,
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.stop_reason == "grade_regressing"
+    assert result.iteration_count == 2
+    assert [item.grade for item in result.iterations] == [0.8, 0.5]
+    assert evolve.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_grade_with_none_resets_regression_streak() -> None:
+    """[0.8, None] must NOT trigger grade_regressing; None is a neutral observation."""
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "qa": {"score": 0.8, "verdict": "fail"}},
+            # No qa block at all → grade is None.
+            {"action": "continue"},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_none_resets",
+            max_generations=2,
+            grade_regression_window=2,
+        )
+    )
+
+    # Loop ran to max_generations rather than tripping a no-progress guard.
+    assert result.status == "completed"
+    assert result.stop_reason == "max_generations reached"
+    assert result.iteration_count == 2
+    assert [item.grade for item in result.iterations] == [0.8, None]
+
+
+@pytest.mark.asyncio
+async def test_equal_grades_do_not_trigger_grade_regressing() -> None:
+    """[0.8, 0.8] is flat, not strictly decreasing — must not stop early."""
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "qa": {"score": 0.8, "verdict": "fail"}},
+            {"action": "continue", "qa": {"score": 0.8, "verdict": "fail"}},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_flat",
+            max_generations=2,
+            grade_regression_window=2,
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.stop_reason == "max_generations reached"
+    assert result.iteration_count == 2
+    assert [item.grade for item in result.iterations] == [0.8, 0.8]
+
+
+@pytest.mark.asyncio
+async def test_mixed_hashes_do_not_trigger_oscillation_stop() -> None:
+    """Same hash 2× then a new hash on iteration 3 must not stop with oscillation."""
+    repeated = _findings("a")
+    different = _findings("b")
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "findings": repeated},
+            {"action": "continue", "findings": repeated},
+            {"action": "continue", "findings": different},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_mixed",
+            max_generations=3,
+            oscillation_window=3,
+        )
+    )
+
+    assert result.status == "completed"
+    assert result.stop_reason == "max_generations reached"
+    assert result.iteration_count == 3
+    hashes = [item.findings_hash for item in result.iterations]
+    assert hashes[0] == hashes[1]
+    assert hashes[2] != hashes[0]
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_oscillation_window_zero() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_osc_zero",
+            "oscillation_window": 0,
+        }
+    )
+
+    assert result.is_err
+    assert "oscillation_window" in str(result.error)
+    assert "between 1 and 10" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_oscillation_window_above_ceiling() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_osc_high",
+            "oscillation_window": 11,
+        }
+    )
+
+    assert result.is_err
+    assert "oscillation_window" in str(result.error)
+    assert "between 1 and 10" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_grade_regression_window_zero() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_grade_zero",
+            "grade_regression_window": 0,
+        }
+    )
+
+    assert result.is_err
+    assert "grade_regression_window" in str(result.error)
+    assert "between 1 and 10" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_precomputed_findings_hash_is_used_verbatim() -> None:
+    """If meta provides a findings_hash string, it must pass through unchanged."""
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "findings_hash": "deadbeef"},
+            {"action": "continue", "findings_hash": "deadbeef"},
+            {"action": "continue", "findings_hash": "deadbeef"},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_precomputed",
+            max_generations=5,
+            oscillation_window=3,
+        )
+    )
+
+    assert result.stop_reason == "oscillation_detected"
+    assert all(item.findings_hash == "deadbeef" for item in result.iterations)
+
+
+@pytest.mark.asyncio
+async def test_letter_grade_b_maps_to_three_quarters() -> None:
+    """Grade letter ``B`` must yield 0.75 and feed regression detection."""
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "qa": {"grade": "A", "verdict": "fail"}},
+            {"action": "continue", "qa": {"grade": "B", "verdict": "fail"}},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_letters",
+            max_generations=5,
+            grade_regression_window=2,
+        )
+    )
+
+    assert result.stop_reason == "grade_regressing"
+    assert [item.grade for item in result.iterations] == [1.0, 0.75]

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -241,6 +241,70 @@ async def test_ralph_handler_rejects_oscillation_window_above_ceiling() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ralph_handler_rejects_fractional_oscillation_window() -> None:
+    """Fractional floats must not be silently truncated to int.
+
+    Wiring lock for #788 review-3: ``int(2.9)`` would coerce to ``2`` and
+    pass the floor check, changing oscillation semantics behind the
+    caller's back. The MCP parameter is declared INTEGER, so reject any
+    float that is not exactly integral.
+    """
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    for value in (2.9, 2.5, 3.1):
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_osc_frac",
+                "oscillation_window": value,
+            }
+        )
+        assert result.is_err, f"value={value!r} should be rejected"
+        assert "oscillation_window" in str(result.error)
+        assert "integer" in str(result.error)
+
+
+def test_coerce_window_accepts_integer_valued_float_and_strings() -> None:
+    """Integer-valued floats / numeric strings round-trip; bools fall through.
+
+    Direct unit test of the helper — exercising it via ``RalphHandler.handle``
+    would also spin up a job manager and event store, which is unrelated to
+    the contract under test.
+    """
+    from ouroboros.mcp.errors import MCPToolError
+    from ouroboros.mcp.tools.ralph_handlers import _coerce_window
+
+    assert _coerce_window(3, field_name="x") == 3
+    assert _coerce_window(3.0, field_name="x") == 3
+    assert _coerce_window("4", field_name="x") == 4
+
+    bad = _coerce_window(2.9, field_name="oscillation_window")
+    assert isinstance(bad, MCPToolError)
+    assert "oscillation_window" in str(bad)
+    assert "integer" in str(bad)
+
+    bad_str = _coerce_window("not-a-number", field_name="oscillation_window")
+    assert isinstance(bad_str, MCPToolError)
+    assert "oscillation_window" in str(bad_str)
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_fractional_grade_regression_window() -> None:
+    """Mirror of the oscillation fractional check on the grade-regression input."""
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_grade_frac",
+            "grade_regression_window": 2.5,
+        }
+    )
+
+    assert result.is_err
+    assert "grade_regression_window" in str(result.error)
+    assert "integer" in str(result.error)
+
+
+@pytest.mark.asyncio
 async def test_ralph_handler_rejects_grade_regression_window_below_floor() -> None:
     """grade_regression_window < 2 must be rejected; strict-decrease needs two grades.
 

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -208,19 +208,20 @@ async def test_mixed_hashes_do_not_trigger_oscillation_stop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ralph_handler_rejects_oscillation_window_zero() -> None:
+async def test_ralph_handler_rejects_oscillation_window_below_floor() -> None:
+    """oscillation_window < 2 must be rejected; one iteration cannot oscillate."""
     handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
 
-    result = await handler.handle(
-        {
-            "lineage_id": "lin_osc_zero",
-            "oscillation_window": 0,
-        }
-    )
-
-    assert result.is_err
-    assert "oscillation_window" in str(result.error)
-    assert "between 1 and 10" in str(result.error)
+    for value in (0, 1):
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_osc_low",
+                "oscillation_window": value,
+            }
+        )
+        assert result.is_err, f"value={value} should be rejected"
+        assert "oscillation_window" in str(result.error)
+        assert "between 2 and 10" in str(result.error)
 
 
 @pytest.mark.asyncio
@@ -236,23 +237,30 @@ async def test_ralph_handler_rejects_oscillation_window_above_ceiling() -> None:
 
     assert result.is_err
     assert "oscillation_window" in str(result.error)
-    assert "between 1 and 10" in str(result.error)
+    assert "between 2 and 10" in str(result.error)
 
 
 @pytest.mark.asyncio
-async def test_ralph_handler_rejects_grade_regression_window_zero() -> None:
+async def test_ralph_handler_rejects_grade_regression_window_below_floor() -> None:
+    """grade_regression_window < 2 must be rejected; strict-decrease needs two grades.
+
+    Wiring lock for #788 review-2: previously the handler accepted
+    ``grade_regression_window=1`` but the runner's ``_is_grade_regressing``
+    returns ``False`` whenever ``window < 2``, so callers using ``1`` had a
+    silently disabled stop condition. Public contract now matches runtime.
+    """
     handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
 
-    result = await handler.handle(
-        {
-            "lineage_id": "lin_grade_zero",
-            "grade_regression_window": 0,
-        }
-    )
-
-    assert result.is_err
-    assert "grade_regression_window" in str(result.error)
-    assert "between 1 and 10" in str(result.error)
+    for value in (0, 1):
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_grade_low",
+                "grade_regression_window": value,
+            }
+        )
+        assert result.is_err, f"value={value} should be rejected"
+        assert "grade_regression_window" in str(result.error)
+        assert "between 2 and 10" in str(result.error)
 
 
 @pytest.mark.asyncio
@@ -277,6 +285,89 @@ async def test_precomputed_findings_hash_is_used_verbatim() -> None:
 
     assert result.stop_reason == "oscillation_detected"
     assert all(item.findings_hash == "deadbeef" for item in result.iterations)
+
+
+@pytest.mark.asyncio
+async def test_oscillation_detected_from_qa_differences_in_meta() -> None:
+    """In-process loop must hash QA differences/suggestions when no top-level findings.
+
+    Wiring lock for #788 review-2: ``EvolveStepHandler`` only attaches a
+    ``qa`` block to its result meta — it does not synthesize a top-level
+    ``findings`` or ``findings_hash`` field. Oscillation detection must
+    therefore fall back to ``meta["qa"]["differences"]`` and
+    ``meta["qa"]["suggestions"]`` to fire on the real production path.
+    """
+    qa_payload = {
+        "score": 0.4,
+        "verdict": "fail",
+        "differences": ["acceptance: missing implementation in module X"],
+        "suggestions": ["add unit test in tests/unit/test_x.py"],
+    }
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {"action": "continue", "qa": dict(qa_payload)},
+            {"action": "continue", "qa": dict(qa_payload)},
+            {"action": "continue", "qa": dict(qa_payload)},
+            {"action": "continue", "qa": dict(qa_payload)},
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_qa_osc",
+            max_generations=5,
+            oscillation_window=3,
+        )
+    )
+
+    assert result.stop_reason == "oscillation_detected"
+    assert result.iteration_count == 3
+    hashes = [item.findings_hash for item in result.iterations]
+    assert hashes[0] is not None
+    assert all(h == hashes[0] for h in hashes)
+
+
+@pytest.mark.asyncio
+async def test_qa_differences_fingerprint_changes_when_diffs_change() -> None:
+    """Different QA differences across iterations must yield different hashes.
+
+    Without this, the QA-derived fingerprint would be a constant and would
+    spuriously trigger oscillation_detected on any loop that happens to run
+    QA at all.
+    """
+    evolve = _ScriptedEvolveHandler(
+        metas=[
+            {
+                "action": "continue",
+                "qa": {"differences": ["a"], "suggestions": ["fix a"]},
+            },
+            {
+                "action": "continue",
+                "qa": {"differences": ["b"], "suggestions": ["fix b"]},
+            },
+            {
+                "action": "continue",
+                "qa": {"differences": ["a"], "suggestions": ["fix a"]},
+            },
+        ]
+    )
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_qa_diff",
+            max_generations=3,
+            oscillation_window=3,
+        )
+    )
+
+    assert result.stop_reason == "max_generations reached"
+    assert result.iteration_count == 3
+    hashes = [item.findings_hash for item in result.iterations]
+    assert hashes[0] is not None
+    assert hashes[0] == hashes[2]
+    assert hashes[1] != hashes[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_ralph_loop_progress.py
+++ b/tests/unit/test_ralph_loop_progress.py
@@ -300,3 +300,107 @@ async def test_letter_grade_b_maps_to_three_quarters() -> None:
 
     assert result.stop_reason == "grade_regressing"
     assert [item.grade for item in result.iterations] == [1.0, 0.75]
+
+
+@pytest.mark.asyncio
+async def test_plugin_dispatch_forwards_progress_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plugin-mode dispatch must forward both progress windows.
+
+    Wiring lock for #788 review-1: when ``should_dispatch_via_plugin`` returns
+    True, the produced ``_subagent`` payload context must include both
+    ``oscillation_window`` and ``grade_regression_window``. Otherwise the
+    public ``stop_reason=oscillation_detected`` and
+    ``stop_reason=grade_regressing`` contracts are silently dropped on the
+    plugin path while the in-process path still honors them.
+    """
+    import json as _json
+
+    from ouroboros.mcp.tools import ralph_handlers as _ralph_handlers
+
+    handler = RalphHandler(
+        evolve_handler=_ImmediateEvolveHandler(),  # type: ignore[arg-type]
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _noop_emit(event_store, *, session_id, payload):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(
+        _ralph_handlers,
+        "emit_subagent_dispatched_event",
+        _noop_emit,
+    )
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_plugin_progress",
+            "seed_content": "goal: ship",
+            "max_generations": 5,
+            "oscillation_window": 4,
+            "grade_regression_window": 3,
+        }
+    )
+
+    assert result.is_ok
+    tool_result = result.value
+    body = _json.loads(tool_result.content[0].text)
+    sub = body["_subagent"]
+    assert sub["tool_name"] == "ouroboros_ralph"
+    assert sub["context"]["oscillation_window"] == 4
+    assert sub["context"]["grade_regression_window"] == 3
+    assert "oscillation_window: 4" in sub["prompt"]
+    assert "grade_regression_window: 3" in sub["prompt"]
+    assert "stop_reason=oscillation_detected" in sub["prompt"]
+    assert "stop_reason=grade_regressing" in sub["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_plugin_dispatch_uses_default_progress_windows_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defaults must round-trip through the plugin payload unchanged.
+
+    A caller that does not pass ``oscillation_window`` or
+    ``grade_regression_window`` still picks up the documented defaults
+    (3 / 2). The plugin payload must reflect those, otherwise the in-process
+    and plugin paths diverge by silent omission.
+    """
+    import json as _json
+
+    from ouroboros.mcp.tools import ralph_handlers as _ralph_handlers
+    from ouroboros.ralph_loop import (
+        DEFAULT_GRADE_REGRESSION_WINDOW,
+        DEFAULT_OSCILLATION_WINDOW,
+    )
+
+    handler = RalphHandler(
+        evolve_handler=_ImmediateEvolveHandler(),  # type: ignore[arg-type]
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _noop_emit(event_store, *, session_id, payload):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(
+        _ralph_handlers,
+        "emit_subagent_dispatched_event",
+        _noop_emit,
+    )
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_plugin_defaults",
+            "seed_content": "goal: ship",
+            "max_generations": 5,
+        }
+    )
+
+    assert result.is_ok
+    body = _json.loads(result.value.content[0].text)
+    sub = body["_subagent"]
+    assert sub["context"]["oscillation_window"] == DEFAULT_OSCILLATION_WINDOW
+    assert sub["context"]["grade_regression_window"] == DEFAULT_GRADE_REGRESSION_WINDOW


### PR DESCRIPTION
Closes #778.

**Stacked on** #784 (#776 — per-iteration timeout). Merge order: #784 → this PR.

## Summary

- Adds `findings_hash` to `RalphIteration` — a sha256 over `json.dumps(findings, sort_keys=True, default=str, ensure_ascii=False)`, or a verbatim pass-through of a precomputed `findings_hash` string in meta.
- Adds `grade` to `RalphIteration` — sourced from `meta.qa.score` (numeric, clamped to [0.0, 1.0]) or from `meta.qa.grade` letter via `{"A":1.0, "B":0.75, "C":0.5, "D":0.25, "F":0.0}`; `None` otherwise.
- New stop reason `oscillation_detected`: when the last `oscillation_window` (default 3) iterations all carry an identical non-None `findings_hash` and QA has not passed.
- New stop reason `grade_regressing`: when the last `grade_regression_window` (default 2) iterations all have non-None grades and the sequence is strictly decreasing; iterations with `grade=None` reset the streak as a neutral observation.
- `RalphLoopConfig` and the `ouroboros_ralph` MCP handler expose `oscillation_window` and `grade_regression_window`, validated to `1 <= x <= MAX_RALPH_GENERATIONS` (10).
- 10 regression cases in `tests/unit/test_ralph_loop_progress.py` covering all six AC scenarios from the issue plus precomputed-hash pass-through, letter-grade mapping, and MCP arg validation (zero / above-ceiling).

## Test plan

- [x] `pytest tests/unit/test_ralph_loop_progress.py -v` — 10 passed.
- [x] 3 iterations same `findings_hash`, no QA pass → `stop_reason="oscillation_detected"`.
- [x] 2 iterations grades `[0.8, 0.5]` → `stop_reason="grade_regressing"`.
- [x] 2 iterations grades `[0.8, None]` → no early stop (None resets streak).
- [x] 2 iterations grades `[0.8, 0.8]` → no early stop (not strictly decreasing).
- [x] Mixed: same hash 2× then different → no oscillation stop.
- [x] MCP `oscillation_window=0` and `oscillation_window=11` rejected with "between 1 and 10".
- [x] `pytest tests/unit -k ralph -v` — 61 passed (no regressions in #776 timeout suite).
- [x] `ruff check src/ tests/` and `ruff format --check src/ tests/` clean.