### PR TITLE
feat(mcp): structured envelope for interview length-guard branch (#831)

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -480,6 +480,15 @@ If MCP returns `is_error=true` with `meta.recoverable=true`:
 3. If still failing: "MCP is having trouble. Switching to direct interview mode."
    Then switch to Path B and continue from where you left off.
 
+**Special case — `meta.reason == "initial_context_too_large"`**: When the
+response carries this reason (also `is_error=true`, `recoverable=true`), the
+text body is a meta-directive asking *you* to re-send a shorter context — it
+is **NOT** an interview question. Do not route it via AskUserQuestion.
+Instead, produce a concise summary of the original `initial_context`
+(≤ `meta.max_chars` characters; covers goal, constraints, success criteria)
+and re-call `ouroboros_interview` with `session_id=<from meta>` and the
+summary as `answer`. The next response will contain the real first question.
+
 **Advantages of MCP mode**: State persists to disk, ambiguity scoring, direct `ooo seed` integration via session ID. Code-enriched confirmation questions reduce user burden — only human-judgment questions require user input.
 
 ### Path B: Plugin Fallback (No MCP Server)

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -481,9 +481,11 @@ If MCP returns `is_error=true` with `meta.recoverable=true`:
    Then switch to Path B and continue from where you left off.
 
 **Special case — `meta.reason == "initial_context_too_large"`**: When the
-response carries this reason (also `is_error=true`, `recoverable=true`), the
-text body is a meta-directive asking *you* to re-send a shorter context — it
-is **NOT** an interview question. Do not route it via AskUserQuestion.
+response carries this `meta.reason` (with `meta.recoverable=true` and
+`is_error=false` — the wire success/failure axis is intentionally **not**
+flipped, to keep existing callers like the auto driver working), the text
+body is a meta-directive asking *you* to re-send a shorter context — it is
+**NOT** an interview question. Do not route it via AskUserQuestion.
 Instead, produce a concise summary of the original `initial_context`
 (≤ `meta.max_chars` characters; covers goal, constraints, success criteria)
 and re-call `ouroboros_interview` with `session_id=<from meta>` and the

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1479,9 +1479,13 @@ class InterviewHandler:
                 }
                 if is_length_guard:
                     # Q00/ouroboros#831: surface the length-guard meta-directive
-                    # as a structured envelope so clients do not mis-route it
-                    # to a human via AskUserQuestion.  Text body is preserved
-                    # verbatim so the CLI interview UX is unchanged.
+                    # via structured meta keys so clients can branch on
+                    # ``meta.reason`` instead of mis-routing the text body to a
+                    # human via AskUserQuestion.  ``is_error`` is intentionally
+                    # left ``False`` -- the wire success/failure axis must not
+                    # flip or ``HandlerInterviewBackend.start`` (auto driver)
+                    # would raise on every oversized ``initial_context`` where
+                    # it previously delivered the summarize question.
                     start_meta.update(_length_guard_meta_fields())
                 return Result.ok(
                     MCPToolResult(
@@ -1494,7 +1498,7 @@ class InterviewHandler:
                                 ),
                             ),
                         ),
-                        is_error=is_length_guard,
+                        is_error=False,
                         meta=start_meta,
                     )
                 )
@@ -1538,7 +1542,9 @@ class InterviewHandler:
                     if resume_is_length_guard:
                         # Q00/ouroboros#831: structured signal when resuming
                         # an interview whose pending round is the length-guard
-                        # meta-directive.
+                        # meta-directive.  ``is_error`` stays ``False`` so
+                        # callers like the auto driver do not treat the
+                        # summarize prompt as a hard failure.
                         resume_meta.update(_length_guard_meta_fields())
                     return Result.ok(
                         MCPToolResult(
@@ -1548,7 +1554,7 @@ class InterviewHandler:
                                     text=f"Session {session_id}\n\n{display_question}",
                                 ),
                             ),
-                            is_error=resume_is_length_guard,
+                            is_error=False,
                             meta=resume_meta,
                         )
                     )
@@ -1909,6 +1915,8 @@ class InterviewHandler:
                     # question after an answer is again the length-guard
                     # meta-directive (the post-answer scoring path may still
                     # require the user to summarize before continuing).
