### PR TITLE
feat(mcp): diagnostic event for interview response shape (#831)

### DIFF
--- a/src/ouroboros/events/interview.py
+++ b/src/ouroboros/events/interview.py
@@ -71,3 +71,49 @@ def interview_failed(
             "phase": phase,
         },
     )
+
+
+def interview_response_emitted(
+    interview_id: str,
+    *,
+    response_kind: str,
+    round_number: int,
+    payload_chars: int,
+    transcript_chars: int,
+    ambiguity_prefix_present: bool,
+    is_length_guard: bool,
+) -> BaseEvent:
+    """Diagnostic event recording the shape of an MCP question-bearing response.
+
+    No behaviour change: emitted alongside the existing lifecycle events so
+    a later investigation can correlate hang reports (e.g. claude-agent-sdk
+    producing an empty-``thinking`` / ``stop_reason=tool_use`` turn after
+    receiving an interview question) with response payload characteristics.
+    See Q00/ouroboros#831 comment thread for the hang trace context.
+
+    Args:
+        interview_id: Session id.
+        response_kind: One of ``"start"`` / ``"resume_pending"`` /
+            ``"answer"`` -- which build path produced the response.
+        round_number: Round count at emission time (``len(state.rounds)``).
+        payload_chars: Total characters in the response text body.
+        transcript_chars: Sum of ``len(question) + len(user_response)`` for
+            every completed round in ``state.rounds``.
+        ambiguity_prefix_present: ``True`` when the response text begins
+            with ``(ambiguity: ...)``.
+        is_length_guard: ``True`` when the response carries the
+            ``INITIAL_CONTEXT_SUMMARY_QUESTION`` meta-directive.
+    """
+    return BaseEvent(
+        type="interview.response.emitted",
+        aggregate_type="interview",
+        aggregate_id=interview_id,
+        data={
+            "response_kind": response_kind,
+            "round_number": round_number,
+            "payload_chars": payload_chars,
+            "transcript_chars": transcript_chars,
+            "ambiguity_prefix_present": ambiguity_prefix_present,
+            "is_length_guard": is_length_guard,
+        },
+    )

