### PR TITLE
feat(ralph): total wall-clock budget max_total_seconds

### DIFF
--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -370,6 +370,7 @@ class RalphHandler:
                 per_iteration_timeout_seconds=config.per_iteration_timeout_seconds,
                 oscillation_window=config.oscillation_window,
                 grade_regression_window=config.grade_regression_window,
+                max_total_seconds=config.max_total_seconds,
             )
             await self._event_store.initialize()
             await emit_subagent_dispatched_event(

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -320,7 +320,8 @@ class RalphHandler:
                     )
                 )
             if (
-                max_total_seconds < MIN_MAX_TOTAL_SECONDS
+                not math.isfinite(max_total_seconds)
+                or max_total_seconds < MIN_MAX_TOTAL_SECONDS
                 or max_total_seconds > MAX_MAX_TOTAL_SECONDS
             ):
                 return Result.err(

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -178,11 +178,16 @@ class RalphHandler:
                     name="max_total_seconds",
                     type=ToolInputType.NUMBER,
                     description=(
-                        "Total wall-clock budget for the entire Ralph loop in "
-                        "seconds. Checked at the top of every iteration BEFORE "
-                        "launching evolve_step; on exhaustion the loop stops "
-                        "with stop_reason='wall_clock_exhausted'. When omitted, "
-                        "a derived ceiling of "
+                        "Total wall-clock budget for the entire Ralph loop "
+                        "in seconds. In the in-process runner this is "
+                        "enforced by RalphLoopRunner: checked at the top of "
+                        "every iteration BEFORE launching evolve_step, and "
+                        "on exhaustion the loop stops with "
+                        "stop_reason='wall_clock_exhausted'. In OpenCode "
+                        "plugin mode the bound is forwarded to the child "
+                        "session and the plugin is expected to self-enforce; "
+                        "the MCP server cannot abort a foreign child "
+                        "process. When omitted, a derived ceiling of "
                         "max_generations * per_iteration_timeout_seconds is "
                         "auto-applied (with a WARNING log) for standalone "
                         "callers. Range: 1-86400."
@@ -359,6 +364,12 @@ class RalphHandler:
         )
 
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):
+            # Plugin mode: per_iteration_timeout_seconds and max_total_seconds
+            # are forwarded to the child session as instructions. The MCP
+            # server cannot enforce them server-side because execution lives
+            # in a foreign OpenCode child process this server does not own;
+            # the in-process RalphLoopRunner is the only path with hard
+            # enforcement. See build_ralph_subagent docstring (#789 review-2).
             payload = build_ralph_subagent(
                 lineage_id=config.lineage_id,
                 seed_content=config.seed_content,

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -7,6 +7,7 @@ longer have to own the multi-generation loop in prompt/skill pseudo-code.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import logging
 import math
 from typing import Any
 
@@ -42,6 +43,10 @@ MAX_RALPH_GENERATIONS = 10
 MIN_PER_ITERATION_TIMEOUT_SECONDS = 30.0
 MAX_PER_ITERATION_TIMEOUT_SECONDS = 7200.0
 MIN_PROGRESS_WINDOW = 2  # smallest window where strict-decrease / repeat checks are meaningful
+MIN_MAX_TOTAL_SECONDS = 1.0
+MAX_MAX_TOTAL_SECONDS = 86400.0
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -169,6 +174,21 @@ class RalphHandler:
                     required=False,
                     default=DEFAULT_GRADE_REGRESSION_WINDOW,
                 ),
+                MCPToolParameter(
+                    name="max_total_seconds",
+                    type=ToolInputType.NUMBER,
+                    description=(
+                        "Total wall-clock budget for the entire Ralph loop in "
+                        "seconds. Checked at the top of every iteration BEFORE "
+                        "launching evolve_step; on exhaustion the loop stops "
+                        "with stop_reason='wall_clock_exhausted'. When omitted, "
+                        "a derived ceiling of "
+                        "max_generations * per_iteration_timeout_seconds is "
+                        "auto-applied (with a WARNING log) for standalone "
+                        "callers. Range: 1-86400."
+                    ),
+                    required=False,
+                ),
             ),
         )
 
@@ -280,6 +300,42 @@ class RalphHandler:
                 )
             )
 
