### PR TITLE
fix(providers): pop CLAUDECODE from os.environ for SDK call, not mask

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -619,8 +619,22 @@ class ClaudeCodeAdapter:
         # The bundled CLI refuses to start when CLAUDECODE is set (nested
         # session check).  The Agent SDK sets CLAUDE_CODE_ENTRYPOINT=sdk-py
         # to signal it's an SDK call, but the older check on CLAUDECODE fires
-        # first, causing silent empty responses.  Strip it via env override.
-        claudecode_present = bool(os.environ.get("CLAUDECODE"))
+        # first, causing silent empty responses.
+        #
+        # Earlier this set ``env_overrides["CLAUDECODE"] = ""`` to mask the
+        # value, but the SDK builds the subprocess env via
+        # ``{**os.environ, ..., **options.env, ...}``
+        # (claude_agent_sdk/_internal/transport/subprocess_cli.py around
+        # line 348). An overlay value of ``""`` keeps the KEY present in the
+        # final env dict — so any nested-session check that uses key
+        # presence (``"CLAUDECODE" in env`` / ``${CLAUDECODE+x}``) rather
+        # than value truthiness still fires. To make the unset robust
+        # regardless of which check the CLI performs, we temporarily pop
+        # the var from ``os.environ`` while the SDK overlays — that
+        # removes it from the final subprocess env entirely. The pop is
+        # restored in a ``try/finally`` after the awaitable completes so
+        # concurrent code in the same interpreter never sees the var
+        # missing for longer than this single call.
         env_overrides: dict[str, str] = {
             # Skip the per-call `claude -v` subprocess that the Agent SDK runs
             # to verify version compatibility.  This is advisory-only — version
@@ -632,8 +646,6 @@ class ClaudeCodeAdapter:
                 "OUROBOROS_SKIP_VERSION_CHECK", "1"
             ),
         }
-        if claudecode_present:
-            env_overrides["CLAUDECODE"] = ""
 
         stderr_lines: list[str] = []
 
@@ -743,6 +755,15 @@ class ClaudeCodeAdapter:
 
         options = ClaudeAgentOptions(**options_kwargs)
 
+        # Snapshot CLAUDECODE before the SDK overlays os.environ. We pop
+        # it from os.environ for the duration of the SDK call below so the
+        # bundled CLI's nested-session check sees no key at all (which is
+        # robust against both ``[ -n $CLAUDECODE ]`` value-truthy and
+        # ``${CLAUDECODE+x}`` key-presence variants). Restored in the
+        # finally below.
+        claudecode_present = "CLAUDECODE" in os.environ
+        claudecode_saved = os.environ.get("CLAUDECODE")
+
         log.debug(
             "claude_code_adapter.sdk_request_configured",
             max_turns=options_kwargs["max_turns"],
@@ -780,6 +801,11 @@ class ClaudeCodeAdapter:
                 except StopAsyncIteration:
                     break
 
+        # Pop CLAUDECODE from os.environ for the duration of the SDK
+        # call so it is genuinely absent from the spawned subprocess's
+        # environment, not merely valued at the empty string.
+        if claudecode_present:
+            os.environ.pop("CLAUDECODE", None)
         try:
             async for sdk_message in _safe_query():
                 class_name = type(sdk_message).__name__
@@ -893,6 +919,10 @@ class ClaudeCodeAdapter:
                             },
                         )
         except asyncio.CancelledError:
+            # Restore on cancel before re-raising so a cancelled call
+            # does not leave the parent process without CLAUDECODE.
+            if claudecode_present and "CLAUDECODE" not in os.environ:
+                os.environ["CLAUDECODE"] = claudecode_saved or ""
             raise
         except Exception as exc:
             stderr_tail = "\n".join(stderr_lines[-20:]) if stderr_lines else ""
@@ -925,6 +955,12 @@ class ClaudeCodeAdapter:
                     },
                 )
             )
