### PR TITLE
feat(auto): chain RUN→RALPH automatically with --complete-product

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -234,6 +234,38 @@ class HandlerRalphStarter:
         }
 
 
+class HandlerRalphPoller:
+    """Callable Ralph job poller backed by the same ``RalphHandler`` ``JobManager``.
+
+    Used by :class:`AutoPipeline` on resume from a persisted ``RALPH_HANDOFF``
+    checkpoint (Q00/ouroboros#773 review-5 finding 1). Without this hook a
+    long-lived runtime such as MCP — where the Ralph background job keeps
+    running after the client disconnects — would leave any interrupted
+    ``--complete-product`` session stranded in the non-terminal handoff
+    state forever, since the legacy resume path only emitted guidance text.
+    The poller waits for the persisted ``ralph_job_id`` to reach a terminal
+    snapshot and returns the same ``terminal_status`` / ``stop_reason`` /
+    ``dispatch_mode`` shape as :class:`HandlerRalphStarter` so the pipeline
+    can re-use a single COMPLETE / BLOCKED / FAILED mapping.
+    """
+
+    def __init__(self, handler: RalphHandler) -> None:
+        self.handler = handler
+
+    async def __call__(self, *, job_id: str) -> dict[str, Any]:
+        job_manager = self.handler._job_manager  # noqa: SLF001
+        terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
+        terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
+        stop_reason = _optional_str(terminal_meta.get("stop_reason"))
+        return {
+            "job_id": job_id,
+            "lineage_id": _optional_str(terminal_meta.get("lineage_id")),
+            "dispatch_mode": "job",
+            "terminal_status": terminal_status,
+            "stop_reason": stop_reason,
+        }
+
+
 async def _wait_for_job_terminal(
     job_manager: JobManager, job_id: str, *, poll_interval: float = 0.05
 ) -> dict[str, Any]:

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 from ouroboros.auto.interview_driver import InterviewBackend, InterviewTurn
 from ouroboros.core.seed import Seed
 from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.job_manager import JobManager, JobStatus
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import MCPToolResult
 
 
@@ -156,6 +160,101 @@ class HandlerRunStarter:
         if isinstance(meta.get("_subagent"), dict):
             run_meta["_subagent"] = meta["_subagent"]
         return run_meta
+
+
+class HandlerRalphStarter:
+    """Callable Ralph starter backed by ``ouroboros_ralph``.
+
+    Bridges :class:`AutoPipeline`'s RUN → RALPH_HANDOFF transition to the
+    runtime-owned Ralph loop introduced in Q00/ouroboros#528. Awaits the
+    background job to a terminal state in non-plugin runtimes so the auto
+    pipeline can produce a final ``COMPLETE`` / ``BLOCKED`` / ``FAILED``
+    auto phase from the same ``AutoPipeline.run()`` call. In plugin mode
+    the handler returns ``delegated_to_plugin`` immediately and the
+    pipeline records ``ralph_dispatch_mode="plugin"`` without invoking
+    job tools.
+    """
+
+    def __init__(self, handler: RalphHandler) -> None:
+        self.handler = handler
+
+    async def __call__(
+        self,
+        seed: Seed,
+        *,
+        lineage_id: str,
+        max_total_seconds: float | None = None,
+        per_iteration_timeout_seconds: float | None = None,
+    ) -> dict[str, Any]:
+        seed_yaml = yaml.dump(
+            seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
+        )
+        arguments: dict[str, Any] = {
+            "lineage_id": lineage_id,
+            "seed_content": seed_yaml,
+        }
+        if max_total_seconds is not None:
+            arguments["max_total_seconds"] = max_total_seconds
+        if per_iteration_timeout_seconds is not None:
+            arguments["per_iteration_timeout_seconds"] = per_iteration_timeout_seconds
+        result = _unwrap(
+            await self.handler.handle(arguments),
+            tool_name="ouroboros_ralph",
+        )
+        meta = result.meta or {}
+        dispatch_mode = _optional_str(meta.get("dispatch_mode"))
+        status = _optional_str(meta.get("status"))
+        # Plugin mode: handler returned an envelope with no job_id and a
+        # ``delegated_to_plugin`` status. The auto pipeline records this and
+        # transitions straight to COMPLETE — there is nothing to wait for.
+        if status == "delegated_to_plugin" or dispatch_mode == "plugin":
+            return {
+                "job_id": None,
+                "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
+                "dispatch_mode": "plugin",
+                "terminal_status": "delegated_to_plugin",
+                "stop_reason": None,
+            }
+        # Job mode: wait for the background job to terminate, then map the
+        # final job snapshot back into the structured terminal status the
+        # pipeline maps onto an auto phase.
+        job_id = _optional_str(meta.get("job_id"))
+        if not job_id:
+            raise HandlerError("ouroboros_ralph did not return a job_id")
+        job_manager = self.handler._job_manager  # noqa: SLF001
+        terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
+        terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
+        stop_reason = _optional_str(terminal_meta.get("stop_reason"))
+        return {
+            "job_id": job_id,
+            "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": terminal_status,
+            "stop_reason": stop_reason,
+        }
+
+
+async def _wait_for_job_terminal(
+    job_manager: JobManager, job_id: str, *, poll_interval: float = 0.05
+) -> dict[str, Any]:
+    """Poll the job manager until ``job_id`` reaches a terminal state.
+
+    Returns the materialized ``result_meta`` from the terminal snapshot so
+    callers can extract ralph's ``status`` / ``stop_reason``. ``status`` in
+    the returned mapping is always populated — it falls back to the job's
+    own terminal status (e.g. ``"failed"`` for an exception path) when the
+    inner ralph result did not provide one.
+    """
+    while True:
+        snapshot = await job_manager.get_snapshot(job_id)
+        if snapshot.is_terminal:
+            meta = dict(snapshot.result_meta or {})
+            meta.setdefault(
+                "status",
+                "completed" if snapshot.status is JobStatus.COMPLETED else "failed",
+            )
+            return meta
+        await asyncio.sleep(poll_interval)
 
 
 def load_seed(path: str | Path) -> Seed:

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -185,7 +186,20 @@ class HandlerRalphStarter:
         lineage_id: str,
         max_total_seconds: float | None = None,
         per_iteration_timeout_seconds: float | None = None,
+        on_dispatched: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
+        """Dispatch the Ralph loop and wait for terminal completion.
+
+        ``on_dispatched`` is invoked with the dispatch envelope *before*
+        the wait-for-terminal poll begins, so callers (notably
+        :meth:`AutoPipeline._handoff_to_ralph`) can checkpoint
+        ``ralph_job_id`` / ``ralph_dispatch_mode`` immediately after the
+        background job has been created. Without this hook, a process
+        restart, deadline trip, or client disconnect *after* dispatch but
+        *before* terminal completion would leave the persisted state with
+        only ``ralph_lineage_id`` — and resume could not poll the
+        still-running job (Q00/ouroboros#773 review-6).
+        """
         seed_yaml = yaml.dump(
             seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
         )
@@ -208,19 +222,34 @@ class HandlerRalphStarter:
         # ``delegated_to_plugin`` status. The auto pipeline records this and
         # transitions straight to COMPLETE — there is nothing to wait for.
         if status == "delegated_to_plugin" or dispatch_mode == "plugin":
-            return {
+            envelope = {
                 "job_id": None,
                 "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
                 "dispatch_mode": "plugin",
                 "terminal_status": "delegated_to_plugin",
                 "stop_reason": None,
             }
+            if on_dispatched is not None:
+                on_dispatched(envelope)
+            return envelope
         # Job mode: wait for the background job to terminate, then map the
         # final job snapshot back into the structured terminal status the
         # pipeline maps onto an auto phase.
         job_id = _optional_str(meta.get("job_id"))
         if not job_id:
             raise HandlerError("ouroboros_ralph did not return a job_id")
+        if on_dispatched is not None:
+            # Fire BEFORE we block on the terminal poll so callers can
+            # persist ``ralph_job_id`` immediately. The terminal_status /
+            # stop_reason are intentionally omitted here — they are not
+            # known until the poll returns.
+            on_dispatched(
+                {
+                    "job_id": job_id,
+                    "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
+                    "dispatch_mode": "job",
+                }
+            )
         job_manager = self.handler._job_manager  # noqa: SLF001
         terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         terminal_status = _optional_str(terminal_meta.get("status")) or "failed"

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -70,6 +70,15 @@ _RESUME_EXPIRED_MESSAGE = "pipeline_timeout (deadline expired before resume)"
 # dispatch so an insufficient top-level pipeline budget remains a pipeline
 # timeout, not a Ralph argument-validation failure.
 _MIN_RALPH_MAX_TOTAL_SECONDS = 1.0
+# Mirrors RalphHandler.MIN_PER_ITERATION_TIMEOUT_SECONDS / DEFAULT_PER_ITERATION_TIMEOUT_SECONDS.
+# When the remaining pipeline budget is shorter than the Ralph default
+# per-iteration timeout, the auto layer caps ``per_iteration_timeout_seconds``
+# so a single ``evolve_step`` cannot block past ``deadline_at``. RalphLoopRunner
+# only checks ``max_total_seconds`` at iteration boundaries, so without this cap
+# the first iteration could still run for the full default 1800s — violating
+# the top-level pipeline deadline contract pinned by Q00/ouroboros#779.
+_MIN_RALPH_PER_ITERATION_SECONDS = 30.0
+_DEFAULT_RALPH_PER_ITERATION_SECONDS = 1800.0
 
 
 _RETRY_GUIDANCE_PHRASE = "retried once with idempotency key"
@@ -175,6 +184,39 @@ class AutoPipeline:
         )
         if self.skip_run and not state.skip_run:
             state.skip_run = True
+        # Q00/ouroboros#773 (review-3): ``complete_product`` is durable session
+        # intent, not a per-invocation flag. On a fresh session the constructor
+        # writes the operator's choice into the state; on resume we honor the
+        # persisted value even when the caller forgot to re-pass the flag, so
+        # a session originally started with ``--complete-product`` keeps
+        # chaining RUN → RALPH_HANDOFF after restart. Lowering is intentional:
+        # explicit ``complete_product=True`` raises the bound; absence keeps
+        # the persisted truth.
+        if self.complete_product and not state.complete_product:
+            state.complete_product = True
+        elif state.complete_product and not self.complete_product:
+            self.complete_product = True
+        # Validate the persisted Seed artifact BEFORE any other path can
+        # trigger a state-validating save. ``AutoStore.save`` re-validates the
+        # full state, so a malformed ``seed_artifact`` would otherwise raise a
+        # raw ``ValueError`` from the very first save (e.g. the legacy
+        # deadline-arm or resume-expired branches below) instead of being
+        # converted into a clean ``FAILED`` outcome by
+        # ``_mark_invalid_seed_artifact``.
+        if state.seed_artifact:
+            try:
+                Seed.from_dict(state.seed_artifact)
+            except Exception as exc:
+                _mark_invalid_seed_artifact(state, f"persisted Seed artifact is invalid: {exc}")
+                self._save(state)
+                return self._result(state, ledger, blocker=state.last_error)
+            # Backfill legacy resumed sessions: pre-PR auto pipelines were the
+            # only writer of state.seed_artifact, so a valid persisted Seed
+            # paired with seed_origin=none can only have come from this
+            # pipeline. Inferring it once on resume keeps the new contract
+            # accurate for sessions created before this field existed.
+            if state.seed_origin is SeedOrigin.NONE:
+                state.seed_origin = SeedOrigin.AUTO_PIPELINE
         _arm_legacy_missing_deadline(state)
         # Top-level deadline check on resume (#779). When ``deadline_at`` is
         # already set and has passed before this process even starts work,
@@ -195,20 +237,6 @@ class AutoPipeline:
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
         resume_tool_name = state.last_tool_name