+        raw_max_total_seconds = arguments.get("max_total_seconds")
+        max_total_seconds: float | None
+        if raw_max_total_seconds is None:
+            max_total_seconds = None
+        else:
+            try:
+                max_total_seconds = float(raw_max_total_seconds)
+            except (TypeError, ValueError):
+                return Result.err(
+                    MCPToolError(
+                        "max_total_seconds must be a number",
+                        tool_name="ouroboros_ralph",
+                    )
+                )
+            if (
+                max_total_seconds < MIN_MAX_TOTAL_SECONDS
+                or max_total_seconds > MAX_MAX_TOTAL_SECONDS
+            ):
+                return Result.err(
+                    MCPToolError(
+                        "max_total_seconds must be between "
+                        f"{MIN_MAX_TOTAL_SECONDS:g} and "
+                        f"{MAX_MAX_TOTAL_SECONDS:g}",
+                        tool_name="ouroboros_ralph",
+                    )
+                )
+
+        if max_total_seconds is None:
+            derived = float(max_generations) * per_iteration_timeout_seconds
+            logger.warning(
+                "max_total_seconds not provided; auto-applying derived ceiling "
+                "of %ss based on max_generations × per_iteration_timeout_seconds",
+                f"{derived:g}",
+            )
+            max_total_seconds = derived
+
         if arguments.get("delegation_depth", 0):
             return Result.err(
                 MCPToolError(
@@ -299,6 +355,7 @@ class RalphHandler:
             per_iteration_timeout_seconds=per_iteration_timeout_seconds,
             oscillation_window=oscillation_window,
             grade_regression_window=grade_regression_window,
+            max_total_seconds=max_total_seconds,
         )
 
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1171,6 +1171,7 @@ def build_ralph_subagent(
     per_iteration_timeout_seconds: float | None = None,
     oscillation_window: int | None = None,
     grade_regression_window: int | None = None,
+    max_total_seconds: float | None = None,
     delegation_depth: int = 1,
     allow_nested_ouroboros_ralph: bool = False,
 ) -> SubagentPayload:
@@ -1204,6 +1205,14 @@ def build_ralph_subagent(
             ``grade`` values must be strictly decreasing before the plugin
             child session must stop with ``stop_reason=grade_regressing``. When
             ``None``, the block is omitted from the prompt and context.
+        max_total_seconds: Total wall-clock budget for the entire Ralph loop,
+            forwarded from the MCP handler. The plugin child session must
+            check the cumulative wall-clock elapsed since the loop started
+            BEFORE launching each iteration and surface
+            ``stop_reason=wall_clock_exhausted`` to the parent on exhaustion.
+            When ``None``, the field is omitted from prompt and context
+            (legacy shape preserved for callers that don't care about the
+            bound).
     """
     seed_note = ""
     if seed_content is not None:
@@ -1268,6 +1277,18 @@ def build_ralph_subagent(
     if progress_stop_lines:
         progress_note = "\n## Progress Stop Conditions\n" + "\n".join(progress_stop_lines) + "\n"
 
+    budget_note = ""
+    if max_total_seconds is not None:
+        budget_note = (
+            "\n## Total Wall-Clock Budget\n"
+            f"max_total_seconds: {max_total_seconds:g}\n"
+            "Track wall-clock elapsed since the loop started. BEFORE launching "
+            "each next `evolve_step` iteration, abort the loop if the cumulative "
+            f"elapsed wall clock has met or exceeded {max_total_seconds:g} seconds; "
+            "that satisfies the public contract "
+            "`stop_reason=wall_clock_exhausted`.\n"
+        )
+
     prompt = f"""## Your Task
 
 Run a Ralph loop for the given lineage inside this OpenCode child session.
@@ -1283,6 +1304,8 @@ Repeat one evolutionary generation at a time until one stop condition is met:
   not yet passed (when supplied) — return stop_reason=oscillation_detected
 - the last `grade_regression_window` non-None grades are strictly decreasing
   (when supplied) — return stop_reason=grade_regressing
+- cumulative wall clock since loop start meets or exceeds max_total_seconds
+  (when supplied) — return stop_reason=wall_clock_exhausted
 
 ## Lineage ID
 {lineage_id}
@@ -1295,7 +1318,7 @@ Repeat one evolutionary generation at a time until one stop condition is met:
 - allow_nested_ouroboros_ralph: {str(allow_nested_ouroboros_ralph).lower()}
 - Do not call ouroboros_ralph from this child session. Run the loop directly
   by executing/evaluating one generation at a time.
-{seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{timeout_note}{progress_note}
+{seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{timeout_note}{progress_note}{budget_note}
 For generation 1, use the seed content when present. For later generations,
 reconstruct state from the lineage and continue without resending seed_content.
 
@@ -1321,6 +1344,8 @@ do not enqueue another background Ralph job."""
         context["oscillation_window"] = oscillation_window
     if grade_regression_window is not None:
         context["grade_regression_window"] = grade_regression_window
+    if max_total_seconds is not None:
+        context["max_total_seconds"] = max_total_seconds
 
     return build_subagent_payload(
         tool_name="ouroboros_ralph",

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1182,6 +1182,18 @@ def build_ralph_subagent(
     ``_subagent`` envelope and let the plugin's Task pane own execution rather
     than enqueueing an unobservable local background job.
 
+    Cross-runtime contract (#789 review-2): the in-process ``RalphLoopRunner``
+    enforces ``per_iteration_timeout_seconds`` and ``max_total_seconds`` itself
+    via ``asyncio.wait_for`` and a monotonic budget check. The plugin path
+    cannot enforce those limits server-side — execution happens inside a
+    foreign child session this server does not control — so both bounds are
+    forwarded into the prompt **and** context as instructions for the child to
+    self-enforce. Honesty about that split is encoded in the prompt
+    (``stop_reason=iteration_timeout`` / ``stop_reason=wall_clock_exhausted``
+    are framed as obligations of the child session) and in the public MCP
+    parameter descriptions so callers know plugin-mode bounds are
+    plugin-honored, not MCP-enforced.
+
     Args:
         per_iteration_timeout_seconds: Per-iteration wall-clock bound forwarded
             from the MCP handler.
@@ -1210,7 +1222,7 @@ def build_ralph_subagent(
             check the cumulative wall-clock elapsed since the loop started
             BEFORE launching each iteration and surface
             ``stop_reason=wall_clock_exhausted`` to the parent on exhaustion.
-            When ``None``, the field is omitted from prompt and context
+            When ``None``, the field is omitted from both prompt and context
             (legacy shape preserved for callers that don't care about the
             bound).
     """

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -147,25 +147,29 @@ class RalphLoopRunner:
             ):
                 status = "failed"
                 stop_reason = "wall_clock_exhausted"
-                if final_result is None:
-                    final_result = MCPToolResult(
-                        content=(
-                            MCPContentItem(
-                                type=ContentType.TEXT,
-                                text=(
-                                    "Ralph loop wall-clock budget exhausted before "
-                                    f"iteration {iteration_index} could start "
-                                    f"(max_total_seconds={config.max_total_seconds:g})."
-                                ),
+                # Always replace final_result. After iteration 2+ a prior
+                # successful generation would otherwise leak its action/text/meta
+                # into the terminal MCPToolResult, contradicting the new
+                # stop_reason. The synthetic result is the only authoritative
+                # record of the budget-exhausted terminal state.
+                final_result = MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text=(
+                                "Ralph loop wall-clock budget exhausted before "
+                                f"iteration {iteration_index} could start "
+                                f"(max_total_seconds={config.max_total_seconds:g})."
                             ),
                         ),
-                        is_error=True,
-                        meta={
-                            "lineage_id": config.lineage_id,
-                            "action": "wall_clock_exhausted",
-                            "generation": None,
-                        },
-                    )
+                    ),
+                    is_error=True,
+                    meta={
+                        "lineage_id": config.lineage_id,
+                        "action": "wall_clock_exhausted",
+                        "generation": None,
+                    },
+                )
                 break
 
             arguments: dict[str, Any] = {
@@ -206,25 +210,29 @@ class RalphLoopRunner:
                 )
                 status = "failed"
                 stop_reason = "iteration_timeout"
-                if final_result is None:
-                    final_result = MCPToolResult(
-                        content=(
-                            MCPContentItem(
-                                type=ContentType.TEXT,
-                                text=(
-                                    "Ralph iteration "
-                                    f"{iteration_index} exceeded "
-                                    f"{config.per_iteration_timeout_seconds:.0f}s timeout."
-                                ),
+                # Always replace final_result. After iteration 2+ a prior
+                # successful generation would otherwise leak its action/text/meta
+                # into the terminal MCPToolResult, contradicting the new
+                # stop_reason. The synthetic result is the only authoritative
+                # record of the timed-out terminal state.
+                final_result = MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text=(
+                                "Ralph iteration "
+                                f"{iteration_index} exceeded "
+                                f"{config.per_iteration_timeout_seconds:.0f}s timeout."
                             ),
                         ),
-                        is_error=True,
-                        meta={
-                            "lineage_id": config.lineage_id,
-                            "action": "iteration_timeout",
-                            "generation": None,
-                        },
-                    )
+                    ),
+                    is_error=True,
+                    meta={
+                        "lineage_id": config.lineage_id,
+                        "action": "iteration_timeout",
+                        "generation": None,
+                    },
+                )
                 break
 
             if result.is_err:

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -11,6 +11,7 @@ import asyncio
 from dataclasses import dataclass, field
 import hashlib
 import json
+import time
 from typing import Any, Protocol
 
 from ouroboros.core.types import Result
@@ -53,6 +54,7 @@ class RalphLoopConfig:
     per_iteration_timeout_seconds: float = DEFAULT_PER_ITERATION_TIMEOUT_SECONDS
     oscillation_window: int = DEFAULT_OSCILLATION_WINDOW
     grade_regression_window: int = DEFAULT_GRADE_REGRESSION_WINDOW
+    max_total_seconds: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,8 +138,36 @@ class RalphLoopRunner:
         seed_content = config.seed_content
         stop_reason = "max_generations reached"
         status = "completed"
+        loop_start_monotonic = time.monotonic()
 
         for iteration_index in range(1, config.max_generations + 1):
+            if (
+                config.max_total_seconds is not None
+                and time.monotonic() - loop_start_monotonic >= config.max_total_seconds
+            ):
+                status = "failed"
+                stop_reason = "wall_clock_exhausted"
+                if final_result is None:
+                    final_result = MCPToolResult(
+                        content=(
+                            MCPContentItem(
+                                type=ContentType.TEXT,
+                                text=(
+                                    "Ralph loop wall-clock budget exhausted before "
+                                    f"iteration {iteration_index} could start "
+                                    f"(max_total_seconds={config.max_total_seconds:g})."
+                                ),
+                            ),
+                        ),
+                        is_error=True,
+                        meta={
+                            "lineage_id": config.lineage_id,
+                            "action": "wall_clock_exhausted",
+                            "generation": None,
+                        },
+                    )
+                break
+
             arguments: dict[str, Any] = {
                 "lineage_id": config.lineage_id,
                 "execute": config.execute,

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -246,6 +246,8 @@ class TestBuildRalphSubagent:
         assert "Per-Iteration Timeout" not in payload.prompt
         # Likewise the progress-stop block is omitted when no windows supplied.
         assert "Progress Stop Conditions" not in payload.prompt
+        # Without max_total_seconds, the wall-clock budget block is omitted.
+        assert "Total Wall-Clock Budget" not in payload.prompt
         assert payload.context == {
             "lineage_id": "lin-ralph",
             "seed_content": "goal: ship",
@@ -296,6 +298,19 @@ class TestBuildRalphSubagent:
         assert "grade_regression_window: 3" in payload.prompt
         assert "stop_reason=oscillation_detected" in payload.prompt
         assert "stop_reason=grade_regressing" in payload.prompt
+
+    def test_forwards_max_total_seconds_to_prompt_and_context(self) -> None:
+        payload = build_ralph_subagent(
+            lineage_id="lin-budget",
+            seed_content="goal: ship",
+            max_generations=3,
+            max_total_seconds=1500,
+        )
+
+        assert payload.context["max_total_seconds"] == 1500
+        assert "max_total_seconds: 1500" in payload.prompt
+        assert "stop_reason=wall_clock_exhausted" in payload.prompt
+        assert "1500 seconds" in payload.prompt
 
     def test_serializes_seed_content_as_json_data(self) -> None:
         payload = build_ralph_subagent(

--- a/tests/unit/test_ralph_loop_budget.py
+++ b/tests/unit/test_ralph_loop_budget.py
@@ -329,6 +329,23 @@ async def test_ralph_handler_rejects_non_numeric_max_total_seconds() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+async def test_ralph_handler_rejects_non_finite_max_total_seconds(value: str) -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_budget_non_finite",
+            "max_total_seconds": value,
+        }
+    )
+
+    assert result.is_err
+    assert "max_total_seconds" in str(result.error)
+    assert "between 1 and 86400" in str(result.error)
+
+
+@pytest.mark.asyncio
 async def test_plugin_dispatch_forwards_max_total_seconds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_ralph_loop_budget.py
+++ b/tests/unit/test_ralph_loop_budget.py
@@ -1,0 +1,252 @@
+"""Regression tests for the total wall-clock budget in Ralph loop.
+
+Covers issue #777: a Ralph loop with `max_total_seconds` set must skip launching
+new iterations once the cumulative wall-clock budget is exhausted, surfacing
+``stop_reason="wall_clock_exhausted"`` to clients. The MCP layer validates the
+user-supplied bound at ``1 <= x <= 86400`` seconds, and standalone callers that
+omit ``max_total_seconds`` get a derived ceiling
+(``max_generations * per_iteration_timeout_seconds``) auto-applied with a
+WARNING log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+import logging
+from typing import Any
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.ralph_loop import RalphLoopConfig, RalphLoopRunner
+
+
+@dataclass
+class _SleepingEvolveHandler:
+    """Evolve handler whose ``handle`` blocks for a configurable duration."""
+
+    sleep_seconds: float
+    calls: int = 0
+    started: asyncio.Event = field(default_factory=asyncio.Event)
+
+    async def handle(self, arguments: dict[str, Any]):
+        self.calls += 1
+        self.started.set()
+        await asyncio.sleep(self.sleep_seconds)
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": self.calls,
+                    "action": "continue",
+                },
+            )
+        )
+
+
+@dataclass
+class _ImmediateEvolveHandler:
+    """Trivial evolve handler so RalphHandler validation tests can be wired."""
+
+    async def handle(self, arguments: dict[str, Any]):  # pragma: no cover - unused path
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": 1,
+                    "action": "converged",
+                },
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_ralph_loop_skips_iteration_when_wall_clock_exhausted() -> None:
+    """First iteration runs; second is skipped pre-launch on budget exhaustion."""
+    # Iteration sleeps 0.07s, budget is 0.1s. After iter 1 ~0.07s elapsed; iter 2
+    # check happens; iter 2 still runs (0.07 < 0.1). After iter 2 ~0.14s elapsed,
+    # iter 3 check trips the budget. Use a 2-iteration variant that guarantees
+    # second iteration is skipped: sleep 0.07s, budget 0.05s — but that means
+    # iter 1 itself overruns the budget at completion. The check is at the TOP
+    # of each iteration, so iter 1 launches (elapsed ~0s < 0.05s) and runs to
+    # 0.07s; iter 2's pre-check sees 0.07s >= 0.05s and skips. Exactly the
+    # contract the AC asks for.
+    evolve = _SleepingEvolveHandler(sleep_seconds=0.07)
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_budget",
+            seed_content="goal: budget",
+            max_generations=5,
+            per_iteration_timeout_seconds=1.0,
+            max_total_seconds=0.05,
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.stop_reason == "wall_clock_exhausted"
+    # Exactly one iteration ran; iteration 2 was skipped pre-launch.
+    assert evolve.calls == 1
+    assert result.iteration_count == 1
+    assert result.iterations[0].action == "continue"
+
+
+@pytest.mark.asyncio
+async def test_ralph_loop_wall_clock_exhausted_surfaces_in_tool_result_meta() -> None:
+    """``iterations`` end-to-end metadata exposes wall-clock exhaustion."""
+    evolve = _SleepingEvolveHandler(sleep_seconds=0.07)
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_budget_meta",
+            max_generations=3,
+            per_iteration_timeout_seconds=1.0,
+            max_total_seconds=0.05,
+        )
+    )
+
+    tool_result = result.to_tool_result()
+    assert tool_result.is_error is True
+    assert tool_result.meta["status"] == "failed"
+    assert tool_result.meta["stop_reason"] == "wall_clock_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_ralph_loop_max_total_seconds_none_does_not_constrain() -> None:
+    """When max_total_seconds is None at the runner level, no extra cap applies."""
+    evolve = _SleepingEvolveHandler(sleep_seconds=0.0)
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_none",
+            max_generations=2,
+            per_iteration_timeout_seconds=1.0,
+            max_total_seconds=None,
+        )
+    )
+
+    # Both iterations should complete with action="continue", reaching the
+    # max_generations terminal.
+    assert result.stop_reason == "max_generations reached"
+    assert evolve.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_auto_applies_derived_ceiling_when_omitted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Standalone callers that omit max_total_seconds get a derived ceiling + WARNING."""
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResult:
+        def to_tool_result(self) -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                is_error=False,
+                meta={"action": "converged"},
+            )
+
+    class _CapturingRunner:
+        def __init__(self, evolve_handler: Any) -> None:
+            self.evolve_handler = evolve_handler
+
+        async def run(self, config: RalphLoopConfig) -> Any:
+            captured["config"] = config
+            return _FakeResult()
+
+    from ouroboros.mcp.tools import ralph_handlers as _ralph_handlers
+
+    original_runner = _ralph_handlers.RalphLoopRunner
+    _ralph_handlers.RalphLoopRunner = _CapturingRunner  # type: ignore[assignment]
+    try:
+        with caplog.at_level(logging.WARNING, logger="ouroboros.mcp.tools.ralph_handlers"):
+            result = await handler.handle(
+                {
+                    "lineage_id": "lin_derived",
+                    "max_generations": 4,
+                    "per_iteration_timeout_seconds": 60,
+                    # max_total_seconds intentionally omitted
+                }
+            )
+    finally:
+        _ralph_handlers.RalphLoopRunner = original_runner  # type: ignore[assignment]
+
+    assert result.is_ok
+    # Wait for the captured runner config — start_job runs the coroutine which
+    # awaits runner.run. JobManager kicks the runner asynchronously, so wait
+    # briefly for it to land.
+    for _ in range(200):
+        if "config" in captured:
+            break
+        await asyncio.sleep(0.01)
+    assert "config" in captured, "Runner.run was never invoked"
+    config = captured["config"]
+    # 4 generations * 60s/iter = 240s derived ceiling.
+    assert config.max_total_seconds == pytest.approx(240.0)
+
+    warnings = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING and "max_total_seconds not provided" in rec.getMessage()
+    ]
+    assert warnings, f"Expected WARNING about derived ceiling, got: {caplog.records}"
+    assert "240" in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_max_total_seconds_below_floor() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_budget_floor",
+            "max_total_seconds": 0,
+        }
+    )
+
+    assert result.is_err
+    assert "max_total_seconds" in str(result.error)
+    assert "between 1 and 86400" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_max_total_seconds_above_ceiling() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_budget_ceil",
+            "max_total_seconds": 100000,
+        }
+    )
+
+    assert result.is_err
+    assert "max_total_seconds" in str(result.error)
+    assert "between 1 and 86400" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_rejects_non_numeric_max_total_seconds() -> None:
+    handler = RalphHandler(evolve_handler=_ImmediateEvolveHandler())  # type: ignore[arg-type]
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_budget_bad",
+            "max_total_seconds": "not-a-number",
+        }
+    )
+
+    assert result.is_err
+    assert "max_total_seconds must be a number" in str(result.error)