+        finally:
+            # Always restore CLAUDECODE so a sibling adapter call (or any
+            # other code in the same interpreter that observes os.environ)
+            # never sees the var missing for longer than this single call.
+            if claudecode_present and "CLAUDECODE" not in os.environ:
+                os.environ["CLAUDECODE"] = claudecode_saved or ""
 
         # After generator completes naturally, check for errors
         if error_result:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -323,6 +323,76 @@ class TestAdapterOverheadReductions:
         env = options_call_kwargs.get("env", {})
         assert env.get("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK") == "0"
 
+    @pytest.mark.asyncio
+    async def test_claudecode_var_is_popped_for_subprocess_call(self) -> None:
+        """``CLAUDECODE=1`` (set by Claude Code itself when it spawns a
+        nested process) must NOT leak into the SDK subprocess.
+
+        Earlier the adapter did ``env_overrides["CLAUDECODE"] = ""`` to
+        mask the value, but the SDK builds the subprocess env via
+        ``{**os.environ, ..., **options.env, ...}``. An overlay value
+        of ``""`` keeps the KEY present in the final env dict — so any
+        nested-session check that uses key presence
+        (``"CLAUDECODE" in env``, shell ``${CLAUDECODE+x}``) still
+        fires and the bundled CLI silently produces an empty response.
+
+        The fix pops ``CLAUDECODE`` from ``os.environ`` for the
+        duration of the SDK call, which removes the key from the
+        merged subprocess env entirely.
+        """
+        adapter = ClaudeCodeAdapter()
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+        # Capture os.environ at the moment `query` is called — that is
+        # exactly when the SDK builds the subprocess env from
+        # ``{**os.environ, ..., **options.env, ...}``.
+        captured_environ_snapshot: dict[str, str] = {}
+
+        async def fake_query(*args, **kwargs):
+            captured_environ_snapshot.update(os.environ)
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "claude_agent_sdk": sdk_module,
+                    "claude_agent_sdk._errors": sdk_module._errors,
+                },
+            ),
+            patch.dict("os.environ", {"CLAUDECODE": "1"}, clear=False),
+        ):
+            assert os.environ.get("CLAUDECODE") == "1"
+            await adapter._execute_single_request("test prompt", config)
+            # After the call returns, CLAUDECODE must be restored to its
+            # original value so concurrent code in the same interpreter
+            # never sees the var missing for longer than the call.
+            assert os.environ.get("CLAUDECODE") == "1", (
+                "CLAUDECODE must be restored after the SDK call"
+            )
+
+        # During the SDK call itself the key was absent.
+        assert "CLAUDECODE" not in captured_environ_snapshot, (
+            "CLAUDECODE must be popped from os.environ for the duration of the SDK call"
+        )
+
+        # And the env_overrides dict no longer carries the empty-string
+        # masking value (which left the key present in the merged env).
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        env = options_call_kwargs.get("env", {})
+        assert "CLAUDECODE" not in env, (
+            "env overrides must not re-introduce CLAUDECODE — the os.environ pop "
+            "is the single source of truth for the unset"
+        )
+
     def test_initial_backoff_is_half_second(self) -> None:
         """_INITIAL_BACKOFF_SECONDS should be 0.5 for interactive responsiveness."""
         from ouroboros.providers.claude_code_adapter import _INITIAL_BACKOFF_SECONDS


### PR DESCRIPTION
## Summary
- ``env_overrides[\"CLAUDECODE\"] = \"\"`` masked the value but kept the key. SDK env build is ``{**os.environ, ..., **options.env, ...}`` — overlay merges values, cannot remove a key.
- Nested-session checks that use key presence (``in env`` / ``${CLAUDECODE+x}``) still fire, producing the empty-response failure mode the original strip was meant to prevent.
- Fix: pop ``CLAUDECODE`` from ``os.environ`` for the SDK call duration; restore in ``finally`` (and ``CancelledError`` path).

## Reproduction
```python
import os
os.environ[\"CLAUDECODE\"] = \"1\"
overlay = {\"CLAUDECODE\": \"\"}
merged = {**os.environ, **overlay}
print(\"CLAUDECODE\" in merged)   # True — key still present
```
Bundled CLI's nested-session detection observes the key and returns empty.

## Test plan
- [x] new ``test_claudecode_var_is_popped_for_subprocess_call`` captures ``os.environ`` at SDK ``query`` time
- [x] all 45 adapter tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)