-        if state.seed_artifact:
-            try:
-                Seed.from_dict(state.seed_artifact)
-            except Exception as exc:
-                _mark_invalid_seed_artifact(state, f"persisted Seed artifact is invalid: {exc}")
-                self._save(state)
-                return self._result(state, ledger, blocker=state.last_error)
-            # Backfill legacy resumed sessions: pre-PR auto pipelines were the
-            # only writer of state.seed_artifact, so a valid persisted Seed
-            # paired with seed_origin=none can only have come from this
-            # pipeline. Inferring it once on resume keeps the new contract
-            # accurate for sessions created before this field existed.
-            if state.seed_origin is SeedOrigin.NONE:
-                state.seed_origin = SeedOrigin.AUTO_PIPELINE
         self._save(state)
 
         if self.reconcile_run and state.phase == AutoPhase.COMPLETE:
@@ -799,6 +827,7 @@ class AutoPipeline:
         )
         self._save(state)
         max_total_seconds: float | None = None
+        per_iteration_timeout_seconds: float | None = None
         if state.deadline_at is not None:
             remaining = state.deadline_at - time.monotonic()
             if remaining < _MIN_RALPH_MAX_TOTAL_SECONDS:
@@ -817,11 +846,28 @@ class AutoPipeline:
                     run_subagent=run_subagent,
                 )
             max_total_seconds = remaining
