### PR TITLE
feat(orchestrator): durable pause/resume for AgentProcess via CheckpointStore (#518)

### DIFF
--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -485,14 +485,20 @@ class AgentProcessHandle:
         if self._status in _TERMINAL_STATUSES and not force:
             return
         if self._pause_checkpoint_requested:
-            self._save_lifecycle_checkpoint(
-                phase="agent_process_failed",
-                status="failed",
-                event_key="failed_at",
-                log_key="terminal",
-                store=self._pause_checkpoint_store,
-                strict=True,
-            )
+            try:
+                self._save_lifecycle_checkpoint(
+                    phase="agent_process_failed",
+                    status="failed",
+                    event_key="failed_at",
+                    log_key="terminal",
+                    store=self._pause_checkpoint_store,
+                    strict=True,
+                )
+            except Exception:
+                logger.warning(
+                    "agent_process.failed_checkpoint_cleanup_failed",
+                    extra={"process_id": self.process_id},
+                )
         self._status = AgentProcessStatus.FAILED
         if self._emit_directive is not None:
             await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -654,10 +654,19 @@ class AgentProcess:
                 logger.exception("agent_process.work_failed", extra={"process_id": pid})
                 return
             else:
-                if handle.should_cancel():
-                    await handle._mark_cancelled()
-                else:
-                    await handle._mark_completed(reason="work returned")
+                try:
+                    if handle.should_cancel():
+                        await handle._mark_cancelled()
+                    else:
+                        await handle._mark_completed(reason="work returned")
+                except BaseException as exc:  # noqa: BLE001 — terminal durability failure
+                    await handle._mark_failed(
+                        reason=f"terminal transition failed {type(exc).__name__}: {exc!s}"
+                    )
+                    logger.exception(
+                        "agent_process.terminal_transition_failed",
+                        extra={"process_id": pid},
+                    )
 
         # Spawn but do not await — the caller drives lifecycle through
         # the handle.

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -333,6 +333,7 @@ class AgentProcessHandle:
             event_key="resumed_at",
             log_key="resume",
             store=self._pause_checkpoint_store,
+            strict=True,
         )
         self._pause_checkpoint_reason = None
         self._pause_checkpoint_requested = False
@@ -440,6 +441,7 @@ class AgentProcessHandle:
                     log_key="pause",
                     reason=self._pause_checkpoint_reason,
                     store=self._pause_checkpoint_store,
+                    strict=True,
                 )
         await self._paused_event.wait()
         if self._status is AgentProcessStatus.PAUSED and not self.should_cancel():
@@ -485,6 +487,7 @@ class AgentProcessHandle:
                 event_key="failed_at",
                 log_key="terminal",
                 store=self._pause_checkpoint_store,
+                strict=True,
             )
         self._completed_event.set()
 
@@ -526,8 +529,9 @@ class AgentProcessHandle:
         log_key: str,
         reason: str | None = None,
         store: CheckpointStore | None = None,
+        strict: bool = False,
     ) -> None:
-        """Best-effort durable lifecycle checkpoint for restart recovery."""
+        """Persist a durable lifecycle checkpoint for restart recovery."""
         checkpoint_store = store if store is not None else CheckpointStore()
         try:
             checkpoint_store.initialize()
@@ -548,11 +552,17 @@ class AgentProcessHandle:
                     f"agent_process.{log_key}_checkpoint_save_failed",
                     extra={"process_id": self.process_id, "error": str(result.error)},
                 )
-        except Exception:  # noqa: BLE001 — fault-tolerant; in-memory state is authoritative
+                if strict:
+                    raise result.error
+        except Exception:
             logger.warning(
                 f"agent_process.{log_key}_checkpoint_save_failed",
                 extra={"process_id": self.process_id},
             )
+            if strict:
+                raise
+            if strict:
+                raise
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 import logging
 from typing import Any, Final, Protocol
@@ -63,6 +63,7 @@ from uuid import uuid4
 from ouroboros.core.control_contract import ControlContract
 from ouroboros.core.directive import Directive
 from ouroboros.events.control import create_control_directive_emitted_event
+from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
 
 logger = logging.getLogger(__name__)
 
@@ -269,28 +270,100 @@ class AgentProcessHandle:
     # External lifecycle verbs
     # ------------------------------------------------------------------
 
-    async def pause(self) -> None:
+    async def pause(
+        self,
+        *,
+        reason: str | None = None,
+        store: CheckpointStore | None = None,
+    ) -> None:
         """Request a cooperative pause.
 
         The work loop reaches a checkpoint, awaits :meth:`wait_unpaused`,
         and resumes only when :meth:`resume` is called. No-op when the
         process has already terminated.
+
+        Slice 2 (#518): also persists a checkpoint so the pause survives
+        a process restart. Callers can supply an optional *store*; if
+        omitted the default :class:`CheckpointStore` location is used.
+        Persistence failures are logged as warnings and never raised —
+        the in-memory flag is the authoritative source.
+
+        Note: ``process_id`` is UUID4 hex (32 hex chars, no separators)
+        which contains only ``[0-9a-f]`` — safe for :class:`CheckpointStore`
+        sanitization without truncation or collision.
         """
         if self._status in _TERMINAL_STATUSES or self.should_cancel():
             return
         self._paused_event.clear()
 
-    async def resume(self) -> None:
+        # Persist pause state so a restarted process can detect it.
+        _checkpoint_store = store if store is not None else CheckpointStore()
+        try:
+            _checkpoint_store.initialize()
+            checkpoint = CheckpointData.create(
+                seed_id=self.process_id,
+                phase="agent_process_paused",
+                state={
+                    "status": "paused",
+                    "reason": reason,
+                    "paused_at": datetime.now(UTC).isoformat(),
+                },
+            )
+            result = _checkpoint_store.save(checkpoint)
+            if result.is_err:
+                logger.warning(
+                    "agent_process.pause_checkpoint_save_failed",
+                    extra={"process_id": self.process_id, "error": str(result.error)},
+                )
+        except Exception:  # noqa: BLE001 — fault-tolerant; in-memory flag is authoritative
+            logger.warning(
+                "agent_process.pause_checkpoint_save_failed",
+                extra={"process_id": self.process_id},
+            )
+
+    async def resume(
+        self,
+        *,
+        store: CheckpointStore | None = None,
+    ) -> None:
         """Release a paused work loop.
 
         No-op when the process is not currently paused. Returns it to
         :attr:`AgentProcessStatus.RUNNING`.
+
+        Slice 2 (#518): overwrites the persisted pause checkpoint with a
+        ``running`` row so ``load_persisted_pause`` returns False after
+        resume. Failures are logged and never raised.
         """
         if self._status in _TERMINAL_STATUSES or not self.should_pause():
             return
         self._paused_event.set()
         if self._status is AgentProcessStatus.PAUSED:
             await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
