### PR TITLE
feat(evolution): pin v0 watchdog cancellation contract (#578)

### DIFF
--- a/docs/contributing/watchdog-cancellation.md
+++ b/docs/contributing/watchdog-cancellation.md
@@ -1,0 +1,58 @@
+# Watchdog Cancellation Contract
+
+This document records the v0 cancellation contract for
+`GenerationProgressWatchdog.watch()` and explains what would need to change
+to introduce two-stage escalation in the future.
+
+## v0 Contract: `cooperative_direct_one_stage`
+
+The constant `WATCHDOG_CANCELLATION_MODE = "cooperative_direct_one_stage"` in
+`src/ouroboros/evolution/watchdog.py` names the current behavior:
+
+| Term          | Meaning                                                                                      |
+|---------------|----------------------------------------------------------------------------------------------|
+| Cooperative   | The inner task receives a `CancelledError` and may run cleanup in its `except` block.        |
+| Direct        | The watchdog holds the `asyncio.Task` handle and calls `task.cancel()` inline — no `AgentProcess` intermediary. |
+| One-stage     | A single cancel is issued. There is no SIGTERM-then-SIGKILL style escalation sequence.       |
+
+### Sequence (on threshold exceeded)
+
+1. `_raise_if_threshold_exceeded()` raises `GenerationWatchdogTimeout`.
+2. `watch()` catches it, calls `task.cancel()`.
+3. `await task` is called inside `except asyncio.CancelledError: pass` so the
+   inner coroutine can run its own cleanup before the watchdog continues.
+4. `emit_decision()` persists a `lineage.generation.watchdog_decision` event
+   with `details["cancellation_mode"] == "cooperative_direct_one_stage"`.
+5. The `GenerationWatchdogTimeout` is re-raised to the caller.
+
+### Why not two-stage?
+
+Two-stage escalation (soft cancel → grace period → hard cancel) adds
+complexity that is not yet justified:
+
+- Ouroboros generations run inside asyncio tasks, not OS processes, so there
+  is no OS-level signal boundary to cross.
+- The cooperative `CancelledError` already gives the inner task a chance to
+  flush state via standard Python `try/finally` or `except CancelledError`.
+- No production incident or performance data has shown that the current
+  approach leaves tasks in a bad state.
+
+## Future: Introducing Two-Stage Escalation
+
+If a future use case requires a grace period before hard cancellation (e.g.
+because a generation holds an external resource that needs flushing), the
+implementation change would be:
+
+1. Issue a soft-cancel signal (e.g. set a threading `Event` or push to a
+   `Queue` the inner task monitors).
+2. `await asyncio.wait({task}, timeout=grace_period_seconds)`.
+3. If the task has not finished, call `task.cancel()` (hard cancel).
+4. Update `WATCHDOG_CANCELLATION_MODE` to `"cooperative_soft_then_hard"` (or
+   a more descriptive name).
+5. Update this document and add a migration note in `CHANGELOG.md`.
+6. Update `test_no_material_progress_timeout_emits_cancellation_mode` to
+   assert the new mode value.
+
+The `WATCHDOG_CANCELLATION_MODE` constant is the single source of truth.
+Downstream projectors that branch on cancellation mode should compare against
+the constant, not a hardcoded string.

--- a/src/ouroboros/evolution/watchdog.py
+++ b/src/ouroboros/evolution/watchdog.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Awaitable
 from dataclasses import dataclass, field
 import time
-from typing import Any
+from typing import Any, Final
 
 from ouroboros.config.models import RuntimeControlsConfig
 from ouroboros.core.errors import OuroborosError
@@ -20,6 +20,10 @@ from ouroboros.evolution.material_progress import (
 )
 from ouroboros.persistence.event_store import EventStore
 
+#: v0 cancellation contract (see docs/contributing/watchdog-cancellation.md).
+#: Kept as a named constant so projectors and tests can assert the mode without
+#: hardcoding the string.
+WATCHDOG_CANCELLATION_MODE: Final[str] = "cooperative_direct_one_stage"
 
 class GenerationWatchdogTimeout(OuroborosError):
     """Raised when a generation watchdog threshold is exceeded."""
@@ -80,7 +84,34 @@ class GenerationProgressWatchdog:
     _baseline_initialized: bool = False
 
     async def watch[T](self, awaitable: Awaitable[T]) -> T:
-        """Run *awaitable* until it finishes or watchdog policy cancels it."""
+        """Run *awaitable* until it finishes or watchdog policy cancels it.
+
+        Cancellation contract (v0 — ``cooperative_direct_one_stage``):
+
+        When a threshold is exceeded the watchdog:
+
+        (a) Calls ``task.cancel()`` directly — one stage, no escalation.
+            There is no SIGTERM-then-SIGKILL style two-stage sequence; a
+            single ``CancelledError`` injection is the entire escalation path.
+        (b) Awaits the cancelled task and swallows ``CancelledError`` so the
+            inner coroutine has a chance to run its ``except CancelledError``
+            cleanup block before control returns here.
+        (c) Emits ``lineage.generation.watchdog_decision`` and
+            ``control.directive.emitted`` events that carry
+            ``cancellation_mode = WATCHDOG_CANCELLATION_MODE``.
+
+        *Cooperative* because the inner task observes the ``CancelledError``
+        and can react (e.g. flush state).  *Direct* because no
+        ``AgentProcess`` intermediary is involved — the watchdog holds the
+        asyncio task handle and cancels it inline.  *One-stage* because there
+        is no escalation from a soft signal to a hard kill.
+
+        To introduce two-stage escalation in the future, add a
+        ``SIGTERM``-equivalent soft-cancel step, give the inner task a
+        configurable grace period, then hard-cancel if still running.  Update
+        ``WATCHDOG_CANCELLATION_MODE`` and the doc in
+        ``docs/contributing/watchdog-cancellation.md`` accordingly.
+        """
         await self.initialize_baseline()
         task: asyncio.Task[T] = asyncio.create_task(awaitable)
         try:
@@ -153,7 +184,15 @@ class GenerationProgressWatchdog:
         reason: str,
         details: dict[str, Any] | None = None,
     ) -> None:
