### PR TITLE
docs(interview): unify Step 9 payload schema and define Add context retry

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -343,11 +343,12 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    once more. Do not send the payload to MCP while the user is still telling
    you that required text is missing or the answer should be rewritten. If the
    second Refine response again says "Add to Constraints", "Add to Out of
-   scope", or "Rewrite", ask a targeted PATH 2 follow-up for the exact missing
-   text and withhold the MCP answer until the user either supplies that text or
-   explicitly accepts the structured payload. Never infer omitted content from
-   the option label, and prefer stopping over forwarding a payload the user has
-   identified as incomplete.
+   scope", "Add context", or "Rewrite", ask a targeted PATH 2 follow-up for the
+   exact missing text and withhold the MCP answer until the user either
+   supplies that text or explicitly accepts the structured payload. The
+   `Add context` option is handled identically to the other three on the
+   second pass — never infer omitted content from the option label, and prefer
+   stopping over forwarding a payload the user has identified as incomplete.
 
 5. **Mark the answer as Refine-passed**:
    Append `[refined]` to the prefix when sending the structured payload to
@@ -425,9 +426,17 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    Treat the follow-up text as a real interview correction, not a local-only
    wording tweak. Route the follow-up text through the Refine gate before
    forwarding it: build the same structured multi-section payload from Step 3
-   with `answer_summary` describing the corrected one-line goal, `reasoning`
-   preserving why the wording/scope changed, and `constraints`, `out_of_scope`,
-   or `open_questions` populated from the user's correction where applicable.
+   using the canonical five-section schema —
+   - **Decision**: the corrected one-line goal verbatim.
+   - **Reasoning**: why the wording/scope changed (carry over the user's
+     correction text, do not paraphrase).
+   - **Constraints (user-stated)**: any constraint introduced or tightened
+     by the correction.
+   - **Out of scope (user-stated)**: anything the correction marks as
+     explicitly excluded.
+   - **Codebase context (main session verified)**: the file paths, configs,
+     or facts the main session checked while preparing the restated goal, or
+     omit the section entirely if no code reference is involved.
    Send that structured restate correction back to MCP with
    `[from-user][refined]`, preserving the corrected goal line and the user's
    stated wording or missing scope. Because this is a post-seed-ready follow-up


### PR DESCRIPTION
## Summary

Follow-up to #824. Closes the remaining two non-blocking follow-ups from the final APPROVE review at commit `b783fdd`. Pairs with #827 (Restate bypass fix); both stay in `skills/interview/SKILL.md`.

| Step | Change |
|---|---|
| **4** | Second-pass Refine list now includes `Add context` alongside `Add to Constraints / Add to Out of scope / Rewrite`. Adds one sentence stating it is handled identically — collect exact text via a targeted PATH 2 follow-up, withhold the MCP answer until the user supplies it or explicitly accepts. |
| **9** | Restate correction payload rewritten to use the canonical 5-section schema from Step 3 (`Decision / Reasoning / Constraints (user-stated) / Out of scope (user-stated) / Codebase context (main session verified)`). Drops `answer_summary` / `open_questions`. |

## Why

### A — \`Add context\` second-pass undefined

Step 4 lists four Refine options:

> `Send as-is` / `Add to Constraints` / `Add to Out of scope` / `Add context` / `Rewrite`

The second-pass paragraph (the \"what if the user still isn't happy after one revision\" branch) named only three: `Add to Constraints`, `Add to Out of scope`, `Rewrite`. If the user said the payload was still missing **reasoning, code reference, or research context** on the second pass, the documented state machine had no defined next step. An agent could legitimately:

- forward the payload the user just called incomplete, or
- silently loop forever asking the Refine gate again, or
- improvise.

The fix is one-line: `Add context` is now the fourth trigger and is explicitly stated to behave identically to the other three.

### B — Step 3 and Step 9 used two different schemas

The canonical Step 3 payload (line ~264) uses **prose section headers**:

```
[from-user][refined]
Decision: …
Reasoning: …
Constraints (user-stated): …
Out of scope (user-stated): …
Codebase context (main session verified): …
```

But Step 9's Restate correction paragraph told the agent to *\"build the same structured multi-section payload from Step 3\"* and then named completely different fields:

```
answer_summary / reasoning / constraints / out_of_scope / open_questions
```

This was the contract drift flagged by `ouroboros-agent[bot]` in the final review of #824:

> *\"Step 9 says to 'build the same structured multi-section payload from Step 3' but then names fields (`answer_summary`, `open_questions`) that do not appear in Step 3's payload example…\"*

The fix unifies on Step 3's schema and drops `open_questions` entirely (a different concept — it tracks unresolved ambiguity tracks, not user-stated content). `Codebase context` is marked omittable when the Restate correction does not involve a code reference, so short corrections like *\"Exclude retry scheduling from the seed.\"* still produce a valid 1–4 section payload.

After this change, an agent building the Restate correction payload uses the exact same five field names as Step 3 — no mental mapping required.

## What this PR does NOT touch

The Step 4 / Step 9 Refine **runtime bypass** for short PATH 2 corrections is fixed in #827 (separate PR). This PR is documentation consistency only — no behavior bypass changes.

## Recommended merge order

1. Merge #827 first (runtime contract fix — higher urgency).
2. Rebase this PR on the new `main` and merge.

The two PRs touch adjacent paragraphs in Step 9 (specifically the *\"Treat the follow-up text as a real interview correction…\"* sentence), so a trivial rebase will likely be needed. Both PRs are intentionally scoped small to keep that rebase mechanical.

## Test plan

Documentation-only change — reviewer checklist:

- [ ] Second-pass Refine block in Step 4 lists all four non-`Send as-is` options (`Add to Constraints`, `Add to Out of scope`, `Add context`, `Rewrite`).
- [ ] Step 9 Restate correction paragraph names exactly the five Step 3 sections — no references to `answer_summary` or `open_questions` remain in the file.
- [ ] `grep -E 'answer_summary|open_questions' skills/interview/SKILL.md` returns no matches.
- [ ] `Codebase context` is documented as omittable in Step 9 when no code reference is involved, so short Restate corrections still produce a valid payload.
- [ ] `git diff main -- skills/interview/SKILL.md` shows only additive/replacement changes (+17 / -8 net) in two regions; no unrelated edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)