+                    # ``is_error`` stays ``False`` so the auto driver's
+                    # ``answer()`` path is not raised on.
                     answer_meta.update(_length_guard_meta_fields())
                 return Result.ok(
                     MCPToolResult(
@@ -1918,7 +1926,7 @@ class InterviewHandler:
                                 text=f"Session {session_id}\n\n{display_question}",
                             ),
                         ),
-                        is_error=answer_is_length_guard,
+                        is_error=False,
                         meta=answer_meta,
                     )
                 )

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -29,6 +29,8 @@ from ouroboros.bigbang.ambiguity import (
     qualifies_for_seed_completion,
 )
 from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
+    MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS,
     MIN_ROUNDS_BEFORE_EARLY_EXIT,
     InterviewEngine,
     InterviewState,
@@ -233,6 +235,35 @@ def _format_question_with_ambiguity(question: str, score: AmbiguityScore | None)
     if score is None:
         return question
     return f"(ambiguity: {score.overall_score:.2f}) {question}"
+
+
+def _is_initial_context_length_guard_question(question: str) -> bool:
+    """Return True when ``question`` is the length-guard meta-directive.
+
+    The interview engine surfaces a fixed string as the "next question" when
+    ``initial_context`` exceeds ``MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS``.
+    That string is not a real interview question — it asks the *caller* to
+    re-send a shorter summary — so MCP responses carrying it must carry a
+    distinguishing meta signal.  See Q00/ouroboros#831.
+    """
+    return question == INITIAL_CONTEXT_SUMMARY_QUESTION
+
+
+def _length_guard_meta_fields() -> dict[str, Any]:
+    """Return the meta keys that mark a length-guard response.
+
+    The handler merges these into the existing ``meta`` dict (``session_id``,
+    ``ambiguity_score``, etc.) when the returned question is the length-guard
+    meta-directive.  Clients can branch on ``meta.reason`` to handle the case
+    programmatically instead of mis-routing the question to a human via
+    AskUserQuestion.
+    """
+    return {
+        "recoverable": True,
+        "reason": "initial_context_too_large",
+        "expected_action": "resend_with_summary",
+        "max_chars": MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS,
+    }
 
 
 def _ambiguity_warning_for_failed_question(
@@ -1435,6 +1466,23 @@ class InterviewHandler:
                     session_id=state.interview_id,
                 )
 
+                is_length_guard = _is_initial_context_length_guard_question(question)
+                start_meta: dict[str, Any] = {
+                    "session_id": state.interview_id,
+                    "ambiguity_score": (
+                        live_score.overall_score if live_score is not None else None
+                    ),
+                    "milestone": _milestone_for_score(live_score),
+                    "seed_ready": (
+                        live_score.is_ready_for_seed if live_score is not None else None
+                    ),
+                }
+                if is_length_guard:
+                    # Q00/ouroboros#831: surface the length-guard meta-directive
+                    # as a structured envelope so clients do not mis-route it
+                    # to a human via AskUserQuestion.  Text body is preserved
+                    # verbatim so the CLI interview UX is unchanged.
+                    start_meta.update(_length_guard_meta_fields())
                 return Result.ok(
                     MCPToolResult(
                         content=(
@@ -1446,17 +1494,8 @@ class InterviewHandler:
                                 ),
                             ),
                         ),
-                        is_error=False,
-                        meta={
-                            "session_id": state.interview_id,
-                            "ambiguity_score": (
-                                live_score.overall_score if live_score is not None else None
-                            ),
-                            "milestone": _milestone_for_score(live_score),
-                            "seed_ready": (
-                                live_score.is_ready_for_seed if live_score is not None else None
-                            ),
-                        },
+                        is_error=is_length_guard,
+                        meta=start_meta,
                     )
                 )
 
@@ -1475,10 +1514,32 @@ class InterviewHandler:
                 _interview_id = session_id
 
                 if not answer and state.rounds and state.rounds[-1].user_response is None:
+                    pending_question = state.rounds[-1].question
                     display_question = _format_question_with_ambiguity(
-                        state.rounds[-1].question,
+                        pending_question,
                         _load_state_ambiguity_score(state),
                     )