+
+        # Overwrite the paused checkpoint so load_persisted_pause returns False.
+        _checkpoint_store = store if store is not None else CheckpointStore()
+        try:
+            _checkpoint_store.initialize()
+            checkpoint = CheckpointData.create(
+                seed_id=self.process_id,
+                phase="agent_process_running",
+                state={
+                    "status": "running",
+                    "resumed_at": datetime.now(UTC).isoformat(),
+                },
+            )
+            result = _checkpoint_store.save(checkpoint)
+            if result.is_err:
+                logger.warning(
+                    "agent_process.resume_checkpoint_save_failed",
+                    extra={"process_id": self.process_id, "error": str(result.error)},
+                )
+        except Exception:  # noqa: BLE001 — fault-tolerant
+            logger.warning(
+                "agent_process.resume_checkpoint_save_failed",
+                extra={"process_id": self.process_id},
+            )
 
     async def cancel(self, reason: str = "cancel requested") -> None:
         """Request a cooperative cancel.
@@ -318,6 +391,48 @@ class AgentProcessHandle:
     def status(self) -> AgentProcessStatus:
         """Return the current lifecycle status."""
         return self._status
+
+    @classmethod
+    def load_persisted_pause(
+        cls,
+        process_id: str,
+        *,
+        store: CheckpointStore | None = None,
+    ) -> bool:
+        """Return True iff the latest persisted checkpoint marks this process as paused.
+
+        This is the restart-recovery primitive for slice 2 (#518). A caller
+        restarting the process calls this to ask "was I paused before the
+        restart?" and, if True, calls :meth:`pause` again to restore the
+        in-memory flag.
+
+        Args:
+            process_id: The process identifier to look up. UUID4 hex is
+                used by default (:func:`_new_process_id`); the hex alphabet
+                ``[0-9a-f]`` is safe through :meth:`CheckpointStore._sanitize_seed_id`
+                without truncation or collision.
+            store: Optional :class:`CheckpointStore` override. When omitted,
+                the default store location (``~/.ouroboros/data/checkpoints/``)
+                is used.
+
+        Returns:
+            ``True`` when the latest checkpoint phase is
+            ``"agent_process_paused"``, ``False`` for any other phase or
+            when no checkpoint exists.
+        """
+        _store = store if store is not None else CheckpointStore()
+        try:
+            _store.initialize()
+            result = _store.load(process_id)
+            if result.is_err:
+                return False
+            return result.value.phase == "agent_process_paused"
+        except Exception:  # noqa: BLE001 — fault-tolerant; absence of checkpoint == not paused
+            logger.warning(
+                "agent_process.load_persisted_pause_failed",
+                extra={"process_id": process_id},
+            )
+            return False
 
     # ------------------------------------------------------------------
     # Internal cooperative signals (consumed by the work loop)

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -425,14 +425,15 @@ class AgentProcessHandle:
         """
         if self.should_pause() and self._status is AgentProcessStatus.RUNNING:
             await self._set_status(AgentProcessStatus.PAUSED, reason="pause acknowledged")
-            self._save_lifecycle_checkpoint(
-                phase="agent_process_paused",
-                status="paused",
-                event_key="paused_at",
-                log_key="pause",
-                reason=self._pause_checkpoint_reason,
-                store=self._pause_checkpoint_store,
-            )
+            if self.should_pause() and self._status is AgentProcessStatus.PAUSED:
+                self._save_lifecycle_checkpoint(
+                    phase="agent_process_paused",
+                    status="paused",
+                    event_key="paused_at",
+                    log_key="pause",
+                    reason=self._pause_checkpoint_reason,
+                    store=self._pause_checkpoint_store,
+                )
         await self._paused_event.wait()
         if self._status is AgentProcessStatus.PAUSED and not self.should_cancel():
             await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -317,16 +317,18 @@ class AgentProcessHandle:
 
         Slice 2 (#518): overwrites the persisted pause checkpoint with a
         ``running`` row so ``load_persisted_pause`` returns False after
-        resume. Failures are logged and never raised.
+        resume. Persistence failures are raised before the loop is released
+        so durable state cannot remain paused while in-memory work resumes.
+        If *store* differs from the store captured by the acknowledged
+        pause, the captured store remains authoritative and *store* is
+        ignored.
         """
         if self._status in _TERMINAL_STATUSES or not self.should_pause():
             return
-        self._paused_event.set()
-        if self._status is AgentProcessStatus.PAUSED:
-            await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
 
-        # Overwrite any acknowledged paused checkpoint so restart recovery
-        # no longer treats this process as paused.
+        # Overwrite any acknowledged paused checkpoint before releasing the
+        # work loop; otherwise a failed save could leave durable state paused
+        # while in-memory work has resumed.
         self._save_lifecycle_checkpoint(
             phase="agent_process_running",
             status="running",
@@ -337,6 +339,10 @@ class AgentProcessHandle:
         )
         self._pause_checkpoint_reason = None
         self._pause_checkpoint_requested = False
+
+        self._paused_event.set()
+        if self._status is AgentProcessStatus.PAUSED:
+            await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
 
     async def cancel(self, reason: str = "cancel requested") -> None:
         """Request a cooperative cancel.
@@ -477,9 +483,6 @@ class AgentProcessHandle:
         """
         if self._status in _TERMINAL_STATUSES and not force:
             return
-        self._status = AgentProcessStatus.FAILED
-        if self._emit_directive is not None:
-            await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)
         if self._pause_checkpoint_requested:
             self._save_lifecycle_checkpoint(
                 phase="agent_process_failed",
@@ -489,6 +492,9 @@ class AgentProcessHandle:
                 store=self._pause_checkpoint_store,
                 strict=True,
             )
+        self._status = AgentProcessStatus.FAILED
+        if self._emit_directive is not None:
+            await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)
         self._completed_event.set()
 
     async def _mark_cancelled(self) -> None:
@@ -505,19 +511,20 @@ class AgentProcessHandle:
     async def _set_status(self, new_status: AgentProcessStatus, *, reason: str) -> None:
         if new_status == self._status:
             return
+        if new_status in _TERMINAL_STATUSES and self._pause_checkpoint_requested:
+            self._save_lifecycle_checkpoint(
+                phase=f"agent_process_{new_status.value}",
+                status=new_status.value,
+                event_key=f"{new_status.value}_at",
+                log_key="terminal",
+                store=self._pause_checkpoint_store,
+                strict=True,
+            )
         self._status = new_status
         directive = _TRANSITION_DIRECTIVE.get(new_status)
         if directive is not None and self._emit_directive is not None:
             await self._emit_directive(directive, reason, new_status)
         if new_status in _TERMINAL_STATUSES:
-            if self._pause_checkpoint_requested:
-                self._save_lifecycle_checkpoint(
-                    phase=f"agent_process_{new_status.value}",
-                    status=new_status.value,
-                    event_key=f"{new_status.value}_at",
-                    log_key="terminal",
-                    store=self._pause_checkpoint_store,
-                )
             self._completed_event.set()
 
     def _save_lifecycle_checkpoint(

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -394,7 +394,11 @@ class AgentProcessHandle:
         _store = store if store is not None else CheckpointStore()
         try:
             _store.initialize()
-            result = _store.load(process_id)
+            # Pause recovery needs the newest durable lifecycle truth, not
+            # CheckpointStore.load()'s generic rollback-to-older-valid behavior:
+            # if the latest row is corrupt, fail closed to not paused rather
+            # than resurrecting a stale paused checkpoint from .1/.2/.3.
+            result = _store._load_checkpoint_level(process_id, 0)  # noqa: SLF001
             if result.is_err:
                 return False
             return result.value.phase == "agent_process_paused"

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -327,15 +327,13 @@ class AgentProcessHandle:
 
         # Overwrite any acknowledged paused checkpoint so restart recovery
         # no longer treats this process as paused.
-        checkpoint_store = store if store is not None else self._pause_checkpoint_store
         self._save_lifecycle_checkpoint(
             phase="agent_process_running",
             status="running",
             event_key="resumed_at",
             log_key="resume",
-            store=checkpoint_store,
+            store=self._pause_checkpoint_store,
         )
-        self._pause_checkpoint_store = checkpoint_store
         self._pause_checkpoint_reason = None
         self._pause_checkpoint_requested = False
 

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -297,6 +297,8 @@ class AgentProcessHandle:
         """
         if self._status in _TERMINAL_STATUSES or self.should_cancel():
             return
+        if self.should_pause():
+            return
         self._paused_event.clear()
         self._pause_checkpoint_store = store
         self._pause_checkpoint_reason = reason

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -499,6 +499,7 @@ class AgentProcessHandle:
                     "agent_process.failed_checkpoint_cleanup_failed",
                     extra={"process_id": self.process_id},
                 )
+                self._delete_lifecycle_checkpoint(store=self._pause_checkpoint_store)
         self._status = AgentProcessStatus.FAILED
         if self._emit_directive is not None:
             await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)