--- a/tests/unit/test_ralph_loop_budget.py
+++ b/tests/unit/test_ralph_loop_budget.py
@@ -250,3 +250,104 @@ async def test_ralph_handler_rejects_non_numeric_max_total_seconds() -> None:
 
     assert result.is_err
     assert "max_total_seconds must be a number" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_plugin_dispatch_forwards_max_total_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plugin-mode dispatch must forward ``max_total_seconds``.
+
+    Wiring lock for #789 review-1: when ``should_dispatch_via_plugin`` returns
+    True, the produced ``_subagent`` payload context must include
+    ``max_total_seconds`` and the prompt must surface the
+    ``stop_reason=wall_clock_exhausted`` contract. Otherwise the public
+    wall-clock budget contract is silently dropped on the plugin path and the
+    child session can run past an explicit total budget.
+    """
+    import json as _json
+
+    from ouroboros.mcp.tools import ralph_handlers as _ralph_handlers
+
+    handler = RalphHandler(
+        evolve_handler=_ImmediateEvolveHandler(),  # type: ignore[arg-type]
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _noop_emit(event_store, *, session_id, payload):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(
+        _ralph_handlers,
+        "emit_subagent_dispatched_event",
+        _noop_emit,
+    )
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_plugin_budget",
+            "seed_content": "goal: ship",
+            "max_generations": 3,
+            "per_iteration_timeout_seconds": 600,
+            "max_total_seconds": 4321,
+        }
+    )
+
+    assert result.is_ok
+    tool_result = result.value
+    body = _json.loads(tool_result.content[0].text)
+    sub = body["_subagent"]
+    assert sub["tool_name"] == "ouroboros_ralph"
+    assert sub["context"]["max_total_seconds"] == 4321
+    assert "max_total_seconds: 4321" in sub["prompt"]
+    assert "stop_reason=wall_clock_exhausted" in sub["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_plugin_dispatch_forwards_derived_max_total_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plugin-mode dispatch forwards the derived ceiling when budget is omitted.
+
+    Standalone callers that omit ``max_total_seconds`` get a derived ceiling
+    of ``max_generations × per_iteration_timeout_seconds`` auto-applied at the
+    handler. The plugin path must forward that derived value too so the child
+    session enforces the same implicit ceiling rather than running unbounded.
+    """
+    import json as _json
+
+    from ouroboros.mcp.tools import ralph_handlers as _ralph_handlers
+
+    handler = RalphHandler(
+        evolve_handler=_ImmediateEvolveHandler(),  # type: ignore[arg-type]
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _noop_emit(event_store, *, session_id, payload):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(
+        _ralph_handlers,
+        "emit_subagent_dispatched_event",
+        _noop_emit,
+    )
+
+    result = await handler.handle(
+        {
+            "lineage_id": "lin_plugin_derived",
+            "seed_content": "goal: ship",
+            "max_generations": 4,
+            "per_iteration_timeout_seconds": 60,
+            # max_total_seconds intentionally omitted
+        }
+    )
+
+    assert result.is_ok
+    tool_result = result.value
+    body = _json.loads(tool_result.content[0].text)
+    sub = body["_subagent"]
+    assert sub["context"]["max_total_seconds"] == pytest.approx(240.0)
+    assert "max_total_seconds: 240" in sub["prompt"]
+    assert "stop_reason=wall_clock_exhausted" in sub["prompt"]

--- a/tests/unit/test_ralph_loop_budget.py
+++ b/tests/unit/test_ralph_loop_budget.py
@@ -120,6 +120,82 @@ async def test_ralph_loop_wall_clock_exhausted_surfaces_in_tool_result_meta() ->
     assert tool_result.meta["stop_reason"] == "wall_clock_exhausted"
 
 
+@dataclass
+class _SuccessThenSlowEvolveHandler:
+    """First call returns immediately; later calls sleep, exhausting the budget."""
+
+    slow_sleep_seconds: float
+    calls: int = 0
+
+    async def handle(self, arguments: dict[str, Any]):
+        self.calls += 1
+        if self.calls > 1:
+            await asyncio.sleep(self.slow_sleep_seconds)
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text=f"iter{self.calls}-output"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": self.calls,
+                    "action": "continue",
+                },
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_wall_clock_exhausted_after_successful_iteration_replaces_terminal_result() -> None:
+    """Budget exhaustion after iteration 1 must NOT leak iter 1's output.
+
+    Regression for #789 review-3: when iteration N+1 was skipped pre-launch
+    on budget exhaustion, the runner used to keep ``final_result`` pointing
+    at the prior successful iteration's MCPToolResult, so the terminal
+    response reported ``stop_reason=wall_clock_exhausted`` while its
+    content/meta still carried ``action=continue`` and the prior iteration
+    number. The fix always replaces ``final_result`` with the synthetic
+    exhaustion result.
+    """
+    # Iter 1 finishes immediately (~0s), iter 2 sleeps 0.12s. Budget = 0.05s.
+    # Top-of-iter-2 check sees ~0s elapsed and lets iter 2 run; iter 2
+    # completes at ~0.12s. Top-of-iter-3 check sees 0.12s >= 0.05s and skips,
+    # firing the budget-exhausted branch with a prior successful final_result
+    # in flight.
+    evolve = _SuccessThenSlowEvolveHandler(slow_sleep_seconds=0.12)
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_budget_after_success",
+            seed_content="goal: budget",
+            max_generations=5,
+            per_iteration_timeout_seconds=1.0,
+            max_total_seconds=0.05,
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.stop_reason == "wall_clock_exhausted"
+    assert evolve.calls == 2  # iter 1 + iter 2 ran; iter 3 skipped pre-launch.
+    assert result.iteration_count == 2  # only the two successful iterations.
+    assert result.iterations[0].action == "continue"
+    assert result.iterations[1].action == "continue"
+
+    # Terminal MCPToolResult must reflect budget exhaustion, not iter 2's output.
+    assert result.final_result.meta["action"] == "wall_clock_exhausted"
+    assert result.final_result.meta["generation"] is None
+    assert "wall-clock budget exhausted" in result.final_result.text_content
+    assert "iter1-output" not in result.final_result.text_content
+    assert "iter2-output" not in result.final_result.text_content
+
+    tool_result = result.to_tool_result()
+    assert tool_result.is_error is True
+    assert tool_result.meta["status"] == "failed"
+    assert tool_result.meta["stop_reason"] == "wall_clock_exhausted"
+    assert "iter1-output" not in tool_result.text_content
+    assert "iter2-output" not in tool_result.text_content
+
+
 @pytest.mark.asyncio
 async def test_ralph_loop_max_total_seconds_none_does_not_constrain() -> None:
     """When max_total_seconds is None at the runner level, no extra cap applies."""