+                    resume_is_length_guard = _is_initial_context_length_guard_question(
+                        pending_question
+                    )
+                    resume_meta: dict[str, Any] = {
+                        "session_id": session_id,
+                        "ambiguity_score": state.ambiguity_score,
+                        "milestone": (
+                            get_milestone(state.ambiguity_score)[0].value
+                            if state.ambiguity_score is not None
+                            else None
+                        ),
+                        "seed_ready": (
+                            state.ambiguity_score is not None
+                            and state.ambiguity_score <= AMBIGUITY_THRESHOLD
+                        ),
+                    }
+                    if resume_is_length_guard:
+                        # Q00/ouroboros#831: structured signal when resuming
+                        # an interview whose pending round is the length-guard
+                        # meta-directive.
+                        resume_meta.update(_length_guard_meta_fields())
                     return Result.ok(
                         MCPToolResult(
                             content=(
@@ -1487,20 +1548,8 @@ class InterviewHandler:
                                     text=f"Session {session_id}\n\n{display_question}",
                                 ),
                             ),
-                            is_error=False,
-                            meta={
-                                "session_id": session_id,
-                                "ambiguity_score": state.ambiguity_score,
-                                "milestone": (
-                                    get_milestone(state.ambiguity_score)[0].value
-                                    if state.ambiguity_score is not None
-                                    else None
-                                ),
-                                "seed_ready": (
-                                    state.ambiguity_score is not None
-                                    and state.ambiguity_score <= AMBIGUITY_THRESHOLD
-                                ),
-                            },
+                            is_error=resume_is_length_guard,
+                            meta=resume_meta,
                         )
                     )
 
@@ -1844,6 +1893,23 @@ class InterviewHandler:
                     session_id=session_id,
                 )
 
+                answer_is_length_guard = _is_initial_context_length_guard_question(question)
+                answer_meta: dict[str, Any] = {
+                    "session_id": session_id,
+                    "ambiguity_score": (
+                        live_score.overall_score if live_score is not None else None
+                    ),
+                    "milestone": _milestone_for_score(live_score),
+                    "seed_ready": (
+                        live_score.is_ready_for_seed if live_score is not None else None
+                    ),
+                }
+                if answer_is_length_guard:
+                    # Q00/ouroboros#831: structured signal when the next
+                    # question after an answer is again the length-guard
+                    # meta-directive (the post-answer scoring path may still
+                    # require the user to summarize before continuing).
+                    answer_meta.update(_length_guard_meta_fields())
                 return Result.ok(
                     MCPToolResult(
                         content=(
@@ -1852,17 +1918,8 @@ class InterviewHandler:
                                 text=f"Session {session_id}\n\n{display_question}",
                             ),
                         ),
-                        is_error=False,
-                        meta={
-                            "session_id": session_id,
-                            "ambiguity_score": (
-                                live_score.overall_score if live_score is not None else None
-                            ),
-                            "milestone": _milestone_for_score(live_score),
-                            "seed_ready": (
-                                live_score.is_ready_for_seed if live_score is not None else None
-                            ),
-                        },
+                        is_error=answer_is_length_guard,
+                        meta=answer_meta,
                     )
                 )
 

