### PR TITLE
fix(plugin): escape all C0/DEL chars in lockfile TOML basic strings

### DIFF
--- a/src/ouroboros/plugin/lockfile.py
+++ b/src/ouroboros/plugin/lockfile.py
@@ -59,22 +59,44 @@ class LockEntry:
         return lines
 
 
+_TOML_BASIC_ESCAPES: dict[str, str] = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\n": "\\n",
+    "\t": "\\t",
+    "\r": "\\r",
+    "\b": "\\b",
+    "\f": "\\f",
+}
+
+
 def _toml_str(value: str) -> str:
-    """Serialize a string value as TOML basic string. Restricts content to
-    avoid escaping edge cases — the lockfile only stores names, paths, hashes
-    and timestamps, none of which contain control chars or non-ASCII in
-    practice."""
-    if any(ch == "\\" or ch == '"' or ord(ch) < 0x20 for ch in value):
-        # Use TOML's basic string escapes for the small set we actually need.
-        escaped = (
-            value.replace("\\", "\\\\")
-            .replace('"', '\\"')
-            .replace("\n", "\\n")
-            .replace("\t", "\\t")
-            .replace("\r", "\\r")
-        )
-        return f'"{escaped}"'
-    return f'"{value}"'
+    """Serialize a string value as a TOML basic string.
+
+    The lockfile normally stores names, paths, hashes and timestamps, none of
+    which contain control characters in practice. The escape table previously
+    only covered ``\\``, ``"``, ``\\n``, ``\\t`` and ``\\r``, so any other C0
+    byte (e.g. ``\\x0b``, ``\\x0c``, ``\\x05``) was emitted verbatim into the
+    output even though :func:`tomllib.loads` rejects bare C0 inside basic
+    strings — meaning a value like ``"sha256:\\x0b..."`` produced a lockfile
+    that the next ``Lockfile.read()`` call would fail to parse.
+
+    The fix keeps the well-known escapes for ``\\b`` and ``\\f`` (TOML 1.0
+    §2.1) and falls back to ``\\uXXXX`` for any remaining ``ord(ch) < 0x20``
+    or ``ord(ch) == 0x7f`` (DEL) byte. ASCII printable values are still
+    emitted verbatim, so existing well-formed lockfiles remain unchanged.
+    """
+    if not any(ch in _TOML_BASIC_ESCAPES or ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+        return f'"{value}"'
+    parts: list[str] = []
+    for ch in value:
+        if ch in _TOML_BASIC_ESCAPES:
+            parts.append(_TOML_BASIC_ESCAPES[ch])
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            parts.append(f"\\u{ord(ch):04x}")
+        else:
+            parts.append(ch)
+    return f'"{"".join(parts)}"'
 
 
 class Lockfile:

--- a/tests/unit/plugin/test_lockfile.py
+++ b/tests/unit/plugin/test_lockfile.py
@@ -27,26 +27,24 @@ def _make_entry(name: str = "github-pr-ops", version: str = "0.1.0") -> LockEntr
     )
 
 