--- a/src/ouroboros/events/interview.py
+++ b/src/ouroboros/events/interview.py
@@ -98,7 +98,8 @@ def interview_response_emitted(
         round_number: Round count at emission time (``len(state.rounds)``).
         payload_chars: Total characters in the response text body.
         transcript_chars: Sum of ``len(question) + len(user_response)`` for
-            every completed round in ``state.rounds``.
+            every round in ``state.rounds``, including pending questions with
+            no response yet.
         ambiguity_prefix_present: ``True`` when the response text begins
             with ``(ambiguity: ...)``.
         is_length_guard: ``True`` when the response carries the

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -224,6 +224,19 @@ def _milestone_for_score(score: AmbiguityScore | None) -> str | None:
     return milestone.value
 
 
+def _compute_transcript_chars(state: InterviewState) -> int:
+    """Sum question + user_response length over every round in ``state``.
+
+    Used by the response-shape diagnostic event (Q00/ouroboros#831) so we
+    can correlate hang reports with cumulative interview context size.
+    """
+    total = 0
+    for round_data in state.rounds:
+        total += len(round_data.question or "")
+        total += len(round_data.user_response or "")
+    return total
+
+
 def _format_question_with_ambiguity(question: str, score: AmbiguityScore | None) -> str:
     """Attach the current ambiguity score to a question for display.
 
@@ -1478,24 +1491,40 @@ class InterviewHandler:
                     ),
                 }
                 if is_length_guard:
-                    # Q00/ouroboros#831: surface the length-guard meta-directive
-                    # via structured meta keys so clients can branch on
-                    # ``meta.reason`` instead of mis-routing the text body to a
-                    # human via AskUserQuestion.  ``is_error`` is intentionally
-                    # left ``False`` -- the wire success/failure axis must not
-                    # flip or ``HandlerInterviewBackend.start`` (auto driver)
-                    # would raise on every oversized ``initial_context`` where
-                    # it previously delivered the summarize question.
+                    # Q00/ouroboros#831 (Direction A): surface the length-guard
+                    # meta-directive via structured meta keys so clients can
+                    # branch on ``meta.reason`` instead of mis-routing the text
+                    # body to a human via AskUserQuestion.  ``is_error`` is
+                    # intentionally left ``False`` -- the wire success/failure
+                    # axis must not flip or ``HandlerInterviewBackend.start``
+                    # would raise on every oversized ``initial_context``.
                     start_meta.update(_length_guard_meta_fields())
+
+                start_response_text = (
+                    f"Interview started. Session ID: {state.interview_id}\n\n{display_question}"
+                )
+                # Q00/ouroboros#831 (diagnostics): capture the shape of every
+                # MCP question-bearing response so future hang reports can be
+                # correlated with response size / transcript pressure.
+                from ouroboros.events.interview import interview_response_emitted
+
+                self._emit_event_bg(
+                    interview_response_emitted(
+                        state.interview_id,
+                        response_kind="start",
+                        round_number=len(state.rounds),
+                        payload_chars=len(start_response_text),
+                        transcript_chars=_compute_transcript_chars(state),
+                        ambiguity_prefix_present=display_question.startswith("(ambiguity:"),
+                        is_length_guard=is_length_guard,
+                    )
+                )
                 return Result.ok(
                     MCPToolResult(
                         content=(
                             MCPContentItem(
                                 type=ContentType.TEXT,
-                                text=(
-                                    f"Interview started. Session ID: {state.interview_id}\n\n"
-                                    f"{display_question}"
-                                ),
+                                text=start_response_text,
                             ),
                         ),
                         is_error=False,
@@ -1540,18 +1569,35 @@ class InterviewHandler:
                         ),
                     }
                     if resume_is_length_guard:
-                        # Q00/ouroboros#831: structured signal when resuming
-                        # an interview whose pending round is the length-guard
-                        # meta-directive.  ``is_error`` stays ``False`` so
-                        # callers like the auto driver do not treat the
+                        # Q00/ouroboros#831 (Direction A): structured signal
+                        # when resuming an interview whose pending round is
+                        # the length-guard meta-directive.  ``is_error`` stays
+                        # ``False`` so the auto driver does not treat the
                         # summarize prompt as a hard failure.
                         resume_meta.update(_length_guard_meta_fields())
+
+                    resume_response_text = f"Session {session_id}\n\n{display_question}"
+                    # Q00/ouroboros#831 (diagnostics): response-shape event for
+                    # the resume-pending branch.  Pure observability.
+                    from ouroboros.events.interview import interview_response_emitted
+
+                    self._emit_event_bg(
+                        interview_response_emitted(
+                            session_id,
+                            response_kind="resume_pending",
+                            round_number=len(state.rounds),
+                            payload_chars=len(resume_response_text),
+                            transcript_chars=_compute_transcript_chars(state),
+                            ambiguity_prefix_present=display_question.startswith("(ambiguity:"),
+                            is_length_guard=resume_is_length_guard,
+                        )
+                    )
                     return Result.ok(
                         MCPToolResult(
                             content=(
                                 MCPContentItem(
                                     type=ContentType.TEXT,
-                                    text=f"Session {session_id}\n\n{display_question}",
+                                    text=resume_response_text,
                                 ),
                             ),
                             is_error=False,
@@ -1911,19 +1957,34 @@ class InterviewHandler:
                     ),
                 }
                 if answer_is_length_guard:
-                    # Q00/ouroboros#831: structured signal when the next
-                    # question after an answer is again the length-guard
-                    # meta-directive (the post-answer scoring path may still
-                    # require the user to summarize before continuing).
-                    # ``is_error`` stays ``False`` so the auto driver's
-                    # ``answer()`` path is not raised on.
+                    # Q00/ouroboros#831 (Direction A): structured signal when
+                    # the next question after an answer is again the length-
+                    # guard meta-directive.  ``is_error`` stays ``False`` so
+                    # the auto driver's ``answer()`` path is not raised on.
                     answer_meta.update(_length_guard_meta_fields())
+
+                answer_response_text = f"Session {session_id}\n\n{display_question}"
+                # Q00/ouroboros#831 (diagnostics): response-shape event for
+                # the answer branch.  Pure observability.
+                from ouroboros.events.interview import interview_response_emitted
+
+                self._emit_event_bg(
+                    interview_response_emitted(
+                        session_id,
+                        response_kind="answer",
+                        round_number=len(state.rounds),
+                        payload_chars=len(answer_response_text),
+                        transcript_chars=_compute_transcript_chars(state),
+                        ambiguity_prefix_present=display_question.startswith("(ambiguity:"),
+                        is_length_guard=answer_is_length_guard,
+                    )
+                )
                 return Result.ok(
                     MCPToolResult(
                         content=(
                             MCPContentItem(
                                 type=ContentType.TEXT,
-                                text=f"Session {session_id}\n\n{display_question}",
+                                text=answer_response_text,
                             ),
                         ),
                         is_error=False,

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1515,7 +1515,7 @@ class InterviewHandler:
                         round_number=len(state.rounds),
                         payload_chars=len(start_response_text),
                         transcript_chars=_compute_transcript_chars(state),
-                        ambiguity_prefix_present=display_question.startswith("(ambiguity:"),
+                        ambiguity_prefix_present=start_response_text.startswith("(ambiguity:"),
                         is_length_guard=is_length_guard,
                     )
                 )
@@ -1588,7 +1588,7 @@ class InterviewHandler:
                             round_number=len(state.rounds),
                             payload_chars=len(resume_response_text),
                             transcript_chars=_compute_transcript_chars(state),
-                            ambiguity_prefix_present=display_question.startswith("(ambiguity:"),
+                            ambiguity_prefix_present=resume_response_text.startswith("(ambiguity:"),
                             is_length_guard=resume_is_length_guard,
                         )
                     )
@@ -1975,7 +1975,7 @@ class InterviewHandler:
                         round_number=len(state.rounds),
                         payload_chars=len(answer_response_text),
                         transcript_chars=_compute_transcript_chars(state),
-                        ambiguity_prefix_present=display_question.startswith("(ambiguity:"),
+                        ambiguity_prefix_present=answer_response_text.startswith("(ambiguity:"),
                         is_length_guard=answer_is_length_guard,
                     )
                 )

--- a/tests/unit/mcp/tools/test_interview_response_diagnostics.py
+++ b/tests/unit/mcp/tools/test_interview_response_diagnostics.py
@@ -77,6 +77,22 @@ class _StubInterviewEngine:
     async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
         return Result.ok(self.next_question)
 
+    async def record_response(
+        self,
+        state: InterviewState,
+        user_response: str,
+        question: str,
+    ) -> Result[InterviewState, MCPServerError]:
+        state.rounds.append(
+            InterviewRound(
+                round_number=state.current_round_number,
+                question=question,
+                user_response=user_response,
+            )
+        )
+        state.mark_updated()
+        return Result.ok(state)
+
     async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
         self.state_dir.mkdir(parents=True, exist_ok=True)
         path = self.state_dir / f"interview_{state.interview_id}.json"
@@ -207,3 +223,97 @@ async def test_resume_pending_emits_response_diagnostic_event(tmp_path: Path) ->
     assert diagnostic.data["is_length_guard"] is False
     # Transcript chars must include the pending question text length.
     assert diagnostic.data["transcript_chars"] >= len("What is the main goal?")
+
+
+@pytest.mark.asyncio
+async def test_resume_pending_ambiguity_prefix_reflects_full_response_text(
+    tmp_path: Path,
+) -> None:
+    """The diagnostic flag is about the emitted body, not the embedded question."""
+    pending_state = InterviewState(
+        interview_id="interview_resume00000002",
+        initial_context="ctx",
+        status=InterviewStatus.IN_PROGRESS,
+        ambiguity_score=0.42,
+    )
+    pending_state.rounds.append(
+        InterviewRound(
+            round_number=1,
+            question="What is the main goal?",
+            user_response=None,
+        )
+    )
+
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(state_dir=tmp_path, initial_state=pending_state)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle({"session_id": pending_state.interview_id})
+    assert outcome.is_ok
+    response_text = outcome.value.content[0].text
+    assert response_text.startswith("Session ")
+    assert "(ambiguity: 0.42)" in response_text
+    await _drain_bg_tasks(handler)
+
+    diagnostic = _find_event(event_store.events, event_type="interview.response.emitted")
+    assert diagnostic is not None
+    assert diagnostic.data["ambiguity_prefix_present"] is False
+
+
+@pytest.mark.asyncio
+async def test_answer_emits_response_diagnostic_event(tmp_path: Path) -> None:
+    """Answer path: recording an answer and returning the next question emits diagnostics."""
+    pending_state = InterviewState(
+        interview_id="interview_answer00000001",
+        initial_context="ctx",
+        status=InterviewStatus.IN_PROGRESS,
+    )
+    pending_state.rounds.append(
+        InterviewRound(
+            round_number=1,
+            question="What should this tool do?",
+            user_response=None,
+        )
+    )
+
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(
+        state_dir=tmp_path,
+        initial_state=pending_state,
+        next_question="Who uses it first?",
+    )
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {"session_id": pending_state.interview_id, "answer": "It creates reports."}
+    )
+    assert outcome.is_ok
+    assert outcome.value.content[0].text == (
+        f"Session {pending_state.interview_id}\n\nWho uses it first?"
+    )
+    await _drain_bg_tasks(handler)
+
+    diagnostic = _find_event(event_store.events, event_type="interview.response.emitted")
+    assert diagnostic is not None
+    assert diagnostic.data["response_kind"] == "answer"
+    assert diagnostic.data["round_number"] == 2
+    assert diagnostic.data["payload_chars"] == len(outcome.value.content[0].text)
+    assert diagnostic.data["transcript_chars"] == (
+        len("What should this tool do?")
+        + len("It creates reports.")
+        + len("Who uses it first?")
+    )
+    assert diagnostic.data["ambiguity_prefix_present"] is False
+    assert diagnostic.data["is_length_guard"] is False

--- a/tests/unit/mcp/tools/test_interview_response_diagnostics.py
+++ b/tests/unit/mcp/tools/test_interview_response_diagnostics.py
@@ -1,0 +1,209 @@
+"""Diagnostic-event regression for Q00/ouroboros#831 (follow-up to PR #834).
+
+The ``InterviewHandler`` must emit an ``interview.response.emitted`` event
+every time it returns an MCP response that carries an interview question.
+The event payload captures response-shape characteristics (payload size,
+transcript pressure, prefix presence, length-guard flag) so a later
+investigation can correlate hang reports with response shape.  Pure
+observability -- no behaviour change.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ouroboros.bigbang.interview import (
+    INITIAL_CONTEXT_SUMMARY_QUESTION,
+    InterviewRound,
+    InterviewState,
+    InterviewStatus,
+)
+from ouroboros.core.types import Result
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+
+@dataclass(slots=True)
+class _CapturingEventStore:
+    """In-memory event sink that records every BaseEvent appended.
+
+    Mirrors the surface of ``ouroboros.persistence.event_store.EventStore``
+    that ``InterviewHandler._emit_event`` actually touches: an async
+    ``initialize`` (idempotent) and an async ``append``.  Anything beyond
+    that the production store offers is intentionally not stubbed.
+    """
+
+    events: list[BaseEvent] = field(default_factory=list)
+    _initialized: bool = False
+
+    async def initialize(self) -> None:
+        self._initialized = True
+
+    async def append(self, event: BaseEvent) -> None:
+        self.events.append(event)
+
+
+@dataclass(slots=True)
+class _StubInterviewEngine:
+    """Minimal engine: returns whatever question we configure for the next turn."""
+
+    state_dir: Path
+    next_question: str = "What is the primary user persona?"
+    initial_state: InterviewState | None = None
+    saved_states: list[InterviewState] = field(default_factory=list)
+
+    async def start_interview(
+        self,
+        initial_context: str,
+        cwd: str | None = None,
+        interview_id: str | None = None,
+    ) -> Result[InterviewState, MCPServerError]:
+        sid = interview_id or "interview_diagnostics00001"
+        state = InterviewState(
+            interview_id=sid,
+            initial_context=initial_context,
+            status=InterviewStatus.IN_PROGRESS,
+        )
+        await self.save_state(state)
+        return Result.ok(state)
+
+    async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
+        return Result.ok(self.next_question)
+
+    async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        path = self.state_dir / f"interview_{state.interview_id}.json"
+        path.write_text(
+            json.dumps({"interview_id": state.interview_id}),
+            encoding="utf-8",
+        )
+        self.saved_states.append(state)
+        return Result.ok(path)
+
+    async def load_state(self, session_id: str) -> Result[InterviewState, MCPServerError]:
+        if self.initial_state is None:
+            raise NotImplementedError
+        # Always return the same canonical state object.
+        return Result.ok(self.initial_state)
+
+
+async def _drain_bg_tasks(handler: InterviewHandler) -> None:
+    """Flush the handler's fire-and-forget event tasks deterministically."""
+    if handler._bg_tasks:
+        await asyncio.gather(*handler._bg_tasks, return_exceptions=True)
+
+
+def _find_event(events: list[BaseEvent], *, event_type: str) -> BaseEvent | None:
+    for event in events:
+        if event.type == event_type:
+            return event
+    return None
+
+
+@pytest.mark.asyncio
+async def test_start_emits_response_diagnostic_event(tmp_path: Path) -> None:
+    """Start path: a normal first question emits the response.emitted event."""
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {"initial_context": "Build a CLI", "cwd": str(tmp_path)},
+    )
+    assert outcome.is_ok
+    await _drain_bg_tasks(handler)
+
+    diagnostic = _find_event(event_store.events, event_type="interview.response.emitted")
+    assert diagnostic is not None, "start path must emit interview.response.emitted"
+
+    data: dict[str, Any] = diagnostic.data
+    assert data["response_kind"] == "start"
+    assert data["round_number"] == 1, "start path should fire after the pending round is appended"
+    assert data["payload_chars"] > 0
+    assert data["transcript_chars"] >= 0
+    assert isinstance(data["ambiguity_prefix_present"], bool)
+    assert data["is_length_guard"] is False
+    assert diagnostic.aggregate_id == "interview_diagnostics00001"
+
+
+@pytest.mark.asyncio
+async def test_start_with_length_guard_question_marks_event(tmp_path: Path) -> None:
+    """Start path: when the engine returns the length-guard meta-directive, the
+    event must carry ``is_length_guard=True``.  This is what a future analysis
+    will use to distinguish the two response shapes without re-parsing text.
+    """
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(
+        state_dir=tmp_path,
+        next_question=INITIAL_CONTEXT_SUMMARY_QUESTION,
+    )
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {"initial_context": "Build a CLI", "cwd": str(tmp_path)},
+    )
+    assert outcome.is_ok
+    await _drain_bg_tasks(handler)
+
+    diagnostic = _find_event(event_store.events, event_type="interview.response.emitted")
+    assert diagnostic is not None
+    assert diagnostic.data["is_length_guard"] is True
+    assert diagnostic.data["response_kind"] == "start"
+
+
+@pytest.mark.asyncio
+async def test_resume_pending_emits_response_diagnostic_event(tmp_path: Path) -> None:
+    """Resume path (session_id only, no answer, pending round)."""
+    pending_state = InterviewState(
+        interview_id="interview_resume00000001",
+        initial_context="ctx",
+        status=InterviewStatus.IN_PROGRESS,
+    )
+    pending_state.rounds.append(
+        InterviewRound(
+            round_number=1,
+            question="What is the main goal?",
+            user_response=None,
+        )
+    )
+
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(state_dir=tmp_path, initial_state=pending_state)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle({"session_id": pending_state.interview_id})
+    assert outcome.is_ok
+    await _drain_bg_tasks(handler)
+
+    diagnostic = _find_event(event_store.events, event_type="interview.response.emitted")
+    assert diagnostic is not None
+    assert diagnostic.data["response_kind"] == "resume_pending"
+    assert diagnostic.data["round_number"] == 1
+    assert diagnostic.data["is_length_guard"] is False
+    # Transcript chars must include the pending question text length.
+    assert diagnostic.data["transcript_chars"] >= len("What is the main goal?")