@@ -575,8 +576,22 @@ class AgentProcessHandle:
             )
             if strict:
                 raise
-            if strict:
-                raise
+
+    def _delete_lifecycle_checkpoint(self, *, store: CheckpointStore | None = None) -> None:
+        """Best-effort fail-closed deletion of a stale pause checkpoint."""
+        checkpoint_store = store if store is not None else CheckpointStore()
+        try:
+            checkpoint_store.initialize()
+            checkpoint_path = checkpoint_store._get_checkpoint_path(  # noqa: SLF001
+                _pause_checkpoint_seed_id(self.process_id), 0
+            )
+            if checkpoint_path.exists():
+                checkpoint_path.unlink()
+        except Exception:  # noqa: BLE001 — no safer recovery remains
+            logger.warning(
+                "agent_process.lifecycle_checkpoint_delete_failed",
+                extra={"process_id": self.process_id},
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -642,7 +657,16 @@ class AgentProcess:
                 await work_fn(handle)
             except asyncio.CancelledError:
                 await handle.cancel(reason="cancelled by event loop")
-                await handle._mark_cancelled()
+                try:
+                    await handle._mark_cancelled()
+                except BaseException as exc:  # noqa: BLE001 — terminal durability failure
+                    await handle._mark_failed(
+                        reason=f"cancel finalization failed {type(exc).__name__}: {exc!s}"
+                    )
+                    logger.exception(
+                        "agent_process.cancel_finalization_failed",
+                        extra={"process_id": pid},
+                    )
                 raise
             except BaseException as exc:  # noqa: BLE001 — runtime must capture every failure
                 if handle.status() in _TERMINAL_STATUSES:

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -56,6 +56,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+import hashlib
 import logging
 from typing import Any, Final, Protocol
 from uuid import uuid4
@@ -291,9 +292,9 @@ class AgentProcessHandle:
         :attr:`AgentProcessStatus.PAUSED`, so restart recovery reflects
         acknowledged lifecycle truth rather than a merely requested pause.
 
-        Note: ``process_id`` is UUID4 hex (32 hex chars, no separators)
-        which contains only ``[0-9a-f]`` — safe for :class:`CheckpointStore`
-        sanitization without truncation or collision.
+        Checkpoint rows use an agent-process-specific key derived from
+        ``process_id`` so lifecycle persistence cannot collide with generic
+        workflow checkpoints in the shared :class:`CheckpointStore`.
         """
         if self._status in _TERMINAL_STATUSES or self.should_cancel():
             return
@@ -400,7 +401,9 @@ class AgentProcessHandle:
             # CheckpointStore.load()'s generic rollback-to-older-valid behavior:
             # if the latest row is corrupt, fail closed to not paused rather
             # than resurrecting a stale paused checkpoint from .1/.2/.3.
-            result = _store._load_checkpoint_level(process_id, 0)  # noqa: SLF001
+            result = _store._load_checkpoint_level(  # noqa: SLF001
+                _pause_checkpoint_seed_id(process_id), 0
+            )
             if result.is_err:
                 return False
             return result.value.phase == "agent_process_paused"
@@ -537,7 +540,7 @@ class AgentProcessHandle:
             if reason is not None:
                 state["reason"] = reason
             checkpoint = CheckpointData.create(
-                seed_id=self.process_id,
+                seed_id=_pause_checkpoint_seed_id(self.process_id),
                 phase=phase,
                 state=state,
             )
@@ -671,6 +674,11 @@ class AgentProcess:
                 )
 
         return emit
+
+
+def _pause_checkpoint_seed_id(process_id: str) -> str:
+    """Return the CheckpointStore key for agent-process pause state."""
+    return f"agent_process_{hashlib.sha256(process_id.encode()).hexdigest()}"
 
 
 def _new_process_id() -> str:

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -259,6 +259,9 @@ class AgentProcessHandle:
     _completed_event: asyncio.Event = field(default_factory=asyncio.Event)
     _cancel_reason: str = "cancel requested"
     _emit_directive: Callable[[Directive, str, AgentProcessStatus], Awaitable[None]] | None = None
+    _pause_checkpoint_store: CheckpointStore | None = field(default=None, repr=False)
+    _pause_checkpoint_reason: str | None = field(default=None, repr=False)
+    _pause_checkpoint_requested: bool = field(default=False, repr=False)
 
     def __post_init__(self) -> None:
         # The paused-event is "set" when the loop is *not* paused so a
@@ -282,11 +285,11 @@ class AgentProcessHandle:
         and resumes only when :meth:`resume` is called. No-op when the
         process has already terminated.
 
-        Slice 2 (#518): also persists a checkpoint so the pause survives
-        a process restart. Callers can supply an optional *store*; if
-        omitted the default :class:`CheckpointStore` location is used.
-        Persistence failures are logged as warnings and never raised —
-        the in-memory flag is the authoritative source.
+        Slice 2 (#518): records the checkpoint store/reason for durable
+        pause acknowledgement. The checkpoint itself is written only when
+        the work loop reaches :meth:`wait_unpaused` and enters
+        :attr:`AgentProcessStatus.PAUSED`, so restart recovery reflects
+        acknowledged lifecycle truth rather than a merely requested pause.
 
         Note: ``process_id`` is UUID4 hex (32 hex chars, no separators)
         which contains only ``[0-9a-f]`` — safe for :class:`CheckpointStore`
@@ -295,31 +298,9 @@ class AgentProcessHandle:
         if self._status in _TERMINAL_STATUSES or self.should_cancel():
             return
         self._paused_event.clear()
-
-        # Persist pause state so a restarted process can detect it.
-        _checkpoint_store = store if store is not None else CheckpointStore()
-        try:
-            _checkpoint_store.initialize()
-            checkpoint = CheckpointData.create(
-                seed_id=self.process_id,
-                phase="agent_process_paused",
-                state={
-                    "status": "paused",
-                    "reason": reason,
-                    "paused_at": datetime.now(UTC).isoformat(),
-                },
-            )
-            result = _checkpoint_store.save(checkpoint)
-            if result.is_err:
-                logger.warning(
-                    "agent_process.pause_checkpoint_save_failed",
-                    extra={"process_id": self.process_id, "error": str(result.error)},
-                )
-        except Exception:  # noqa: BLE001 — fault-tolerant; in-memory flag is authoritative
-            logger.warning(
-                "agent_process.pause_checkpoint_save_failed",
-                extra={"process_id": self.process_id},
-            )
+        self._pause_checkpoint_store = store
+        self._pause_checkpoint_reason = reason
+        self._pause_checkpoint_requested = True
 
     async def resume(
         self,
@@ -341,29 +322,19 @@ class AgentProcessHandle:
         if self._status is AgentProcessStatus.PAUSED:
             await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
 
-        # Overwrite the paused checkpoint so load_persisted_pause returns False.
-        _checkpoint_store = store if store is not None else CheckpointStore()
-        try:
-            _checkpoint_store.initialize()
-            checkpoint = CheckpointData.create(
-                seed_id=self.process_id,
-                phase="agent_process_running",
-                state={
-                    "status": "running",
-                    "resumed_at": datetime.now(UTC).isoformat(),
-                },
-            )
-            result = _checkpoint_store.save(checkpoint)
-            if result.is_err:
-                logger.warning(
-                    "agent_process.resume_checkpoint_save_failed",
-                    extra={"process_id": self.process_id, "error": str(result.error)},
-                )
-        except Exception:  # noqa: BLE001 — fault-tolerant
-            logger.warning(
-                "agent_process.resume_checkpoint_save_failed",
-                extra={"process_id": self.process_id},
-            )
+        # Overwrite any acknowledged paused checkpoint so restart recovery
+        # no longer treats this process as paused.
+        checkpoint_store = store if store is not None else self._pause_checkpoint_store
+        self._save_lifecycle_checkpoint(
+            phase="agent_process_running",
+            status="running",
+            event_key="resumed_at",
+            log_key="resume",
+            store=checkpoint_store,
+        )
+        self._pause_checkpoint_store = checkpoint_store
+        self._pause_checkpoint_reason = None
+        self._pause_checkpoint_requested = False
 
     async def cancel(self, reason: str = "cancel requested") -> None:
         """Request a cooperative cancel.
@@ -454,6 +425,14 @@ class AgentProcessHandle:
         """
         if self.should_pause() and self._status is AgentProcessStatus.RUNNING:
             await self._set_status(AgentProcessStatus.PAUSED, reason="pause acknowledged")
+            self._save_lifecycle_checkpoint(
+                phase="agent_process_paused",
+                status="paused",
+                event_key="paused_at",
+                log_key="pause",
+                reason=self._pause_checkpoint_reason,
+                store=self._pause_checkpoint_store,
+            )
         await self._paused_event.wait()
         if self._status is AgentProcessStatus.PAUSED and not self.should_cancel():
             await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
@@ -491,6 +470,14 @@ class AgentProcessHandle:
         self._status = AgentProcessStatus.FAILED
         if self._emit_directive is not None:
             await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)
+        if self._pause_checkpoint_requested:
+            self._save_lifecycle_checkpoint(
+                phase="agent_process_failed",
+                status="failed",
+                event_key="failed_at",
+                log_key="terminal",
+                store=self._pause_checkpoint_store,
+            )
         self._completed_event.set()
 
     async def _mark_cancelled(self) -> None:
@@ -512,7 +499,52 @@ class AgentProcessHandle:
         if directive is not None and self._emit_directive is not None:
             await self._emit_directive(directive, reason, new_status)
         if new_status in _TERMINAL_STATUSES:
+            if self._pause_checkpoint_requested:
+                self._save_lifecycle_checkpoint(
+                    phase=f"agent_process_{new_status.value}",
+                    status=new_status.value,
+                    event_key=f"{new_status.value}_at",
+                    log_key="terminal",
+                    store=self._pause_checkpoint_store,
+                )
             self._completed_event.set()
+
+    def _save_lifecycle_checkpoint(
+        self,
+        *,
+        phase: str,
+        status: str,
+        event_key: str,
+        log_key: str,
+        reason: str | None = None,
+        store: CheckpointStore | None = None,
+    ) -> None:
+        """Best-effort durable lifecycle checkpoint for restart recovery."""
+        checkpoint_store = store if store is not None else CheckpointStore()
+        try:
+            checkpoint_store.initialize()
+            state: dict[str, str | None] = {
+                "status": status,
+                event_key: datetime.now(UTC).isoformat(),
+            }
+            if reason is not None:
+                state["reason"] = reason
+            checkpoint = CheckpointData.create(
+                seed_id=self.process_id,
+                phase=phase,
+                state=state,
+            )
+            result = checkpoint_store.save(checkpoint)
+            if result.is_err:
+                logger.warning(
+                    f"agent_process.{log_key}_checkpoint_save_failed",
+                    extra={"process_id": self.process_id, "error": str(result.error)},
+                )
+        except Exception:  # noqa: BLE001 — fault-tolerant; in-memory state is authoritative
+            logger.warning(
+                f"agent_process.{log_key}_checkpoint_save_failed",
+                extra={"process_id": self.process_id},
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -741,6 +741,40 @@ async def test_resume_clears_persisted_pause(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_load_persisted_pause_does_not_rollback_to_stale_paused_checkpoint(
+    tmp_path: Path,
+) -> None:
+    """Corrupt latest lifecycle truth must fail closed instead of resurrecting .1 paused."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=ck_store)
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+    await handle.resume(store=ck_store)
+
+    current_checkpoint = tmp_path / f"checkpoint_{handle.process_id}.json"
+    current_checkpoint.write_text("{not valid json", encoding="utf-8")
+
+    # The generic API rolls back to the older paused row, but pause recovery
+    # must use stricter latest-row semantics and return False.
+    assert ck_store.load(handle.process_id).value.phase == "agent_process_paused"
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is False
+
+    await handle.cancel(reason="end test")
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_pause_swallows_checkpoint_save_error() -> None:
     """pause() must flip the in-memory flag and not raise even when CheckpointStore.save errors."""
     erroring_store = _ErroringCheckpointStore()

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -9,15 +9,20 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
+from ouroboros.core.errors import PersistenceError
+from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.agent_process import (
     AgentProcess,
+    AgentProcessHandle,
     AgentProcessStatus,
     project_agent_process_snapshot,
 )
+from ouroboros.persistence.checkpoint import CheckpointStore
 from ouroboros.persistence.event_store import EventStore
 
 
@@ -563,3 +568,100 @@ async def test_lifecycle_reasons_are_prefixed_once() -> None:
     assert "ralph: spawned" in reasons
     assert "ralph: work returned" in reasons
     assert all("ralph: ralph:" not in reason for reason in reasons)
+
+
+# ---------------------------------------------------------------------------
+# Slice 2 (#518): durable pause/resume via CheckpointStore
+# ---------------------------------------------------------------------------
+
+
+class _ErroringCheckpointStore(CheckpointStore):
+    """A CheckpointStore whose save() always returns an error, for fault-tolerance tests."""
+
+    def save(self, checkpoint):  # type: ignore[override]
+        return Result.err(PersistenceError("simulated save error", operation="write", details={}))
+
+
+@pytest.mark.asyncio
+async def test_pause_persists_state_via_checkpoint_store(tmp_path: Path) -> None:
+    """pause() must write an agent_process_paused checkpoint so load_persisted_pause returns True."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=ck_store)
+
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is True
+
+    await handle.cancel(reason="end test")
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_resume_clears_persisted_pause(tmp_path: Path) -> None:
+    """resume() must overwrite the checkpoint so load_persisted_pause returns False."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=ck_store)
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+    await handle.resume(store=ck_store)
+
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is False
+
+    await handle.cancel(reason="end test")
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_pause_swallows_checkpoint_save_error() -> None:
+    """pause() must flip the in-memory flag and not raise even when CheckpointStore.save errors."""
+    erroring_store = _ErroringCheckpointStore()
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    # Must not raise even though the store always errors.
+    await handle.pause(store=erroring_store)
+
+    # In-memory flag must still be set.
+    assert handle.should_pause() is True
+
+    await handle.cancel(reason="end test")
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_load_persisted_pause_returns_false_when_no_checkpoint(tmp_path: Path) -> None:
+    """load_persisted_pause must return False for a process_id with no prior checkpoint."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    fresh_process_id = "deadbeefdeadbeefdeadbeefdeadbeef"
+
+    assert AgentProcessHandle.load_persisted_pause(fresh_process_id, store=ck_store) is False

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -963,6 +963,53 @@ async def test_resume_surfaces_checkpoint_save_error(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_failed_finalization_deletes_stale_pause_when_failed_checkpoint_save_fails(
+    tmp_path: Path,
+) -> None:
+    """If failed cleanup cannot write a tombstone, stale paused truth is deleted."""
+    ck_store = _FailingSecondSaveCheckpointStore(base_path=tmp_path)
+    handle = AgentProcessHandle(process_id="failed-delete")
+
+    await handle.pause(store=ck_store)
+    waiter = asyncio.create_task(handle.wait_unpaused())
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    await handle._mark_failed(reason="simulated failure")
+
+    assert handle.status() is AgentProcessStatus.FAILED
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is False
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+
+@pytest.mark.asyncio
+async def test_spawned_cancel_finalization_failure_completes_failed(tmp_path: Path) -> None:
+    """Event-loop cancellation cleanup must not strand completion waiters on save failure."""
+    ck_store = _FailingSecondSaveCheckpointStore(base_path=tmp_path)
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        await handle.pause(store=ck_store)
+        started.set()
+        await handle.wait_unpaused()
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    work_task = handle._work_task
+    assert work_task is not None
+
+    work_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await work_task
+
+    assert handle.status() is AgentProcessStatus.FAILED
+    assert handle._completed_event.is_set()
+
+
+@pytest.mark.asyncio
 async def test_spawned_process_fails_closed_when_terminal_checkpoint_save_fails() -> None:
     """A terminal durability failure in the runner must not leave waiters hanging."""
     process = AgentProcess(event_store=None)

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -584,7 +584,7 @@ class _ErroringCheckpointStore(CheckpointStore):
 
 @pytest.mark.asyncio
 async def test_pause_persists_state_via_checkpoint_store(tmp_path: Path) -> None:
-    """pause() must write an agent_process_paused checkpoint so load_persisted_pause returns True."""
+    """Acknowledged pause must persist so load_persisted_pause returns True."""
     ck_store = CheckpointStore(base_path=tmp_path)
     process = AgentProcess(event_store=None)
     started = asyncio.Event()
@@ -599,11 +599,68 @@ async def test_pause_persists_state_via_checkpoint_store(tmp_path: Path) -> None
     await asyncio.wait_for(started.wait(), timeout=1.0)
 
     await handle.pause(store=ck_store)
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
 
     assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is True
 
     await handle.cancel(reason="end test")
     await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_pause_request_does_not_persist_until_acknowledged(tmp_path: Path) -> None:
+    """Restart recovery must not restore a merely requested, unacknowledged pause."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def work(handle):  # noqa: ARG001 - intentionally ignores pause checkpoints until released
+        started.set()
+        await release.wait()
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=ck_store)
+
+    assert handle.should_pause() is True
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is False
+
+    await handle.cancel(reason="end test")
+    release.set()
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_cancel_clears_persisted_pause_checkpoint(tmp_path: Path) -> None:
+    """A paused-then-cancelled process must not restart as paused."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+    saw_cancel = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while True:
+            await handle.wait_unpaused()
+            if handle.should_cancel():
+                saw_cancel.set()
+                return
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=ck_store)
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is True
+
+    await handle.cancel(reason="cancel while paused")
+    await asyncio.wait_for(saw_cancel.wait(), timeout=1.0)
+    await handle.wait_until_complete(timeout=1.0)
+
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is False
 
 
 @pytest.mark.asyncio
@@ -648,8 +705,10 @@ async def test_pause_swallows_checkpoint_save_error() -> None:
     handle = await process.spawn(intent="ralph", work_fn=work)
     await asyncio.wait_for(started.wait(), timeout=1.0)
 
-    # Must not raise even though the store always errors.
+    # Must not raise even though the store always errors once the loop
+    # acknowledges the pause and attempts to persist it.
     await handle.pause(store=erroring_store)
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
 
     # In-memory flag must still be set.
     assert handle.should_pause() is True

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -22,7 +23,7 @@ from ouroboros.orchestrator.agent_process import (
     AgentProcessStatus,
     project_agent_process_snapshot,
 )
-from ouroboros.persistence.checkpoint import CheckpointStore
+from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
 from ouroboros.persistence.event_store import EventStore
 
 
@@ -793,16 +794,71 @@ async def test_load_persisted_pause_does_not_rollback_to_stale_paused_checkpoint
     await _wait_for_status(handle, AgentProcessStatus.PAUSED)
     await handle.resume(store=ck_store)
 
-    current_checkpoint = tmp_path / f"checkpoint_{handle.process_id}.json"
+    checkpoint_seed = f"agent_process_{hashlib.sha256(handle.process_id.encode()).hexdigest()}"
+    current_checkpoint = tmp_path / f"checkpoint_{checkpoint_seed}.json"
     current_checkpoint.write_text("{not valid json", encoding="utf-8")
 
     # The generic API rolls back to the older paused row, but pause recovery
     # must use stricter latest-row semantics and return False.
-    assert ck_store.load(handle.process_id).value.phase == "agent_process_paused"
+    assert ck_store.load(checkpoint_seed).value.phase == "agent_process_paused"
     assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is False
 
     await handle.cancel(reason="end test")
     await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_pause_checkpoint_uses_agent_process_namespace(tmp_path: Path) -> None:
+    """Agent pause persistence must not overwrite a workflow checkpoint with the same id."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    process_id = "shared-id"
+    workflow_checkpoint = CheckpointData.create(
+        seed_id=process_id,
+        phase="workflow_running",
+        state={"owner": "workflow"},
+    )
+    assert ck_store.save(workflow_checkpoint).is_ok
+
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work, process_id=process_id)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=ck_store)
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    assert AgentProcessHandle.load_persisted_pause(process_id, store=ck_store) is True
+    loaded_workflow = ck_store.load(process_id)
+    assert loaded_workflow.is_ok
+    assert loaded_workflow.value.phase == "workflow_running"
+    assert loaded_workflow.value.state == {"owner": "workflow"}
+
+    await handle.cancel(reason="end test")
+    await handle.wait_until_complete(timeout=1.0)
+
+
+def test_pause_checkpoint_key_avoids_sanitizer_collisions(tmp_path: Path) -> None:
+    """Distinct process ids that sanitize alike must not share pause recovery state."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    colliding_raw_id = "a/b"
+    other_raw_id = "a_b"
+
+    checkpoint = CheckpointData.create(
+        seed_id=f"agent_process_{hashlib.sha256(colliding_raw_id.encode()).hexdigest()}",
+        phase="agent_process_paused",
+        state={"status": "paused"},
+    )
+    assert ck_store.save(checkpoint).is_ok
+
+    assert AgentProcessHandle.load_persisted_pause(colliding_raw_id, store=ck_store) is True
+    assert AgentProcessHandle.load_persisted_pause(other_raw_id, store=ck_store) is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -741,6 +741,37 @@ async def test_resume_clears_persisted_pause(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_repeated_pause_preserves_original_checkpoint_store(tmp_path: Path) -> None:
+    """A duplicate pause must not strand the acknowledged pause marker in its first store."""
+    first_store = CheckpointStore(base_path=tmp_path / "first")
+    second_store = CheckpointStore(base_path=tmp_path / "second")
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=first_store)
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=first_store) is True
+
+    await handle.pause(store=second_store)
+    await handle.resume()
+
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=first_store) is False
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=second_store) is False
+
+    await handle.cancel(reason="end test")
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_load_persisted_pause_does_not_rollback_to_stale_paused_checkpoint(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -963,6 +963,23 @@ async def test_resume_surfaces_checkpoint_save_error(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_spawned_process_fails_closed_when_terminal_checkpoint_save_fails() -> None:
+    """A terminal durability failure in the runner must not leave waiters hanging."""
+    process = AgentProcess(event_store=None)
+    erroring_store = _ErroringCheckpointStore()
+
+    async def work(handle):
+        await handle.pause(store=erroring_store)
+        return None
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+
+    final = await handle.wait_until_complete(timeout=1.0)
+
+    assert final is AgentProcessStatus.FAILED
+
+
+@pytest.mark.asyncio
 async def test_terminal_transition_surfaces_checkpoint_save_error(tmp_path: Path) -> None:
     """Terminal cleanup must not silently leave durable pause truth stale."""
     ck_store = _FailingSecondSaveCheckpointStore(base_path=tmp_path)

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -925,6 +925,23 @@ async def test_pause_acknowledgement_surfaces_checkpoint_save_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_spawned_process_fails_closed_when_pause_checkpoint_save_fails() -> None:
+    """A work-loop checkpoint failure must complete the handle as FAILED, not hang."""
+    process = AgentProcess(event_store=None)
+    erroring_store = _ErroringCheckpointStore()
+
+    async def work(handle):
+        await handle.pause(store=erroring_store)
+        await handle.wait_unpaused()
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+
+    final = await handle.wait_until_complete(timeout=1.0)
+
+    assert final is AgentProcessStatus.FAILED
+
+
+@pytest.mark.asyncio
 async def test_resume_surfaces_checkpoint_save_error(tmp_path: Path) -> None:
     """A failed running overwrite must be visible because stale paused recovery remains."""
     ck_store = _FailingSecondSaveCheckpointStore(base_path=tmp_path)

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -592,10 +592,26 @@ async def test_lifecycle_reasons_are_prefixed_once() -> None:
 
 
 class _ErroringCheckpointStore(CheckpointStore):
-    """A CheckpointStore whose save() always returns an error, for fault-tolerance tests."""
+    """A CheckpointStore whose save() always returns an error."""
 
     def save(self, checkpoint):  # type: ignore[override]
         return Result.err(PersistenceError("simulated save error", operation="write", details={}))
+
+
+class _FailingSecondSaveCheckpointStore(CheckpointStore):
+    """A CheckpointStore that succeeds once, then fails subsequent saves."""
+
+    def __init__(self, *, base_path: Path) -> None:
+        super().__init__(base_path=base_path)
+        self.save_count = 0
+
+    def save(self, checkpoint):  # type: ignore[override]
+        self.save_count += 1
+        if self.save_count >= 2:
+            return Result.err(
+                PersistenceError("simulated save error", operation="write", details={})
+            )
+        return super().save(checkpoint)
 
 
 @pytest.mark.asyncio
@@ -894,31 +910,36 @@ def test_pause_checkpoint_key_avoids_sanitizer_collisions(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_pause_swallows_checkpoint_save_error() -> None:
-    """pause() must flip the in-memory flag and not raise even when CheckpointStore.save errors."""
+async def test_pause_acknowledgement_surfaces_checkpoint_save_error() -> None:
+    """Acknowledged durable pause must not silently hide CheckpointStore.save errors."""
     erroring_store = _ErroringCheckpointStore()
-    process = AgentProcess(event_store=None)
-    started = asyncio.Event()
+    handle = AgentProcessHandle(process_id="erroring-pause")
 
-    async def work(handle):
-        started.set()
-        while not handle.should_cancel():
-            await handle.wait_unpaused()
-            await asyncio.sleep(0.005)
-
-    handle = await process.spawn(intent="ralph", work_fn=work)
-    await asyncio.wait_for(started.wait(), timeout=1.0)
-
-    # Must not raise even though the store always errors once the loop
-    # acknowledges the pause and attempts to persist it.
     await handle.pause(store=erroring_store)
-    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
 
-    # In-memory flag must still be set.
+    with pytest.raises(PersistenceError):
+        await handle.wait_unpaused()
+
+    assert handle.status() is AgentProcessStatus.PAUSED
     assert handle.should_pause() is True
 
-    await handle.cancel(reason="end test")
-    await handle.wait_until_complete(timeout=1.0)
+
+@pytest.mark.asyncio
+async def test_resume_surfaces_checkpoint_save_error(tmp_path: Path) -> None:
+    """A failed running overwrite must be visible because stale paused recovery remains."""
+    ck_store = _FailingSecondSaveCheckpointStore(base_path=tmp_path)
+    handle = AgentProcessHandle(process_id="erroring-resume")
+
+    await handle.pause(store=ck_store)
+    waiter = asyncio.create_task(handle.wait_unpaused())
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    with pytest.raises(PersistenceError):
+        await handle.resume()
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -742,6 +742,38 @@ async def test_resume_clears_persisted_pause(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_resume_clears_original_pause_store_when_called_with_different_store(
+    tmp_path: Path,
+) -> None:
+    """Resume must clear the store that owns the acknowledged paused marker."""
+    pause_store = CheckpointStore(base_path=tmp_path / "pause")
+    resume_store = CheckpointStore(base_path=tmp_path / "resume")
+    process = AgentProcess(event_store=None)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=pause_store)
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=pause_store) is True
+
+    await handle.resume(store=resume_store)
+
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=pause_store) is False
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=resume_store) is False
+
+    await handle.cancel(reason="end test")
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_repeated_pause_preserves_original_checkpoint_store(tmp_path: Path) -> None:
     """A duplicate pause must not strand the acknowledged pause marker in its first store."""
     first_store = CheckpointStore(base_path=tmp_path / "first")

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -937,6 +937,30 @@ async def test_resume_surfaces_checkpoint_save_error(tmp_path: Path) -> None:
     with pytest.raises(PersistenceError):
         await handle.resume()
 
+    assert handle.status() is AgentProcessStatus.PAUSED
+    assert handle.should_pause() is True
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+
+@pytest.mark.asyncio
+async def test_terminal_transition_surfaces_checkpoint_save_error(tmp_path: Path) -> None:
+    """Terminal cleanup must not silently leave durable pause truth stale."""
+    ck_store = _FailingSecondSaveCheckpointStore(base_path=tmp_path)
+    handle = AgentProcessHandle(process_id="erroring-terminal")
+
+    await handle.pause(store=ck_store)
+    waiter = asyncio.create_task(handle.wait_unpaused())
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    with pytest.raises(PersistenceError):
+        await handle._mark_cancelled()
+
+    assert handle.status() is AgentProcessStatus.PAUSED
+    assert handle.should_pause() is True
+
     waiter.cancel()
     with pytest.raises(asyncio.CancelledError):
         await waiter

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -34,6 +34,21 @@ class _FakeEventStore:
         self.appended.append(event)
 
 
+class _BlockingWaitEventStore(_FakeEventStore):
+    """Event store that holds the WAIT append open to expose resume races."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.wait_append_started = asyncio.Event()
+        self.release_wait_append = asyncio.Event()
+
+    async def append(self, event: BaseEvent) -> None:
+        self.appended.append(event)
+        if event.data.get("directive") == "wait":
+            self.wait_append_started.set()
+            await self.release_wait_append.wait()
+
+
 def _types(events: list[BaseEvent]) -> list[str]:
     return [e.type for e in events]
 
