### PR TITLE
fix(scripts): skip symlinks in check-auto-boundary scan

### DIFF
--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -209,38 +209,44 @@ def _resolve_scan_targets() -> tuple[list[Path], list[str]]:
     targets: list[Path] = []
     seen: set[Path] = set()
 
+    repo_root_resolved = REPO_ROOT.resolve()
     for d in SCAN_DIRS:
         root = REPO_ROOT / d
         if root.is_dir():
             for p in sorted(root.rglob("*.py")):
-                # Path.rglob follows symlinks by default. A symlink farm
-                # under SCAN_DIRS (e.g. ``src/ouroboros/auto/external ->
-                # ../../vendor/sdk``) would silently pull every ``*.py``
-                # under the link target into the scan, producing false
-                # positives for code we explicitly chose not to police —
-                # and training reviewers to add spurious allowlist markers
-                # to vendored files. Skip any symlink (file or directory
-                # link) so the scan stays anchored to in-tree files.
-                if p.is_symlink():
+                # ``Path.rglob`` follows symlinks by default. The risk a
+                # symlink farm introduces is *escape from the repo*: a
+                # link such as ``src/ouroboros/auto/external ->
+                # /home/user/vendor/sdk`` pulls every ``*.py`` under the
+                # link target into the scan, producing false positives
+                # for code we deliberately did not police.
+                #
+                # The meaningful architectural boundary here is "does
+                # this file still resolve inside the repo?", not "is
+                # this path a symlink?". A symlink that points to
+                # *another in-repo file* is just an implementation
+                # detail (``src/ouroboros/auto/legacy.py ->
+                # ../shared/legacy.py``) — Python imports it normally,
+                # so the boundary guard must scan it normally too.
+                # Earlier revisions skipped every symlink unconditionally
+                # and turned in-repo links into unscanned blind spots,
+                # weakening the guard's contract (Q00/ouroboros#797
+                # review feedback).
+                try:
+                    resolved = p.resolve(strict=False)
+                except OSError:  # broken symlink — treat as escape
                     continue
-                # Also skip files whose any parent on the scan path is a
-                # symlink: ``rglob`` traverses symlinked directories, and
-                # only the directory entry itself shows up as a symlink —
-                # the leaf ``*.py`` it descends into does not. Walk up
-                # from the file to ``root`` and reject if any intermediate
-                # directory is a symlink.
-                walked = p.parent
-                via_symlink = False
-                while walked != root and walked.parent != walked:
-                    if walked.is_symlink():
-                        via_symlink = True
-                        break
-                    walked = walked.parent
-                if via_symlink:
+                try:
+                    resolved.relative_to(repo_root_resolved)
+                except ValueError:
+                    # Resolved path is outside REPO_ROOT → either a
+                    # symlink to an external file, or a symlinked
+                    # directory whose target lives outside the repo.
+                    # Either way the file is not "in-repo code" and
+                    # must not be policed by the boundary guard.
                     continue
-                rp = p.resolve()
-                if rp not in seen:
-                    seen.add(rp)
+                if resolved not in seen:
+                    seen.add(resolved)
                     targets.append(p)
 
     for rel in SCAN_EXTRA_FILES:

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -251,11 +251,28 @@ def _resolve_scan_targets() -> tuple[list[Path], list[str]]:
 
     for rel in SCAN_EXTRA_FILES:
         p = REPO_ROOT / rel