--- a/tests/unit/mcp/tools/test_interview_length_guard_envelope.py
+++ b/tests/unit/mcp/tools/test_interview_length_guard_envelope.py
@@ -1,0 +1,182 @@
+"""Regression test for Q00/ouroboros#831.
+
+The interview length-guard branch (oversized ``initial_context``) returns a
+fixed meta-directive in the question slot.  Without a structured envelope,
+MCP clients (notably the Claude Code plugin) cannot distinguish it from a
+normal interview question and mis-route it through AskUserQuestion, causing
+multi-minute hangs.  After the fix the response must carry:
+
+* ``is_error=True``
+* ``meta.recoverable=True``
+* ``meta.reason="initial_context_too_large"``
+* ``meta.expected_action="resend_with_summary"``
+* ``meta.max_chars=MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS``
+
+while preserving the human-readable text body verbatim so the CLI interview
+UX is unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
+    MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS,
+    InterviewState,
+    InterviewStatus,
+)
+from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+
+@dataclass(slots=True)
+class _LengthGuardEngine:
+    """Engine stub: returns the length-guard meta-directive as next question."""
+
+    state_dir: Path
+    saved_states: list[InterviewState] = field(default_factory=list)
+
+    async def start_interview(
+        self,
+        initial_context: str,
+        cwd: str | None = None,
+        interview_id: str | None = None,
+    ) -> Result[InterviewState, MCPServerError]:
+        sid = interview_id or "interview_lengthguard0001"
+        state = InterviewState(
+            interview_id=sid,
+            initial_context=initial_context,
+            status=InterviewStatus.IN_PROGRESS,
+        )
+        await self.save_state(state)
+        return Result.ok(state)
+
+    async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
+        # Mirror the in-process engine's length-guard branch.
+        return Result.ok(INITIAL_CONTEXT_SUMMARY_QUESTION)
+
+    async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        path = self.state_dir / f"interview_{state.interview_id}.json"
+        path.write_text(
+            json.dumps({"interview_id": state.interview_id}),
+            encoding="utf-8",
+        )
+        self.saved_states.append(state)
+        return Result.ok(path)
+
+    async def load_state(
+        self, session_id: str
+    ) -> Result[InterviewState, MCPServerError]:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_start_with_oversized_context_returns_structured_length_guard_envelope(
+    tmp_path: Path,
+) -> None:
+    """Start path: oversized initial_context must surface a structured signal."""
+    engine = _LengthGuardEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    # Padding makes the validator/length guard trip even though the engine
+    # stub itself is the one returning the meta-directive; the body just has
+    # to be plausibly long.
+    oversized = "x" * (MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS + 100)
+
+    outcome = await handler.handle(
+        {"initial_context": oversized, "cwd": str(tmp_path)},
+    )
+
+    assert outcome.is_ok, "handler must surface a recoverable result"
+    mcp_result = outcome.value
+
+    # Contract: structured envelope for the length-guard branch.
+    assert mcp_result.is_error is True, "length-guard response must set is_error=True"
+    meta = mcp_result.meta or {}
+    assert meta.get("recoverable") is True
+    assert meta.get("reason") == "initial_context_too_large"
+    assert meta.get("expected_action") == "resend_with_summary"
+    assert meta.get("max_chars") == MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
+    assert isinstance(meta.get("session_id"), str) and meta["session_id"]
+
+    # Text body MUST be preserved verbatim — CLI UX unchanged.
+    assert mcp_result.content, "response must carry at least one content item"
+    text_body = mcp_result.content[0].text
+    assert INITIAL_CONTEXT_SUMMARY_QUESTION in text_body
+    assert "Interview started" in text_body
+
+
+@pytest.mark.asyncio
+async def test_normal_question_does_not_set_length_guard_meta(tmp_path: Path) -> None:
+    """Sanity guard: a normal first question keeps is_error=False and no length-guard meta."""
+
+    @dataclass(slots=True)
+    class _NormalEngine:
+        state_dir: Path
+        saved_states: list[InterviewState] = field(default_factory=list)
+
+        async def start_interview(
+            self,
+            initial_context: str,
+            cwd: str | None = None,
+            interview_id: str | None = None,
+        ) -> Result[InterviewState, MCPServerError]:
+            sid = interview_id or "interview_normal000000001"
+            state = InterviewState(
+                interview_id=sid,
+                initial_context=initial_context,
+                status=InterviewStatus.IN_PROGRESS,
+            )
+            await self.save_state(state)
+            return Result.ok(state)
+
+        async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
+            return Result.ok("What is the primary user persona?")
+
+        async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
+            self.state_dir.mkdir(parents=True, exist_ok=True)
+            path = self.state_dir / f"interview_{state.interview_id}.json"
+            path.write_text(
+                json.dumps({"interview_id": state.interview_id}),
+                encoding="utf-8",
+            )
+            self.saved_states.append(state)
+            return Result.ok(path)
+
+        async def load_state(
+            self, session_id: str
+        ) -> Result[InterviewState, MCPServerError]:  # pragma: no cover - unused
+            raise NotImplementedError
+
+    engine = _NormalEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {"initial_context": "Build a CLI", "cwd": str(tmp_path)},
+    )
+
+    assert outcome.is_ok
+    mcp_result = outcome.value
+    assert mcp_result.is_error is False
+    meta = mcp_result.meta or {}
+    # None of the length-guard keys may appear on a normal response.
+    assert "reason" not in meta
+    assert "expected_action" not in meta
+    assert "max_chars" not in meta

--- a/tests/unit/mcp/tools/test_interview_length_guard_envelope.py
+++ b/tests/unit/mcp/tools/test_interview_length_guard_envelope.py
@@ -28,6 +28,7 @@ import pytest
 from ouroboros.bigbang.interview import (
     INITIAL_CONTEXT_SUMMARY_QUESTION,
     MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS,
+    InterviewRound,
     InterviewState,
     InterviewStatus,
 )
@@ -42,6 +43,7 @@ class _LengthGuardEngine:
 
     state_dir: Path
     saved_states: list[InterviewState] = field(default_factory=list)
+    states_by_id: dict[str, InterviewState] = field(default_factory=dict)
 
     async def start_interview(
         self,
@@ -62,6 +64,24 @@ class _LengthGuardEngine:
         # Mirror the in-process engine's length-guard branch.
         return Result.ok(INITIAL_CONTEXT_SUMMARY_QUESTION)
 
+    async def record_response(
+        self,
+        state: InterviewState,
+        answer: str,
+        pending_question: str,
+    ) -> Result[InterviewState, MCPServerError]:
+        if state.rounds and state.rounds[-1].user_response is None:
+            state.rounds[-1].user_response = answer
+        else:
+            state.rounds.append(
+                InterviewRound(
+                    round_number=state.current_round_number,
+                    question=pending_question,
+                    user_response=answer,
+                )
+            )
+        return Result.ok(state)
+
     async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
         self.state_dir.mkdir(parents=True, exist_ok=True)
         path = self.state_dir / f"interview_{state.interview_id}.json"
@@ -70,12 +90,11 @@ class _LengthGuardEngine:
             encoding="utf-8",
         )
         self.saved_states.append(state)
+        self.states_by_id[state.interview_id] = state
         return Result.ok(path)
 
-    async def load_state(
-        self, session_id: str
-    ) -> Result[InterviewState, MCPServerError]:  # pragma: no cover - unused
-        raise NotImplementedError
+    async def load_state(self, session_id: str) -> Result[InterviewState, MCPServerError]:
+        return Result.ok(self.states_by_id[session_id])
 
 
 @pytest.mark.asyncio
@@ -120,6 +139,86 @@ async def test_start_with_oversized_context_returns_structured_length_guard_enve
     text_body = mcp_result.content[0].text
     assert INITIAL_CONTEXT_SUMMARY_QUESTION in text_body
     assert "Interview started" in text_body
+
+
+@pytest.mark.asyncio
+async def test_resume_pending_length_guard_keeps_structured_envelope(
+    tmp_path: Path,
+) -> None:
+    """Resume path: a pending length-guard round must not become a hard error."""
+    engine = _LengthGuardEngine(state_dir=tmp_path)
+    session_id = "interview_resume_lengthguard"
+    state = InterviewState(
+        interview_id=session_id,
+        initial_context="x" * (MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS + 100),
+        status=InterviewStatus.IN_PROGRESS,
+        rounds=[
+            InterviewRound(
+                round_number=1,
+                question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+                user_response=None,
+            )
+        ],
+    )
+    await engine.save_state(state)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle({"session_id": session_id})
+
+    assert outcome.is_ok
+    mcp_result = outcome.value
+    assert mcp_result.is_error is False
+    meta = mcp_result.meta or {}
+    assert meta.get("recoverable") is True
+    assert meta.get("reason") == "initial_context_too_large"
+    assert meta.get("expected_action") == "resend_with_summary"
+    assert meta.get("max_chars") == MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
+    assert INITIAL_CONTEXT_SUMMARY_QUESTION in mcp_result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_answer_path_length_guard_keeps_structured_envelope(
+    tmp_path: Path,
+) -> None:
+    """Answer path: a generated length-guard follow-up must not raise/return error."""
+    engine = _LengthGuardEngine(state_dir=tmp_path)
+    session_id = "interview_answer_lengthguard"
+    state = InterviewState(
+        interview_id=session_id,
+        initial_context="x" * (MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS + 100),
+        status=InterviewStatus.IN_PROGRESS,
+        rounds=[
+            InterviewRound(
+                round_number=1,
+                question="What are the main requirements?",
+                user_response=None,
+            )
+        ],
+    )
+    await engine.save_state(state)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle({"session_id": session_id, "answer": "Build a robust CLI."})
+
+    assert outcome.is_ok
+    mcp_result = outcome.value
+    assert mcp_result.is_error is False
+    meta = mcp_result.meta or {}
+    assert meta.get("recoverable") is True
+    assert meta.get("reason") == "initial_context_too_large"
+    assert meta.get("expected_action") == "resend_with_summary"
+    assert meta.get("max_chars") == MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
+    assert INITIAL_CONTEXT_SUMMARY_QUESTION in mcp_result.content[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_interview_length_guard_envelope.py
+++ b/tests/unit/mcp/tools/test_interview_length_guard_envelope.py
@@ -4,16 +4,17 @@ The interview length-guard branch (oversized ``initial_context``) returns a
 fixed meta-directive in the question slot.  Without a structured envelope,
 MCP clients (notably the Claude Code plugin) cannot distinguish it from a
 normal interview question and mis-route it through AskUserQuestion, causing
-multi-minute hangs.  After the fix the response must carry:
+multi-minute hangs.  After the fix the response must carry, in ``meta``:
 
-* ``is_error=True``
 * ``meta.recoverable=True``
 * ``meta.reason="initial_context_too_large"``
 * ``meta.expected_action="resend_with_summary"``
 * ``meta.max_chars=MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS``
 
-while preserving the human-readable text body verbatim so the CLI interview
-UX is unchanged.
+``is_error`` is intentionally left **False** (the wire success/failure axis
+must not flip, or ``HandlerInterviewBackend.start`` would raise on every
+oversized ``initial_context``).  The human-readable text body is preserved
+verbatim so the CLI interview UX is unchanged.
 """
 
 from __future__ import annotations
