### PR TITLE
feat(cli/plugin): warn on stderr when `ooo plugin list` row has unreadable trust.json (#806)

### DIFF
--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1131,6 +1131,29 @@ def list_command(
         typer.echo(json.dumps(rows, indent=2))
         return
 
+    # Operator-facing diagnostic: when any row's trust file failed to
+    # parse, the table column flips to ``trust_unreadable`` but does NOT
+    # carry the underlying parser message. Surface it on stderr so the
+    # operator sees both (a) which plugin's trust file is broken and
+    # (b) the literal recovery action, without polluting stdout (which
+    # remains the structured table for ``less`` / ``column`` /
+    # screenshotting). The ``--json`` path already exposes the same
+    # information via the ``trust_read_error`` field, so we only emit
+    # the stderr warning on the human surface. ``typer.echo(..., err=True)``
+    # resolves ``sys.stderr`` at call time, which is what
+    # ``CliRunner(mix_stderr=False)`` needs to capture the warning under
+    # test.
+    unreadable = [row for row in rows if row.get("trust_read_error") is not None]
+    for row in unreadable:
+        typer.echo(
+            f"warning: trust file for {row['name']!r} is unreadable "
+            f"({row['trust_read_error']}); the row is shown with "
+            f"trust_state=trust_unreadable and empty scopes. Inspect or "
+            f"replace the file, then re-grant scopes via "
+            f"`ooo plugin trust {row['name']} --scope <...>`.",
+            err=True,
+        )
+
     table = create_table(title="Installed UserLevel plugins")
     for column in ("name", "version", "source", "trust", "scopes"):
         table.add_column(column)

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -1030,6 +1030,75 @@ def test_list_survives_corrupt_trust_with_readable_manifest(
     assert bad_row["trust_read_error"]
 
 
+def test_list_table_warns_on_unreadable_trust_via_stderr(runner: CliRunner, tmp_path: Path) -> None:
+    """Regression for #806: when ``ooo plugin list`` (no ``--json``) walks
+    a row whose ``trust.json`` is malformed, the table column already
+    flips to ``trust_unreadable`` but the parser's reason is lost. The
+    table view must surface that fact on **stderr** so an operator
+    reading the human output sees both which plugin's trust file is
+    broken and the literal recovery command, while stdout stays clean
+    for piping/screenshotting.
+
+    The ``--json`` path is covered by
+    ``test_list_survives_corrupt_trust_with_readable_manifest`` (the
+    ``trust_read_error`` field assertion); this test pins the human
+    surface that consumes the same signal.
+    """
+    clean_home = tmp_path / "clean_home"
+    _write_manifest(clean_home, {**REFERENCE_MANIFEST, "name": "clean-plugin"})
+    bad_home = tmp_path / "bad_home"
+    _write_manifest(bad_home, {**REFERENCE_MANIFEST, "name": "bad-plugin"})
+
+    lock_path = tmp_path / "plugins.lock"
+    trust_root = tmp_path / "trust"
+    lock = Lockfile(lock_path)
+    for name, home in (("clean-plugin", clean_home), ("bad-plugin", bad_home)):
+        lock.add(
+            LockEntry(
+                name=name,
+                version="0.1.0",
+                source_kind="local",
+                repository=None,
+                git_sha=None,
+                manifest_checksum="sha256:0",
+                installed_at="2026-05-08T00:00:00Z",
+                plugin_home=str(home),
+            )
+        )
+    bad_trust = trust_root / "bad-plugin" / "trust.json"
+    bad_trust.parent.mkdir(parents=True, exist_ok=True)
+    bad_trust.write_text("{not valid json")
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "list",
+            "--lockfile",
+            str(lock_path),
+            "--trust-root",
+            str(trust_root),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # The warning lands on stderr, names the offending plugin, and
+    # points at the recovery command. Operators piping stdout to
+    # ``less`` / ``column`` still see the structured table; the warning
+    # is delivered out-of-band on stderr.
+    assert "trust file for 'bad-plugin' is unreadable" in result.stderr
+    assert "ooo plugin trust bad-plugin" in result.stderr
+    # The clean plugin must not appear in any warning line — only the
+    # row whose trust file actually failed gets surfaced.
+    assert "clean-plugin" not in result.stderr
+    # The table itself still renders on stdout (so the operator sees
+    # every installed plugin alongside the warning).
+    assert "bad-plugin" in result.stdout
+    assert "clean-plugin" in result.stdout
+    # And stdout must remain free of the warning prefix so it is safe
+    # to pipe / screenshot without the side-channel signal bleeding in.
+    assert "warning:" not in result.stdout
+
+
 FIRST_PARTY_REQUIRED_MANIFEST: dict = {
     **REFERENCE_MANIFEST,
     "name": "ouroboros-builtin",


### PR DESCRIPTION
## Summary

- Adds a per-row stderr warning to `ooo plugin list` (human/table view) whenever a row's `trust.json` failed to parse. The warning names the offending plugin, surfaces the underlying parser message, and points the operator at the recovery command (`ooo plugin trust <name> --scope <...>`).
- Stdout stays free of the warning so the structured table is still safe to pipe to `less` / `column` / a screenshot.
- Uses `typer.echo(..., err=True)` (not a module-level `rich.Console(stderr=True)`) so `CliRunner` can observe stderr separately — see commit body for why.

## Why

Companion to PR #832 (which lands `trust_read_error` on `--json`). Together they close #806: machine consumers get the deterministic field, humans get the side-channel signal. This PR keeps the table view's stdout contract unchanged while making sure operators reading the human output actually notice that one of their trust files is malformed.

## Stack

Stacked on **#832**. Until #832 merges, the diff here will show both commits; when reviewing this PR, focus on the latest commit (`67c4affd feat(cli/plugin): warn on stderr when …`). After #832 merges this PR's mergeable diff will collapse to the +92 lines added here.

## Test plan

- [x] New `test_list_table_warns_on_unreadable_trust_via_stderr` pins:
  - the warning lands on stderr and names only the offending plugin,
  - the recovery command (`ooo plugin trust bad-plugin --scope ...`) appears in stderr,
  - stdout renders the full table (both clean and degraded rows),
  - stdout carries no `warning:` prefix.
- [x] Full plugin command suite green (`pytest tests/unit/cli/test_plugin_command.py` → 28 passed).
- [x] `ruff check` / `ruff format --check` clean on both touched files.

Closes #806 (human surface — final piece).