-        if p.is_file():
-            rp = p.resolve()
-            if rp not in seen:
-                seen.add(rp)
-                targets.append(p)
+        if not p.is_file():
+            continue
+        # Apply the same repo-boundary check used for SCAN_DIRS: if the
+        # extra-file slot is itself a symlink to something outside the
+        # repo (e.g. a contributor accidentally points
+        # ``src/ouroboros/cli/commands/auto.py`` at a vendored copy
+        # outside the tree), the scan must skip it. Without this, the
+        # SCAN_DIRS path enforces "in-repo only" but the explicit
+        # extra-files path silently re-introduces the same false-positive
+        # class — flagged on PR #797 by the bot reviewer (auto.py ->
+        # external file containing GitHubVendor reproduced rc=1).
+        try:
+            resolved = p.resolve(strict=False)
+        except OSError:  # broken symlink — treat as escape
+            continue
+        try:
+            resolved.relative_to(repo_root_resolved)
+        except ValueError:
+            continue
+        if resolved not in seen:
+            seen.add(resolved)
+            targets.append(p)
 
     missing = [rel for rel in ANCHOR_FILES if not (REPO_ROOT / rel).is_file()]
     return targets, missing

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -213,6 +213,31 @@ def _resolve_scan_targets() -> tuple[list[Path], list[str]]:
         root = REPO_ROOT / d
         if root.is_dir():
             for p in sorted(root.rglob("*.py")):
+                # Path.rglob follows symlinks by default. A symlink farm
+                # under SCAN_DIRS (e.g. ``src/ouroboros/auto/external ->
+                # ../../vendor/sdk``) would silently pull every ``*.py``
+                # under the link target into the scan, producing false
+                # positives for code we explicitly chose not to police —
+                # and training reviewers to add spurious allowlist markers
+                # to vendored files. Skip any symlink (file or directory
+                # link) so the scan stays anchored to in-tree files.
+                if p.is_symlink():
+                    continue
+                # Also skip files whose any parent on the scan path is a
+                # symlink: ``rglob`` traverses symlinked directories, and
+                # only the directory entry itself shows up as a symlink —
+                # the leaf ``*.py`` it descends into does not. Walk up
+                # from the file to ``root`` and reject if any intermediate
+                # directory is a symlink.
+                walked = p.parent
+                via_symlink = False
+                while walked != root and walked.parent != walked:
+                    if walked.is_symlink():
+                        via_symlink = True
+                        break
+                    walked = walked.parent
+                if via_symlink:
+                    continue
                 rp = p.resolve()
                 if rp not in seen:
                     seen.add(rp)