@@ -99,11 +100,14 @@ async def test_start_with_oversized_context_returns_structured_length_guard_enve
         {"initial_context": oversized, "cwd": str(tmp_path)},
     )
 
-    assert outcome.is_ok, "handler must surface a recoverable result"
+    assert outcome.is_ok, "handler must surface a successful result with meta hints"
     mcp_result = outcome.value
 
-    # Contract: structured envelope for the length-guard branch.
-    assert mcp_result.is_error is True, "length-guard response must set is_error=True"
+    # Contract: structured meta-only envelope for the length-guard branch.
+    # is_error stays False so HandlerInterviewBackend.start does not raise.
+    assert mcp_result.is_error is False, (
+        "length-guard response must keep is_error=False to preserve auto driver semantics"
+    )
     meta = mcp_result.meta or {}
     assert meta.get("recoverable") is True
     assert meta.get("reason") == "initial_context_too_large"
@@ -180,3 +184,39 @@ async def test_normal_question_does_not_set_length_guard_meta(tmp_path: Path) ->
     assert "reason" not in meta
     assert "expected_action" not in meta
     assert "max_chars" not in meta
+
+
+@pytest.mark.asyncio
+async def test_auto_driver_does_not_raise_on_length_guard_response(tmp_path: Path) -> None:
+    """Regression: HandlerInterviewBackend.start must surface the length-guard
+    response as a normal interview turn, not as ``PartialInterviewStartError``.
+
+    Before the fix in this PR landed, an earlier draft flipped ``is_error``
+    to ``True`` on the length-guard branch.  That made ``adapters.py:75-87``
+    raise on every oversized ``initial_context``, breaking ``ooo auto`` for
+    any large brownfield context.  This test locks the contract in: the
+    length-guard branch must keep ``is_error=False`` so the auto driver
+    continues to deliver the summarize-prompt as the first interview turn.
+    """
+    from ouroboros.auto.adapters import HandlerInterviewBackend
+
+    engine = _LengthGuardEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+    backend = HandlerInterviewBackend(handler, cwd=str(tmp_path))
+
+    oversized = "x" * (MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS + 100)
+    turn = await backend.start(oversized, cwd=str(tmp_path))
+
+    # The driver must receive a normal turn carrying the summarize prompt as
+    # its question.  Specifically: no exception raised, and the turn payload
+    # contains the length-guard question text.
+    assert turn is not None
+    assert INITIAL_CONTEXT_SUMMARY_QUESTION in (turn.question or ""), (
+        "auto driver must see the length-guard meta-directive as the next "
+        "question to answer, exactly as it did before #831 / #834 landed"
+    )


