### PR TITLE
docs(rfc): unified runtime timeout contract (#578)

### DIFF
--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -171,8 +171,12 @@ terminal tool error, such as the existing
 adapter envelope, but they still must not emit `Directive.RETRY` without a
 durable retry token. A future MCP retry directive is allowed only if the MCP
 surface first adds persisted retry-pending state that satisfies I4/I5. The
-event target is `target_type="execution"` with `execution_id` from the
-surrounding context.
+event target is either an execution/session/control target explicitly passed
+through the `MCPToolProvider.call_tool(...)` and `_call_with_retry(...)` call
+chain, or a different currently available aggregation target selected by the
+implementation and documented with its resume semantics. The current MCP
+provider path must not assume `execution_id` is already available at the
+terminal adapter decision site.
 
 ### Watchdog timeout mapping
 
@@ -219,13 +223,19 @@ Phase timeouts in `src/ouroboros/auto/pipeline.py` catch `asyncio.TimeoutError`
 and update mutable `AutoPipelineState`. Every auto-pipeline `except
 TimeoutError` branch that marks the state blocked, enforces the pipeline
 deadline, or returns early must emit exactly one source-specific
-`control.directive.emitted` event before the state mutation or immediately
-before the early return. The event target is always `target_type="session"`,
-`target_id=state.auto_session_id`; `extra` should include the current
-`state.phase.value`, the timeout seconds used by the bounded call when
-available, `state.last_tool_name` or the tool name being marked, and any
-phase-specific handle fields needed for resume (`run_handoff_status`,
-`ralph_job_id`, `ralph_lineage_id`, `ralph_dispatch_mode`).
+`control.directive.emitted` event at the timeout decision point. Terminal
+`Directive.CANCEL` branches may emit at the terminal decision before the state
+mutation or immediately before the early return. Non-terminal
+`Directive.RETRY` branches must first persist and commit, or atomically commit
+with the directive emission, the retry-pending state transition that makes the
+retry durable. A non-terminal `RETRY` event must never become durable without
+the corresponding durable retry marker. The event target is always
+`target_type="session"`, `target_id=state.auto_session_id`; `extra` should
+include the current `state.phase.value`, the timeout seconds used by the
+bounded call when available, `state.last_tool_name` or the tool name being
+marked, and any phase-specific handle fields needed for resume
+(`run_handoff_status`, `ralph_job_id`, `ralph_lineage_id`,
+`ralph_dispatch_mode`).
 
 Most auto-pipeline timeout branches are terminal for the current auto attempt:
 interview, seed generation, repair, review, Ralph handoff, Ralph poll,
@@ -234,7 +244,10 @@ or return early. The run-handoff branch is the only currently defined
 auto-pipeline timeout branch with a non-terminal retry directive: first
 `"unknown_timeout"` while no retry has been attempted emits `Directive.RETRY`;
 retried `"unknown_timeout"`, `"unknown_retry_failed"`, or a deadline
-enforcement path emits `Directive.CANCEL`.
+enforcement path emits `Directive.CANCEL`. For the first `auto.run_handoff`
+`RETRY`, the persisted `run_start_attempted`/`run_handoff_status` transition is
+the retry-pending marker and must be durable before, or atomically with,
+`control.directive.emitted`.
 
 ## Invariants
 
@@ -265,7 +278,10 @@ persisted local retry-pending state or token still indicates that the retry is
 pending; if the owning surface has since succeeded or transitioned state, that
 local state supersedes the stale trailing `RETRY` without requiring a success
 directive. The current MCP Phase 1 contract has no such persisted token, so MCP
-does not emit `Directive.RETRY`.
+does not emit `Directive.RETRY`. Producers must preserve the same ordering on
+write: a non-terminal `RETRY` may be appended only after, or in the same atomic
+commit as, the persisted retry-pending state transition that makes it
+actionable on resume.
 
 **I5 — Retry success clears actionability without success spam.** If a
 timed-out operation succeeds on a subsequent attempt, no additional
@@ -279,12 +295,19 @@ retry-pending state, including current MCP Phase 1, must keep internal retry
 attempts out of the directive journal. This keeps the directive journal as a
 decision log, not a full-trace log.
 
+**I6 — Non-terminal retry durability is atomic with its marker.** A
+non-terminal `RETRY` directive and its owning surface's retry-pending marker
+are a single durable resume contract. If the marker cannot be persisted, the
+directive must not be appended. If the directive append succeeds, resume must be
+able to find the corresponding marker and determine whether the retry remains
+pending.
+
 ## Migration plan
 
 Migration is phased to keep blast radius small. Each step is additive and
 independently deployable. No flag day required.
 
-### Phase 1 — MCP tool timeout (smallest blast radius)
+### Phase 1 — MCP tool timeout target plumbing and terminal emission
 
 `MCPTimeoutError` is produced by the manager and consumed within the
 orchestrator layer. No lineage state is touched on this path. Phase 1 emits
@@ -292,17 +315,25 @@ only terminal MCP timeout directives because `_call_with_retry(...)` and
 `Result.err(MCPTimeoutError)` do not persist retry-pending state. Emit one
 terminal `Directive.CANCEL` from the caller-visible terminal decision site when
 the `MAX_RETRIES`/adapter envelope is exhausted and a terminal tool error is
-returned. Requires passing `execution_id` into the emission context; this
-context is already available via the surrounding tool-invocation frame.
+returned. Phase 1 also requires an API/plumbing change for the emission target:
+either pass an execution/session/control target context through
+`MCPToolProvider.call_tool(...)` and `_call_with_retry(...)`, or select a
+different aggregation target that is already available at the terminal decision
+site and document its resume semantics. The current `MCPToolProvider` call path
+must not be treated as if `execution_id` or session context is already
+available at `_call_with_retry(...)`.
 
 ### Phase 2 — Auto handoff timeout
 
 Implement the run-handoff branch first because it already has a bounded retry
 state machine (`run_handoff_status`, `run_start_attempted`, and
 `run_handoff_guidance`) and is the narrowest auto-pipeline change. Add the
-`control.directive.emitted` emission immediately before the existing state
-mutation or early return. `state.auto_session_id` is available throughout the
-pipeline.
+`control.directive.emitted` emission at the existing timeout decision point.
+For the non-terminal first-time `RETRY`, commit the
+`run_start_attempted`/`run_handoff_status` retry-pending transition before, or
+atomically with, the directive append. Terminal `CANCEL` paths may emit at the
+terminal decision or immediately before the early return. `state.auto_session_id`
+is available throughout the pipeline.
 
 ### Phase 2b — Remaining auto-pipeline timeout branches
 
@@ -339,10 +370,11 @@ resilience budget, and record `timeout_kind` only in `extra`.
   pattern are all preserved. The directive emission is observational; it does
   not change how cancellation propagates.
 
-- **Not introducing a ControlBus or reactive consumer.** Reactive consumption
-  of `control.directive.emitted` is explicitly deferred per the
+- **Not adding new ControlBus wiring or a reactive consumer.** Reactive
+  consumption of `control.directive.emitted` is explicitly deferred per the
   "observational-first" stance documented in `src/ouroboros/events/control.py:43`.
-  This RFC adds emission sites only.
+  `control_bus.py` already exists; this RFC adds emission sites only and does
+  not expand ControlBus wiring.
 
 ## Open questions
 

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -140,16 +140,16 @@ is determined per-surface as follows.
 |---|---|---|---|
 | MCP tool timeout | `"mcp.tool_timeout"` | `Directive.CANCEL` | `MAX_RETRIES`/adapter retry envelope exhausted and terminal tool error returned |
 | Watchdog timeout | `"generation.watchdog"` | same directive the evolution loop would emit for the failed generation outcome via `step_action_to_directive(...)` | generation retry/resilience-budget dependent |
-| Auto interview timeout | `"auto.interview"` | `Directive.CANCEL` | `interview_driver.run(...)` times out and the pipeline marks blocked or returns early |
-| Auto seed-generation timeout | `"auto.seed_generation"` | `Directive.CANCEL` | `seed_generator(...)` times out and the pipeline marks blocked or returns early |
-| Auto repair timeout | `"auto.repair"` | `Directive.CANCEL` | `repairer.converge(...)` times out and the pipeline marks blocked or returns early |
-| Auto review timeout | `"auto.review"` | `Directive.CANCEL` | `reviewer.review(...)` times out and the pipeline marks blocked or returns early |
+| Auto interview timeout | `"auto.interview"` | `Directive.WAIT` when resumably blocked; `Directive.CANCEL` only for terminal/deadline-enforced/non-resumable termination | `interview_driver.run(...)` times out and the pipeline blocks or terminates |
+| Auto seed-generation timeout | `"auto.seed_generation"` | `Directive.WAIT` when resumably blocked; `Directive.CANCEL` only for terminal/deadline-enforced/non-resumable termination | `seed_generator(...)` times out and the pipeline blocks or terminates |
+| Auto repair timeout | `"auto.repair"` | `Directive.WAIT` when resumably blocked; `Directive.CANCEL` only for terminal/deadline-enforced/non-resumable termination | `repairer.converge(...)` times out and the pipeline blocks or terminates |
+| Auto review timeout | `"auto.review"` | `Directive.WAIT` when resumably blocked; `Directive.CANCEL` only for terminal/deadline-enforced/non-resumable termination | `reviewer.review(...)` times out and the pipeline blocks or terminates |
 | Auto handoff timeout — first occurrence | `"auto.run_handoff"` | `Directive.RETRY` | `run_handoff_status == "unknown_timeout"` and not yet retried |
-| Auto handoff timeout — terminal | `"auto.run_handoff"` | `Directive.CANCEL` | retry exhausted while still `unknown_timeout`, retry failed with `unknown_retry_failed`, or deadline enforced |
-| Auto Ralph handoff timeout | `"auto.ralph_handoff"` | `Directive.CANCEL` | `ralph_starter(...)` times out and the pipeline marks blocked or returns early |
-| Auto Ralph poll timeout | `"auto.ralph_poll"` | `Directive.CANCEL` | `ralph_resumer(...)` times out and the pipeline marks blocked or returns early |
-| Auto evaluator timeout | `"auto.evaluate"` | `Directive.CANCEL` | `evaluator(...)` times out and the pipeline marks blocked or returns early |
-| Auto lateral-thinker timeout | `"auto.lateral"` | `Directive.CANCEL` | `lateral_thinker(...)` times out and the pipeline marks blocked or returns early |
+| Auto handoff timeout — blocked after retry | `"auto.run_handoff"` | `Directive.WAIT` when blocked awaiting user/upstream resume on the same `auto_session_id`; `Directive.CANCEL` only when the auto attempt is truly terminal/deadline-enforced/non-resumable | retry exhausted while still `unknown_timeout`, retry failed with `unknown_retry_failed`, or deadline enforced |
+| Auto Ralph handoff timeout | `"auto.ralph_handoff"` | `Directive.WAIT` when resumably blocked; `Directive.CANCEL` only for terminal/deadline-enforced/non-resumable termination | `ralph_starter(...)` times out and the pipeline blocks or terminates |
+| Auto Ralph poll timeout | `"auto.ralph_poll"` | `Directive.WAIT` when resumably blocked; `Directive.CANCEL` only for terminal/deadline-enforced/non-resumable termination | `ralph_resumer(...)` times out and the pipeline blocks or terminates |
+| Auto evaluator timeout | `"auto.evaluate"` | `Directive.WAIT` when resumably blocked; `Directive.CANCEL` only for terminal/deadline-enforced/non-resumable termination | `evaluator(...)` times out and the pipeline blocks or terminates |
+| Auto lateral-thinker timeout | `"auto.lateral"` | `Directive.WAIT` when resumably blocked; `Directive.CANCEL` only for terminal/deadline-enforced/non-resumable termination | `lateral_thinker(...)` times out and the pipeline blocks or terminates |
 
 ### MCP tool timeout mapping
 
@@ -171,12 +171,14 @@ terminal tool error, such as the existing
 adapter envelope, but they still must not emit `Directive.RETRY` without a
 durable retry token. A future MCP retry directive is allowed only if the MCP
 surface first adds persisted retry-pending state that satisfies I4/I5. The
-event target is either an execution/session/control target explicitly passed
-through the `MCPToolProvider.call_tool(...)` and `_call_with_retry(...)` call
-chain, or a different currently available aggregation target selected by the
-implementation and documented with its resume semantics. The current MCP
-provider path must not assume `execution_id` is already available at the
-terminal adapter decision site.
+canonical MCP timeout directive target is execution-scoped:
+`target_type="execution"`, `target_id=execution_id`, and
+`execution_id=execution_id`. Phase 1 must plumb this execution/control target
+context through both `MCPToolProvider.call_tool(...)` and `_call_with_retry(...)`
+before any MCP timeout directive can be emitted. If a call site cannot provide
+`execution_id`, that site must not emit `control.directive.emitted` for MCP
+timeouts until the missing plumbing exists; it must continue using the local
+terminal tool error path only. There is no alternate MCP timeout target.
 
 ### Watchdog timeout mapping
 
@@ -203,19 +205,26 @@ the watchdog decision metadata needed for audit.
 
 The watchdog source owns source-specific directive identity for
 `GenerationWatchdogTimeout` instances raised by `GenerationProgressWatchdog`,
-but it must not suppress or bypass the generation retry-budget semantics. A
-caller that catches the bubbled exception, including the current `evolve_step`
-path that can emit a generic `emitted_by="evolver"` directive for a failed
-generation, must not emit a second directive for the same watchdog timeout. The
-deduplication key is the timeout decision identity: `target_type`, `target_id`,
-timeout source (`GenerationWatchdogTimeout` / `generation.watchdog`),
-`timeout_kind`, and the triggering watchdog decision event or timestamp
-recorded with the existing lineage watchdog decision. If a source-specific
-`generation.watchdog` directive exists for that key, the generic evolver
-directive for the same failed generation is suppressed or replaced while
-preserving the directive value that `step_action_to_directive(...)` and the
-resilience budget selected. A generic evolver directive is allowed only when no
-source-specific timeout directive already exists for the same timeout decision.
+but it must not suppress or bypass the generation retry-budget semantics. Phase
+3 must make the identity concrete: `emit_decision(...)` must return or preserve
+the persisted `lineage.generation.watchdog_decision` event id, or an equivalent
+stable idempotency key, and attach it to the raised
+`GenerationWatchdogTimeout` before re-raise, for example as
+`exc.details["watchdog_decision_event_id"]`. The source-specific
+`generation.watchdog` directive must derive its `idempotency_key` from that
+stable decision identity plus `lineage_id`, `generation_number`, and
+`timeout_kind`.
+
+A caller that catches the bubbled exception, including the current
+`evolve_step` path that can emit a generic `emitted_by="evolver"` directive for
+a failed generation, must not emit a second directive for the same watchdog
+timeout. `evolve_step` and generic evolver emission sites must check the
+propagated watchdog `idempotency_key` or
+`watchdog_decision_event_id` on `GenerationWatchdogTimeout` and skip generic
+emission for that same watchdog decision. Without this propagated stable id,
+Phase 3 is not implementable. A generic evolver directive is allowed only when
+no source-specific timeout directive already exists for the same timeout
+decision.
 
 ### Auto pipeline timeout mapping
 
@@ -223,30 +232,39 @@ Phase timeouts in `src/ouroboros/auto/pipeline.py` catch `asyncio.TimeoutError`
 and update mutable `AutoPipelineState`. Every auto-pipeline `except
 TimeoutError` branch that marks the state blocked, enforces the pipeline
 deadline, or returns early must emit exactly one source-specific
-`control.directive.emitted` event at the timeout decision point. Terminal
-`Directive.CANCEL` branches may emit at the terminal decision before the state
-mutation or immediately before the early return. Non-terminal
-`Directive.RETRY` branches must first persist and commit, or atomically commit
-with the directive emission, the retry-pending state transition that makes the
-retry durable. A non-terminal `RETRY` event must never become durable without
-the corresponding durable retry marker. The event target is always
-`target_type="session"`, `target_id=state.auto_session_id`; `extra` should
-include the current `state.phase.value`, the timeout seconds used by the
-bounded call when available, `state.last_tool_name` or the tool name being
-marked, and any phase-specific handle fields needed for resume
+`control.directive.emitted` event at the timeout decision point. A timeout that
+blocks a resumable auto phase on the same `auto_session_id` emits
+`Directive.WAIT`, not terminal `Directive.CANCEL`. `Directive.CANCEL` is
+reserved for explicit terminal termination: deadline-enforced aborts, explicit
+terminal decisions, and non-resumable failures that must not be resumed on the
+same auto session. Non-terminal `Directive.RETRY` branches must first persist
+and commit, or atomically commit with the directive emission, the retry-pending
+state transition that makes the retry durable. A non-terminal `RETRY` event
+must never become durable without the corresponding durable retry marker. The
+event target is always `target_type="session"`,
+`target_id=state.auto_session_id`; `extra` should include the current
+`state.phase.value`, the timeout seconds used by the bounded call when
+available, `state.last_tool_name` or the tool name being marked,
+`resume_tool_name` or the resume tool surfaced by the blocked state, and any
+phase-specific handle fields needed for resume
 (`run_handoff_status`, `ralph_job_id`, `ralph_lineage_id`,
 `ralph_dispatch_mode`).
 
-Most auto-pipeline timeout branches are terminal for the current auto attempt:
-interview, seed generation, repair, review, Ralph handoff, Ralph poll,
-evaluator, and lateral-thinker timeouts emit `Directive.CANCEL` when they block
-or return early. The run-handoff branch is the only currently defined
-auto-pipeline timeout branch with a non-terminal retry directive: first
-`"unknown_timeout"` while no retry has been attempted emits `Directive.RETRY`;
-retried `"unknown_timeout"`, `"unknown_retry_failed"`, or a deadline
-enforcement path emits `Directive.CANCEL`. For the first `auto.run_handoff`
-`RETRY`, the persisted `run_start_attempted`/`run_handoff_status` transition is
-the retry-pending marker and must be durable before, or atomically with,
+Under the current auto resume model, blocked interview, seed generation,
+repair, review, Ralph handoff, Ralph poll, evaluator, and lateral-thinker phase
+timeouts are resumable when the auto session remains blocked with a resume tool
+on the same `auto_session_id`; those sites emit `Directive.WAIT` with
+`extra.phase`, resume tool information, and phase handles needed to resume. The
+run-handoff branch has the only currently defined auto-pipeline timeout
+`Directive.RETRY`: first `"unknown_timeout"` while no retry has been attempted
+emits `Directive.RETRY` and records the durable retry marker. After that, a
+retried `"unknown_timeout"` or `"unknown_retry_failed"` emits `Directive.WAIT`
+when the state is blocked awaiting user or upstream resume on the same
+`auto_session_id`; it emits `Directive.CANCEL` only when deadline enforcement
+or another explicit terminal path makes the auto attempt truly terminal. For
+the first `auto.run_handoff` `RETRY`, the persisted
+`run_start_attempted`/`run_handoff_status` transition is the retry-pending
+marker and must be durable before, or atomically with,
 `control.directive.emitted`.
 
 ## Invariants
@@ -265,23 +283,32 @@ inspecting `extra`.
 **I3 — Terminal vs non-terminal is explicit.** Each emitted directive's
 `is_terminal` property (defined on `Directive` in `src/ouroboros/core/directive.py:99`)
 must match the actual run outcome at that site. `Directive.CANCEL` is terminal;
-`Directive.RETRY` is not. No site may emit a terminal directive and then
-continue executing.
+`Directive.RETRY` and `Directive.WAIT` are not. No site may emit a terminal
+directive and then continue executing or resume the same target. A terminal
+`Directive.CANCEL` must brick only the target it truly terminates: an
+execution-scoped MCP timeout cancels that execution target, a lineage-scoped
+watchdog terminal outcome cancels that lineage/generation target, and a
+session-scoped auto `CANCEL` is valid only when the auto session is truly
+terminal, deadline-enforced, or non-resumable.
 
 **I4 — Resume combines the trailing directive with local state.** On session
 resume, the control-plane consumer reads the last `control.directive.emitted`
 event for the relevant target before deciding whether to continue or abort.
 This links to #578 item 4 (resume-path directive consumption). A terminal
-`CANCEL` directive on resume is authoritative and must not restart work. A
-non-terminal `RETRY` directive is actionable only while the corresponding
-persisted local retry-pending state or token still indicates that the retry is
-pending; if the owning surface has since succeeded or transitioned state, that
-local state supersedes the stale trailing `RETRY` without requiring a success
-directive. The current MCP Phase 1 contract has no such persisted token, so MCP
-does not emit `Directive.RETRY`. Producers must preserve the same ordering on
-write: a non-terminal `RETRY` may be appended only after, or in the same atomic
-commit as, the persisted retry-pending state transition that makes it
-actionable on resume.
+`CANCEL` directive on resume is authoritative only for the target it actually
+terminates and must not be generalized to unrelated resumable state. A
+non-terminal `WAIT` directive means the owning surface is blocked and resume
+must use the directive `extra` plus local state, such as `extra.phase` and the
+recorded resume tool, to continue on the same durable target when the blocker
+is cleared. A non-terminal `RETRY` directive is actionable only while the
+corresponding persisted local retry-pending state or token still indicates that
+the retry is pending; if the owning surface has since succeeded or transitioned
+state, that local state supersedes the stale trailing `RETRY` without requiring
+a success directive. The current MCP Phase 1 contract has no such persisted
+token, so MCP does not emit `Directive.RETRY`. Producers must preserve the same
+ordering on write: a non-terminal `RETRY` may be appended only after, or in the
+same atomic commit as, the persisted retry-pending state transition that makes
+it actionable on resume.
 
 **I5 — Retry success clears actionability without success spam.** If a
 timed-out operation succeeds on a subsequent attempt, no additional
@@ -315,13 +342,14 @@ only terminal MCP timeout directives because `_call_with_retry(...)` and
 `Result.err(MCPTimeoutError)` do not persist retry-pending state. Emit one
 terminal `Directive.CANCEL` from the caller-visible terminal decision site when
 the `MAX_RETRIES`/adapter envelope is exhausted and a terminal tool error is
-returned. Phase 1 also requires an API/plumbing change for the emission target:
-either pass an execution/session/control target context through
-`MCPToolProvider.call_tool(...)` and `_call_with_retry(...)`, or select a
-different aggregation target that is already available at the terminal decision
-site and document its resume semantics. The current `MCPToolProvider` call path
-must not be treated as if `execution_id` or session context is already
-available at `_call_with_retry(...)`.
+returned. Phase 1 also requires an API/plumbing change for the canonical
+execution target: pass `execution_id` and the execution/control target context
+through `MCPToolProvider.call_tool(...)` and `_call_with_retry(...)`, then emit
+with `target_type="execution"`, `target_id=execution_id`, and
+`execution_id=execution_id`. The current `MCPToolProvider` call path must not
+be treated as if `execution_id` is already available at `_call_with_retry(...)`.
+Any site that cannot provide `execution_id` after the Phase 1 plumbing must not
+emit an MCP timeout directive until that site is plumbed.
 
 ### Phase 2 — Auto handoff timeout
 
@@ -331,9 +359,13 @@ state machine (`run_handoff_status`, `run_start_attempted`, and
 `control.directive.emitted` emission at the existing timeout decision point.
 For the non-terminal first-time `RETRY`, commit the
 `run_start_attempted`/`run_handoff_status` retry-pending transition before, or
-atomically with, the directive append. Terminal `CANCEL` paths may emit at the
-terminal decision or immediately before the early return. `state.auto_session_id`
-is available throughout the pipeline.
+atomically with, the directive append. After the first retry, a timeout that
+blocks the same auto session awaiting user or upstream resume emits
+`Directive.WAIT` with `extra.phase` and resume tool information. Terminal
+`Directive.CANCEL` paths are limited to deadline-enforced, explicit terminal,
+or non-resumable termination and may emit at the terminal decision or
+immediately before the early return. `state.auto_session_id` is available
+throughout the pipeline.
 
 ### Phase 2b — Remaining auto-pipeline timeout branches
 
@@ -342,7 +374,11 @@ branch that marks blocked or returns early: interview, seed generation, repair,
 review, Ralph handoff, Ralph poll, evaluator, and lateral thinker. This phase
 is still additive and small-blast-radius because it changes only emission at
 existing timeout decision points; it does not alter phase ordering, retry
-counts, state transitions, or resume behavior.
+counts, state transitions, or resume behavior. Resumable blocked phase
+timeouts emit `Directive.WAIT` on `target_type="session"` with `extra.phase`,
+resume tool information, and any phase handles needed to resume on the same
+`auto_session_id`; `Directive.CANCEL` is reserved for explicit
+terminal/deadline-enforced/non-resumable termination.
 
 ### Phase 3 — Watchdog timeout (deferred to #836)
 
@@ -352,7 +388,14 @@ existing lineage event without changing the generation retry-budget contract.
 #836 must not map `timeout_kind` directly to `Directive.RETRY` or
 `Directive.CANCEL`; it should preserve the directive that the failed generation
 would receive through `step_action_to_directive(...)` with the active
-resilience budget, and record `timeout_kind` only in `extra`.
+resilience budget, and record `timeout_kind` only in `extra`. The implementation
+must also make `emit_decision(...)` return or preserve the persisted
+`lineage.generation.watchdog_decision` event id, or an equivalent stable
+idempotency key, attach it to `GenerationWatchdogTimeout` before re-raise, and
+derive the `generation.watchdog` directive `idempotency_key` from that stable
+decision id plus lineage/generation/timeout kind. `evolve_step` and generic
+evolver emission must check the propagated key and skip generic emission for
+the same watchdog decision.
 
 ## Non-goals
 

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -140,11 +140,13 @@ The `emitted_by` field distinguishes the source surface. The `directive` field
 is determined per-surface as follows.
 
 Target types follow `CANONICAL_CONTROL_TARGET_TYPES` where an existing durable
-target has the right resume semantics (`session`, `execution`, `lineage`,
-`agent_process`, `contract`, `execution_node`). This RFC also introduces the
-additive `lineage_generation` target for generation-local watchdog decisions;
-`ControlContract.target_type` is advisory rather than closed, so additive Agent
-OS targets may be documented without changing stored event schemas.
+target has the right replay semantics (`session`, `execution`, `lineage`,
+`agent_process`, `contract`, `execution_node`). Generation-local watchdog
+decisions still aggregate under `target_type="lineage"`, `target_id=lineage_id`
+so `EventStore.replay_lineage(lineage_id)` and existing lineage projectors see
+the interleaved directive stream. Their generation scope is expressed by the
+required `generation_number` correlation field and idempotency key, not by a
+new aggregate type.
 
 ### Mapping table
 
@@ -212,14 +214,15 @@ maps `timeout_kind` directly to `Directive.RETRY` or `Directive.CANCEL`. If
 #836 introduces watchdog-specific helper wiring, it must either call
 `step_action_to_directive(...)` with the same retry budget the evolution loop
 would use, or accept the already-computed directive from the loop. The watchdog
-event appends `control.directive.emitted` with
-`emitted_by="generation.watchdog"` on a generation-scoped target:
-`target_type="lineage_generation"`,
-`target_id=f"{lineage_id}:{generation_number}"`, `lineage_id=lineage_id`, and
+event appends `control.directive.emitted` under the existing lineage aggregate:
+`emitted_by="generation.watchdog"`, `target_type="lineage"`,
+`target_id=lineage_id`, `lineage_id=lineage_id`, and
 `generation_number=generation_number`. `extra` includes `timeout_kind`,
-thresholds, and the watchdog decision metadata needed for audit. This target is
-generation-local even when the directive is terminal; a watchdog `CANCEL` bricks
-only that failed generation attempt, not the whole lineage chain.
+thresholds, and the watchdog decision metadata needed for audit. This preserves
+`EventStore.replay_lineage(lineage_id)` visibility while making the decision
+generation-local: lineage resume readers must treat a watchdog directive with a
+`generation_number` as scoped to that generation and must not interpret a
+watchdog `CANCEL` as canceling the whole lineage chain.
 
 The watchdog source owns source-specific directive identity for
 `GenerationWatchdogTimeout` instances raised by `GenerationProgressWatchdog`,
@@ -246,11 +249,15 @@ decision.
 
 ### Auto pipeline timeout mapping
 
-Phase timeouts in `src/ouroboros/auto/pipeline.py` catch `asyncio.TimeoutError`
-and update mutable `AutoPipelineState`. Every auto-pipeline `except
-TimeoutError` branch that marks the state blocked, enforces the pipeline
-deadline, or returns early must emit exactly one source-specific
-`control.directive.emitted` event at the timeout decision point. A timeout that
+Auto timeout decisions are not confined to `src/ouroboros/auto/pipeline.py`.
+Most phase timeouts catch `asyncio.TimeoutError` in the pipeline and update
+mutable `AutoPipelineState`, but interview timeouts are decided inside
+`src/ouroboros/auto/interview_driver.py`: `_with_timeout()` raises the
+tool-specific timeout, and `run()` catches it, marks the interview session
+blocked, saves state, and returns a blocked result. Every auto timeout branch at
+the actual decision site—pipeline `except TimeoutError` branches and the
+interview driver timeout handlers that mark blocked/save/return—must emit
+exactly one source-specific `control.directive.emitted` event. A timeout that
 blocks a resumable auto phase on the same `auto_session_id` emits
 `Directive.WAIT`, not terminal `Directive.CANCEL`. `Directive.CANCEL` is
 reserved for explicit terminal termination: deadline-enforced aborts, explicit
@@ -303,19 +310,23 @@ inspecting `extra`.
 must match the actual run outcome at that site. `Directive.CANCEL` is terminal;
 `Directive.RETRY` and `Directive.WAIT` are not. No site may emit a terminal
 directive and then continue executing or resume the same target. A terminal
-`Directive.CANCEL` must brick only the target it truly terminates: an
-execution-scoped MCP timeout cancels that execution target, a
-generation-scoped watchdog terminal outcome cancels only the
-`lineage_generation` target for that `lineage_id`/`generation_number`, and a
-session-scoped auto `CANCEL` is valid only when the auto session is truly
-terminal, deadline-enforced, or non-resumable.
+`Directive.CANCEL` must brick only the decision scope it truly terminates: an
+execution-scoped MCP timeout cancels that execution target, a watchdog terminal
+outcome stored on the lineage aggregate cancels only the correlated
+`generation_number` within that lineage, and a session-scoped auto `CANCEL` is
+valid only when the auto session is truly terminal, deadline-enforced, or
+non-resumable.
 
 **I4 — Resume combines the trailing directive with local state.** On session
 resume, the control-plane consumer reads the last `control.directive.emitted`
 event for the relevant target before deciding whether to continue or abort.
 This links to #578 item 4 (resume-path directive consumption). A terminal
-`CANCEL` directive on resume is authoritative only for the target it actually
-terminates and must not be generalized to unrelated resumable state. A
+`CANCEL` directive on resume is authoritative only for the target and
+correlation scope it actually terminates and must not be generalized to
+unrelated resumable state. For lineage replay, consumers selecting generation
+resume behavior must filter lineage-aggregate directives by
+`generation_number`; a generation-scoped watchdog `CANCEL` is not a lineage-wide
+cancel. A
 non-terminal `WAIT` directive means the owning surface is blocked and resume
 must use the directive `extra` plus local state, such as `extra.phase` and the
 recorded resume tool, to continue on the same durable target when the blocker
@@ -388,15 +399,17 @@ throughout the pipeline.
 
 ### Phase 2b — Remaining auto-pipeline timeout branches
 
-Extend the same auto-pipeline helper to every other `except TimeoutError`
-branch that marks blocked or returns early: interview, seed generation, repair,
-review, Ralph handoff, Ralph poll, evaluator, and lateral thinker. This phase
-is still additive and small-blast-radius because it changes only emission at
-existing timeout decision points; it does not alter phase ordering, retry
-counts, state transitions, or resume behavior. Resumable blocked phase
-timeouts emit `Directive.WAIT` on `target_type="session"` with `extra.phase`,
-resume tool information, and any phase handles needed to resume on the same
-`auto_session_id`; `Directive.CANCEL` is reserved for explicit
+Extend the same emission helper to every other auto timeout decision site that
+marks blocked or returns early: seed generation, repair, review, Ralph handoff,
+Ralph poll, evaluator, and lateral thinker in `auto/pipeline.py`, plus the
+interview timeout handlers in `auto/interview_driver.py` that already catch the
+timeout, mark the interview session blocked, save state, and return a blocked
+result. This phase is still additive and small-blast-radius because it changes
+only emission at existing timeout decision points; it does not alter phase
+ordering, retry counts, state transitions, or resume behavior. Resumable blocked
+phase timeouts emit `Directive.WAIT` on `target_type="session"` with
+`extra.phase`, resume tool information, and any phase handles needed to resume
+on the same `auto_session_id`; `Directive.CANCEL` is reserved for explicit
 terminal/deadline-enforced/non-resumable termination.
 
 ### Phase 3 — Watchdog timeout (deferred to #836)
@@ -413,9 +426,8 @@ must also make `emit_decision(...)` return or preserve the persisted
 idempotency key, attach it to `GenerationWatchdogTimeout` before re-raise, and
 derive the `generation.watchdog` directive `idempotency_key` from that stable
 decision id plus `lineage_id`, `generation_number`, and `timeout_kind` on the
-`lineage_generation` target. `evolve_step` and generic evolver emission must
-check the propagated key and skip generic emission for the same watchdog
-decision.
+lineage aggregate. `evolve_step` and generic evolver emission must check the
+propagated key and skip generic emission for the same watchdog decision.
 
 ## Non-goals
 

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -100,12 +100,14 @@ object's `last_error`, phase, resume tool, and run/Ralph handoff fields.
 The three surfaces described above share no control-plane representation:
 
 1. **Three exception types** — `MCPTimeoutError`, `GenerationWatchdogTimeout`,
-   and `asyncio.TimeoutError` (re-raised by the auto pipeline) — carry
-   incompatible fields and are caught at different abstraction levels.
+   and `asyncio.TimeoutError` (handled in place by the auto pipeline and
+   returned as blocked or early-return state) — carry incompatible fields and
+   are caught at different abstraction levels.
 
 2. **Three cancellation mechanisms** — the MCP layer retries internally then
-   raises; the watchdog cancels the async task then persists a lineage event;
-   the auto pipeline writes to a mutable `state` object and returns early.
+   returns a terminal tool error; the watchdog cancels the async task then
+   persists a lineage event; the auto pipeline writes to a mutable `state`
+   object and returns early.
 
 3. **No shared source-specific signal** — these timeout surfaces do not emit a
    consistent `control.directive.emitted` event at the timeout decision point. A
@@ -136,9 +138,8 @@ is determined per-surface as follows.
 
 | Surface | `emitted_by` | `directive` | Condition |
 |---|---|---|---|
-| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.RETRY` | adapter exposes caller-visible retry with `MAX_RETRIES` budget remaining |
-| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.CANCEL` | `MAX_RETRIES` budget exhausted and terminal tool error returned |
-| Watchdog timeout | `"generation.watchdog"` | mapped by `watchdog_timeout_to_directive` (proposed in #836) | budget-dependent |
+| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.CANCEL` | `MAX_RETRIES`/adapter retry envelope exhausted and terminal tool error returned |
+| Watchdog timeout | `"generation.watchdog"` | same directive the evolution loop would emit for the failed generation outcome via `step_action_to_directive(...)` | generation retry/resilience-budget dependent |
 | Auto interview timeout | `"auto.interview"` | `Directive.CANCEL` | `interview_driver.run(...)` times out and the pipeline marks blocked or returns early |
 | Auto seed-generation timeout | `"auto.seed_generation"` | `Directive.CANCEL` | `seed_generator(...)` times out and the pipeline marks blocked or returns early |
 | Auto repair timeout | `"auto.repair"` | `Directive.CANCEL` | `repairer.converge(...)` times out and the pipeline marks blocked or returns early |
@@ -152,48 +153,65 @@ is determined per-surface as follows.
 
 ### MCP tool timeout mapping
 
-`MCPTimeoutError` sets `is_retriable=True`. The authoritative retry budget for
-MCP timeout directives is the adapter retry envelope in
-`src/ouroboros/orchestrator/mcp_tools.py`: `MAX_RETRIES` and the surrounding
-`retry_async(..., attempts=MAX_RETRIES)` policy. This budget applies to both
-raised timeout paths (`asyncio.TimeoutError` caught by `retry_async`) and
-manager-originated `Result.err(MCPTimeoutError)` values. The manager path must
-be lifted into the same envelope or explicitly consume the same counter at the
-`Result.err` decision point; it must not define a second retry budget.
+`MCPTimeoutError` sets `is_retriable=True`, but Phase 1 must not translate that
+flag into `Directive.RETRY`. The MCP adapter's retry envelope in
+`src/ouroboros/orchestrator/mcp_tools.py` is currently in-memory:
+`_call_with_retry(...)` uses `retry_async(..., attempts=MAX_RETRIES)` for raised
+timeout paths, and manager-originated `Result.err(MCPTimeoutError)` values flow
+through the generic `call_failed` conversion. Neither path persists a
+retry-pending token or state that a resume consumer could later consult.
 
-`Directive.RETRY` is emitted only when the adapter exposes a caller-visible
-retry decision before the terminal result, with retry budget remaining under
-that envelope. Internal retry attempts hidden inside a single tool invocation
-do not each emit. `Directive.CANCEL` is emitted when the same budget is
-exhausted and the adapter returns the terminal non-retriable tool error, such
-as the existing `orchestrator.mcp_tools.timeout_after_retries` path. The event
-target is `target_type="execution"` with `execution_id` from the surrounding
-context.
+For current Phase 1, MCP internal retries are therefore invisible to the
+directive journal. The MCP surface emits exactly one timeout directive, and
+only at the terminal caller-visible decision point: `Directive.CANCEL` when the
+`MAX_RETRIES`/adapter envelope is exhausted and the adapter returns the
+terminal tool error, such as the existing
+`orchestrator.mcp_tools.timeout_after_retries` path. Manager-originated
+`Result.err(MCPTimeoutError)` values may be normalized into the same terminal
+adapter envelope, but they still must not emit `Directive.RETRY` without a
+durable retry token. A future MCP retry directive is allowed only if the MCP
+surface first adds persisted retry-pending state that satisfies I4/I5. The
+event target is `target_type="execution"` with `execution_id` from the
+surrounding context.
 
 ### Watchdog timeout mapping
 
 `GenerationWatchdogTimeout` is already handled in the `watch()` method of
-`GenerationProgressWatchdog` (`src/ouroboros/evolution/watchdog.py:65–91`).
-Issue #836 proposes a `watchdog_timeout_to_directive` helper that maps
-`timeout_kind` to `Directive.RETRY` (transient; material progress recoverable)
-or `Directive.CANCEL` (safety or idle threshold exceeded). The watchdog site
-calls this helper immediately after its existing `emit_decision()` call and
-appends the corresponding `control.directive.emitted` event with
-`emitted_by="generation.watchdog"`. Target: `target_type="lineage"`,
-`target_id=lineage_id`.
+`GenerationProgressWatchdog` (`src/ouroboros/evolution/watchdog.py:65–91`) and
+returned to the evolution loop as a failed generation outcome. The watchdog
+source-specific emission must preserve the current generation control contract:
+the directive for a watchdog timeout is the same directive the existing
+evolution loop would have emitted for that failed generation outcome via
+`step_action_to_directive(StepAction.FAILED, retry_budget_remaining=...)`.
+That means the generation retry/resilience budget decides `Directive.RETRY`
+versus `Directive.CANCEL`; `timeout_kind` is metadata/classification in
+`extra`, not the authority for the directive value.
 
-The watchdog owns directive emission for `GenerationWatchdogTimeout` instances
-raised by `GenerationProgressWatchdog`. A caller that catches the bubbled
-exception, including the current `evolve_step` path that can emit a generic
-`emitted_by="evolver"` directive, must not emit a second directive for the same
-watchdog timeout. The deduplication key is the timeout decision identity:
-`target_type`, `target_id`, timeout source (`GenerationWatchdogTimeout` /
-`generation.watchdog`), `timeout_kind`, and the triggering watchdog decision
-event or timestamp recorded with the existing lineage watchdog decision. If a
-source-specific `generation.watchdog` directive exists for that key, the
-generic evolver timeout directive is suppressed or replaced. A generic evolver
-timeout directive is allowed only when no source-specific timeout directive
-already exists for the same timeout decision.
+Issue #836 should therefore avoid a `watchdog_timeout_to_directive` helper that
+maps `timeout_kind` directly to `Directive.RETRY` or `Directive.CANCEL`. If
+#836 introduces watchdog-specific helper wiring, it must either call
+`step_action_to_directive(...)` with the same retry budget the evolution loop
+would use, or accept the already-computed directive from the loop. The watchdog
+event appends `control.directive.emitted` with
+`emitted_by="generation.watchdog"`, `target_type="lineage"`,
+`target_id=lineage_id`, and `extra` including `timeout_kind`, thresholds, and
+the watchdog decision metadata needed for audit.
+
+The watchdog source owns source-specific directive identity for
+`GenerationWatchdogTimeout` instances raised by `GenerationProgressWatchdog`,
+but it must not suppress or bypass the generation retry-budget semantics. A
+caller that catches the bubbled exception, including the current `evolve_step`
+path that can emit a generic `emitted_by="evolver"` directive for a failed
+generation, must not emit a second directive for the same watchdog timeout. The
+deduplication key is the timeout decision identity: `target_type`, `target_id`,
+timeout source (`GenerationWatchdogTimeout` / `generation.watchdog`),
+`timeout_kind`, and the triggering watchdog decision event or timestamp
+recorded with the existing lineage watchdog decision. If a source-specific
+`generation.watchdog` directive exists for that key, the generic evolver
+directive for the same failed generation is suppressed or replaced while
+preserving the directive value that `step_action_to_directive(...)` and the
+resilience budget selected. A generic evolver directive is allowed only when no
+source-specific timeout directive already exists for the same timeout decision.
 
 ### Auto pipeline timeout mapping
 
@@ -246,7 +264,8 @@ non-terminal `RETRY` directive is actionable only while the corresponding
 persisted local retry-pending state or token still indicates that the retry is
 pending; if the owning surface has since succeeded or transitioned state, that
 local state supersedes the stale trailing `RETRY` without requiring a success
-directive.
+directive. The current MCP Phase 1 contract has no such persisted token, so MCP
+does not emit `Directive.RETRY`.
 
 **I5 — Retry success clears actionability without success spam.** If a
 timed-out operation succeeds on a subsequent attempt, no additional
@@ -255,7 +274,9 @@ surface instead clears or updates its persisted retry-pending state or token as
 part of the normal success/state transition. The earlier `RETRY` remains in the
 directive journal as the recorded timeout decision, but it is no longer
 actionable on resume once local state shows that the retry has completed or the
-operation has moved to a later state. This keeps the directive journal as a
+operation has moved to a later state. Surfaces without persisted
+retry-pending state, including current MCP Phase 1, must keep internal retry
+attempts out of the directive journal. This keeps the directive journal as a
 decision log, not a full-trace log.
 
 ## Migration plan
@@ -266,12 +287,13 @@ independently deployable. No flag day required.
 ### Phase 1 — MCP tool timeout (smallest blast radius)
 
 `MCPTimeoutError` is produced by the manager and consumed within the
-orchestrator layer. No lineage state is touched on this path. First decide
-whether manager timeouts should be raised into `retry_async` or handled from the
-returned `Result.err(MCPTimeoutError)` value; emit `control.directive.emitted`
-from that caller-visible decision site. Requires passing `execution_id` into
-the emission context; this context is already available via the surrounding
-tool-invocation frame.
+orchestrator layer. No lineage state is touched on this path. Phase 1 emits
+only terminal MCP timeout directives because `_call_with_retry(...)` and
+`Result.err(MCPTimeoutError)` do not persist retry-pending state. Emit one
+terminal `Directive.CANCEL` from the caller-visible terminal decision site when
+the `MAX_RETRIES`/adapter envelope is exhausted and a terminal tool error is
+returned. Requires passing `execution_id` into the emission context; this
+context is already available via the surrounding tool-invocation frame.
 
 ### Phase 2 — Auto handoff timeout
 
@@ -294,10 +316,12 @@ counts, state transitions, or resume behavior.
 ### Phase 3 — Watchdog timeout (deferred to #836)
 
 `GenerationProgressWatchdog.watch()` already calls `emit_decision()`. Phase 3
-adds the `watchdog_timeout_to_directive` function (proposed in #836) and
-appends the corresponding `control.directive.emitted` call alongside the
-existing lineage event. This phase is deferred because #836 must first settle
-the `timeout_kind → Directive` mapping.
+adds the source-specific `control.directive.emitted` call alongside the
+existing lineage event without changing the generation retry-budget contract.
+#836 must not map `timeout_kind` directly to `Directive.RETRY` or
+`Directive.CANCEL`; it should preserve the directive that the failed generation
+would receive through `step_action_to_directive(...)` with the active
+resilience budget, and record `timeout_kind` only in `extra`.
 
 ## Non-goals
 

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -1,0 +1,258 @@
+# RFC — Unified runtime timeout contract
+
+> Status: **Draft**
+> Relates to [#578](https://github.com/Q00/ouroboros/issues/578) (item 5: cross-surface timeout unification).
+> Related: [#836](https://github.com/Q00/ouroboros/issues/836) (watchdog directive mapping), [#476](https://github.com/Q00/ouroboros/issues/476) Phase 2 Agent OS roadmap, [#492](https://github.com/Q00/ouroboros/pull/492) (`control.directive.emitted` factory).
+
+## Summary
+
+Three independent timeout surfaces exist today. Each raises its own exception
+and signals cancellation through its own mechanism. None of them emit a
+`control.directive.emitted` event, so the control plane has no unified
+visibility into why a run was interrupted. This RFC proposes a contract that
+maps every timeout surface onto the `Directive` vocabulary and requires each
+site to emit `control.directive.emitted` as the canonical control-plane signal.
+
+## Context
+
+### Surface 1 — MCP tool timeout
+
+**Files:** `src/ouroboros/mcp/errors.py`, `src/ouroboros/mcp/client/manager.py`,
+`src/ouroboros/orchestrator/mcp_tools.py`, `src/ouroboros/config/models.py`
+
+`MCPTimeoutError` (defined in `src/ouroboros/mcp/errors.py:170`) is a subclass
+of `MCPClientError` and is raised by the MCP client manager
+(`src/ouroboros/mcp/client/manager.py:460–463`) when an MCP tool call exceeds
+its wall-clock budget. The timeout budget is controlled by
+`RuntimeControlsConfig.mcp_tool_timeout_seconds` (default `0`, which disables
+the adapter-level guard):
+
+```python
+# src/ouroboros/config/models.py:322
+mcp_tool_timeout_seconds: float = Field(default=0, ge=0)
+```
+
+`MCPTimeoutError` is marked `is_retriable=True` at construction. The retry
+logic in `src/ouroboros/orchestrator/mcp_tools.py:2156` catches
+`(MCPConnectionError, asyncio.TimeoutError)` and re-attempts up to `MAX_RETRIES`
+times before emitting the structured log event
+`orchestrator.mcp_tools.timeout_after_retries` and raising a non-retriable
+`MCPClientError`. No `control.directive.emitted` event is produced.
+
+### Surface 2 — Generation watchdog timeout
+
+**Files:** `src/ouroboros/evolution/watchdog.py`, `src/ouroboros/config/models.py`
+
+`GenerationWatchdogTimeout` (defined in `src/ouroboros/evolution/watchdog.py:24`)
+is raised by `GenerationProgressWatchdog._raise_if_threshold_exceeded` when one
+of three thresholds is breached:
+
+- `generation_idle_timeout_seconds` (default 7200 s) — no event activity
+- `generation_no_progress_timeout_seconds` (default 14400 s) — activity without
+  material progress
+- `generation_safety_timeout_seconds` (default `0`, disabled) — absolute
+  wall-clock cap
+
+When raised, the watchdog calls `emit_decision(action="timeout", ...)` which
+persists a `lineage.generation.watchdog_decision` event via the `EventStore`.
+This is a lineage-scoped event, not a `control.directive.emitted` event, so it
+does not appear in the control-plane directive stream.
+
+### Surface 3 — Auto-run handoff timeout
+
+**Files:** `src/ouroboros/auto/pipeline.py`, `src/ouroboros/config/models.py`
+
+The auto pipeline coordinates interview, seed generation, repair, review, and
+run handoff phases. Each phase runs under a `TimeoutError`-bounded `asyncio`
+call. The run-start phase is the most nuanced: a first `TimeoutError` sets
+`run_handoff_status = "unknown_timeout"` and schedules one retry; a second
+`TimeoutError` on the retry marks `run_handoff_status = "unknown_retry_failed"`
+and blocks further attempts:
+
+```python
+# src/ouroboros/auto/pipeline.py:801–814
+except TimeoutError as exc:
+    if self._enforce_deadline(state):
+        return self._result(state, ledger, review=review, blocker=state.last_error)
+    _mark_unknown_run_handoff(state, status="unknown_timeout")
+    if retried:
+        state.run_handoff_guidance = (...)
+        state.mark_blocked(...)
+        ...
+        return self._result(...)
+```
+
+No `control.directive.emitted` event is produced for any phase timeout. The
+caller learns about the timeout only through the in-memory/persisted `state`
+object's `last_error` and `run_handoff_status` fields.
+
+## Problem
+
+The three surfaces described above share no control-plane representation:
+
+1. **Three exception types** — `MCPTimeoutError`, `GenerationWatchdogTimeout`,
+   and `asyncio.TimeoutError` (re-raised by the auto pipeline) — carry
+   incompatible fields and are caught at different abstraction levels.
+
+2. **Three cancellation mechanisms** — the MCP layer retries internally then
+   raises; the watchdog cancels the async task then persists a lineage event;
+   the auto pipeline writes to a mutable `state` object and returns early.
+
+3. **No shared signal** — none of the three surfaces emit
+   `control.directive.emitted`. A lineage projector, TUI renderer, or external
+   monitor cannot reconstruct *why* a run stopped from the directive journal
+   alone.
+
+This gap is item 5 of Q00/ouroboros#578, which asks for a unified
+control-plane representation across all timeout surfaces so that consumers can
+treat `control.directive.emitted` as the sole authoritative signal for "a
+runtime decision was made here."
+
+## Proposed contract
+
+All three surfaces must, after exhausting their local retry/cancellation
+logic, emit one `control.directive.emitted` event via
+`create_control_directive_emitted_event` from `src/ouroboros/events/control.py`.
+The `emitted_by` field distinguishes the source surface. The `directive` field
+is determined per-surface as follows.
+
+### Mapping table
+
+| Surface | `emitted_by` | `directive` | Condition |
+|---|---|---|---|
+| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.RETRY` | retry budget > 0 |
+| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.CANCEL` | retry budget exhausted |
+| Watchdog timeout | `"watchdog"` | mapped by `watchdog_timeout_to_directive` (proposed in #836) | budget-dependent |
+| Auto handoff timeout — first occurrence | `"auto.run_handoff"` | `Directive.RETRY` | `run_handoff_status == "unknown_timeout"` and not yet retried |
+| Auto handoff timeout — terminal | `"auto.run_handoff"` | `Directive.CANCEL` | retry exhausted (`unknown_retry_failed`) or deadline enforced |
+
+### MCP tool timeout mapping
+
+`MCPTimeoutError` sets `is_retriable=True`. The adapter in
+`src/ouroboros/orchestrator/mcp_tools.py` already tracks retry iterations.
+After each failed attempt the site emits `Directive.RETRY`; after the final
+exhausted attempt it emits `Directive.CANCEL`. The event target is
+`target_type="execution"` with `execution_id` from the surrounding context.
+
+### Watchdog timeout mapping
+
+`GenerationWatchdogTimeout` is already handled in the `watch()` method of
+`GenerationProgressWatchdog` (`src/ouroboros/evolution/watchdog.py:65–91`).
+Issue #836 proposes a `watchdog_timeout_to_directive` helper that maps
+`timeout_kind` to `Directive.RETRY` (transient; material progress recoverable)
+or `Directive.CANCEL` (safety or idle threshold exceeded). The watchdog site
+calls this helper immediately after its existing `emit_decision()` call and
+appends the corresponding `control.directive.emitted` event. Target:
+`target_type="lineage"`, `target_id=lineage_id`.
+
+### Auto handoff timeout mapping
+
+Phase timeouts in `src/ouroboros/auto/pipeline.py` catch `asyncio.TimeoutError`
+and update mutable `AutoPipelineState`. The proposal requires each
+`except TimeoutError` branch to additionally call
+`create_control_directive_emitted_event` before returning or blocking. The
+`run_handoff_status` value at the catch site determines the directive:
+`"unknown_timeout"` → `Directive.RETRY`; `"unknown_retry_failed"` or a deadline
+enforcement path → `Directive.CANCEL`. Target: `target_type="session"`,
+`target_id=state.session_id`.
+
+## Invariants
+
+**I1 — One directive per timeout decision.** Every timeout that advances or
+terminates a run produces exactly one `control.directive.emitted` event. Retries
+that are invisible to the caller (e.g. internal MCP adapter retries within a
+single call-site invocation) do not each emit a directive; only the
+caller-visible decision point does.
+
+**I2 — `emitted_by` distinguishes source surfaces.** The `emitted_by` string
+uses a two-segment dot notation (`<surface>.<sub-surface>` as shown in the
+mapping table) so projectors and audit tools can filter by origin without
+inspecting `extra`.
+
+**I3 — Terminal vs non-terminal is explicit.** Each emitted directive's
+`is_terminal` property (defined on `Directive` in `src/ouroboros/core/directive.py:99`)
+must match the actual run outcome at that site. `Directive.CANCEL` is terminal;
+`Directive.RETRY` is not. No site may emit a terminal directive and then
+continue executing.
+
+**I4 — The resumer reads the trailing directive.** On session resume, the
+control-plane consumer reads the last `control.directive.emitted` event for the
+relevant target before deciding whether to continue or abort. This links to
+#578 item 4 (resume-path directive consumption). A `CANCEL` directive on resume
+must not restart work; a `RETRY` directive should re-enter the appropriate
+phase.
+
+**I5 — No duplicate emission on retry success.** If a timed-out operation
+succeeds on a subsequent attempt, no `control.directive.emitted` event is
+emitted for that timeout — only for the retry-triggering failure. This keeps
+the directive journal as a decision log, not a full-trace log.
+
+## Migration plan
+
+Migration is phased to keep blast radius small. Each step is additive and
+independently deployable. No flag day required.
+
+### Phase 1 — MCP tool timeout (smallest blast radius)
+
+`MCPTimeoutError` is raised and caught within the orchestrator layer. No
+lineage state is touched on this path. Emit `control.directive.emitted` from
+the catch site in `src/ouroboros/orchestrator/mcp_tools.py` (the
+`timeout_after_retries` log event already signals this is the final decision
+point). Requires passing `execution_id` into the emission context; this context
+is already available via the surrounding tool-invocation frame.
+
+### Phase 2 — Auto handoff timeout
+
+Each `except TimeoutError` branch in `src/ouroboros/auto/pipeline.py`
+already calls `state.mark_blocked()` or returns early — a well-defined decision
+point. Add the `control.directive.emitted` emission immediately before the
+existing state mutation. `state.session_id` is available throughout the
+pipeline.
+
+### Phase 3 — Watchdog timeout (deferred to #836)
+
+`GenerationProgressWatchdog.watch()` already calls `emit_decision()`. Phase 3
+adds the `watchdog_timeout_to_directive` function (proposed in #836) and
+appends the corresponding `control.directive.emitted` call alongside the
+existing lineage event. This phase is deferred because #836 must first settle
+the `timeout_kind → Directive` mapping.
+
+## Non-goals
+
+- **Not replacing per-surface timeout configuration.** `RuntimeControlsConfig`
+  fields (`mcp_tool_timeout_seconds`, `generation_idle_timeout_seconds`, etc.)
+  remain as-is. This RFC does not propose a unified timeout config object.
+
+- **Not replacing existing exception types.** `MCPTimeoutError`,
+  `GenerationWatchdogTimeout`, and `asyncio.TimeoutError` remain. This RFC
+  layers an emission requirement on top; it does not create a new exception
+  hierarchy.
+
+- **Not changing cancellation mechanisms.** The MCP adapter's internal retry
+  loop, the watchdog's `task.cancel()`, and the auto pipeline's early-return
+  pattern are all preserved. The directive emission is observational; it does
+  not change how cancellation propagates.
+
+- **Not introducing a ControlBus or reactive consumer.** Reactive consumption
+  of `control.directive.emitted` is explicitly deferred per the
+  "observational-first" stance documented in `src/ouroboros/events/control.py:43`.
+  This RFC adds emission sites only.
+
+## Open questions
+
+**Q1 — Should phase-internal timeouts (interview, repair) also emit directives?**
+The mapping table covers the run-handoff `TimeoutError` branches explicitly.
+The interview phase (`src/ouroboros/auto/pipeline.py:368`) and repair phase
+(`src/ouroboros/auto/pipeline.py:603`) also catch `TimeoutError` and call
+`state.mark_blocked()`. Should those sites also emit `Directive.CANCEL`, or is
+the run-handoff path sufficient for #578 item 5? The maintainer's answer will
+determine whether Phase 2 covers all `except TimeoutError` branches or only
+the run-handoff branch.
+
+**Q2 — What is the authoritative retry budget for the MCP surface?**
+`MCPTimeoutError.is_retriable=True` signals the error is retriable, but the
+adapter in `src/ouroboros/orchestrator/mcp_tools.py` caps retries at
+`MAX_RETRIES` internally via a `tenacity`-style retry decorator. The
+`Directive.RETRY` emission proposed here should fire once per caller-visible
+retry opportunity. Is `MAX_RETRIES` the right boundary, or should the directive
+budget be configurable independently of the transport-level retry count?

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -264,8 +264,11 @@ reserved for explicit terminal termination: deadline-enforced aborts, explicit
 terminal decisions, and non-resumable failures that must not be resumed on the
 same auto session. Non-terminal `Directive.RETRY` branches must first persist
 and commit, or atomically commit with the directive emission, the retry-pending
-state transition that makes the retry durable. A non-terminal `RETRY` event
-must never become durable without the corresponding durable retry marker. The
+state transition that makes the retry durable. Non-terminal `Directive.WAIT`
+branches must first persist, or atomically persist with the directive emission,
+the blocked-state fields and resume handle that make the wait resumable. A
+non-terminal `RETRY` or `WAIT` event must never become durable without the
+corresponding durable local state it asks the resume path to honor. The
 event target is always `target_type="session"`,
 `target_id=state.auto_session_id`; `extra` should include the current
 `state.phase.value`, the timeout seconds used by the bounded call when
@@ -278,17 +281,25 @@ phase-specific handle fields needed for resume
 Under the current auto resume model, blocked interview, seed generation,
 repair, review, Ralph handoff, Ralph poll, evaluator, and lateral-thinker phase
 timeouts are resumable when the auto session remains blocked with a resume tool
-on the same `auto_session_id`; those sites emit `Directive.WAIT` with
-`extra.phase`, resume tool information, and phase handles needed to resume. The
+on the same `auto_session_id`; those sites emit `Directive.WAIT` only after the blocked
+state, resume tool, and phase handles have been saved or atomically committed
+with the event. The event `extra` repeats `extra.phase`, resume tool
+information, and phase handles needed to resume. The
 run-handoff branch has the only currently defined auto-pipeline timeout
 `Directive.RETRY`: first `"unknown_timeout"` while no retry has been attempted
-emits `Directive.RETRY` and records the durable retry marker. After that, a
+emits `Directive.RETRY` and records the durable retry marker. `run_start_attempted`
+alone is not that marker: it is set before the bounded `run_starter(...)` call
+and can predate a timeout decision. The retry marker is the committed
+transition to `run_handoff_status == "unknown_timeout"` (plus the same
+`auto_session_id`/idempotency-key context), because that transition is the
+state resume readers use to prove the first unknown handoff is retryable. After
+that, a
 retried `"unknown_timeout"` or `"unknown_retry_failed"` emits `Directive.WAIT`
 when the state is blocked awaiting user or upstream resume on the same
 `auto_session_id`; it emits `Directive.CANCEL` only when deadline enforcement
 or another explicit terminal path makes the auto attempt truly terminal. For
 the first `auto.run_handoff` `RETRY`, the persisted
-`run_start_attempted`/`run_handoff_status` transition is the retry-pending
+`run_handoff_status == "unknown_timeout"` transition is the retry-pending
 marker and must be durable before, or atomically with,
 `control.directive.emitted`.
 

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -6,12 +6,13 @@
 
 ## Summary
 
-Three independent timeout surfaces exist today. Each raises its own exception
-and signals cancellation through its own mechanism. None of them emit a
-`control.directive.emitted` event, so the control plane has no unified
-visibility into why a run was interrupted. This RFC proposes a contract that
-maps every timeout surface onto the `Directive` vocabulary and requires each
-site to emit `control.directive.emitted` as the canonical control-plane signal.
+Three independent timeout surfaces exist today. Each raises or returns its own
+timeout representation and signals cancellation through its own mechanism.
+They do not provide a consistent, source-specific `control.directive.emitted`
+signal, so the control plane has no unified visibility into why a run was
+interrupted. This RFC proposes a contract that maps every timeout surface onto
+the `Directive` vocabulary and requires each site to emit
+`control.directive.emitted` as the canonical control-plane signal.
 
 ## Context
 
@@ -21,9 +22,9 @@ site to emit `control.directive.emitted` as the canonical control-plane signal.
 `src/ouroboros/orchestrator/mcp_tools.py`, `src/ouroboros/config/models.py`
 
 `MCPTimeoutError` (defined in `src/ouroboros/mcp/errors.py:170`) is a subclass
-of `MCPClientError` and is raised by the MCP client manager
-(`src/ouroboros/mcp/client/manager.py:460–463`) when an MCP tool call exceeds
-its wall-clock budget. The timeout budget is controlled by
+of `MCPClientError` and is returned as `Result.err(...)` by the MCP client
+manager (`src/ouroboros/mcp/client/manager.py:460–463`) when an MCP tool call
+exceeds its wall-clock budget. The timeout budget is controlled by
 `RuntimeControlsConfig.mcp_tool_timeout_seconds` (default `0`, which disables
 the adapter-level guard):
 
@@ -33,17 +34,20 @@ mcp_tool_timeout_seconds: float = Field(default=0, ge=0)
 ```
 
 `MCPTimeoutError` is marked `is_retriable=True` at construction. The retry
-logic in `src/ouroboros/orchestrator/mcp_tools.py:2156` catches
-`(MCPConnectionError, asyncio.TimeoutError)` and re-attempts up to `MAX_RETRIES`
-times before emitting the structured log event
-`orchestrator.mcp_tools.timeout_after_retries` and raising a non-retriable
-`MCPClientError`. No `control.directive.emitted` event is produced.
+logic in `src/ouroboros/orchestrator/mcp_tools.py:2156` catches raised
+`(MCPConnectionError, asyncio.TimeoutError)` exceptions and re-attempts up to
+`MAX_RETRIES` times before emitting the structured log event
+`orchestrator.mcp_tools.timeout_after_retries` and returning a non-retriable
+tool error. Manager-originated `MCPTimeoutError` values currently bypass that
+exception retry path because they are returned as `Result.err(...)`; the
+orchestrator converts them through its generic `call_failed` path. No
+`control.directive.emitted` event is produced.
 
 ### Surface 2 — Generation watchdog timeout
 
 **Files:** `src/ouroboros/evolution/watchdog.py`, `src/ouroboros/config/models.py`
 
-`GenerationWatchdogTimeout` (defined in `src/ouroboros/evolution/watchdog.py:24`)
+`GenerationWatchdogTimeout` (defined in `src/ouroboros/evolution/watchdog.py:65`)
 is raised by `GenerationProgressWatchdog._raise_if_threshold_exceeded` when one
 of three thresholds is breached:
 
@@ -56,7 +60,10 @@ of three thresholds is breached:
 When raised, the watchdog calls `emit_decision(action="timeout", ...)` which
 persists a `lineage.generation.watchdog_decision` event via the `EventStore`.
 This is a lineage-scoped event, not a `control.directive.emitted` event, so it
-does not appear in the control-plane directive stream.
+does not appear in the control-plane directive stream. One caller path,
+`evolve_step`, can later convert the failed step into a generic
+`control.directive.emitted` event with `emitted_by="evolver"`; that does not
+identify the watchdog timeout as the source surface.
 
 ### Surface 3 — Auto-run handoff timeout
 
@@ -66,8 +73,9 @@ The auto pipeline coordinates interview, seed generation, repair, review, and
 run handoff phases. Each phase runs under a `TimeoutError`-bounded `asyncio`
 call. The run-start phase is the most nuanced: a first `TimeoutError` sets
 `run_handoff_status = "unknown_timeout"` and schedules one retry; a second
-`TimeoutError` on the retry marks `run_handoff_status = "unknown_retry_failed"`
-and blocks further attempts:
+`TimeoutError` on the retry leaves the status as `"unknown_timeout"` and blocks
+further attempts. The `"unknown_retry_failed"` status is used by the non-timeout
+exception path on the retry:
 
 ```python
 # src/ouroboros/auto/pipeline.py:801–814
@@ -98,10 +106,10 @@ The three surfaces described above share no control-plane representation:
    raises; the watchdog cancels the async task then persists a lineage event;
    the auto pipeline writes to a mutable `state` object and returns early.
 
-3. **No shared signal** — none of the three surfaces emit
-   `control.directive.emitted`. A lineage projector, TUI renderer, or external
-   monitor cannot reconstruct *why* a run stopped from the directive journal
-   alone.
+3. **No shared source-specific signal** — these timeout surfaces do not emit a
+   consistent `control.directive.emitted` event at the timeout decision point. A
+   lineage projector, TUI renderer, or external monitor cannot reconstruct
+   *why* a run stopped from the directive journal alone.
 
 This gap is item 5 of Q00/ouroboros#578, which asks for a unified
 control-plane representation across all timeout surfaces so that consumers can
@@ -124,15 +132,18 @@ is determined per-surface as follows.
 | MCP tool timeout | `"mcp.tool_timeout"` | `Directive.CANCEL` | retry budget exhausted |
 | Watchdog timeout | `"watchdog"` | mapped by `watchdog_timeout_to_directive` (proposed in #836) | budget-dependent |
 | Auto handoff timeout — first occurrence | `"auto.run_handoff"` | `Directive.RETRY` | `run_handoff_status == "unknown_timeout"` and not yet retried |
-| Auto handoff timeout — terminal | `"auto.run_handoff"` | `Directive.CANCEL` | retry exhausted (`unknown_retry_failed`) or deadline enforced |
+| Auto handoff timeout — terminal | `"auto.run_handoff"` | `Directive.CANCEL` | retry exhausted while still `unknown_timeout`, retry failed with `unknown_retry_failed`, or deadline enforced |
 
 ### MCP tool timeout mapping
 
 `MCPTimeoutError` sets `is_retriable=True`. The adapter in
-`src/ouroboros/orchestrator/mcp_tools.py` already tracks retry iterations.
-After each failed attempt the site emits `Directive.RETRY`; after the final
-exhausted attempt it emits `Directive.CANCEL`. The event target is
-`target_type="execution"` with `execution_id` from the surrounding context.
+`src/ouroboros/orchestrator/mcp_tools.py` already tracks retry iterations for
+raised retryable exceptions, but manager-originated timeouts are currently
+returned as `Result.err(MCPTimeoutError)` and must either be lifted into the
+retry path or handled explicitly at the `Result.err` decision point. A
+caller-visible retry decision emits `Directive.RETRY`; an exhausted retry budget
+emits `Directive.CANCEL`. The event target is `target_type="execution"` with
+`execution_id` from the surrounding context.
 
 ### Watchdog timeout mapping
 
@@ -151,10 +162,11 @@ Phase timeouts in `src/ouroboros/auto/pipeline.py` catch `asyncio.TimeoutError`
 and update mutable `AutoPipelineState`. The proposal requires each
 `except TimeoutError` branch to additionally call
 `create_control_directive_emitted_event` before returning or blocking. The
-`run_handoff_status` value at the catch site determines the directive:
-`"unknown_timeout"` → `Directive.RETRY`; `"unknown_retry_failed"` or a deadline
-enforcement path → `Directive.CANCEL`. Target: `target_type="session"`,
-`target_id=state.session_id`.
+`run_handoff_status` value and retry context at the catch site determine the
+directive: first `"unknown_timeout"` → `Directive.RETRY`; retried
+`"unknown_timeout"`, `"unknown_retry_failed"`, or a deadline enforcement path →
+`Directive.CANCEL`. Target: `target_type="session"`,
+`target_id=state.auto_session_id`.
 
 ## Invariants
 
@@ -183,9 +195,10 @@ must not restart work; a `RETRY` directive should re-enter the appropriate
 phase.
 
 **I5 — No duplicate emission on retry success.** If a timed-out operation
-succeeds on a subsequent attempt, no `control.directive.emitted` event is
-emitted for that timeout — only for the retry-triggering failure. This keeps
-the directive journal as a decision log, not a full-trace log.
+succeeds on a subsequent attempt, no additional
+`control.directive.emitted` event is emitted for the success — only the
+retry-triggering timeout decision is recorded. This keeps the directive journal
+as a decision log, not a full-trace log.
 
 ## Migration plan
 
@@ -194,19 +207,20 @@ independently deployable. No flag day required.
 
 ### Phase 1 — MCP tool timeout (smallest blast radius)
 
-`MCPTimeoutError` is raised and caught within the orchestrator layer. No
-lineage state is touched on this path. Emit `control.directive.emitted` from
-the catch site in `src/ouroboros/orchestrator/mcp_tools.py` (the
-`timeout_after_retries` log event already signals this is the final decision
-point). Requires passing `execution_id` into the emission context; this context
-is already available via the surrounding tool-invocation frame.
+`MCPTimeoutError` is produced by the manager and consumed within the
+orchestrator layer. No lineage state is touched on this path. First decide
+whether manager timeouts should be raised into `retry_async` or handled from the
+returned `Result.err(MCPTimeoutError)` value; emit `control.directive.emitted`
+from that caller-visible decision site. Requires passing `execution_id` into
+the emission context; this context is already available via the surrounding
+tool-invocation frame.
 
 ### Phase 2 — Auto handoff timeout
 
 Each `except TimeoutError` branch in `src/ouroboros/auto/pipeline.py`
 already calls `state.mark_blocked()` or returns early — a well-defined decision
 point. Add the `control.directive.emitted` emission immediately before the
-existing state mutation. `state.session_id` is available throughout the
+existing state mutation. `state.auto_session_id` is available throughout the
 pipeline.
 
 ### Phase 3 — Watchdog timeout (deferred to #836)
@@ -240,19 +254,24 @@ the `timeout_kind → Directive` mapping.
 
 ## Open questions
 
-**Q1 — Should phase-internal timeouts (interview, repair) also emit directives?**
+**Q1 — Should phase-internal timeouts also emit directives?**
 The mapping table covers the run-handoff `TimeoutError` branches explicitly.
-The interview phase (`src/ouroboros/auto/pipeline.py:368`) and repair phase
-(`src/ouroboros/auto/pipeline.py:603`) also catch `TimeoutError` and call
-`state.mark_blocked()`. Should those sites also emit `Directive.CANCEL`, or is
-the run-handoff path sufficient for #578 item 5? The maintainer's answer will
-determine whether Phase 2 covers all `except TimeoutError` branches or only
-the run-handoff branch.
+The interview phase (`src/ouroboros/auto/pipeline.py:368`), seed-generation
+phase (`src/ouroboros/auto/pipeline.py:455`), repair phase
+(`src/ouroboros/auto/pipeline.py:603`), review phase
+(`src/ouroboros/auto/pipeline.py:700`), and later Ralph/evaluate/unstuck/poll
+helpers also catch `TimeoutError` and call `state.mark_blocked()` or return
+early. Should those sites also emit `Directive.CANCEL`, or is the run-handoff
+path sufficient for #578 item 5? The maintainer's answer will determine
+whether Phase 2 covers all `except TimeoutError` branches or only the
+run-handoff branch.
 
 **Q2 — What is the authoritative retry budget for the MCP surface?**
 `MCPTimeoutError.is_retriable=True` signals the error is retriable, but the
 adapter in `src/ouroboros/orchestrator/mcp_tools.py` caps retries at
-`MAX_RETRIES` internally via a `tenacity`-style retry decorator. The
-`Directive.RETRY` emission proposed here should fire once per caller-visible
-retry opportunity. Is `MAX_RETRIES` the right boundary, or should the directive
-budget be configurable independently of the transport-level retry count?
+`MAX_RETRIES` internally via the local `retry_async` helper for raised
+exceptions. Manager-originated `Result.err(MCPTimeoutError)` values do not
+currently consume that retry budget. The `Directive.RETRY` emission proposed
+here should fire once per caller-visible retry opportunity. Is `MAX_RETRIES`
+the right boundary, or should the directive budget be configurable
+independently of the transport-level retry count?

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -11,8 +11,9 @@ timeout representation and signals cancellation through its own mechanism.
 They do not provide a consistent, source-specific `control.directive.emitted`
 signal, so the control plane has no unified visibility into why a run was
 interrupted. This RFC proposes a contract that maps every timeout surface onto
-the `Directive` vocabulary and requires each site to emit
-`control.directive.emitted` as the canonical control-plane signal.
+the `Directive` vocabulary and, once that surface's target plumbing is
+migrated, requires each site to emit `control.directive.emitted` as the
+canonical control-plane signal.
 
 ## Context
 
@@ -121,18 +122,29 @@ runtime decision was made here."
 
 ## Proposed contract
 
-All three surfaces must emit `control.directive.emitted` via
-`create_control_directive_emitted_event` from `src/ouroboros/events/control.py`
-at the local timeout decision point. The event is the sole authoritative
-control-plane signal that a timeout caused a retry, block, cancellation, or
-early return. Existing exception types, state mutation, and lineage events
-remain as local implementation details; consumers should derive timeout control
-decisions from the directive journal, with non-terminal retry actionability
-resolved against the owning surface's persisted retry-pending state as defined
-in I4.
+In the completed migration state, all three surfaces must emit
+`control.directive.emitted` via `create_control_directive_emitted_event` from
+`src/ouroboros/events/control.py` at the local timeout decision point. The event
+is the sole authoritative control-plane signal that a migrated timeout decision
+caused a retry, block, cancellation, or early return. A migration phase is not
+complete for a surface until every covered decision site has both the local
+timeout decision and the durable control target needed to emit that directive;
+unplumbed sites remain explicitly outside that phase's completed coverage rather
+than silently violating I1. Existing exception types, state mutation, and
+lineage events remain as local implementation details; consumers should derive
+timeout control decisions from the directive journal for migrated sites, with
+non-terminal retry actionability resolved against the owning surface's persisted
+retry-pending state as defined in I4.
 
 The `emitted_by` field distinguishes the source surface. The `directive` field
 is determined per-surface as follows.
+
+Target types follow `CANONICAL_CONTROL_TARGET_TYPES` where an existing durable
+target has the right resume semantics (`session`, `execution`, `lineage`,
+`agent_process`, `contract`, `execution_node`). This RFC also introduces the
+additive `lineage_generation` target for generation-local watchdog decisions;
+`ControlContract.target_type` is advisory rather than closed, so additive Agent
+OS targets may be documented without changing stored event schemas.
 
 ### Mapping table
 
@@ -175,10 +187,12 @@ canonical MCP timeout directive target is execution-scoped:
 `target_type="execution"`, `target_id=execution_id`, and
 `execution_id=execution_id`. Phase 1 must plumb this execution/control target
 context through both `MCPToolProvider.call_tool(...)` and `_call_with_retry(...)`
-before any MCP timeout directive can be emitted. If a call site cannot provide
-`execution_id`, that site must not emit `control.directive.emitted` for MCP
-timeouts until the missing plumbing exists; it must continue using the local
-terminal tool error path only. There is no alternate MCP timeout target.
+before the MCP surface is considered migrated. If a call site cannot provide
+`execution_id`, Phase 1 is incomplete for that call site and it must continue
+using the local terminal tool error path only; implementations must not claim
+unified MCP timeout coverage until all caller-visible MCP timeout decisions in
+scope have the execution target plumbing. There is no alternate MCP timeout
+target.
 
 ### Watchdog timeout mapping
 
@@ -199,9 +213,13 @@ maps `timeout_kind` directly to `Directive.RETRY` or `Directive.CANCEL`. If
 `step_action_to_directive(...)` with the same retry budget the evolution loop
 would use, or accept the already-computed directive from the loop. The watchdog
 event appends `control.directive.emitted` with
-`emitted_by="generation.watchdog"`, `target_type="lineage"`,
-`target_id=lineage_id`, and `extra` including `timeout_kind`, thresholds, and
-the watchdog decision metadata needed for audit.
+`emitted_by="generation.watchdog"` on a generation-scoped target:
+`target_type="lineage_generation"`,
+`target_id=f"{lineage_id}:{generation_number}"`, `lineage_id=lineage_id`, and
+`generation_number=generation_number`. `extra` includes `timeout_kind`,
+thresholds, and the watchdog decision metadata needed for audit. This target is
+generation-local even when the directive is terminal; a watchdog `CANCEL` bricks
+only that failed generation attempt, not the whole lineage chain.
 
 The watchdog source owns source-specific directive identity for
 `GenerationWatchdogTimeout` instances raised by `GenerationProgressWatchdog`,
@@ -286,8 +304,9 @@ must match the actual run outcome at that site. `Directive.CANCEL` is terminal;
 `Directive.RETRY` and `Directive.WAIT` are not. No site may emit a terminal
 directive and then continue executing or resume the same target. A terminal
 `Directive.CANCEL` must brick only the target it truly terminates: an
-execution-scoped MCP timeout cancels that execution target, a lineage-scoped
-watchdog terminal outcome cancels that lineage/generation target, and a
+execution-scoped MCP timeout cancels that execution target, a
+generation-scoped watchdog terminal outcome cancels only the
+`lineage_generation` target for that `lineage_id`/`generation_number`, and a
 session-scoped auto `CANCEL` is valid only when the auto session is truly
 terminal, deadline-enforced, or non-resumable.
 
@@ -393,9 +412,10 @@ must also make `emit_decision(...)` return or preserve the persisted
 `lineage.generation.watchdog_decision` event id, or an equivalent stable
 idempotency key, attach it to `GenerationWatchdogTimeout` before re-raise, and
 derive the `generation.watchdog` directive `idempotency_key` from that stable
-decision id plus lineage/generation/timeout kind. `evolve_step` and generic
-evolver emission must check the propagated key and skip generic emission for
-the same watchdog decision.
+decision id plus `lineage_id`, `generation_number`, and `timeout_kind` on the
+`lineage_generation` target. `evolve_step` and generic evolver emission must
+check the propagated key and skip generic emission for the same watchdog
+decision.
 
 ## Non-goals
 

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -69,9 +69,10 @@ identify the watchdog timeout as the source surface.
 
 **Files:** `src/ouroboros/auto/pipeline.py`, `src/ouroboros/config/models.py`
 
-The auto pipeline coordinates interview, seed generation, repair, review, and
-run handoff phases. Each phase runs under a `TimeoutError`-bounded `asyncio`
-call. The run-start phase is the most nuanced: a first `TimeoutError` sets
+The auto pipeline coordinates interview, seed generation, repair, review, run
+handoff, Ralph handoff/poll, evaluator, and lateral-thinker phases. Each
+long-running phase runs under a `TimeoutError`-bounded `asyncio` call. The
+run-start phase is the most nuanced: a first `TimeoutError` sets
 `run_handoff_status = "unknown_timeout"` and schedules one retry; a second
 `TimeoutError` on the retry leaves the status as `"unknown_timeout"` and blocks
 further attempts. The `"unknown_retry_failed"` status is used by the non-timeout
@@ -92,7 +93,7 @@ except TimeoutError as exc:
 
 No `control.directive.emitted` event is produced for any phase timeout. The
 caller learns about the timeout only through the in-memory/persisted `state`
-object's `last_error` and `run_handoff_status` fields.
+object's `last_error`, phase, resume tool, and run/Ralph handoff fields.
 
 ## Problem
 
@@ -118,9 +119,14 @@ runtime decision was made here."
 
 ## Proposed contract
 
-All three surfaces must, after exhausting their local retry/cancellation
-logic, emit one `control.directive.emitted` event via
-`create_control_directive_emitted_event` from `src/ouroboros/events/control.py`.
+All three surfaces must emit `control.directive.emitted` via
+`create_control_directive_emitted_event` from `src/ouroboros/events/control.py`
+at the local timeout decision point. The event is the sole authoritative
+control-plane signal that a timeout caused a retry, block, cancellation, or
+early return. Existing exception types, state mutation, and lineage events
+remain as local implementation details; consumers should derive timeout control
+state from the directive journal.
+
 The `emitted_by` field distinguishes the source surface. The `directive` field
 is determined per-surface as follows.
 
@@ -128,22 +134,39 @@ is determined per-surface as follows.
 
 | Surface | `emitted_by` | `directive` | Condition |
 |---|---|---|---|
-| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.RETRY` | retry budget > 0 |
-| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.CANCEL` | retry budget exhausted |
-| Watchdog timeout | `"watchdog"` | mapped by `watchdog_timeout_to_directive` (proposed in #836) | budget-dependent |
+| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.RETRY` | adapter exposes caller-visible retry with `MAX_RETRIES` budget remaining |
+| MCP tool timeout | `"mcp.tool_timeout"` | `Directive.CANCEL` | `MAX_RETRIES` budget exhausted and terminal tool error returned |
+| Watchdog timeout | `"generation.watchdog"` | mapped by `watchdog_timeout_to_directive` (proposed in #836) | budget-dependent |
+| Auto interview timeout | `"auto.interview"` | `Directive.CANCEL` | `interview_driver.run(...)` times out and the pipeline marks blocked or returns early |
+| Auto seed-generation timeout | `"auto.seed_generation"` | `Directive.CANCEL` | `seed_generator(...)` times out and the pipeline marks blocked or returns early |
+| Auto repair timeout | `"auto.repair"` | `Directive.CANCEL` | `repairer.converge(...)` times out and the pipeline marks blocked or returns early |
+| Auto review timeout | `"auto.review"` | `Directive.CANCEL` | `reviewer.review(...)` times out and the pipeline marks blocked or returns early |
 | Auto handoff timeout — first occurrence | `"auto.run_handoff"` | `Directive.RETRY` | `run_handoff_status == "unknown_timeout"` and not yet retried |
 | Auto handoff timeout — terminal | `"auto.run_handoff"` | `Directive.CANCEL` | retry exhausted while still `unknown_timeout`, retry failed with `unknown_retry_failed`, or deadline enforced |
+| Auto Ralph handoff timeout | `"auto.ralph_handoff"` | `Directive.CANCEL` | `ralph_starter(...)` times out and the pipeline marks blocked or returns early |
+| Auto Ralph poll timeout | `"auto.ralph_poll"` | `Directive.CANCEL` | `ralph_resumer(...)` times out and the pipeline marks blocked or returns early |
+| Auto evaluator timeout | `"auto.evaluate"` | `Directive.CANCEL` | `evaluator(...)` times out and the pipeline marks blocked or returns early |
+| Auto lateral-thinker timeout | `"auto.lateral"` | `Directive.CANCEL` | `lateral_thinker(...)` times out and the pipeline marks blocked or returns early |
 
 ### MCP tool timeout mapping
 
-`MCPTimeoutError` sets `is_retriable=True`. The adapter in
-`src/ouroboros/orchestrator/mcp_tools.py` already tracks retry iterations for
-raised retryable exceptions, but manager-originated timeouts are currently
-returned as `Result.err(MCPTimeoutError)` and must either be lifted into the
-retry path or handled explicitly at the `Result.err` decision point. A
-caller-visible retry decision emits `Directive.RETRY`; an exhausted retry budget
-emits `Directive.CANCEL`. The event target is `target_type="execution"` with
-`execution_id` from the surrounding context.
+`MCPTimeoutError` sets `is_retriable=True`. The authoritative retry budget for
+MCP timeout directives is the adapter retry envelope in
+`src/ouroboros/orchestrator/mcp_tools.py`: `MAX_RETRIES` and the surrounding
+`retry_async(..., attempts=MAX_RETRIES)` policy. This budget applies to both
+raised timeout paths (`asyncio.TimeoutError` caught by `retry_async`) and
+manager-originated `Result.err(MCPTimeoutError)` values. The manager path must
+be lifted into the same envelope or explicitly consume the same counter at the
+`Result.err` decision point; it must not define a second retry budget.
+
+`Directive.RETRY` is emitted only when the adapter exposes a caller-visible
+retry decision before the terminal result, with retry budget remaining under
+that envelope. Internal retry attempts hidden inside a single tool invocation
+do not each emit. `Directive.CANCEL` is emitted when the same budget is
+exhausted and the adapter returns the terminal non-retriable tool error, such
+as the existing `orchestrator.mcp_tools.timeout_after_retries` path. The event
+target is `target_type="execution"` with `execution_id` from the surrounding
+context.
 
 ### Watchdog timeout mapping
 
@@ -153,20 +176,32 @@ Issue #836 proposes a `watchdog_timeout_to_directive` helper that maps
 `timeout_kind` to `Directive.RETRY` (transient; material progress recoverable)
 or `Directive.CANCEL` (safety or idle threshold exceeded). The watchdog site
 calls this helper immediately after its existing `emit_decision()` call and
-appends the corresponding `control.directive.emitted` event. Target:
-`target_type="lineage"`, `target_id=lineage_id`.
+appends the corresponding `control.directive.emitted` event with
+`emitted_by="generation.watchdog"`. Target: `target_type="lineage"`,
+`target_id=lineage_id`.
 
-### Auto handoff timeout mapping
+### Auto pipeline timeout mapping
 
 Phase timeouts in `src/ouroboros/auto/pipeline.py` catch `asyncio.TimeoutError`
-and update mutable `AutoPipelineState`. The proposal requires each
-`except TimeoutError` branch to additionally call
-`create_control_directive_emitted_event` before returning or blocking. The
-`run_handoff_status` value and retry context at the catch site determine the
-directive: first `"unknown_timeout"` → `Directive.RETRY`; retried
-`"unknown_timeout"`, `"unknown_retry_failed"`, or a deadline enforcement path →
-`Directive.CANCEL`. Target: `target_type="session"`,
-`target_id=state.auto_session_id`.
+and update mutable `AutoPipelineState`. Every auto-pipeline `except
+TimeoutError` branch that marks the state blocked, enforces the pipeline
+deadline, or returns early must emit exactly one source-specific
+`control.directive.emitted` event before the state mutation or immediately
+before the early return. The event target is always `target_type="session"`,
+`target_id=state.auto_session_id`; `extra` should include the current
+`state.phase.value`, the timeout seconds used by the bounded call when
+available, `state.last_tool_name` or the tool name being marked, and any
+phase-specific handle fields needed for resume (`run_handoff_status`,
+`ralph_job_id`, `ralph_lineage_id`, `ralph_dispatch_mode`).
+
+Most auto-pipeline timeout branches are terminal for the current auto attempt:
+interview, seed generation, repair, review, Ralph handoff, Ralph poll,
+evaluator, and lateral-thinker timeouts emit `Directive.CANCEL` when they block
+or return early. The run-handoff branch is the only currently defined
+auto-pipeline timeout branch with a non-terminal retry directive: first
+`"unknown_timeout"` while no retry has been attempted emits `Directive.RETRY`;
+retried `"unknown_timeout"`, `"unknown_retry_failed"`, or a deadline
+enforcement path emits `Directive.CANCEL`.
 
 ## Invariants
 
@@ -217,11 +252,21 @@ tool-invocation frame.
 
 ### Phase 2 — Auto handoff timeout
 
-Each `except TimeoutError` branch in `src/ouroboros/auto/pipeline.py`
-already calls `state.mark_blocked()` or returns early — a well-defined decision
-point. Add the `control.directive.emitted` emission immediately before the
-existing state mutation. `state.auto_session_id` is available throughout the
+Implement the run-handoff branch first because it already has a bounded retry
+state machine (`run_handoff_status`, `run_start_attempted`, and
+`run_handoff_guidance`) and is the narrowest auto-pipeline change. Add the
+`control.directive.emitted` emission immediately before the existing state
+mutation or early return. `state.auto_session_id` is available throughout the
 pipeline.
+
+### Phase 2b — Remaining auto-pipeline timeout branches
+
+Extend the same auto-pipeline helper to every other `except TimeoutError`
+branch that marks blocked or returns early: interview, seed generation, repair,
+review, Ralph handoff, Ralph poll, evaluator, and lateral thinker. This phase
+is still additive and small-blast-radius because it changes only emission at
+existing timeout decision points; it does not alter phase ordering, retry
+counts, state transitions, or resume behavior.
 
 ### Phase 3 — Watchdog timeout (deferred to #836)
 
@@ -254,24 +299,6 @@ the `timeout_kind → Directive` mapping.
 
 ## Open questions
 
-**Q1 — Should phase-internal timeouts also emit directives?**
-The mapping table covers the run-handoff `TimeoutError` branches explicitly.
-The interview phase (`src/ouroboros/auto/pipeline.py:368`), seed-generation
-phase (`src/ouroboros/auto/pipeline.py:455`), repair phase
-(`src/ouroboros/auto/pipeline.py:603`), review phase
-(`src/ouroboros/auto/pipeline.py:700`), and later Ralph/evaluate/unstuck/poll
-helpers also catch `TimeoutError` and call `state.mark_blocked()` or return
-early. Should those sites also emit `Directive.CANCEL`, or is the run-handoff
-path sufficient for #578 item 5? The maintainer's answer will determine
-whether Phase 2 covers all `except TimeoutError` branches or only the
-run-handoff branch.
-
-**Q2 — What is the authoritative retry budget for the MCP surface?**
-`MCPTimeoutError.is_retriable=True` signals the error is retriable, but the
-adapter in `src/ouroboros/orchestrator/mcp_tools.py` caps retries at
-`MAX_RETRIES` internally via the local `retry_async` helper for raised
-exceptions. Manager-originated `Result.err(MCPTimeoutError)` values do not
-currently consume that retry budget. The `Directive.RETRY` emission proposed
-here should fire once per caller-visible retry opportunity. Is `MAX_RETRIES`
-the right boundary, or should the directive budget be configurable
-independently of the transport-level retry count?
+None. This RFC intentionally makes the auto-pipeline timeout coverage and MCP
+retry-budget authority decisive. Future implementation PRs may choose helper
+names and wiring details, but not different directive semantics.

--- a/docs/rfc/runtime-timeout-contract.md
+++ b/docs/rfc/runtime-timeout-contract.md
@@ -125,7 +125,9 @@ at the local timeout decision point. The event is the sole authoritative
 control-plane signal that a timeout caused a retry, block, cancellation, or
 early return. Existing exception types, state mutation, and lineage events
 remain as local implementation details; consumers should derive timeout control
-state from the directive journal.
+decisions from the directive journal, with non-terminal retry actionability
+resolved against the owning surface's persisted retry-pending state as defined
+in I4.
 
 The `emitted_by` field distinguishes the source surface. The `directive` field
 is determined per-surface as follows.
@@ -180,6 +182,19 @@ appends the corresponding `control.directive.emitted` event with
 `emitted_by="generation.watchdog"`. Target: `target_type="lineage"`,
 `target_id=lineage_id`.
 
+The watchdog owns directive emission for `GenerationWatchdogTimeout` instances
+raised by `GenerationProgressWatchdog`. A caller that catches the bubbled
+exception, including the current `evolve_step` path that can emit a generic
+`emitted_by="evolver"` directive, must not emit a second directive for the same
+watchdog timeout. The deduplication key is the timeout decision identity:
+`target_type`, `target_id`, timeout source (`GenerationWatchdogTimeout` /
+`generation.watchdog`), `timeout_kind`, and the triggering watchdog decision
+event or timestamp recorded with the existing lineage watchdog decision. If a
+source-specific `generation.watchdog` directive exists for that key, the
+generic evolver timeout directive is suppressed or replaced. A generic evolver
+timeout directive is allowed only when no source-specific timeout directive
+already exists for the same timeout decision.
+
 ### Auto pipeline timeout mapping
 
 Phase timeouts in `src/ouroboros/auto/pipeline.py` catch `asyncio.TimeoutError`
@@ -222,18 +237,26 @@ must match the actual run outcome at that site. `Directive.CANCEL` is terminal;
 `Directive.RETRY` is not. No site may emit a terminal directive and then
 continue executing.
 
-**I4 — The resumer reads the trailing directive.** On session resume, the
-control-plane consumer reads the last `control.directive.emitted` event for the
-relevant target before deciding whether to continue or abort. This links to
-#578 item 4 (resume-path directive consumption). A `CANCEL` directive on resume
-must not restart work; a `RETRY` directive should re-enter the appropriate
-phase.
+**I4 — Resume combines the trailing directive with local state.** On session
+resume, the control-plane consumer reads the last `control.directive.emitted`
+event for the relevant target before deciding whether to continue or abort.
+This links to #578 item 4 (resume-path directive consumption). A terminal
+`CANCEL` directive on resume is authoritative and must not restart work. A
+non-terminal `RETRY` directive is actionable only while the corresponding
+persisted local retry-pending state or token still indicates that the retry is
+pending; if the owning surface has since succeeded or transitioned state, that
+local state supersedes the stale trailing `RETRY` without requiring a success
+directive.
 
-**I5 — No duplicate emission on retry success.** If a timed-out operation
-succeeds on a subsequent attempt, no additional
-`control.directive.emitted` event is emitted for the success — only the
-retry-triggering timeout decision is recorded. This keeps the directive journal
-as a decision log, not a full-trace log.
+**I5 — Retry success clears actionability without success spam.** If a
+timed-out operation succeeds on a subsequent attempt, no additional
+`control.directive.emitted` event is emitted for the success. The owning
+surface instead clears or updates its persisted retry-pending state or token as
+part of the normal success/state transition. The earlier `RETRY` remains in the
+directive journal as the recorded timeout decision, but it is no longer
+actionable on resume once local state shows that the retry has completed or the
+operation has moved to a later state. This keeps the directive journal as a
+decision log, not a full-trace log.
 
 ## Migration plan
 


### PR DESCRIPTION
## Summary

- Adds `docs/rfc/runtime-timeout-contract.md` (Draft RFC, item 5 of #578)
- Documents the three current timeout surfaces: `MCPTimeoutError` (`src/ouroboros/mcp/errors.py`), `GenerationWatchdogTimeout` (`src/ouroboros/evolution/watchdog.py`), and `asyncio.TimeoutError` in the auto pipeline (`src/ouroboros/auto/pipeline.py`)
- Proposes mapping all three onto the `Directive` vocabulary via `control.directive.emitted`, with `emitted_by` distinguishing each surface

## Why

None of the three timeout surfaces currently emit `control.directive.emitted`. A lineage projector or TUI renderer cannot reconstruct why a run stopped from the directive journal alone. This RFC establishes the contract so implementation PRs have a shared specification to target.

## Decision required from maintainer

1. **Q1**: Should phase-internal timeouts (interview at `pipeline.py:368`, repair at `pipeline.py:603`) also emit `Directive.CANCEL`, or is the run-handoff surface sufficient for #578 item 5?
2. **Q2**: Is `MAX_RETRIES` in `mcp_tools.py` the right retry-budget boundary for the `Directive.RETRY` → `Directive.CANCEL` transition on the MCP surface, or should that be independently configurable?

## Out of scope

- No code changes; this is a documentation-only PR
- Does not replace exception types, cancellation mechanisms, or per-surface timeout config
- Does not introduce a ControlBus or reactive consumer (deferred per `events/control.py` observational-first stance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)