--- a/scripts/check-auto-boundary.py
+++ b/scripts/check-auto-boundary.py
@@ -198,83 +198,98 @@ _COMPILED_PATTERNS: tuple[re.Pattern[str], ...] = tuple(re.compile(p) for p in F
 ALLOWLIST_MARKER = "domain-keyword-allowed:"
 
 
+def _resolve_inside_repo(path: Path, repo_root_resolved: Path) -> Path | None:
+    """Return ``path.resolve()`` iff it stays inside ``repo_root_resolved``.
+
+    The architectural boundary for the scan is "does this path resolve
+    to a location inside the repo?", not "is this path a symlink?". A
+    symlink to another in-repo file is an implementation detail —
+    Python imports it normally and the guard must police it. A symlink
+    whose target escapes the tree is not in-repo code and must not be
+    policed (Q00/ouroboros#797 review).
+    """
+    try:
+        resolved = path.resolve(strict=False)
+    except OSError:  # broken symlink, permission denied, ELOOP, ...
+        return None
+    try:
+        resolved.relative_to(repo_root_resolved)
+    except ValueError:
+        return None
+    return resolved
+
+
 def _resolve_scan_targets() -> tuple[list[Path], list[str]]:
     """Return ``(scan_targets, missing_anchors)``.
 
     ``scan_targets`` is the union of every existing ``*.py`` file under
     SCAN_DIRS plus any SCAN_EXTRA_FILES that exist. ``missing_anchors``
-    is the list of ANCHOR_FILES that do not exist on disk; a non-empty
-    list means the guard must fail loud.
+    is the list of ANCHOR_FILES that do not exist on disk *or* whose
+    resolved path leaves the repo (e.g. their parent directory is a
+    symlink to an external tree); a non-empty list means the guard
+    must fail loud.
     """
     targets: list[Path] = []
     seen: set[Path] = set()
 
     repo_root_resolved = REPO_ROOT.resolve()
+
     for d in SCAN_DIRS:
         root = REPO_ROOT / d
-        if root.is_dir():
-            for p in sorted(root.rglob("*.py")):
-                # ``Path.rglob`` follows symlinks by default. The risk a
-                # symlink farm introduces is *escape from the repo*: a
-                # link such as ``src/ouroboros/auto/external ->
-                # /home/user/vendor/sdk`` pulls every ``*.py`` under the
-                # link target into the scan, producing false positives
-                # for code we deliberately did not police.
-                #
-                # The meaningful architectural boundary here is "does
-                # this file still resolve inside the repo?", not "is
-                # this path a symlink?". A symlink that points to
-                # *another in-repo file* is just an implementation
-                # detail (``src/ouroboros/auto/legacy.py ->
-                # ../shared/legacy.py``) — Python imports it normally,
-                # so the boundary guard must scan it normally too.
-                # Earlier revisions skipped every symlink unconditionally
-                # and turned in-repo links into unscanned blind spots,
-                # weakening the guard's contract (Q00/ouroboros#797
-                # review feedback).
-                try:
-                    resolved = p.resolve(strict=False)
-                except OSError:  # broken symlink — treat as escape
-                    continue
-                try:
-                    resolved.relative_to(repo_root_resolved)
-                except ValueError:
-                    # Resolved path is outside REPO_ROOT → either a
-                    # symlink to an external file, or a symlinked
-                    # directory whose target lives outside the repo.
-                    # Either way the file is not "in-repo code" and
-                    # must not be policed by the boundary guard.
-                    continue
-                if resolved not in seen:
-                    seen.add(resolved)
-                    targets.append(p)
+        if not root.is_dir():
+            continue
+        # Root-level escape: if SCAN_DIR itself is a symlink whose
+        # target lives outside the repo (``src/ouroboros/auto ->
+        # /tmp/external_auto``), every per-file boundary check below
+        # would fail and ``targets`` would be empty for this root —
+        # silently stripping coverage for the entire subtree. Skip
+        # the rglob walk; the missing-anchor check below makes this
+        # fail loud, because anchors that live under this root no
+        # longer resolve in-repo (Q00/ouroboros#797 review).
+        if _resolve_inside_repo(root, repo_root_resolved) is None:
+            continue
+        for p in sorted(root.rglob("*.py")):
+            resolved = _resolve_inside_repo(p, repo_root_resolved)
+            if resolved is None:
+                # File resolved outside REPO_ROOT — symlink leaf to an
+                # external file, or a descendant of an in-rglob
+                # symlinked directory whose target escapes. Either way,
+                # not in-repo code: do not police it.
+                continue
+            if resolved not in seen:
+                seen.add(resolved)
+                targets.append(p)
 
     for rel in SCAN_EXTRA_FILES:
         p = REPO_ROOT / rel
         if not p.is_file():
             continue
-        # Apply the same repo-boundary check used for SCAN_DIRS: if the
-        # extra-file slot is itself a symlink to something outside the
-        # repo (e.g. a contributor accidentally points
-        # ``src/ouroboros/cli/commands/auto.py`` at a vendored copy
-        # outside the tree), the scan must skip it. Without this, the
-        # SCAN_DIRS path enforces "in-repo only" but the explicit
-        # extra-files path silently re-introduces the same false-positive
-        # class — flagged on PR #797 by the bot reviewer (auto.py ->
-        # external file containing GitHubVendor reproduced rc=1).
-        try:
-            resolved = p.resolve(strict=False)
-        except OSError:  # broken symlink — treat as escape
-            continue
-        try:
-            resolved.relative_to(repo_root_resolved)
-        except ValueError:
+        # Same repo-boundary rule as SCAN_DIRS, applied to the explicit
+        # extra-file slot: a contributor accidentally pointing
+        # ``src/ouroboros/cli/commands/auto.py`` at an external file
+        # would otherwise re-introduce the same false-positive class
+        # the SCAN_DIRS check rejects.
+        resolved = _resolve_inside_repo(p, repo_root_resolved)
+        if resolved is None:
             continue
         if resolved not in seen:
             seen.add(resolved)
             targets.append(p)
 
-    missing = [rel for rel in ANCHOR_FILES if not (REPO_ROOT / rel).is_file()]
+    # An anchor file is "present" only if it (a) exists and (b) still
+    # resolves inside the repo. ``is_file()`` follows symlink chains,
+    # so a parent directory that has been symlinked out of the tree
+    # would otherwise let an anchor look healthy on disk while no
+    # longer being scanned — exactly the coverage-stripping escape the
+    # guard is meant to catch.
+    missing: list[str] = []
+    for rel in ANCHOR_FILES:
+        anchor = REPO_ROOT / rel
+        if not anchor.is_file():
+            missing.append(rel)
+            continue
+        if _resolve_inside_repo(anchor, repo_root_resolved) is None:
+            missing.append(rel)
     return targets, missing
 
 

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -287,19 +287,18 @@ def test_clean_auto_dir_with_anchors_passes(
     assert rc == 0
 
 
-def test_symlink_directory_under_scan_root_is_skipped(
+def test_symlink_directory_resolving_outside_repo_is_skipped(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A symlinked directory under the scan root must not pull files
-    from outside the boundary into the scan.
+    """A symlinked directory that resolves OUTSIDE the repo must not
+    pull files into the scan.
 
-    Without ``is_symlink()`` filtering, ``Path.rglob`` happily descends
-    into a directory symlink and pulls every ``*.py`` under the link
-    target into the scan. A symlink farm such as
-    ``src/ouroboros/auto/external -> ../../vendor/sdk`` would then
-    produce false-positive failures on files we deliberately did not
-    police, training reviewers to add spurious allowlist markers to
-    vendored code.
+    The boundary the guard cares about is "does this file still resolve
+    inside the repo?", not "is this path a symlink?". A symlink farm
+    such as ``src/ouroboros/auto/external -> /home/user/vendor/sdk``
+    would otherwise make ``Path.rglob`` descend into the link target
+    and produce false-positive failures on vendored code we
+    deliberately did not police.
     """
     module = _load_module()
     fake_repo = tmp_path / "repo"
@@ -321,20 +320,16 @@ def test_symlink_directory_under_scan_root_is_skipped(
 
     _isolate(module, monkeypatch, fake_repo)
     rc = module.main()
-    assert rc == 0, (
-        "scan should not descend through the symlink and should not fail "
-        "on files outside the scan boundary"
-    )
+    assert rc == 0, "scan should skip files whose resolved path is outside REPO_ROOT"
 
 
-def test_symlinked_python_file_under_scan_root_is_skipped(
+def test_symlinked_python_file_resolving_outside_repo_is_skipped(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A symlinked ``*.py`` file under the scan root is also skipped.
-
-    Same boundary contract as the directory-symlink case above, applied
-    to a single-file symlink (``auto/legacy.py -> ../../vendor/sdk.py``).
-    """
+    """A symlinked ``*.py`` file whose target lives outside the repo is
+    skipped — same out-of-repo boundary as the directory-symlink case
+    above, applied to a single-file symlink such as
+    ``auto/legacy.py -> /usr/local/vendor/sdk.py``."""
     module = _load_module()
     fake_repo = tmp_path / "repo"
     auto_dir = fake_repo / "src" / "ouroboros" / "auto"
@@ -350,7 +345,76 @@ def test_symlinked_python_file_under_scan_root_is_skipped(
 
     _isolate(module, monkeypatch, fake_repo)
     rc = module.main()
-    assert rc == 0, "single-file symlink must not pull external file into scan"
+    assert rc == 0, "single-file symlink resolving outside REPO_ROOT must not be scanned"
+
+
+def test_in_repo_symlink_clean_target_still_scanned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An in-repo symlink (target still resolves inside the repo) must
+    remain in the scan set.
+
+    Pins the contract boundary the bot review on PR #797 flagged: the
+    earlier ``is_symlink()``-based filter turned every in-repo symlink
+    into an unscanned blind spot, even though Python imports the
+    symlinked file normally and a contributor could quietly stash
+    domain-specific code behind such a link. The fix anchors the
+    exclusion on "resolved target escapes REPO_ROOT", not on path
+    type.
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "auto.py").write_text("# clean\n")
+
+    # In-repo destination — the scan target file lives elsewhere in the
+    # repo, but is reachable through the auto/ symlink.
+    shared = fake_repo / "src" / "ouroboros" / "shared"
+    shared.mkdir(parents=True)
+    (shared / "legacy.py").write_text("# clean\n")
+    (auto_dir / "legacy.py").symlink_to(shared / "legacy.py")
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 0, "in-repo symlink to clean file must not regress the scan"
+
+
+def test_in_repo_symlink_dirty_target_is_caught(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An in-repo symlink whose target carries a forbidden keyword MUST
+    be caught — the resolved path is in-repo, so it is part of the
+    boundary contract.
+
+    This is the exact regression class the bot review on PR #797
+    described: ``auto/legacy.py -> ../shared/has_github.py`` would have
+    been silently skipped under the prior is-symlink filter, allowing a
+    contributor to launder domain code behind a symlink.
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "auto.py").write_text("# clean\n")
+
+    shared = fake_repo / "src" / "ouroboros" / "shared"
+    shared.mkdir(parents=True)
+    (shared / "leaked.py").write_text("class GitHubAdapter:\n    pass\n")
+    # In-repo symlink that lives under SCAN_DIRS — Python would import
+    # this file normally, so the guard MUST police it.
+    (auto_dir / "leaked.py").symlink_to(shared / "leaked.py")
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1, (
+        "an in-repo symlink whose target contains a forbidden token must be "
+        "caught — the boundary is REPO_ROOT, not symlink-or-not"
+    )
 
 
 def test_keyword_in_docstring_of_watched_file_is_caught(

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -287,40 +287,119 @@ def test_clean_auto_dir_with_anchors_passes(
     assert rc == 0
 
 
-def test_symlink_directory_resolving_outside_repo_is_skipped(
+def test_scan_root_symlink_to_outside_repo_fails_loud(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A symlinked directory that resolves OUTSIDE the repo must not
-    pull files into the scan.
+    """The most damaging escape: SCAN_DIRS root itself is a symlink
+    whose target lives outside the repo (``src/ouroboros/auto ->
+    /tmp/external_auto``).
 
-    The boundary the guard cares about is "does this file still resolve
-    inside the repo?", not "is this path a symlink?". A symlink farm
-    such as ``src/ouroboros/auto/external -> /home/user/vendor/sdk``
-    would otherwise make ``Path.rglob`` descend into the link target
-    and produce false-positive failures on vendored code we
-    deliberately did not police.
+    Bot review on PR #797 reproduced this against the prior patch: the
+    per-file ``resolve()/relative_to()`` filter rejects every file
+    under the symlinked root, so ``targets`` ends up empty for that
+    root and the guard *silently* returns 0 — the entire ``auto/``
+    package can be moved out of tree and stop being policed. ``main()``
+    must instead fail loud, surfacing the missing in-repo anchors.
+
+    Pinning the loud-failure behavior here is important because the
+    older descendant-symlink test was *vacuous* on Python 3.13+:
+    ``Path.rglob`` does not recurse into descendant symlinked
+    directories there, so it passed without exercising the actual
+    failure mode the guard claims to defend against.
     """
     module = _load_module()
     fake_repo = tmp_path / "repo"
-    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
-    auto_dir.mkdir(parents=True)
-    (auto_dir / "clean.py").write_text("# clean\n")
+    fake_repo.mkdir()
     cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
     cli_dir.mkdir(parents=True)
     (cli_dir / "auto.py").write_text("# clean\n")
 
-    # External vendored tree containing a forbidden token. This is OUTSIDE
-    # the scan boundary by intent.
-    external = tmp_path / "external_vendor"
+    # External tree carrying a forbidden token AND fake-anchor files
+    # that look in-repo by name. This is the coverage-stripping farm.
+    external = tmp_path / "external_auto"
     external.mkdir()
-    (external / "github_helper.py").write_text("class GitHubAdapter:\n    pass\n")
+    (external / "pipeline.py").write_text("class GitHubAdapter:\n    pass\n")
+    for anchor_leaf in (
+        "interview_driver.py",
+        "state.py",
+        "adapters.py",
+        "grading.py",
+        "seed_repairer.py",
+        "seed_reviewer.py",
+        "progress.py",
+    ):
+        (external / anchor_leaf).write_text("# placeholder\n")
 
-    # Build the symlink farm: ``auto/external -> external_vendor``.
-    (auto_dir / "external").symlink_to(external, target_is_directory=True)
+    # ``src/ouroboros/auto -> /tmp/external_auto`` — the SCAN_DIRS root
+    # itself escapes the repo.
+    (fake_repo / "src" / "ouroboros" / "auto").symlink_to(external, target_is_directory=True)
 
-    _isolate(module, monkeypatch, fake_repo)
+    _isolate(
+        module,
+        monkeypatch,
+        fake_repo,
+        anchor_files=(
+            "src/ouroboros/cli/commands/auto.py",
+            "src/ouroboros/auto/pipeline.py",
+            "src/ouroboros/auto/interview_driver.py",
+            "src/ouroboros/auto/state.py",
+            "src/ouroboros/auto/adapters.py",
+            "src/ouroboros/auto/grading.py",
+            "src/ouroboros/auto/seed_repairer.py",
+            "src/ouroboros/auto/seed_reviewer.py",
+            "src/ouroboros/auto/progress.py",
+        ),
+    )
     rc = module.main()
-    assert rc == 0, "scan should skip files whose resolved path is outside REPO_ROOT"
+    assert rc == 1, (
+        "SCAN_DIRS root symlinked to an external tree must fail loud, "
+        "not silently strip coverage by producing zero targets"
+    )
+
+
+def test_anchor_behind_outside_repo_symlink_dir_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An anchor file that looks present via ``is_file()`` but whose
+    parent directory is a symlink to an external tree must be reported
+    as missing.
+
+    Without this, the SCAN_DIRS root-escape detection is incomplete:
+    ``(REPO_ROOT / 'src/ouroboros/auto/pipeline.py').is_file()`` returns
+    True (``is_file`` follows symlink chains) and the anchor check
+    passes even though no in-repo code was actually scanned. The
+    boundary contract is "anchor resolves inside the repo", not
+    "anchor exists somewhere reachable through the path".
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    fake_repo.mkdir()
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "auto.py").write_text("# clean\n")
+
+    external = tmp_path / "external_auto"
+    external.mkdir()
+    (external / "pipeline.py").write_text("# placeholder\n")
+    (fake_repo / "src" / "ouroboros" / "auto").symlink_to(external, target_is_directory=True)
+
+    _isolate(
+        module,
+        monkeypatch,
+        fake_repo,
+        anchor_files=(
+            "src/ouroboros/cli/commands/auto.py",
+            "src/ouroboros/auto/pipeline.py",
+        ),
+    )
+    targets, missing = module._resolve_scan_targets()
+    assert "src/ouroboros/auto/pipeline.py" in missing, (
+        "anchor reachable only through an out-of-repo symlinked parent "
+        "must be reported missing — is_file() alone is not the boundary"
+    )
+    # The in-repo extra-file is still there and clean, so it is the
+    # only target — the symlinked-out auto/ tree contributes nothing.
+    assert all("/auto/" not in str(t) for t in targets)
 
 
 def test_symlinked_python_file_resolving_outside_repo_is_skipped(
@@ -385,15 +464,20 @@ def test_in_repo_symlink_clean_target_still_scanned(
 def test_scan_extra_file_symlink_to_outside_repo_is_skipped(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Regression for PR #797 review: the repo-boundary check must apply
-    to ``SCAN_EXTRA_FILES`` too, not only to ``SCAN_DIRS``.
+    """Regression for PR #797 review #2: the repo-boundary check must
+    apply to ``SCAN_EXTRA_FILES`` too, not only to ``SCAN_DIRS``.
 
-    Reproduces the exact failure the bot flagged: ``auto.py`` (a
-    SCAN_EXTRA_FILES entry) is a symlink to a file containing
-    ``GitHubVendor`` outside the repo. The earlier patch only applied
-    the resolve-and-check rule inside the SCAN_DIRS loop, so the extra-
-    file slot still resolved and scanned the external file
-    unconditionally and ``main()`` returned 1.
+    Reproduces the bot's exact false-positive scenario — a SCAN_EXTRA_FILES
+    entry that is a symlink to an external file containing a forbidden
+    token used to cause ``rc=1`` because the external file was scanned.
+    Now the boundary check skips it cleanly.
+
+    The extra-file is *not* configured as an anchor in this test so we
+    isolate the SCAN_EXTRA_FILES skip semantics from the anchor-escape
+    contract (those interact when the same path appears in both lists,
+    which the production config does — see
+    ``test_scan_root_symlink_to_outside_repo_fails_loud`` and
+    ``test_anchor_behind_outside_repo_symlink_dir_is_missing``).
     """
     module = _load_module()
     fake_repo = tmp_path / "repo"
@@ -402,14 +486,28 @@ def test_scan_extra_file_symlink_to_outside_repo_is_skipped(
     (auto_dir / "clean.py").write_text("# clean\n")
     cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
     cli_dir.mkdir(parents=True)
+    # Anchor lives in-repo and is clean — the test isolates the
+    # SCAN_EXTRA_FILES skip behavior from any anchor concern.
+    (cli_dir / "auto.py").write_text("# clean\n")
 
-    # External file outside the repo, carrying a forbidden token.
-    external = tmp_path / "external_auto.py"
+    # An *additional* extra-file slot that is NOT an anchor, symlinked
+    # out of the repo — this is the slot under test.
+    extra_dir = fake_repo / "src" / "ouroboros" / "ext"
+    extra_dir.mkdir(parents=True)
+    external = tmp_path / "external_helper.py"
     external.write_text("class GitHubVendor:\n    pass\n")
-    # The SCAN_EXTRA_FILES entry is a symlink to that external file.
-    (cli_dir / "auto.py").symlink_to(external)
+    (extra_dir / "helper.py").symlink_to(external)
 
-    _isolate(module, monkeypatch, fake_repo)
+    _isolate(
+        module,
+        monkeypatch,
+        fake_repo,
+        scan_extra_files=(
+            "src/ouroboros/cli/commands/auto.py",
+            "src/ouroboros/ext/helper.py",
+        ),
+        anchor_files=("src/ouroboros/cli/commands/auto.py",),
+    )
     rc = module.main()
     assert rc == 0, "SCAN_EXTRA_FILES entry resolving outside REPO_ROOT must not be scanned"
 

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -287,6 +287,72 @@ def test_clean_auto_dir_with_anchors_passes(
     assert rc == 0
 
 
+def test_symlink_directory_under_scan_root_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A symlinked directory under the scan root must not pull files
+    from outside the boundary into the scan.
+
+    Without ``is_symlink()`` filtering, ``Path.rglob`` happily descends
+    into a directory symlink and pulls every ``*.py`` under the link
+    target into the scan. A symlink farm such as
+    ``src/ouroboros/auto/external -> ../../vendor/sdk`` would then
+    produce false-positive failures on files we deliberately did not
+    police, training reviewers to add spurious allowlist markers to
+    vendored code.
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    (auto_dir / "clean.py").write_text("# clean\n")
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "auto.py").write_text("# clean\n")
+
+    # External vendored tree containing a forbidden token. This is OUTSIDE
+    # the scan boundary by intent.
+    external = tmp_path / "external_vendor"
+    external.mkdir()
+    (external / "github_helper.py").write_text("class GitHubAdapter:\n    pass\n")
+
+    # Build the symlink farm: ``auto/external -> external_vendor``.
+    (auto_dir / "external").symlink_to(external, target_is_directory=True)
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 0, (
+        "scan should not descend through the symlink and should not fail "
+        "on files outside the scan boundary"
+    )
+
+
+def test_symlinked_python_file_under_scan_root_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A symlinked ``*.py`` file under the scan root is also skipped.
+
+    Same boundary contract as the directory-symlink case above, applied
+    to a single-file symlink (``auto/legacy.py -> ../../vendor/sdk.py``).
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    (auto_dir / "clean.py").write_text("# clean\n")
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "auto.py").write_text("# clean\n")
+
+    external = tmp_path / "vendor.py"
+    external.write_text("class GitHubVendor:\n    pass\n")
+    (auto_dir / "legacy.py").symlink_to(external)
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 0, "single-file symlink must not pull external file into scan"
+
+
 def test_keyword_in_docstring_of_watched_file_is_caught(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/scripts/test_check_auto_boundary.py
+++ b/tests/unit/scripts/test_check_auto_boundary.py
@@ -382,6 +382,66 @@ def test_in_repo_symlink_clean_target_still_scanned(
     assert rc == 0, "in-repo symlink to clean file must not regress the scan"
 
 
+def test_scan_extra_file_symlink_to_outside_repo_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for PR #797 review: the repo-boundary check must apply
+    to ``SCAN_EXTRA_FILES`` too, not only to ``SCAN_DIRS``.
+
+    Reproduces the exact failure the bot flagged: ``auto.py`` (a
+    SCAN_EXTRA_FILES entry) is a symlink to a file containing
+    ``GitHubVendor`` outside the repo. The earlier patch only applied
+    the resolve-and-check rule inside the SCAN_DIRS loop, so the extra-
+    file slot still resolved and scanned the external file
+    unconditionally and ``main()`` returned 1.
+    """
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    (auto_dir / "clean.py").write_text("# clean\n")
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+
+    # External file outside the repo, carrying a forbidden token.
+    external = tmp_path / "external_auto.py"
+    external.write_text("class GitHubVendor:\n    pass\n")
+    # The SCAN_EXTRA_FILES entry is a symlink to that external file.
+    (cli_dir / "auto.py").symlink_to(external)
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 0, "SCAN_EXTRA_FILES entry resolving outside REPO_ROOT must not be scanned"
+
+
+def test_scan_extra_file_in_repo_symlink_is_still_scanned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Conjugate of the above: an in-repo symlink at the
+    SCAN_EXTRA_FILES slot must remain scanned. ``auto.py`` →
+    ``shared/auto.py`` (same repo) carrying a forbidden token must be
+    caught — the boundary is REPO_ROOT, not symlink-or-not."""
+    module = _load_module()
+    fake_repo = tmp_path / "repo"
+    auto_dir = fake_repo / "src" / "ouroboros" / "auto"
+    auto_dir.mkdir(parents=True)
+    (auto_dir / "clean.py").write_text("# clean\n")
+    cli_dir = fake_repo / "src" / "ouroboros" / "cli" / "commands"
+    cli_dir.mkdir(parents=True)
+
+    shared = fake_repo / "src" / "ouroboros" / "shared"
+    shared.mkdir(parents=True)
+    (shared / "auto.py").write_text("class GitHubAdapter:\n    pass\n")
+    # In-repo symlink at the SCAN_EXTRA_FILES slot.
+    (cli_dir / "auto.py").symlink_to(shared / "auto.py")
+
+    _isolate(module, monkeypatch, fake_repo)
+    rc = module.main()
+    assert rc == 1, (
+        "in-repo symlink at SCAN_EXTRA_FILES carrying a forbidden token must still be caught"
+    )
+
+
 def test_in_repo_symlink_dirty_target_is_caught(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- ``Path.rglob(\"*.py\")`` follows symlinks; a symlink farm under SCAN_DIRS pulled vendored ``*.py`` into the scan and produced false positives.
- Fix: skip both leaf symlinks and any candidate whose parent walk hits a symlinked directory before reaching the scan root.

## Reproduction
```bash
mkdir -p src/ouroboros/auto/
ln -s /tmp/external src/ouroboros/auto/external
echo 'class GitHubVendor: pass' > /tmp/external/sdk.py
python3 scripts/check-auto-boundary.py   # before: fails; after: passes
```

## Test plan
- [x] new directory-symlink + file-symlink regressions
- [x] all 68 existing scripts/check-auto-boundary tests still pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)