### PR TITLE
feat(evolution): map watchdog timeouts onto Directive vocabulary (#578)

### DIFF
--- a/src/ouroboros/evolution/directive_mapping.py
+++ b/src/ouroboros/evolution/directive_mapping.py
@@ -106,3 +106,88 @@ def is_terminal_directive(directive: Directive) -> bool:
     timelines visually.
     """
     return directive in {Directive.CONVERGE, Directive.CANCEL}
+
+
+# Canonical watchdog timeout kinds. Sourced from
+# ``ouroboros.evolution.watchdog.GenerationProgressWatchdog._raise_timeout``
+# — kept as a module-level constant so the mapping below and tests can
+# share the alphabet without round-tripping a string back into the
+# watchdog. Update both together when the watchdog grows a new
+# threshold.
+WATCHDOG_TIMEOUT_KINDS: frozenset[str] = frozenset(
+    {
+        "safety_timeout",
+        "idle_timeout",
+        "no_material_progress_timeout",
+    }
+)
+
+# Watchdog-timeout → directive lookup. The mapping is conservative by
+# design (see #578 maintainer comment):
+#
+# - ``safety_timeout`` is the hard absolute upper bound. Once exceeded
+#   the runtime CANNOT continue regardless of whether work was
+#   happening; the only safe directive is the terminal ``CANCEL``.
+# - ``idle_timeout`` means the EventStore observed zero activity for
+#   the threshold window. With no live signal, neither ``RETRY``
+#   (re-run the same hung unit) nor ``UNSTUCK`` (lateral persona —
+#   itself depends on receiving activity) can recover the lineage.
+#   ``CANCEL`` is the defensive default; an operator can re-issue a
+#   fresh attempt out-of-band if desired.
+# - ``no_material_progress_timeout`` is the canonical "stuck doing
+#   busywork" signal: events keep arriving but no material progress
+#   accrues. That is exactly the precondition ``UNSTUCK`` exists for
+#   (invoke a lateral persona to change approach), so we route the
+#   directive accordingly.
+#
+# WAIT is intentionally absent: a watchdog firing means the runtime
+# already waited past its budget. Returning WAIT would ask the runtime
+# to wait longer, which is the failure mode the watchdog exists to
+# prevent. RETRY is also absent — the watchdog acts at the
+# *generation* boundary, not the *step* boundary; retry budgeting
+# lives one layer down (``step_action_to_directive``).
+_WATCHDOG_TIMEOUT_DIRECTIVES: dict[str, Directive] = {
+    "safety_timeout": Directive.CANCEL,
+    "idle_timeout": Directive.CANCEL,
+    "no_material_progress_timeout": Directive.UNSTUCK,
+}
+
+
+def watchdog_timeout_to_directive(timeout_kind: str) -> Directive | None:
+    """Translate a watchdog ``timeout_kind`` into a control ``Directive``.
+
+    Issue #578 — Directive mapping for the RuntimeControls watchdog.
+    Mirrors :func:`step_action_to_directive`: the loop already maps
+    ``StepAction`` outcomes onto the shared ``Directive`` vocabulary,
+    and the watchdog needs the same translation so its timeout
+    decisions land on the control plane alongside step-level
+    directives instead of as opaque local errors.
+
+    Args:
+        timeout_kind: The ``timeout_kind`` field carried on
+            :class:`GenerationWatchdogTimeout` and on the
+            ``lineage.generation.watchdog_decision`` event payload.
+            Canonical values come from
+            :data:`WATCHDOG_TIMEOUT_KINDS`.
+
+    Returns:
+        The :class:`Directive` to emit, or ``None`` when
+        ``timeout_kind`` is unrecognized. Forward-compatible: a future
+        watchdog threshold name that lands before this mapping is
+        updated will silently be treated as "do not emit a directive",
+        matching the no-op behaviour of
+        :func:`step_action_to_directive` for unknown
+        ``StepAction`` values.
+
+    Mapping table:
+
+    ====================================  =========================
+    ``timeout_kind``                      ``Directive``
+    ====================================  =========================
+    ``safety_timeout``                    ``CANCEL``
+    ``idle_timeout``                      ``CANCEL``
+    ``no_material_progress_timeout``      ``UNSTUCK``
+    *unknown*                             ``None`` (no emission)
+    ====================================  =========================
+    """
+    return _WATCHDOG_TIMEOUT_DIRECTIVES.get(timeout_kind)

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -154,6 +154,16 @@ class StepResult:
         return self.action == StepAction.INTERRUPTED
 
 
+def _watchdog_timeout_step_action(timeout_kind: str) -> StepAction:
+    """Return the public ``evolve_step`` action matching a watchdog directive."""
+    directive = watchdog_timeout_to_directive(timeout_kind)
+    if directive is None:
+        return StepAction.FAILED
+    if is_terminal_directive(directive):
+        return StepAction.EXHAUSTED
+    return StepAction.STAGNATED
+
+
 class EvolutionaryLoop:
     """Manages the evolutionary cycle across generations.
 
@@ -316,6 +326,7 @@ class EvolutionaryLoop:
         lineage_id: str,
         generation_number: int,
         phase: str,
+        action: StepAction | None = None,
     ) -> None:
         """Emit ``control.directive.emitted`` for a mapped watchdog timeout."""
         directive = watchdog_timeout_to_directive(exc.timeout_kind)
