### PR TITLE
feat(auto): EVALUATE phase verifies run output against seed AC (#809 P2.1)

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -264,8 +264,12 @@ class HandlerRalphStarter:
             "stop_reason": stop_reason,
             # RFC #809 Phase 2.1: surface the Ralph job's result_text so
             # ``AutoPipeline._evaluate_or_complete`` can grade it against
-            # the Seed AC via ``HandlerEvaluator``.
-            "result_text": _optional_str(terminal_meta.get("__result_text__")),
+            # the Seed AC via ``HandlerEvaluator``. ``""`` is a VALID graded
+            # artifact (a Ralph run with intentionally empty output must
+            # still be graded), so route through ``_artifact_text`` —
+            # ``_optional_str`` would collapse the empty string to None and
+            # silently skip EVALUATE.
+            "result_text": _artifact_text(terminal_meta.get("__result_text__")),
         }
 
 
@@ -300,8 +304,10 @@ class HandlerRalphPoller:
             "stop_reason": stop_reason,
             # RFC #809 Phase 2.1: surface the Ralph job's result_text so a
             # resumed RALPH_HANDOFF checkpoint can still grade the artifact
-            # via EVALUATE — same contract as the starter path.
-            "result_text": _optional_str(terminal_meta.get("__result_text__")),
+            # via EVALUATE — same contract as the starter path. ``""`` is a
+            # VALID graded artifact, so use ``_artifact_text`` rather than
+            # ``_optional_str``.
+            "result_text": _artifact_text(terminal_meta.get("__result_text__")),
         }
 
 
@@ -474,3 +480,15 @@ def _extract_seed_yaml(text: str) -> str:
 
 def _optional_str(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _artifact_text(value: object) -> str | None:
+    """Return ``value`` verbatim when it is a string (including ``""``), else None.
+
+    Distinct from :func:`_optional_str` because an artifact graded by
+    EVALUATE is a valid input even when empty: a Ralph job whose output is
+    intentionally empty must still be evaluated against the Seed AC.
+    Returning ``None`` for ``""`` would silently skip EVALUATE and produce a
+    false-pass — the bug fixed by RFC #809 Phase 2.1.
+    """
+    return value if isinstance(value, str) else None

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -262,6 +262,10 @@ class HandlerRalphStarter:
             "dispatch_mode": "job",
             "terminal_status": terminal_status,
             "stop_reason": stop_reason,
+            # RFC #809 Phase 2.1: surface the Ralph job's result_text so
+            # ``AutoPipeline._evaluate_or_complete`` can grade it against
+            # the Seed AC via ``HandlerEvaluator``.
+            "result_text": _optional_str(terminal_meta.get("__result_text__")),
         }
 
 
@@ -294,6 +298,10 @@ class HandlerRalphPoller:
             "dispatch_mode": "job",
             "terminal_status": terminal_status,
             "stop_reason": stop_reason,
+            # RFC #809 Phase 2.1: surface the Ralph job's result_text so a
+            # resumed RALPH_HANDOFF checkpoint can still grade the artifact
+            # via EVALUATE — same contract as the starter path.
+            "result_text": _optional_str(terminal_meta.get("__result_text__")),
         }
 
 
