### PR TITLE
feat(auto+jobs): unified status surface for auto + ralph

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -246,9 +246,9 @@ class HandlerRalphStarter:
         # ``"plugin"`` for the post-call confirmation envelope below;
         # :meth:`AutoPipeline._resume_ralph_handoff` retries dispatch when it
         # observes the unconfirmed marker.
-        plugin_dispatch = should_dispatch_via_plugin(
-            self.handler.agent_runtime_backend, self.handler.opencode_mode
-        )
+        runtime_backend = _optional_runtime_attr(self.handler, "agent_runtime_backend")
+        opencode_mode = _optional_runtime_attr(self.handler, "opencode_mode")
+        plugin_dispatch = should_dispatch_via_plugin(runtime_backend, opencode_mode)
         if plugin_dispatch and on_dispatched is not None:
             on_dispatched(
                 {
@@ -737,6 +737,11 @@ def _extract_seed_yaml(text: str) -> str:
 
 def _optional_str(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _optional_runtime_attr(handler: object, name: str) -> str | None:
+    value = getattr(handler, name, None)
+    return value if isinstance(value, str) else None
 
 
 def _optional_int(value: object) -> int | None:

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -12,10 +12,11 @@ import yaml
 from ouroboros.auto.interview_driver import InterviewBackend, InterviewTurn
 from ouroboros.core.seed import Seed
 from ouroboros.mcp.errors import MCPServerError
-from ouroboros.mcp.job_manager import JobManager, JobStatus
+from ouroboros.mcp.job_manager import JobManager
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
 from ouroboros.mcp.types import MCPToolResult
 
 
@@ -179,6 +180,12 @@ class HandlerRalphStarter:
     def __init__(self, handler: RalphHandler) -> None:
         self.handler = handler
 
+    @property
+    def job_event_store(self) -> Any:
+        """Expose Ralph's JobManager event store for the auto status mirror."""
+        job_manager = getattr(self.handler, "_job_manager", None)
+        return getattr(job_manager, "_event_store", None)
+
     async def __call__(
         self,
         seed: Seed,
@@ -211,6 +218,32 @@ class HandlerRalphStarter:
             arguments["max_total_seconds"] = max_total_seconds
         if per_iteration_timeout_seconds is not None:
             arguments["per_iteration_timeout_seconds"] = per_iteration_timeout_seconds
+        # Q00/ouroboros#782 review-5 BLOCKING #2 + review-12 BLOCKING #2:
+        # the plugin ``ouroboros_ralph`` call commits an externally observable
+        # side effect (``mcp.subagent.dispatched`` event + the bridge's child
+        # session). If the process dies between that side effect and the
+        # post-call save, resume must detect the dispatch already happened
+        # and transition to COMPLETE instead of dispatching a duplicate.
+        # However, the pre-call checkpoint MUST distinguish "dispatch attempted"
+        # from "dispatch succeeded" — otherwise a crash *before* the handler
+        # actually emits the subagent event leaves persisted state that looks
+        # like a completed plugin dispatch even though no child session was
+        # ever started, and resume falsely transitions to COMPLETE. We
+        # therefore use ``"plugin_pending"`` for the pre-call checkpoint and
+        # ``"plugin"`` for the post-call confirmation envelope below;
+        # :meth:`AutoPipeline._resume_ralph_handoff` retries dispatch when it
+        # observes the unconfirmed marker.
+        plugin_dispatch = should_dispatch_via_plugin(
+            self.handler.agent_runtime_backend, self.handler.opencode_mode
+        )
+        if plugin_dispatch and on_dispatched is not None:
+            on_dispatched(
+                {
+                    "job_id": None,
+                    "lineage_id": lineage_id,
+                    "dispatch_mode": "plugin_pending",
+                }
+            )
         result = _unwrap(
             await self.handler.handle(arguments),
             tool_name="ouroboros_ralph",
@@ -222,12 +255,16 @@ class HandlerRalphStarter:
         # ``delegated_to_plugin`` status. The auto pipeline records this and
         # transitions straight to COMPLETE — there is nothing to wait for.
         if status == "delegated_to_plugin" or dispatch_mode == "plugin":
+            ralph_subagent = (
+                meta.get("_subagent") if isinstance(meta.get("_subagent"), dict) else None
+            )
             envelope = {
                 "job_id": None,
                 "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
                 "dispatch_mode": "plugin",
                 "terminal_status": "delegated_to_plugin",
                 "stop_reason": None,
+                "_subagent": ralph_subagent,
             }
             if on_dispatched is not None:
                 on_dispatched(envelope)
@@ -254,12 +291,16 @@ class HandlerRalphStarter:
         terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
         stop_reason = _optional_str(terminal_meta.get("stop_reason"))
+        current_generation = _optional_int(terminal_meta.get("current_generation"))
+        if current_generation is None:
+            current_generation = _last_int(terminal_meta.get("generations"))
         return {
             "job_id": job_id,
             "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
             "dispatch_mode": "job",
             "terminal_status": terminal_status,
             "stop_reason": stop_reason,
+            "current_generation": current_generation,
         }
 
 
@@ -281,17 +322,29 @@ class HandlerRalphPoller:
     def __init__(self, handler: RalphHandler) -> None:
         self.handler = handler
 
+    @property
+    def job_event_store(self) -> Any:
+        """Expose Ralph's JobManager event store for the auto status mirror."""
+        job_manager = getattr(self.handler, "_job_manager", None)
+        return getattr(job_manager, "_event_store", None)
+
     async def __call__(self, *, job_id: str) -> dict[str, Any]:
         job_manager = self.handler._job_manager  # noqa: SLF001
         terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
         stop_reason = _optional_str(terminal_meta.get("stop_reason"))
+        current_generation = _optional_int(terminal_meta.get("current_generation"))
+        if current_generation is None:
+            current_generation = _optional_int(terminal_meta.get("iterations"))
+        if current_generation is None:
+            current_generation = _last_int(terminal_meta.get("generations"))
         return {
             "job_id": job_id,
             "lineage_id": _optional_str(terminal_meta.get("lineage_id")),
             "dispatch_mode": "job",
             "terminal_status": terminal_status,
             "stop_reason": stop_reason,
+            "current_generation": current_generation,
         }
 
 
@@ -310,10 +363,7 @@ async def _wait_for_job_terminal(
         snapshot = await job_manager.get_snapshot(job_id)
         if snapshot.is_terminal:
             meta = dict(snapshot.result_meta or {})
-            meta.setdefault(
-                "status",
-                "completed" if snapshot.status is JobStatus.COMPLETED else "failed",
-            )
+            meta.setdefault("status", snapshot.status.value)
             return meta
         await asyncio.sleep(poll_interval)
 
@@ -378,3 +428,17 @@ def _extract_seed_yaml(text: str) -> str:
 
 def _optional_str(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _optional_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _last_int(value: object) -> int | None:
+    if not isinstance(value, list):
+        return None
+    for item in reversed(value):
+        found = _optional_int(item)
+        if found is not None:
+            return found
+    return None

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -291,9 +291,7 @@ class HandlerRalphStarter:
         terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
         stop_reason = _optional_str(terminal_meta.get("stop_reason"))
-        current_generation = _optional_int(terminal_meta.get("current_generation"))
-        if current_generation is None:
-            current_generation = _last_int(terminal_meta.get("generations"))
+        current_generation = _current_generation_from_meta(terminal_meta)
         return {
             "job_id": job_id,
             "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
@@ -333,11 +331,7 @@ class HandlerRalphPoller:
         terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
         stop_reason = _optional_str(terminal_meta.get("stop_reason"))
-        current_generation = _optional_int(terminal_meta.get("current_generation"))
-        if current_generation is None:
-            current_generation = _optional_int(terminal_meta.get("iterations"))
-        if current_generation is None:
-            current_generation = _last_int(terminal_meta.get("generations"))
+        current_generation = _current_generation_from_meta(terminal_meta)
         return {
             "job_id": job_id,
             "lineage_id": _optional_str(terminal_meta.get("lineage_id")),
@@ -442,3 +436,13 @@ def _last_int(value: object) -> int | None:
         if found is not None:
             return found
     return None
+
+
+def _current_generation_from_meta(meta: dict[str, Any]) -> int | None:
+    current_generation = _optional_int(meta.get("current_generation"))
+    if current_generation is not None:
+        return current_generation
+    generations_generation = _last_int(meta.get("generations"))
+    if generations_generation is not None:
+        return generations_generation
+    return _optional_int(meta.get("iterations"))

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -305,7 +305,7 @@ class HandlerRalphStarter:
         terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
         stop_reason = _optional_str(terminal_meta.get("stop_reason"))
         current_generation = _current_generation_from_meta(terminal_meta)
-        result = {
+        terminal_result: dict[str, Any] = {
             "job_id": job_id,
             "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
             "dispatch_mode": "job",
@@ -322,8 +322,8 @@ class HandlerRalphStarter:
             # still be graded), so route through ``_artifact_text`` —
             # ``_optional_str`` would collapse the empty string to None and
             # silently skip EVALUATE.
-            result["result_text"] = artifact_text
-        return result
+            terminal_result["result_text"] = artifact_text
+        return terminal_result
 
 
 class HandlerRalphPoller:

--- a/src/ouroboros/auto/listeners.py
+++ b/src/ouroboros/auto/listeners.py
@@ -1,0 +1,319 @@
+"""Event listeners that mirror linked subsystem state into ``AutoPipelineState``.
+
+This module exists so the unified status surface (Q00/ouroboros#782) can answer
+"where is my session?" without polling. The listener subscribes to the
+``mcp.job.*`` topics emitted by ``JobManager`` (``mcp.job.status`` /
+``mcp.job.cancelled`` / ``mcp.job.terminal``) via the existing ``EventStore``
+incremental query API and updates four mirror fields on ``AutoPipelineState``:
+
+- ``ralph_job_status`` — last-seen ``JobStatus`` value
+- ``ralph_last_event_at`` — ``time.monotonic()`` seconds of the last event
+- ``ralph_stop_reason`` — populated when the ralph job reaches a terminal status
+- ``ralph_current_generation`` — last reported lineage generation index
+
+Cancel propagation: when ``JobManager.cancel_job`` drives the linked ralph job
+into ``cancelled`` (or the persisted equivalent), the listener marks the auto
+state ``BLOCKED("ralph cancelled by user")`` — but only if the auto session is
+not already in a terminal phase, otherwise we would clobber a successful
+``COMPLETE`` with a noisy blocker.
+
+The listener is **best-effort**: the production bridge polls the job event
+store while the Ralph job is running and persists mirror updates as they arrive.
+The acceptance tests also exercise the pure apply step directly so the parsing
+contract stays testable without tying every test to an asyncio loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from dataclasses import dataclass
+import time
+from typing import Any
+
+from ouroboros.auto.state import (
+    TERMINAL_PHASES,
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+)
+from ouroboros.events.base import BaseEvent
+from ouroboros.persistence.event_store import EventStore
+
+# Job event types we mirror onto the auto state. Anything outside this set is
+# ignored so an unrelated mcp.* topic cannot scribble across the mirror fields.
+_RALPH_JOB_EVENT_TYPES = frozenset(
+    {
+        "mcp.job.created",
+        "mcp.job.updated",
+        "mcp.job.completed",
+        "mcp.job.failed",
+        "mcp.job.cancelled",
+        "mcp.job.interrupted",
+    }
+)
+
+# Statuses we treat as ralph-terminal for cancel propagation. ``"interrupted"``
+# is included because ``JobManager`` emits an ``interrupted`` terminal when the
+# runner returns the documented interrupt sentinel; the ralph loop surfaces it
+# the same way externally.
+_RALPH_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "interrupted"})
+
+# The cancel propagation reason is pinned by the issue acceptance criteria so a
+# downstream reader (CLI, MCP, future TUI) can string-match it deterministically.
+RALPH_CANCEL_BLOCKER_REASON = "ralph cancelled by user"
+
+
+@dataclass(frozen=True, slots=True)
+class _RalphEventReading:
+    """Normalized projection of a single ``mcp.job.*`` event for the mirror.
+
+    Lives only inside this module — callers see ``apply_event`` updates
+    instead. The dataclass is the natural home for the small parsing branch
+    so the apply step stays a pure assignment.
+    """
+
+    status: str | None
+    stop_reason: str | None
+    error: str | None
+    lineage_id: str | None
+    is_terminal: bool
+
+
+def _coerce_lineage_id(payload: dict[str, Any]) -> str | None:
+    """Return the lineage id embedded in a ``mcp.job.*`` payload, if any.
+
+    JobManager emits ``links.lineage_id`` on every event; some legacy or
+    error paths flatten this to a top-level ``lineage_id``. The listener
+    tolerates both shapes so we don't silently miss events from older builds.
+    """
+    links = payload.get("links")
+    if isinstance(links, dict):
+        lineage = links.get("lineage_id")
+        if isinstance(lineage, str) and lineage:
+            return lineage
+    flat = payload.get("lineage_id")
+    if isinstance(flat, str) and flat:
+        return flat
+    return None
+
+
+def _result_meta(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return sanitized terminal ``result_meta`` when JobManager provides it."""
+    value = payload.get("result_meta")
+    return value if isinstance(value, dict) else {}
+
+
+def _optional_nonempty_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_generation(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, str) and value.isdigit():
+        parsed = int(value)
+        return parsed if parsed >= 0 else None
+    return None
+
+
+def _project_event(event: BaseEvent) -> _RalphEventReading | None:
+    """Project a ``BaseEvent`` into the mirror-relevant slice.
+
+    Returns ``None`` for events outside the ``mcp.job.*`` whitelist so the
+    caller can ignore them cheaply. The projection is intentionally narrow:
+    we never look at ``result_text`` or any other field that could leak
+    arbitrary subagent output into the auto state.
+    """
+    if event.type not in _RALPH_JOB_EVENT_TYPES:
+        return None
+    payload = event.data if isinstance(event.data, dict) else {}
+    meta = _result_meta(payload)
+    status = _optional_nonempty_str(payload.get("status")) or _optional_nonempty_str(
+        meta.get("status")
+    )
+    stop_reason = _optional_nonempty_str(payload.get("stop_reason")) or _optional_nonempty_str(
+        meta.get("stop_reason")
+    )
+    error = _optional_nonempty_str(payload.get("error")) or _optional_nonempty_str(
+        meta.get("error")
+    )
+    is_terminal = event.type in {
+        "mcp.job.completed",
+        "mcp.job.failed",
+        "mcp.job.cancelled",
+        "mcp.job.interrupted",
+    } or (status in _RALPH_TERMINAL_STATUSES)
+    return _RalphEventReading(
+        status=status,
+        stop_reason=stop_reason,
+        error=error,
+        lineage_id=_coerce_lineage_id(payload),
+        is_terminal=is_terminal,
+    )
+
+
+def _coerce_generation(payload: dict[str, Any]) -> int | None:
+    """Return ``current_generation`` from job payload metadata or message.
+
+    Terminal ``JobManager`` events carry Ralph details under ``result_meta``.
+    Progress updates may only carry the derived status message, so keep the
+    older ``"Generation N | <phase>"`` parser as the fallback.
+    """
+    meta = _result_meta(payload)
+    meta_generation = _optional_generation(meta.get("current_generation"))
+    if meta_generation is not None:
+        return meta_generation
+    meta_iterations = _optional_generation(meta.get("iterations"))
+    if meta_iterations is not None:
+        return meta_iterations
+    message = payload.get("message")
+    if not isinstance(message, str) or not message:
+        return None
+    if not message.startswith("Generation "):
+        return None
+    rest = message[len("Generation ") :]
+    head = rest.split(" ", 1)[0].split("|", 1)[0].strip()
+    if not head.isdigit():
+        return None
+    try:
+        value = int(head)
+    except ValueError:
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _event_is_terminal(event: BaseEvent) -> bool:
+    reading = _project_event(event)
+    return bool(reading and reading.is_terminal)
+
+
+def apply_event(state: AutoPipelineState, event: BaseEvent) -> bool:
+    """Mirror a single ``mcp.job.*`` event onto ``state``.
+
+    Returns ``True`` when the event was applied (lineage *or* job_id matched
+    and the event is a relevant ``mcp.job.*`` topic), ``False`` otherwise.
+    Callers can use the return value to decide whether to schedule a state
+    save — the listener itself never persists.
+
+    Filtering accepts a match on either ``links.lineage_id`` (the canonical
+    join key emitted on ``mcp.job.created``) or ``aggregate_id`` matching
+    the persisted ``state.ralph_job_id``. ``JobManager.update_status``
+    omits the lineage on subsequent events, so a strict lineage filter
+    would silently drop every status update after creation.
+
+    Cancel propagation: when the event is a terminal ``cancelled`` reading
+    and the auto state is not already terminal, transition to BLOCKED with
+    the pinned :data:`RALPH_CANCEL_BLOCKER_REASON`.
+    """
+    if state.ralph_lineage_id is None and state.ralph_job_id is None:
+        return False
+    if state.ralph_dispatch_mode == "plugin":
+        # Plugin delegations have no in-process job to mirror; the OpenCode
+        # Task widget owns the lifecycle. Fail closed instead of fabricating
+        # a status from somebody else's events.
+        return False
+    reading = _project_event(event)
+    if reading is None:
+        return False
+    matches_lineage = (
+        reading.lineage_id is not None and reading.lineage_id == state.ralph_lineage_id
+    )
+    matches_job_id = (
+        state.ralph_job_id is not None
+        and event.aggregate_id == state.ralph_job_id
+        and event.aggregate_type == "job"
+    )
+    if not (matches_lineage or matches_job_id):
+        return False
+
+    state.ralph_last_event_at = time.monotonic()
+    if reading.status is not None:
+        state.ralph_job_status = reading.status
+    if reading.is_terminal:
+        # Prefer the explicit stop_reason; fall back to the error string for
+        # ``mcp.job.failed`` so the unified status surface always has *some*
+        # blocker text to render.
+        state.ralph_stop_reason = reading.stop_reason or reading.error or reading.status
+    payload = event.data if isinstance(event.data, dict) else {}
+    generation = _coerce_generation(payload)
+    if generation is not None:
+        state.ralph_current_generation = generation
+
+    # Cancel propagation per the acceptance criteria — only mutate phase if
+    # the cancel observation is fresh and the auto state still has somewhere
+    # to go. ``mark_blocked`` performs the transition validation itself.
+    if (
+        event.type == "mcp.job.cancelled" or (reading.is_terminal and reading.status == "cancelled")
+    ) and state.phase not in TERMINAL_PHASES:
+        try:
+            state.mark_blocked(
+                RALPH_CANCEL_BLOCKER_REASON,
+                tool_name="ralph_starter",
+            )
+        except ValueError:
+            # The state machine forbids the transition (e.g. CREATED -> BLOCKED
+            # is allowed, but tests may exercise unusual phases). Swallow so
+            # the listener never crashes the event subscriber for a bookkeeping
+            # mismatch — the mirror fields above are still updated.
+            pass
+
+    return True
+
+
+def apply_events(state: AutoPipelineState, events: Iterable[BaseEvent]) -> int:
+    """Apply an iterable of events; return the number actually mirrored.
+
+    Convenience for tests and the future background subscriber. Iterating
+    here lets the listener cheaply replay a batch returned from
+    ``EventStore.get_events_after`` without exposing the rowid cursor to
+    callers.
+    """
+    applied = 0
+    for event in events:
+        if apply_event(state, event):
+            applied += 1
+    return applied
+
+
+async def mirror_ralph_job_events(
+    state: AutoPipelineState,
+    store: AutoStore,
+    event_store: EventStore,
+    job_id: str,
+    *,
+    poll_interval: float = 0.05,
+) -> None:
+    """Persist mirrored Ralph job events until the linked job is terminal.
+
+    This is the production bridge from real ``JobManager`` ``mcp.job.*`` events
+    into the auto state mirror. It starts at cursor 0 so a listener created
+    just after job dispatch still observes the initial and terminal events.
+    """
+    cursor = 0
+    while True:
+        events, cursor = await event_store.get_events_after("job", job_id, last_row_id=cursor)
+        applied = apply_events(state, events)
+        if applied:
+            store.save(state)
+        if any(_event_is_terminal(event) for event in events):
+            return
+        await asyncio.sleep(poll_interval)
+
+
+__all__ = [
+    "RALPH_CANCEL_BLOCKER_REASON",
+    "apply_event",
+    "apply_events",
+    "mirror_ralph_job_events",
+]
+
+
+# Defensive sanity check — keep the terminal-phase set used for cancel
+# propagation in sync with ``state._ALLOWED_TRANSITIONS`` so a future addition
+# (e.g. a new "abandoned" phase) cannot silently bypass the gate.
+assert AutoPhase.COMPLETE in TERMINAL_PHASES  # noqa: S101 - import-time guard

--- a/src/ouroboros/auto/listeners.py
+++ b/src/ouroboros/auto/listeners.py
@@ -119,6 +119,26 @@ def _optional_generation(value: object) -> int | None:
     return None
 
 
+def _last_generation(value: object) -> int | None:
+    if not isinstance(value, list):
+        return None
+    for item in reversed(value):
+        found = _optional_generation(item)
+        if found is not None:
+            return found
+    return None
+
+
+def _metadata_generation(meta: dict[str, Any]) -> int | None:
+    meta_generation = _optional_generation(meta.get("current_generation"))
+    if meta_generation is not None:
+        return meta_generation
+    meta_generation = _last_generation(meta.get("generations"))
+    if meta_generation is not None:
+        return meta_generation
+    return _optional_generation(meta.get("iterations"))
+
+
 def _project_event(event: BaseEvent) -> _RalphEventReading | None:
     """Project a ``BaseEvent`` into the mirror-relevant slice.
 
@@ -163,12 +183,12 @@ def _coerce_generation(payload: dict[str, Any]) -> int | None:
     older ``"Generation N | <phase>"`` parser as the fallback.
     """
     meta = _result_meta(payload)
-    meta_generation = _optional_generation(meta.get("current_generation"))
+    meta_generation = _metadata_generation(meta)
     if meta_generation is not None:
         return meta_generation
-    meta_iterations = _optional_generation(meta.get("iterations"))
-    if meta_iterations is not None:
-        return meta_iterations
+    payload_generation = _metadata_generation(payload)
+    if payload_generation is not None:
+        return payload_generation
     message = payload.get("message")
     if not isinstance(message, str) or not message:
         return None

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 import inspect
 import threading
@@ -14,6 +15,7 @@ from ouroboros.auto.blocker_attribution import record_authoring_backend
 from ouroboros.auto.grading import GradeGate, deterministic_floor
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.listeners import RALPH_CANCEL_BLOCKER_REASON, mirror_ralph_job_events
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
@@ -82,6 +84,23 @@ _DEFAULT_RALPH_PER_ITERATION_SECONDS = 1800.0
 
 
 _RETRY_GUIDANCE_PHRASE = "retried once with idempotency key"
+
+# Mirror of ``ouroboros.mcp.tools.ralph_handlers.MIN_MAX_TOTAL_SECONDS``.
+# Defined locally to keep ``auto/pipeline.py`` import-light; parity is asserted
+# in ``tests/unit/auto/test_pipeline_deadline.py`` so silent drift surfaces as
+# a test failure rather than a runtime "max_total_seconds must be between …"
+# error during the RUN→RALPH handoff (Q00/ouroboros#782 review-3).
+_RALPH_MIN_BUDGET_SECONDS = 1.0
+
+# Q00/ouroboros#782 review-12 BLOCKING #1: when the top-level deadline has
+# already expired but a persisted Ralph job awaits reconciliation, give the
+# resume poller a brief grace window so an already-terminal job is detected
+# (snapshot returns immediately) before ``_enforce_deadline`` trips
+# ``pipeline_timeout``. ``asyncio.wait_for(coro, 0)`` cancels the coroutine
+# before it can read the first snapshot, so the inner ``get_snapshot`` would
+# never run without this floor — silently demoting a legitimately completed
+# Ralph loop to a false ``pipeline_timeout`` BLOCKED.
+_RALPH_RESUME_PEEK_SECONDS = 1.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -233,10 +252,26 @@ class AutoPipeline:
         # message is the literal one the issue contract requires so external
         # surfaces can distinguish a resume-expired session from a freshly
         # tripped deadline mid-run.
+        #
+        # Q00/ouroboros#782 review-12 BLOCKING #1: never gate ``RALPH_HANDOFF``
+        # resume on the deadline-expired early returns when there is a
+        # persisted Ralph job / confirmed plugin dispatch waiting on
+        # reconciliation. Falling through to ``_resume_ralph_handoff`` lets
+        # the poller (or plugin-confirmed transition) finalize the auto
+        # phase if Ralph already finished in the background while the
+        # client was disconnected. If the job is still running, the
+        # poller's own deadline-aware wait fires the same ``pipeline_timeout``
+        # BLOCKED state via ``_enforce_deadline``. Same exception applies
+        # to the second ``_enforce_deadline`` gate after the BLOCKED/FAILED
+        # recovery branch below.
+        ralph_resume_pending = state.phase is AutoPhase.RALPH_HANDOFF and (
+            state.ralph_job_id is not None or state.ralph_dispatch_mode == "plugin"
+        )
         if (
             state.deadline_at is not None
             and not state.is_terminal()
             and state.is_deadline_expired()
+            and not ralph_resume_pending
         ):
             state.last_tool_name = PIPELINE_DEADLINE_TOOL_NAME
             state.mark_blocked(
@@ -285,7 +320,14 @@ class AutoPipeline:
             self._save(state)
 
         review: SeedReview | None = None
-        if self._enforce_deadline(state):
+        # Q00/ouroboros#782 review-12 BLOCKING #1: same exception as the
+        # early-return above — let RALPH_HANDOFF resume reach
+        # ``_resume_ralph_handoff`` so an already-terminal Ralph job can be
+        # reconciled. The poller's deadline-aware ``wait_for`` (and
+        # subsequent ``_enforce_deadline`` call inside ``_poll_ralph_job``)
+        # still fires ``pipeline_timeout`` if the job is genuinely still
+        # running after the persisted budget has expired.
+        if not ralph_resume_pending and self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
         if state.phase in {AutoPhase.CREATED, AutoPhase.INTERVIEW}:
             # Arm the top-level pipeline deadline (#779) on the first
@@ -359,7 +401,10 @@ class AutoPipeline:
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
 
-        if self._enforce_deadline(state):
+        # Q00/ouroboros#782 review-12 BLOCKING #1: same exception — let
+        # ``RALPH_HANDOFF`` resume reach ``_resume_ralph_handoff`` so the
+        # poller can reconcile an already-terminal Ralph job.
+        if not ralph_resume_pending and self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
         if state.phase == AutoPhase.SEED_GENERATION:
             if state.seed_artifact:
@@ -464,7 +509,7 @@ class AutoPipeline:
             return self._result(state, ledger, blocker=state.last_error)
 
         if state.phase == AutoPhase.RALPH_HANDOFF:
-            return await self._resume_ralph_handoff(state, ledger, review=review)
+            return await self._resume_ralph_handoff(state, ledger, review=review, seed=seed)
 
         if self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
@@ -839,12 +884,23 @@ class AutoPipeline:
         widget guidance to the operator.
         """
         assert self.ralph_starter is not None  # noqa: S101 - guarded by caller
-        lineage_id = f"ralph-{seed.metadata.seed_id}-{state.auto_session_id[:8]}"
-        state.ralph_lineage_id = lineage_id
-        state.transition(
-            AutoPhase.RALPH_HANDOFF,
-            f"handing off grade {state.last_grade or state.required_grade} Seed to Ralph loop",
+        # Preserve a previously persisted lineage on resume so the re-dispatch
+        # remains correlated with prior ``mcp.job.*`` events; only mint a fresh
+        # one when this is the first handoff attempt for the session.
+        lineage_id = state.ralph_lineage_id or (
+            f"ralph-{seed.metadata.seed_id}-{state.auto_session_id[:8]}"
         )
+        state.ralph_lineage_id = lineage_id
+        if state.phase != AutoPhase.RALPH_HANDOFF:
+            state.transition(
+                AutoPhase.RALPH_HANDOFF,
+                f"handing off grade {state.last_grade or state.required_grade} Seed to Ralph loop",
+            )
+        else:
+            state.mark_progress(
+                "re-entering Ralph handoff after resume",
+                tool_name="ralph_starter",
+            )
         self._save(state)
         max_total_seconds: float | None = None
         per_iteration_timeout_seconds: float | None = None
@@ -883,6 +939,8 @@ class AutoPipeline:
                 min(_DEFAULT_RALPH_PER_ITERATION_SECONDS, remaining),
             )
 
+        ralph_mirror_task: asyncio.Task[None] | None = None
+
         # Q00/ouroboros#773 (review-6): persist the Ralph dispatch handle as
         # soon as the background job exists, BEFORE we await terminal
         # completion. Without this checkpoint, a process restart, deadline
@@ -894,6 +952,7 @@ class AutoPipeline:
         # solve. The starter callable invokes this hook BEFORE blocking on
         # the terminal-status poll.
         def _checkpoint_dispatch(envelope: dict[str, Any]) -> None:
+            nonlocal ralph_mirror_task
             state.ralph_job_id = _optional_str(envelope.get("job_id"))
             state.ralph_dispatch_mode = _optional_str(envelope.get("dispatch_mode"))
             persisted_lineage = _optional_str(envelope.get("lineage_id"))
@@ -901,6 +960,22 @@ class AutoPipeline:
                 state.ralph_lineage_id = persisted_lineage
             state.last_tool_name = "ralph_starter"
             self._save(state)
+            if (
+                self.store is not None
+                and state.ralph_job_id is not None
+                and state.ralph_dispatch_mode != "plugin"
+                and ralph_mirror_task is None
+            ):
+                event_store = getattr(self.ralph_starter, "job_event_store", None)
+                if event_store is not None:
+                    ralph_mirror_task = asyncio.create_task(
+                        mirror_ralph_job_events(
+                            state,
+                            self.store,
+                            event_store,
+                            state.ralph_job_id,
+                        )
+                    )
 
         # Q00/ouroboros#773 (review-7): decide compatibility BEFORE invocation,
         # never by retrying on a post-dispatch ``TypeError``. ``RalphHandler``
@@ -946,11 +1021,13 @@ class AutoPipeline:
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
             )
         except Exception as exc:
+            await _cancel_ralph_status_mirror(ralph_mirror_task)
             state.mark_failed(f"ralph handoff failed: {exc}", tool_name="ralph_starter")
             self._save(state)
             return self._result(
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
             )
+        await _drain_ralph_status_mirror(ralph_mirror_task)
         if not isinstance(ralph_meta, dict):
             state.mark_failed(
                 f"ralph starter returned {type(ralph_meta).__name__}, expected dict",
@@ -964,6 +1041,15 @@ class AutoPipeline:
         state.ralph_dispatch_mode = _optional_str(ralph_meta.get("dispatch_mode"))
         terminal_status = _optional_str(ralph_meta.get("terminal_status"))
         stop_reason = _optional_str(ralph_meta.get("stop_reason"))
+        current_generation = _optional_int(ralph_meta.get("current_generation")) or _optional_int(
+            ralph_meta.get("iterations")
+        )
+        if terminal_status is not None:
+            state.ralph_job_status = terminal_status
+        if stop_reason is not None:
+            state.ralph_stop_reason = stop_reason
+        if current_generation is not None:
+            state.ralph_current_generation = current_generation
         # Plugin delegation: nothing to await, transition straight to
         # COMPLETE and surface the OpenCode Task widget guidance.
         if state.ralph_dispatch_mode == "plugin":
@@ -972,12 +1058,25 @@ class AutoPipeline:
                 "Track progress through the OpenCode Task widget; this auto "
                 "session will not block on the loop's completion."
             )
+            # Q00/ouroboros#782 review-5 BLOCKING #1: surface Ralph's
+            # ``_subagent`` envelope so the OpenCode bridge actually spawns
+            # the child session. In ``--complete-product`` plugin mode the
+            # Ralph subagent supersedes the run-handoff subagent — the run
+            # already kicked off and the loop is what the plugin must own.
+            ralph_subagent = (
+                ralph_meta.get("_subagent")
+                if isinstance(ralph_meta.get("_subagent"), dict)
+                else None
+            )
+            effective_subagent = ralph_subagent or run_subagent
+            if ralph_subagent is not None:
+                state.run_subagent = ralph_subagent
             state.transition(
                 AutoPhase.COMPLETE,
                 "ralph loop delegated to OpenCode plugin child session",
             )
             self._save(state)
-            return self._result(state, ledger, review=review, run_subagent=run_subagent)
+            return self._result(state, ledger, review=review, run_subagent=effective_subagent)
         if terminal_status == "completed":
             state.transition(
                 AutoPhase.COMPLETE,
@@ -985,6 +1084,13 @@ class AutoPipeline:
             )
             self._save(state)
             return self._result(state, ledger, review=review, run_subagent=run_subagent)
+        if terminal_status == "cancelled":
+            if state.phase is not AutoPhase.BLOCKED:
+                state.mark_blocked(RALPH_CANCEL_BLOCKER_REASON, tool_name="ralph_starter")
+                self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
             state.mark_blocked(stop_reason, tool_name="ralph_starter")
             self._save(state)
@@ -1010,6 +1116,7 @@ class AutoPipeline:
         ledger: SeedDraftLedger,
         *,
         review: SeedReview | None,
+        seed: Seed | None = None,
     ) -> AutoPipelineResult:
         """Resume a persisted Ralph handoff checkpoint.
 
@@ -1024,7 +1131,37 @@ class AutoPipeline:
         no ``ralph_job_id`` was persisted) the method falls back to
         guidance-only behavior so callers without a job-manager handle
         still get a coherent message instead of a polling failure.
+
+        ``seed`` is required to recover from an unconfirmed plugin dispatch
+        (``ralph_dispatch_mode == "plugin_pending"``); the dispatch is
+        retried via :meth:`_handoff_to_ralph` so a crash *before* the bridge
+        actually received the ``_subagent`` envelope does not falsely
+        transition the auto session to COMPLETE
+        (Q00/ouroboros#782 review-12 BLOCKING #2).
         """
+        # Q00/ouroboros#782 review-12 BLOCKING #2: retry an interrupted
+        # plugin dispatch BEFORE trusting the confirmed-plugin marker. A
+        # ``"plugin_pending"`` checkpoint means the auto pipeline persisted
+        # the dispatch intent but the actual ``ouroboros_ralph`` handler
+        # call did not return a delegated_to_plugin response, so the bridge
+        # may never have received the child-session envelope. Redispatch
+        # with the same persisted lineage so any half-emitted events stay
+        # correlated.
+        if state.ralph_dispatch_mode == "plugin_pending":
+            if seed is not None and self.ralph_starter is not None:
+                state.ralph_dispatch_mode = None
+                state.ralph_job_id = None
+                self._save(state)
+                return await self._handoff_to_ralph(
+                    state, ledger, seed, review=review, run_subagent=None
+                )
+            state.mark_blocked(
+                "ralph plugin dispatch was interrupted before confirmation; "
+                "resume could not retry without a persisted Seed",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
         if state.ralph_dispatch_mode == "plugin":
             state.run_handoff_guidance = (
                 state.run_handoff_guidance
@@ -1032,6 +1169,17 @@ class AutoPipeline:
                 "Track progress through the OpenCode Task widget; this auto "
                 "session will not block on the loop's completion."
             )
+            # Q00/ouroboros#782 review-13 BLOCKING #1: a confirmed plugin
+            # dispatch is a one-shot side effect — the bridge already received
+            # the ``_subagent`` envelope and may have already spawned the
+            # child session. Re-emitting the persisted ``state.run_subagent``
+            # on resume can trigger a duplicate OpenCode child session via
+            # ``meta["_subagent"]`` in :class:`AutoHandler.handle`. Clear the
+            # persisted envelope here so neither this ``_result(...)`` call
+            # nor any future re-resume replays it. ``state.run_subagent``
+            # is typed as a dict, so we reset to ``{}`` rather than ``None``;
+            # ``_result()`` treats the empty dict as falsy and emits ``None``.
+            state.run_subagent = {}
             state.transition(
                 AutoPhase.COMPLETE,
                 "resumed OpenCode plugin Ralph delegation checkpoint",
@@ -1075,14 +1223,38 @@ class AutoPipeline:
         """
         assert self.ralph_resumer is not None  # noqa: S101 - guarded by caller
         assert state.ralph_job_id is not None  # noqa: S101 - guarded by caller
+        ralph_mirror_task: asyncio.Task[None] | None = None
+        if (
+            self.store is not None
+            and state.ralph_dispatch_mode != "plugin"
+            and state.ralph_job_id is not None
+        ):
+            event_store = getattr(self.ralph_resumer, "job_event_store", None)
+            if event_store is not None:
+                ralph_mirror_task = asyncio.create_task(
+                    mirror_ralph_job_events(
+                        state,
+                        self.store,
+                        event_store,
+                        state.ralph_job_id,
+                    )
+                )
         try:
             poll_call = self.ralph_resumer(job_id=state.ralph_job_id)
             if state.deadline_at is None:
                 ralph_meta = await poll_call
             else:
-                poll_timeout = max(0.0, state.deadline_at - time.monotonic())
+                # Q00/ouroboros#782 review-12 BLOCKING #1: floor at
+                # ``_RALPH_RESUME_PEEK_SECONDS`` so an already-terminal Ralph
+                # job can be reconciled even when the top-level deadline has
+                # expired. ``asyncio.wait_for`` with timeout=0 cancels the
+                # coroutine before it can read the first snapshot, which
+                # would silently turn a completed loop into ``pipeline_timeout``.
+                remaining = state.deadline_at - time.monotonic()
+                poll_timeout = max(remaining, _RALPH_RESUME_PEEK_SECONDS)
                 ralph_meta = await asyncio.wait_for(poll_call, timeout=poll_timeout)
         except TimeoutError:
+            await _cancel_ralph_status_mirror(ralph_mirror_task)
             if self._enforce_deadline(state):
                 return self._result(state, ledger, review=review, blocker=state.last_error)
             state.mark_blocked(
@@ -1092,9 +1264,11 @@ class AutoPipeline:
             self._save(state)
             return self._result(state, ledger, review=review, blocker=state.last_error)
         except Exception as exc:
+            await _cancel_ralph_status_mirror(ralph_mirror_task)
             state.mark_failed(f"ralph resume poll failed: {exc}", tool_name="ralph_starter")
             self._save(state)
             return self._result(state, ledger, review=review, blocker=state.last_error)
+        await _drain_ralph_status_mirror(ralph_mirror_task)
         if not isinstance(ralph_meta, dict):
             state.mark_failed(
                 f"ralph resumer returned {type(ralph_meta).__name__}, expected dict",
@@ -1104,6 +1278,15 @@ class AutoPipeline:
             return self._result(state, ledger, review=review, blocker=state.last_error)
         terminal_status = _optional_str(ralph_meta.get("terminal_status"))
         stop_reason = _optional_str(ralph_meta.get("stop_reason"))
+        current_generation = _optional_int(ralph_meta.get("current_generation")) or _optional_int(
+            ralph_meta.get("iterations")
+        )
+        if terminal_status is not None:
+            state.ralph_job_status = terminal_status
+        if stop_reason is not None:
+            state.ralph_stop_reason = stop_reason
+        if current_generation is not None:
+            state.ralph_current_generation = current_generation
         if terminal_status == "completed":
             state.transition(
                 AutoPhase.COMPLETE,
@@ -1111,6 +1294,17 @@ class AutoPipeline:
             )
             self._save(state)
             return self._result(state, ledger, review=review)
+        # Q00/ouroboros#782 review-10 BLOCKING #2: ``terminal_status ==
+        # "cancelled"`` must map to BLOCKED with the pinned
+        # ``RALPH_CANCEL_BLOCKER_REASON`` — same as the live ``_handoff_to_ralph``
+        # path. Falling through to the generic failure branch would mark a
+        # user-cancelled session FAILED on resume, regressing the live-path
+        # contract for a normal user action.
+        if terminal_status == "cancelled":
+            if state.phase is not AutoPhase.BLOCKED:
+                state.mark_blocked(RALPH_CANCEL_BLOCKER_REASON, tool_name="ralph_starter")
+                self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
             state.mark_blocked(stop_reason, tool_name="ralph_starter")
             self._save(state)
@@ -1124,6 +1318,127 @@ class AutoPipeline:
         state.mark_failed(message, tool_name="ralph_starter")
         self._save(state)
         return self._result(state, ledger, review=review, blocker=state.last_error)
+
+    def _remaining_deadline_seconds(self, state: AutoPipelineState) -> float | None:
+        """Return remaining pipeline budget in seconds, if a deadline is armed."""
+        if state.deadline_at is None or state.is_terminal():
+            return None
+        return max(0.0, state.deadline_at - time.monotonic())
+
+    def _phase_timeout_with_deadline(self, state: AutoPipelineState, phase_timeout: float) -> float:
+        """Cap a phase-local timeout by the remaining top-level pipeline budget."""
+        remaining = self._remaining_deadline_seconds(state)
+        if remaining is None:
+            return phase_timeout
+        return max(0.0, min(phase_timeout, remaining))
+
+    def _deadline_timeout_elapsed(self, state: AutoPipelineState) -> bool:
+        """Return True when a wait_for timeout should be classified as pipeline_timeout."""
+        return state.deadline_at is not None and state.is_deadline_expired()
+
+    def _mark_pipeline_timeout(self, state: AutoPipelineState) -> None:
+        """Persist a top-level deadline BLOCKED state after an in-flight await overruns."""
+        remaining = (state.deadline_at - time.monotonic()) if state.deadline_at is not None else 0.0
+        message = (
+            f"pipeline_timeout: deadline exceeded by "
+            f"{abs(remaining):.1f}s during {state.phase.value}"
+        )
+        state.last_tool_name = PIPELINE_DEADLINE_TOOL_NAME
+        state.mark_blocked(message, tool_name=PIPELINE_DEADLINE_TOOL_NAME)
+        self._save(state)
+
+    async def _reattach_ralph_job(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+    ) -> AutoPipelineResult:
+        """Wait on an already-dispatched Ralph job rather than dispatching a duplicate.
+
+        Q00/ouroboros#782 review-6 BLOCKING #2. Resume after a crash that
+        happened between ``persist_started_ralph`` saving ``ralph_job_id``
+        and the original ``HandlerRalphStarter`` finishing its terminal
+        wait. Calls ``ralph_starter`` with ``attach_job_id=state.ralph_job_id``
+        so no fresh ``mcp.subagent.dispatched`` / job-create side effect
+        runs; the same terminal-status mapping handles the result.
+
+        Intentionally does NOT call ``_enforce_deadline`` first
+        (Q00/ouroboros#782 review-7 BLOCKING #1): re-attach is just
+        observing an already-dispatched job's terminal state, so a long
+        offline gap that pushed past ``deadline_at`` must NOT strand a
+        successfully completed Ralph job as a false ``pipeline_timeout``.
+        """
+        assert self.ralph_starter is not None  # noqa: S101 - guarded by caller
+        ralph_mirror_task: asyncio.Task[None] | None = None
+        if (
+            self.store is not None
+            and state.ralph_dispatch_mode != "plugin"
+            and state.ralph_job_id is not None
+        ):
+            event_store = getattr(self.ralph_starter, "job_event_store", None)
+            if event_store is not None:
+                ralph_mirror_task = asyncio.create_task(
+                    mirror_ralph_job_events(
+                        state,
+                        self.store,
+                        event_store,
+                        state.ralph_job_id,
+                    )
+                )
+        try:
+            ralph_meta = await self.ralph_starter(
+                None,  # type: ignore[arg-type]
+                lineage_id=state.ralph_lineage_id or "",
+                attach_job_id=state.ralph_job_id,
+            )
+        except Exception as exc:
+            await _cancel_ralph_status_mirror(ralph_mirror_task)
+            state.mark_failed(
+                f"ralph re-attach failed: {exc}",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return self._result(state, ledger, blocker=state.last_error)
+        await _drain_ralph_status_mirror(ralph_mirror_task)
+        if not isinstance(ralph_meta, dict):
+            state.mark_failed(
+                f"ralph re-attach returned {type(ralph_meta).__name__}, expected dict",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return self._result(state, ledger, blocker=state.last_error)
+        terminal_status = _optional_str(ralph_meta.get("terminal_status"))
+        stop_reason = _optional_str(ralph_meta.get("stop_reason"))
+        current_generation = _optional_int(ralph_meta.get("current_generation"))
+        if terminal_status is not None:
+            state.ralph_job_status = terminal_status
+        if stop_reason is not None:
+            state.ralph_stop_reason = stop_reason
+        if current_generation is not None:
+            state.ralph_current_generation = current_generation
+        if terminal_status == "completed":
+            state.transition(
+                AutoPhase.COMPLETE,
+                f"ralph loop completed on re-attach ({stop_reason or 'qa passed'})",
+            )
+            self._save(state)
+            return self._result(state, ledger)
+        if terminal_status == "cancelled":
+            if state.phase is not AutoPhase.BLOCKED:
+                state.mark_blocked(RALPH_CANCEL_BLOCKER_REASON, tool_name="ralph_starter")
+                self._save(state)
+            return self._result(state, ledger, blocker=state.last_error)
+        if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
+            state.mark_blocked(stop_reason, tool_name="ralph_starter")
+            self._save(state)
+            return self._result(state, ledger, blocker=state.last_error)
+        message = (
+            f"ralph loop failed on re-attach: {stop_reason}"
+            if stop_reason
+            else f"ralph loop failed on re-attach: terminal_status={terminal_status or 'unknown'}"
+        )
+        state.mark_failed(message, tool_name="ralph_starter")
+        self._save(state)
+        return self._result(state, ledger, blocker=state.last_error)
 
     def _enforce_deadline(self, state: AutoPipelineState) -> bool:
         """Return True when the pipeline must abort because the deadline expired.
@@ -1509,3 +1824,26 @@ def _first_nonempty(*values: str | None) -> str | None:
 
 def _optional_str(value: object) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _optional_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+async def _drain_ralph_status_mirror(task: asyncio.Task[None] | None) -> None:
+    if task is None:
+        return
+    try:
+        await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
+    except TimeoutError:
+        await _cancel_ralph_status_mirror(task)
+    except Exception:
+        pass
+
+
+async def _cancel_ralph_status_mirror(task: asyncio.Task[None] | None) -> None:
+    if task is None or task.done():
+        return
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -299,14 +299,11 @@ class AutoPipeline:
         # BLOCKED state via ``_enforce_deadline``. Same exception applies
         # to the second ``_enforce_deadline`` gate after the BLOCKED/FAILED
         # recovery branch below.
-        ralph_resume_pending = state.phase is AutoPhase.RALPH_HANDOFF and (
-            state.ralph_job_id is not None or state.ralph_dispatch_mode == "plugin"
-        )
         if (
             state.deadline_at is not None
             and not state.is_terminal()
             and state.is_deadline_expired()
-            and not ralph_resume_pending
+            and not _has_reconciliable_ralph_resume_checkpoint(state)
         ):
             state.last_tool_name = PIPELINE_DEADLINE_TOOL_NAME
             state.mark_blocked(
@@ -362,7 +359,7 @@ class AutoPipeline:
         # subsequent ``_enforce_deadline`` call inside ``_poll_ralph_job``)
         # still fires ``pipeline_timeout`` if the job is genuinely still
         # running after the persisted budget has expired.
-        if not ralph_resume_pending and self._enforce_deadline(state):
+        if not _has_reconciliable_ralph_resume_checkpoint(state) and self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
         if state.phase in {AutoPhase.CREATED, AutoPhase.INTERVIEW}:
             # Arm the top-level pipeline deadline (#779) on the first
@@ -448,7 +445,7 @@ class AutoPipeline:
         # Q00/ouroboros#782 review-12 BLOCKING #1: same exception — let
         # ``RALPH_HANDOFF`` resume reach ``_resume_ralph_handoff`` so the
         # poller can reconcile an already-terminal Ralph job.
-        if not ralph_resume_pending and self._enforce_deadline(state):
+        if not _has_reconciliable_ralph_resume_checkpoint(state) and self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
         if state.phase == AutoPhase.SEED_GENERATION:
             if state.seed_artifact:
@@ -2418,6 +2415,18 @@ def _arm_legacy_missing_deadline(state: AutoPipelineState) -> bool:
         return False
     state.arm_deadline()
     return True
+
+
+def _has_reconciliable_ralph_resume_checkpoint(state: AutoPipelineState) -> bool:
+    """Return True when deadline gating should allow Ralph reconciliation.
+
+    Only persisted job handles and confirmed plugin dispatches qualify. An
+    unconfirmed ``plugin_pending`` checkpoint must still obey normal deadline
+    enforcement because resume has to retry the side-effecting plugin dispatch.
+    """
+    if state.phase is not AutoPhase.RALPH_HANDOFF:
+        return False
+    return state.ralph_job_id is not None or state.ralph_dispatch_mode == "plugin"
 
 
 def _first_nonempty(*values: str | None) -> str | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1041,9 +1041,7 @@ class AutoPipeline:
         state.ralph_dispatch_mode = _optional_str(ralph_meta.get("dispatch_mode"))
         terminal_status = _optional_str(ralph_meta.get("terminal_status"))
         stop_reason = _optional_str(ralph_meta.get("stop_reason"))
-        current_generation = _optional_int(ralph_meta.get("current_generation")) or _optional_int(
-            ralph_meta.get("iterations")
-        )
+        current_generation = _ralph_current_generation_from_meta(ralph_meta)
         if terminal_status is not None:
             state.ralph_job_status = terminal_status
         if stop_reason is not None:
@@ -1278,9 +1276,7 @@ class AutoPipeline:
             return self._result(state, ledger, review=review, blocker=state.last_error)
         terminal_status = _optional_str(ralph_meta.get("terminal_status"))
         stop_reason = _optional_str(ralph_meta.get("stop_reason"))
-        current_generation = _optional_int(ralph_meta.get("current_generation")) or _optional_int(
-            ralph_meta.get("iterations")
-        )
+        current_generation = _ralph_current_generation_from_meta(ralph_meta)
         if terminal_status is not None:
             state.ralph_job_status = terminal_status
         if stop_reason is not None:
@@ -1408,7 +1404,7 @@ class AutoPipeline:
             return self._result(state, ledger, blocker=state.last_error)
         terminal_status = _optional_str(ralph_meta.get("terminal_status"))
         stop_reason = _optional_str(ralph_meta.get("stop_reason"))
-        current_generation = _optional_int(ralph_meta.get("current_generation"))
+        current_generation = _ralph_current_generation_from_meta(ralph_meta)
         if terminal_status is not None:
             state.ralph_job_status = terminal_status
         if stop_reason is not None:
@@ -1828,6 +1824,26 @@ def _optional_str(value: object) -> str | None:
 
 def _optional_int(value: object) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _last_int(value: object) -> int | None:
+    if not isinstance(value, list):
+        return None
+    for item in reversed(value):
+        found = _optional_int(item)
+        if found is not None:
+            return found
+    return None
+
+
+def _ralph_current_generation_from_meta(meta: dict[str, Any]) -> int | None:
+    current_generation = _optional_int(meta.get("current_generation"))
+    if current_generation is not None:
+        return current_generation
+    generations_generation = _last_int(meta.get("generations"))
+    if generations_generation is not None:
+        return generations_generation
+    return _optional_int(meta.get("iterations"))
 
 
 async def _drain_ralph_status_mirror(task: asyncio.Task[None] | None) -> None:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -817,6 +817,7 @@ class AutoPipelineState:
             "ralph_job_id",
             "ralph_lineage_id",
             "ralph_dispatch_mode",
+            "ralph_opencode_mode",
             "ralph_job_status",
             "ralph_stop_reason",
             "last_grade",

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -274,6 +274,18 @@ class AutoPipelineState:
     ralph_job_id: str | None = None
     ralph_lineage_id: str | None = None
     ralph_dispatch_mode: str | None = None
+    # Q00/ouroboros#782 review-8: preserve the un-demoted OpenCode mode used
+    # to construct the Ralph handler across resume. ``state.opencode_mode`` may
+    # be demoted from plugin→subprocess for authoring/run-handoff handlers, but
+    # Ralph still needs the original plugin mode to return a subagent envelope.
+    ralph_opencode_mode: str | None = None
+    # Q00/ouroboros#782: best-effort mirror of the linked Ralph job's most
+    # recent observation, populated from mcp.job.* events. Defaults keep legacy
+    # state files compatible and let status surfaces render the handoff gap.
+    ralph_job_status: str | None = None
+    ralph_last_event_at: float | None = None
+    ralph_stop_reason: str | None = None
+    ralph_current_generation: int | None = None
     # Q00/ouroboros#773: persisted intent for ``--complete-product`` /
     # ``complete_product=True``. The flag is durable session state — not a
     # per-invocation argument — so a session originally started with
@@ -583,6 +595,11 @@ class AutoPipelineState:
         payload.setdefault("ralph_job_id", None)
         payload.setdefault("ralph_lineage_id", None)
         payload.setdefault("ralph_dispatch_mode", None)
+        payload.setdefault("ralph_opencode_mode", None)
+        payload.setdefault("ralph_job_status", None)
+        payload.setdefault("ralph_last_event_at", None)
+        payload.setdefault("ralph_stop_reason", None)
+        payload.setdefault("ralph_current_generation", None)
         payload.setdefault("complete_product", False)
         payload.setdefault("provenance", None)
         payload.setdefault("auto_answer_log", [])
@@ -597,8 +614,9 @@ class AutoPipelineState:
         # epoch field is present, derive ``deadline_at`` from the offset
         # between ``time.monotonic()`` and ``time.time()`` so the absolute
         # deadline survives a process restart. If both fields are missing
-        # (legacy state file or never-armed session), leave them None and let
-        # ``arm_deadline()`` decide when to set them.
+        # (legacy state file or never-armed non-terminal session), arm a fresh
+        # deadline after construction so resumed sessions still honor the
+        # top-level timeout contract.
         epoch_value = payload.get("deadline_at_epoch")
         if isinstance(epoch_value, int | float) and not isinstance(epoch_value, bool):
             now_epoch = time.time()
@@ -630,6 +648,12 @@ class AutoPipelineState:
         ):
             state.arm_deadline()
         state._validate_loaded()
+        if (
+            state.deadline_at is None
+            and state.deadline_at_epoch is None
+            and not state.is_terminal()
+        ):
+            state.arm_deadline()
         return state
 
     def _validate_loaded(self) -> None:
@@ -673,6 +697,25 @@ class AutoPipelineState:
                 continue
             if isinstance(value, bool) or not isinstance(value, int | float):
                 msg = f"{field_name} must be a number or null"
+                raise ValueError(msg)
+
+        # Q00/ouroboros#782 ralph mirror fields. ``ralph_last_event_at`` is a
+        # ``time.monotonic()``-domain reading set by the listener; persisted
+        # values from a prior process are still numerically valid for sorting
+        # but must not be reused as live monotonic deltas across processes.
+        if self.ralph_last_event_at is not None:
+            if isinstance(self.ralph_last_event_at, bool) or not isinstance(
+                self.ralph_last_event_at, int | float
+            ):
+                msg = "ralph_last_event_at must be a number or null"
+                raise ValueError(msg)
+        if self.ralph_current_generation is not None:
+            if (
+                isinstance(self.ralph_current_generation, bool)
+                or not isinstance(self.ralph_current_generation, int)
+                or self.ralph_current_generation < 0
+            ):
+                msg = "ralph_current_generation must be a non-negative integer or null"
                 raise ValueError(msg)
 
         for field_name in (
@@ -774,6 +817,8 @@ class AutoPipelineState:
             "ralph_job_id",
             "ralph_lineage_id",
             "ralph_dispatch_mode",
+            "ralph_job_status",
+            "ralph_stop_reason",
             "last_grade",
             "pending_question",
             "last_tool_name",

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -348,13 +348,30 @@ async def _run_auto(
             state.pipeline_timeout_seconds = float(pipeline_timeout_seconds)
 
     if runtime == "opencode":
-        opencode_mode = state.opencode_mode or get_opencode_mode()
+        # Q00/ouroboros#782 review-7 BLOCKING #3 + review-8 BLOCKING #1: keep
+        # the un-demoted opencode_mode for the Ralph handoff so a CLI launched
+        # from *inside* an OpenCode plugin session can still dispatch the new
+        # ``--complete-product`` Ralph loop via the plugin ``_subagent``
+        # envelope (matching the MCP entrypoint's behavior). The historical
+        # CLI demotion to ``subprocess`` was uniform and therefore disabled
+        # the plugin Ralph contract introduced by this PR.
+        #
+        # Persist the un-demoted value as ``state.ralph_opencode_mode`` and
+        # honor a previously persisted value on resume — ``state.opencode_mode``
+        # itself stores the demoted form (used by authoring/run-handoff
+        # handlers), so it cannot serve as a source of truth for plugin Ralph.
+        ralph_opencode_mode = (
+            state.ralph_opencode_mode or state.opencode_mode or get_opencode_mode()
+        )
+        opencode_mode = ralph_opencode_mode
         if opencode_mode == "plugin":
             opencode_mode = "subprocess"
     else:
         opencode_mode = None
+        ralph_opencode_mode = None
     state.runtime_backend = runtime
     state.opencode_mode = opencode_mode
+    state.ralph_opencode_mode = ralph_opencode_mode
     state.skip_run = skip_run
     if incoming_provenance is not None:
         if resume and state.provenance is None:
@@ -389,7 +406,11 @@ async def _run_auto(
         timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
     )
     ralph_handler = (
-        RalphHandler(agent_runtime_backend=runtime, opencode_mode=opencode_mode)
+        # Q00/ouroboros#782 review-7/8/10: pass the un-demoted
+        # ``ralph_opencode_mode`` so an OpenCode plugin session can take the
+        # plugin ``_subagent`` dispatch path. ``opencode_mode`` (demoted) is
+        # still correct for the authoring/run-handoff handlers above.
+        RalphHandler(agent_runtime_backend=runtime, opencode_mode=ralph_opencode_mode)
         if complete_product
         else None
     )

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -7,7 +7,8 @@ from typing import Annotated
 
 import typer
 
-from ouroboros.cli.formatters.panels import print_info
+from ouroboros.auto.state import AutoPhase, AutoStore
+from ouroboros.cli.formatters.panels import print_error, print_info
 from ouroboros.cli.formatters.tables import create_status_table, print_table
 
 app = typer.Typer(
@@ -15,6 +16,82 @@ app = typer.Typer(
     help="Check Ouroboros system status.",
     no_args_is_help=True,
 )
+
+
+def _format_auto_status(state) -> str:
+    """Render a unified auto + ralph status block as plain text.
+
+    Pinned by the snapshot test in ``tests/integration/auto/test_status_unified.py``.
+    Each line is intentionally compact (one fact per line) so a human can grep
+    the output and a Cucumber-style assertion can match it line-by-line. Layout
+    mirrors :py:meth:`SessionStatusHandler._handle_auto_session` so the CLI and
+    MCP surfaces never disagree.
+    """
+    lines = [
+        "Auto status",
+        "===========",
+        f"Auto session: {state.auto_session_id}",
+        f"Phase: {state.phase.value}",
+    ]
+
+    is_terminal = state.phase in {
+        AutoPhase.COMPLETE,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    }
+    lines.append(f"Terminal: {is_terminal}")
+    lines.append(f"Last progress: {state.last_progress_message}")
+
+    is_gap_window = (
+        state.phase is AutoPhase.RALPH_HANDOFF
+        and state.ralph_lineage_id is not None
+        and state.ralph_job_id is None
+        and state.ralph_dispatch_mode != "plugin"
+    )
+
+    if state.ralph_dispatch_mode == "plugin":
+        lines.append("Ralph (plugin):")
+        lines.append("  dispatch_mode: plugin")
+        lines.append("  guidance: ralph delegated to OpenCode Task widget; follow that lifecycle")
+    elif state.ralph_job_id is not None:
+        lines.append("Ralph (job):")
+        lines.append(f"  job_id: {state.ralph_job_id}")
+        lines.append(f"  lineage_id: {state.ralph_lineage_id}")
+        lines.append(f"  status: {state.ralph_job_status}")
+        lines.append(f"  current_generation: {state.ralph_current_generation}")
+        lines.append(f"  stop_reason: {state.ralph_stop_reason}")
+    elif is_gap_window:
+        lines.append("Ralph (pending):")
+        lines.append(f"  lineage_id: {state.ralph_lineage_id}")
+        lines.append("  pending: starting ralph")
+
+    if state.last_error:
+        lines.append(f"Blocker: {state.last_error}")
+
+    return "\n".join(lines) + "\n"
+
+
+@app.command()
+def auto(
+    auto_session_id: Annotated[
+        str,
+        typer.Argument(help="Auto session id to inspect (auto_<hex>)."),
+    ],
+) -> None:
+    """Show unified auto + ralph status for an ``ooo auto`` session.
+
+    Q00/ouroboros#782 — renders both the auto pipeline phase and the ralph
+    sub-block in a single human-readable view.
+    """
+    if not auto_session_id.startswith("auto_"):
+        print_error("auto_session_id must start with auto_")
+        raise typer.Exit(1)
+    try:
+        state = AutoStore().load(auto_session_id)
+    except ValueError as exc:
+        print_error(f"Auto status failed: {exc}")
+        raise typer.Exit(1) from exc
+    typer.echo(_format_auto_status(state), nl=False)
 
 
 @app.command()

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -46,13 +46,23 @@ def _format_auto_status(state) -> str:
         state.phase is AutoPhase.RALPH_HANDOFF
         and state.ralph_lineage_id is not None
         and state.ralph_job_id is None
-        and state.ralph_dispatch_mode != "plugin"
+        and state.ralph_dispatch_mode not in {"plugin", "plugin_pending"}
+    )
+    is_plugin_pending = (
+        state.phase is AutoPhase.RALPH_HANDOFF
+        and state.ralph_dispatch_mode == "plugin_pending"
     )
 
     if state.ralph_dispatch_mode == "plugin":
         lines.append("Ralph (plugin):")
         lines.append("  dispatch_mode: plugin")
         lines.append("  guidance: ralph delegated to OpenCode Task widget; follow that lifecycle")
+    elif is_plugin_pending:
+        lines.append("Ralph (plugin pending):")
+        lines.append("  dispatch_mode: plugin_pending")
+        lines.append(f"  lineage_id: {state.ralph_lineage_id}")
+        lines.append("  status: interrupted plugin dispatch")
+        lines.append("  guidance: plugin dispatch unconfirmed; resume will retry or block")
     elif state.ralph_job_id is not None:
         lines.append("Ralph (job):")
         lines.append(f"  job_id: {state.ralph_job_id}")

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -49,8 +49,7 @@ def _format_auto_status(state) -> str:
         and state.ralph_dispatch_mode not in {"plugin", "plugin_pending"}
     )
     is_plugin_pending = (
-        state.phase is AutoPhase.RALPH_HANDOFF
-        and state.ralph_dispatch_mode == "plugin_pending"
+        state.phase is AutoPhase.RALPH_HANDOFF and state.ralph_dispatch_mode == "plugin_pending"
     )
 
     if state.ralph_dispatch_mode == "plugin":

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -277,6 +277,12 @@ class AutoHandler:
                 state.pipeline_timeout_seconds = pipeline_timeout_seconds
         state.runtime_backend = runtime_backend
         state.opencode_mode = opencode_mode
+        # Q00/ouroboros#782 review-8 BLOCKING #1: persist the (un-demoted)
+        # mode for the Ralph handoff so resume reconstructs plugin Ralph
+        # dispatch even when the historical demoted form is later relied on
+        # for authoring/run-handoff handlers (matches the CLI behavior).
+        if opencode_mode is not None:
+            state.ralph_opencode_mode = state.ralph_opencode_mode or opencode_mode
         state.skip_run = skip_run
 
         authoring_opencode_mode = "subprocess" if opencode_mode == "plugin" else opencode_mode
@@ -309,10 +315,18 @@ class AutoHandler:
             timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
             context_provider=context_provider,
         )
+        # Q00/ouroboros#782 review-11 BLOCKING #1: pass the un-demoted
+        # ``state.ralph_opencode_mode`` (already populated above at line 251-252,
+        # and preserved across CLI-created sessions where ``state.opencode_mode``
+        # holds the demoted authoring/run-handoff form) so MCP-side resumes of
+        # an OpenCode plugin ``--complete-product`` session take the plugin
+        # ``_subagent`` dispatch path instead of silently downgrading Ralph to
+        # in-process job mode. Mirrors the CLI fix in ``cli/commands/auto.py``.
+        ralph_opencode_mode = state.ralph_opencode_mode or opencode_mode
         ralph_handler = (
             RalphHandler(
                 agent_runtime_backend=runtime_backend,
-                opencode_mode=opencode_mode,
+                opencode_mode=ralph_opencode_mode,
             )
             if complete_product
             else None

--- a/src/ouroboros/mcp/tools/query_handlers.py
+++ b/src/ouroboros/mcp/tools/query_handlers.py
@@ -105,6 +105,16 @@ class SessionStatusHandler:
                 "dispatch_mode": "plugin",
                 "guidance": ("ralph delegated to OpenCode Task widget; follow that lifecycle"),
             }
+        if (
+            state.phase is AutoPhase.RALPH_HANDOFF
+            and state.ralph_dispatch_mode == "plugin_pending"
+        ):
+            return {
+                "dispatch_mode": "plugin_pending",
+                "lineage_id": state.ralph_lineage_id,
+                "status": "interrupted_plugin_dispatch",
+                "guidance": "plugin dispatch unconfirmed; resume will retry or block",
+            }
         if state.ralph_job_id is not None:
             return {
                 "job_id": state.ralph_job_id,
@@ -146,7 +156,7 @@ class SessionStatusHandler:
             state.phase is AutoPhase.RALPH_HANDOFF
             and state.ralph_lineage_id is not None
             and state.ralph_job_id is None
-            and state.ralph_dispatch_mode != "plugin"
+            and state.ralph_dispatch_mode not in {"plugin", "plugin_pending"}
         )
         phase_value = "ralph_handoff" if is_gap_window else state.phase.value
         is_terminal = state.phase in {

--- a/src/ouroboros/mcp/tools/query_handlers.py
+++ b/src/ouroboros/mcp/tools/query_handlers.py
@@ -105,10 +105,7 @@ class SessionStatusHandler:
                 "dispatch_mode": "plugin",
                 "guidance": ("ralph delegated to OpenCode Task widget; follow that lifecycle"),
             }
-        if (
-            state.phase is AutoPhase.RALPH_HANDOFF
-            and state.ralph_dispatch_mode == "plugin_pending"
-        ):
+        if state.phase is AutoPhase.RALPH_HANDOFF and state.ralph_dispatch_mode == "plugin_pending":
             return {
                 "dispatch_mode": "plugin_pending",
                 "lineage_id": state.ralph_lineage_id,

--- a/src/ouroboros/mcp/tools/query_handlers.py
+++ b/src/ouroboros/mcp/tools/query_handlers.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import structlog
 
+from ouroboros.auto.state import AutoPhase, AutoStore
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.tools.ac_tree_hud_handler import (
@@ -39,12 +40,17 @@ class SessionStatusHandler:
     """
 
     event_store: EventStore | None = field(default=None, repr=False)
+    auto_store: AutoStore | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         """Initialize the session repository after dataclass creation."""
         self._owns_event_store = self.event_store is None
         self._event_store = self.event_store or EventStore()
         self._session_repo = SessionRepository(self._event_store)
+        # Auto sessions are read from a separate JSON-file store; the
+        # repository is created lazily so callers that never query an
+        # ``auto_<id>`` session do not pay the file-system cost.
+        self._auto_store = self.auto_store or AutoStore()
         self._initialized = False
 
     async def _ensure_initialized(self) -> None:
@@ -78,6 +84,132 @@ class SessionStatusHandler:
             ),
         )
 
+    def _build_ralph_block(self, state: Any) -> dict[str, Any] | None:
+        """Build the ``ralph`` sub-block for an auto session, if applicable.
+
+        Returns ``None`` when no ralph context exists yet (no lineage, no
+        job, no plugin delegation). When a ``ralph_dispatch_mode`` is
+        ``"plugin"`` the block intentionally omits ``job_id`` per the issue
+        contract — the OpenCode Task widget owns the lifecycle and the
+        block instead exposes the operator-facing guidance string.
+
+        For job-mode dispatch the block carries the four mirror fields
+        populated by ``ouroboros.auto.listeners`` plus the ``lineage_id``
+        already pinned at handoff time. ``last_event_at`` is forwarded
+        as-is even though it is a monotonic-clock reading; the unified
+        status surface only uses it for ordering, never for absolute time
+        rendering.
+        """
+        if state.ralph_dispatch_mode == "plugin":
+            return {
+                "dispatch_mode": "plugin",
+                "guidance": ("ralph delegated to OpenCode Task widget; follow that lifecycle"),
+            }
+        if state.ralph_job_id is not None:
+            return {
+                "job_id": state.ralph_job_id,
+                "lineage_id": state.ralph_lineage_id,
+                "status": state.ralph_job_status,
+                "last_event_at": state.ralph_last_event_at,
+                "current_generation": state.ralph_current_generation,
+                "stop_reason": state.ralph_stop_reason,
+                "dispatch_mode": state.ralph_dispatch_mode or "job",
+            }
+        return None
+
+    def _handle_auto_session(
+        self,
+        session_id: str,
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Build the unified status response for an ``auto_<id>`` session.
+
+        Synchronous because ``AutoStore`` is a JSON-file store, not async.
+        The handler intentionally returns a ``MCPToolError`` with the same
+        ``tool_name`` as the orchestrator branch so client error handling
+        does not need to special-case the auto path.
+        """
+        try:
+            state = self._auto_store.load(session_id)
+        except ValueError as exc:
+            return Result.err(
+                MCPToolError(
+                    f"Auto session not found: {exc}",
+                    tool_name="ouroboros_session_status",
+                )
+            )
+
+        # Gap window per the issue contract: between RUN's run_handoff_status
+        # transitioning to "started" and the RALPH_HANDOFF entry persisting a
+        # job_id, the session phase is reported as ``ralph_handoff`` with a
+        # ``pending`` marker so the operator never sees a missing-status hole.
+        is_gap_window = (
+            state.phase is AutoPhase.RALPH_HANDOFF
+            and state.ralph_lineage_id is not None
+            and state.ralph_job_id is None
+            and state.ralph_dispatch_mode != "plugin"
+        )
+        phase_value = "ralph_handoff" if is_gap_window else state.phase.value
+        is_terminal = state.phase in {
+            AutoPhase.COMPLETE,
+            AutoPhase.BLOCKED,
+            AutoPhase.FAILED,
+        }
+        ralph_block = self._build_ralph_block(state)
+
+        # Render a short text block; the structured detail lives in ``meta``
+        # so machine consumers do not have to parse strings. Keep the layout
+        # stable so the CLI snapshot test in ``tests/integration/auto`` can
+        # pin it.
+        lines = [
+            f"Auto session: {state.auto_session_id}",
+            f"Phase: {phase_value}",
+            f"Terminal: {is_terminal}",
+            f"Last progress: {state.last_progress_message}",
+        ]
+        if state.last_grade:
+            lines.append(f"Seed grade: {state.last_grade}")
+        if is_gap_window:
+            lines.append("Pending: starting ralph")
+        if ralph_block is not None:
+            lines.append("Ralph:")
+            for key in (
+                "dispatch_mode",
+                "job_id",
+                "lineage_id",
+                "status",
+                "current_generation",
+                "stop_reason",
+                "guidance",
+            ):
+                if key in ralph_block:
+                    lines.append(f"  {key}: {ralph_block[key]}")
+        status_text = "\n".join(lines) + "\n"
+
+        meta: dict[str, Any] = {
+            "session_id": state.auto_session_id,
+            "auto_session_id": state.auto_session_id,
+            "phase": phase_value,
+            "is_terminal": is_terminal,
+            "ralph_job_id": state.ralph_job_id,
+            "ralph_lineage_id": state.ralph_lineage_id,
+            "last_progress_message": state.last_progress_message,
+            "last_progress_at": state.last_progress_at,
+        }
+        if state.last_error:
+            meta["blocker"] = state.last_error
+        if is_gap_window:
+            meta["pending"] = "starting ralph"
+        if ralph_block is not None:
+            meta["ralph"] = ralph_block
+
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text=status_text),),
+                is_error=False,
+                meta=meta,
+            )
+        )
+
     async def handle(
         self,
         arguments: dict[str, Any],
@@ -100,6 +232,24 @@ class SessionStatusHandler:
             )
 
         log.info("mcp.tool.session_status", session_id=session_id)
+
+        # Q00/ouroboros#782: ``ouroboros_session_status`` is the unified
+        # surface for both orchestrator sessions (``exec_*`` / arbitrary IDs
+        # tracked by ``SessionRepository``) and ``ooo auto`` sessions
+        # (``auto_<hex>`` tracked by ``AutoStore``). The auto branch returns a
+        # superset shape with a ``ralph`` sub-block when a ralph job has been
+        # linked or is being prepared.
+        if isinstance(session_id, str) and session_id.startswith("auto_"):
+            try:
+                return self._handle_auto_session(session_id)
+            except Exception as e:  # pragma: no cover - defensive
+                log.error("mcp.tool.session_status.auto_error", error=str(e))
+                return Result.err(
+                    MCPToolError(
+                        f"Failed to get auto session status: {e}",
+                        tool_name="ouroboros_session_status",
+                    )
+                )
 
         try:
             # Ensure event store is initialized

--- a/tests/integration/auto/test_status_unified.py
+++ b/tests/integration/auto/test_status_unified.py
@@ -1,0 +1,453 @@
+"""Unified auto + ralph status surface (Q00/ouroboros#782).
+
+Pinned cases — see the issue for the full acceptance grid:
+
+1. Happy path: ralph reaches ``qa passed`` → ``session_status`` reflects the
+   terminal ralph state and the auto phase is ``COMPLETE``.
+2. Cancel path: ``JobManager.cancel_job`` → auto state transitions to
+   ``BLOCKED("ralph cancelled by user")`` within one simulated event-bus tick.
+3. Gap window: ``ralph_lineage_id`` set but ``ralph_job_id is None`` → status
+   reports ``pending: "starting ralph"`` and the phase string ``ralph_handoff``.
+4. Plugin delegation: ``ralph_dispatch_mode = "plugin"`` → no job query is
+   attempted; the ``ralph`` block carries the operator guidance only.
+
+The integration suite uses real ``EventStore`` / ``JobManager`` in-memory so
+the listener is exercised against the same code path that ships to users.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.listeners import (
+    RALPH_CANCEL_BLOCKER_REASON,
+    apply_event,
+    apply_events,
+    mirror_ralph_job_events,
+)
+from ouroboros.auto.state import (
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+)
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
+from ouroboros.mcp.tools.query_handlers import SessionStatusHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.persistence.event_store import EventStore
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers — keep state setup compact so each test focuses on one acceptance
+# bullet. ``_state_at_run`` lands the state machine inside RALPH_HANDOFF the
+# same way the production pipeline does.
+# ---------------------------------------------------------------------------
+
+
+def _state_at_run(tmp_path) -> AutoPipelineState:
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.arm_deadline()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_stub"
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.last_grade = "A"
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    return state
+
+
+def _state_at_ralph_handoff(tmp_path, *, with_job_id: bool = True) -> AutoPipelineState:
+    state = _state_at_run(tmp_path)
+    state.ralph_lineage_id = "ralph-seed-test_001-deadbeef"
+    state.transition(AutoPhase.RALPH_HANDOFF, "handing off")
+    if with_job_id:
+        state.ralph_job_id = "job_ralph_001"
+        state.ralph_dispatch_mode = "job"
+    return state
+
+
+def _make_job_event(
+    event_type: str,
+    *,
+    job_id: str,
+    lineage_id: str,
+    status: str | None = None,
+    stop_reason: str | None = None,
+    error: str | None = None,
+    message: str | None = None,
+    result_meta: dict[str, Any] | None = None,
+) -> BaseEvent:
+    payload: dict[str, Any] = {
+        "links": {"lineage_id": lineage_id},
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    if status is not None:
+        payload["status"] = status
+    if stop_reason is not None:
+        payload["stop_reason"] = stop_reason
+    if error is not None:
+        payload["error"] = error
+    if message is not None:
+        payload["message"] = message
+    if result_meta is not None:
+        payload["result_meta"] = result_meta
+    return BaseEvent(
+        type=event_type,
+        aggregate_type="job",
+        aggregate_id=job_id,
+        data=payload,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path — qa passed terminal status reaches the auto state.
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_qa_passed_completes_auto(tmp_path) -> None:
+    """Ralph completes ⇒ session_status shows COMPLETE + terminal ralph."""
+    state = _state_at_ralph_handoff(tmp_path)
+    state.transition(AutoPhase.COMPLETE, "ralph loop completed (qa passed)")
+    AutoStore(tmp_path).save(state)
+
+    # Listener mirrors the terminal job event onto the persisted state.
+    completed_event = _make_job_event(
+        "mcp.job.completed",
+        job_id=state.ralph_job_id,
+        lineage_id=state.ralph_lineage_id,
+        status=JobStatus.COMPLETED.value,
+        result_meta={
+            "status": "completed",
+            "stop_reason": "qa passed",
+            "iterations": 4,
+        },
+    )
+    assert apply_event(state, completed_event) is True
+    AutoStore(tmp_path).save(state)
+
+    handler = SessionStatusHandler(auto_store=AutoStore(tmp_path))
+    result = asyncio.run(handler.handle({"session_id": state.auto_session_id}))
+    assert result.is_ok
+    meta = result.value.meta
+    assert meta["phase"] == "complete"
+    assert meta["is_terminal"] is True
+    ralph = meta["ralph"]
+    assert ralph["dispatch_mode"] == "job"
+    assert ralph["job_id"] == "job_ralph_001"
+    assert ralph["status"] == JobStatus.COMPLETED.value
+    assert ralph["stop_reason"] == "qa passed"
+    assert ralph["current_generation"] == 4
+    assert ralph["lineage_id"] == state.ralph_lineage_id
+
+
+# ---------------------------------------------------------------------------
+# 2. Cancel propagation — cancel within one simulated event tick.
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_propagation_marks_auto_blocked(tmp_path) -> None:
+    """A single ``mcp.job.cancelled`` tick blocks the auto session."""
+    state = _state_at_ralph_handoff(tmp_path)
+    AutoStore(tmp_path).save(state)
+
+    cancel_event = _make_job_event(
+        "mcp.job.cancelled",
+        job_id=state.ralph_job_id,
+        lineage_id=state.ralph_lineage_id,
+        status="cancelled",
+    )
+    applied = apply_events(state, [cancel_event])
+    assert applied == 1
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_error == RALPH_CANCEL_BLOCKER_REASON
+    assert state.ralph_job_status == "cancelled"
+
+
+def test_cancel_terminal_after_complete_is_a_noop(tmp_path) -> None:
+    """A late cancel must not clobber an already-COMPLETE auto session."""
+    state = _state_at_ralph_handoff(tmp_path)
+    state.transition(AutoPhase.COMPLETE, "ralph loop completed (qa passed)")
+
+    cancel_event = _make_job_event(
+        "mcp.job.cancelled",
+        job_id=state.ralph_job_id,
+        lineage_id=state.ralph_lineage_id,
+        status="cancelled",
+    )
+    apply_event(state, cancel_event)
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_via_job_manager_propagates(tmp_path) -> None:
+    """End-to-end cancel: ``JobManager.cancel_job`` → auto BLOCKED via listener.
+
+    Wires a real ``JobManager`` against an in-memory event store, replays the
+    persisted job events through ``apply_events`` and asserts the listener
+    surfaces the cancellation onto the auto state.
+    """
+    event_store = EventStore("sqlite+aiosqlite:///:memory:")
+    await event_store.initialize()
+    manager = JobManager(event_store=event_store)
+
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=False)
+
+    async def _runner() -> Any:  # pragma: no cover - cancelled before completion
+        await asyncio.sleep(60)
+
+    snapshot = await manager.start_job(
+        job_type="ralph",
+        initial_message="ralph starting",
+        runner=_runner(),
+        links=JobLinks(lineage_id=state.ralph_lineage_id),
+    )
+    state.ralph_job_id = snapshot.job_id
+    state.ralph_dispatch_mode = "job"
+    AutoStore(tmp_path).save(state)
+
+    # Allow the job to reach RUNNING and emit at least one mcp.job.* event.
+    await asyncio.sleep(0.05)
+    cancelled_snapshot = await manager.cancel_job(snapshot.job_id)
+    assert cancelled_snapshot.status in {
+        JobStatus.CANCELLED,
+        JobStatus.CANCEL_REQUESTED,
+    }
+
+    # ``cancel_job`` cancels the runner Task; the terminal ``mcp.job.cancelled``
+    # event is appended by ``_run_job`` once the cancellation propagates. Poll
+    # the persisted history for up to ~1s so the integration test does not
+    # depend on event-loop scheduling order.
+    deadline = asyncio.get_running_loop().time() + 1.0
+    persisted_cancelled = False
+    while asyncio.get_running_loop().time() < deadline:
+        events = await event_store.replay("job", snapshot.job_id)
+        if any(ev.type == "mcp.job.cancelled" for ev in events):
+            persisted_cancelled = True
+            break
+        await asyncio.sleep(0.02)
+    assert persisted_cancelled, (
+        f"expected mcp.job.cancelled in persisted events, got {[ev.type for ev in events]}"
+    )
+
+    apply_events(state, events)
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_error == RALPH_CANCEL_BLOCKER_REASON
+
+    await event_store.close()
+
+
+@pytest.mark.asyncio
+async def test_status_mirror_persists_real_job_manager_payloads(tmp_path) -> None:
+    """Mirror real ``mcp.job.*`` events while the Ralph job is still running."""
+    event_store = EventStore("sqlite+aiosqlite:///:memory:")
+    await event_store.initialize()
+    manager = JobManager(event_store=event_store)
+
+    auto_store = AutoStore(tmp_path)
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=False)
+    finished = asyncio.Event()
+
+    async def _runner() -> MCPToolResult:
+        await finished.wait()
+        return MCPToolResult(
+            content=(MCPContentItem(type=ContentType.TEXT, text="ralph done"),),
+            meta={
+                "status": "completed",
+                "stop_reason": "qa passed",
+                "iterations": 4,
+            },
+        )
+
+    snapshot = await manager.start_job(
+        job_type="ralph",
+        initial_message="ralph starting",
+        runner=_runner(),
+        links=JobLinks(lineage_id=state.ralph_lineage_id),
+    )
+    state.ralph_job_id = snapshot.job_id
+    state.ralph_dispatch_mode = "job"
+    auto_store.save(state)
+
+    mirror_task = asyncio.create_task(
+        mirror_ralph_job_events(
+            state,
+            auto_store,
+            event_store,
+            snapshot.job_id,
+            poll_interval=0.01,
+        )
+    )
+    await manager.update_status(
+        snapshot.job_id,
+        JobStatus.RUNNING,
+        "Generation 3 | review",
+        links=JobLinks(lineage_id=state.ralph_lineage_id),
+    )
+
+    deadline = asyncio.get_running_loop().time() + 1.0
+    while asyncio.get_running_loop().time() < deadline:
+        saved = auto_store.load(state.auto_session_id)
+        if saved.ralph_current_generation == 3 and saved.ralph_job_status == "running":
+            break
+        await asyncio.sleep(0.02)
+    else:
+        pytest.fail("status mirror did not persist running generation progress")
+
+    finished.set()
+    await asyncio.wait_for(mirror_task, timeout=1.0)
+    saved = auto_store.load(state.auto_session_id)
+    assert saved.ralph_job_status == "completed"
+    assert saved.ralph_stop_reason == "qa passed"
+    assert saved.ralph_current_generation == 4
+
+    await event_store.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. Gap window — lineage_id set, no job_id yet.
+# ---------------------------------------------------------------------------
+
+
+def test_gap_window_reports_pending_starting_ralph(tmp_path) -> None:
+    """``ouroboros_session_status`` surfaces the gap window explicitly."""
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=False)
+    AutoStore(tmp_path).save(state)
+
+    handler = SessionStatusHandler(auto_store=AutoStore(tmp_path))
+    result = asyncio.run(handler.handle({"session_id": state.auto_session_id}))
+    assert result.is_ok
+    meta = result.value.meta
+    assert meta["phase"] == "ralph_handoff"
+    assert meta["pending"] == "starting ralph"
+    # No ``ralph`` block — there is nothing to mirror yet.
+    assert "ralph" not in meta
+    text = result.value.content[0].text
+    assert "Pending: starting ralph" in text
+
+
+@pytest.mark.parametrize("phase", (AutoPhase.BLOCKED, AutoPhase.FAILED))
+def test_terminal_lineage_without_job_id_is_not_gap_window(tmp_path, phase: AutoPhase) -> None:
+    """Terminal auto state must not be masked as a pending Ralph handoff."""
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=False)
+    if phase is AutoPhase.BLOCKED:
+        state.mark_blocked("ralph handoff failed", tool_name="ralph_starter")
+    else:
+        state.mark_failed("ralph handoff failed", tool_name="ralph_starter")
+    AutoStore(tmp_path).save(state)
+
+    handler = SessionStatusHandler(auto_store=AutoStore(tmp_path))
+    result = asyncio.run(handler.handle({"session_id": state.auto_session_id}))
+    assert result.is_ok
+    meta = result.value.meta
+    assert meta["phase"] == phase.value
+    assert meta["is_terminal"] is True
+    assert "pending" not in meta
+    assert "ralph" not in meta
+    assert "Pending: starting ralph" not in result.value.content[0].text
+
+
+@pytest.mark.parametrize("phase", (AutoPhase.BLOCKED, AutoPhase.FAILED))
+def test_cli_terminal_lineage_without_job_id_is_not_gap_window(tmp_path, phase: AutoPhase) -> None:
+    """CLI pending gap warning is only valid during RALPH_HANDOFF."""
+    from ouroboros.cli.commands.status import _format_auto_status
+
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=False)
+    if phase is AutoPhase.BLOCKED:
+        state.mark_blocked("ralph handoff failed", tool_name="ralph_starter")
+    else:
+        state.mark_failed("ralph handoff failed", tool_name="ralph_starter")
+
+    rendered = _format_auto_status(state)
+    assert "Phase: " + phase.value in rendered
+    assert "Ralph (pending):" not in rendered
+    assert "pending: starting ralph" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# 4. Plugin delegation — no job query is attempted.
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_dispatch_mode_no_job_query(tmp_path) -> None:
+    """Plugin delegation surfaces guidance and skips the job lookup entirely."""
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=False)
+    state.ralph_dispatch_mode = "plugin"
+    state.transition(AutoPhase.COMPLETE, "ralph loop delegated")
+    AutoStore(tmp_path).save(state)
+
+    handler = SessionStatusHandler(auto_store=AutoStore(tmp_path))
+    result = asyncio.run(handler.handle({"session_id": state.auto_session_id}))
+    assert result.is_ok
+    meta = result.value.meta
+    assert meta["phase"] == "complete"
+    ralph = meta["ralph"]
+    assert ralph == {
+        "dispatch_mode": "plugin",
+        "guidance": "ralph delegated to OpenCode Task widget; follow that lifecycle",
+    }
+
+    # The listener must refuse to apply events while the dispatch mode is plugin
+    # so we never accidentally mirror an unrelated event onto a delegated session.
+    plugin_event = _make_job_event(
+        "mcp.job.completed",
+        job_id="job_other",
+        lineage_id=state.ralph_lineage_id,
+        status="completed",
+    )
+    assert apply_event(state, plugin_event) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. CLI snapshot — pin layout (covers the ``ooo status auto`` rendering).
+# ---------------------------------------------------------------------------
+
+
+def test_cli_status_auto_snapshot(tmp_path) -> None:
+    """Pin ``ooo status auto`` text layout for the unified surface."""
+    from ouroboros.cli.commands.status import _format_auto_status
+
+    state = AutoPipelineState(
+        goal="Build a CLI",
+        cwd=str(tmp_path),
+        auto_session_id="auto_pinned00001",
+    )
+    state.arm_deadline()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.last_grade = "A"
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.ralph_lineage_id = "ralph-seed-test_001-pinned00"
+    state.transition(AutoPhase.RALPH_HANDOFF, "handing off")
+    state.ralph_job_id = "job_pinned"
+    state.ralph_dispatch_mode = "job"
+    state.ralph_job_status = "running"
+    state.ralph_current_generation = 3
+    state.transition(AutoPhase.COMPLETE, "ralph loop completed (qa passed)")
+    state.ralph_stop_reason = "qa passed"
+
+    rendered = _format_auto_status(state)
+    expected = (
+        "Auto status\n"
+        "===========\n"
+        "Auto session: auto_pinned00001\n"
+        "Phase: complete\n"
+        "Terminal: True\n"
+        "Last progress: ralph loop completed (qa passed)\n"
+        "Ralph (job):\n"
+        "  job_id: job_pinned\n"
+        "  lineage_id: ralph-seed-test_001-pinned00\n"
+        "  status: running\n"
+        "  current_generation: 3\n"
+        "  stop_reason: qa passed\n"
+    )
+    assert rendered == expected

--- a/tests/integration/auto/test_status_unified.py
+++ b/tests/integration/auto/test_status_unified.py
@@ -354,6 +354,47 @@ def test_gap_window_reports_pending_starting_ralph(tmp_path) -> None:
     assert "Pending: starting ralph" in text
 
 
+def test_plugin_pending_reports_interrupted_dispatch_not_starting_gap(tmp_path) -> None:
+    """Unconfirmed plugin dispatch is distinct from the normal startup gap."""
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=False)
+    state.ralph_dispatch_mode = "plugin_pending"
+    AutoStore(tmp_path).save(state)
+
+    handler = SessionStatusHandler(auto_store=AutoStore(tmp_path))
+    result = asyncio.run(handler.handle({"session_id": state.auto_session_id}))
+    assert result.is_ok
+    meta = result.value.meta
+    assert meta["phase"] == "ralph_handoff"
+    assert "pending" not in meta
+    assert meta["ralph"] == {
+        "dispatch_mode": "plugin_pending",
+        "lineage_id": state.ralph_lineage_id,
+        "status": "interrupted_plugin_dispatch",
+        "guidance": "plugin dispatch unconfirmed; resume will retry or block",
+    }
+    text = result.value.content[0].text
+    assert "Pending: starting ralph" not in text
+    assert "dispatch_mode: plugin_pending" in text
+    assert "status: interrupted_plugin_dispatch" in text
+
+
+def test_cli_plugin_pending_reports_interrupted_dispatch_not_starting_gap(tmp_path) -> None:
+    """CLI mirrors the MCP distinction for plugin_pending checkpoints."""
+    from ouroboros.cli.commands.status import _format_auto_status
+
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=False)
+    state.ralph_dispatch_mode = "plugin_pending"
+
+    rendered = _format_auto_status(state)
+
+    assert "Ralph (plugin pending):" in rendered
+    assert "dispatch_mode: plugin_pending" in rendered
+    assert "status: interrupted plugin dispatch" in rendered
+    assert "guidance: plugin dispatch unconfirmed; resume will retry or block" in rendered
+    assert "Ralph (pending):" not in rendered
+    assert "pending: starting ralph" not in rendered
+
+
 @pytest.mark.parametrize("phase", (AutoPhase.BLOCKED, AutoPhase.FAILED))
 def test_terminal_lineage_without_job_id_is_not_gap_window(tmp_path, phase: AutoPhase) -> None:
     """Terminal auto state must not be masked as a pending Ralph handoff."""

--- a/tests/integration/auto/test_status_unified.py
+++ b/tests/integration/auto/test_status_unified.py
@@ -147,6 +147,27 @@ def test_happy_path_qa_passed_completes_auto(tmp_path) -> None:
     assert ralph["lineage_id"] == state.ralph_lineage_id
 
 
+def test_listener_prefers_terminal_generations_over_iterations(tmp_path) -> None:
+    """Terminal metadata must mirror lineage generation, not loop iteration count."""
+    state = _state_at_ralph_handoff(tmp_path)
+
+    completed_event = _make_job_event(
+        "mcp.job.completed",
+        job_id=state.ralph_job_id,
+        lineage_id=state.ralph_lineage_id,
+        status=JobStatus.COMPLETED.value,
+        result_meta={
+            "status": "completed",
+            "stop_reason": "qa passed",
+            "iterations": 2,
+            "generations": [9, 10],
+        },
+    )
+
+    assert apply_event(state, completed_event) is True
+    assert state.ralph_current_generation == 10
+
+
 # ---------------------------------------------------------------------------
 # 2. Cancel propagation — cancel within one simulated event tick.
 # ---------------------------------------------------------------------------

--- a/tests/unit/auto/test_adapters_ralph_poller.py
+++ b/tests/unit/auto/test_adapters_ralph_poller.py
@@ -1,0 +1,52 @@
+"""Focused tests for AutoPipeline Ralph handler adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ouroboros.auto import adapters
+from ouroboros.auto.adapters import HandlerRalphPoller
+
+
+class _FakeJobManager:
+    def __init__(self) -> None:
+        self._event_store = object()
+
+
+class _FakeRalphHandler:
+    def __init__(self) -> None:
+        self._job_manager = _FakeJobManager()
+
+
+@pytest.mark.asyncio
+async def test_handler_ralph_poller_propagates_terminal_generation_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal job metadata must restore auto state's Ralph generation on resume."""
+    handler = _FakeRalphHandler()
+    poller = HandlerRalphPoller(handler)  # type: ignore[arg-type]
+
+    async def wait_for_terminal(_job_manager: Any, job_id: str) -> dict[str, Any]:
+        assert job_id == "job_ralph_existing"
+        return {
+            "status": "completed",
+            "stop_reason": "qa passed",
+            "lineage_id": "lineage-1",
+            "iterations": 7,
+        }
+
+    monkeypatch.setattr(adapters, "_wait_for_job_terminal", wait_for_terminal)
+
+    result = await poller(job_id="job_ralph_existing")
+
+    assert poller.job_event_store is handler._job_manager._event_store
+    assert result == {
+        "job_id": "job_ralph_existing",
+        "lineage_id": "lineage-1",
+        "dispatch_mode": "job",
+        "terminal_status": "completed",
+        "stop_reason": "qa passed",
+        "current_generation": 7,
+    }

--- a/tests/unit/auto/test_adapters_ralph_poller.py
+++ b/tests/unit/auto/test_adapters_ralph_poller.py
@@ -50,3 +50,28 @@ async def test_handler_ralph_poller_propagates_terminal_generation_metadata(
         "stop_reason": "qa passed",
         "current_generation": 7,
     }
+
+
+@pytest.mark.asyncio
+async def test_handler_ralph_poller_prefers_generations_over_iterations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resume metadata must preserve lineage generation, not loop iteration count."""
+    handler = _FakeRalphHandler()
+    poller = HandlerRalphPoller(handler)  # type: ignore[arg-type]
+
+    async def wait_for_terminal(_job_manager: Any, job_id: str) -> dict[str, Any]:
+        assert job_id == "job_ralph_existing"
+        return {
+            "status": "completed",
+            "stop_reason": "qa passed",
+            "lineage_id": "lineage-1",
+            "iterations": 2,
+            "generations": [9, 10],
+        }
+
+    monkeypatch.setattr(adapters, "_wait_for_job_terminal", wait_for_terminal)
+
+    result = await poller(job_id="job_ralph_existing")
+
+    assert result["current_generation"] == 10

--- a/tests/unit/auto/test_pipeline_deadline.py
+++ b/tests/unit/auto/test_pipeline_deadline.py
@@ -324,6 +324,21 @@ async def test_legacy_blocked_session_arms_deadline_on_recovery(tmp_path) -> Non
     assert armed.deadline_at_epoch > time.time()
 
 
+def test_legacy_nonterminal_state_load_arms_deadline() -> None:
+    """Legacy resumed sessions without deadline fields still get a top-level timeout."""
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+    payload = state.to_dict()
+    payload.pop("deadline_at", None)
+    payload.pop("deadline_at_epoch", None)
+
+    loaded = AutoPipelineState.from_dict(payload)
+
+    assert loaded.deadline_at is not None
+    assert loaded.deadline_at_epoch is not None
+    assert not loaded.is_deadline_expired()
+
+
 @pytest.mark.asyncio
 async def test_resume_after_deadline_expired_immediately_blocks(tmp_path) -> None:
     """Loading a state whose deadline already passed must transition to BLOCKED on entry."""

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -829,6 +829,42 @@ async def test_ralph_handoff_resume_polls_persisted_job_to_complete(tmp_path) ->
     assert state.phase is AutoPhase.COMPLETE
 
 
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_prefers_generations_over_iterations(tmp_path) -> None:
+    """Resumed poller metadata must preserve lineage generation over iteration count."""
+    state = _state_in_ralph_handoff(tmp_path)
+
+    async def ralph_resumer(*, job_id: str) -> dict[str, Any]:
+        return {
+            "job_id": job_id,
+            "lineage_id": state.ralph_lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+            "iterations": 2,
+            "generations": [9, 10],
+        }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("resume must not start a duplicate Ralph handoff")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        ralph_resumer=ralph_resumer,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.ralph_current_generation == 10
+
+
 class _ResumeMirrorEventStore:
     """Deterministic job-event source for resume mirror lifecycle tests."""
 

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -8,6 +8,7 @@ pre-#773 result shape.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import asdict
 import time
 from typing import Any
@@ -29,6 +30,7 @@ from ouroboros.auto.state import (
     AutoPhase,
     AutoPipelineState,
     AutoResumeCapability,
+    AutoStore,
 )
 from ouroboros.core.seed import (
     EvaluationPrinciple,
@@ -38,6 +40,7 @@ from ouroboros.core.seed import (
     Seed,
     SeedMetadata,
 )
+from ouroboros.events.base import BaseEvent
 
 
 def _build_seed(seed_id: str = "seed_test_001") -> Seed:
@@ -157,6 +160,31 @@ class _PassReviewer(SeedReviewer):
         return SeedReview(grade_result=grade, findings=())
 
 
+def _ralph_job_event(
+    event_type: str,
+    *,
+    job_id: str,
+    lineage_id: str,
+    status: str,
+    message: str | None = None,
+    result_meta: dict[str, Any] | None = None,
+) -> BaseEvent:
+    data: dict[str, Any] = {
+        "links": {"lineage_id": lineage_id},
+        "status": status,
+    }
+    if message is not None:
+        data["message"] = message
+    if result_meta is not None:
+        data["result_meta"] = result_meta
+    return BaseEvent(
+        type=event_type,
+        aggregate_type="job",
+        aggregate_id=job_id,
+        data=data,
+    )
+
+
 # ---------------------------------------------------------------------------
 # State machine — transitions added by #773
 # ---------------------------------------------------------------------------
@@ -223,6 +251,7 @@ async def test_ralph_qa_passed_completes_auto(tmp_path) -> None:
             "dispatch_mode": "job",
             "terminal_status": "completed",
             "stop_reason": "qa passed",
+            "current_generation": 4,
         }
 
     pipeline = AutoPipeline(
@@ -240,6 +269,9 @@ async def test_ralph_qa_passed_completes_auto(tmp_path) -> None:
     assert state.phase is AutoPhase.COMPLETE
     assert state.ralph_job_id == "job_ralph_001"
     assert state.ralph_dispatch_mode == "job"
+    assert state.ralph_job_status == "completed"
+    assert state.ralph_stop_reason == "qa passed"
+    assert state.ralph_current_generation == 4
     assert result.ralph_job_id == "job_ralph_001"
     assert result.ralph_dispatch_mode == "job"
     # ``lineage_id`` is deterministic per the issue contract
@@ -249,6 +281,54 @@ async def test_ralph_qa_passed_completes_auto(tmp_path) -> None:
     assert state.ralph_lineage_id is not None
     assert state.ralph_lineage_id.startswith(f"ralph-{_build_seed().metadata.seed_id}-")
     assert captured["kwargs"]["lineage_id"] == state.ralph_lineage_id
+
+
+@pytest.mark.asyncio
+async def test_ralph_job_id_persisted_while_starter_waits_for_terminal(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+    store = AutoStore(tmp_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        kwargs["on_dispatched"](
+            {
+                "job_id": "job_ralph_waiting",
+                "lineage_id": kwargs["lineage_id"],
+                "dispatch_mode": "job",
+            }
+        )
+        started.set()
+        await release.wait()
+        return {
+            "job_id": "job_ralph_waiting",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        store=store,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    task = asyncio.create_task(pipeline.run(state))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    persisted = store.load(state.auto_session_id)
+    assert persisted.phase is AutoPhase.RALPH_HANDOFF
+    assert persisted.ralph_job_id == "job_ralph_waiting"
+    assert persisted.ralph_dispatch_mode == "job"
+
+    release.set()
+    result = await task
+    assert result.status == "complete"
 
 
 # ---------------------------------------------------------------------------
@@ -657,6 +737,35 @@ def test_state_legacy_payload_defaults_complete_product_false(tmp_path) -> None:
     assert restored.complete_product is False
 
 
+def test_ralph_opencode_mode_persisted_for_resume() -> None:
+    """``ralph_opencode_mode`` must round-trip so plugin resume rebuilds plugin Ralph.
+
+    Q00/ouroboros#782 review-8 BLOCKING #1. ``state.opencode_mode`` is
+    overwritten with the demoted form (``plugin``→``subprocess``) by the CLI
+    entrypoint, so it cannot be the source of truth for plugin Ralph
+    dispatch on resume — the un-demoted value lives on this field.
+    """
+    state = AutoPipelineState(goal="g", cwd="/tmp")
+    assert state.ralph_opencode_mode is None  # legacy default
+
+    state.ralph_opencode_mode = "plugin"
+    payload = state.to_dict()
+    assert payload["ralph_opencode_mode"] == "plugin"
+
+    loaded = AutoPipelineState.from_dict(payload)
+    assert loaded.ralph_opencode_mode == "plugin"
+
+
+def test_ralph_opencode_mode_legacy_state_dict_loads_as_none() -> None:
+    """Legacy state files (no ``ralph_opencode_mode`` key) must default to None."""
+    state = AutoPipelineState(goal="g", cwd="/tmp")
+    payload = state.to_dict()
+    payload.pop("ralph_opencode_mode", None)
+
+    loaded = AutoPipelineState.from_dict(payload)
+    assert loaded.ralph_opencode_mode is None
+
+
 # ---------------------------------------------------------------------------
 # Resume polling — review-5 finding 1.
 #
@@ -720,6 +829,159 @@ async def test_ralph_handoff_resume_polls_persisted_job_to_complete(tmp_path) ->
     assert state.phase is AutoPhase.COMPLETE
 
 
+class _ResumeMirrorEventStore:
+    """Deterministic job-event source for resume mirror lifecycle tests."""
+
+    def __init__(self, state: AutoPipelineState) -> None:
+        self.state = state
+        self.terminal_ready = asyncio.Event()
+        self.started = asyncio.Event()
+        self.block_first_fetch = False
+        self.cancelled = False
+
+    async def get_events_after(
+        self,
+        aggregate_type: str,
+        aggregate_id: str,
+        *,
+        last_row_id: int = 0,
+    ) -> tuple[list[BaseEvent], int]:
+        assert aggregate_type == "job"
+        assert aggregate_id == self.state.ralph_job_id
+        self.started.set()
+        try:
+            if self.block_first_fetch:
+                await self.terminal_ready.wait()
+            if last_row_id == 0:
+                return [
+                    _ralph_job_event(
+                        "mcp.job.updated",
+                        job_id=aggregate_id,
+                        lineage_id=self.state.ralph_lineage_id or "",
+                        status="running",
+                        message="Generation 3 | review",
+                    )
+                ], 1
+            if self.terminal_ready.is_set() and last_row_id == 1:
+                return [
+                    _ralph_job_event(
+                        "mcp.job.completed",
+                        job_id=aggregate_id,
+                        lineage_id=self.state.ralph_lineage_id or "",
+                        status="completed",
+                        result_meta={
+                            "status": "completed",
+                            "stop_reason": "qa passed",
+                            "current_generation": 4,
+                        },
+                    )
+                ], 2
+            await asyncio.sleep(0.01)
+            return [], last_row_id
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+class _ResumePoller:
+    def __init__(self, event_store: _ResumeMirrorEventStore, auto_store: AutoStore) -> None:
+        self.job_event_store = event_store
+        self._event_store = event_store
+        self._auto_store = auto_store
+
+    async def __call__(self, *, job_id: str) -> dict[str, Any]:
+        await asyncio.wait_for(self._event_store.started.wait(), timeout=1.0)
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while asyncio.get_running_loop().time() < deadline:
+            saved = self._auto_store.load(self._event_store.state.auto_session_id)
+            if saved.ralph_job_status == "running" and saved.ralph_current_generation == 3:
+                break
+            await asyncio.sleep(0.01)
+        else:  # pragma: no cover - assertion branch
+            raise AssertionError("resume mirror did not persist running generation")
+        self._event_store.terminal_ready.set()
+        return {
+            "job_id": job_id,
+            "lineage_id": self._event_store.state.ralph_lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+            "current_generation": 4,
+        }
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_poller_mirrors_live_status_until_terminal(
+    tmp_path,
+) -> None:
+    """Resume polling starts the same Ralph status mirror used by fresh
+    handoff/re-attach, so running generation progress is persisted before
+    the terminal snapshot completes."""
+    state = _state_in_ralph_handoff(tmp_path)
+    auto_store = AutoStore(tmp_path)
+    auto_store.save(state)
+    event_store = _ResumeMirrorEventStore(state)
+    ralph_resumer = _ResumePoller(event_store, auto_store)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        store=auto_store,
+        reviewer=_PassReviewer(),
+        ralph_resumer=ralph_resumer,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.ralph_job_status == "completed"
+    assert state.ralph_stop_reason == "qa passed"
+    assert state.ralph_current_generation == 4
+    saved = auto_store.load(state.auto_session_id)
+    assert saved.ralph_job_status == "completed"
+    assert saved.ralph_current_generation == 4
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_poller_cancels_status_mirror_on_poll_error(
+    tmp_path,
+) -> None:
+    """If the resume poll fails, the background mirror task is cancelled
+    instead of being left running against the auto state."""
+    state = _state_in_ralph_handoff(tmp_path)
+    auto_store = AutoStore(tmp_path)
+    auto_store.save(state)
+    event_store = _ResumeMirrorEventStore(state)
+    event_store.block_first_fetch = True
+
+    class FailingPoller:
+        job_event_store = event_store
+
+        async def __call__(self, *, job_id: str) -> dict[str, Any]:  # noqa: ARG002
+            await asyncio.wait_for(event_store.started.wait(), timeout=1.0)
+            raise RuntimeError("snapshot unavailable")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        store=auto_store,
+        reviewer=_PassReviewer(),
+        ralph_resumer=FailingPoller(),
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "failed"
+    assert state.phase is AutoPhase.FAILED
+    assert state.last_error == "ralph resume poll failed: snapshot unavailable"
+    assert event_store.cancelled is True
+
+
 @pytest.mark.asyncio
 async def test_ralph_handoff_resume_polls_persisted_job_blocks_on_timeout(tmp_path) -> None:
     """Resume maps an ``iteration_timeout`` terminal status onto ``BLOCKED``
@@ -750,6 +1012,42 @@ async def test_ralph_handoff_resume_polls_persisted_job_blocks_on_timeout(tmp_pa
     assert result.status == "blocked"
     assert state.last_error == "iteration_timeout"
     assert state.last_tool_name == "ralph_starter"
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_polls_persisted_job_blocks_on_user_cancel(tmp_path) -> None:
+    """Resume polling must map ``terminal_status="cancelled"`` to BLOCKED with the
+    pinned ``RALPH_CANCEL_BLOCKER_REASON``, mirroring the live ``_handoff_to_ralph``
+    contract (Q00/ouroboros#782 review-10 BLOCKING #2). Falling through to the
+    generic failure branch would mark a user-cancelled session FAILED on resume,
+    which is a state-machine regression for a normal user action."""
+    state = _state_in_ralph_handoff(tmp_path)
+
+    async def ralph_resumer(*, job_id: str) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "job_id": "job_ralph_existing",
+            "lineage_id": state.ralph_lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "cancelled",
+            "stop_reason": None,
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_resumer=ralph_resumer,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_error == "ralph cancelled by user"
+    assert state.last_tool_name == "ralph_starter"
+    assert state.ralph_job_status == "cancelled"
 
 
 @pytest.mark.asyncio
@@ -1014,3 +1312,192 @@ async def test_handoff_to_ralph_does_not_retry_type_error_after_dispatch(tmp_pat
     assert state.phase is AutoPhase.FAILED
     assert state.ralph_job_id == "job_ralph_dispatched_once"
     assert state.last_error == "ralph handoff failed: starter failed after dispatch"
+
+
+# ---------------------------------------------------------------------------
+# Q00/ouroboros#782 review-12 BLOCKING #1 — RALPH_HANDOFF resume must
+# reconcile an already-terminal Ralph job even when the top-level deadline
+# has expired. Without this, a client that disconnects, lets Ralph finish
+# in the background, and then resumes after ``deadline_at`` is silently
+# demoted to ``pipeline_timeout`` instead of seeing the real COMPLETE/BLOCKED.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_reconciles_terminal_job_after_deadline_expired(
+    tmp_path,
+) -> None:
+    """Resume must poll an already-terminal Ralph job even when ``deadline_at``
+    has expired before the resume call. The poller's snapshot returns the
+    terminal status immediately (the loop already finished), so transitioning
+    to COMPLETE preserves the live-path contract instead of falsely tripping
+    ``pipeline_timeout``."""
+    state = _state_in_ralph_handoff(tmp_path)
+    # Deadline already in the past — the legacy early-return would have
+    # blocked this resume with ``pipeline_timeout (deadline expired before
+    # resume)`` before reaching ``_resume_ralph_handoff``.
+    state.deadline_at = time.monotonic() - 60.0
+
+    polled_job: dict[str, Any] = {}
+
+    async def ralph_resumer(*, job_id: str) -> dict[str, Any]:
+        polled_job["job_id"] = job_id
+        return {
+            "job_id": job_id,
+            "lineage_id": state.ralph_lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("resume must not start a duplicate Ralph handoff")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        ralph_resumer=ralph_resumer,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert polled_job["job_id"] == "job_ralph_existing"
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# Q00/ouroboros#782 review-12 BLOCKING #2 — plugin pre-call checkpoint must
+# distinguish "dispatch attempted" from "dispatch confirmed". A crash before
+# the bridge actually receives the ``_subagent`` envelope leaves persisted
+# state with ``ralph_dispatch_mode == "plugin_pending"``; resume must retry
+# rather than falsely transition to COMPLETE.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_plugin_pending_retries_dispatch(tmp_path) -> None:
+    """``ralph_dispatch_mode == "plugin_pending"`` means the auto pipeline
+    persisted the dispatch intent BEFORE the ``ouroboros_ralph`` handler
+    actually emitted ``mcp.subagent.dispatched``. On resume, this must
+    retry the handoff via ``_handoff_to_ralph`` with the same persisted
+    lineage instead of trusting the unconfirmed marker and short-circuiting
+    to COMPLETE."""
+    state = _state_in_ralph_handoff(tmp_path)
+    state.ralph_dispatch_mode = "plugin_pending"
+    state.ralph_job_id = None
+
+    retry_calls: list[dict[str, Any]] = []
+
+    async def ralph_starter(seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        retry_calls.append({"seed": seed, "kwargs": kwargs})
+        return {
+            "job_id": None,
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "plugin",
+            "terminal_status": "delegated_to_plugin",
+            "stop_reason": None,
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert len(retry_calls) == 1, (
+        "plugin_pending resume must retry _handoff_to_ralph exactly once, not "
+        "trust the unconfirmed checkpoint as a completed dispatch"
+    )
+    # Retried with the same persisted lineage so any half-emitted events
+    # stay correlated.
+    assert retry_calls[0]["kwargs"]["lineage_id"] == "ralph-seed_test_001-auto_abc"
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    # Post-call confirmation overrode the unconfirmed marker.
+    assert state.ralph_dispatch_mode == "plugin"
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_plugin_pending_blocks_when_starter_unwired(
+    tmp_path,
+) -> None:
+    """Without a wired ``ralph_starter`` (e.g. a library caller without a
+    job-manager handle), the pipeline cannot retry safely on a
+    ``plugin_pending`` checkpoint, so it must surface a recoverable
+    BLOCKED rather than silently transitioning to COMPLETE."""
+    state = _state_in_ralph_handoff(tmp_path)
+    state.ralph_dispatch_mode = "plugin_pending"
+    state.ralph_job_id = None
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        # No ralph_starter — cannot retry plugin dispatch.
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert "interrupted before confirmation" in (state.last_error or "")
+
+
+# ---------------------------------------------------------------------------
+# Q00/ouroboros#782 review-13 BLOCKING #1 — Resuming a plugin-dispatched
+# Ralph handoff must NOT re-emit the persisted ``state.run_subagent``. The
+# bridge already received the original ``_subagent`` envelope (that's what
+# "confirmed plugin dispatch" means); replaying it on resume can spawn a
+# duplicate OpenCode child session via ``meta["_subagent"]``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ralph_handoff_resume_confirmed_plugin_does_not_replay_subagent(
+    tmp_path,
+) -> None:
+    """A RALPH_HANDOFF resume with ``ralph_dispatch_mode == "plugin"`` is a
+    confirmed one-shot dispatch — the persisted ``run_subagent`` envelope
+    must be suppressed in the result, not replayed via ``_result()``'s
+    fallback to ``state.run_subagent``."""
+    state = _state_in_ralph_handoff(tmp_path)
+    state.ralph_dispatch_mode = "plugin"
+    state.ralph_job_id = None
+    # Simulate a session whose RUN handoff persisted a ``_subagent`` envelope
+    # before the Ralph plugin dispatch confirmed. Without the fix,
+    # ``_result()`` would fall back to this dict and re-emit it as
+    # ``meta["_subagent"]``, causing the bridge to spawn another child.
+    state.run_subagent = {
+        "type": "ralph_loop",
+        "lineage_id": state.ralph_lineage_id,
+    }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    # The result must NOT replay the persisted envelope.
+    assert result.run_subagent is None
+    # And the persisted state must be cleared so a future re-resume also
+    # doesn't replay it.
+    assert state.run_subagent == {}

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1571,3 +1571,106 @@ async def test_ralph_handoff_resume_confirmed_plugin_does_not_replay_subagent(
     # And the persisted state must be cleared so a future re-resume also
     # doesn't replay it.
     assert state.run_subagent == {}
+
+
+@pytest.mark.asyncio
+async def test_expired_deadline_after_recovery_allows_persisted_ralph_job_poll(
+    tmp_path,
+) -> None:
+    """A recoverable BLOCKED state with a persisted Ralph job must poll first.
+
+    The deadline exception has to be recomputed after BLOCKED -> RALPH_HANDOFF
+    recovery; otherwise an expired deadline masks an already-finished Ralph job
+    as ``pipeline_timeout``.
+    """
+    state = _state_in_ralph_handoff(tmp_path)
+    state.deadline_at = time.monotonic() - 5.0
+    state.deadline_at_epoch = time.time() - 5.0
+    state.mark_blocked("ralph handoff timed out before terminal status", tool_name="ralph_starter")
+
+    polled: list[str] = []
+
+    async def ralph_resumer(*, job_id: str) -> dict[str, Any]:
+        polled.append(job_id)
+        return {
+            "job_id": job_id,
+            "lineage_id": state.ralph_lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_resumer=ralph_resumer,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert polled == ["job_ralph_existing"]
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.last_tool_name != PIPELINE_DEADLINE_TOOL_NAME
+
+
+@pytest.mark.asyncio
+async def test_expired_deadline_after_recovery_allows_confirmed_plugin_checkpoint(
+    tmp_path,
+) -> None:
+    """Confirmed plugin dispatches are also reconciled after recovery."""
+    state = _state_in_ralph_handoff(tmp_path)
+    state.ralph_job_id = None
+    state.ralph_dispatch_mode = "plugin"
+    state.deadline_at = time.monotonic() - 5.0
+    state.deadline_at_epoch = time.time() - 5.0
+    state.mark_blocked("ralph handoff timed out before terminal status", tool_name="ralph_starter")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.last_tool_name != PIPELINE_DEADLINE_TOOL_NAME
+
+
+@pytest.mark.asyncio
+async def test_expired_deadline_after_recovery_blocks_unconfirmed_plugin_pending(
+    tmp_path,
+) -> None:
+    """Unconfirmed plugin_pending checkpoints still obey normal deadlines."""
+    state = _state_in_ralph_handoff(tmp_path)
+    state.ralph_job_id = None
+    state.ralph_dispatch_mode = "plugin_pending"
+    state.deadline_at = time.monotonic() - 5.0
+    state.deadline_at_epoch = time.time() - 5.0
+    state.mark_blocked("ralph handoff timed out before terminal status", tool_name="ralph_starter")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("plugin_pending must not retry after deadline expiry")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == PIPELINE_DEADLINE_TOOL_NAME
+    assert "pipeline_timeout" in (state.last_error or "")

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -315,6 +315,7 @@ def test_store_load_rejects_malformed_optional_strings(tmp_path) -> None:
         ("seed_path", {"path": "seed.json"}),
         ("seed_id", ""),
         ("execution_id", []),
+        ("ralph_opencode_mode", []),
         ("last_progress_message", []),
     ):
         data = state.to_dict()

--- a/tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py
+++ b/tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py
@@ -1,0 +1,98 @@
+"""Pin MCP ``ouroboros_auto`` Ralph-runtime construction across resume.
+
+Q00/ouroboros#782 review-11 BLOCKING #1: when an OpenCode ``--complete-product``
+session was originally started by the CLI inside plugin mode, the CLI
+demotes ``state.opencode_mode`` to ``"subprocess"`` for the authoring /
+run-handoff handlers and stores the un-demoted mode separately as
+``state.ralph_opencode_mode`` so the persisted-session contract can rebuild
+the plugin Ralph dispatch on resume. The MCP entrypoint must use the same
+discipline — otherwise resuming such a session through MCP silently
+downgrades Ralph from plugin delegation to in-process job mode and the
+caller loses the expected ``_subagent`` child-session handoff.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.mcp.tools.auto_handler import AutoHandler
+
+
+def test_mcp_resume_passes_undemoted_ralph_opencode_mode_to_ralph_handler(
+    tmp_path,
+) -> None:
+    """MCP resume of a CLI-created plugin session must rebuild Ralph in plugin mode.
+
+    Background: a CLI session originally started with
+    ``opencode_mode="plugin"`` persists ``state.opencode_mode == "subprocess"``
+    (demoted form for authoring/run-handoff) and
+    ``state.ralph_opencode_mode == "plugin"`` (un-demoted form, the actual
+    Ralph dispatch mode). The MCP resume path must read the un-demoted form
+    when constructing :class:`RalphHandler`, otherwise the plugin
+    ``_subagent`` dispatch contract is silently broken on cross-entrypoint
+    resume.
+    """
+    state = AutoPipelineState(goal="ralph plugin resume", cwd=str(tmp_path))
+    state.runtime_backend = "opencode"
+    # Demoted form persisted by the CLI for authoring/run-handoff.
+    state.opencode_mode = "subprocess"
+    # Un-demoted form persisted by the CLI specifically for Ralph dispatch.
+    state.ralph_opencode_mode = "plugin"
+    state.skip_run = True
+    state.max_interview_rounds = 2
+    state.max_repair_rounds = 1
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    captured: dict[str, Any] = {}
+
+    class _CapturingRalphHandler:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+            self._kwargs = kwargs
+            self.agent_runtime_backend = kwargs.get("agent_runtime_backend")
+            self.opencode_mode = kwargs.get("opencode_mode")
+
+    async def _noop_run(self, state):  # noqa: ARG001
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    handler = AutoHandler(store=store, agent_runtime_backend="opencode")
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.auto_handler.RalphHandler",
+            new=_CapturingRalphHandler,
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_noop_run,
+        ),
+    ):
+        asyncio.run(
+            handler.handle(
+                {
+                    "resume": state.auto_session_id,
+                    "complete_product": True,
+                }
+            )
+        )
+
+    assert "kwargs" in captured, (
+        "RalphHandler must be constructed when resuming a complete-product session"
+    )
+    assert captured["kwargs"]["agent_runtime_backend"] == "opencode"
+    # The fix: Ralph must see the un-demoted plugin mode, NOT the demoted
+    # ``state.opencode_mode == "subprocess"`` used for authoring/run handlers.
+    assert captured["kwargs"]["opencode_mode"] == "plugin"


### PR DESCRIPTION
Closes #782.

**Base status**: rebased directly on `main` after #791 merged; this PR is now the standalone follow-up for the unified auto/Ralph status surface.

## May 11 maintenance update

- Rebased the PR branch directly onto current `main` after #791 landed, removing the stale stacked-PR ancestry from the branch.
- Added `ralph_opencode_mode` to the persisted-state optional-string validation allowlist and covered malformed non-string state in `tests/unit/auto/test_state.py`.

## Summary

- Adds four ``AutoPipelineState`` mirror fields (``ralph_job_status``,
  ``ralph_last_event_at``, ``ralph_stop_reason``, ``ralph_current_generation``)
  populated by an event-driven listener in ``ouroboros.auto.listeners``.
- The listener subscribes to the existing ``mcp.job.*`` topics (created /
  updated / completed / failed / cancelled / interrupted) via the
  ``EventStore`` API, filters by ``links.lineage_id == state.ralph_lineage_id``
  (with a ``aggregate_id == ralph_job_id`` fallback because
  ``JobManager.update_status`` does not re-emit the lineage on every event),
  and updates the four mirror fields atomically. No polling.
- ``JobManager.cancel_job`` propagates: a ``mcp.job.cancelled`` reading
  marks the auto state ``BLOCKED("ralph cancelled by user")`` when the
  session is not already in a terminal phase.
- ``ouroboros_session_status`` MCP handler accepts ``auto_<id>`` session ids
  and returns a ``ralph`` sub-block. Gap-window state (lineage_id set but
  job_id missing) returns ``phase="ralph_handoff"`` with
  ``pending: "starting ralph"``. Plugin-delegation returns
  ``{"dispatch_mode": "plugin", "guidance": ...}`` and never queries a job.
- New ``ooo status auto <auto_session_id>`` CLI subcommand renders the auto
  phase + ralph block in a single human-readable view, pinned by snapshot
  test.

## Test plan

- [x] `PYTHONPATH=src /opt/hermes/.venv/bin/pytest tests/unit/auto/test_state.py tests/integration/auto/test_status_unified.py tests/unit/auto/test_adapters_ralph_poller.py tests/unit/auto/test_pipeline_deadline.py tests/unit/auto/test_pipeline_ralph_handoff.py tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py -q` — 117 passed
- [x] GitHub checks on `a4f67108`: Bridge TypeScript, MyPy, Ruff, Python 3.12/3.13/3.14, enforce-boundary, enforce-envelope all passed

- [x] `PYTHONPATH=src python3 -m pytest tests/integration/auto/test_status_unified.py -v` — 7 passed
- [x] `PYTHONPATH=src python3 -m pytest tests/integration/auto/test_status_unified.py tests/unit/auto/ tests/unit/mcp/tools/test_definitions.py` — 557 passed
- [x] `ruff format --check src/ tests/`
- [x] `ruff check src/ tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)