### PR TITLE
fix(auto): NFKC-normalize unsafe-context input before regex bank

### DIFF
--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
+import unicodedata
 
 from ouroboros.auto.ledger import (
     LedgerEntry,
@@ -263,14 +264,24 @@ def _unsafe_context_reason(
     "non-goals are credentials and production deployment" as active unsafe
     scope would invert the user's intent.
     """
-    context = "\n".join(
-        value
-        for value in (
-            goal,
-            *_unsafe_ledger_values(ledger),
-            *_interview_answers(ledger),
-        )
-        if value.strip()
+    # NFKC compatibility decomposition collapses fullwidth/half-width Latin,
+    # ligatures and other compatibility variants onto their canonical ASCII
+    # form, so the unsafe-context regex bank cannot be silently bypassed by
+    # text such as ``ｄｅｐｌｏｙ to ｐｒｏｄｕｃｔｉｏｎ`` (fullwidth Latin
+    # block, U+FF21..U+FF5A) or ``ﬁnalize`` (the ``fi`` ligature U+FB01).
+    # Without the normalization step ``\b(deploy|production|...)\b`` would
+    # not match those forms, defeating the gate's purpose.
+    context = unicodedata.normalize(
+        "NFKC",
+        "\n".join(
+            value
+            for value in (
+                goal,
+                *_unsafe_ledger_values(ledger),
+                *_interview_answers(ledger),
+            )
+            if value.strip()
+        ),
     ).lower()
     context = _strip_negated_clauses(context)
     for reason, pattern in _UNSAFE_CONTEXT_PATTERNS:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -560,26 +560,33 @@ def test_safe_default_allows_benign_production_mentions(goal: str) -> None:
     [
         # Fullwidth Latin block (U+FF21..U+FF5A) — visually identical to
         # ASCII for end users and routinely produced by IMEs that round-trip
-        # through CJK keyboards. Without NFKC normalization the
-        # ``\b(deploy|production|...)\b`` regex bank would not see these
-        # forms and the unsafe-context gate would silently mark a production
-        # cutover as safe-defaultable.
+        # through CJK keyboards. The unsafe-context "external side effect"
+        # arm matches the action verbs (``deploy``/``release``/``publish``/
+        # ``go live``/``push live``/``database migration``/...). Without
+        # NFKC normalization those alternations cannot see the fullwidth
+        # form, and the gate silently authorizes a production cutover.
         "ｄｅｐｌｏｙ to ｐｒｏｄｕｃｔｉｏｎ this Friday",
         "ｒｅｌｅａｓｅ version 2 to ｐｒｏｄ",
-        # Compatibility ligature (U+FB01 ``ﬁ``) is a less common but legal
-        # NFKC variant of ``fi``; pair it with a real production-action
-        # verb to lock in normalization on the verb side.
+        # Compatibility ligature (U+FB01 ``ﬁ``) paired with a real
+        # production-action verb so the regression covers normalization on
+        # the verb-token side as well.
         "ﬁnalize ｄｅｐｌｏｙ to production tomorrow",
     ],
 )
 def test_safe_default_blocks_unicode_compat_production_actions(goal: str) -> None:
     """Fullwidth/ligature Unicode must not bypass the unsafe-context regex bank.
 
-    Without ``unicodedata.normalize('NFKC', context)`` before the
-    ``re.search`` calls in ``_unsafe_context_reason``, the goal
-    ``ｄｅｐｌｏｙ to ｐｒｏｄｕｃｔｉｏｎ`` returns ``None`` (no unsafe
-    reason), letting the safe-default policy auto-default a session that
-    actually authorizes a production deploy.
+    The relevant arm is the "ambiguous external side effect" pattern,
+    which matches the action verbs (``deploy``/``release``/``publish``/
+    ``send email``/``webhook``/``database migration``/``go live``/
+    ``push live``/...). Bare ``production``/``prod``/``live`` is *not*
+    by itself flagged any more — the verb token is what carries the
+    block decision. Without ``unicodedata.normalize("NFKC", context)``
+    before the ``re.search`` calls in ``_unsafe_context_reason``, those
+    verb alternations cannot see fullwidth Latin (``ｄｅｐｌｏｙ``) or
+    ligature (``ﬁ``) variants, and the safe-default policy
+    auto-defaults a session that actually authorizes a production
+    deploy.
     """
     ledger = SeedDraftLedger.from_goal(goal)
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -558,6 +558,47 @@ def test_safe_default_allows_benign_production_mentions(goal: str) -> None:
 @pytest.mark.parametrize(
     "goal",
     [
+        # Fullwidth Latin block (U+FF21..U+FF5A) — visually identical to
+        # ASCII for end users and routinely produced by IMEs that round-trip
+        # through CJK keyboards. Without NFKC normalization the
+        # ``\b(deploy|production|...)\b`` regex bank would not see these
+        # forms and the unsafe-context gate would silently mark a production
+        # cutover as safe-defaultable.
+        "ｄｅｐｌｏｙ to ｐｒｏｄｕｃｔｉｏｎ this Friday",
+        "ｒｅｌｅａｓｅ version 2 to ｐｒｏｄ",
+        # Compatibility ligature (U+FB01 ``ﬁ``) is a less common but legal
+        # NFKC variant of ``fi``; pair it with a real production-action
+        # verb to lock in normalization on the verb side.
+        "ﬁnalize ｄｅｐｌｏｙ to production tomorrow",
+    ],
+)
+def test_safe_default_blocks_unicode_compat_production_actions(goal: str) -> None:
+    """Fullwidth/ligature Unicode must not bypass the unsafe-context regex bank.
+
+    Without ``unicodedata.normalize('NFKC', context)`` before the
+    ``re.search`` calls in ``_unsafe_context_reason``, the goal
+    ``ｄｅｐｌｏｙ to ｐｒｏｄｕｃｔｉｏｎ`` returns ``None`` (no unsafe
+    reason), letting the safe-default policy auto-default a session that
+    actually authorizes a production deploy.
+    """
+    ledger = SeedDraftLedger.from_goal(goal)
+
+    result = finalize_safe_defaultable_gaps(
+        ledger,
+        goal=goal,
+        provenance="unit test",
+    )
+
+    assert not result.completed, (
+        f"NFKC-equivalent goal {goal!r} authorizes a production action; finalization must block"
+    )
+    assert any("external side effect" in gap.lower() for gap in result.unsafe_gaps)
+    assert not ledger.is_seed_ready()
+
+
+@pytest.mark.parametrize(
+    "goal",
+    [
         "Deploy the new service to production for the launch event",
         "Release version 2 to prod after the freeze",
         "Push live the cutover migration on Friday",


### PR DESCRIPTION
## Summary
- `_unsafe_context_reason` only `.lower()`'d the input — Unicode compatibility variants (fullwidth Latin, ligatures) bypassed the `\b(deploy|production|...)\b` regex bank.
- A goal like `ｄｅｐｌｏｙ to ｐｒｏｄｕｃｔｉｏｎ` (visually identical to ASCII, common from CJK IMEs) returned `None` instead of `ambiguous external side effect`, letting `finalize_safe_defaultable_gaps` auto-default a session that actually authorizes a production deploy.
- Fix: `unicodedata.normalize("NFKC", joined)` before `.lower()`. The negation pre-pass and regex bank both run on the normalized form, no pattern needs rewriting.

## Reproduction
```python
from ouroboros.auto.safe_defaults import _unsafe_context_reason
from ouroboros.auto.ledger import SeedDraftLedger
_unsafe_context_reason(
    SeedDraftLedger(),
    goal="ｄｅｐｌｏｙ to ｐｒｏｄｕｃｔｉｏｎ",
    pending_question=None,
)  # before: None — bypass; after: "ambiguous external side effect"
```

## Test plan
- [x] new `test_safe_default_blocks_unicode_compat_production_actions` (fullwidth + ligature variants)
- [x] adjacent 37 safe-default tests still pass
- [x] ruff check + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)