--- a/tests/unit/mcp/tools/test_interview_response_diagnostics.py
+++ b/tests/unit/mcp/tools/test_interview_response_diagnostics.py
@@ -311,9 +311,7 @@ async def test_answer_emits_response_diagnostic_event(tmp_path: Path) -> None:
     assert diagnostic.data["round_number"] == 2
     assert diagnostic.data["payload_chars"] == len(outcome.value.content[0].text)
     assert diagnostic.data["transcript_chars"] == (
-        len("What should this tool do?")
-        + len("It creates reports.")
-        + len("Who uses it first?")
+        len("What should this tool do?") + len("It creates reports.") + len("Who uses it first?")
     )
     assert diagnostic.data["ambiguity_prefix_present"] is False
     assert diagnostic.data["is_length_guard"] is False


### PR DESCRIPTION
## Summary

Follow-up to #831 (and to PR #834). Adds a new diagnostic event
`interview.response.emitted` fired every time `InterviewHandler` returns
an MCP response carrying an interview question — start, resume-pending,
and answer build paths. **Pure observability; no behaviour change.**

## Why

The hang trace attached to #831 shows two instances of
`stop_reason=tool_use` with an empty `thinking` block and zero `tool_use`
blocks, both *after normal MCP question responses*. That anomaly almost
certainly originates in the `claude-agent-sdk` / Claude Code layer, but
the trigger surface correlates with the response payload ouroboros sends
back. Today we have no way to verify whether response size, transcript
pressure, prefix presence, or round number actually correlate with hang
frequency — every analysis is speculation against a single trace.

