### PR TITLE
fix(hook): tighten _word_boundary_match to reject hyphen as token edge

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -188,8 +188,37 @@ def is_first_time() -> bool:
 
 
 def _word_boundary_match(pattern: str, text: str) -> bool:
-    """Match pattern using word boundaries to avoid false positives."""
-    return bool(re.search(r"(?:^|\b)" + re.escape(pattern) + r"(?:\b|$)", text))
+    """Match ``pattern`` against ``text`` with strong end-of-token boundaries.
+
+    The naive ``(?:^|\\b)pattern(?:\\b|$)`` form mis-matches when the
+    pattern ends in a hyphenated token. ``\\b`` triggers on any
+    word-character ↔ non-word-character transition, so a pattern like
+    ``"ooo resume-session"`` matched ``"ooo resume-session-extra"``
+    because ``\\b`` fired between ``n`` and the trailing ``-``. The
+    detector then routed legitimately-different commands (e.g. a future
+    ``ooo resume-session-cleanup``) to ``/ouroboros:resume-session``.
+
+    Tighten both sides:
+
+    * Leading boundary: start-of-string OR a non-word, non-hyphen
+      character before the pattern. Prevents ``myooo auto`` from
+      matching ``ooo auto`` (the ``\\b`` form already did this; we
+      preserve that) AND prevents a leading hyphen from forming a
+      false token break.
+    * Trailing boundary: end-of-string OR a non-word, non-hyphen
+      character. The non-hyphen requirement is what actually fixes the
+      bug: now ``ooo resume-session-extra`` no longer matches
+      ``ooo resume-session`` because the trailing ``-`` is rejected as
+      a boundary.
+
+    The pattern itself can still legitimately *contain* a hyphen
+    (``"ooo resume-session"`` matches ``"ooo resume-session"`` because
+    ``re.escape`` quotes the inner ``-`` literally and the boundary
+    only inspects the character that comes AFTER the match).
+    """
+    boundary_lead = r"(?:^|[^\w-])"
+    boundary_trail = r"(?:$|[^\w-])"
+    return bool(re.search(boundary_lead + re.escape(pattern) + boundary_trail, text))
 
 
 def detect_keywords(text: str) -> dict:

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -142,6 +142,36 @@ class TestDetectKeywords:
         result = detect_keywords("ooo resume")
         assert result["suggested_skill"] != "/ouroboros:resume-session"
 
+    def test_ooo_resume_session_does_not_collide_with_hyphen_extension(self):
+        """Regression: ``ooo resume-session-extra`` (a future hypothetical
+        sibling command, or a typo) used to falsely route to
+        ``/ouroboros:resume-session`` because ``\\b`` triggers on every
+        word/non-word transition — including the boundary between
+        ``session`` and the trailing ``-``. The tightened end-boundary
+        rejects a hyphen as a valid token terminator, so longer
+        hyphenated identifiers cannot silently masquerade as the
+        canonical command.
+        """
+        result = detect_keywords("ooo resume-session-extra --all")
+        assert result["suggested_skill"] != "/ouroboros:resume-session", (
+            "ooo resume-session-extra must not collapse onto resume-session"
+        )
+
+    def test_ooo_resume_session_with_trailing_punctuation_still_matches(self):
+        """Sanity: trailing non-hyphen punctuation (space, ``.``, ``:``,
+        newline, end-of-string) still terminates the match cleanly."""
+        for text in (
+            "ooo resume-session",
+            "ooo resume-session ",
+            "ooo resume-session.",
+            "ooo resume-session: please",
+            "ooo resume-session\nfollow-up",
+        ):
+            result = detect_keywords(text)
+            assert result["suggested_skill"] == "/ouroboros:resume-session", (
+                f"resume-session should still match for {text!r}"
+            )
+
 
 class TestSetupBypass:
     """qa skill has a no-MCP fallback, so it must bypass the setup gate."""


### PR DESCRIPTION
## Summary
- ``\\b`` triggers on any word/non-word transition, including the boundary between ``session`` and a trailing ``-``. Pattern ``\"ooo resume-session\"`` therefore matched ``\"ooo resume-session-extra\"``.
- A future ``ooo resume-session-cleanup`` (or a typo) would silently route to ``/ouroboros:resume-session`` and hide the misrouted command.
- Fix: replace ``\\b`` with ``[^\\w-]`` (or start/end of string) on both sides.

## Reproduction
```python
from importlib.util import spec_from_file_location, module_from_spec
spec = spec_from_file_location(\"kd\", \"scripts/keyword-detector.py\"); m = module_from_spec(spec); spec.loader.exec_module(m)
m._word_boundary_match(\"ooo resume-session\", \"ooo resume-session-extra\")
# Before: True (bug); After: False
```

## Test plan
- [x] new ``test_ooo_resume_session_does_not_collide_with_hyphen_extension``
- [x] new ``test_ooo_resume_session_with_trailing_punctuation_still_matches``
- [x] all 35 existing keyword-detector tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)