@@ -336,6 +347,7 @@ class EvolutionaryLoop:
                     "timeout_kind": exc.timeout_kind,
                     "watchdog_details": dict(exc.details),
                     "is_terminal": is_terminal_directive(directive),
+                    **({"step_action": action.value} if action is not None else {}),
                 },
             )
         )
@@ -460,6 +472,7 @@ class EvolutionaryLoop:
                         lineage_id=lineage.lineage_id,
                         generation_number=generation_number,
                     ),
+                    action=_watchdog_timeout_step_action(gen_result.error.timeout_kind),
                 )
                 break
 
@@ -803,6 +816,7 @@ class EvolutionaryLoop:
                 ontology_similarity=0.0,
                 generation=generation_number,
             )
+            watchdog_action = _watchdog_timeout_step_action(gen_result.error.timeout_kind)
             await self._emit_watchdog_timeout_directive(
                 gen_result.error,
                 lineage_id=lineage.lineage_id,
@@ -811,13 +825,14 @@ class EvolutionaryLoop:
                     lineage_id=lineage.lineage_id,
                     generation_number=generation_number,
                 ),
+                action=watchdog_action,
             )
             return Result.ok(
                 StepResult(
                     generation_result=failed_gen,
                     convergence_signal=conv_signal,
                     lineage=lineage,
-                    action=StepAction.FAILED,
+                    action=watchdog_action,
                     next_generation=generation_number,
                 )
             )

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -53,6 +53,7 @@ from ouroboros.evolution.convergence import ConvergenceCriteria, ConvergenceSign
 from ouroboros.evolution.directive_mapping import (
     is_terminal_directive,
     step_action_to_directive,
+    watchdog_timeout_to_directive,
 )
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ReflectEngine, ReflectOutput
@@ -308,6 +309,37 @@ class EvolutionaryLoop:
             )
         )
 
+    async def _emit_watchdog_timeout_directive(
+        self,
+        exc: GenerationWatchdogTimeout,
+        *,
+        lineage_id: str,
+        generation_number: int,
+        phase: str,
+    ) -> None:
+        """Emit ``control.directive.emitted`` for a mapped watchdog timeout."""
+        directive = watchdog_timeout_to_directive(exc.timeout_kind)
+        if directive is None:
+            return
+        await self.event_store.append(
+            create_control_directive_emitted_event(
+                target_type="lineage",
+                target_id=lineage_id,
+                emitted_by="evolver.watchdog",
+                directive=directive,
+                reason=exc.message,
+                execution_id=exc.details.get("execution_id"),
+                lineage_id=lineage_id,
+                generation_number=generation_number,
+                phase=phase,
+                extra={
+                    "timeout_kind": exc.timeout_kind,
+                    "watchdog_details": dict(exc.details),
+                    "is_terminal": is_terminal_directive(directive),
+                },
+            )
+        )
+
     async def _phase_for_failed_step_directive(
         self,
         *,
@@ -419,6 +451,15 @@ class EvolutionaryLoop:
                         "timeout_kind": gen_result.error.timeout_kind,
                         "details": gen_result.error.details,
                     },