@@ -384,6 +392,13 @@ async def _wait_for_job_terminal(
     the returned mapping is always populated — it falls back to the job's
     own terminal status (e.g. ``"failed"`` for an exception path) when the
     inner ralph result did not provide one.
+
+    Surfaces the snapshot's ``result_text`` under the synthetic
+    ``__result_text__`` key so callers (notably the Ralph adapter ⇒ EVALUATE
+    pipeline path) can grade the human-readable artifact without having to
+    re-poll the job manager themselves. The key is namespaced with
+    leading/trailing underscores to avoid colliding with any
+    Ralph-supplied meta key.
     """
     while True:
         snapshot = await job_manager.get_snapshot(job_id)
@@ -393,6 +408,8 @@ async def _wait_for_job_terminal(
                 "status",
                 "completed" if snapshot.status is JobStatus.COMPLETED else "failed",
             )
+            if snapshot.result_text is not None:
+                meta["__result_text__"] = snapshot.result_text
             return meta
         await asyncio.sleep(poll_interval)
 

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ from ouroboros.mcp.errors import MCPServerError
 from ouroboros.mcp.job_manager import JobManager, JobStatus
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
+from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import MCPToolResult
 
@@ -293,6 +295,83 @@ class HandlerRalphPoller:
             "terminal_status": terminal_status,
             "stop_reason": stop_reason,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluateResult:
+    """Structured result returned by :class:`HandlerEvaluator`.
+
+    Mirrors the relevant subset of ``ouroboros_qa``'s response meta so the
+    pipeline can persist the verdict on :class:`AutoPipelineState` and reuse
+    it on resume without re-invoking the LLM judge.
+
+    ``error`` is non-empty when the QA handler returned a transient failure
+    (resumable). The pipeline treats this as a BLOCKED state, not FAILED.
+    """
+
+    passed: bool
+    score: float
+    verdict: str
+    differences: tuple[str, ...] = ()
+    suggestions: tuple[str, ...] = ()
+    error: str | None = None
+
+
+class HandlerEvaluator:
+    """Callable QA evaluator backed by ``ouroboros_qa`` :class:`QAHandler`.
+
+    Builds a ``quality_bar`` from the Seed's acceptance criteria using the
+    exact phrasing established by ``evolution_handlers.py`` ("The execution
+    must satisfy all acceptance criteria"). Grades a run artifact against
+    that bar with ``pass_threshold=0.80`` and returns a typed
+    :class:`EvaluateResult`. The artifact is opaque to the adapter — callers
+    pull it from the appropriate runtime surface (e.g. the Ralph terminal
+    job snapshot's ``result_text``).
+
+    The adapter is intentionally thin so :class:`AutoPipeline._run_evaluate`
+    owns the decision policy (transition to COMPLETE vs mark_blocked, cache
+    by artifact hash for resume idempotency, etc.).
+    """
+
+    def __init__(self, qa_handler: QAHandler) -> None:
+        self.qa_handler = qa_handler
+
+    async def __call__(self, seed: Seed, run_artifact: str) -> EvaluateResult:
+        if seed.acceptance_criteria:
+            ac_lines = [f"- {ac}" for ac in seed.acceptance_criteria]
+            quality_bar = "The execution must satisfy all acceptance criteria:\n" + "\n".join(
+                ac_lines
+            )
+        else:
+            quality_bar = "The execution must satisfy the seed's intent."
+
+        seed_yaml = yaml.dump(
+            seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
+        )
+        result = await self.qa_handler.handle(
+            {
+                "artifact": run_artifact,
+                "artifact_type": "test_output",
+                "quality_bar": quality_bar,
+                "seed_content": seed_yaml,
+                "pass_threshold": 0.80,
+            }
+        )
+        if result.is_err:
+            return EvaluateResult(
+                passed=False,
+                score=0.0,
+                verdict="fail",
+                error=str(result.error),
+            )
+        meta = result.value.meta or {}
+        return EvaluateResult(
+            passed=bool(meta.get("passed", False)),
+            score=float(meta.get("score", 0.0)),
+            verdict=str(meta.get("verdict", "fail")),
+            differences=tuple(meta.get("differences", ()) or ()),
+            suggestions=tuple(meta.get("suggestions", ()) or ()),
+        )
 
 
 async def _wait_for_job_terminal(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -10,6 +10,7 @@ import threading
 import time
 from typing import Any, Protocol
 
+from ouroboros.auto.adapters import EvaluateResult
 from ouroboros.auto.blocker_attribution import record_authoring_backend
 from ouroboros.auto.grading import GradeGate, deterministic_floor
 from ouroboros.auto.interview_driver import AutoInterviewDriver
@@ -45,6 +46,10 @@ class RunStarter(Protocol):
 RalphStarter = Callable[..., Awaitable[dict[str, Any]]]
 SeedSaver = Callable[[Seed], str]
 SeedLoader = Callable[[str], Seed]
+# Evaluator contract: takes a Seed and the run artifact (typically a
+# JobSnapshot.result_text from Ralph's terminal snapshot), returns a typed
+# EvaluateResult. See HandlerEvaluator for the production implementation.
+Evaluator = Callable[[Seed, str], Awaitable[EvaluateResult]]
 
 # Ralph stop_reason values that map to a recoverable BLOCKED auto phase
 # rather than a hard FAILED. Pinned by Q00/ouroboros#773 and asserted by
@@ -115,6 +120,11 @@ class AutoPipelineResult:
     ralph_job_id: str | None = None
     ralph_lineage_id: str | None = None
     ralph_dispatch_mode: str | None = None
+    # RFC #809 Phase 2.1 — EVALUATE phase QA verdict surfaced to MCP/CLI.
+    last_qa_score: float | None = None
+    last_qa_verdict: str | None = None
+    last_qa_differences: tuple[str, ...] = ()
+    last_qa_suggestions: tuple[str, ...] = ()
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
@@ -172,6 +182,14 @@ class AutoPipeline:
     # the legacy guidance-only behavior.
     ralph_resumer: RalphStarter | None = None
     complete_product: bool = False
+    # RFC #809 Phase 2.1 — when set AND ``complete_product`` is True, the
+    # pipeline inserts an EVALUATE phase between the Ralph terminal verdict
+    # and the COMPLETE transition. The evaluator grades the Ralph artifact
+    # against the Seed's acceptance criteria via ``ouroboros_qa``. On QA
+    # pass the pipeline still reaches COMPLETE; on QA fail it transitions
+    # to BLOCKED with the QA differences/suggestions in ``last_error``.
+    # See :class:`HandlerEvaluator` in adapters.py for the production wiring.
+    evaluator: Evaluator | None = None
     _last_emitted_phase: str | None = field(default=None, init=False, repr=False)
     _last_emitted_grade: str | None = field(default=None, init=False, repr=False)
     _last_emitted_repair: int | None = field(default=None, init=False, repr=False)
@@ -464,7 +482,21 @@ class AutoPipeline:
             return self._result(state, ledger, blocker=state.last_error)
 
         if state.phase == AutoPhase.RALPH_HANDOFF:
-            return await self._resume_ralph_handoff(state, ledger, review=review)
+            return await self._resume_ralph_handoff(state, ledger, seed, review=review)
+
+        if state.phase == AutoPhase.EVALUATE:
+            # Re-enter the evaluator. ``_run_evaluate`` is idempotent via the
+            # artifact-hash cache, so a resumed session with the same artifact
+            # and a persisted verdict short-circuits without re-calling QA.
+            return await self._run_evaluate(
+                state,
+                ledger,
+                seed,
+                review=review,
+                run_subagent=None,
+                ralph_result_text=None,
+                stop_reason=None,
+            )
 
         if self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
@@ -979,12 +1011,15 @@ class AutoPipeline:
             self._save(state)
             return self._result(state, ledger, review=review, run_subagent=run_subagent)
         if terminal_status == "completed":
-            state.transition(
-                AutoPhase.COMPLETE,
-                f"ralph loop completed ({stop_reason or 'qa passed'})",
+            return await self._evaluate_or_complete(
+                state,
+                ledger,
+                seed,
+                review=review,
+                run_subagent=run_subagent,
+                stop_reason=stop_reason,
+                ralph_result_text=_optional_str(ralph_meta.get("result_text")),
             )
-            self._save(state)
-            return self._result(state, ledger, review=review, run_subagent=run_subagent)
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
             state.mark_blocked(stop_reason, tool_name="ralph_starter")
             self._save(state)
@@ -1004,10 +1039,216 @@ class AutoPipeline:
             state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
         )
 
+    async def _evaluate_or_complete(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+        *,
+        review: SeedReview | None,
+        run_subagent: dict[str, Any] | None,
+        stop_reason: str | None,
+        ralph_result_text: str | None,
+        resumed: bool = False,
+    ) -> AutoPipelineResult:
+        """Branch between EVALUATE and COMPLETE after a Ralph terminal verdict.
+
+        Inserted by RFC #809 Phase 2.1. When ``self.evaluator`` is wired AND
+        the session is in complete-product mode AND Ralph produced a
+        ``result_text`` artifact, transitions to EVALUATE and invokes
+        :meth:`_run_evaluate`. Otherwise falls back to the pre-Phase-2.1
+        behaviour: transition to COMPLETE directly.
+        """
+        if self.evaluator is not None and state.complete_product and ralph_result_text:
+            state.transition(AutoPhase.EVALUATE, "evaluating ralph artifact against seed AC")
+            self._save(state)
+            return await self._run_evaluate(
+                state,
+                ledger,
+                seed,
+                review=review,
+                run_subagent=run_subagent,
+                ralph_result_text=ralph_result_text,
+                stop_reason=stop_reason,
+            )
+        message_prefix = "resumed ralph loop completed" if resumed else "ralph loop completed"
+        state.transition(
+            AutoPhase.COMPLETE,
+            f"{message_prefix} ({stop_reason or 'qa passed'})",
+        )
+        self._save(state)
+        return self._result(state, ledger, review=review, run_subagent=run_subagent)
+
+    async def _run_evaluate(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+        *,
+        review: SeedReview | None,
+        run_subagent: dict[str, Any] | None,
+        ralph_result_text: str | None,
+        stop_reason: str | None,
+    ) -> AutoPipelineResult:
+        """Run the EVALUATE phase: grade the run artifact against the Seed AC.
+
+        Idempotent on resume — when ``state.evaluate_artifact_hash`` matches a
+        freshly-computed hash of the current artifact AND a verdict was
+        already persisted, the cached verdict is reused without re-invoking
+        the LLM judge. A different artifact (e.g. Ralph re-ran on resume)
+        forces re-evaluation.
+
+        On QA pass → COMPLETE with the verdict in the progress message.
+        On QA fail → BLOCKED with the verdict + top-3 differences/suggestions
+        in the blocker text. On timeout / handler error → BLOCKED with
+        ``tool_name="evaluator"`` so the session remains resumable.
+        """
+        assert self.evaluator is not None  # noqa: S101 — guarded by caller
+
+        # Resolve the artifact: prefer the freshly-passed text from the Ralph
+        # snapshot; on EVALUATE-phase resume the caller passes None and we
+        # rely entirely on the cached verdict.
+        if ralph_result_text:
+            import hashlib
+
+            artifact = ralph_result_text
+            artifact_hash = hashlib.sha256(artifact.encode("utf-8")).hexdigest()
+        else:
+            artifact = ""
+            artifact_hash = state.evaluate_artifact_hash
+
+        cache_hit = (
+            artifact_hash is not None
+            and state.evaluate_artifact_hash == artifact_hash
+            and state.last_qa_verdict is not None
+        )
+        if cache_hit:
+            cached_passed = bool(state.last_qa_verdict == "pass")
+            cached_score = state.last_qa_score or 0.0
+            return self._finalize_evaluate(
+                state,
+                ledger,
+                review=review,
+                run_subagent=run_subagent,
+                passed=cached_passed,
+                score=cached_score,
+                verdict=state.last_qa_verdict or "fail",
+                differences=tuple(state.last_qa_differences),
+                suggestions=tuple(state.last_qa_suggestions),
+                stop_reason=stop_reason,
+                from_cache=True,
+            )
+
+        if not artifact:
+            # Resume in EVALUATE with no cached verdict and no fresh artifact —
+            # we cannot move forward deterministically. Mark blocked so an
+            # operator can attach or re-supply context.
+            state.mark_blocked(
+                "EVALUATE resume found no cached verdict and no run artifact to re-grade",
+                tool_name="evaluator",
+            )
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
+
+        phase_timeout = state.phase_timeout_seconds(AutoPhase.EVALUATE)
+        try:
+            eval_result = await asyncio.wait_for(
+                self.evaluator(seed, artifact), timeout=phase_timeout
+            )
+        except TimeoutError:
+            state.mark_blocked(
+                f"evaluator timed out after {phase_timeout:.0f}s",
+                tool_name="evaluator",
+            )
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
+        except Exception as exc:
+            state.mark_blocked(f"evaluator raised: {exc}", tool_name="evaluator")
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
+
+        if eval_result.error:
+            state.mark_blocked(
+                f"evaluator reported transient error: {eval_result.error}",
+                tool_name="evaluator",
+            )
+            state.evaluate_artifact_hash = artifact_hash
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
+
+        state.last_qa_score = float(eval_result.score)
+        state.last_qa_verdict = str(eval_result.verdict)
+        state.last_qa_differences = list(eval_result.differences)
+        state.last_qa_suggestions = list(eval_result.suggestions)
+        state.evaluate_artifact_hash = artifact_hash
+        self._save(state)
+
+        return self._finalize_evaluate(
+            state,
+            ledger,
+            review=review,
+            run_subagent=run_subagent,
+            passed=eval_result.passed,
+            score=eval_result.score,
+            verdict=eval_result.verdict,
+            differences=eval_result.differences,
+            suggestions=eval_result.suggestions,
+            stop_reason=stop_reason,
+            from_cache=False,
+        )
+
+    def _finalize_evaluate(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        review: SeedReview | None,
+        run_subagent: dict[str, Any] | None,
+        passed: bool,
+        score: float,
+        verdict: str,
+        differences: tuple[str, ...],
+        suggestions: tuple[str, ...],
+        stop_reason: str | None,
+        from_cache: bool,
+    ) -> AutoPipelineResult:
+        """Transition out of EVALUATE based on the resolved QA verdict."""
+        cache_suffix = " [cached]" if from_cache else ""
+        if passed:
+            state.transition(
+                AutoPhase.COMPLETE,
+                f"evaluator passed: {verdict} (score {score:.2f}){cache_suffix}"
+                + (f"; ralph stop_reason={stop_reason}" if stop_reason else ""),
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, run_subagent=run_subagent)
+
+        diff_preview = "; ".join(differences[:3]) if differences else ""
+        sug_preview = "; ".join(suggestions[:3]) if suggestions else ""
+        summary_parts = [f"evaluator did not pass: {verdict} (score {score:.2f}){cache_suffix}"]
+        if diff_preview:
+            summary_parts.append(f"differences: {diff_preview}")
+        if sug_preview:
+            summary_parts.append(f"suggestions: {sug_preview}")
+        state.mark_blocked("; ".join(summary_parts), tool_name="evaluator")
+        self._save(state)
+        return self._result(
+            state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+        )
+
     async def _resume_ralph_handoff(
         self,
         state: AutoPipelineState,
         ledger: SeedDraftLedger,
+        seed: Seed,
         *,
         review: SeedReview | None,
     ) -> AutoPipelineResult:
@@ -1040,7 +1281,7 @@ class AutoPipeline:
             return self._result(state, ledger, review=review)
 
         if self.ralph_resumer is not None and state.ralph_job_id:
-            return await self._poll_ralph_job(state, ledger, review=review)
+            return await self._poll_ralph_job(state, ledger, seed, review=review)
 
         handle = state.ralph_job_id or state.ralph_lineage_id
         if handle:
@@ -1063,6 +1304,7 @@ class AutoPipeline:
         self,
         state: AutoPipelineState,
         ledger: SeedDraftLedger,
+        seed: Seed,
         *,
         review: SeedReview | None,
     ) -> AutoPipelineResult:
@@ -1105,12 +1347,16 @@ class AutoPipeline:
         terminal_status = _optional_str(ralph_meta.get("terminal_status"))
         stop_reason = _optional_str(ralph_meta.get("stop_reason"))
         if terminal_status == "completed":
-            state.transition(
-                AutoPhase.COMPLETE,
-                f"resumed ralph loop completed ({stop_reason or 'qa passed'})",
+            return await self._evaluate_or_complete(
+                state,
+                ledger,
+                seed,
+                review=review,
+                run_subagent=None,
+                stop_reason=stop_reason,
+                ralph_result_text=_optional_str(ralph_meta.get("result_text")),
+                resumed=True,
             )
-            self._save(state)
-            return self._result(state, ledger, review=review)
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
             state.mark_blocked(stop_reason, tool_name="ralph_starter")
             self._save(state)
@@ -1218,6 +1464,10 @@ class AutoPipeline:
             ralph_job_id=state.ralph_job_id,
             ralph_lineage_id=state.ralph_lineage_id,
             ralph_dispatch_mode=state.ralph_dispatch_mode,
+            last_qa_score=state.last_qa_score,
+            last_qa_verdict=state.last_qa_verdict,
+            last_qa_differences=tuple(state.last_qa_differences),
+            last_qa_suggestions=tuple(state.last_qa_suggestions),
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1018,7 +1018,7 @@ class AutoPipeline:
                 review=review,
                 run_subagent=run_subagent,
                 stop_reason=stop_reason,
-                ralph_result_text=_optional_str(ralph_meta.get("result_text")),
+                ralph_result_text=_artifact_text(ralph_meta.get("result_text")),
             )
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
             state.mark_blocked(stop_reason, tool_name="ralph_starter")
@@ -1059,7 +1059,12 @@ class AutoPipeline:
         :meth:`_run_evaluate`. Otherwise falls back to the pre-Phase-2.1
         behaviour: transition to COMPLETE directly.
         """
-        if self.evaluator is not None and state.complete_product and ralph_result_text:
+        if self.evaluator is not None and state.complete_product and ralph_result_text is not None:
+            # ``is not None`` not truthiness: an empty-but-valid Ralph
+            # artifact is still a graded artifact. Skipping EVALUATE on
+            # ``""`` would produce a silent false-pass for runs whose output
+            # is intentionally empty, violating the
+            # "complete_product + evaluator → graded COMPLETE" contract.
             state.transition(AutoPhase.EVALUATE, "evaluating ralph artifact against seed AC")
             self._save(state)
             return await self._run_evaluate(
@@ -1107,23 +1112,22 @@ class AutoPipeline:
 
         # Resolve the artifact:
         # 1. Fresh call from the Ralph terminal path → use ``ralph_result_text``
+        #    (``is not None`` so an empty-but-valid artifact still grades)
         # 2. EVALUATE-phase resume after a prior call → use the persisted
         #    ``state.evaluate_artifact`` so a timeout/transient-error path is
         #    genuinely recoverable (without persistence, ``--resume`` had no
         #    artifact to grade and dropped into a permanent BLOCKED).
         import hashlib
 
-        if ralph_result_text:
+        artifact: str | None = None
+        if ralph_result_text is not None:
             artifact = ralph_result_text
-            artifact_hash = hashlib.sha256(artifact.encode("utf-8")).hexdigest()
-        elif state.evaluate_artifact:
+        elif state.evaluate_artifact is not None:
             artifact = state.evaluate_artifact
-            artifact_hash = (
-                state.evaluate_artifact_hash or hashlib.sha256(artifact.encode("utf-8")).hexdigest()
-            )
-        else:
-            artifact = ""
+        if artifact is None:
             artifact_hash = state.evaluate_artifact_hash
+        else:
+            artifact_hash = hashlib.sha256(artifact.encode("utf-8")).hexdigest()
 
         cache_hit = (
             artifact_hash is not None
@@ -1147,7 +1151,7 @@ class AutoPipeline:
                 from_cache=True,
             )
 
-        if not artifact:
+        if artifact is None:
             # Resume in EVALUATE with no cached verdict and no fresh artifact —
             # we cannot move forward deterministically. Mark blocked so an
             # operator can attach or re-supply context.
@@ -1165,6 +1169,18 @@ class AutoPipeline:
         # recoverable trail on disk. The artifact must be stored verbatim
         # (no truncation) so the recomputed hash on resume matches the one
         # persisted here — truncation would silently invalidate the cache.
+        #
+        # Critical: when the artifact has CHANGED (hash differs from the
+        # previously persisted one), the stale verdict from the previous
+        # artifact MUST be cleared. Otherwise, if the evaluator times out
+        # or transiently errors after persisting the new hash, ``--resume``
+        # would see ``hash(new) == hash(new)`` paired with the verdict from
+        # ``hash(old)`` and incorrectly take the cache-hit path.
+        if state.evaluate_artifact_hash != artifact_hash:
+            state.last_qa_score = None
+            state.last_qa_verdict = None
+            state.last_qa_differences = []
+            state.last_qa_suggestions = []
         state.evaluate_artifact = artifact
         state.evaluate_artifact_hash = artifact_hash
         self._save(state)
@@ -1370,7 +1386,7 @@ class AutoPipeline:
                 review=review,
                 run_subagent=None,
                 stop_reason=stop_reason,
-                ralph_result_text=_optional_str(ralph_meta.get("result_text")),
+                ralph_result_text=_artifact_text(ralph_meta.get("result_text")),
                 resumed=True,
             )
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
@@ -1783,3 +1799,15 @@ def _first_nonempty(*values: str | None) -> str | None:
 
 def _optional_str(value: object) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _artifact_text(value: object) -> str | None:
+    """Return ``value`` verbatim when it is a string (including ``""``), else None.
+
+    Distinct from :func:`_optional_str` because an artifact graded by EVALUATE
+    is a valid input even when empty: a Ralph job whose output is
+    intentionally empty must still be evaluated against the Seed AC. Returning
+    None for ``""`` would cause ``_evaluate_or_complete`` to skip EVALUATE
+    and silently transition to COMPLETE.
+    """
+    return value if isinstance(value, str) else None

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1105,14 +1105,22 @@ class AutoPipeline:
         """
         assert self.evaluator is not None  # noqa: S101 — guarded by caller
 
-        # Resolve the artifact: prefer the freshly-passed text from the Ralph
-        # snapshot; on EVALUATE-phase resume the caller passes None and we
-        # rely entirely on the cached verdict.
-        if ralph_result_text:
-            import hashlib
+        # Resolve the artifact:
+        # 1. Fresh call from the Ralph terminal path → use ``ralph_result_text``
+        # 2. EVALUATE-phase resume after a prior call → use the persisted
+        #    ``state.evaluate_artifact`` so a timeout/transient-error path is
+        #    genuinely recoverable (without persistence, ``--resume`` had no
+        #    artifact to grade and dropped into a permanent BLOCKED).
+        import hashlib
 
+        if ralph_result_text:
             artifact = ralph_result_text
             artifact_hash = hashlib.sha256(artifact.encode("utf-8")).hexdigest()
+        elif state.evaluate_artifact:
+            artifact = state.evaluate_artifact
+            artifact_hash = (
+                state.evaluate_artifact_hash or hashlib.sha256(artifact.encode("utf-8")).hexdigest()
+            )
         else:
             artifact = ""
             artifact_hash = state.evaluate_artifact_hash
@@ -1152,6 +1160,15 @@ class AutoPipeline:
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
             )
 
+        # Persist the artifact + hash BEFORE invoking the evaluator so any
+        # subsequent timeout / exception / transient QA error leaves a
+        # recoverable trail on disk. The artifact must be stored verbatim
+        # (no truncation) so the recomputed hash on resume matches the one
+        # persisted here — truncation would silently invalidate the cache.
+        state.evaluate_artifact = artifact
+        state.evaluate_artifact_hash = artifact_hash
+        self._save(state)
+
         phase_timeout = state.phase_timeout_seconds(AutoPhase.EVALUATE)
         try:
             eval_result = await asyncio.wait_for(
@@ -1178,7 +1195,6 @@ class AutoPipeline:
                 f"evaluator reported transient error: {eval_result.error}",
                 tool_name="evaluator",
             )
-            state.evaluate_artifact_hash = artifact_hash
             self._save(state)
             return self._result(
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1129,21 +1129,25 @@ class AutoPipeline:
         else:
             artifact_hash = hashlib.sha256(artifact.encode("utf-8")).hexdigest()
 
+        # Cache hit requires the persisted ``last_qa_passed`` boolean — the
+        # canonical pass decision derived from ``score >= pass_threshold``
+        # by the QA handler. Using ``last_qa_verdict == "pass"`` as the
+        # cache key would silently reclassify a ``passed=True`` /
+        # ``verdict="revise"`` result as BLOCKED on resume, breaking
+        # idempotent resume behaviour.
         cache_hit = (
             artifact_hash is not None
             and state.evaluate_artifact_hash == artifact_hash
-            and state.last_qa_verdict is not None
+            and state.last_qa_passed is not None
         )
         if cache_hit:
-            cached_passed = bool(state.last_qa_verdict == "pass")
-            cached_score = state.last_qa_score or 0.0
             return self._finalize_evaluate(
                 state,
                 ledger,
                 review=review,
                 run_subagent=run_subagent,
-                passed=cached_passed,
-                score=cached_score,
+                passed=bool(state.last_qa_passed),
+                score=state.last_qa_score or 0.0,
                 verdict=state.last_qa_verdict or "fail",
                 differences=tuple(state.last_qa_differences),
                 suggestions=tuple(state.last_qa_suggestions),
@@ -1174,11 +1178,12 @@ class AutoPipeline:
         # previously persisted one), the stale verdict from the previous
         # artifact MUST be cleared. Otherwise, if the evaluator times out
         # or transiently errors after persisting the new hash, ``--resume``
-        # would see ``hash(new) == hash(new)`` paired with the verdict from
-        # ``hash(old)`` and incorrectly take the cache-hit path.
+        # would see ``hash(new) == hash(new)`` paired with the cached pass
+        # flag from ``hash(old)`` and incorrectly take the cache-hit path.
         if state.evaluate_artifact_hash != artifact_hash:
             state.last_qa_score = None
             state.last_qa_verdict = None
+            state.last_qa_passed = None
             state.last_qa_differences = []
             state.last_qa_suggestions = []
         state.evaluate_artifact = artifact
@@ -1236,6 +1241,12 @@ class AutoPipeline:
 
         state.last_qa_score = float(eval_result.score)
         state.last_qa_verdict = str(eval_result.verdict)
+        # Persist the canonical pass flag explicitly (score >= threshold
+        # per the QA contract). Resume reuses this boolean rather than
+        # re-deriving ``passed`` from the verdict string — verdicts and
+        # the passed flag can diverge (e.g. score 0.85, threshold 0.80
+        # ⇒ passed=True but verdict="revise" when the LLM is conservative).
+        state.last_qa_passed = bool(eval_result.passed)
         state.last_qa_differences = list(eval_result.differences)
         state.last_qa_suggestions = list(eval_result.suggestions)
         state.evaluate_artifact_hash = artifact_hash

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1186,13 +1186,31 @@ class AutoPipeline:
         self._save(state)
 
         phase_timeout = state.phase_timeout_seconds(AutoPhase.EVALUATE)
+        # Cap the per-phase budget by the remaining top-level pipeline
+        # deadline (Q00/ouroboros#779). Without this cap a late EVALUATE
+        # entry could block past ``deadline_at`` and report
+        # ``"evaluator timed out"`` instead of the canonical
+        # ``pipeline_timeout`` blocker every other long-running phase
+        # produces.
+        capped_timeout = self._deadline_capped_timeout(state, phase_timeout)
         try:
             eval_result = await asyncio.wait_for(
-                self.evaluator(seed, artifact), timeout=phase_timeout
+                self.evaluator(seed, artifact), timeout=capped_timeout
             )
         except TimeoutError:
+            # If the deadline expired during the call, surface the canonical
+            # pipeline-timeout blocker so resume / status surfaces see the
+            # same shape as every other deadline trip in the pipeline.
+            if self._enforce_deadline(state):
+                return self._result(
+                    state,
+                    ledger,
+                    review=review,
+                    blocker=state.last_error,
+                    run_subagent=run_subagent,
+                )
             state.mark_blocked(
-                f"evaluator timed out after {phase_timeout:.0f}s",
+                f"evaluator timed out after {capped_timeout:.0f}s",
                 tool_name="evaluator",
             )
             self._save(state)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -369,6 +369,7 @@ class AutoPipeline:
             AutoPhase.REVIEW,
             AutoPhase.RUN,
             AutoPhase.RALPH_HANDOFF,
+            AutoPhase.EVALUATE,
         }:
             state.mark_blocked(
                 f"Cannot resume auto pipeline from {state.phase.value} without persisted Seed artifact",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1736,6 +1736,14 @@ def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
         return AutoPhase.RUN
     if tool_name == "ralph_starter":
         return AutoPhase.RALPH_HANDOFF
+    if tool_name == "evaluator":
+        # RFC #809 Phase 2.1: when the evaluator times out or the QA handler
+        # returns a transient infrastructure error, the session is marked
+        # BLOCKED with this tool name. ``--resume`` must dispatch back into
+        # EVALUATE so the cached verdict (if present) or a fresh evaluator
+        # call (if not) can drive the session forward instead of leaving it
+        # stranded in a non-resumable BLOCKED state.
+        return AutoPhase.EVALUATE
     return None
 
 

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -336,6 +336,13 @@ class AutoPipelineState:
     # verdict is honored; otherwise the evaluator re-runs.
     last_qa_score: float | None = None
     last_qa_verdict: str | None = None
+    # The QA handler's canonical pass condition is ``score >= pass_threshold``
+    # (see ``QAHandler``), which can be True even when ``verdict`` is
+    # ``"revise"``. Persist the boolean separately so the EVALUATE cache
+    # resume path reuses the authoritative passed flag instead of
+    # re-deriving from verdict text (the LLM's free-form verdict string
+    # is not the source of truth for the pass decision).
+    last_qa_passed: bool | None = None
     last_qa_differences: list[str] = field(default_factory=list)
     last_qa_suggestions: list[str] = field(default_factory=list)
     evaluate_artifact_hash: str | None = None
@@ -586,7 +593,7 @@ class AutoPipelineState:
         # blocked after persisting ``""`` is still resumable.
         if recoverable == AutoPhase.EVALUATE:
             if self.evaluate_artifact is not None or (
-                self.evaluate_artifact_hash is not None and self.last_qa_verdict is not None
+                self.evaluate_artifact_hash is not None and self.last_qa_passed is not None
             ):
                 return AutoResumeCapability.RESUME
             return AutoResumeCapability.NONE
@@ -639,6 +646,7 @@ class AutoPipelineState:
         payload.setdefault("user_preferences", {})
         payload.setdefault("last_qa_score", None)
         payload.setdefault("last_qa_verdict", None)
+        payload.setdefault("last_qa_passed", None)
         payload.setdefault("last_qa_differences", [])
         payload.setdefault("last_qa_suggestions", [])
         payload.setdefault("evaluate_artifact_hash", None)
@@ -798,6 +806,9 @@ class AutoPipelineState:
             not isinstance(self.last_qa_verdict, str) or not self.last_qa_verdict.strip()
         ):
             msg = "last_qa_verdict must be a non-empty string or null"
+            raise ValueError(msg)
+        if self.last_qa_passed is not None and not isinstance(self.last_qa_passed, bool):
+            msg = "last_qa_passed must be a boolean or null"
             raise ValueError(msg)
         if not isinstance(self.last_qa_differences, list) or any(
             not isinstance(item, str) for item in self.last_qa_differences

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -580,8 +580,12 @@ class AutoPipelineState:
         # persisted artifact (so the evaluator can re-grade) OR a cached
         # verdict matching the persisted hash (so the cache hit drives the
         # decision without re-invoking the LLM). Neither present → NONE.
+        #
+        # ``is not None`` rather than truthiness on ``evaluate_artifact``:
+        # an empty-string artifact is a valid graded input, so a session
+        # blocked after persisting ``""`` is still resumable.
         if recoverable == AutoPhase.EVALUATE:
-            if self.evaluate_artifact or (
+            if self.evaluate_artifact is not None or (
                 self.evaluate_artifact_hash is not None and self.last_qa_verdict is not None
             ):
                 return AutoResumeCapability.RESUME

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -339,6 +339,15 @@ class AutoPipelineState:
     last_qa_differences: list[str] = field(default_factory=list)
     last_qa_suggestions: list[str] = field(default_factory=list)
     evaluate_artifact_hash: str | None = None
+    # The actual artifact text graded during EVALUATE. Persisted verbatim
+    # on first entry into ``_run_evaluate`` so a timeout / exception /
+    # transient QA error leaves a recoverable trail: on ``--resume`` the
+    # pipeline re-enters EVALUATE with this artifact rather than dropping
+    # into the "no cached verdict and no artifact" BLOCKED branch. Stored
+    # without truncation so the recomputed hash on resume matches the
+    # persisted ``evaluate_artifact_hash`` — truncation would silently
+    # invalidate the cache.
+    evaluate_artifact: str | None = None
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.
@@ -618,6 +627,7 @@ class AutoPipelineState:
         payload.setdefault("last_qa_differences", [])
         payload.setdefault("last_qa_suggestions", [])
         payload.setdefault("evaluate_artifact_hash", None)
+        payload.setdefault("evaluate_artifact", None)
         # Convert the persisted ``deadline_at_epoch`` (epoch seconds) back into
         # a monotonic-clock value usable from this process. If the companion
         # epoch field is present, derive ``deadline_at`` from the offset
@@ -789,6 +799,9 @@ class AutoPipelineState:
             or not self.evaluate_artifact_hash.strip()
         ):
             msg = "evaluate_artifact_hash must be a non-empty string or null"
+            raise ValueError(msg)
+        if self.evaluate_artifact is not None and not isinstance(self.evaluate_artifact, str):
+            msg = "evaluate_artifact must be a string or null"
             raise ValueError(msg)
         if self.provenance is not None:
             if not isinstance(self.provenance, dict):

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -576,6 +576,17 @@ class AutoPipelineState:
                 return AutoResumeCapability.PARTIAL_RESUME
             return AutoResumeCapability.NONE
 
+        # EVALUATE phase (RFC #809 Phase 2.1). Recovery requires either the
+        # persisted artifact (so the evaluator can re-grade) OR a cached
+        # verdict matching the persisted hash (so the cache hit drives the
+        # decision without re-invoking the LLM). Neither present → NONE.
+        if recoverable == AutoPhase.EVALUATE:
+            if self.evaluate_artifact or (
+                self.evaluate_artifact_hash is not None and self.last_qa_verdict is not None
+            ):
+                return AutoResumeCapability.RESUME
+            return AutoResumeCapability.NONE
+
         return AutoResumeCapability.NONE  # defensive
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -22,6 +22,7 @@ class AutoPhase(StrEnum):
     REPAIR = "repair"
     RUN = "run"
     RALPH_HANDOFF = "ralph_handoff"
+    EVALUATE = "evaluate"
     COMPLETE = "complete"
     BLOCKED = "blocked"
     FAILED = "failed"
@@ -59,6 +60,7 @@ DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
     AutoPhase.REVIEW.value: 90,
     AutoPhase.REPAIR.value: 90,
     AutoPhase.RUN.value: 60,
+    AutoPhase.EVALUATE.value: 90,
 }
 
 # Top-level pipeline deadline (Q00/ouroboros#779). Default of 7200s (2h) covers
@@ -200,6 +202,12 @@ _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
         AutoPhase.FAILED,
     },
     AutoPhase.RALPH_HANDOFF: {
+        AutoPhase.EVALUATE,
+        AutoPhase.COMPLETE,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    },
+    AutoPhase.EVALUATE: {
         AutoPhase.COMPLETE,
         AutoPhase.BLOCKED,
         AutoPhase.FAILED,
@@ -211,6 +219,7 @@ _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
         AutoPhase.REVIEW,
         AutoPhase.RUN,
         AutoPhase.RALPH_HANDOFF,
+        AutoPhase.EVALUATE,
     },
     AutoPhase.FAILED: {
         AutoPhase.INTERVIEW,
@@ -218,6 +227,7 @@ _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
         AutoPhase.REVIEW,
         AutoPhase.RUN,
         AutoPhase.RALPH_HANDOFF,
+        AutoPhase.EVALUATE,
     },
 }
 
@@ -318,6 +328,17 @@ class AutoPipelineState:
     # ``REQUIRED_SECTIONS`` at construction time by the MCP handler — only
     # known section keys with non-empty string values land here.
     user_preferences: dict[str, str] = field(default_factory=dict)
+    # QA verdict captured during the EVALUATE phase (RFC #809 Phase 2.1).
+    # Persisted so a resumed session reuses the verdict without re-invoking
+    # the LLM-driven judge when the underlying artifact has not changed.
+    # ``evaluate_artifact_hash`` is a sha256 of the run artifact that was
+    # graded: if the hash on resume matches the cached one, the cached
+    # verdict is honored; otherwise the evaluator re-runs.
+    last_qa_score: float | None = None
+    last_qa_verdict: str | None = None
+    last_qa_differences: list[str] = field(default_factory=list)
+    last_qa_suggestions: list[str] = field(default_factory=list)
+    evaluate_artifact_hash: str | None = None
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.
@@ -592,6 +613,11 @@ class AutoPipelineState:
         payload.setdefault("deadline_at", None)
         payload.setdefault("deadline_at_epoch", None)
         payload.setdefault("user_preferences", {})
+        payload.setdefault("last_qa_score", None)
+        payload.setdefault("last_qa_verdict", None)
+        payload.setdefault("last_qa_differences", [])
+        payload.setdefault("last_qa_suggestions", [])
+        payload.setdefault("evaluate_artifact_hash", None)
         # Convert the persisted ``deadline_at_epoch`` (epoch seconds) back into
         # a monotonic-clock value usable from this process. If the companion
         # epoch field is present, derive ``deadline_at`` from the offset
@@ -738,6 +764,32 @@ class AutoPipelineState:
                     "MCP handler which validates against REQUIRED_SECTIONS"
                 )
                 raise ValueError(msg)
+        if self.last_qa_score is not None and (
+            isinstance(self.last_qa_score, bool) or not isinstance(self.last_qa_score, int | float)
+        ):
+            msg = "last_qa_score must be a number or null"
+            raise ValueError(msg)
+        if self.last_qa_verdict is not None and (
+            not isinstance(self.last_qa_verdict, str) or not self.last_qa_verdict.strip()
+        ):
+            msg = "last_qa_verdict must be a non-empty string or null"
+            raise ValueError(msg)
+        if not isinstance(self.last_qa_differences, list) or any(
+            not isinstance(item, str) for item in self.last_qa_differences
+        ):
+            msg = "last_qa_differences must be a list of strings"
+            raise ValueError(msg)
+        if not isinstance(self.last_qa_suggestions, list) or any(
+            not isinstance(item, str) for item in self.last_qa_suggestions
+        ):
+            msg = "last_qa_suggestions must be a list of strings"
+            raise ValueError(msg)
+        if self.evaluate_artifact_hash is not None and (
+            not isinstance(self.evaluate_artifact_hash, str)
+            or not self.evaluate_artifact_hash.strip()
+        ):
+            msg = "evaluate_artifact_hash must be a non-empty string or null"
+            raise ValueError(msg)
         if self.provenance is not None:
             if not isinstance(self.provenance, dict):
                 msg = "provenance must be an object or null"

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -334,10 +334,11 @@ class AutoHandler:
         # artifact to grade; instantiating QAHandler would be wasted setup.
         evaluator = None
         if complete_product:
+            qa_opencode_mode = "subprocess" if opencode_mode == "plugin" else opencode_mode
             qa_handler = QAHandler(
                 llm_backend=self.llm_backend,
                 agent_runtime_backend=runtime_backend,
-                opencode_mode=opencode_mode,
+                opencode_mode=qa_opencode_mode,
             )
             evaluator = HandlerEvaluator(qa_handler)
         pipeline = AutoPipeline(

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ouroboros.auto.adapters import (
+    HandlerEvaluator,
     HandlerInterviewBackend,
     HandlerRalphPoller,
     HandlerRalphStarter,
@@ -38,6 +39,7 @@ from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
+from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import (
     ContentType,
@@ -326,6 +328,18 @@ class AutoHandler:
         # ``EventStore``) — without that share the poller would query a
         # fresh, empty job table.
         ralph_resumer = HandlerRalphPoller(ralph_handler) if ralph_handler is not None else None
+        # RFC #809 Phase 2.1 — wire the QA-backed evaluator only when the
+        # session is in complete-product mode. Outside that mode the chain
+        # is RUN → COMPLETE (async run handoff) so there is no synchronous
+        # artifact to grade; instantiating QAHandler would be wasted setup.
+        evaluator = None
+        if complete_product:
+            qa_handler = QAHandler(
+                llm_backend=self.llm_backend,
+                agent_runtime_backend=runtime_backend,
+                opencode_mode=opencode_mode,
+            )
+            evaluator = HandlerEvaluator(qa_handler)
         pipeline = AutoPipeline(
             driver,
             HandlerSeedGenerator(generate_seed_handler),
@@ -344,6 +358,7 @@ class AutoHandler:
             ralph_starter=ralph_starter,
             ralph_resumer=ralph_resumer,
             complete_product=complete_product,
+            evaluator=evaluator,
         )
         return await pipeline.run(state)
 
@@ -402,6 +417,17 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["ralph_lineage_id"] = result.ralph_lineage_id
     if result.ralph_dispatch_mode:
         meta["ralph_dispatch_mode"] = result.ralph_dispatch_mode
+    # RFC #809 Phase 2.1 — surface the EVALUATE verdict when present. None
+    # signals "EVALUATE did not run" so clients can distinguish "not graded"
+    # from "graded and failed".
+    if result.last_qa_score is not None:
+        meta["last_qa_score"] = result.last_qa_score
+    if result.last_qa_verdict is not None:
+        meta["last_qa_verdict"] = result.last_qa_verdict
+    if result.last_qa_differences:
+        meta["last_qa_differences"] = list(result.last_qa_differences)
+    if result.last_qa_suggestions:
+        meta["last_qa_suggestions"] = list(result.last_qa_suggestions)
     # Always emit the ledger-provenance surface so MCP clients can distinguish
     # "computed and empty" (no resolved sections yet, or no per-source split
     # available) from "field not provided at all".  Empty containers are part
@@ -680,6 +706,18 @@ def _format_result(result: AutoPipelineResult) -> str:
             lines.append(f"  job_id: {result.ralph_job_id}")
         if result.ralph_lineage_id:
             lines.append(f"  lineage_id: {result.ralph_lineage_id}")
+    # RFC #809 Phase 2.1 — render the EVALUATE verdict when present so resume
+    # surfaces tell the user whether the session converged on AC verification
+    # or stalled with QA findings the operator must act on.
+    if result.last_qa_verdict is not None:
+        score = f"{result.last_qa_score:.2f}" if result.last_qa_score is not None else "n/a"
+        lines.append(f"QA verdict: {result.last_qa_verdict} (score {score})")
+        if result.last_qa_differences:
+            lines.append("  differences:")
+            lines.extend(f"  - {item}" for item in result.last_qa_differences[:3])
+        if result.last_qa_suggestions:
+            lines.append("  suggestions:")
+            lines.extend(f"  - {item}" for item in result.last_qa_suggestions[:3])
     if result.assumptions:
         lines.append("Assumptions:")
         lines.extend(f"- {item}" for item in result.assumptions)

--- a/src/ouroboros/mcp/tools/qa.py
+++ b/src/ouroboros/mcp/tools/qa.py
@@ -492,7 +492,7 @@ class QAHandler:
     ) -> Result[MCPToolResult, MCPServerError]:
         """Handle a QA verdict request."""
         artifact = arguments.get("artifact")
-        if not artifact:
+        if "artifact" not in arguments or not isinstance(artifact, str):
             return Result.err(
                 MCPToolError(
                     "artifact is required",

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -801,3 +801,154 @@ def test_state_round_trips_evaluate_artifact(tmp_path) -> None:
     reloaded = store.load(state.auto_session_id)
     assert reloaded.evaluate_artifact == "persisted artifact"
     assert reloaded.evaluate_artifact_hash == "deadbeef"
+
+
+# ---------------------------------------------------------------------------
+# Cache correctness: a new artifact must not inherit stale verdict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_artifact_does_not_inherit_stale_verdict(tmp_path) -> None:
+    """If artifact A was graded pass, then artifact B enters EVALUATE and
+    the evaluator times out, ``--resume`` must NOT reuse A's verdict
+    against B. The pipeline clears stale qa fields whenever the artifact
+    hash changes."""
+    state = _state_at_run_phase(tmp_path)
+    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 1
+
+    call_count = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return EvaluateResult(passed=True, score=0.95, verdict="pass")
+        # Second call (for artifact B) hangs → times out
+        await asyncio.sleep(10)
+        return EvaluateResult(passed=True, score=1.0, verdict="pass")
+
+    pipeline_a = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact A"),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    # Pass artifact A — verdict cached.
+    await pipeline_a.run(state)
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.last_qa_verdict == "pass"
+    a_hash = state.evaluate_artifact_hash
+
+    # Now feed artifact B directly into _run_evaluate. The evaluator times
+    # out, leaving state in BLOCKED. Critical: the stale "pass" verdict
+    # from A must be cleared so a future cache check cannot mistakenly
+    # reuse it for B.
+    state.phase = AutoPhase.EVALUATE
+    await pipeline_a._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text="artifact B (different)",
+        stop_reason=None,
+    )
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_qa_verdict is None  # stale verdict cleared
+    assert state.last_qa_score is None
+    assert state.evaluate_artifact_hash != a_hash
+    assert state.evaluate_artifact == "artifact B (different)"
+
+
+# ---------------------------------------------------------------------------
+# Empty Ralph artifact must still be graded (not silent false-pass)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_ralph_artifact_still_enters_evaluate(tmp_path) -> None:
+    """``ralph_result_text == ""`` is a valid graded artifact; the gate
+    used ``ralph_result_text is not None`` (not truthiness) so the
+    pipeline does not silently mark an empty-output run as a pass."""
+    state = _state_at_run_phase(tmp_path)
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        # An empty artifact should fail QA against AC like "Command prints
+        # stable output". Return fail to make the contract explicit.
+        return EvaluateResult(
+            passed=False,
+            score=0.10,
+            verdict="fail",
+            differences=("artifact is empty",),
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text=""),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+    assert eval_calls == 1
+    assert state.phase is AutoPhase.BLOCKED
+    assert result.last_qa_verdict == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Resume capability advertises EVALUATE recoverability
+# ---------------------------------------------------------------------------
+
+
+def test_resume_capability_advertises_evaluate_as_resumable(tmp_path) -> None:
+    """An EVALUATE-blocked session with the persisted artifact in place
+    must report ``RESUME`` capability so the CLI/MCP surfaces emit the
+    resume hint. Previously the method fell through to ``NONE`` for
+    EVALUATE-blocked states — a public-surface contract bug."""
+    from ouroboros.auto.state import AutoResumeCapability
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.phase = AutoPhase.BLOCKED
+    state.last_tool_name = "evaluator"
+    state.evaluate_artifact = "some artifact text"
+    state.evaluate_artifact_hash = "abc123"
+
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_evaluate_blocked_without_artifact_is_none(tmp_path) -> None:
+    """Without a persisted artifact AND without a cached verdict, EVALUATE
+    has nothing to drive forward on resume — capability must be NONE."""
+    from ouroboros.auto.state import AutoResumeCapability
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.phase = AutoPhase.BLOCKED
+    state.last_tool_name = "evaluator"
+    # No evaluate_artifact, no last_qa_verdict
+    assert state.resume_capability() is AutoResumeCapability.NONE
+
+
+def test_resume_capability_evaluate_blocked_with_cached_verdict_is_resumable(tmp_path) -> None:
+    """A cached verdict + hash is enough to drive the resume to COMPLETE
+    (cache-hit short-circuit), so capability is RESUME even without the
+    raw artifact text."""
+    from ouroboros.auto.state import AutoResumeCapability
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.phase = AutoPhase.BLOCKED
+    state.last_tool_name = "evaluator"
+    state.evaluate_artifact_hash = "abc123"
+    state.last_qa_verdict = "pass"
+    state.last_qa_score = 0.92
+    assert state.resume_capability() is AutoResumeCapability.RESUME

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -701,3 +701,103 @@ def test_recoverable_phase_for_evaluator_tool() -> None:
     from ouroboros.auto.pipeline import _recoverable_phase_for_tool
 
     assert _recoverable_phase_for_tool("evaluator") is AutoPhase.EVALUATE
+
+
+# ---------------------------------------------------------------------------
+# Evaluator durability: artifact must persist across timeout → resume
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluator_timeout_persists_artifact_for_resume(tmp_path) -> None:
+    """After an evaluator timeout, ``state.evaluate_artifact`` must hold the
+    artifact text so ``--resume`` can re-grade it instead of falling into
+    the "no cached verdict and no artifact" BLOCKED branch."""
+    state = _state_at_run_phase(tmp_path)
+    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 1
+
+    async def hanging_evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        await asyncio.sleep(10)
+        return EvaluateResult(passed=True, score=1.0, verdict="pass")
+
+    pipeline_timeout = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="ralph artifact payload"),
+        complete_product=True,
+        evaluator=hanging_evaluator,
+    )
+
+    await pipeline_timeout.run(state)
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "evaluator"
+    assert state.evaluate_artifact == "ralph artifact payload"
+    assert state.evaluate_artifact_hash is not None
+
+
+@pytest.mark.asyncio
+async def test_resume_after_evaluator_timeout_re_runs_with_persisted_artifact(tmp_path) -> None:
+    """Simulating the full resume contract: an evaluator that times out on
+    first call, then succeeds on a retry. The persisted artifact allows
+    ``_run_evaluate`` to re-grade on resume — the recovery path that the
+    earlier review iteration silently broke."""
+    state = _state_at_run_phase(tmp_path)
+    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 1
+    call_count = 0
+
+    async def flaky_evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            await asyncio.sleep(10)  # times out
+        return EvaluateResult(
+            passed=True, score=0.91, verdict="pass", differences=(), suggestions=()
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="durable ralph artifact"),
+        complete_product=True,
+        evaluator=flaky_evaluator,
+    )
+
+    # First call → evaluator times out → BLOCKED but artifact persisted
+    await pipeline.run(state)
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.evaluate_artifact == "durable ralph artifact"
+    assert call_count == 1
+
+    # Simulate resume by re-entering EVALUATE directly (production resume
+    # uses ``_recoverable_phase_for_tool("evaluator") == EVALUATE`` which we
+    # just verified above). The pipeline pulls the persisted artifact from
+    # state and re-invokes the evaluator.
+    state.phase = AutoPhase.EVALUATE
+    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 60
+    result = await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text=None,  # caller passes None on resume
+        stop_reason=None,
+    )
+    assert result.status == "complete"
+    assert state.last_qa_verdict == "pass"
+    assert call_count == 2  # evaluator was re-invoked with the persisted artifact
+
+
+def test_state_round_trips_evaluate_artifact(tmp_path) -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.evaluate_artifact = "persisted artifact"
+    state.evaluate_artifact_hash = "deadbeef"
+    store = AutoStore(tmp_path)
+    store.save(state)
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded.evaluate_artifact == "persisted artifact"
+    assert reloaded.evaluate_artifact_hash == "deadbeef"

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -1021,6 +1021,45 @@ async def test_handler_ralph_starter_preserves_empty_result_text() -> None:
 
 
 @pytest.mark.asyncio
+async def test_evaluator_respects_top_level_pipeline_deadline(tmp_path) -> None:
+    """If only N seconds remain on the pipeline deadline when EVALUATE is
+    entered, the evaluator call must be capped at ``min(N, phase_timeout)``
+    and a deadline trip during the call must surface the canonical
+    ``pipeline_timeout`` blocker (tool_name=``pipeline_deadline``), not the
+    per-phase ``evaluator timed out`` message. This keeps EVALUATE inside
+    the same budget framework as every other long-running phase."""
+    import time as _time
+
+    from ouroboros.auto.pipeline import PIPELINE_DEADLINE_TOOL_NAME
+
+    state = _state_at_run_phase(tmp_path)
+    # Force a near-expired deadline: 0.1 seconds from now.
+    state.deadline_at = _time.monotonic() + 0.1
+    # Per-phase timeout is much larger, so the deadline must dominate.
+    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 90
+
+    async def hanging_evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        await asyncio.sleep(10)
+        return EvaluateResult(passed=True, score=1.0, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="ralph artifact"),
+        complete_product=True,
+        evaluator=hanging_evaluator,
+    )
+
+    result = await pipeline.run(state)
+    assert result.status == "blocked"
+    # Deadline trip uses the canonical tool name, NOT "evaluator"
+    assert state.last_tool_name == PIPELINE_DEADLINE_TOOL_NAME
+    assert "pipeline_timeout" in (state.last_error or "")
+
+
+@pytest.mark.asyncio
 async def test_handler_ralph_poller_preserves_empty_result_text() -> None:
     """Same contract on the resume poller path."""
     from ouroboros.auto.adapters import HandlerRalphPoller

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -1,0 +1,613 @@
+"""Phase 2.1 tests — EVALUATE phase + HandlerEvaluator + state plumbing.
+
+Covers RFC #809 Phase 2.1: a successful Ralph terminal verdict no longer goes
+straight to COMPLETE when an evaluator is wired. Instead the pipeline grades
+the run artifact against the Seed's acceptance criteria via ``ouroboros_qa``
+and only transitions to COMPLETE on QA pass. QA fail → BLOCKED with the
+verdict summary in ``state.last_error``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.adapters import EvaluateResult, HandlerEvaluator
+from ouroboros.auto.grading import GradeResult, SeedGrade
+from ouroboros.auto.interview_driver import AutoInterviewResult
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
+from ouroboros.auto.state import (
+    _ALLOWED_TRANSITIONS,
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+)
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_seed(seed_id: str = "seed_eval_001") -> Seed:
+    return Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(seed_id=seed_id, ambiguity_score=0.12),
+    )
+
+
+class _StubInterviewDriver:
+    def __init__(self) -> None:
+        self.progress_callback = None
+
+    async def run(self, state: AutoPipelineState, ledger: Any) -> AutoInterviewResult:
+        state.interview_session_id = "interview_stub"
+        state.interview_completed = True
+        return AutoInterviewResult(
+            status="seed_ready",
+            session_id="interview_stub",
+            ledger=ledger,
+            rounds=1,
+        )
+
+
+def _state_at_run_phase(tmp_path) -> AutoPipelineState:
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.arm_deadline()
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_stub"
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    seed = _build_seed()
+    state.seed_id = seed.metadata.seed_id
+    state.seed_artifact = seed.to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    return state
+
+
+async def _run_starter_ok(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+    return {
+        "job_id": "job_run_001",
+        "session_id": "exec_session_001",
+        "execution_id": "execution_001",
+    }
+
+
+async def _seed_generator_unused(_session_id: str) -> Seed:  # pragma: no cover
+    raise AssertionError("seed generator should not run when seed_artifact is set")
+
+
+class _PassReviewer(SeedReviewer):
+    def __init__(self) -> None:
+        pass
+
+    def review(self, seed: Seed, *, ledger: Any = None) -> SeedReview:  # noqa: ARG002
+        grade = GradeResult(grade=SeedGrade.A, scores={}, findings=[], blockers=[], may_run=True)
+        return SeedReview(grade_result=grade, findings=())
+
+
+class _StubLedger:
+    """Minimal ledger stub for direct ``_run_evaluate`` calls.
+
+    The pipeline only calls ``summary()``, ``assumptions()``, and ``non_goals()``
+    on the ledger inside ``_result()`` (via ``ledger.summary()``). All return
+    empty so the test focuses on EVALUATE transition behaviour rather than
+    ledger-summary coverage."""
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "provenance": {},
+            "evidence_backed_sections": (),
+            "assumption_only_sections": (),
+        }
+
+    def assumptions(self) -> list[str]:
+        return []
+
+    def non_goals(self) -> list[str]:
+        return []
+
+
+def _ralph_starter(*, result_text: str = "stdout: ok\nexit_code: 0"):
+    async def _starter(seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "job_id": "job_ralph_001",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+            "result_text": result_text,
+        }
+
+    return _starter
+
+
+# ---------------------------------------------------------------------------
+# State-machine sanity
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_phase_in_allowed_transitions() -> None:
+    assert AutoPhase.EVALUATE in _ALLOWED_TRANSITIONS[AutoPhase.RALPH_HANDOFF]
+    assert _ALLOWED_TRANSITIONS[AutoPhase.EVALUATE] == {
+        AutoPhase.COMPLETE,
+        AutoPhase.BLOCKED,
+        AutoPhase.FAILED,
+    }
+    # Recovery from terminal-but-resumable phases must be able to re-enter EVALUATE
+    assert AutoPhase.EVALUATE in _ALLOWED_TRANSITIONS[AutoPhase.BLOCKED]
+    assert AutoPhase.EVALUATE in _ALLOWED_TRANSITIONS[AutoPhase.FAILED]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline EVALUATE happy/fail/timeout paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_pass_transitions_to_complete(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+    eval_calls: list[tuple[Seed, str]] = []
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:
+        eval_calls.append((seed, artifact))
+        return EvaluateResult(
+            passed=True,
+            score=0.92,
+            verdict="pass",
+            differences=(),
+            suggestions=(),
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.last_qa_verdict == "pass"
+    assert state.last_qa_score == 0.92
+    assert result.last_qa_verdict == "pass"
+    assert result.last_qa_score == 0.92
+    assert len(eval_calls) == 1
+    assert "stdout: ok" in eval_calls[0][1]
+    assert state.evaluate_artifact_hash is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_fail_transitions_to_blocked(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False,
+            score=0.42,
+            verdict="revise",
+            differences=("missing stable stdout", "wrong exit code"),
+            suggestions=("emit final newline", "return 0 on success"),
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_qa_verdict == "revise"
+    assert state.last_qa_score == 0.42
+    assert state.last_tool_name == "evaluator"
+    assert "missing stable stdout" in (state.last_error or "")
+    assert "emit final newline" in (state.last_error or "")
+    assert result.blocker is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_timeout_blocks(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+    state.timeout_seconds_by_phase[AutoPhase.EVALUATE.value] = 1
+
+    async def hanging_evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        await asyncio.sleep(10)
+        return EvaluateResult(passed=True, score=1.0, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=hanging_evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "evaluator"
+    assert "timed out" in (state.last_error or "")
+    # No verdict was captured because the call timed out
+    assert state.last_qa_verdict is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_handler_error_blocks(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+
+    async def transient_evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False, score=0.0, verdict="fail", error="QA service unreachable"
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=transient_evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "evaluator"
+    assert "QA service unreachable" in (state.last_error or "")
+
+
+# ---------------------------------------------------------------------------
+# Opt-in / wiring guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_only_fires_when_complete_product_set(tmp_path) -> None:
+    """When ``complete_product`` is False, EVALUATE must NOT run even if an
+    evaluator is wired. The pipeline goes RUN → COMPLETE directly (the run is
+    async and there is no synchronous artifact to grade)."""
+    state = _state_at_run_phase(tmp_path)
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        return EvaluateResult(passed=True, score=1.0, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=None,  # no chain
+        complete_product=False,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert eval_calls == 0
+    assert state.last_qa_verdict is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_skipped_when_evaluator_none(tmp_path) -> None:
+    """``complete_product=True`` without an evaluator wired falls through to
+    legacy RALPH_HANDOFF → COMPLETE behaviour."""
+    state = _state_at_run_phase(tmp_path)
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=None,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.last_qa_verdict is None
+    # The pipeline never touched EVALUATE
+    assert state.phase is AutoPhase.COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_skipped_when_no_result_text(tmp_path) -> None:
+    """If Ralph terminal meta lacks ``result_text``, EVALUATE has nothing to
+    grade and the pipeline falls back to COMPLETE without invoking the
+    evaluator."""
+    state = _state_at_run_phase(tmp_path)
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        return EvaluateResult(passed=True, score=1.0, verdict="pass")
+
+    async def ralph_starter(seed: Seed, **kwargs: Any) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "job_id": "job_ralph_002",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+            # No result_text key
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert eval_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Resume idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_uses_cached_verdict_on_resume(tmp_path) -> None:
+    """A second pass with the same artifact hash and a persisted verdict
+    must NOT re-invoke the evaluator (LLM call is cached on disk)."""
+    state = _state_at_run_phase(tmp_path)
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        return EvaluateResult(passed=True, score=0.91, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    # First run — evaluator called once.
+    await pipeline.run(state)
+    assert eval_calls == 1
+
+    # Simulate resume in EVALUATE phase. Bypass ``state.transition`` since
+    # COMPLETE is terminal in production; real resume reloads a state file
+    # that was persisted while phase=EVALUATE before COMPLETE was reached.
+    state.phase = AutoPhase.EVALUATE
+
+    seed = _build_seed()
+    result = await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=seed,
+        review=None,
+        run_subagent=None,
+        ralph_result_text=None,  # caller passes None on resume; cache must serve
+        stop_reason=None,
+    )
+    assert eval_calls == 1  # NOT incremented
+    assert result.status == "complete"
+    assert state.last_qa_verdict == "pass"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_evaluate_reevaluates_when_artifact_changes(tmp_path) -> None:
+    """A different artifact hash forces re-evaluation."""
+    state = _state_at_run_phase(tmp_path)
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        # First run: pass; subsequent runs: fail
+        if eval_calls == 1:
+            return EvaluateResult(passed=True, score=0.92, verdict="pass")
+        return EvaluateResult(
+            passed=False,
+            score=0.30,
+            verdict="fail",
+            differences=("changed output is wrong",),
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    await pipeline.run(state)
+    assert eval_calls == 1
+    first_hash = state.evaluate_artifact_hash
+
+    # Now simulate a resume with a fresh, different artifact. Bypass
+    # ``state.transition`` per the cache test's rationale.
+    state.phase = AutoPhase.EVALUATE
+    seed_resume = _build_seed()
+    await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=seed_resume,
+        review=None,
+        run_subagent=None,
+        ralph_result_text="entirely different artifact content",
+        stop_reason=None,
+    )
+    assert eval_calls == 2
+    assert state.evaluate_artifact_hash != first_hash
+    assert state.last_qa_verdict == "fail"
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def test_state_round_trips_qa_fields(tmp_path) -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.last_qa_score = 0.83
+    state.last_qa_verdict = "pass"
+    state.last_qa_differences = ["a", "b"]
+    state.last_qa_suggestions = ["fix a", "fix b"]
+    state.evaluate_artifact_hash = "deadbeef"
+    store = AutoStore(tmp_path)
+    store.save(state)
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded.last_qa_score == 0.83
+    assert reloaded.last_qa_verdict == "pass"
+    assert reloaded.last_qa_differences == ["a", "b"]
+    assert reloaded.last_qa_suggestions == ["fix a", "fix b"]
+    assert reloaded.evaluate_artifact_hash == "deadbeef"
+
+
+def test_state_loads_legacy_dump_without_qa_fields(tmp_path) -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    raw = state.to_dict()
+    for key in (
+        "last_qa_score",
+        "last_qa_verdict",
+        "last_qa_differences",
+        "last_qa_suggestions",
+        "evaluate_artifact_hash",
+    ):
+        raw.pop(key, None)
+    reloaded = AutoPipelineState.from_dict(raw)
+    assert reloaded.last_qa_score is None
+    assert reloaded.last_qa_verdict is None
+    assert reloaded.last_qa_differences == []
+    assert reloaded.last_qa_suggestions == []
+    assert reloaded.evaluate_artifact_hash is None
+
+
+# ---------------------------------------------------------------------------
+# HandlerEvaluator adapter unit test
+# ---------------------------------------------------------------------------
+
+
+class _StubQAHandler:
+    """Stand-in for ``QAHandler`` capturing the call payload."""
+
+    def __init__(self, meta: dict[str, Any] | None = None, is_err: bool = False) -> None:
+        self._meta = meta or {
+            "passed": True,
+            "score": 0.85,
+            "verdict": "pass",
+            "differences": [],
+            "suggestions": [],
+        }
+        self._is_err = is_err
+        self.last_arguments: dict[str, Any] | None = None
+
+    async def handle(self, arguments: dict[str, Any]):  # noqa: ANN201
+        self.last_arguments = arguments
+        # Mimic the Result wrapper shape used by QAHandler
+        from ouroboros.core.types import Result
+        from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+        if self._is_err:
+            from ouroboros.mcp.errors import MCPToolError
+
+            return Result.err(MCPToolError("qa unreachable", tool_name="ouroboros_qa"))
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                is_error=False,
+                meta=self._meta,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_handler_evaluator_builds_quality_bar_from_seed_ac() -> None:
+    stub = _StubQAHandler()
+    evaluator = HandlerEvaluator(stub)
+    seed = _build_seed()
+
+    result = await evaluator(seed, "stdout: ok\nexit_code: 0")
+
+    assert result.passed is True
+    assert result.score == 0.85
+    assert result.verdict == "pass"
+    args = stub.last_arguments
+    assert args is not None
+    # Quality bar must contain every acceptance criterion
+    for ac in seed.acceptance_criteria:
+        assert ac in args["quality_bar"]
+    # Default arg shape
+    assert args["artifact_type"] == "test_output"
+    assert args["pass_threshold"] == 0.80
+    assert args["seed_content"]  # non-empty seed yaml
+    assert args["artifact"] == "stdout: ok\nexit_code: 0"
+
+
+@pytest.mark.asyncio
+async def test_handler_evaluator_maps_qa_error_to_evaluate_result() -> None:
+    stub = _StubQAHandler(is_err=True)
+    evaluator = HandlerEvaluator(stub)
+    result = await evaluator(_build_seed(), "any artifact")
+    assert result.passed is False
+    assert result.verdict == "fail"
+    assert result.error is not None
+    assert "qa unreachable" in result.error.lower()

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -940,7 +940,7 @@ def test_resume_capability_evaluate_blocked_without_artifact_is_none(tmp_path) -
 
 
 def test_resume_capability_evaluate_blocked_with_cached_verdict_is_resumable(tmp_path) -> None:
-    """A cached verdict + hash is enough to drive the resume to COMPLETE
+    """A cached pass flag + hash is enough to drive the resume to COMPLETE
     (cache-hit short-circuit), so capability is RESUME even without the
     raw artifact text."""
     from ouroboros.auto.state import AutoResumeCapability
@@ -950,8 +950,61 @@ def test_resume_capability_evaluate_blocked_with_cached_verdict_is_resumable(tmp
     state.last_tool_name = "evaluator"
     state.evaluate_artifact_hash = "abc123"
     state.last_qa_verdict = "pass"
+    state.last_qa_passed = True
     state.last_qa_score = 0.92
     assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+@pytest.mark.asyncio
+async def test_evaluate_cache_reuses_passed_flag_for_revise_verdict(tmp_path) -> None:
+    """End-to-end async version: ``passed=True, verdict="revise"`` must
+    yield COMPLETE on first call AND cached COMPLETE on resume."""
+    state = _state_at_run_phase(tmp_path)
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        return EvaluateResult(
+            passed=True,
+            score=0.85,
+            verdict="revise",  # NOT "pass" — verdict diverges from passed flag
+            differences=("minor formatting issue",),
+            suggestions=("trim trailing whitespace",),
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="some artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    # First call: passed=True with verdict="revise" should still COMPLETE.
+    result = await pipeline.run(state)
+    assert result.status == "complete"
+    assert state.last_qa_passed is True
+    assert state.last_qa_verdict == "revise"
+    assert eval_calls == 1
+
+    # Simulated resume — cache must use last_qa_passed (True), not the
+    # verdict string. Reset phase to EVALUATE so we can call _run_evaluate
+    # directly (production resume gets here via _recoverable_phase_for_tool).
+    state.phase = AutoPhase.EVALUATE
+    resume_result = await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text=None,
+        stop_reason=None,
+    )
+    assert resume_result.status == "complete"  # NOT blocked
+    assert eval_calls == 1  # cache hit, evaluator NOT re-invoked
 
 
 def test_resume_capability_evaluate_blocked_with_empty_artifact_is_resumable(tmp_path) -> None:

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -792,6 +792,35 @@ async def test_resume_after_evaluator_timeout_re_runs_with_persisted_artifact(tm
     assert call_count == 2  # evaluator was re-invoked with the persisted artifact
 
 
+@pytest.mark.asyncio
+async def test_pipeline_run_resumes_evaluate_with_persisted_artifact(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+    state.phase = AutoPhase.EVALUATE
+    state.evaluate_artifact = "persisted Ralph artifact"
+    eval_calls: list[str] = []
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        eval_calls.append(artifact)
+        return EvaluateResult(passed=True, score=0.91, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="should not be used"),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert eval_calls == ["persisted Ralph artifact"]
+    assert state.last_qa_verdict == "pass"
+
+
 def test_state_round_trips_evaluate_artifact(tmp_path) -> None:
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.evaluate_artifact = "persisted artifact"

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -611,3 +611,93 @@ async def test_handler_evaluator_maps_qa_error_to_evaluate_result() -> None:
     assert result.verdict == "fail"
     assert result.error is not None
     assert "qa unreachable" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Ralph adapter must surface result_text so production EVALUATE can fire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_for_job_terminal_surfaces_result_text() -> None:
+    """The Ralph adapter pulls ``snapshot.result_text`` so EVALUATE has an
+    artifact to grade in production. Before this fix the adapter only
+    returned ``result_meta`` and real MCP/CLI runs skipped EVALUATE."""
+    from ouroboros.auto.adapters import _wait_for_job_terminal
+    from ouroboros.mcp.job_manager import JobStatus
+
+    class _StubSnapshot:
+        def __init__(self) -> None:
+            self.is_terminal = True
+            self.status = JobStatus.COMPLETED
+            self.result_meta: dict[str, Any] = {"status": "completed", "stop_reason": "ok"}
+            self.result_text = "stdout: hello\nexit_code: 0"
+
+    class _StubJobManager:
+        async def get_snapshot(self, _job_id: str) -> _StubSnapshot:
+            return _StubSnapshot()
+
+    meta = await _wait_for_job_terminal(_StubJobManager(), "job_X")  # type: ignore[arg-type]
+    assert meta["status"] == "completed"
+    assert meta["__result_text__"] == "stdout: hello\nexit_code: 0"
+
+
+@pytest.mark.asyncio
+async def test_handler_ralph_starter_returns_result_text() -> None:
+    """The production ``HandlerRalphStarter`` chain must propagate the
+    artifact into the dict the pipeline reads (`result_text` key) so
+    EVALUATE actually fires for real Ralph runs."""
+    from ouroboros.auto.adapters import HandlerRalphStarter
+    from ouroboros.mcp.job_manager import JobStatus
+
+    class _StubSnapshot:
+        def __init__(self) -> None:
+            self.is_terminal = True
+            self.status = JobStatus.COMPLETED
+            self.result_meta: dict[str, Any] = {"status": "completed", "stop_reason": "qa passed"}
+            self.result_text = "ralph artifact text"
+
+    class _StubJobManager:
+        async def get_snapshot(self, _job_id: str) -> _StubSnapshot:
+            return _StubSnapshot()
+
+    class _StubRalphHandler:
+        _job_manager = _StubJobManager()
+
+        async def handle(self, _arguments: dict[str, Any]):  # noqa: ANN201
+            from ouroboros.core.types import Result
+            from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="dispatched"),),
+                    is_error=False,
+                    meta={
+                        "job_id": "job_ralph_X",
+                        "lineage_id": "lineage_X",
+                        "dispatch_mode": "job",
+                        "status": "running",
+                    },
+                )
+            )
+
+    starter = HandlerRalphStarter(_StubRalphHandler())  # type: ignore[arg-type]
+    result = await starter(_build_seed(), lineage_id="lineage_X")
+    assert result["result_text"] == "ralph artifact text"
+    assert result["terminal_status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Evaluator tool name must be recoverable on --resume
+# ---------------------------------------------------------------------------
+
+
+def test_recoverable_phase_for_evaluator_tool() -> None:
+    """When evaluator times out or returns a transient error, the session
+    is marked BLOCKED with ``tool_name="evaluator"``. ``--resume`` must
+    dispatch back into EVALUATE so the session is genuinely recoverable
+    (the cached verdict or a fresh evaluator call drives progress).
+    """
+    from ouroboros.auto.pipeline import _recoverable_phase_for_tool
+
+    assert _recoverable_phase_for_tool("evaluator") is AutoPhase.EVALUATE

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -952,3 +952,95 @@ def test_resume_capability_evaluate_blocked_with_cached_verdict_is_resumable(tmp
     state.last_qa_verdict = "pass"
     state.last_qa_score = 0.92
     assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+def test_resume_capability_evaluate_blocked_with_empty_artifact_is_resumable(tmp_path) -> None:
+    """An empty-string artifact is a valid graded input — resume capability
+    must use ``is not None``, not truthiness. Previously a session blocked
+    after persisting ``""`` was incorrectly reported as non-resumable."""
+    from ouroboros.auto.state import AutoResumeCapability
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.phase = AutoPhase.BLOCKED
+    state.last_tool_name = "evaluator"
+    state.evaluate_artifact = ""  # empty but persisted
+    state.evaluate_artifact_hash = "hash_of_empty"
+    assert state.resume_capability() is AutoResumeCapability.RESUME
+
+
+# ---------------------------------------------------------------------------
+# Ralph adapter empty-artifact contract (production path, not stubs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_ralph_starter_preserves_empty_result_text() -> None:
+    """Production ``HandlerRalphStarter`` must propagate ``""`` (an empty-
+    but-valid artifact) as a real string into the pipeline. ``_optional_str``
+    would have collapsed it to None and silently skipped EVALUATE — the
+    very false-pass this PR claims to fix."""
+    from ouroboros.auto.adapters import HandlerRalphStarter
+    from ouroboros.mcp.job_manager import JobStatus
+
+    class _StubSnapshot:
+        def __init__(self) -> None:
+            self.is_terminal = True
+            self.status = JobStatus.COMPLETED
+            self.result_meta: dict[str, Any] = {"status": "completed", "stop_reason": "qa passed"}
+            self.result_text = ""  # intentionally empty artifact
+
+    class _StubJobManager:
+        async def get_snapshot(self, _job_id: str) -> _StubSnapshot:
+            return _StubSnapshot()
+
+    class _StubRalphHandler:
+        _job_manager = _StubJobManager()
+
+        async def handle(self, _arguments: dict[str, Any]):  # noqa: ANN201
+            from ouroboros.core.types import Result
+            from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="dispatched"),),
+                    is_error=False,
+                    meta={
+                        "job_id": "job_ralph_empty",
+                        "lineage_id": "lineage_empty",
+                        "dispatch_mode": "job",
+                        "status": "running",
+                    },
+                )
+            )
+
+    starter = HandlerRalphStarter(_StubRalphHandler())  # type: ignore[arg-type]
+    result = await starter(_build_seed(), lineage_id="lineage_empty")
+    # Critical: result_text must be ``""`` (a string), NOT None.
+    assert result["result_text"] == ""
+    assert isinstance(result["result_text"], str)
+
+
+@pytest.mark.asyncio
+async def test_handler_ralph_poller_preserves_empty_result_text() -> None:
+    """Same contract on the resume poller path."""
+    from ouroboros.auto.adapters import HandlerRalphPoller
+    from ouroboros.mcp.job_manager import JobStatus
+
+    class _StubSnapshot:
+        def __init__(self) -> None:
+            self.is_terminal = True
+            self.status = JobStatus.COMPLETED
+            self.result_meta: dict[str, Any] = {"status": "completed"}
+            self.result_text = ""
+
+    class _StubJobManager:
+        async def get_snapshot(self, _job_id: str) -> _StubSnapshot:
+            return _StubSnapshot()
+
+    class _StubRalphHandler:
+        _job_manager = _StubJobManager()
+
+    poller = HandlerRalphPoller(_StubRalphHandler())  # type: ignore[arg-type]
+    result = await poller(job_id="job_empty")
+    assert result["result_text"] == ""
+    assert isinstance(result["result_text"], str)

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -168,8 +168,12 @@ def test_state_machine_allows_run_to_ralph_handoff() -> None:
 
 
 def test_state_machine_allows_ralph_handoff_terminal_transitions() -> None:
-    """RALPH_HANDOFF must be terminal-bound to COMPLETE/BLOCKED/FAILED."""
+    """RALPH_HANDOFF must reach COMPLETE/BLOCKED/FAILED. EVALUATE is the
+    intermediate verification gate added by RFC #809 Phase 2.1, but it is
+    not itself terminal — the assertion checks that every direct successor
+    of RALPH_HANDOFF is either terminal or the EVALUATE bridge."""
     assert _ALLOWED_TRANSITIONS[AutoPhase.RALPH_HANDOFF] == {
+        AutoPhase.EVALUATE,
         AutoPhase.COMPLETE,
         AutoPhase.BLOCKED,
         AutoPhase.FAILED,

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1013,6 +1013,65 @@ async def test_auto_handler_preserves_plugin_mode_for_execution_handoff(
 
 
 @pytest.mark.asyncio
+async def test_auto_handler_complete_product_uses_subprocess_qa_evaluator_for_plugin_mode(
+    monkeypatch, tmp_path
+) -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.auto.state import AutoStore
+    from ouroboros.mcp.tools import auto_handler as auto_module
+    from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
+
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def __init__(self, driver, _seed_generator, **kwargs):  # noqa: ANN001, ANN003
+            evaluator = kwargs["evaluator"]
+            run_starter = kwargs["run_starter"]
+            ralph_starter = kwargs["ralph_starter"]
+            ralph_resumer = kwargs["ralph_resumer"]
+
+            captured["authoring_mode"] = driver.backend.handler.opencode_mode
+            captured["run_mode"] = run_starter.handler.opencode_mode
+            captured["execute_mode"] = run_starter.handler.execute_handler.opencode_mode
+            captured["ralph_mode"] = ralph_starter.handler.opencode_mode
+            captured["ralph_resumer_mode"] = ralph_resumer.handler.opencode_mode
+            captured["complete_product"] = kwargs["complete_product"]
+            captured["evaluator_present"] = evaluator is not None
+            captured["qa_runtime"] = evaluator.qa_handler.agent_runtime_backend
+            captured["qa_mode"] = evaluator.qa_handler.opencode_mode
+
+        async def run(self, run_state):  # noqa: ANN001
+            captured["state_mode"] = run_state.opencode_mode
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+
+    result = await AutoHandler(agent_runtime_backend="opencode", opencode_mode="plugin").handle(
+        {"goal": "Build a CLI", "cwd": str(tmp_path), "complete_product": True}
+    )
+
+    assert result.is_ok
+    assert captured == {
+        "authoring_mode": "subprocess",
+        "run_mode": "plugin",
+        "execute_mode": "plugin",
+        "ralph_mode": "plugin",
+        "ralph_resumer_mode": "plugin",
+        "complete_product": True,
+        "evaluator_present": True,
+        "qa_runtime": "opencode",
+        "qa_mode": "subprocess",
+        "state_mode": "plugin",
+    }
+    assert should_dispatch_via_plugin("opencode", captured["qa_mode"]) is False
+
+
+@pytest.mark.asyncio
 async def test_auto_handler_fresh_session_persists_resolved_runtime(monkeypatch, tmp_path) -> None:
     from ouroboros.auto.pipeline import AutoPipelineResult
     from ouroboros.auto.state import AutoStore

--- a/tests/unit/mcp/tools/test_handler_subagent_wiring.py
+++ b/tests/unit/mcp/tools/test_handler_subagent_wiring.py
@@ -63,9 +63,19 @@ class TestQAHandlerSubagentDispatch:
         result = await handler.handle({"quality_bar": "good"})
         assert result.is_err
 
+    async def test_still_validates_non_string_artifact(self, handler) -> None:
+        result = await handler.handle({"artifact": [], "quality_bar": "good"})
+        assert result.is_err
+
     async def test_still_validates_missing_quality_bar(self, handler) -> None:
         result = await handler.handle({"artifact": "code"})
         assert result.is_err
+
+    async def test_empty_artifact_reaches_qa_evaluation(self, handler) -> None:
+        result = await handler.handle({"artifact": "", "quality_bar": "good"})
+        assert result.is_ok
+        ctx = result.value.meta["_subagent"]["context"]
+        assert ctx["artifact"] == ""
 
     async def test_context_includes_arguments(self, handler) -> None:
         result = await handler.handle(


### PR DESCRIPTION
## Summary

RFC #809 Phase 2.1. Inserts a deterministic **EVALUATE** phase between Ralph's "converged" verdict and `ooo auto`'s COMPLETE. Loads the Ralph terminal artifact, grades it against the Seed's acceptance criteria via the existing `ouroboros_qa` handler, and only transitions to COMPLETE on QA pass. QA fail → BLOCKED with verdict + top-3 differences/suggestions in the blocker text so a human (or Phase 2.2 lateral recovery) can act on it.

```
RUN → RALPH_HANDOFF → EVALUATE → COMPLETE          (QA passed)
                                ↘ BLOCKED          (QA failed / timeout / handler error)
```

Builds on Phase 1 (#811). Confines EVALUATE to the `--complete-product` flow (synchronous Ralph chain has a `result_text` to grade); plain `ooo auto` is unchanged because that run is async with no synchronous artifact.

## Design highlights

### Reuse `ouroboros_qa`
No new evaluator class. `HandlerEvaluator` builds `quality_bar` from `seed.acceptance_criteria` using the exact phrasing already used in `evolution_handlers.py`, calls `QAHandler.handle(...)` with `artifact_type="test_output"`, `pass_threshold=0.80`, and seed YAML context. Maps `meta["passed"]/score/verdict/differences/suggestions` onto a typed `EvaluateResult`.

### Single-shot, resumable
`max_evaluate_rounds = 1` for Phase 2.1. The verdict is persisted on `AutoPipelineState` along with a sha256 of the graded artifact. On resume:
- same artifact hash + persisted verdict → reuse cached decision (no LLM call)
- different artifact → re-evaluate
- no cached verdict, no artifact → BLOCKED (operator must reattach)

### Opt-in
EVALUATE only fires when **both** `complete_product=True` and `evaluator` is wired. Three-way guard:
1. `complete_product=False` → RUN → COMPLETE (no chain, no EVALUATE)
2. `complete_product=True`, `evaluator=None` → legacy RALPH_HANDOFF → COMPLETE
3. Ralph terminal meta lacks `result_text` → fall back to legacy COMPLETE (nothing to grade)

### Bounded
- `AutoPhase.EVALUATE` phase timeout default: 90s
- `asyncio.wait_for(...)` on the evaluator call
- Timeout or handler error → BLOCKED with `tool_name="evaluator"` (resumable, not failed)

## Files

| File | Change |
|---|---|
| `src/ouroboros/auto/state.py` | `AutoPhase.EVALUATE` + 5 new state fields + `_ALLOWED_TRANSITIONS` + setdefaults + validation |
| `src/ouroboros/auto/adapters.py` | `EvaluateResult` dataclass + `HandlerEvaluator` class |
| `src/ouroboros/auto/pipeline.py` | `Evaluator` callable type, `evaluator` field on AutoPipeline, `_evaluate_or_complete` and `_run_evaluate` methods, 4 new `last_qa_*` fields on `AutoPipelineResult` |
| `src/ouroboros/mcp/tools/auto_handler.py` | Instantiate `QAHandler` only when `complete_product=True`; wire `HandlerEvaluator` into pipeline; surface QA verdict in `_result_meta` and `_format_result` |
| `tests/unit/auto/test_pipeline_evaluate.py` | 14 new tests |
| `tests/unit/auto/test_pipeline_ralph_handoff.py` | Adjust the pinned RALPH_HANDOFF transition assertion to accept the new EVALUATE bridge |

## Test plan

- [x] `uv run pytest tests/unit/auto/test_pipeline_evaluate.py` — 14/14 pass
- [x] `uv run pytest tests/unit/auto/ tests/unit/mcp/` — 1308/1308 pass
- [x] `uv run ruff check src/ouroboros/auto/ src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_pipeline_evaluate.py` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/ouroboros/auto/ src/ouroboros/mcp/tools/auto_handler.py` — clean

### What the tests cover

- State machine: EVALUATE in allowed transitions (both forward and recovery)
- Happy path: pass → COMPLETE
- Fail paths: revise → BLOCKED with diffs/suggestions in `last_error`; timeout → BLOCKED; handler error → BLOCKED
- Opt-in guards: 3 cases (no `complete_product`, no `evaluator`, no `result_text`)
- Resume idempotency: cached verdict on matching hash; re-evaluates on changed artifact
- State persistence: round-trip via `to_dict`/`from_dict`; legacy state loads without QA fields
- `HandlerEvaluator` unit tests: quality_bar derivation, QA `Result.err` mapping

## Backward compat

- New `AutoPhase.EVALUATE` enum + 5 new state fields, all `setdefault`-ed for legacy state files
- Default-off: `evaluator` field defaults to `None`, so existing callers see no behavior change
- New `last_qa_*` fields on `AutoPipelineResult` default to `None`/`()`; MCP meta only emits them when populated

## Out of scope (Phase 2.2 follow-up)

- SEED_REGENERATE recovery loop on QA fail
- UNSTUCK_LATERAL persona invocation when verification path is broken (Xcode example from RFC)
- `max_evaluate_rounds > 1` with fingerprint-based loop guards
- Plain `ooo auto` EVALUATE (requires async run polling and a `--wait-for-run` arg)

Refs: RFC #809, Phase 1 PR #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)