This event makes the correlation queryable. After this lands, the next
hang report can be joined against `interview.response.emitted` rows in
the event store and we can confirm or rule out the response-shape
hypothesis with data instead of more guessing.

## Payload

```
interview.response.emitted {
  interview_id,
  response_kind:           "start" | "resume_pending" | "answer",
  round_number,
  payload_chars,           # full response text body length
  transcript_chars,        # sum of question+user_response over rounds
  ambiguity_prefix_present # response starts with "(ambiguity: …)"
  is_length_guard,         # response is INITIAL_CONTEXT_SUMMARY_QUESTION
}
```

## What this PR is NOT

- Not a fix for the hang. The empty-`tool_use` anomaly is in the
  Claude Code / claude-agent-sdk layer and needs a separate upstream
  report.
- Not a contract change. Existing `MCPToolResult` shape (text, `is_error`,
  `meta`) is identical to today's behaviour.
- Not coupled to PR #834 (Direction A). This PR branches from
  `upstream/main` and works whether or not #834 lands. The
  `is_length_guard` field here is computed locally by direct comparison
  with `INITIAL_CONTEXT_SUMMARY_QUESTION`; it does not depend on the
  structured envelope introduced in #834.

## Test plan

- [x] New regression test `tests/unit/mcp/tools/test_interview_response_diagnostics.py`:
  - Start path with a normal question — asserts `response_kind="start"`,
    `round_number=1`, payload/transcript char fields populated,
    `is_length_guard=False`.
  - Start path with the length-guard meta-directive — asserts
    `is_length_guard=True`.
  - Resume-pending path — asserts `response_kind="resume_pending"` and
    that `transcript_chars` reflects the pending round's question
    length.
  - Uses an in-memory `_CapturingEventStore` that mirrors only the
    `initialize` / `append` surface `_emit_event` actually touches.
- [x] `pytest tests/unit/mcp/tools/ tests/unit/bigbang/test_interview.py` — 623 passing.
- [x] `ruff format` clean; `ruff check` clean.

## Notes for reviewer

- Event helper: `interview_response_emitted` in
  `src/ouroboros/events/interview.py`, following the existing
  `dot.notation.past_tense` naming convention.
- Three emission sites in `src/ouroboros/mcp/tools/authoring_handlers.py`
  mirror the three `MCPToolResult` build paths in `InterviewHandler.handle`.
  The response text body is now bound to a local variable at each site so
  `len(response_text)` can be captured without re-formatting.
- A tiny module-level helper `_compute_transcript_chars` keeps the
  per-site code one-line short and the test surface single-call.
- Fire-and-forget via the existing `self._emit_event_bg` path; failures
  to emit are swallowed by the existing `_emit_event` warning path, so
  the event store being temporarily unavailable cannot break interview
  flow.

Refs #831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)