### PR TITLE
fix(plugin): deep-copy audit event in unwrap_plugin_event

### DIFF
--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -150,7 +150,12 @@ def unwrap_plugin_event(envelope: dict) -> dict:
     payload = envelope.get("payload")
     if not isinstance(payload, dict):
         raise ValueError("envelope payload is missing or not a dict")
-    return dict(payload)
+    # Deep copy to mirror ``wrap_plugin_event``'s defensive copy on the way
+    # in. ``dict(payload)`` is a shallow copy: mutating any nested dict on
+    # the returned value (e.g. ``result["plugin"]["name"] = "X"``) would
+    # write through to the live envelope still referenced by the event
+    # store, silently corrupting the audit log.
+    return copy.deepcopy(payload)
 
 
 def make_event_sink(

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -107,6 +107,34 @@ def test_round_trip_for_all_seven_event_types() -> None:
         assert env["event_type"] == event_type
 
 
+def test_unwrap_returned_value_is_isolated_from_envelope() -> None:
+    """Mutating the unwrapped audit event must not corrupt the envelope.
+
+    `wrap_plugin_event` deep-copies on the way in (line 125 of
+    ``ledger_adapter.py``); the inverse must also deep-copy on the way out.
+    If ``unwrap_plugin_event`` returned only ``dict(payload)`` (shallow),
+    a caller writing ``result["plugin"]["name"] = "X"`` would mutate the
+    live envelope still referenced by the event store, corrupting the
+    audit log without any visible API surface to detect it.
+    """
+    ev = _audit_event("plugin.completed")
+    env = wrap_plugin_event(ev, correlation_id="x")
+    unwrapped = unwrap_plugin_event(env)
+
+    # Mutate every nested container the audit event has.
+    unwrapped["plugin"]["name"] = "MUTATED-PLUGIN-NAME"
+    unwrapped["command"]["argv"].append("--injected")
+    unwrapped["capabilities_used"].append("fs.write")
+    unwrapped["result"]["status"] = "MUTATED-STATUS"
+
+    # The envelope's payload must be unchanged.
+    payload = env["payload"]
+    assert payload["plugin"]["name"] != "MUTATED-PLUGIN-NAME"
+    assert "--injected" not in payload["command"].get("argv", [])
+    assert "fs.write" not in payload["capabilities_used"]
+    assert payload["result"]["status"] != "MUTATED-STATUS"
+
+
 def test_unwrap_rejects_non_plugin_envelope() -> None:
     """Envelope with the wrong aggregate_type is rejected."""
     fake = {


### PR DESCRIPTION
## Summary
- ``wrap_plugin_event`` defensively ``copy.deepcopy``s the audit event on the way into the envelope (ledger_adapter.py:125), but the inverse ``unwrap_plugin_event`` returned only ``dict(payload)`` — shallow.
- A caller mutating a nested container on the unwrapped value (e.g. ``result[\"plugin\"][\"name\"] = \"X\"``) wrote through to the envelope still referenced by the event store, silently corrupting the audit log.
- Fix: return ``copy.deepcopy(payload)`` to restore symmetry. ``envelope_to_base_event`` (line 269) already uses ``copy.deepcopy``.

## Reproduction
```python
env = wrap_plugin_event({\"event_type\":\"plugin.invoked\",\"plugin\":{\"name\":\"foo\"},...}, correlation_id=\"c\")
out = unwrap_plugin_event(env)
out[\"plugin\"][\"name\"] = \"MUTATED\"
env[\"payload\"][\"plugin\"][\"name\"]   # before: 'MUTATED' — corrupted; after: 'foo'
```

## Test plan
- [x] new ``test_unwrap_returned_value_is_isolated_from_envelope`` covers mutations on every nested container
- [x] all 22 existing ledger_adapter tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)