+            # Cap per-iteration so a single ``evolve_step`` cannot block past
+            # the remaining deadline. ``RalphLoopRunner`` checks
+            # ``max_total_seconds`` only at the top of each iteration, so
+            # without this cap the first iteration could still run for the
+            # full default 1800s after the deadline expired. Floored at the
+            # Ralph minimum (30s) — when the remaining budget is itself below
+            # that floor we still cap at 30s rather than rejecting at the
+            # auto layer, since the pre-dispatch ``MIN_RALPH_MAX_TOTAL_SECONDS``
+            # check already protects against a sub-second budget. The
+            # ``max_total_seconds`` cap then aborts the loop before any
+            # follow-up iteration starts, so the worst-case overshoot is one
+            # iteration of up to 30 seconds.
+            per_iteration_timeout_seconds = max(
+                _MIN_RALPH_PER_ITERATION_SECONDS,
+                min(_DEFAULT_RALPH_PER_ITERATION_SECONDS, remaining),
+            )
         try:
             ralph_meta = await self.ralph_starter(
                 seed,
                 lineage_id=lineage_id,
                 max_total_seconds=max_total_seconds,
+                per_iteration_timeout_seconds=per_iteration_timeout_seconds,
             )
         except Exception as exc:
             state.mark_failed(f"ralph handoff failed: {exc}", tool_name="ralph_starter")

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -66,6 +66,10 @@ _RALPH_BLOCKED_STOP_REASONS: frozenset[str] = frozenset(
 # per-tool blockers without scanning the error message.
 PIPELINE_DEADLINE_TOOL_NAME = "pipeline_deadline"
 _RESUME_EXPIRED_MESSAGE = "pipeline_timeout (deadline expired before resume)"
+# Mirrors RalphHandler.MIN_MAX_TOTAL_SECONDS. The auto layer checks this before
+# dispatch so an insufficient top-level pipeline budget remains a pipeline
+# timeout, not a Ralph argument-validation failure.
+_MIN_RALPH_MAX_TOTAL_SECONDS = 1.0
 
 
 _RETRY_GUIDANCE_PHRASE = "retried once with idempotency key"
@@ -304,7 +308,12 @@ class AutoPipeline:
         elif state.phase == AutoPhase.REPAIR:
             state.transition(AutoPhase.REVIEW, "resuming review after repair checkpoint")
             self._save(state)
-        elif state.phase not in {AutoPhase.SEED_GENERATION, AutoPhase.REVIEW, AutoPhase.RUN}:
+        elif state.phase not in {
+            AutoPhase.SEED_GENERATION,
+            AutoPhase.REVIEW,
+            AutoPhase.RUN,
+            AutoPhase.RALPH_HANDOFF,
+        }:
             state.mark_blocked(
                 f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",
                 tool_name="auto_pipeline",
@@ -415,6 +424,9 @@ class AutoPipeline:
             )
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
+
+        if state.phase == AutoPhase.RALPH_HANDOFF:
+            return self._resume_ralph_handoff(state, ledger, review=review)
 
         if self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
@@ -784,7 +796,23 @@ class AutoPipeline:
         self._save(state)
         max_total_seconds: float | None = None
         if state.deadline_at is not None:
-            max_total_seconds = max(0.0, state.deadline_at - time.monotonic())
+            remaining = state.deadline_at - time.monotonic()
+            if remaining < _MIN_RALPH_MAX_TOTAL_SECONDS:
+                message = (
+                    "pipeline_timeout: remaining deadline budget "
+                    f"{max(0.0, remaining):.1f}s is below Ralph minimum "
+                    f"{_MIN_RALPH_MAX_TOTAL_SECONDS:.0f}s during {state.phase.value}"
+                )
+                state.mark_blocked(message, tool_name=PIPELINE_DEADLINE_TOOL_NAME)
+                self._save(state)
+                return self._result(
+                    state,
+                    ledger,
+                    review=review,
+                    blocker=state.last_error,
+                    run_subagent=run_subagent,
+                )
+            max_total_seconds = remaining
         try:
             ralph_meta = await self.ralph_starter(
                 seed,
@@ -849,6 +877,45 @@ class AutoPipeline:
         return self._result(
             state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
         )
+
+    def _resume_ralph_handoff(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        review: SeedReview | None,
+    ) -> AutoPipelineResult:
+        """Resume a persisted Ralph handoff checkpoint without duplicate dispatch."""
+        if state.ralph_dispatch_mode == "plugin":
+            state.run_handoff_guidance = (
+                state.run_handoff_guidance
+                or "Ralph loop delegated to the OpenCode plugin child session. "
+                "Track progress through the OpenCode Task widget; this auto "
+                "session will not block on the loop's completion."
+            )
+            state.transition(
+                AutoPhase.COMPLETE,
+                "resumed OpenCode plugin Ralph delegation checkpoint",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review)
+
+        handle = state.ralph_job_id or state.ralph_lineage_id
+        if handle:
+            state.run_handoff_guidance = (
+                "Ralph handoff already has a persisted tracking handle; resume did "
+                "not start duplicate run or Ralph work. Track the existing Ralph "
+                f"lineage/job: {handle}."
+            )
+        else:
+            state.run_handoff_guidance = (
+                "Ralph handoff checkpoint has no persisted Ralph job handle; resume "
+                "did not start duplicate run or Ralph work. Inspect the Ralph runtime "
+                "before dispatching manually."
+            )
+        state.mark_progress(state.run_handoff_guidance, tool_name="ralph_starter")
+        self._save(state)
+        return self._result(state, ledger, review=review)
 
     def _enforce_deadline(self, state: AutoPipelineState) -> bool:
         """Return True when the pipeline must abort because the deadline expired.

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -162,6 +162,15 @@ class AutoPipeline:
     # defaults to False (opt-in safety) so existing callers see no behavior
     # change.
     ralph_starter: RalphStarter | None = None
+    # Q00/ouroboros#773 (review-5): poller invoked by ``_resume_ralph_handoff``
+    # to translate a persisted ``ralph_job_id`` back into a terminal status
+    # dict so a session interrupted in ``RALPH_HANDOFF`` (e.g. MCP client
+    # disconnects while the background Ralph job keeps running) actually
+    # reconciles to ``COMPLETE`` / ``BLOCKED`` / ``FAILED`` on resume instead
+    # of staying stranded in the non-terminal handoff state. Defaults to
+    # None for backward compatibility — when unset, resume falls back to
+    # the legacy guidance-only behavior.
+    ralph_resumer: RalphStarter | None = None
     complete_product: bool = False
     _last_emitted_phase: str | None = field(default=None, init=False, repr=False)
     _last_emitted_grade: str | None = field(default=None, init=False, repr=False)
@@ -455,7 +464,7 @@ class AutoPipeline:
             return self._result(state, ledger, blocker=state.last_error)
 
         if state.phase == AutoPhase.RALPH_HANDOFF:
-            return self._resume_ralph_handoff(state, ledger, review=review)
+            return await self._resume_ralph_handoff(state, ledger, review=review)
 
         if self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
@@ -547,6 +556,17 @@ class AutoPipeline:
             if any((state.job_id, state.execution_id, state.run_session_id)):
                 state.run_handoff_status = "started"
                 state.run_handoff_guidance = None
+                # Q00/ouroboros#773 (review-5 finding 2): honor the durable
+                # ``complete_product`` intent on RUN resume. Without this
+                # branch, a crash between run handoff and ``_handoff_to_ralph``
+                # would silently bypass Ralph on resume even though the
+                # operator explicitly opted into RUN → RALPH_HANDOFF — a
+                # regression of the persisted-session contract added in
+                # this PR.
+                if self.complete_product and self.ralph_starter is not None:
+                    return await self._handoff_to_ralph(
+                        state, ledger, seed, review, run_subagent=None
+                    )
                 state.transition(
                     AutoPhase.COMPLETE, "execution already started; using persisted run handle"
                 )
@@ -928,14 +948,27 @@ class AutoPipeline:
             state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
         )
 
-    def _resume_ralph_handoff(
+    async def _resume_ralph_handoff(
         self,
         state: AutoPipelineState,
         ledger: SeedDraftLedger,
         *,
         review: SeedReview | None,
     ) -> AutoPipelineResult:
-        """Resume a persisted Ralph handoff checkpoint without duplicate dispatch."""
+        """Resume a persisted Ralph handoff checkpoint.
+
+        Plugin-mode dispatches transition straight to COMPLETE (the plugin
+        child session is fire-and-forget — there is no in-process job to
+        await). Job-mode dispatches with a configured ``ralph_resumer``
+        poll the persisted ``ralph_job_id`` and map the terminal status
+        back onto the same auto phase as :meth:`_handoff_to_ralph`, so a
+        session interrupted between dispatch and terminal status (review-5
+        finding 1) is actually reconciled instead of stranded in
+        ``RALPH_HANDOFF`` forever. When no ``ralph_resumer`` is wired (or
+        no ``ralph_job_id`` was persisted) the method falls back to
+        guidance-only behavior so callers without a job-manager handle
+        still get a coherent message instead of a polling failure.
+        """
         if state.ralph_dispatch_mode == "plugin":
             state.run_handoff_guidance = (
                 state.run_handoff_guidance
@@ -949,6 +982,9 @@ class AutoPipeline:
             )
             self._save(state)
             return self._result(state, ledger, review=review)
+
+        if self.ralph_resumer is not None and state.ralph_job_id:
+            return await self._poll_ralph_job(state, ledger, review=review)
 
         handle = state.ralph_job_id or state.ralph_lineage_id
         if handle:
@@ -966,6 +1002,72 @@ class AutoPipeline:
         state.mark_progress(state.run_handoff_guidance, tool_name="ralph_starter")
         self._save(state)
         return self._result(state, ledger, review=review)
+
+    async def _poll_ralph_job(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        review: SeedReview | None,
+    ) -> AutoPipelineResult:
+        """Poll a persisted Ralph job and map its terminal status onto an auto phase.
+
+        Used only by :meth:`_resume_ralph_handoff` when ``ralph_resumer`` is
+        wired and ``state.ralph_job_id`` is present. The polling shape mirrors
+        :meth:`_handoff_to_ralph` so the COMPLETE / BLOCKED / FAILED contract
+        pinned by :data:`_RALPH_BLOCKED_STOP_REASONS` stays single-sourced.
+        """
+        assert self.ralph_resumer is not None  # noqa: S101 - guarded by caller
+        assert state.ralph_job_id is not None  # noqa: S101 - guarded by caller
+        try:
+            poll_call = self.ralph_resumer(job_id=state.ralph_job_id)
+            if state.deadline_at is None:
+                ralph_meta = await poll_call
+            else:
+                poll_timeout = max(0.0, state.deadline_at - time.monotonic())
+                ralph_meta = await asyncio.wait_for(poll_call, timeout=poll_timeout)
+        except TimeoutError:
+            if self._enforce_deadline(state):
+                return self._result(state, ledger, review=review, blocker=state.last_error)
+            state.mark_blocked(
+                "ralph resume poll timed out before terminal status",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
+        except Exception as exc:
+            state.mark_failed(f"ralph resume poll failed: {exc}", tool_name="ralph_starter")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
+        if not isinstance(ralph_meta, dict):
+            state.mark_failed(
+                f"ralph resumer returned {type(ralph_meta).__name__}, expected dict",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
+        terminal_status = _optional_str(ralph_meta.get("terminal_status"))
+        stop_reason = _optional_str(ralph_meta.get("stop_reason"))
+        if terminal_status == "completed":
+            state.transition(
+                AutoPhase.COMPLETE,
+                f"resumed ralph loop completed ({stop_reason or 'qa passed'})",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review)
+        if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
+            state.mark_blocked(stop_reason, tool_name="ralph_starter")
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
+        # Any other failure is a hard FAILED, mirroring _handoff_to_ralph.
+        message = (
+            f"ralph loop failed: {stop_reason}"
+            if stop_reason
+            else f"ralph loop failed: terminal_status={terminal_status or 'unknown'}"
+        )
+        state.mark_failed(message, tool_name="ralph_starter")
+        self._save(state)
+        return self._result(state, ledger, review=review, blocker=state.last_error)
 
     def _enforce_deadline(self, state: AutoPipelineState) -> bool:
         """Return True when the pipeline must abort because the deadline expired.

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -42,8 +42,23 @@ class RunStarter(Protocol):
     async def __call__(self, seed: Seed, *, idempotency_key: str = "") -> dict[str, Any]: ...
 
 
+RalphStarter = Callable[..., Awaitable[dict[str, Any]]]
 SeedSaver = Callable[[Seed], str]
 SeedLoader = Callable[[str], Seed]
+
+# Ralph stop_reason values that map to a recoverable BLOCKED auto phase
+# rather than a hard FAILED. Pinned by Q00/ouroboros#773 and asserted by
+# tests/unit/auto/test_pipeline_ralph_handoff.py so silent drift surfaces
+# as test failure.
+_RALPH_BLOCKED_STOP_REASONS: frozenset[str] = frozenset(
+    {
+        "iteration_timeout",
+        "wall_clock_exhausted",
+        "oscillation_detected",
+        "grade_regressing",
+        "max_generations reached",
+    }
+)
 
 # Tool-name marker recorded on ``state.last_tool_name`` whenever the top-level
 # pipeline deadline (#779) trips. Distinct from per-phase tool names so that
@@ -84,6 +99,9 @@ class AutoPipelineResult:
     run_reconciliation_status: str | None = None
     run_reconciliation_source: str | None = None
     run_reconciled_at: str | None = None
+    ralph_job_id: str | None = None
+    ralph_lineage_id: str | None = None
+    ralph_dispatch_mode: str | None = None
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
@@ -126,6 +144,12 @@ class AutoPipeline:
     seed_timeout_seconds: float = 120.0
     run_start_timeout_seconds: float = 60.0
     progress_callback: AutoProgressCallback | None = None
+    # Q00/ouroboros#773: chain RUN → RALPH_HANDOFF when ``complete_product``
+    # is true and a ``ralph_starter`` is configured. ``complete_product``
+    # defaults to False (opt-in safety) so existing callers see no behavior
+    # change.
+    ralph_starter: RalphStarter | None = None
+    complete_product: bool = False
     _last_emitted_phase: str | None = field(default=None, init=False, repr=False)
     _last_emitted_grade: str | None = field(default=None, init=False, repr=False)
     _last_emitted_repair: int | None = field(default=None, init=False, repr=False)
@@ -671,6 +695,13 @@ class AutoPipeline:
                 if any((state.job_id, state.execution_id, state.run_session_id)):
                     state.run_handoff_status = "started"
                     state.run_handoff_guidance = None
+                    # Q00/ouroboros#773: when ``--complete-product`` is set
+                    # and a ralph starter is configured, chain RUN →
+                    # RALPH_HANDOFF instead of going straight to COMPLETE.
+                    if self.complete_product and self.ralph_starter is not None:
+                        return await self._handoff_to_ralph(
+                            state, ledger, seed, review, run_subagent
+                        )
                     state.transition(
                         AutoPhase.COMPLETE,
                         f"execution started for grade "
@@ -724,6 +755,100 @@ class AutoPipeline:
         if remaining <= 0:
             return 0.0
         return float(min(float(phase_timeout), remaining))
+
+    async def _handoff_to_ralph(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+        review: SeedReview | None,
+        run_subagent: dict[str, Any] | None,
+    ) -> AutoPipelineResult:
+        """Run the RUN → RALPH_HANDOFF → terminal-phase chain.
+
+        Builds a deterministic ``lineage_id``, forwards the remaining
+        pipeline budget as ``max_total_seconds``, and maps the ralph
+        terminal status back into one of ``COMPLETE`` / ``BLOCKED`` /
+        ``FAILED`` per the contract pinned by
+        :data:`_RALPH_BLOCKED_STOP_REASONS`. Plugin-mode dispatches
+        transition to COMPLETE immediately and surface the OpenCode Task
+        widget guidance to the operator.
+        """
+        assert self.ralph_starter is not None  # noqa: S101 - guarded by caller
+        lineage_id = f"ralph-{seed.metadata.seed_id}-{state.auto_session_id[:8]}"
+        state.ralph_lineage_id = lineage_id
+        state.transition(
+            AutoPhase.RALPH_HANDOFF,
+            f"handing off grade {state.last_grade or state.required_grade} Seed to Ralph loop",
+        )
+        self._save(state)
+        max_total_seconds: float | None = None
+        if state.deadline_at is not None:
+            max_total_seconds = max(0.0, state.deadline_at - time.monotonic())
+        try:
+            ralph_meta = await self.ralph_starter(
+                seed,
+                lineage_id=lineage_id,
+                max_total_seconds=max_total_seconds,
+            )
+        except Exception as exc:
+            state.mark_failed(f"ralph handoff failed: {exc}", tool_name="ralph_starter")
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
+        if not isinstance(ralph_meta, dict):
+            state.mark_failed(
+                f"ralph starter returned {type(ralph_meta).__name__}, expected dict",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
+        state.ralph_job_id = _optional_str(ralph_meta.get("job_id"))
+        state.ralph_dispatch_mode = _optional_str(ralph_meta.get("dispatch_mode"))
+        terminal_status = _optional_str(ralph_meta.get("terminal_status"))
+        stop_reason = _optional_str(ralph_meta.get("stop_reason"))
+        # Plugin delegation: nothing to await, transition straight to
+        # COMPLETE and surface the OpenCode Task widget guidance.
+        if state.ralph_dispatch_mode == "plugin":
+            state.run_handoff_guidance = (
+                "Ralph loop delegated to the OpenCode plugin child session. "
+                "Track progress through the OpenCode Task widget; this auto "
+                "session will not block on the loop's completion."
+            )
+            state.transition(
+                AutoPhase.COMPLETE,
+                "ralph loop delegated to OpenCode plugin child session",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, run_subagent=run_subagent)
+        if terminal_status == "completed":
+            state.transition(
+                AutoPhase.COMPLETE,
+                f"ralph loop completed ({stop_reason or 'qa passed'})",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, run_subagent=run_subagent)
+        if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
+            state.mark_blocked(stop_reason, tool_name="ralph_starter")
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
+        # Any other failure (terminal failure action, exception bubbled up,
+        # or an unrecognized status) is a hard FAILED.
+        message = (
+            f"ralph loop failed: {stop_reason}"
+            if stop_reason
+            else f"ralph loop failed: terminal_status={terminal_status or 'unknown'}"
+        )
+        state.mark_failed(message, tool_name="ralph_starter")
+        self._save(state)
+        return self._result(
+            state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+        )
 
     def _enforce_deadline(self, state: AutoPipelineState) -> bool:
         """Return True when the pipeline must abort because the deadline expired.
@@ -815,6 +940,9 @@ class AutoPipeline:
             run_reconciliation_status=state.run_reconciliation_status,
             run_reconciliation_source=state.run_reconciliation_source,
             run_reconciled_at=state.run_reconciled_at,
+            ralph_job_id=state.ralph_job_id,
+            ralph_lineage_id=state.ralph_lineage_id,
+            ralph_dispatch_mode=state.ralph_dispatch_mode,
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -882,12 +882,68 @@ class AutoPipeline:
                 _MIN_RALPH_PER_ITERATION_SECONDS,
                 min(_DEFAULT_RALPH_PER_ITERATION_SECONDS, remaining),
             )
+
+        # Q00/ouroboros#773 (review-6): persist the Ralph dispatch handle as
+        # soon as the background job exists, BEFORE we await terminal
+        # completion. Without this checkpoint, a process restart, deadline
+        # trip, or client disconnect after dispatch but before terminal
+        # would leave the persisted state with only ``ralph_lineage_id`` —
+        # ``_resume_ralph_handoff`` then cannot call ``ralph_resumer``
+        # (which keys off ``ralph_job_id``) and falls back to guidance-only
+        # text, reintroducing the stranded-resume bug this PR is meant to
+        # solve. The starter callable invokes this hook BEFORE blocking on
+        # the terminal-status poll.
+        def _checkpoint_dispatch(envelope: dict[str, Any]) -> None:
+            state.ralph_job_id = _optional_str(envelope.get("job_id"))
+            state.ralph_dispatch_mode = _optional_str(envelope.get("dispatch_mode"))
+            persisted_lineage = _optional_str(envelope.get("lineage_id"))
+            if persisted_lineage:
+                state.ralph_lineage_id = persisted_lineage
+            state.last_tool_name = "ralph_starter"
+            self._save(state)
+
+        # Q00/ouroboros#773 (review-7): decide compatibility BEFORE invocation,
+        # never by retrying on a post-dispatch ``TypeError``. ``RalphHandler``
+        # creates a brand-new background job on every call and has no
+        # idempotency key (unlike the run starter's ``idempotency_key`` path),
+        # so a second invocation after a real ``TypeError`` thrown post-dispatch
+        # would create a duplicate Ralph loop mutating the same lineage.
+        # Inspect the callable's signature once and route the kwargs through
+        # the right shape on a single attempt.
+        starter_kwargs: dict[str, Any] = {
+            "lineage_id": lineage_id,
+            "max_total_seconds": max_total_seconds,
+            "per_iteration_timeout_seconds": per_iteration_timeout_seconds,
+        }
+        if _accepts_keyword(self.ralph_starter, "on_dispatched"):
+            starter_kwargs["on_dispatched"] = _checkpoint_dispatch
         try:
-            ralph_meta = await self.ralph_starter(
-                seed,
-                lineage_id=lineage_id,
-                max_total_seconds=max_total_seconds,
-                per_iteration_timeout_seconds=per_iteration_timeout_seconds,
+            ralph_call = self.ralph_starter(seed, **starter_kwargs)
+            if state.deadline_at is None:
+                ralph_meta = await ralph_call
+            else:
+                ralph_timeout = max(0.0, state.deadline_at - time.monotonic())
+                ralph_meta = await asyncio.wait_for(ralph_call, timeout=ralph_timeout)
+        except TimeoutError:
+            # Even if the deadline trips, the Ralph job may already exist
+            # server-side (the dispatch checkpoint above persisted its
+            # handle). Resume will then poll it via ``_resume_ralph_handoff``
+            # rather than treating the session as terminally lost.
+            if self._enforce_deadline(state):
+                return self._result(
+                    state,
+                    ledger,
+                    review=review,
+                    blocker=state.last_error,
+                    run_subagent=run_subagent,
+                )
+            state.mark_blocked(
+                "ralph handoff timed out before terminal status",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
             )
         except Exception as exc:
             state.mark_failed(f"ralph handoff failed: {exc}", tool_name="ralph_starter")

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -175,6 +175,7 @@ class AutoPipeline:
         )
         if self.skip_run and not state.skip_run:
             state.skip_run = True
+        _arm_legacy_missing_deadline(state)
         # Top-level deadline check on resume (#779). When ``deadline_at`` is
         # already set and has passed before this process even starts work,
         # immediately transition to BLOCKED so no phase work is invoked. The
@@ -631,8 +632,11 @@ class AutoPipeline:
             run_meta: dict[str, Any] | None = None
             run_start_timeout = self._deadline_capped_timeout(state, self.run_start_timeout_seconds)
             try:
+                run_kwargs: dict[str, Any] = {}
+                if _accepts_keyword(self.run_starter, "idempotency_key"):
+                    run_kwargs["idempotency_key"] = idempotency_key
                 run_meta = await asyncio.wait_for(
-                    self.run_starter(seed, idempotency_key=idempotency_key),
+                    self.run_starter(seed, **run_kwargs),
                     timeout=run_start_timeout,
                 )
                 if not isinstance(run_meta, dict):
@@ -1276,7 +1280,19 @@ def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
         return AutoPhase.REVIEW
     if tool_name == "run_starter":
         return AutoPhase.RUN
+    if tool_name == "ralph_starter":
+        return AutoPhase.RALPH_HANDOFF
     return None
+
+
+def _arm_legacy_missing_deadline(state: AutoPipelineState) -> bool:
+    """Arm #779 deadline for legacy resumed sessions already past CREATED."""
+    if state.phase in {AutoPhase.CREATED, AutoPhase.COMPLETE}:
+        return False
+    if state.deadline_at is not None or state.deadline_at_epoch is not None:
+        return False
+    state.arm_deadline()
+    return True
 
 
 def _first_nonempty(*values: str | None) -> str | None:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -68,11 +68,6 @@ DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
 DEFAULT_PIPELINE_TIMEOUT_SECONDS: float = 7200.0
 MIN_PIPELINE_TIMEOUT_SECONDS: float = 60.0
 MAX_PIPELINE_TIMEOUT_SECONDS: float = 86400.0
-# TODO(#773): on RALPH_HANDOFF, pipeline computes
-# max_total_seconds = max(0.0, deadline_at - time.monotonic()) and forwards it
-# to ouroboros_ralph as the field added in #777. Hook lives in pipeline.py at
-# the run-handoff site once #773 introduces the RALPH_HANDOFF transition.
-
 # Allowed keys for the optional gateway-provenance metadata recorded on auto state.
 # Strict allowlist: anything not listed here is dropped during redaction so that
 # tokens, credentials, or raw user utterances cannot be persisted by accident.
@@ -279,6 +274,13 @@ class AutoPipelineState:
     ralph_job_id: str | None = None
     ralph_lineage_id: str | None = None
     ralph_dispatch_mode: str | None = None
+    # Q00/ouroboros#773: persisted intent for ``--complete-product`` /
+    # ``complete_product=True``. The flag is durable session state — not a
+    # per-invocation argument — so a session originally started with
+    # ``--complete-product`` keeps chaining RUN → RALPH_HANDOFF on resume even
+    # when the operator forgets to re-pass the flag. Defaults to False so
+    # legacy state files load unchanged.
+    complete_product: bool = False
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
@@ -581,6 +583,7 @@ class AutoPipelineState:
         payload.setdefault("ralph_job_id", None)
         payload.setdefault("ralph_lineage_id", None)
         payload.setdefault("ralph_dispatch_mode", None)
+        payload.setdefault("complete_product", False)
         payload.setdefault("provenance", None)
         payload.setdefault("auto_answer_log", [])
         payload.setdefault("seed_origin", SeedOrigin.NONE.value)
@@ -786,7 +789,12 @@ class AutoPipelineState:
             if not value.strip():
                 msg = f"{field_name} must be a non-empty string or null"
                 raise ValueError(msg)
-        for field_name in ("interview_completed", "skip_run", "run_start_attempted"):
+        for field_name in (
+            "interview_completed",
+            "skip_run",
+            "run_start_attempted",
+            "complete_product",
+        ):
             if type(getattr(self, field_name)) is not bool:
                 msg = f"{field_name} must be a boolean"
                 raise ValueError(msg)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -21,6 +21,7 @@ class AutoPhase(StrEnum):
     REVIEW = "review"
     REPAIR = "repair"
     RUN = "run"
+    RALPH_HANDOFF = "ralph_handoff"
     COMPLETE = "complete"
     BLOCKED = "blocked"
     FAILED = "failed"
@@ -197,7 +198,17 @@ _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
         AutoPhase.FAILED,
     },
     AutoPhase.REPAIR: {AutoPhase.REVIEW, AutoPhase.BLOCKED, AutoPhase.FAILED},
-    AutoPhase.RUN: {AutoPhase.COMPLETE, AutoPhase.BLOCKED, AutoPhase.FAILED},
+    AutoPhase.RUN: {
+        AutoPhase.COMPLETE,
+        AutoPhase.RALPH_HANDOFF,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    },
+    AutoPhase.RALPH_HANDOFF: {
+        AutoPhase.COMPLETE,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    },
     AutoPhase.COMPLETE: set(),
     AutoPhase.BLOCKED: {
         AutoPhase.INTERVIEW,
@@ -258,6 +269,14 @@ class AutoPipelineState:
     run_reconciliation_status: str | None = None
     run_reconciliation_source: str | None = None
     run_reconciled_at: str | None = None
+    # Ralph handoff persistence (Q00/ouroboros#773). Populated only when
+    # ``--complete-product`` chains RUN → RALPH_HANDOFF after a successful run
+    # handoff. ``ralph_dispatch_mode`` is ``"job"`` for in-process job-manager
+    # dispatches and ``"plugin"`` for OpenCode-plugin delegations. All three
+    # default to None so legacy state files load unchanged.
+    ralph_job_id: str | None = None
+    ralph_lineage_id: str | None = None
+    ralph_dispatch_mode: str | None = None
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)
@@ -544,6 +563,9 @@ class AutoPipelineState:
         payload.setdefault("run_reconciliation_status", None)
         payload.setdefault("run_reconciliation_source", None)
         payload.setdefault("run_reconciled_at", None)
+        payload.setdefault("ralph_job_id", None)
+        payload.setdefault("ralph_lineage_id", None)
+        payload.setdefault("ralph_dispatch_mode", None)
         payload.setdefault("provenance", None)
         payload.setdefault("auto_answer_log", [])
         payload.setdefault("seed_origin", SeedOrigin.NONE.value)
@@ -731,6 +753,9 @@ class AutoPipelineState:
             "run_reconciliation_status",
             "run_reconciliation_source",
             "run_reconciled_at",
+            "ralph_job_id",
+            "ralph_lineage_id",
+            "ralph_dispatch_mode",
             "last_grade",
             "pending_question",
             "last_tool_name",

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -215,12 +215,14 @@ _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
         AutoPhase.SEED_GENERATION,
         AutoPhase.REVIEW,
         AutoPhase.RUN,
+        AutoPhase.RALPH_HANDOFF,
     },
     AutoPhase.FAILED: {
         AutoPhase.INTERVIEW,
         AutoPhase.SEED_GENERATION,
         AutoPhase.REVIEW,
         AutoPhase.RUN,
+        AutoPhase.RALPH_HANDOFF,
     },
 }
 
@@ -523,6 +525,19 @@ class AutoPipelineState:
                 return AutoResumeCapability.RESUME
             if self.run_start_attempted:
                 return AutoResumeCapability.NONE
+            if self.seed_artifact:
+                return AutoResumeCapability.RESUME
+            if self.seed_path:
+                return AutoResumeCapability.PARTIAL_RESUME
+            return AutoResumeCapability.NONE
+
+        # Ralph handoff phase. Persisted Ralph handles or plugin dispatch
+        # markers let the pipeline resume without starting duplicate run/Ralph
+        # work; otherwise a Seed is enough to return to the checkpoint and
+        # surface manual recovery guidance.
+        if recoverable == AutoPhase.RALPH_HANDOFF:
+            if any((self.ralph_job_id, self.ralph_lineage_id, self.ralph_dispatch_mode)):
+                return AutoResumeCapability.RESUME
             if self.seed_artifact:
                 return AutoResumeCapability.RESUME
             if self.seed_path:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -13,6 +13,7 @@ import typer
 
 from ouroboros.auto.adapters import (
     HandlerInterviewBackend,
+    HandlerRalphStarter,
     HandlerRunStarter,
     HandlerSeedGenerator,
     load_seed,
@@ -37,6 +38,7 @@ from ouroboros.cli.formatters.panels import print_error, print_info, print_succe
 from ouroboros.config import get_opencode_mode
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.orchestrator import resolve_agent_runtime_backend
 
 
@@ -161,6 +163,17 @@ def auto_command(
             ),
         ),
     ] = None,