### PR DESCRIPTION
## Summary

**Direction A from #831 only.** Stops the interview length-guard branch from masquerading as a normal interview question, so a programmatic client can branch on `meta.reason` instead of mis-routing the meta-directive to a human via `AskUserQuestion`.

**This PR is a meta-only envelope:** `is_error` stays `False`, the text body is preserved verbatim, and the new structured information lives entirely in `meta`. *Earlier commits in this branch flipped `is_error` to `True` on the length-guard branch — that turned out to break `HandlerInterviewBackend.start` (the auto driver) and the follow-up commit on this branch walks the flip back and adds a regression test that locks the auto driver semantics.* The wire success/failure axis is intentionally NOT flipped.

## What this PR does

- When `initial_context` exceeds `MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS`, the response (in all three return sites: `start`, `resume_pending`, `answer`) merges these keys into `meta`:

  ```
  meta.recoverable     = True
  meta.reason          = "initial_context_too_large"
  meta.expected_action = "resend_with_summary"
  meta.max_chars       = MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
  ```

- `is_error` stays `False`.
- Text body is byte-identical to today.
- `skills/interview/SKILL.md` gains a one-paragraph clause under the existing *Retry on Failure* section telling the routing layer: if `meta.reason == "initial_context_too_large"`, summarize `initial_context` locally (≤ `meta.max_chars`) and re-call `ouroboros_interview` with the summary as `answer`. Do not route it via `AskUserQuestion`.