@@ -630,6 +645,42 @@ async def test_pause_request_does_not_persist_until_acknowledged(tmp_path: Path)
     await handle.cancel(reason="end test")
     release.set()
     await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_fast_resume_during_pause_ack_does_not_rewrite_stale_pause(
+    tmp_path: Path,
+) -> None:
+    """A resume that wins while WAIT is being emitted must remain durable truth."""
+    ck_store = CheckpointStore(base_path=tmp_path)
+    event_store = _BlockingWaitEventStore()
+    process = AgentProcess(event_store=event_store)
+    started = asyncio.Event()
+    checkpoint = asyncio.Event()
+    wait_returned = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        await checkpoint.wait()
+        await handle.wait_unpaused()
+        wait_returned.set()
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await handle.pause(store=ck_store)
+    checkpoint.set()
+    await asyncio.wait_for(event_store.wait_append_started.wait(), timeout=1.0)
+    assert handle.status() is AgentProcessStatus.PAUSED
+
+    await handle.resume(store=ck_store)
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is False
+
+    event_store.release_wait_append.set()
+    await asyncio.wait_for(wait_returned.wait(), timeout=1.0)
+    await handle.wait_until_complete(timeout=1.0)
+
+    assert AgentProcessHandle.load_persisted_pause(handle.process_id, store=ck_store) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements slice 2 of #518 (M6 Agent OS RFC). The module docstring (lines 17–21) deferred this work explicitly: *"Slice 2 (#518) extends the existing CheckpointStore (#338) so pause survives a process restart."* This PR delivers exactly that.