+                )
+                await self._emit_watchdog_timeout_directive(
+                    gen_result.error,
+                    lineage_id=lineage.lineage_id,
+                    generation_number=generation_number,
+                    phase=await self._phase_for_failed_step_directive(
+                        lineage_id=lineage.lineage_id,
+                        generation_number=generation_number,
+                    ),
                 )
                 break
 
@@ -762,15 +803,14 @@ class EvolutionaryLoop:
                 ontology_similarity=0.0,
                 generation=generation_number,
             )
-            await self._emit_step_directive(
-                StepAction.FAILED,
+            await self._emit_watchdog_timeout_directive(
+                gen_result.error,
                 lineage_id=lineage.lineage_id,
                 generation_number=generation_number,
                 phase=await self._phase_for_failed_step_directive(
                     lineage_id=lineage.lineage_id,
                     generation_number=generation_number,
                 ),
-                reason=conv_signal.reason,
             )
             return Result.ok(
                 StepResult(

--- a/tests/unit/evolution/test_directive_mapping.py
+++ b/tests/unit/evolution/test_directive_mapping.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 from ouroboros.core.directive import Directive
 from ouroboros.evolution.directive_mapping import (
+    WATCHDOG_TIMEOUT_KINDS,
     is_terminal_directive,
     step_action_to_directive,
+    watchdog_timeout_to_directive,
 )
 from ouroboros.evolution.loop import StepAction
 
@@ -70,3 +72,58 @@ class TestTerminalClassification:
 
     def test_unstuck_is_not_terminal(self) -> None:
         assert is_terminal_directive(Directive.UNSTUCK) is False
+
+
+class TestWatchdogTimeoutMapping:
+    """Pin the watchdog-timeout → directive matrix for #578.
+
+    Conservative-by-design mapping documented in
+    ``ouroboros.evolution.directive_mapping``: safety/idle ⇒ CANCEL,
+    no-material-progress ⇒ UNSTUCK. WAIT and RETRY are intentionally
+    not produced — the watchdog has already waited past its budget,
+    and retry budgeting lives at the step layer below.
+    """
+
+    def test_safety_timeout_maps_to_cancel(self) -> None:
+        directive = watchdog_timeout_to_directive("safety_timeout")
+        assert directive == Directive.CANCEL
+        assert directive is not None and directive.is_terminal is True
+
+    def test_idle_timeout_maps_to_cancel(self) -> None:
+        directive = watchdog_timeout_to_directive("idle_timeout")
+        assert directive == Directive.CANCEL
+        assert directive is not None and directive.is_terminal is True
+
+    def test_no_material_progress_timeout_maps_to_unstuck(self) -> None:
+        """No-progress is the canonical lateral-thinking trigger; the
+        directive must be non-terminal so the runtime can route the
+        lineage through an UNSTUCK persona rather than aborting."""
+        directive = watchdog_timeout_to_directive("no_material_progress_timeout")
+        assert directive == Directive.UNSTUCK
+        assert directive is not None and directive.is_terminal is False
+
+    def test_unknown_timeout_kind_returns_none(self) -> None:
+        """Forward-compatible: an unrecognized timeout name silently
+        maps to None so a future watchdog threshold lands without
+        breaking older callers."""
+        assert watchdog_timeout_to_directive("future_threshold_we_have_not_named") is None
+        assert watchdog_timeout_to_directive("") is None
+
+    def test_no_watchdog_timeout_produces_wait_or_retry(self) -> None:
+        """Pin the intentional absence of WAIT/RETRY in the watchdog
+        mapping — see module docstring rationale. WAIT would ask the
+        runtime to wait longer (the very thing the watchdog exists to
+        cut short); RETRY belongs at the step layer below."""
+        produced = {watchdog_timeout_to_directive(kind) for kind in WATCHDOG_TIMEOUT_KINDS}
+        assert Directive.WAIT not in produced
+        assert Directive.RETRY not in produced
+
+    def test_every_kind_in_the_alphabet_has_a_mapping(self) -> None:
+        """``WATCHDOG_TIMEOUT_KINDS`` is the public alphabet of timeout
+        names the watchdog can raise. Adding a name without an entry
+        in the lookup table would silently fall back to ``None`` and
+        skip directive emission, which masks the watchdog decision on
+        the control plane. The mapping table must therefore cover
+        every kind in the constant."""
+        for kind in WATCHDOG_TIMEOUT_KINDS:
+            assert watchdog_timeout_to_directive(kind) is not None, kind

--- a/tests/unit/evolution/test_directive_mapping.py
+++ b/tests/unit/evolution/test_directive_mapping.py
@@ -6,6 +6,10 @@ Closes #516 and pins the decision matrix the maintainer alignment in
 
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
+
 from ouroboros.core.directive import Directive
 from ouroboros.evolution.directive_mapping import (
     WATCHDOG_TIMEOUT_KINDS,
@@ -14,6 +18,7 @@ from ouroboros.evolution.directive_mapping import (
     watchdog_timeout_to_directive,
 )
 from ouroboros.evolution.loop import StepAction
+from ouroboros.evolution.watchdog import GenerationProgressWatchdog
 
 
 class TestStepActionMapping:
@@ -127,3 +132,29 @@ class TestWatchdogTimeoutMapping:
         every kind in the constant."""
         for kind in WATCHDOG_TIMEOUT_KINDS:
             assert watchdog_timeout_to_directive(kind) is not None, kind
+
+    def test_timeout_alphabet_matches_watchdog_raise_sites(self) -> None:
+        """Pin the mapping alphabet to the watchdog's actual timeout raises.
+
+        This catches drift in either direction: adding a new
+        ``_raise_timeout("...")`` call without extending the directive
+        alphabet, or leaving a stale mapping kind after the watchdog stops
+        raising it.
+        """
+        tree = ast.parse(
+            textwrap.dedent(
+                inspect.getsource(GenerationProgressWatchdog._raise_if_threshold_exceeded)
+            )
+        )
+        raised_kinds = {
+            call.args[0].value
+            for call in ast.walk(tree)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "_raise_timeout"
+            and call.args
+            and isinstance(call.args[0], ast.Constant)
+            and isinstance(call.args[0].value, str)
+        }
+
+        assert raised_kinds == set(WATCHDOG_TIMEOUT_KINDS)

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -46,6 +46,7 @@ from ouroboros.evolution.loop import (
 )
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ReflectOutput
+from ouroboros.evolution.watchdog import GenerationWatchdogTimeout
 from ouroboros.evolution.wonder import WonderOutput
 from ouroboros.mcp.server.adapter import _extract_feedback_metadata_from_artifact
 from ouroboros.persistence.event_store import EventStore
@@ -173,6 +174,29 @@ def make_loop(
         loop._run_generation = AsyncMock(return_value=Result.err(gen_error))
 
     return loop
+
+
+def make_watchdog_timeout(
+    timeout_kind: str,
+    lineage_id: str,
+    generation_number: int = 1,
+) -> GenerationWatchdogTimeout:
+    """Create a watchdog timeout with the fields emitted by the real watchdog."""
+    return GenerationWatchdogTimeout(
+        timeout_kind=timeout_kind,
+        reason=f"synthetic {timeout_kind}",
+        details={
+            "timeout_kind": timeout_kind,
+            "lineage_id": lineage_id,
+            "generation_number": generation_number,
+            "execution_id": f"evolve:{lineage_id}:generation:{generation_number}",
+            "elapsed_seconds": 10.0,
+            "idle_seconds": 7.0,
+            "no_material_progress_seconds": 5.0,
+            "activity_event_count": 2,
+            "material_event_count": 0,
+        },
+    )
 
 
 async def seed_events_for_gen1(
@@ -843,6 +867,68 @@ class TestEvolveStepErrors:
         assert result.is_ok  # evolve_step wraps errors in StepResult
         step = result.value
         assert step.action == StepAction.FAILED
+
+
+class TestWatchdogDirectiveEmission:
+    """Watchdog timeouts must land on the control-plane directive stream."""
+
+    @pytest.mark.asyncio
+    async def test_run_watchdog_no_material_progress_emits_unstuck_directive(self) -> None:
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_run_watchdog")
+        timeout = make_watchdog_timeout(
+            "no_material_progress_timeout",
+            "lin_run_watchdog",
+        )
+        loop = EvolutionaryLoop(event_store=store)
+        loop._run_generation_with_watchdog = AsyncMock(return_value=Result.err(timeout))
+
+        result = await loop.run(seed, lineage_id="lin_run_watchdog")
+
+        assert result.is_err
+        events = await store.replay_lineage("lin_run_watchdog")
+        directives = [event for event in events if event.type == "control.directive.emitted"]
+        assert len(directives) == 1
+        directive = directives[0]
+        assert directive.data["directive"] == Directive.UNSTUCK.value
+        assert directive.data["is_terminal"] is False
+        assert directive.data["emitted_by"] == "evolver.watchdog"
+        assert directive.data["reason"] == timeout.message
+        assert directive.data["execution_id"] == "evolve:lin_run_watchdog:generation:1"
+        assert directive.data["extra"]["timeout_kind"] == "no_material_progress_timeout"
+        assert directive.data["extra"]["is_terminal"] is False
+        assert directive.data["extra"]["watchdog_details"]["timeout_kind"] == (
+            "no_material_progress_timeout"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("timeout_kind", ["safety_timeout", "idle_timeout"])
+    async def test_evolve_step_watchdog_terminal_timeouts_emit_cancel_directive(
+        self,
+        timeout_kind: str,
+    ) -> None:
+        store = await create_event_store()
+        seed = make_seed(seed_id=f"seed_{timeout_kind}")
+        timeout = make_watchdog_timeout(timeout_kind, "lin_step_watchdog")
+        loop = EvolutionaryLoop(event_store=store)
+        loop._run_generation_with_watchdog = AsyncMock(return_value=Result.err(timeout))
+
+        result = await loop.evolve_step("lin_step_watchdog", initial_seed=seed)
+
+        assert result.is_ok
+        assert result.value.action is StepAction.FAILED
+        events = await store.replay_lineage("lin_step_watchdog")
+        directives = [event for event in events if event.type == "control.directive.emitted"]
+        assert len(directives) == 1
+        directive = directives[0]
+        assert directive.data["directive"] == Directive.CANCEL.value
+        assert directive.data["is_terminal"] is True
+        assert directive.data["emitted_by"] == "evolver.watchdog"
+        assert directive.data["reason"] == timeout.message
+        assert directive.data["execution_id"] == "evolve:lin_step_watchdog:generation:1"
+        assert directive.data["extra"]["timeout_kind"] == timeout_kind
+        assert directive.data["extra"]["is_terminal"] is True
+        assert directive.data["extra"]["watchdog_details"]["timeout_kind"] == timeout_kind
 
 
 class TestRunEmitsSeedJson:

--- a/tests/unit/test_evolve_step.py
+++ b/tests/unit/test_evolve_step.py
@@ -897,9 +897,34 @@ class TestWatchdogDirectiveEmission:
         assert directive.data["execution_id"] == "evolve:lin_run_watchdog:generation:1"
         assert directive.data["extra"]["timeout_kind"] == "no_material_progress_timeout"
         assert directive.data["extra"]["is_terminal"] is False
+        assert directive.data["extra"]["step_action"] == StepAction.STAGNATED.value
         assert directive.data["extra"]["watchdog_details"]["timeout_kind"] == (
             "no_material_progress_timeout"
         )
+
+    @pytest.mark.asyncio
+    async def test_evolve_step_watchdog_no_material_progress_returns_stagnated(self) -> None:
+        store = await create_event_store()
+        seed = make_seed(seed_id="seed_step_no_material")
+        timeout = make_watchdog_timeout(
+            "no_material_progress_timeout",
+            "lin_step_no_material",
+        )
+        loop = EvolutionaryLoop(event_store=store)
+        loop._run_generation_with_watchdog = AsyncMock(return_value=Result.err(timeout))
+
+        result = await loop.evolve_step("lin_step_no_material", initial_seed=seed)
+
+        assert result.is_ok
+        assert result.value.action is StepAction.STAGNATED
+        events = await store.replay_lineage("lin_step_no_material")
+        directives = [event for event in events if event.type == "control.directive.emitted"]
+        assert len(directives) == 1
+        directive = directives[0]
+        assert directive.data["directive"] == Directive.UNSTUCK.value
+        assert directive.data["is_terminal"] is False
+        assert directive.data["extra"]["timeout_kind"] == "no_material_progress_timeout"
+        assert directive.data["extra"]["step_action"] == StepAction.STAGNATED.value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("timeout_kind", ["safety_timeout", "idle_timeout"])
@@ -916,7 +941,7 @@ class TestWatchdogDirectiveEmission:
         result = await loop.evolve_step("lin_step_watchdog", initial_seed=seed)
 
         assert result.is_ok
-        assert result.value.action is StepAction.FAILED
+        assert result.value.action is StepAction.EXHAUSTED
         events = await store.replay_lineage("lin_step_watchdog")
         directives = [event for event in events if event.type == "control.directive.emitted"]
         assert len(directives) == 1
@@ -928,6 +953,7 @@ class TestWatchdogDirectiveEmission:
         assert directive.data["execution_id"] == "evolve:lin_step_watchdog:generation:1"
         assert directive.data["extra"]["timeout_kind"] == timeout_kind
         assert directive.data["extra"]["is_terminal"] is True
+        assert directive.data["extra"]["step_action"] == StepAction.EXHAUSTED.value
         assert directive.data["extra"]["watchdog_details"]["timeout_kind"] == timeout_kind
 
 


### PR DESCRIPTION
## Summary

Closes the first half of the #578 *RuntimeControls watchdog contract* gap: a pure mapping function that translates the watchdog's `timeout_kind` strings (`safety_timeout`, `idle_timeout`, `no_material_progress_timeout`) onto the shared `Directive` alphabet. Mirrors `step_action_to_directive` so the watchdog can join the same control-plane lane as evolution-loop step decisions.

This PR is intentionally **observational/typed**: no callers are modified. The follow-up PR will wire `GenerationProgressWatchdog.emit_decision` to call this mapping and emit `control.directive.emitted` alongside the existing `lineage.generation.watchdog_decision`, so the two concerns review independently.

## Mapping

| `timeout_kind`                  | `Directive` | Rationale |
|---------------------------------|-------------|-----------|
| `safety_timeout`                | `CANCEL`    | Terminal hard cap exceeded — runtime cannot continue. |
| `idle_timeout`                  | `CANCEL`    | EventStore observed zero activity; nothing recoverable in-process. |
| `no_material_progress_timeout`  | `UNSTUCK`   | Canonical stagnation signal — events flowing but no progress, route to lateral persona. |
| *unknown*                       | `None`      | Forward-compatible — a future threshold lands without breaking old callers. |

`WAIT` and `RETRY` are intentionally absent — see commit body for the full justification (TL;DR: WAIT would ask the runtime to wait *longer* than the watchdog's budget; RETRY belongs at the step layer, not the generation layer).

## Why this scope

Issue #578's status update from @Q00 lists five remaining contract items. This PR addresses one — *directive mapping* — and keeps each item independently reviewable:
1. ✅ directive mapping (this PR + follow-up wiring)
2. durable activity vs material-progress taxonomy (later)
3. cancellation semantics: cooperative vs direct vs two-stage (later)
4. resume/replay behavior after a watchdog decision (later)
5. cross-surface unification (MCP / generation / handoff) (later)

The `Directive` vocabulary itself landed in PR #621 (#574, just closed); this PR consumes that contract.

## Test plan

- [x] 7 new tests in `tests/unit/evolution/test_directive_mapping.py::TestWatchdogTimeoutMapping`:
  - Each canonical `timeout_kind` → expected `Directive`
  - Unknown / empty kinds map to `None`
  - The mapping never produces `WAIT` or `RETRY` (pins the rationale above)
  - Every member of `WATCHDOG_TIMEOUT_KINDS` has a non-None mapping
- [x] `pytest tests/unit/evolution/test_directive_mapping.py` → 19 passed.
- [x] `ruff check` / `ruff format --check` clean.

## Follow-up

PR 2 (stacked) will:
- Call `watchdog_timeout_to_directive(timeout_kind)` inside `GenerationProgressWatchdog.watch` after `GenerationWatchdogTimeout` is raised.
- Emit `control.directive.emitted` keyed on the lineage aggregate so the existing TUI/HUD/projector lanes (#514) surface the watchdog's decision next to step-level directives.
- Assert (via integration tests) that the `WATCHDOG_TIMEOUT_KINDS` alphabet matches what `GenerationProgressWatchdog._raise_timeout` actually raises.

Part of #578.