### PR TITLE
feat(cli/plugin): surface trust_read_error in `ooo plugin list --json` (#806)

### DIFF
--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1034,6 +1034,7 @@ def list_command(
                     "granted_scopes": [],
                     "missing_required_scopes": [],
                     "trust_version_stale": False,
+                    "trust_read_error": None,
                 }
             )
             continue
@@ -1064,6 +1065,7 @@ def list_command(
                     "granted_scopes": [],
                     "missing_required_scopes": [],
                     "trust_version_stale": False,
+                    "trust_read_error": None,
                 }
             )
             continue
@@ -1072,6 +1074,7 @@ def list_command(
         # is the right command for surfacing exactly which file is
         # corrupt; ``list`` must keep working so the operator can see
         # what else is installed.
+        trust_read_error: str | None = None
         try:
             record = trust.read(entry.name)
             trust_state = _describe_trust_state(
@@ -1082,10 +1085,18 @@ def list_command(
             )
             applies = _record_applies_to_subject(record, manifest=manifest, entry=entry)
             scopes = [g.scope for g in record.granted_scopes] if applies and record else []
-        except (ValueError, OSError):
+        except (ValueError, OSError) as exc:
+            # Operators using ``--json`` need to distinguish "no trust
+            # grant yet" from "trust file is malformed". Capture the
+            # raised reason so the row carries a deterministic
+            # diagnostic signal rather than collapsing onto the
+            # untrusted state. The ``trust_state == "trust_unreadable"``
+            # label already exists; ``trust_read_error`` complements it
+            # with the underlying message.
             record = None
             trust_state = "trust_unreadable"
             scopes = []
+            trust_read_error = str(exc)
         # ``trust_version_stale`` mirrors the firewall's "the recorded
         # grant is bound to a different installed version" predicate.
         # ``_record_applies_to_subject`` already collapses this into
@@ -1111,6 +1122,7 @@ def list_command(
                 "granted_scopes": scopes,
                 "missing_required_scopes": missing,
                 "trust_version_stale": stale_version,
+                "trust_read_error": trust_read_error,
             }
         )
 

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -1010,13 +1010,24 @@ def test_list_survives_corrupt_trust_with_readable_manifest(
     data = json.loads(result.output.strip())
     assert isinstance(data, list) and len(data) == 2
     by_name = {row["name"]: row for row in data}
-    # The clean plugin's row is fully populated.
+    # The clean plugin's row is fully populated and carries the new
+    # ``trust_read_error`` key with a None default — ``--json``
+    # consumers can therefore rely on the field always being present.
     assert "clean-plugin" in by_name
+    assert by_name["clean-plugin"]["trust_read_error"] is None
     # The corrupt-trust plugin's row is degraded but PRESENT — that is
     # the contract being restored.
     assert "bad-plugin" in by_name
     bad_row = by_name["bad-plugin"]
     assert bad_row["granted_scopes"] == []
+    # The row must surface the trust read failure deterministically:
+    # ``trust_state`` flips to ``trust_unreadable`` and the new
+    # ``trust_read_error`` field carries a non-empty diagnostic message
+    # so ``--json`` consumers can distinguish "no trust grant yet" from
+    # "trust file is malformed".
+    assert bad_row["trust_state"] == "trust_unreadable"
+    assert isinstance(bad_row["trust_read_error"], str)
+    assert bad_row["trust_read_error"]
 
 
 FIRST_PARTY_REQUIRED_MANIFEST: dict = {


### PR DESCRIPTION
## Summary

- Adds a per-row `trust_read_error: str | None` field to `ooo plugin list --json` so operators can deterministically tell which plugin's `trust.json` is malformed and what the parser actually saw.
- Schema stays stable: the field is set to `None` on every healthy row (unreadable-manifest branch, first-party branch, normal branch) and to the caught `ValueError`/`OSError` message on the corrupt-trust branch.
- Table view is unchanged in this PR — the operator-facing stderr warning is intentionally split out (see Follow-up below) so the JSON surface can land on its own.

## Why

#806 (the follow-up tracked from PR #798's bot review) flagged that the resilient corrupt-`trust.json` branch overshoots: a row whose trust file is malformed currently reports `trust_state: "trust_unreadable"` (good) but otherwise looks identical to "installed, no grants yet" (bad — `--json` consumers cannot recover the parse error). This PR closes the diagnostic gap on the JSON side without touching the human view.

## Acceptance criteria from the issue

- [x] For a row whose `trust.json` is malformed JSON / missing required keys, `ooo plugin list --json` surfaces that fact deterministically (`trust_read_error` non-null, `trust_state == "trust_unreadable"`).
- [x] Healthy rows expose `trust_read_error: null` so consumers can rely on `row[\"trust_read_error\"]` always being present.

## Test plan

- [x] `tests/unit/cli/test_plugin_command.py::test_list_survives_corrupt_trust_with_readable_manifest` extended to assert both the new field and the existing `trust_state` flip.
- [x] Full plugin command suite green (`pytest tests/unit/cli/test_plugin_command.py` → 27 passed).
- [x] `ruff check` / `ruff format --check` clean on both touched files.

## Out of scope (follow-up PR)

- Stderr warning in the human/table view when any row carries a non-null `trust_read_error` — will stack on this PR so reviewers can evaluate the JSON contract independently of the UX change.

Closes #806 (partial — JSON surface).