### PR TITLE
refactor(evolution): extract material-progress taxonomy module (#578)

### DIFF
--- a/src/ouroboros/evolution/material_progress.py
+++ b/src/ouroboros/evolution/material_progress.py
@@ -1,0 +1,114 @@
+"""Material-progress taxonomy for the Ouroboros watchdog contract.
+
+"Material progress" means an event whose persistence proves that a lineage
+moved forward — not merely that the system was alive.  Contrast with
+*activity* events (heartbeats, idle pings, intermediate log lines) that
+confirm liveness but do not advance the evolutionary state machine.
+
+The watchdog uses this taxonomy to distinguish two timeout clocks:
+
+* ``generation_idle_timeout_seconds`` — no *activity* at all (any event)
+* ``generation_no_progress_timeout_seconds`` — no *material* event
+
+Each surface defines its own set because what counts as "forward motion"
+differs per layer:
+
+* **lineage** — generation lifecycle transitions and ontology mutations.
+* **execution** — coordinator / decomposition / session terminal events.
+* **session** — orchestrator-level task and session lifecycle transitions.
+* **auto** — (intentionally empty) no per-surface material-event vocabulary
+  defined yet for auto-mode; contribution welcome.
+* **agent_process** — (intentionally empty) AgentProcess surface has no
+  dedicated event schema yet; will be populated once the surface matures.
+
+The ``MATERIAL_EVENTS_BY_SURFACE`` mapping makes this taxonomy explicit and
+machine-queryable, surfacing the gaps in auto and agent_process rather than
+hiding them inside private frozensets.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Per-surface material event sets
+# ---------------------------------------------------------------------------
+
+LINEAGE_MATERIAL_EVENTS: frozenset[str] = frozenset(
+    {
+        "lineage.generation.started",
+        "lineage.generation.phase_changed",
+        "lineage.generation.completed",
+        "lineage.generation.interrupted",
+        "lineage.generation.failed",
+        "lineage.ontology.evolved",
+        "lineage.converged",
+        "lineage.stagnated",
+        "lineage.exhausted",
+    }
+)
+
+EXECUTION_MATERIAL_EVENTS: frozenset[str] = frozenset(
+    {
+        "execution.ac.stall_detected",
+        "execution.coordinator.completed",
+        "execution.coordinator.failed",
+        "execution.decomposition.level_started",
+        "execution.decomposition.level_completed",
+        "execution.session.completed",
+        "execution.session.failed",
+        "execution.session.started",
+        "execution.terminal",
+    }
+)
+
+SESSION_MATERIAL_EVENTS: frozenset[str] = frozenset(
+    {
+        "orchestrator.session.cancelled",
+        "orchestrator.session.completed",
+        "orchestrator.session.failed",
+        "orchestrator.session.started",
+        "orchestrator.task.completed",
+        "orchestrator.task.started",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Terminal acceptance-criteria status vocabulary
+# ---------------------------------------------------------------------------
+
+TERMINAL_AC_STATUSES: frozenset[str] = frozenset(
+    {
+        "completed",
+        "failed",
+        "skipped",
+        "blocked",
+        "invalid",
+        "satisfied",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Unified surface map — makes gaps explicit
+# ---------------------------------------------------------------------------
+
+#: Maps surface name → frozenset of event type strings that constitute
+#: material progress for that surface.  Surfaces with an empty frozenset are
+#: *intentionally* empty: their material-event vocabulary has not yet been
+#: formalised.  The empty entries are kept here to make the gap visible to
+#: contributors rather than silently absent.
+MATERIAL_EVENTS_BY_SURFACE: dict[str, frozenset[str]] = {
+    "lineage": LINEAGE_MATERIAL_EVENTS,
+    "execution": EXECUTION_MATERIAL_EVENTS,
+    "session": SESSION_MATERIAL_EVENTS,
+    # auto-mode surface: no dedicated material-event schema yet.
+    "auto": frozenset(),
+    # AgentProcess surface: event schema not yet formalised.
+    "agent_process": frozenset(),
+}
+
+__all__ = [
+    "EXECUTION_MATERIAL_EVENTS",
+    "LINEAGE_MATERIAL_EVENTS",
+    "MATERIAL_EVENTS_BY_SURFACE",
+    "SESSION_MATERIAL_EVENTS",
+    "TERMINAL_AC_STATUSES",
+]

--- a/src/ouroboros/evolution/watchdog.py
+++ b/src/ouroboros/evolution/watchdog.py
@@ -12,54 +12,13 @@ from ouroboros.config.models import RuntimeControlsConfig
 from ouroboros.core.errors import OuroborosError
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.lineage import lineage_generation_watchdog_decision
+from ouroboros.evolution.material_progress import (
+    EXECUTION_MATERIAL_EVENTS,
+    LINEAGE_MATERIAL_EVENTS,
+    SESSION_MATERIAL_EVENTS,
+    TERMINAL_AC_STATUSES,
+)
 from ouroboros.persistence.event_store import EventStore
-
-_LINEAGE_MATERIAL_EVENTS = frozenset(
-    {
-        "lineage.generation.started",
-        "lineage.generation.phase_changed",
-        "lineage.generation.completed",
-        "lineage.generation.interrupted",
-        "lineage.generation.failed",
-        "lineage.ontology.evolved",
-        "lineage.converged",
-        "lineage.stagnated",
-        "lineage.exhausted",
-    }
-)
-_EXECUTION_MATERIAL_EVENTS = frozenset(
-    {
-        "execution.ac.stall_detected",
-        "execution.coordinator.completed",
-        "execution.coordinator.failed",
-        "execution.decomposition.level_started",
-        "execution.decomposition.level_completed",
-        "execution.session.completed",
-        "execution.session.failed",
-        "execution.session.started",
-        "execution.terminal",
-    }
-)
-_SESSION_MATERIAL_EVENTS = frozenset(
-    {
-        "orchestrator.session.cancelled",
-        "orchestrator.session.completed",
-        "orchestrator.session.failed",
-        "orchestrator.session.started",
-        "orchestrator.task.completed",
-        "orchestrator.task.started",
-    }
-)
-_TERMINAL_AC_STATUSES = frozenset(
-    {
-        "completed",
-        "failed",
-        "skipped",
-        "blocked",
-        "invalid",
-        "satisfied",
-    }
-)
 
 
 class GenerationWatchdogTimeout(OuroborosError):
@@ -206,13 +165,13 @@ class GenerationProgressWatchdog:
             self._last_material_event_type = event.type
 
     def _is_material_progress(self, event: BaseEvent) -> bool:
-        if event.type in _LINEAGE_MATERIAL_EVENTS:
+        if event.type in LINEAGE_MATERIAL_EVENTS:
             return self._event_matches_generation(event)
 
-        if event.type in _EXECUTION_MATERIAL_EVENTS:
+        if event.type in EXECUTION_MATERIAL_EVENTS:
             return True
 
-        if event.type in _SESSION_MATERIAL_EVENTS:
+        if event.type in SESSION_MATERIAL_EVENTS:
             return True
 
         if event.type == "workflow.progress.updated":
@@ -369,7 +328,7 @@ class GenerationProgressWatchdog:
             if not isinstance(status, str):
                 continue
             normalized = status.strip().lower()
-            if normalized in _TERMINAL_AC_STATUSES:
+            if normalized in TERMINAL_AC_STATUSES:
                 terminal_count += 1
             statuses.append((criterion.get("index"), normalized))
 

--- a/tests/unit/evolution/test_material_progress.py
+++ b/tests/unit/evolution/test_material_progress.py
@@ -1,0 +1,96 @@
+"""Tests for the material-progress taxonomy module."""
+
+from __future__ import annotations
+
+from ouroboros.evolution.material_progress import (
+    EXECUTION_MATERIAL_EVENTS,
+    LINEAGE_MATERIAL_EVENTS,
+    MATERIAL_EVENTS_BY_SURFACE,
+    SESSION_MATERIAL_EVENTS,
+    TERMINAL_AC_STATUSES,
+)
+
+# ---------------------------------------------------------------------------
+# Pairwise disjointness
+# ---------------------------------------------------------------------------
+
+
+def test_lineage_and_execution_are_disjoint() -> None:
+    overlap = LINEAGE_MATERIAL_EVENTS & EXECUTION_MATERIAL_EVENTS
+    assert not overlap, f"Shared events: {overlap}"
+
+
+def test_lineage_and_session_are_disjoint() -> None:
+    overlap = LINEAGE_MATERIAL_EVENTS & SESSION_MATERIAL_EVENTS
+    assert not overlap, f"Shared events: {overlap}"
+
+
+def test_execution_and_session_are_disjoint() -> None:
+    overlap = EXECUTION_MATERIAL_EVENTS & SESSION_MATERIAL_EVENTS
+    assert not overlap, f"Shared events: {overlap}"
+
+
+# ---------------------------------------------------------------------------
+# Surface prefix sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_lineage_events_have_lineage_prefix() -> None:
+    non_lineage = [e for e in LINEAGE_MATERIAL_EVENTS if not e.startswith("lineage.")]
+    assert not non_lineage, f"Unexpected prefixes: {non_lineage}"
+
+
+def test_execution_events_have_execution_prefix() -> None:
+    non_execution = [e for e in EXECUTION_MATERIAL_EVENTS if not e.startswith("execution.")]
+    assert not non_execution, f"Unexpected prefixes: {non_execution}"
+
+
+def test_session_events_have_orchestrator_prefix() -> None:
+    non_orchestrator = [e for e in SESSION_MATERIAL_EVENTS if not e.startswith("orchestrator.")]
+    assert not non_orchestrator, f"Unexpected prefixes: {non_orchestrator}"
+
+
+# ---------------------------------------------------------------------------
+# MATERIAL_EVENTS_BY_SURFACE coverage
+# ---------------------------------------------------------------------------
+
+_EXPECTED_SURFACES = {"lineage", "execution", "session", "auto", "agent_process"}
+
+
+def test_all_five_surfaces_present() -> None:
+    assert set(MATERIAL_EVENTS_BY_SURFACE.keys()) == _EXPECTED_SURFACES
+
+
+def test_populated_surfaces_match_standalone_sets() -> None:
+    assert MATERIAL_EVENTS_BY_SURFACE["lineage"] == LINEAGE_MATERIAL_EVENTS
+    assert MATERIAL_EVENTS_BY_SURFACE["execution"] == EXECUTION_MATERIAL_EVENTS
+    assert MATERIAL_EVENTS_BY_SURFACE["session"] == SESSION_MATERIAL_EVENTS
+
+
+def test_empty_surfaces_are_explicitly_empty() -> None:
+    assert MATERIAL_EVENTS_BY_SURFACE["auto"] == frozenset()
+    assert MATERIAL_EVENTS_BY_SURFACE["agent_process"] == frozenset()
+
+
+def test_populated_surfaces_are_non_empty() -> None:
+    for surface in ("lineage", "execution", "session"):
+        assert MATERIAL_EVENTS_BY_SURFACE[surface], f"Surface '{surface}' should be non-empty"
+
+
+# ---------------------------------------------------------------------------
+# TERMINAL_AC_STATUSES
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_ac_statuses_non_empty() -> None:
+    assert TERMINAL_AC_STATUSES
+
+
+def test_terminal_ac_statuses_are_lowercase() -> None:
+    non_lower = [s for s in TERMINAL_AC_STATUSES if s != s.lower()]
+    assert not non_lower, f"Non-lowercase statuses: {non_lower}"
+
+
+def test_terminal_ac_statuses_no_whitespace() -> None:
+    with_ws = [s for s in TERMINAL_AC_STATUSES if s != s.strip()]
+    assert not with_ws, f"Statuses with surrounding whitespace: {with_ws}"


### PR DESCRIPTION
## Summary

- Extracts the four private frozensets from `watchdog.py` into a new public module `ouroboros.evolution.material_progress`: `LINEAGE_MATERIAL_EVENTS`, `EXECUTION_MATERIAL_EVENTS`, `SESSION_MATERIAL_EVENTS`, `TERMINAL_AC_STATUSES`.
- Adds `MATERIAL_EVENTS_BY_SURFACE: dict[str, frozenset[str]]` covering all 5 surfaces — the `auto` and `agent_process` surfaces are explicit empty frozensets, making the gap visible instead of hidden.
- Module-level docstring explains the "material progress vs. activity" contract as a formal specification.
- `watchdog.py` now imports the 4 public names; no private aliases kept. **Zero runtime behaviour change — pure rename/extract.**

## Why

Issue #578 (item 2) asks to make the implicit per-surface taxonomy explicit and to cover auto-mode and AgentProcess surfaces. Previously the taxonomy was buried in private module-level variables with no documentation. The new module makes it a queryable, documented contract.

## Test plan

- [x] `test_material_progress.py`: pairwise disjointness, surface-prefix invariants, all 5 surfaces in the map, 2 explicitly empty, `TERMINAL_AC_STATUSES` non-empty + lowercase-only.
- [x] `test_generation_watchdog.py`: existing 10 tests all pass unchanged (confirms no behavioural regression).
- [x] `ruff check` + `ruff format --check` clean on all 3 touched files.

## Stack note

This PR is independent of #836 and #838 — no shared file edits, no ordering dependency. It can be merged in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)