## Why this is NOT a hang fix

On re-reading the JSONL trace in #831, the empty-`thinking` / `stop_reason=tool_use` hangs at `ev[354]` and around `ev[426]` both occurred *after normal MCP question responses*, not after the length-guard `ev[329]` response. That anomaly is a `claude-agent-sdk` / Claude Code layer issue, not ouroboros. This PR addresses a related but *separate* contract design issue surfaced during the same investigation. PR #837 (diagnostics-only event) is the companion that will give us data to confirm/deny the response-shape correlation for the actual hang.

## Test plan

- [x] `tests/unit/mcp/tools/test_interview_length_guard_envelope.py`:
  - Length-guard response: `is_error=False`, all documented `meta` keys present, text body preserved verbatim.
  - Normal first question: `is_error=False`, no length-guard `meta` keys leak.
  - **`test_auto_driver_does_not_raise_on_length_guard_response`** (new): drives `HandlerInterviewBackend.start` end-to-end with an oversized `initial_context`. Asserts no exception is raised and the returned `InterviewTurn` carries the summarize-prompt text as its question — locks the auto driver contract in so a future `is_error` flip would fail this test instead of surfacing as a runtime regression in `ooo auto`.
- [x] `pytest tests/unit/mcp/tools/ tests/unit/auto/ tests/unit/bigbang/test_interview.py tests/unit/bigbang/test_seed_generator.py tests/unit/bigbang/test_pm_interview.py` — 1322 passing.
- [x] `ruff format` clean; `ruff check` clean.

## Out of scope (still open in #831 for maintainer decision)

- **Direction B** (server-side auto-summarization LLM call) — deliberately not implemented; the in-band "ask the human to summarize" question is a deliberate trade-off and an automatic LLM call would change that contract silently.
- **Direction C** (SKILL.md-only handler via literal-string match) — partly subsumed by the structured `meta` field added here.
- No `answer` length cap.
- `_trim_messages_to_budget`, `should_dispatch_via_plugin`, and the `(ambiguity: …)` display prefix are not touched.

## Notes for reviewer

- Two commits on the branch: the initial structured envelope, and a follow-up that walks back the `is_error` flip after the regression on the auto driver was caught. Each commit message explains the rationale; squash-on-merge is fine if maintainers prefer one combined commit.

Refs #831 (Direction A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)