-        """Persist a watchdog control decision for status/debug surfaces."""
+        """Persist a watchdog control decision for status/debug surfaces.
+
+        The stored event always includes ``cancellation_mode`` in its
+        ``details`` dict so downstream projectors and tests can assert which
+        cancellation contract was in effect without inspecting the source.
+        """
+        merged: dict[str, Any] = {"cancellation_mode": WATCHDOG_CANCELLATION_MODE}
+        if details:
+            merged.update(details)
         await self.event_store.append(
             lineage_generation_watchdog_decision(
                 self.lineage_id,
@@ -161,7 +200,7 @@ class GenerationProgressWatchdog:
                 action,
                 reason,
                 execution_id=self.execution_id,
-                details=details,
+                details=merged,
             )
         )
 
@@ -450,4 +489,5 @@ class GenerationProgressWatchdog:
 __all__ = [
     "GenerationProgressWatchdog",
     "GenerationWatchdogTimeout",
+    "WATCHDOG_CANCELLATION_MODE",
 ]

--- a/src/ouroboros/evolution/watchdog.py
+++ b/src/ouroboros/evolution/watchdog.py
@@ -25,6 +25,7 @@ from ouroboros.persistence.event_store import EventStore
 #: hardcoding the string.
 WATCHDOG_CANCELLATION_MODE: Final[str] = "cooperative_direct_one_stage"
 
+
 class GenerationWatchdogTimeout(OuroborosError):
     """Raised when a generation watchdog threshold is exceeded."""
 

--- a/src/ouroboros/evolution/watchdog.py
+++ b/src/ouroboros/evolution/watchdog.py
@@ -96,8 +96,8 @@ class GenerationProgressWatchdog:
         (b) Awaits the cancelled task and swallows ``CancelledError`` so the
             inner coroutine has a chance to run its ``except CancelledError``
             cleanup block before control returns here.