-@pytest.mark.parametrize(
-    "ctrl_char",
-    [
-        "\x01",  # SOH
-        "\x05",  # ENQ
-        "\x08",  # BS — has \b escape but earlier code only handled \n,\t,\r
-        "\x0b",  # VT
-        "\x0c",  # FF — has \f escape but earlier code only handled \n,\t,\r
-        "\x1f",  # US — last C0
-        "\x7f",  # DEL — TOML basic strings forbid this too
-    ],
-)
-def test_toml_str_escapes_all_control_chars(tmp_path: Path, ctrl_char: str) -> None:
-    """Lockfile entries containing C0 bytes (or DEL) must round-trip through tomllib.
+_FORBIDDEN_TOML_CONTROL_BYTES: tuple[str, ...] = tuple(chr(b) for b in [*range(0x00, 0x20), 0x7F])
 
-    Before the escape-table fix, ``_toml_str`` only handled ``\\``, ``"``,
-    ``\\n``, ``\\t`` and ``\\r`` — every other ``ord(ch) < 0x20`` byte was
-    emitted verbatim into the output. ``tomllib.loads`` rejects those bare
-    bytes inside a basic string with ``Illegal character ...``, so the very
-    next ``Lockfile.read()`` after such an ``add()`` would crash.
+
+@pytest.mark.parametrize("ctrl_char", _FORBIDDEN_TOML_CONTROL_BYTES)
+def test_toml_str_escapes_all_control_chars(tmp_path: Path, ctrl_char: str) -> None:
+    """Lockfile entries containing any C0 byte (0x00–0x1f) or DEL (0x7f)
+    must round-trip through tomllib.
+
+    Earlier the escape table covered only ``\\``, ``"``, ``\\n``, ``\\t``
+    and ``\\r``, so every other ``ord(ch) < 0x20`` byte and ``\\x7f``
+    were emitted verbatim. ``tomllib.loads`` rejects those bare bytes
+    inside a basic string with ``Illegal character ...`` — the very next
+    ``Lockfile.read()`` after such an ``add()`` would crash.
+
+    Iterates the **full forbidden range** rather than spot-checking a
+    handful, so the regression coverage matches the implementation
+    (which now handles every byte in the same range). Per ouroboros-
+    agent[bot] non-blocking suggestion on PR #795.
     """
     lock = Lockfile(tmp_path / "plugins.lock")
     # Stuff the control character into a value that survives across the lock

--- a/tests/unit/plugin/test_lockfile.py
+++ b/tests/unit/plugin/test_lockfile.py
@@ -27,6 +27,50 @@ def _make_entry(name: str = "github-pr-ops", version: str = "0.1.0") -> LockEntr
     )
 
 
+@pytest.mark.parametrize(
+    "ctrl_char",
+    [
+        "\x01",  # SOH
+        "\x05",  # ENQ
+        "\x08",  # BS — has \b escape but earlier code only handled \n,\t,\r
+        "\x0b",  # VT
+        "\x0c",  # FF — has \f escape but earlier code only handled \n,\t,\r
+        "\x1f",  # US — last C0
+        "\x7f",  # DEL — TOML basic strings forbid this too
+    ],
+)
+def test_toml_str_escapes_all_control_chars(tmp_path: Path, ctrl_char: str) -> None:
+    """Lockfile entries containing C0 bytes (or DEL) must round-trip through tomllib.
+
+    Before the escape-table fix, ``_toml_str`` only handled ``\\``, ``"``,
+    ``\\n``, ``\\t`` and ``\\r`` — every other ``ord(ch) < 0x20`` byte was
+    emitted verbatim into the output. ``tomllib.loads`` rejects those bare
+    bytes inside a basic string with ``Illegal character ...``, so the very
+    next ``Lockfile.read()`` after such an ``add()`` would crash.
+    """
+    lock = Lockfile(tmp_path / "plugins.lock")
+    # Stuff the control character into a value that survives across the lock
+    # boundary — manifest_checksum is a free-form string in the schema.
+    entry = LockEntry(
+        name="ctrl-char-plugin",
+        version="0.1.0",
+        source_kind="git",
+        repository="https://example.invalid/repo",
+        git_sha="deadbeef",
+        manifest_checksum=f"sha256:abc{ctrl_char}123",
+        installed_at="2026-05-08T03:14:00Z",
+        plugin_home="~/.ouroboros/plugins/ctrl-char-plugin",
+    )
+    lock.add(entry)
+
+    # The bug surfaces here: tomllib refuses to parse the file the lockfile
+    # itself just wrote.
+    fresh = Lockfile(tmp_path / "plugins.lock")
+    entries = fresh.read()
+    assert "ctrl-char-plugin" in entries
+    assert entries["ctrl-char-plugin"].manifest_checksum == f"sha256:abc{ctrl_char}123"
+
+
 def test_install_then_read(tmp_path: Path) -> None:
     """Test 1: install → lockfile entry present; round-trip through TOML."""
     lock = Lockfile(tmp_path / "plugins.lock")


### PR DESCRIPTION
## Summary
- ``_toml_str`` previously only handled ``\``, ``\"``, ``\n``, ``\t`` and ``\r``. Any other ``ord(ch) < 0x20`` byte (e.g. ``\x0b``, ``\x0c``, ``\x05``) was emitted verbatim, but TOML 1.0 §2.1 forbids bare control characters in basic strings.
- The very next ``Lockfile.read()`` after such an ``add()`` then crashed with ``tomllib.TOMLDecodeError: Illegal character`` — leaving the lockfile corrupted in place.
- Fix: extend the escape table with ``\b``/``\f`` and fall back to ``\uXXXX`` for any remaining C0 or DEL byte. ASCII-clean values are unchanged.

## Reproduction
```python
import tomllib
from ouroboros.plugin.lockfile import _toml_str
v = _toml_str("sha256:abc\x0b123")
tomllib.loads(f"x = {v}")
# Before: TOMLDecodeError: Illegal character '\x0b'
# After:  parses cleanly via  escape
```

## Test plan
- [x] new ``test_toml_str_escapes_all_control_chars`` parametrized over ``\x01 \x05 \x08 \x0b \x0c \x1f \x7f``
- [x] all 14 existing lockfile tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)