- **`pause()`** now writes a `CheckpointData` row with `phase="agent_process_paused"`, `seed_id=process_id` (UUID4 hex — safe for `CheckpointStore` path sanitization). Save failures are logged as warnings and never propagated; the in-memory flag remains authoritative.
- **`resume()`** overwrites that row with `phase="agent_process_running"` so `load_persisted_pause()` returns `False` after a resume.
- **`AgentProcessHandle.load_persisted_pause(process_id, *, store)`** — new class method that returns `True` iff the latest checkpoint for this `process_id` has `phase="agent_process_paused"`. Restart-recovery callers use this to restore the paused flag.
- No new persistence module introduced — `CheckpointStore` (#338) is reused as-is.
- `pause()` / `resume()` accept an optional `store` kwarg for DI in tests; existing call sites with no args continue to work unchanged.

## Test plan

Four new tests in `tests/unit/orchestrator/test_agent_process.py`:

- [ ] `test_pause_persists_state_via_checkpoint_store` — `pause()` then `load_persisted_pause()` → `True`
- [ ] `test_resume_clears_persisted_pause` — `pause()`, `resume()`, `load_persisted_pause()` → `False`
- [ ] `test_pause_swallows_checkpoint_save_error` — erroring store injected; in-memory flag still set, no exception
- [ ] `test_load_persisted_pause_returns_false_when_no_checkpoint` — fresh `process_id` → `False`

All 62 unit tests pass (`tests/unit/orchestrator/` + `tests/unit/persistence/`). `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)