### PR TITLE
fix(interview): close Restate gate bypass for short PATH 2 answers

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -325,6 +325,18 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    - Short PATH 2 answers (e.g., "Yes" / single proper noun) with no
      reasoning attached
 
+   **Exception — Restate corrections never skip Refine, regardless of length.**
+   Any free-text follow-up collected by the Step 9 Restate gate
+   ("Adjust wording" / "Missing scope") must go through Refine before being
+   forwarded to MCP. Even a short correction like
+   `"Exclude retry scheduling from the seed."` carries scope/boundary
+   information that MCP needs in structured form during the reopen call, so
+   the short-PATH-2 exemption above does NOT apply to Restate corrections.
+   A single-line Restate correction that bypasses Refine would forward
+   `[from-user]` instead of `[from-user][refined]` and would not trigger the
+   `last_question` reopen, leaving MCP on stale pre-correction state when
+   the seed is generated.
+
    Refine-passed answers count as direct user judgment — they reset the
    Dialectic Rhythm Guard counter to 0 (see below).
 
@@ -425,8 +437,13 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
 
    Treat the follow-up text as a real interview correction, not a local-only
    wording tweak. Route the follow-up text through the Refine gate before
-   forwarding it: build the same structured multi-section payload from Step 3
-   using the canonical five-section schema —
+   forwarding it. **The Step 4 short-PATH-2 skip rule does NOT apply here,
+   even if the correction is a single sentence** — a bare reply like
+   `"Exclude retry scheduling from the seed."` still encodes a boundary
+   decision that must reach MCP as `[from-user][refined]` with the reopen
+   `last_question`; sending it as `[from-user]` would leave MCP on the stale
+   pre-correction state. Then build the same structured multi-section
+   payload from Step 3 using the canonical five-section schema —
    - **Decision**: the corrected one-line goal verbatim.
    - **Reasoning**: why the wording/scope changed (carry over the user's
      correction text, do not paraphrase).


### PR DESCRIPTION
## Summary

Follow-up to #824. Closes one of the three follow-ups flagged on the final APPROVE review at commit `b783fdd`.

Adds an explicit carve-out so the **Step 9 Restate correction** flow never inherits the **Step 4 short-PATH-2 Refine skip** rule.

| Step | Change |
|---|---|
| **4** | New "Exception — Restate corrections never skip Refine, regardless of length" block under the skip list, naming the exact failure mode (`[from-user]` instead of `[from-user][refined]`, no `last_question` reopen). |
| **9** | One-sentence reminder inserted at the start of the "Route the follow-up text through the Refine gate" paragraph: the Step 4 short-PATH-2 skip rule does NOT apply here, even for single-sentence corrections. Uses the same `"Exclude retry scheduling from the seed."` example as Step 4 so both gates point at the same canonical failure case. |

## Why

Step 4 currently lists three Refine skip cases, including *"Short PATH 2 answers (e.g., \"Yes\" / single proper noun) with no reasoning attached"*. Step 9's *"Adjust wording"* / *"Missing scope"* corrections are routed through the Refine gate, but the Step 4 short-PATH-2 exemption is generic and length-based — so a perfectly reasonable Restate correction such as:

> `"Exclude retry scheduling from the seed."`

matches the exemption, lets the agent skip Refine, and forwards `[from-user]` instead of `[from-user][refined]`. That misses two things the Step 9 contract requires:

1. The `[refined]` marker (MCP downgrades ambiguity weight without it).
2. The `last_question` reopen parameter (the interview handler rejects reopen calls that lack it — see `src/ouroboros/mcp/tools/authoring_handlers.py:1682-1702`).

The net effect: the seed is generated from **stale pre-correction MCP state** — the exact failure mode the Restate gate was added to prevent in #824.

## What this PR does NOT touch

The same final-APPROVE review left two other follow-ups that are **documentation-consistency** issues rather than runtime bypass risks:

- Step 9 payload field names (`answer_summary` / `open_questions`) vs. Step 3 schema (`Decision` / `Reasoning` / `Constraints` / `Out of scope` / `Codebase context`).
- 2nd-pass Refine handling of `Add context` (currently undefined for repeated selection).

Those are intentionally left for a separate follow-up PR so this fix can ship fast on its own scope.

## Recommended merge order

This PR is independent of #823/#822/#824 (which are merged) and depends on nothing else. Safe to merge as a hotfix.

## Test plan

Documentation-only change — reviewer checklist:

- [ ] Step 4 skip list now contains an explicit Restate-corrections exemption.
- [ ] Step 9 correction paragraph explicitly says the Step 4 short-PATH-2 skip rule does NOT apply.
- [ ] Both Step 4 and Step 9 reference the same canonical example (`"Exclude retry scheduling from the seed."`) — confirms the two gates are wired to the same contract.
- [ ] The skip-list bullets for PATH 1a / PATH 1b / PATH 4 / short PATH 2 are unchanged (no regression in the other Refine skip cases).
- [ ] `git diff main -- skills/interview/SKILL.md` shows only additive changes (+22 / -4 net) in two contiguous regions; no unrelated edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)