+    complete_product: Annotated[
+        bool,
+        typer.Option(
+            "--complete-product",
+            help=(
+                "Chain RUN → RALPH_HANDOFF after a successful run handoff so a "
+                "single ooo auto invocation iterates Ralph until QA passes, "
+                "convergence, or a budget bound trips. Default off."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Run an A-grade-gated auto pipeline.
 
@@ -205,6 +218,7 @@ def auto_command(
                 reconcile_run=reconcile_run,
                 reconcile_source=reconcile_source,
                 pipeline_timeout_seconds=timeout,
+                complete_product=complete_product,
                 progress_callback=_make_progress_renderer(quiet=quiet),
             )
         )
@@ -247,6 +261,7 @@ async def _run_auto(
     reconcile_run: bool = False,
     reconcile_source: str | None = None,
     pipeline_timeout_seconds: float | None = None,
+    complete_product: bool = False,
     progress_callback: AutoProgressCallback | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
@@ -360,6 +375,13 @@ async def _run_auto(
         max_rounds=max_interview_rounds,
         timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
     )
+    ralph_starter = (
+        HandlerRalphStarter(
+            RalphHandler(agent_runtime_backend=runtime, opencode_mode=opencode_mode)
+        )
+        if complete_product
+        else None
+    )
     pipeline = AutoPipeline(
         driver,
         HandlerSeedGenerator(generate_seed),
@@ -375,6 +397,8 @@ async def _run_auto(
         attach_source=attach_source,
         reconcile_run=reconcile_run,
         reconcile_source=reconcile_source,
+        ralph_starter=ralph_starter,
+        complete_product=complete_product,
         progress_callback=progress_callback,
     )
     result = await pipeline.run(state)

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -318,6 +318,17 @@ async def _run_auto(
         else:
             state.max_repair_rounds = max_repair_rounds
         skip_run = skip_run or state.skip_run
+        # Q00/ouroboros#773 (review-3): ``--complete-product`` is durable
+        # session intent, not a per-invocation flag. Honor the persisted value
+        # on resume so a session originally started with ``--complete-product``
+        # keeps chaining RUN → RALPH_HANDOFF even when the operator forgets to
+        # re-pass the flag. Lowering on resume is rejected to mirror the
+        # ``--max-*-rounds`` policy: a bound that already shaped behavior must
+        # be raised explicitly, never silently tightened.
+        if state.complete_product and not complete_product:
+            complete_product = True
+        elif complete_product and not state.complete_product:
+            state.complete_product = True
     else:
         if goal is None or not goal.strip():
             raise ValueError("goal is required when not resuming")
@@ -331,6 +342,7 @@ async def _run_auto(
         state.skip_run = skip_run
         state.max_interview_rounds = max_interview_rounds
         state.max_repair_rounds = max_repair_rounds
+        state.complete_product = complete_product
         if pipeline_timeout_seconds is not None:
             state.pipeline_timeout_seconds = float(pipeline_timeout_seconds)
 

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -13,6 +13,7 @@ import typer
 
 from ouroboros.auto.adapters import (
     HandlerInterviewBackend,
+    HandlerRalphPoller,
     HandlerRalphStarter,
     HandlerRunStarter,
     HandlerSeedGenerator,
@@ -387,13 +388,20 @@ async def _run_auto(
         max_rounds=max_interview_rounds,
         timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
     )
-    ralph_starter = (
-        HandlerRalphStarter(
-            RalphHandler(agent_runtime_backend=runtime, opencode_mode=opencode_mode)
-        )
+    ralph_handler = (
+        RalphHandler(agent_runtime_backend=runtime, opencode_mode=opencode_mode)
         if complete_product
         else None
     )
+    ralph_starter = HandlerRalphStarter(ralph_handler) if ralph_handler is not None else None
+    # Q00/ouroboros#773 (review-5 finding 1): wire a poller backed by the same
+    # ``RalphHandler`` so a session interrupted in ``RALPH_HANDOFF`` (e.g.
+    # client disconnects while the background Ralph job keeps running) can
+    # actually be reconciled to ``COMPLETE`` / ``BLOCKED`` / ``FAILED`` on
+    # ``--resume`` instead of being stranded in the non-terminal handoff
+    # state forever. Sharing the handler reuses the same ``JobManager``
+    # (and underlying ``EventStore``) so the poller sees the persisted job.
+    ralph_resumer = HandlerRalphPoller(ralph_handler) if ralph_handler is not None else None
     pipeline = AutoPipeline(
         driver,
         HandlerSeedGenerator(generate_seed),
@@ -410,6 +418,7 @@ async def _run_auto(
         reconcile_run=reconcile_run,
         reconcile_source=reconcile_source,
         ralph_starter=ralph_starter,
+        ralph_resumer=ralph_resumer,
         complete_product=complete_product,
         progress_callback=progress_callback,
     )

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from ouroboros.auto.adapters import (
     HandlerInterviewBackend,
+    HandlerRalphPoller,
     HandlerRalphStarter,
     HandlerRunStarter,
     HandlerSeedGenerator,
@@ -308,16 +309,23 @@ class AutoHandler:
             timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
             context_provider=context_provider,
         )
-        ralph_starter = (
-            HandlerRalphStarter(
-                RalphHandler(
-                    agent_runtime_backend=runtime_backend,
-                    opencode_mode=opencode_mode,
-                )
+        ralph_handler = (
+            RalphHandler(
+                agent_runtime_backend=runtime_backend,
+                opencode_mode=opencode_mode,
             )
             if complete_product
             else None
         )
+        ralph_starter = HandlerRalphStarter(ralph_handler) if ralph_handler is not None else None
+        # Q00/ouroboros#773 (review-5 finding 1): wire a poller backed by the
+        # same ``RalphHandler`` so MCP-side resumes of an interrupted
+        # ``RALPH_HANDOFF`` checkpoint actually reconcile the persisted job
+        # to a terminal auto phase. The same handler is reused so both the
+        # starter and the poller share a ``JobManager`` (and underlying
+        # ``EventStore``) — without that share the poller would query a
+        # fresh, empty job table.
+        ralph_resumer = HandlerRalphPoller(ralph_handler) if ralph_handler is not None else None
         pipeline = AutoPipeline(
             driver,
             HandlerSeedGenerator(generate_seed_handler),
@@ -334,6 +342,7 @@ class AutoHandler:
             reconcile_run=reconcile_run,
             reconcile_source=reconcile_source,
             ralph_starter=ralph_starter,
+            ralph_resumer=ralph_resumer,
             complete_product=complete_product,
         )
         return await pipeline.run(state)

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -381,6 +381,18 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["run_reconciliation_status"] = result.run_reconciliation_status
         meta["run_reconciliation_source"] = result.run_reconciliation_source
         meta["run_reconciled_at"] = result.run_reconciled_at
+    # Q00/ouroboros#773 (review-4): surface Ralph handoff tracking handles on
+    # the MCP result contract. Without these, plugin-mode dispatches and
+    # mid-loop checkpoints expose no structured handle for clients to monitor
+    # or correlate the Ralph work, forcing them to read local state files
+    # out-of-band. Each field is emitted only when populated so default-off
+    # ``complete_product=False`` runs keep the legacy meta shape byte-identical.
+    if result.ralph_job_id:
+        meta["ralph_job_id"] = result.ralph_job_id
+    if result.ralph_lineage_id:
+        meta["ralph_lineage_id"] = result.ralph_lineage_id
+    if result.ralph_dispatch_mode:
+        meta["ralph_dispatch_mode"] = result.ralph_dispatch_mode
     # Always emit the ledger-provenance surface so MCP clients can distinguish
     # "computed and empty" (no resolved sections yet, or no per-source split
     # available) from "field not provided at all".  Empty containers are part
@@ -651,6 +663,14 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.append(f"Run reconciliation status: {result.run_reconciliation_status}")
         lines.append(f"Run reconciliation source: {result.run_reconciliation_source}")
         lines.append(f"Run reconciled at: {result.run_reconciled_at}")
+    if result.ralph_dispatch_mode or result.ralph_job_id or result.ralph_lineage_id:
+        lines.append("Ralph handoff:")
+        if result.ralph_dispatch_mode:
+            lines.append(f"  dispatch_mode: {result.ralph_dispatch_mode}")
+        if result.ralph_job_id:
+            lines.append(f"  job_id: {result.ralph_job_id}")
+        if result.ralph_lineage_id:
+            lines.append(f"  lineage_id: {result.ralph_lineage_id}")
     if result.assumptions:
         lines.append("Assumptions:")
         lines.extend(f"- {item}" for item in result.assumptions)

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from ouroboros.auto.adapters import (
     HandlerInterviewBackend,
+    HandlerRalphStarter,
     HandlerRunStarter,
     HandlerSeedGenerator,
     load_seed,
@@ -36,6 +37,7 @@ from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import (
     ContentType,
     MCPContentItem,
@@ -159,6 +161,18 @@ class AutoHandler:
                     ),
                     required=False,
                 ),
+                MCPToolParameter(
+                    "complete_product",
+                    ToolInputType.BOOLEAN,
+                    (
+                        "When true, chain RUN → RALPH_HANDOFF after a successful run "
+                        "handoff so a single ouroboros_auto invocation iterates Ralph "
+                        "until QA passes, convergence, or a budget bound trips. "
+                        "Defaults to false (opt-in)."
+                    ),
+                    required=False,
+                    default=False,
+                ),
             ),
         )
 
@@ -186,6 +200,7 @@ class AutoHandler:
         store = self.store or AutoStore()
         resume = arguments.get("resume")
         requested_skip_run = bool(arguments.get("skip_run", False))
+        complete_product = bool(arguments.get("complete_product", False))
         attach_execution = _optional_text_arg(arguments, "attach_execution")
         attach_job = _optional_text_arg(arguments, "attach_job")
         attach_session = _optional_text_arg(arguments, "attach_session")
@@ -283,6 +298,16 @@ class AutoHandler:
             timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
             context_provider=context_provider,
         )
+        ralph_starter = (
+            HandlerRalphStarter(
+                RalphHandler(
+                    agent_runtime_backend=runtime_backend,
+                    opencode_mode=opencode_mode,
+                )
+            )
+            if complete_product
+            else None
+        )
         pipeline = AutoPipeline(
             driver,
             HandlerSeedGenerator(generate_seed_handler),
@@ -298,6 +323,8 @@ class AutoHandler:
             attach_source=attach_source,
             reconcile_run=reconcile_run,
             reconcile_source=reconcile_source,
+            ralph_starter=ralph_starter,
+            complete_product=complete_product,
         )
         return await pipeline.run(state)
 

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -248,6 +248,15 @@ class AutoHandler:
             # the same input converges to the same Seed.
             if user_preferences_supplied:
                 state.user_preferences = dict(supplied_user_preferences)
+            # Q00/ouroboros#773 (review-3): ``complete_product`` is durable
+            # session intent, not a per-invocation flag. Honor the persisted
+            # value so MCP callers that omit ``complete_product`` on resume
+            # still chain RUN → RALPH_HANDOFF for sessions that originally
+            # opted in. Mirrors the CLI policy in ``cli/commands/auto.py``.
+            if state.complete_product and not complete_product:
+                complete_product = True
+            elif complete_product and not state.complete_product:
+                state.complete_product = True
         else:
             goal = arguments.get("goal")
             if not isinstance(goal, str) or not goal.strip():
@@ -262,6 +271,7 @@ class AutoHandler:
             state.user_preferences = dict(supplied_user_preferences)
             state.max_interview_rounds = max_interview_rounds
             state.max_repair_rounds = max_repair_rounds
+            state.complete_product = complete_product
             if pipeline_timeout_seconds is not None:
                 state.pipeline_timeout_seconds = pipeline_timeout_seconds
         state.runtime_backend = runtime_backend

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1327,7 +1327,6 @@ def build_ralph_subagent(
             f"invocation exceeds {per_iteration_timeout_seconds:g} seconds; "
             "that satisfies the public contract `stop_reason=iteration_timeout`.\n"
         )
-
     progress_stop_lines: list[str] = []
     if oscillation_window is not None:
         progress_stop_lines.append(
@@ -1411,12 +1410,12 @@ do not enqueue another background Ralph job."""
     }
     if per_iteration_timeout_seconds is not None:
         context["per_iteration_timeout_seconds"] = per_iteration_timeout_seconds
+    if max_total_seconds is not None:
+        context["max_total_seconds"] = max_total_seconds
     if oscillation_window is not None:
         context["oscillation_window"] = oscillation_window
     if grade_regression_window is not None:
         context["grade_regression_window"] = grade_regression_window
-    if max_total_seconds is not None:
-        context["max_total_seconds"] = max_total_seconds
 
     return build_subagent_payload(
         tool_name="ouroboros_ralph",

--- a/tests/unit/auto/test_pipeline_deadline.py
+++ b/tests/unit/auto/test_pipeline_deadline.py
@@ -353,6 +353,26 @@ async def test_resume_after_deadline_expired_immediately_blocks(tmp_path) -> Non
     assert driver.invocations == 0
 
 
+@pytest.mark.asyncio
+async def test_legacy_non_created_resume_with_missing_deadline_gets_armed(tmp_path) -> None:
+    """Legacy states past CREATED must not bypass the top-level deadline forever."""
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "legacy interview checkpoint")
+    state.last_tool_name = "unknown_legacy_tool"
+    state.mark_blocked("legacy blocked checkpoint", tool_name="unknown_legacy_tool")
+    assert state.deadline_at is None
+    assert state.deadline_at_epoch is None
+
+    pipeline = AutoPipeline(_NeverInterviewDriver(), _unused_seed_generator)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_error == "legacy blocked checkpoint"
+    assert state.deadline_at is not None
+    assert state.deadline_at_epoch is not None
+
+
 def test_arm_deadline_is_idempotent() -> None:
     """Re-calling ``arm_deadline()`` must not silently shift the absolute target."""
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -934,10 +934,11 @@ async def test_handoff_to_ralph_persists_job_id_before_terminal_poll(tmp_path) -
 @pytest.mark.asyncio
 async def test_handoff_to_ralph_falls_back_for_legacy_starter_without_hook(tmp_path) -> None:
     """Older ``RalphStarter`` implementations that don't accept the
-    ``on_dispatched`` keyword must still work — the pipeline retries
-    without the hook so the legacy contract is preserved (the test/library
-    callers without a job manager opt out of the early-checkpoint
-    guarantee, accepting the documented stranded-resume risk)."""
+    ``on_dispatched`` keyword must still work — the pipeline detects the
+    signature before invocation and calls without the hook so the legacy
+    contract is preserved (the test/library callers without a job manager
+    opt out of the early-checkpoint guarantee, accepting the documented
+    stranded-resume risk)."""
     state = _state_at_run_phase(tmp_path)
 
     async def legacy_ralph_starter(
@@ -968,3 +969,48 @@ async def test_handoff_to_ralph_falls_back_for_legacy_starter_without_hook(tmp_p
 
     assert result.status == "complete"
     assert state.ralph_job_id == "job_legacy_ralph"
+
+
+@pytest.mark.asyncio
+async def test_handoff_to_ralph_does_not_retry_type_error_after_dispatch(tmp_path) -> None:
+    """A starter that accepts ``on_dispatched`` and then fails with
+    ``TypeError`` has already dispatched Ralph work, so the pipeline must
+    fail the session without invoking the starter a second time."""
+    state = _state_at_run_phase(tmp_path)
+    calls = 0
+
+    async def ralph_starter(
+        _seed: Seed,
+        *,
+        lineage_id: str,
+        on_dispatched: Any | None = None,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if on_dispatched is not None:
+            on_dispatched(
+                {
+                    "job_id": "job_ralph_dispatched_once",
+                    "lineage_id": lineage_id,
+                    "dispatch_mode": "job",
+                }
+            )
+        raise TypeError("starter failed after dispatch")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert calls == 1
+    assert result.status == "failed"
+    assert state.phase is AutoPhase.FAILED
+    assert state.ralph_job_id == "job_ralph_dispatched_once"
+    assert state.last_error == "ralph handoff failed: starter failed after dispatch"

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -21,12 +21,14 @@ from ouroboros.auto.pipeline import (
     PIPELINE_DEADLINE_TOOL_NAME,
     AutoPipeline,
     AutoPipelineResult,
+    _recoverable_phase_for_tool,
 )
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
     _ALLOWED_TRANSITIONS,
     AutoPhase,
     AutoPipelineState,
+    AutoResumeCapability,
 )
 from ouroboros.core.seed import (
     EvaluationPrinciple,
@@ -172,6 +174,8 @@ def test_state_machine_allows_ralph_handoff_terminal_transitions() -> None:
         AutoPhase.BLOCKED,
         AutoPhase.FAILED,
     }
+    assert AutoPhase.RALPH_HANDOFF in _ALLOWED_TRANSITIONS[AutoPhase.BLOCKED]
+    assert AutoPhase.RALPH_HANDOFF in _ALLOWED_TRANSITIONS[AutoPhase.FAILED]
 
 
 def test_blocked_stop_reasons_pinned() -> None:
@@ -188,6 +192,15 @@ def test_blocked_stop_reasons_pinned() -> None:
         )
         == _RALPH_BLOCKED_STOP_REASONS
     )
+
+
+def test_ralph_starter_blocker_is_recoverable_to_ralph_handoff(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+    state.ralph_lineage_id = "ralph-seed_test_001-auto_abc"
+    state.mark_blocked("iteration_timeout", tool_name="ralph_starter")
+
+    assert _recoverable_phase_for_tool("ralph_starter") is AutoPhase.RALPH_HANDOFF
+    assert state.resume_capability() is AutoResumeCapability.RESUME
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -478,3 +478,180 @@ async def test_complete_product_off_matches_legacy_shape(tmp_path) -> None:
     assert payload["ralph_job_id"] is None
     assert payload["ralph_lineage_id"] is None
     assert payload["ralph_dispatch_mode"] is None
+
+
+# ---------------------------------------------------------------------------
+# Pipeline deadline contract — per-iteration cap (review-3 finding 1).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_caps_per_iteration_at_remaining_budget(tmp_path) -> None:
+    """A short remaining budget caps ``per_iteration_timeout_seconds``.
+
+    ``RalphLoopRunner`` checks ``max_total_seconds`` only at the top of each
+    iteration. Without a per-iteration cap, the first iteration could still
+    block for the full 1800s default after the deadline expired. Pinning the
+    forwarded value here ensures the deadline contract is honored even on
+    ralph's first generation.
+    """
+    state = _state_at_run_phase(tmp_path)
+    # 60s remaining is well above the 1s minimum and 30s per-iteration floor,
+    # but well below the 1800s default — the cap must equal the remaining.
+    remaining = 60.0
+    state.deadline_at = time.monotonic() + remaining
+    state.deadline_at_epoch = time.time() + remaining
+
+    captured: dict[str, Any] = {}
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        captured["kwargs"] = kwargs
+        return {
+            "job_id": "job_ralph_capped",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    forwarded = captured["kwargs"]
+    assert forwarded["max_total_seconds"] is not None
+    assert forwarded["max_total_seconds"] <= remaining
+    # The per-iteration cap must be at most the remaining budget so a single
+    # ``evolve_step`` cannot block past ``deadline_at``.
+    assert forwarded["per_iteration_timeout_seconds"] is not None
+    assert forwarded["per_iteration_timeout_seconds"] <= remaining
+    # Floor at the Ralph handler's per-iteration minimum (30s).
+    assert forwarded["per_iteration_timeout_seconds"] >= 30.0
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_uses_default_per_iteration_with_ample_budget(tmp_path) -> None:
+    """When remaining budget exceeds the Ralph default, no tighter cap is forwarded.
+
+    Pinning the upper bound prevents accidental over-tightening for the
+    common case (2h default deadline, RUN reached early with hours of
+    budget left): the bot's contract is to honor the deadline, not to
+    aggressively shrink the per-iteration budget below the established
+    1800s default.
+    """
+    state = _state_at_run_phase(tmp_path)
+    # Two hours remaining — well above the 1800s default.
+    state.deadline_at = time.monotonic() + 7200.0
+    state.deadline_at_epoch = time.time() + 7200.0
+
+    captured: dict[str, Any] = {}
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        captured["kwargs"] = kwargs
+        return {
+            "job_id": "job_ralph_default",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    await pipeline.run(state)
+
+    forwarded = captured["kwargs"]
+    # Remaining is much greater than 1800s, so the cap saturates at the
+    # Ralph default — never above it.
+    assert forwarded["per_iteration_timeout_seconds"] == 1800.0
+
+
+# ---------------------------------------------------------------------------
+# Persisted complete_product intent (review-3 finding 2).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_promotes_complete_product_from_persisted_state(tmp_path) -> None:
+    """A session originally started with ``complete_product=True`` keeps the
+    RUN → RALPH_HANDOFF chain on resume even if the caller forgot to re-pass
+    the flag at construction time.
+    """
+    state = _state_at_run_phase(tmp_path)
+    state.complete_product = True
+
+    captured: dict[str, Any] = {}
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        captured["kwargs"] = kwargs
+        return {
+            "job_id": "job_ralph_promoted",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    # Construct the pipeline WITHOUT complete_product=True — only the
+    # persisted state carries the intent. The pipeline must still reach the
+    # ralph handoff because the persisted intent dominates an absent flag.
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=False,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.ralph_job_id == "job_ralph_promoted"
+    assert "kwargs" in captured  # ralph_starter actually invoked
+    # The pipeline's effective complete_product reflects the persisted truth.
+    assert pipeline.complete_product is True
+
+
+def test_state_persists_complete_product_field(tmp_path) -> None:
+    """``complete_product`` must survive ``to_dict`` / ``from_dict`` round-trips.
+
+    Without persistence, a session originally started with the flag would
+    silently fall back to legacy RUN→COMPLETE behavior on resume.
+    """
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.complete_product = True
+    payload = state.to_dict()
+    assert payload["complete_product"] is True
+    restored = AutoPipelineState.from_dict(payload)
+    assert restored.complete_product is True
+
+
+def test_state_legacy_payload_defaults_complete_product_false(tmp_path) -> None:
+    """Legacy state files without ``complete_product`` must load with default False.
+
+    Pre-#773 (review-3) state files do not have the field; loading must not
+    raise and must surface the default-off semantics so existing sessions
+    keep their pre-promotion behavior.
+    """
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    payload = state.to_dict()
+    payload.pop("complete_product")
+    restored = AutoPipelineState.from_dict(payload)
+    assert restored.complete_product is False

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -860,3 +860,111 @@ async def test_run_resume_with_persisted_handle_complete_product_off_completes(
     assert result.status == "complete"
     assert state.phase is AutoPhase.COMPLETE
     assert state.ralph_job_id is None
+
+
+# ---------------------------------------------------------------------------
+# Early dispatch checkpoint — review-6.
+#
+# The Ralph tracking handle must be persisted IMMEDIATELY after the background
+# job is created, BEFORE the auto pipeline blocks on terminal completion.
+# Otherwise a process restart between dispatch and terminal would leave the
+# state with only ``ralph_lineage_id`` and ``_resume_ralph_handoff`` could
+# not poll the still-running Ralph job — reintroducing the stranded-resume
+# bug review-5 was meant to solve.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handoff_to_ralph_persists_job_id_before_terminal_poll(tmp_path) -> None:
+    """``ralph_starter`` receives an ``on_dispatched`` hook and the auto
+    pipeline checkpoints ``ralph_job_id`` synchronously inside that hook —
+    BEFORE the starter's terminal-status await returns."""
+    state = _state_at_run_phase(tmp_path)
+
+    captured: dict[str, Any] = {}
+
+    async def ralph_starter(
+        _seed: Seed,
+        *,
+        lineage_id: str,
+        on_dispatched: Any | None = None,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        # Simulate a real ``HandlerRalphStarter``: emit the dispatch
+        # envelope BEFORE returning the terminal envelope. Capture the
+        # state snapshot at the moment the checkpoint fires so the
+        # assertion can prove ``state.ralph_job_id`` was already set
+        # by the time terminal completion is reached.
+        if on_dispatched is not None:
+            on_dispatched(
+                {
+                    "job_id": "job_ralph_early",
+                    "lineage_id": lineage_id,
+                    "dispatch_mode": "job",
+                }
+            )
+        captured["job_id_at_dispatch"] = state.ralph_job_id
+        return {
+            "job_id": "job_ralph_early",
+            "lineage_id": lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    # The checkpoint hook fired BEFORE the starter returned the terminal
+    # envelope, so ``state.ralph_job_id`` was already populated when the
+    # snapshot was taken — proving the dispatch handle is durable across
+    # a hypothetical process death between dispatch and terminal.
+    assert captured["job_id_at_dispatch"] == "job_ralph_early"
+
+
+@pytest.mark.asyncio
+async def test_handoff_to_ralph_falls_back_for_legacy_starter_without_hook(tmp_path) -> None:
+    """Older ``RalphStarter`` implementations that don't accept the
+    ``on_dispatched`` keyword must still work — the pipeline retries
+    without the hook so the legacy contract is preserved (the test/library
+    callers without a job manager opt out of the early-checkpoint
+    guarantee, accepting the documented stranded-resume risk)."""
+    state = _state_at_run_phase(tmp_path)
+
+    async def legacy_ralph_starter(
+        _seed: Seed,
+        *,
+        lineage_id: str,
+        max_total_seconds: float | None = None,  # noqa: ARG001
+        per_iteration_timeout_seconds: float | None = None,  # noqa: ARG001
+    ) -> dict[str, Any]:
+        return {
+            "job_id": "job_legacy_ralph",
+            "lineage_id": lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=legacy_ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.ralph_job_id == "job_legacy_ralph"

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -655,3 +655,208 @@ def test_state_legacy_payload_defaults_complete_product_false(tmp_path) -> None:
     payload.pop("complete_product")
     restored = AutoPipelineState.from_dict(payload)
     assert restored.complete_product is False
+
+
+# ---------------------------------------------------------------------------
+# Resume polling — review-5 finding 1.
+#
+# A session interrupted in ``RALPH_HANDOFF`` (e.g. MCP client disconnects
+# while the background Ralph job keeps running) must be reconciled to a
+# terminal auto phase on ``--resume``, not stranded forever.
+# ---------------------------------------------------------------------------
+
+
+def _state_in_ralph_handoff(tmp_path) -> AutoPipelineState:
+    """Build a state already persisted at ``RALPH_HANDOFF`` for resume tests."""
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_existing"
+    state.execution_id = "execution_existing"
+    state.run_session_id = "session_existing"
+    state.ralph_lineage_id = "ralph-seed_test_001-auto_abc"
+    state.ralph_job_id = "job_ralph_existing"
+    state.ralph_dispatch_mode = "job"
+    state.transition(AutoPhase.RALPH_HANDOFF, "persisted ralph checkpoint")
+    return state
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_polls_persisted_job_to_complete(tmp_path) -> None:
+    """Resume polls the persisted ``ralph_job_id`` and transitions to COMPLETE
+    when the loop has terminated successfully — closing the bot's review-5
+    finding 1 (stranded RALPH_HANDOFF on long-lived runtimes)."""
+    state = _state_in_ralph_handoff(tmp_path)
+
+    polled_job: dict[str, Any] = {}
+
+    async def ralph_resumer(*, job_id: str) -> dict[str, Any]:
+        polled_job["job_id"] = job_id
+        return {
+            "job_id": job_id,
+            "lineage_id": state.ralph_lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("resume must not start a duplicate Ralph handoff")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        ralph_resumer=ralph_resumer,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert polled_job["job_id"] == "job_ralph_existing"
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_polls_persisted_job_blocks_on_timeout(tmp_path) -> None:
+    """Resume maps an ``iteration_timeout`` terminal status onto ``BLOCKED``
+    so the same recovery contract used by fresh dispatch (#773) applies on
+    the resume path too."""
+    state = _state_in_ralph_handoff(tmp_path)
+
+    async def ralph_resumer(*, job_id: str) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "job_id": "job_ralph_existing",
+            "lineage_id": state.ralph_lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "failed",
+            "stop_reason": "iteration_timeout",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_resumer=ralph_resumer,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_error == "iteration_timeout"
+    assert state.last_tool_name == "ralph_starter"
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_falls_back_to_guidance_without_resumer(tmp_path) -> None:
+    """When no ``ralph_resumer`` is wired, resume preserves legacy
+    guidance-only behavior — no polling, no transition. This keeps in-process
+    test/library callers without a job-manager handle from breaking."""
+    state = _state_in_ralph_handoff(tmp_path)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        # No ralph_resumer.
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "ralph_handoff"
+    assert state.phase is AutoPhase.RALPH_HANDOFF
+    assert state.run_handoff_guidance is not None
+    assert "did not start duplicate run or Ralph work" in state.run_handoff_guidance
+
+
+# ---------------------------------------------------------------------------
+# Resume from RUN with persisted handle — review-5 finding 2.
+#
+# A crash between run-handoff and ``_handoff_to_ralph`` must NOT silently
+# bypass Ralph on resume when the operator opted into ``--complete-product``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_handle_and_complete_product_dispatches_ralph(
+    tmp_path,
+) -> None:
+    """RUN resume with persisted run handles MUST honor ``complete_product``
+    and continue to RALPH_HANDOFF, not short-circuit to COMPLETE."""
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_existing"
+    state.execution_id = "execution_existing"
+    state.run_session_id = "session_existing"
+    state.complete_product = True
+
+    captured: dict[str, Any] = {}
+
+    async def ralph_starter(seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        captured["seed"] = seed
+        captured["kwargs"] = kwargs
+        return {
+            "job_id": "job_ralph_resumed",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    async def run_starter(_seed: Seed, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("resume must not start a duplicate run")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=run_starter,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert "kwargs" in captured  # ralph_starter actually invoked
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.ralph_job_id == "job_ralph_resumed"
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_handle_complete_product_off_completes(
+    tmp_path,
+) -> None:
+    """``complete_product=False`` resume keeps the legacy short-circuit to
+    COMPLETE byte-identical so default-off callers see no behavior change."""
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_existing"
+    state.complete_product = False
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("complete_product=False must not invoke ralph_starter")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=False,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.ralph_job_id is None

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -9,6 +9,7 @@ pre-#773 result shape.
 from __future__ import annotations
 
 from dataclasses import asdict
+import time
 from typing import Any
 
 import pytest
@@ -17,6 +18,7 @@ from ouroboros.auto.grading import GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import AutoInterviewResult
 from ouroboros.auto.pipeline import (
     _RALPH_BLOCKED_STOP_REASONS,
+    PIPELINE_DEADLINE_TOOL_NAME,
     AutoPipeline,
     AutoPipelineResult,
 )
@@ -343,6 +345,87 @@ async def test_ralph_plugin_delegation_completes_auto(tmp_path) -> None:
     # Plugin guidance must surface for the operator.
     assert state.run_handoff_guidance is not None
     assert "OpenCode" in state.run_handoff_guidance
+
+
+# ---------------------------------------------------------------------------
+# Resume safety — persisted RALPH_HANDOFF must not duplicate run/Ralph work.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_does_not_dispatch_duplicate_work(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_existing"
+    state.execution_id = "execution_existing"
+    state.run_session_id = "session_existing"
+    state.ralph_lineage_id = "ralph-seed_test_001-auto_abc"
+    state.ralph_job_id = "job_ralph_existing"
+    state.ralph_dispatch_mode = "job"
+    state.transition(AutoPhase.RALPH_HANDOFF, "persisted ralph checkpoint")
+
+    async def run_starter(_seed: Seed) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("resume must not start a duplicate run")
+
+    async def ralph_starter(_seed: Seed, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("resume must not start a duplicate Ralph handoff")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=run_starter,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "ralph_handoff"
+    assert result.resume_capability.value == "resume"
+    assert state.phase is AutoPhase.RALPH_HANDOFF
+    assert state.job_id == "job_run_existing"
+    assert state.ralph_job_id == "job_ralph_existing"
+    assert state.last_tool_name == "ralph_starter"
+    assert state.last_error is None
+    assert state.run_handoff_guidance is not None
+    assert "did not start duplicate run or Ralph work" in state.run_handoff_guidance
+
+
+# ---------------------------------------------------------------------------
+# Pipeline deadline budget — insufficient Ralph budget is pipeline_timeout.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insufficient_ralph_deadline_budget_blocks_as_pipeline_timeout(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+    state.deadline_at = time.monotonic() + 0.25
+    state.deadline_at_epoch = time.time() + 0.25
+
+    async def ralph_starter(_seed: Seed, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("insufficient pipeline budget must not call ralph_starter")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == PIPELINE_DEADLINE_TOOL_NAME
+    assert state.last_error is not None
+    assert "pipeline_timeout" in state.last_error
+    assert "below Ralph minimum" in state.last_error
+    assert state.ralph_job_id is None
+    assert state.ralph_dispatch_mode is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1,0 +1,384 @@
+"""Regression tests for the RUN → RALPH_HANDOFF chain (Q00/ouroboros#773).
+
+The chain is opt-in via ``--complete-product`` / ``complete_product=True`` and
+maps the Ralph loop's terminal status onto an auto phase per the contract
+pinned in this file. Default-off behavior must be byte-identical to the
+pre-#773 result shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.grading import GradeResult, SeedGrade
+from ouroboros.auto.interview_driver import AutoInterviewResult
+from ouroboros.auto.pipeline import (
+    _RALPH_BLOCKED_STOP_REASONS,
+    AutoPipeline,
+    AutoPipelineResult,
+)
+from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
+from ouroboros.auto.state import (
+    _ALLOWED_TRANSITIONS,
+    AutoPhase,
+    AutoPipelineState,
+)
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _build_seed(seed_id: str = "seed_test_001") -> Seed:
+    """Build the smallest valid Seed the auto pipeline tests can carry through."""
+    return Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(
+                OntologyField(
+                    name="command",
+                    field_type="string",
+                    description="Command",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="testability",
+                description="Observable behavior",
+                weight=1.0,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(seed_id=seed_id, ambiguity_score=0.12),
+    )
+
+
+class _StubInterviewDriver:
+    """Interview driver stub that returns ``seed_ready`` immediately.
+
+    Matches the duck-typed contract used by ``AutoPipeline.run`` — the
+    driver is only invoked from the INTERVIEW phase and we shortcut
+    through it because the focus of these tests is the RUN → RALPH_HANDOFF
+    transition, not the interview machinery.
+    """
+
+    def __init__(self) -> None:
+        self.invocations = 0
+        self.progress_callback = None
+
+    async def run(self, state: AutoPipelineState, ledger: Any) -> AutoInterviewResult:
+        self.invocations += 1
+        state.interview_session_id = "interview_stub"
+        state.interview_completed = True
+        return AutoInterviewResult(
+            status="seed_ready",
+            session_id="interview_stub",
+            ledger=ledger,
+            rounds=1,
+        )
+
+
+def _state_at_run_phase(tmp_path) -> AutoPipelineState:
+    """Build an :class:`AutoPipelineState` already armed and at RUN phase.
+
+    Bypasses interview/seed-generation/review by setting the persisted Seed
+    artifact and walking the state machine forward via ``transition`` so we
+    only exercise the run-handoff → ralph-handoff transition under test.
+    """
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.arm_deadline()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_stub"
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    seed = _build_seed()
+    state.seed_id = seed.metadata.seed_id
+    state.seed_artifact = seed.to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    return state
+
+
+async def _run_starter_ok(_seed: Seed) -> dict[str, Any]:
+    """Minimal run-starter stub returning a job_id like ``HandlerRunStarter``."""
+    return {
+        "job_id": "job_run_001",
+        "session_id": "exec_session_001",
+        "execution_id": "execution_001",
+    }
+
+
+async def _seed_generator_unused(_session_id: str) -> Seed:  # pragma: no cover
+    raise AssertionError("seed generator should not run when seed_artifact is set")
+
+
+class _PassReviewer(SeedReviewer):
+    """SeedReviewer stub that always passes the grade gate.
+
+    The full GradeGate has stricter requirements than the deliberately
+    minimal Seed used in these tests; bypassing it isolates the
+    transition-under-test from the reviewer's evaluation logic.
+    """
+
+    def __init__(self) -> None:  # noqa: D401 - intentionally trivial
+        pass
+
+    def review(self, seed: Seed, *, ledger: Any = None) -> SeedReview:  # noqa: ARG002
+        grade = GradeResult(
+            grade=SeedGrade.A,
+            scores={},
+            findings=[],
+            blockers=[],
+            may_run=True,
+        )
+        return SeedReview(grade_result=grade, findings=())
+
+
+# ---------------------------------------------------------------------------
+# State machine — transitions added by #773
+# ---------------------------------------------------------------------------
+
+
+def test_state_machine_allows_run_to_ralph_handoff() -> None:
+    """``RUN → RALPH_HANDOFF`` must be in ``_ALLOWED_TRANSITIONS`` per the issue."""
+    assert AutoPhase.RALPH_HANDOFF in _ALLOWED_TRANSITIONS[AutoPhase.RUN]
+
+
+def test_state_machine_allows_ralph_handoff_terminal_transitions() -> None:
+    """RALPH_HANDOFF must be terminal-bound to COMPLETE/BLOCKED/FAILED."""
+    assert _ALLOWED_TRANSITIONS[AutoPhase.RALPH_HANDOFF] == {
+        AutoPhase.COMPLETE,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    }
+
+
+def test_blocked_stop_reasons_pinned() -> None:
+    """The stop-reason → BLOCKED mapping is pinned by tests, not ad-hoc."""
+    assert (
+        frozenset(
+            {
+                "iteration_timeout",
+                "wall_clock_exhausted",
+                "oscillation_detected",
+                "grade_regressing",
+                "max_generations reached",
+            }
+        )
+        == _RALPH_BLOCKED_STOP_REASONS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path — ralph completes ⇒ auto state COMPLETE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_qa_passed_completes_auto(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+
+    captured: dict[str, Any] = {}
+
+    async def ralph_starter(seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        captured["seed"] = seed
+        captured["kwargs"] = kwargs
+        return {
+            "job_id": "job_ralph_001",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.ralph_job_id == "job_ralph_001"
+    assert state.ralph_dispatch_mode == "job"
+    assert result.ralph_job_id == "job_ralph_001"
+    assert result.ralph_dispatch_mode == "job"
+    # ``lineage_id`` is deterministic per the issue contract
+    # ``f"ralph-{seed.metadata.seed_id}-{auto_session_id[:8]}"``; the auto
+    # session id always starts with the literal ``"auto_"`` prefix so the
+    # 8-character slice begins after the underscore.
+    assert state.ralph_lineage_id is not None
+    assert state.ralph_lineage_id.startswith(f"ralph-{_build_seed().metadata.seed_id}-")
+    assert captured["kwargs"]["lineage_id"] == state.ralph_lineage_id
+
+
+# ---------------------------------------------------------------------------
+# Mapped-block stop_reason ⇒ BLOCKED with stop_reason in last_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_iteration_timeout_blocks_auto(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+
+    async def ralph_starter(_seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "job_id": "job_ralph_002",
+            "lineage_id": "ralph-x",
+            "dispatch_mode": "job",
+            "terminal_status": "failed",
+            "stop_reason": "iteration_timeout",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_error == "iteration_timeout"
+    assert "iteration_timeout" in (result.blocker or "")
+    assert state.ralph_job_id == "job_ralph_002"
+
+
+# ---------------------------------------------------------------------------
+# Unmapped failure ⇒ FAILED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_terminal_failure_fails_auto(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+
+    async def ralph_starter(_seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "job_id": "job_ralph_003",
+            "lineage_id": "ralph-x",
+            "dispatch_mode": "job",
+            "terminal_status": "failed",
+            "stop_reason": "interrupted",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert state.phase is AutoPhase.FAILED
+    assert "interrupted" in (state.last_error or "")
+
+
+# ---------------------------------------------------------------------------
+# Plugin delegation ⇒ COMPLETE + dispatch_mode=plugin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_plugin_delegation_completes_auto(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+
+    async def ralph_starter(_seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "job_id": None,
+            "lineage_id": "ralph-x",
+            "dispatch_mode": "plugin",
+            "terminal_status": "delegated_to_plugin",
+            "stop_reason": None,
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.ralph_dispatch_mode == "plugin"
+    assert state.ralph_job_id is None
+    assert result.ralph_dispatch_mode == "plugin"
+    # Plugin guidance must surface for the operator.
+    assert state.run_handoff_guidance is not None
+    assert "OpenCode" in state.run_handoff_guidance
+
+
+# ---------------------------------------------------------------------------
+# Flag-off regression: complete_product=False is identical to legacy behavior.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_product_off_matches_legacy_shape(tmp_path) -> None:
+    """``complete_product=False`` must transition straight to COMPLETE without ralph_*."""
+    state = _state_at_run_phase(tmp_path)
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run when complete_product is False")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=False,
+    )
+
+    result = await pipeline.run(state)
+
+    assert isinstance(result, AutoPipelineResult)
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    # All ralph_* state fields must remain at their default ``None`` so the
+    # persisted JSON shape and result shape stay byte-identical to pre-#773
+    # for default-off callers.
+    assert state.ralph_job_id is None
+    assert state.ralph_lineage_id is None
+    assert state.ralph_dispatch_mode is None
+    payload = asdict(result)
+    assert payload["ralph_job_id"] is None
+    assert payload["ralph_lineage_id"] is None
+    assert payload["ralph_dispatch_mode"] is None

--- a/tests/unit/mcp/tools/test_auto_handler_resume_lines.py
+++ b/tests/unit/mcp/tools/test_auto_handler_resume_lines.py
@@ -118,3 +118,74 @@ def test_handle_meta_resume_command_present_for_partial_resume() -> None:
     meta = _invoke(handler)
     assert meta["resume_capability"] == "partial_resume"
     assert meta["resume_command"] == "ooo auto --resume auto_mcp"
+
+
+# --- Ralph handoff meta surface (#773 review-4) -----------------------------
+
+
+def _ralph_result(
+    *,
+    job_id: str | None = "job_ralph_xyz",
+    lineage_id: str | None = "ralph-seed_test_001-auto_abcd",
+    dispatch_mode: str | None = "job",
+) -> AutoPipelineResult:
+    return AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_ralph",
+        phase="complete",
+        resume_capability=AutoResumeCapability.NONE,
+        ralph_job_id=job_id,
+        ralph_lineage_id=lineage_id,
+        ralph_dispatch_mode=dispatch_mode,
+    )
+
+
+def test_handle_meta_includes_ralph_handoff_handles_when_present() -> None:
+    """Bot review-4 blocking finding: MCP clients must be able to monitor and
+    correlate the Ralph loop they just dispatched. Without ``ralph_job_id`` /
+    ``ralph_lineage_id`` / ``ralph_dispatch_mode`` on the meta surface, plugin
+    delegations and mid-loop checkpoints expose no structured handle and
+    clients are forced to read local state files out-of-band.
+    """
+    handler = _StubAutoHandler(_ralph_result())
+    meta = _invoke(handler)
+    assert meta["ralph_job_id"] == "job_ralph_xyz"
+    assert meta["ralph_lineage_id"] == "ralph-seed_test_001-auto_abcd"
+    assert meta["ralph_dispatch_mode"] == "job"
+
+
+def test_handle_meta_includes_plugin_dispatch_mode() -> None:
+    """Plugin-mode delegations have ``job_id=None`` but still need a tracking
+    surface. ``lineage_id`` and ``dispatch_mode`` carry the correlation."""
+    handler = _StubAutoHandler(_ralph_result(job_id=None, dispatch_mode="plugin"))
+    meta = _invoke(handler)
+    assert "ralph_job_id" not in meta
+    assert meta["ralph_lineage_id"] == "ralph-seed_test_001-auto_abcd"
+    assert meta["ralph_dispatch_mode"] == "plugin"
+
+
+def test_handle_meta_omits_ralph_handles_for_legacy_complete_product_off() -> None:
+    """``complete_product=False`` runs must keep the meta shape byte-identical
+    to pre-#773 — none of the three Ralph fields appear when null."""
+    handler = _StubAutoHandler(_ralph_result(job_id=None, lineage_id=None, dispatch_mode=None))
+    meta = _invoke(handler)
+    assert "ralph_job_id" not in meta
+    assert "ralph_lineage_id" not in meta
+    assert "ralph_dispatch_mode" not in meta
+
+
+def test_format_result_renders_ralph_handoff_block_when_present() -> None:
+    """Human-readable text mirrors the structured meta so operators tailing
+    the MCP response without a JSON parser still see the Ralph handles."""
+    output = _format_result(_ralph_result(dispatch_mode="plugin", job_id=None))
+
+    assert "Ralph handoff:" in output
+    assert "dispatch_mode: plugin" in output
+    assert "lineage_id: ralph-seed_test_001-auto_abcd" in output
+    assert "job_id:" not in output  # plugin mode has no job
+
+
+def test_format_result_omits_ralph_block_when_no_handoff() -> None:
+    output = _format_result(_ralph_result(job_id=None, lineage_id=None, dispatch_mode=None))
+
+    assert "Ralph handoff:" not in output

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -270,6 +270,7 @@ class TestBuildRalphSubagent:
             "allow_nested_ouroboros_ralph": False,
         }
         assert "per_iteration_timeout_seconds" not in payload.context
+        assert "max_total_seconds" not in payload.context
 
     def test_forwards_per_iteration_timeout_to_prompt_and_context(self) -> None:
         payload = build_ralph_subagent(

--- a/tests/unit/test_ralph_loop_timeout.py
+++ b/tests/unit/test_ralph_loop_timeout.py
@@ -221,16 +221,16 @@ async def test_ralph_handler_rejects_non_finite_per_iteration_timeout(
 
 
 @pytest.mark.asyncio
-async def test_plugin_dispatch_forwards_per_iteration_timeout_seconds(
+async def test_plugin_dispatch_forwards_timeout_seconds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Plugin-mode dispatch must forward per_iteration_timeout_seconds.
+    """Plugin-mode dispatch must forward per-iteration and total timeouts.
 
     Wiring lock for #784 review-1: when ``should_dispatch_via_plugin`` returns
     True, the produced ``_subagent`` payload context must include
-    ``per_iteration_timeout_seconds``. Otherwise the public stop-reason
-    contract (``iteration_timeout``) is silently dropped on the plugin path
-    and the child session can hang indefinitely.
+    timeout fields. Otherwise the public stop-reason contracts are silently
+    dropped on the plugin path and the child session can exceed its parent
+    deadline indefinitely.
     """
     import json as _json
 
@@ -258,6 +258,7 @@ async def test_plugin_dispatch_forwards_per_iteration_timeout_seconds(
             "seed_content": "goal: ship",
             "max_generations": 3,
             "per_iteration_timeout_seconds": 1234,
+            "max_total_seconds": 120,
         }
     )
 
@@ -267,8 +268,11 @@ async def test_plugin_dispatch_forwards_per_iteration_timeout_seconds(
     sub = body["_subagent"]
     assert sub["tool_name"] == "ouroboros_ralph"
     assert sub["context"]["per_iteration_timeout_seconds"] == 1234
+    assert sub["context"]["max_total_seconds"] == 120
     assert "per_iteration_timeout_seconds: 1234" in sub["prompt"]
     assert "stop_reason=iteration_timeout" in sub["prompt"]
+    assert "max_total_seconds: 120" in sub["prompt"]
+    assert "stop_reason=wall_clock_exhausted" in sub["prompt"]
 
 
 @dataclass


### PR DESCRIPTION
Closes #773.

**Stacked on** #790 (#779 — pipeline deadline). Merge order: #784 → #789 → #790 → this PR.

## Summary

- Adds `AutoPhase.RALPH_HANDOFF` (between `RUN` and `COMPLETE`) and the corresponding state-machine transitions: `RUN → {COMPLETE, RALPH_HANDOFF, BLOCKED, FAILED}` and `RALPH_HANDOFF → {COMPLETE, BLOCKED, FAILED}`.
- Adds opt-in `--complete-product` CLI flag (`ooo auto`) and matching `complete_product: bool = False` MCP arg on `ouroboros_auto`. Default-off so existing flows are byte-identical.
- New `HandlerRalphStarter` adapter wraps the `ouroboros_ralph` MCP handler with a deterministic `lineage_id = ralph-{seed_id}-{auto_session_id[:8]}`, forwards `max_total_seconds = max(0.0, deadline_at - time.monotonic())` (from #779) and `per_iteration_timeout_seconds` (from #776), and awaits the background job to a terminal status before returning structured `{job_id, lineage_id, dispatch_mode, terminal_status, stop_reason}`.
- After a successful RUN handoff, when `complete_product=True` the pipeline transitions to `RALPH_HANDOFF`, calls the ralph starter, and maps the terminal status onto the final auto phase per the contract: `completed → COMPLETE`, `failed` with one of `{iteration_timeout, wall_clock_exhausted, oscillation_detected, grade_regressing, max_generations reached}` → `BLOCKED` with stop_reason in `state.last_error`, any other failure → `FAILED`.
- Plugin delegation (`delegated_to_plugin`) records `ralph_dispatch_mode="plugin"`, transitions to `COMPLETE` immediately without touching job tools, and surfaces guidance about the OpenCode Task widget.
- Persists `ralph_job_id`, `ralph_lineage_id`, `ralph_dispatch_mode` on `AutoPipelineState` (and exposes them on `AutoPipelineResult`).

## Test plan

- [x] `pytest tests/unit/auto/test_pipeline_ralph_handoff.py -v` — 8 new tests covering the state machine, happy path, mapped block stop_reasons, terminal failure, plugin delegation, and the flag-off regression.
- [x] `pytest tests/unit/auto/` — 455 passed (no regression on the surrounding auto suite).
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)