--- a/tests/unit/test_ralph_loop_timeout.py
+++ b/tests/unit/test_ralph_loop_timeout.py
@@ -269,3 +269,80 @@ async def test_plugin_dispatch_forwards_per_iteration_timeout_seconds(
     assert sub["context"]["per_iteration_timeout_seconds"] == 1234
     assert "per_iteration_timeout_seconds: 1234" in sub["prompt"]
     assert "stop_reason=iteration_timeout" in sub["prompt"]
+
+
+@dataclass
+class _SuccessThenHangEvolveHandler:
+    """First call succeeds quickly; subsequent calls hang past the timeout."""
+
+    hang_seconds: float
+    calls: int = 0
+
+    async def handle(self, arguments: dict[str, Any]):
+        self.calls += 1
+        if self.calls == 1:
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="iter1-output"),),
+                    is_error=False,
+                    meta={
+                        "lineage_id": arguments["lineage_id"],
+                        "generation": 1,
+                        "action": "continue",
+                    },
+                )
+            )
+        await asyncio.sleep(self.hang_seconds)
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="late"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": self.calls,
+                    "action": "continue",
+                },
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_iteration_timeout_after_successful_iteration_replaces_terminal_result() -> None:
+    """Timeout after iteration 1 must NOT leak iter 1's output into terminal result.
+
+    Regression for #789 review-3: when iteration 2+ times out, the runner
+    used to keep ``final_result`` pointing at iteration 1's success, so the
+    terminal MCPToolResult reported ``stop_reason=iteration_timeout`` while
+    its content/meta still showed ``action=continue`` from iteration 1. The
+    fix always replaces ``final_result`` with the synthetic timeout result.
+    """
+    evolve = _SuccessThenHangEvolveHandler(hang_seconds=0.5)
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_timeout_after_success",
+            seed_content="goal: timeout",
+            max_generations=5,
+            per_iteration_timeout_seconds=0.05,
+        )
+    )
+
+    assert result.status == "failed"
+    assert result.stop_reason == "iteration_timeout"
+    # Two iterations recorded: success then timeout.
+    assert result.iteration_count == 2
+    assert result.iterations[0].action == "continue"
+    assert result.iterations[1].action == "iteration_timeout"
+
+    # Terminal MCPToolResult must reflect the timeout, not iter 1's output.
+    assert result.final_result.meta["action"] == "iteration_timeout"
+    assert result.final_result.meta["generation"] is None
+    assert "exceeded" in result.final_result.text_content
+    assert "iter1-output" not in result.final_result.text_content
+
+    tool_result = result.to_tool_result()
+    assert tool_result.is_error is True
+    assert tool_result.meta["status"] == "failed"
+    assert tool_result.meta["stop_reason"] == "iteration_timeout"
+    assert "iter1-output" not in tool_result.text_content


