### PR TITLE
fix(plugin): cap argv length in firewall audit events

### DIFF
--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -49,6 +49,54 @@ EventSink = Callable[[dict], None]
 ConfirmFn = Callable[[str], bool]
 
 
+# Per-element and total argv length caps for audit events. The schema
+# header documents argv as bounded; without explicit caps a megabyte-
+# scale argv is copied into every event the firewall emits (invoked,
+# permission_used, completed) and then deep-copied again by
+# ``ledger_adapter.wrap_plugin_event``. That is a local DoS / log-bloat
+# vector with no upside — operators do not benefit from megabyte-long
+# argv records in the audit log. The caps below are conservative for
+# real CLI usage (no realistic plugin command needs 4 KB in a single
+# argv element, and no realistic invocation needs more than 16 KB
+# total). When the caps trip we replace the offending bytes with the
+# ``<truncated:N>`` sentinel so consumers can detect that truncation
+# happened without having to re-derive lengths from the log.
+ARGV_ELEMENT_BYTE_LIMIT = 4 * 1024
+ARGV_TOTAL_BYTE_LIMIT = 16 * 1024
+
+
+def _bound_argv(argv: list[str]) -> list[str]:
+    """Return a length-bounded copy of ``argv`` for audit-event payloads.
+
+    Each element is truncated at ``ARGV_ELEMENT_BYTE_LIMIT`` bytes (UTF-8)
+    and the cumulative byte total is capped at ``ARGV_TOTAL_BYTE_LIMIT``.
+    Truncated elements are replaced with the sentinel
+    ``"<truncated:N>"`` (N = original byte length) so downstream
+    consumers can tell a real argv element from one that was elided.
+    """
+    bounded: list[str] = []
+    remaining = ARGV_TOTAL_BYTE_LIMIT
+    for element in argv:
+        if remaining <= 0:
+            bounded.append(f"<truncated:{len(argv) - len(bounded)}-remaining>")
+            break
+        if not isinstance(element, str):
+            element = str(element)
+        encoded = element.encode("utf-8", errors="replace")
+        original_len = len(encoded)
+        if original_len > ARGV_ELEMENT_BYTE_LIMIT:
+            bounded.append(f"<truncated:{original_len}>")
+            remaining -= len(bounded[-1].encode("utf-8"))
+            continue
+        if original_len > remaining:
+            bounded.append(f"<truncated:{original_len}>")
+            remaining = 0
+            continue
+        bounded.append(element)
+        remaining -= original_len
+    return bounded
+
+
 @dataclass(frozen=True)
 class InvocationResult:
     status: Literal["success", "blocked", "failed"]
