### PR TITLE
fix(hook): structural mcpServers check in is_mcp_configured

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -156,14 +156,36 @@ KEYWORD_MAP = [
 
 
 def is_mcp_configured() -> bool:
-    """Check if MCP server is registered in ~/.claude/mcp.json."""
+    """Check if the Ouroboros MCP server is registered in ~/.claude/mcp.json.
+
+    Earlier this did ``"ouroboros" in mcp_path.read_text()`` — a substring
+    match that returns True whenever the file mentions ``ouroboros``
+    anywhere, even inside a comment, an unrelated server's ``description``
+    field (``"compatible with ouroboros workflows"``), or a path string.
+    The setup gate then silently skipped and routed the user into an
+    MCP-required skill that wasn't actually registered.
+
+    Now we parse the JSON and check that ``ouroboros`` (or any
+    ``ouroboros``-prefixed alias such as ``ouroboros-dev``) is a real key
+    under the ``mcpServers`` object — the structural location Claude
+    Code's MCP loader actually reads.
+    """
     try:
         mcp_path = Path.home() / ".claude" / "mcp.json"
         if not mcp_path.exists():
             return False
-        return "ouroboros" in mcp_path.read_text()
-    except Exception:
+        data = json.loads(mcp_path.read_text())
+    except (OSError, ValueError):
         return False
+    if not isinstance(data, dict):
+        return False
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict):
+        return False
+    return any(
+        isinstance(name, str) and (name == "ouroboros" or name.startswith("ouroboros-"))
+        for name in servers
+    )
 
 
 def is_first_time() -> bool:

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -143,6 +143,68 @@ class TestDetectKeywords:
         assert result["suggested_skill"] != "/ouroboros:resume-session"
 
 
+class TestIsMcpConfigured:
+    """Structural mcpServers parse — never substring 'ouroboros' anywhere."""
+
+    def test_no_mcp_file_returns_false(self, tmp_path):
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert _mod.is_mcp_configured() is False
+
+    def test_unrelated_server_mentioning_ouroboros_in_description_does_not_match(self, tmp_path):
+        """Regression: ``"ouroboros" in mcp.read_text()`` returned True for any
+        unrelated server whose description merely mentioned ouroboros, e.g.::
+
+            {"mcpServers": {"other-server": {"description":
+              "compatible with ouroboros workflows"}}}
+
+        That made the setup gate falsely report MCP as configured and
+        routed users into MCP-required skills that hadn't actually been
+        registered.
+        """
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text(
+            '{"mcpServers": {"unrelated-server": '
+            '{"description": "compatible with ouroboros workflows"}}}'
+        )
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert _mod.is_mcp_configured() is False
+
+    def test_ouroboros_in_path_string_does_not_match(self, tmp_path):
+        """Path strings containing 'ouroboros' (e.g. install path) must not
+        be mistaken for a registered server."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text(
+            '{"mcpServers": {"other-server": {"command": "/usr/local/ouroboros-old/bin/x"}}}'
+        )
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert _mod.is_mcp_configured() is False
+
+    def test_real_ouroboros_server_key_matches(self, tmp_path):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text('{"mcpServers": {"ouroboros": {"command": "ooo"}}}')
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert _mod.is_mcp_configured() is True
+
+    def test_ouroboros_dev_alias_key_matches(self, tmp_path):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text(
+            '{"mcpServers": {"ouroboros-dev": {"command": "uv run ooo"}}}'
+        )
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert _mod.is_mcp_configured() is True
+
+    def test_malformed_json_returns_false(self, tmp_path):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text("{not valid json")
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert _mod.is_mcp_configured() is False
+
+
 class TestSetupBypass:
     """qa skill has a no-MCP fallback, so it must bypass the setup gate."""
 


### PR DESCRIPTION
## Summary
- ``is_mcp_configured`` did ``\"ouroboros\" in mcp.read_text()`` — substring match that returned True for any unrelated mention (description fields, path strings, comments).
- Setup gate then skipped, sending the user into MCP-required skills that hadn't actually been registered.
- Fix: parse JSON, look for a real key under ``mcpServers`` equal to ``ouroboros`` or starting with ``ouroboros-``.

## Reproduction
```bash
echo '{"mcpServers": {"unrelated": {"description": "compatible with ouroboros workflows"}}}' > ~/.claude/mcp.json
echo "ooo run x" | python scripts/keyword-detector.py
# Before: emits /ouroboros:run (gate skipped — false positive)
# After:  emits /ouroboros:setup
```

## Test plan
- [x] 6 new regressions: substring/description/path false positives, malformed JSON, real-key match, alias-key match
- [x] all 39 existing keyword-detector tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)