### PR DESCRIPTION
Closes #777.

**Stacked on** #784 (#776 — per-iteration timeout). Merge order: #784 → this PR.

## Summary

- Adds `RalphLoopConfig.max_total_seconds: float | None = None`. `None` means "no extra wall-clock cap beyond `max_generations × per_iteration_timeout_seconds`".
- `RalphLoopRunner.run` captures `loop_start_monotonic` before the iteration loop and, at the top of each iteration (BEFORE launching `evolve_handler.handle`), checks whether the cumulative budget is exhausted. On exhaustion the iteration is *not* launched; the loop stops with `status="failed"` and `stop_reason="wall_clock_exhausted"`.
- `ouroboros_ralph` MCP tool gains a new `max_total_seconds` argument validated at `1 <= x <= 86400`.
- Standalone callers that omit `max_total_seconds` get a derived ceiling of `max_generations × per_iteration_timeout_seconds` auto-applied at the handler layer with a `WARNING` log; this preserves the public contract that wall-clock can never silently exceed the iteration-count budget. The auto-side caller (#773) will always pass an explicit value.
- New regression test `tests/unit/test_ralph_loop_budget.py` covers: budget exhaustion skipping iteration N+1, `tool_result.meta` surfacing the new stop reason, runner-level `None` not constraining, MCP-layer derived-ceiling fallback + WARNING capture via `caplog`, and validation rejecting `0` and `100000`.

## Out of scope (this PR)

- AC bullet "Auto-side adapter `HandlerRalphStarter` (introduced in #773) computes `max_total_seconds = max(0.0, state.deadline_at - time.monotonic())`" depends on `HandlerRalphStarter`, which is introduced by #773 and `state.deadline_at` from #779 — neither merged yet. Tracked there.

## Test plan

- [x] `PYTHONPATH=src python3 -m pytest tests/unit/test_ralph_loop_budget.py -v` — 7 passed.
- [x] `PYTHONPATH=src python3 -m pytest tests/unit/test_ralph_loop_budget.py tests/unit/test_ralph_loop_timeout.py -v` — 13 passed (no regressions in #776 timeout work).
- [x] `PYTHONPATH=src python3 -m pytest tests/unit -k "ralph"` — 58 passed.
- [x] `ruff format --check src/ tests/` — clean.
- [x] `ruff check src/ tests/` — clean.

Pre-existing main-side failure `tests/unit/orchestrator/test_codex_cli_runtime.py::test_build_command_omits_profile_flag_when_runtime_profile_unset` is unrelated to this change and remains as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)