@@ -83,7 +131,7 @@ def _event_envelope(
     """Build an event matching schemas/0.1/audit-event.schema.json."""
     cmd: dict = {"namespace": namespace, "name": command_name}
     if argv is not None:
-        cmd["argv"] = list(argv)
+        cmd["argv"] = _bound_argv(argv)
     event: dict = {
         "schema_version": SCHEMA_VERSION,
         "event_type": event_type,

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -95,6 +95,91 @@ def _fake_runner(
 # ---------------------------------------------------------------------------
 
 
+def test_argv_per_element_byte_cap_truncates_into_sentinel(tmp_path: Path) -> None:
+    """A single argv element exceeding ARGV_ELEMENT_BYTE_LIMIT is replaced
+    with a ``<truncated:N>`` sentinel rather than copied verbatim into
+    every event the firewall emits.
+
+    Without bounding, a megabyte-scale argv element is copied into
+    ``plugin.invoked``, ``plugin.permission_used`` AND ``plugin.completed``
+    — and then deep-copied again by ``ledger_adapter.wrap_plugin_event``.
+    That is a local DoS / log-bloat vector with no upside.
+    """
+    from ouroboros.plugin.firewall import (
+        ARGV_ELEMENT_BYTE_LIMIT,
+        ARGV_TOTAL_BYTE_LIMIT,
+    )
+
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    huge = "X" * (ARGV_ELEMENT_BYTE_LIMIT + 100)
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["normal", huge, "after"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-cap-1",
+        subprocess_runner=_fake_runner(),
+    )
+    assert result.status == "success"
+    invoked_argv = events[0]["command"]["argv"]
+    # First and third elements survive verbatim.
+    assert invoked_argv[0] == "normal"
+    assert invoked_argv[-1] == "after"
+    # Middle element is replaced with a sentinel that records the
+    # original length so consumers can audit the elision.
+    assert invoked_argv[1] == f"<truncated:{len(huge)}>", invoked_argv
+    # Every emitted event reflects the same bound, not just the first.
+    for event in events:
+        if "argv" in event["command"]:
+            assert all(
+                len(e.encode("utf-8")) <= max(ARGV_ELEMENT_BYTE_LIMIT, 32)
+                for e in event["command"]["argv"]
+            ), event
+
+
+def test_argv_total_byte_cap_truncates_remaining_tail(tmp_path: Path) -> None:
+    """Once the cumulative byte total crosses ARGV_TOTAL_BYTE_LIMIT,
+    remaining elements are folded into a single ``<truncated:...>`` sentinel
+    so the audit event payload stays bounded regardless of element count."""
+    from ouroboros.plugin.firewall import ARGV_TOTAL_BYTE_LIMIT
+
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    # Many medium-sized elements whose total exceeds the cap.
+    big = "Y" * 2048
+    argv = [big] * (ARGV_TOTAL_BYTE_LIMIT // len(big) + 5)
+    events: list[dict] = []
+    invoke_plugin(
+        program,
+        command_name="review",
+        argv=argv,
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-cap-2",
+        subprocess_runner=_fake_runner(),
+    )
+    invoked_argv = events[0]["command"]["argv"]
+    serialized_bytes = sum(len(e.encode("utf-8")) for e in invoked_argv)
+    # Bounded plus a small slack for the sentinel string itself.
+    assert serialized_bytes <= ARGV_TOTAL_BYTE_LIMIT + 64
+    # The tail must be a sentinel describing how many elements were
+    # elided, not silent zero-suffix loss.
+    assert any(e.startswith("<truncated:") for e in invoked_argv)
+
+
 def test_happy_path_emits_invoked_then_permission_then_completed(tmp_path: Path) -> None:
     """Test 1: trusted invocation emits invoked → permission_used → completed."""
     program = _make_program(tmp_path)

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -105,10 +105,7 @@ def test_argv_per_element_byte_cap_truncates_into_sentinel(tmp_path: Path) -> No
     — and then deep-copied again by ``ledger_adapter.wrap_plugin_event``.
     That is a local DoS / log-bloat vector with no upside.
     """
-    from ouroboros.plugin.firewall import (
-        ARGV_ELEMENT_BYTE_LIMIT,
-        ARGV_TOTAL_BYTE_LIMIT,
-    )
+    from ouroboros.plugin.firewall import ARGV_ELEMENT_BYTE_LIMIT
 
     program = _make_program(tmp_path)
     trust = TrustStore(root=tmp_path / "trust").grant(


### PR DESCRIPTION
## Summary
- ``_event_envelope`` copied ``argv`` verbatim into every emitted event with no length bound. ``ledger_adapter.wrap_plugin_event`` then deep-copies it again. A megabyte argv element multiplies into 6× memory and 3× ledger writes.
- Schema header documents argv as bounded; the absence of an actual cap is a local DoS / log-bloat surface.
- Fix: per-element 4 KiB cap and cumulative 16 KiB cap, with ``<truncated:N>`` sentinels recording the elided size so audits can detect the truncation.

## Test plan
- [x] new ``test_argv_per_element_byte_cap_truncates_into_sentinel``
- [x] new ``test_argv_total_byte_cap_truncates_remaining_tail``
- [x] all 19 existing firewall tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)