### PR TITLE
docs(rfc): mark interview-hardening RFC as Accepted

### DIFF
--- a/docs/rfc/interview-hardening.md
+++ b/docs/rfc/interview-hardening.md
@@ -2,7 +2,16 @@
 
 ## Status
 
-**Proposed (2026-05-11).**
+**Accepted (2026-05-11).** Implemented via #822 (adapter isolation), #823
+(prompt budget), and #824 (Refine/Restate gates), all merged 2026-05-11.
+
+Scope note on Change 3: the merged implementation applies
+`strict_mcp_config=True` at the nested MCP handler boundary
+(`mcp/tools/authoring_handlers.py`) rather than globally in
+`InterviewEngine.__post_init__`. CLI and PM interview entrypoints retain
+their existing plugin/project `.mcp.json` behavior. A stricter
+default-on policy for those entrypoints is deferred pending empirical
+self-spawn measurements outside the MCP host (see follow-up).
 
 Three coupled changes harden the interview phase against silent answer
 truncation, single-line answer compression, and self-spawn recursion of


### PR DESCRIPTION
## Summary
Close out the interview-hardening RFC now that all three implementation PRs are merged.

| RFC Change | PR | Status |
|---|---|---|
| 1 — Prompt budget caps | #823 | Merged 2026-05-11 |
| 2 — Refine/Restate gates | #824 | Merged 2026-05-11 |
| 3 — Adapter MCP isolation | #822 | Merged 2026-05-11 |

## Scope note recorded in RFC
Change 3 shipped with a narrower default than originally proposed: `strict_mcp_config=True` is applied at the nested MCP handler boundary (`mcp/tools/authoring_handlers.py`) rather than globally on `InterviewEngine.__post_init__`. CLI and PM interview entrypoints retain their existing plugin/project `.mcp.json` behavior. The RFC text now reflects that, with a follow-up note that stricter default-on for CLI/PM is deferred pending empirical self-spawn measurements outside the MCP host.

## Test plan
- [x] RFC renders correctly; Status line and scope note read consistently with the merged implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)