### PR TITLE
Fix stale welcomeVersion hardcoded in welcome skill

### DIFF
--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -97,7 +97,7 @@ except Exception:
 prefs.update({
     'welcomeShown': True,
     'welcomeCompleted': datetime.now(UTC).isoformat(),
-    'welcomeVersion': '0.14.0',
+    'welcomeVersion': '0.36.0',
 })
 with open(path, 'w', encoding='utf-8') as f:
     json.dump(prefs, f, indent=2)
@@ -276,7 +276,7 @@ prefs.update({
     'star_asked': True,
     'welcomeShown': True,
     'welcomeCompleted': datetime.now(UTC).isoformat(),
-    'welcomeVersion': '0.14.0',
+    'welcomeVersion': '0.36.0',
 })
 with open(path, 'w', encoding='utf-8') as f:
     json.dump(prefs, f, indent=2)
@@ -302,7 +302,7 @@ except Exception:
 prefs.update({
     'welcomeShown': True,
     'welcomeCompleted': datetime.now(UTC).isoformat(),
-    'welcomeVersion': '0.14.0',
+    'welcomeVersion': '0.36.0',
 })
 with open(path, 'w', encoding='utf-8') as f:
     json.dump(prefs, f, indent=2)
@@ -347,7 +347,7 @@ READY TO BUILD:
 {
   "welcomeShown": true,
   "welcomeCompleted": "2025-02-23T15:30:00+09:00",
-  "welcomeVersion": "0.14.0",
+  "welcomeVersion": "0.36.0",
   "star_asked": true
 }
 ```


### PR DESCRIPTION
The `welcome` skill writes `welcomeVersion: '0.14.0'` to ~/.ouroboros/prefs.json
at three exit points, regardless of the installed plugin version. Plugin is currently at 0.36.0; every user who completes the welcome ends up with a stale,
misleading version field.

Affected lines in skills/welcome/SKILL.md:
- L100  (--skip flag flow)
- L279  (Step 6 GH_OK + star_asked branch)
- L305  (Step 6 GH_MISSING / already-asked branch)
- L350  (prefs example block, cosmetic)

Suggested fix
-------------
I've committed a change to update the numbers to the latest. A better solution would be to not hardcode version numbers in welcome prefs. If you must, one solution might be to read the version from .claude-plugin/plugin.json at runtime (same file the optional version-check curl already compares against):

    plugin_path = Path(__file__).parents[2] / '.claude-plugin' / 'plugin.json'
    version = json.loads(plugin_path.read_text()).get('version', 'unknown')

(or however the skill harness exposes plugin metadata)

Scope: skill template only. No code change.