-        (c) Emits ``lineage.generation.watchdog_decision`` and
-            ``control.directive.emitted`` events that carry
+        (c) Emits a ``lineage.generation.watchdog_decision`` event whose
+            details carry
             ``cancellation_mode = WATCHDOG_CANCELLATION_MODE``.
 
         *Cooperative* because the inner task observes the ``CancelledError``

--- a/tests/unit/evolution/test_generation_watchdog.py
+++ b/tests/unit/evolution/test_generation_watchdog.py
@@ -18,6 +18,7 @@ from ouroboros.events.lineage import lineage_generation_failed
 from ouroboros.evolution.loop import EvolutionaryLoop, StepAction
 import ouroboros.evolution.watchdog as watchdog_module
 from ouroboros.evolution.watchdog import (
+    WATCHDOG_CANCELLATION_MODE,
     GenerationProgressWatchdog,
     GenerationWatchdogTimeout,
 )
@@ -562,3 +563,37 @@ async def test_parent_cancellation_cancels_watched_generation() -> None:
     with pytest.raises(asyncio.CancelledError):
         await parent
     await asyncio.wait_for(child_cancelled.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_no_material_progress_timeout_emits_cancellation_mode() -> None:
+    """watchdog_decision event carries cancellation_mode after a no-progress timeout."""
+    event_store = await _store()
+    lineage_id = "lin-cancel-mode"
+    execution_id = "exec-cancel-mode"
+    watchdog = _watchdog(
+        event_store,
+        lineage_id=lineage_id,
+        execution_id=execution_id,
+        generation_no_progress_timeout_seconds=0.07,
+    )
+
+    async def busy_work() -> str:
+        try:
+            while True:
+                await asyncio.sleep(0.02)
+                await event_store.append(_workflow_progress(execution_id, completed_count=0))
+        except asyncio.CancelledError:
+            raise
+
+    with pytest.raises(GenerationWatchdogTimeout) as exc_info:
+        await watchdog.watch(busy_work())
+
+    assert exc_info.value.timeout_kind == "no_material_progress_timeout"
+
+    events = await event_store.replay("lineage", lineage_id)
+    decision_events = [e for e in events if e.type == "lineage.generation.watchdog_decision"]
+    assert decision_events, "expected at least one watchdog_decision event"
+    details = decision_events[-1].data.get("details", {})
+    assert details.get("cancellation_mode") == WATCHDOG_CANCELLATION_MODE
+    assert details["cancellation_mode"] == "cooperative_direct_one_stage"


### PR DESCRIPTION
## Summary

- Adds `WATCHDOG_CANCELLATION_MODE: Final[str] = "cooperative_direct_one_stage"` constant — named contract for the v0 cancellation behavior.
- Documents the contract in `watch()` and `emit_decision()` docstrings: one-stage `task.cancel()`, cooperative `CancelledError` propagation, no two-stage escalation.
- Embeds `cancellation_mode` in every `watchdog_decision` event's `details` for projector/observability use.
- Adds `docs/contributing/watchdog-cancellation.md` — maintainer record + two-stage escalation migration guide.

This PR **pins current behavior only** — no cancellation logic was changed. Closes item 3 of #578.

## Why

#578 identified that the watchdog's cancellation semantics were undocumented. Without a named contract, future contributors cannot safely change the behavior or know what tests to update. This PR makes the implicit explicit.

## Test plan

- [ ] New test `test_no_material_progress_timeout_emits_cancellation_mode` asserts `cancellation_mode == "cooperative_direct_one_stage"` in the emitted `watchdog_decision` event's `details`.
- [ ] All 11 existing watchdog tests pass.
- [ ] `ruff check` and `ruff format --check` clean on modified files.

## Future work

Two-stage escalation (soft cancel → grace period → hard kill) is documented in `docs/contributing/watchdog-cancellation.md` with exact migration steps. `WATCHDOG_CANCELLATION_MODE` is the single update point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)