### PR TITLE
fix(auto): exact-match the canonical key in safe-default rollback

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -646,11 +646,20 @@ def _revert_safe_default_entries(
         section = ledger.sections.get(section_name)
         if section is None:
             continue
-        section.entries = [
-            entry
-            for entry in section.entries
-            if not entry.key.endswith(".safe_default_finalization")
-        ]
+        # Match the EXACT key the safe-default policy writes
+        # (``{section}.safe_default_finalization``) instead of any key
+        # that happens to end with the suffix. The earlier
+        # ``endswith(...)`` form would also delete a user-authored
+        # entry whose key coincidentally ended in
+        # ``.safe_default_finalization`` — for example, an answerer-
+        # synthesized constraint key
+        # ``constraints.my.safe_default_finalization``. The
+        # ``finalize_safe_defaultable_gaps`` writer is the SOLE
+        # producer of the canonical key shape, so an exact equality
+        # check is both correct (matches every entry the policy
+        # wrote) and safer (matches only those entries).
+        canonical_key = f"{section_name}.safe_default_finalization"
+        section.entries = [entry for entry in section.entries if entry.key != canonical_key]
 
 
 def _generate_interview_id() -> str:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -311,6 +311,75 @@ async def test_interview_driver_blocks_when_safe_default_synthesis_rejected(tmp_
     assert state.pending_question is None
 
 
+def test_revert_safe_default_entries_preserves_user_keys_with_matching_suffix() -> None:
+    """Regression: rollback must NOT remove a non-policy entry whose key
+    coincidentally ends with ``.safe_default_finalization``.
+
+    The earlier ``entry.key.endswith(".safe_default_finalization")`` filter
+    would delete a user/answerer-authored ledger entry whose key just
+    happens to share that suffix (for example, an answerer-synthesized
+    constraint key ``constraints.my.safe_default_finalization``).
+    Only the canonical key written by ``finalize_safe_defaultable_gaps``
+    (``{section}.safe_default_finalization``) should be removed on rollback.
+    """
+    from ouroboros.auto.interview_driver import _revert_safe_default_entries
+    from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus
+
+    ledger = SeedDraftLedger.from_goal("Build a small CLI")
+
+    # 1. The canonical safe-default policy entry — must be removed.
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.safe_default_finalization",
+            value="defaulted",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.7,
+            status=LedgerStatus.DEFAULTED,
+            rationale="policy",
+            evidence=("provenance",),
+        ),
+    )
+    # 2. A user-authored entry that ends with the same suffix but is NOT
+    #    the canonical policy key. Must SURVIVE the rollback.
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.my.safe_default_finalization",
+            value="user-specified constraint",
+            source=LedgerSource.USER_GOAL,
+            confidence=0.95,
+            status=LedgerStatus.CONFIRMED,
+            rationale="user said so",
+            evidence=("interview answer",),
+        ),
+    )
+    # 3. An unrelated entry that does not match the suffix at all.
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.other",
+            value="unrelated",
+            source=LedgerSource.USER_GOAL,
+            confidence=0.9,
+            status=LedgerStatus.CONFIRMED,
+            rationale="control",
+            evidence=("control",),
+        ),
+    )
+
+    _revert_safe_default_entries(ledger, ("constraints",))
+
+    remaining_keys = {entry.key for entry in ledger.sections["constraints"].entries}
+    assert "constraints.safe_default_finalization" not in remaining_keys, (
+        "the canonical safe-default policy entry MUST be removed on rollback"
+    )
+    assert "constraints.my.safe_default_finalization" in remaining_keys, (
+        "a user-authored entry whose key shares the suffix MUST survive rollback"
+    )
+    assert "constraints.other" in remaining_keys
+
+
 @pytest.mark.asyncio
 async def test_interview_driver_finalizes_when_backend_requires_two_completion_signals(
     tmp_path,


### PR DESCRIPTION
## Summary
- ``_revert_safe_default_entries`` used ``entry.key.endswith(\".safe_default_finalization\")``. The only producer of that suffix writes the exact key ``{section}.safe_default_finalization``, but the suffix match would also delete unrelated entries (e.g. an answerer-authored ``constraints.my.safe_default_finalization``).
- Fix: switch to exact equality ``entry.key == f\"{section_name}.safe_default_finalization\"``.

## Test plan
- [x] new ``test_revert_safe_default_entries_preserves_user_keys_with_matching_suffix``
- [x] all 128 interview-pipeline tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)