### PR TITLE
feat(orchestrator): durable cancel signal for AgentProcess (#518)

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -7,14 +7,17 @@ from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 import inspect
+import logging
 from typing import Any
 from uuid import uuid4
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.agent_process import AgentProcessHandle
 from ouroboros.orchestrator.events import create_execution_terminal_event
 from ouroboros.orchestrator.heartbeat import is_holder_alive, is_owned_by_current_process
 from ouroboros.orchestrator.runner import clear_cancellation, request_cancellation
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+from ouroboros.persistence.checkpoint import CheckpointStore
 from ouroboros.persistence.event_store import EventStore
 
 
@@ -77,23 +80,41 @@ def _safe_meta(value: Any) -> Any:
 
 
 _JOB_TTL = timedelta(hours=1)
+logger = logging.getLogger(__name__)
 
 
 class JobManager:
     """Owns background MCP jobs and persists their state as events."""
 
-    def __init__(self, event_store: EventStore | None = None) -> None:
+    def __init__(
+        self, event_store: EventStore | None = None, checkpoint_store: CheckpointStore | None = None
+    ) -> None:
         self._event_store = event_store or EventStore()
+        self._checkpoint_store = checkpoint_store
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._runner_tasks: dict[str, asyncio.Task[Any]] = {}
         self._monitors: dict[str, asyncio.Task[None]] = {}
         self._initialized = False
         self._known_job_ids: set[str] = set()
+        self._reserved_job_ids: set[str] = set()
 
     async def _ensure_initialized(self) -> None:
         if not self._initialized:
             await self._event_store.initialize()
             self._initialized = True
+
+    async def allocate_job_id(self) -> str:
+        """Reserve a fresh job ID before constructing a job runner."""
+        await self._ensure_initialized()
+        while True:
+            job_id = f"job_{uuid4().hex[:12]}"
+            if job_id in self._known_job_ids:
+                continue
+            if await self._job_exists(job_id):
+                continue
+            self._known_job_ids.add(job_id)
+            self._reserved_job_ids.add(job_id)
+            return job_id
 
     async def start_job(
         self,
@@ -102,11 +123,18 @@ class JobManager:
         initial_message: str,
         runner: asyncio.Future[Any] | Any,
         links: JobLinks | None = None,
+        job_id: str | None = None,
     ) -> JobSnapshot:
         """Create and start a new background job."""
         await self._ensure_initialized()
 
-        job_id = f"job_{uuid4().hex[:12]}"
+        if job_id is None:
+            job_id = await self.allocate_job_id()
+        elif job_id not in self._reserved_job_ids:
+            if job_id in self._known_job_ids or await self._job_exists(job_id):
+                raise ValueError(f"Job already exists: {job_id}")
+            self._known_job_ids.add(job_id)
+        self._reserved_job_ids.discard(job_id)
         job_links = links or JobLinks()
 
         await self._append_event(
@@ -124,7 +152,6 @@ class JobManager:
             },
         )
 
-        self._known_job_ids.add(job_id)
         # Normalise ``runner`` to a Task so ``_run_job`` can rely on Task
         # semantics (cancellation, ``done()``). Coroutines are wrapped via
         # ``create_task``; pre-built Tasks are reused; bare awaitables (e.g.
@@ -146,6 +173,10 @@ class JobManager:
         self._monitors[job_id] = asyncio.create_task(self._monitor_job(job_id))
 
         return await self.get_snapshot(job_id)
+
+    async def _job_exists(self, job_id: str) -> bool:
+        events, _ = await self._event_store.get_events_after("job", job_id, last_row_id=0)
+        return bool(events)
 
     async def _run_job(
         self,
@@ -457,6 +488,15 @@ class JobManager:
         if snapshot.is_terminal:
             return snapshot
 
+        try:
+            self._persist_durable_cancel(job_id, reason="Background job cancelled")
+        except Exception:  # noqa: BLE001 - durable cancel must not block live cancellation
+            logger.warning(
+                "job_manager.cancel_job: failed to persist durable cancel marker",
+                exc_info=True,
+                extra={"job_id": job_id},
+            )
+
         linked_session_repo: SessionRepository | None = None
         linked_session_reconstructed = False
         linked_session_started = False
@@ -614,6 +654,24 @@ class JobManager:
         if not candidates:
             return None
         return max(candidates, key=lambda s: s.updated_at)
+
+    def _persist_durable_cancel(self, job_id: str, *, reason: str) -> None:
+        """Persist the job-scoped AgentProcess cancel marker before volatile cancel.
+
+        The running AgentProcess normally writes this marker when it observes a
+        cooperative cancel, but ``cancel_job`` is the user-facing accept point.
+        Persisting here closes the crash window between ``CANCEL_REQUESTED`` and
+        runner observation so a restarted job using ``mcp_job:{job_id}`` will
+        still see the cancellation.
+        """
+        store = self._checkpoint_store or CheckpointStore()
+        store.initialize()
+        AgentProcessHandle.persist_cancel_signal(
+            f"mcp_job:{job_id}",
+            store=store,
+            reason=reason,
+            source_process_id=job_id,
+        )
 
     async def cleanup_expired_jobs(self, ttl: timedelta | None = None) -> int:
         """Remove terminal jobs older than *ttl* from the in-memory registry.

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 import os
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import structlog
 import yaml
@@ -891,11 +892,26 @@ class StartEvolveStepHandler:
             )
 
         # Fall-through: real background job path.
-        async def _runner() -> MCPToolResult:
+        async def _runner(handle) -> MCPToolResult:
+            if handle.should_cancel():
+                return MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="evolve_step cancelled before restart work began.",
+                        ),
+                    ),
+                    is_error=True,
+                    meta={"status": "cancelled"},
+                )
             result = await self._evolve_handler.handle(arguments)
             if result.is_err:
                 raise RuntimeError(str(result.error))
             return result.value
+
+        job_id = await self._job_manager.allocate_job_id()
+        agent_process_id = f"evolve_step:{lineage_id}:{uuid4().hex[:12]}"
+        agent_cancel_key = f"mcp_job:{job_id}"
 
         snapshot = await self._job_manager.start_job(
             job_type="evolve_step",
@@ -903,9 +919,12 @@ class StartEvolveStepHandler:
             runner=run_with_agent_process(
                 event_store=self._event_store,
                 intent="evolve_step",
-                work_fn=lambda _handle: _runner(),
+                work_fn=_runner,
+                process_id=agent_process_id,
+                cancel_key=agent_cancel_key,
             ),
             links=JobLinks(lineage_id=lineage_id),
+            job_id=job_id,
         )
 
         text = (

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -1159,7 +1159,18 @@ class StartExecuteSeedHandler:
             execution_id = f"exec_{uuid4().hex[:12]}"
             new_session_id = f"orch_{uuid4().hex[:12]}"
 
-        async def _runner() -> MCPToolResult:
+        async def _runner(handle) -> MCPToolResult:
+            if handle.should_cancel():
+                return MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="Seed execution cancelled before restart work began.",
+                        ),
+                    ),
+                    is_error=True,
+                    meta={"status": "cancelled"},
+                )
             result = await self._execute_handler.handle(
                 arguments,
                 execution_id=execution_id,
@@ -1170,18 +1181,23 @@ class StartExecuteSeedHandler:
                 raise RuntimeError(str(result.error))
             return result.value
 
+        job_id = await self._job_manager.allocate_job_id()
+
         snapshot = await self._job_manager.start_job(
             job_type="execute_seed",
             initial_message="Queued seed execution",
             runner=run_with_agent_process(
                 event_store=self._event_store,
                 intent="execute_seed",
-                work_fn=lambda _handle: _runner(),
+                work_fn=_runner,
+                process_id=f"execute_seed:{execution_id}:{job_id}",
+                cancel_key=f"mcp_job:{job_id}",
             ),
             links=JobLinks(
                 session_id=session_id or new_session_id,
                 execution_id=execution_id,
             ),
+            job_id=job_id,
         )
 
         from ouroboros.orchestrator.runtime_factory import resolve_agent_runtime_backend

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 import logging
 import math
 from typing import Any
+from uuid import uuid4
 
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
@@ -408,9 +409,24 @@ class RalphHandler:
 
         runner = RalphLoopRunner(self._evolve_handler)
 
-        async def _run_loop() -> MCPToolResult:
+        async def _run_loop(handle) -> MCPToolResult:
+            if handle.should_cancel():
+                return MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="Ralph loop cancelled before restart work began.",
+                        ),
+                    ),
+                    is_error=True,
+                    meta={"status": "cancelled"},
+                )
             result = await runner.run(config)
             return result.to_tool_result()
+
+        job_id = await self._job_manager.allocate_job_id()
+        agent_process_id = f"ralph:{config.lineage_id}:{uuid4().hex[:12]}"
+        agent_cancel_key = f"mcp_job:{job_id}"
 
         snapshot = await self._job_manager.start_job(
             job_type="ralph",
@@ -418,9 +434,12 @@ class RalphHandler:
             runner=run_with_agent_process(
                 event_store=self._event_store,
                 intent="ralph",
-                work_fn=lambda _handle: _run_loop(),
+                work_fn=_run_loop,
+                process_id=agent_process_id,
+                cancel_key=agent_cancel_key,
             ),
             links=JobLinks(lineage_id=config.lineage_id),
+            job_id=job_id,
         )
 
         text = (

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -53,6 +53,7 @@ from uuid import uuid4
 
 from ouroboros.core.control_contract import ControlContract
 from ouroboros.core.directive import Directive
+from ouroboros.core.errors import PersistenceError
 from ouroboros.events.control import create_control_directive_emitted_event
 from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
 
@@ -62,6 +63,9 @@ logger = logging.getLogger(__name__)
 _TARGET_TYPE: Final[str] = "agent_process"
 _EMITTED_BY: Final[str] = "agent_process"
 _DIRECTIVE_EMIT_TIMEOUT_SECONDS: Final[float] = 1.0
+_CANCELLED_PHASE: Final[str] = "agent_process_cancelled"
+_CANCEL_CONSUMED_PHASE: Final[str] = "agent_process_cancel_consumed"
+_CANCEL_CONTROL_SEED_PREFIX: Final[str] = "__ouroboros_agent_process_cancel__:"
 
 
 class AgentProcessStatus(StrEnum):
@@ -267,6 +271,8 @@ class AgentProcessHandle:
     _expected_directive_count: int = 0
     _emit_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _work_task: asyncio.Task[None] | None = None
+    _checkpoint_store: CheckpointStore | None = field(default=None, repr=False)
+    _cancel_key: str | None = field(default=None, repr=False)
     _pause_checkpoint_store: CheckpointStore | None = field(default=None, repr=False)
     _pause_checkpoint_reason: str | None = field(default=None, repr=False)
     _pause_checkpoint_requested: bool = field(default=False, repr=False)
@@ -351,16 +357,40 @@ class AgentProcessHandle:
         if self._status is AgentProcessStatus.PAUSED:
             await self._set_status(AgentProcessStatus.RUNNING, reason="resume requested")
 
-    async def cancel(self, reason: str = "cancel requested") -> None:
+    async def cancel(
+        self,
+        reason: str = "cancel requested",
+        *,
+        checkpoint_store: CheckpointStore | None = None,
+    ) -> None:
         """Request a cooperative cancel.
 
         The work loop sees the cancel flag at the next checkpoint and
         exits cleanly. In-flight LLM/tool calls finish naturally; the
-        loop exits before starting the next iteration.
+        loop exits before starting the next iteration. If a checkpoint store
+        is wired, the cancel signal is also persisted as a best-effort hint
+        for restart recovery.
         """
         if self._status in _TERMINAL_STATUSES:
             return
         self._request_cancel(reason)
+
+        store = checkpoint_store or self._checkpoint_store
+        if store is not None:
+            try:
+                cancel_key = self._cancel_key or self.process_id
+                self.persist_cancel_signal(
+                    cancel_key,
+                    store=store,
+                    reason=reason,
+                    source_process_id=self.process_id,
+                )
+            except Exception:  # noqa: BLE001 — live cancellation remains authoritative
+                logger.warning(
+                    "agent_process.cancel_checkpoint_save_failed",
+                    extra={"process_id": self.process_id},
+                    exc_info=True,
+                )
 
     async def abort(self, reason: str = "abort requested") -> None:
         """Cancel the underlying work task for caller-abort propagation."""
@@ -459,6 +489,125 @@ class AgentProcessHandle:
                 extra={"process_id": process_id},
             )
             return False
+
+    @classmethod
+    def persist_cancel_signal(
+        cls,
+        process_id: str,
+        *,
+        store: CheckpointStore,
+        reason: str,
+        source_process_id: str | None = None,
+    ) -> None:
+        """Persist a durable cancel marker for a restart-stable cancel identity."""
+        checkpoint = CheckpointData.create(
+            seed_id=cls._cancel_checkpoint_seed(process_id),
+            phase=_CANCELLED_PHASE,
+            state={
+                "status": "cancelled",
+                "process_id": source_process_id or process_id,
+                "cancel_key": process_id,
+                "reason": reason,
+                "cancelled_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        result = store.save(checkpoint)
+        if result.is_err:
+            raise result.error
+
+    @classmethod
+    def load_persisted_cancel(
+        cls,
+        process_id: str,
+        *,
+        store: CheckpointStore | None = None,
+    ) -> tuple[bool, str | None]:
+        """Return ``(True, reason)`` iff durable state records cancellation.
+
+        Cancel checkpoints live under a dedicated control-plane key so ordinary
+        workflow checkpoints for the same process cannot rotate them out.
+        If any cancel checkpoint artifact exists but cannot be read, this fails
+        closed by raising instead of treating cancellation as absent.
+        """
+        if store is None:
+            return False, None
+        seed_id = cls._cancel_checkpoint_seed(process_id)
+        for level in range(store.MAX_ROLLBACK_DEPTH + 1):
+            if not cls._checkpoint_artifact_exists(store, seed_id, level=level):
+                continue
+            result = store._load_checkpoint_level(seed_id, level)  # noqa: SLF001
+            if result.is_err:
+                raise result.error
+            checkpoint = result.value
+            if checkpoint.phase == _CANCEL_CONSUMED_PHASE:
+                if level > 0:
+                    raise PersistenceError(
+                        "Ambiguous durable cancel state: found a rotated consumed marker "
+                        "without a current checkpoint level",
+                        operation="read",
+                        details={"seed_id": seed_id, "level": level},
+                    )
+                return False, None
+            if checkpoint.phase == _CANCELLED_PHASE:
+                reason = checkpoint.state.get("reason")
+                return True, reason if isinstance(reason, str) else None
+        return False, None
+
+    @staticmethod
+    def _cancel_checkpoint_seed(process_id: str) -> str:
+        """Return the reserved durable checkpoint seed for cancel control state."""
+        AgentProcessHandle._validate_process_id_namespace(process_id)
+        return f"{_CANCEL_CONTROL_SEED_PREFIX}{process_id}"
+
+    @staticmethod
+    def _validate_process_id_namespace(process_id: str) -> None:
+        """Reject caller process IDs that collide with control-plane seeds."""
+        sanitized_process_id = CheckpointStore._sanitize_seed_id(process_id)  # noqa: SLF001
+        sanitized_prefix = CheckpointStore._sanitize_seed_id(  # noqa: SLF001
+            _CANCEL_CONTROL_SEED_PREFIX
+        )
+        if process_id.startswith(_CANCEL_CONTROL_SEED_PREFIX) or sanitized_process_id.startswith(
+            sanitized_prefix
+        ):
+            raise ValueError(
+                "process_id uses the reserved agent-process cancel checkpoint namespace"
+            )
+
+    @classmethod
+    def _consume_persisted_cancel(
+        cls, process_id: str, *, store: CheckpointStore, reason: str | None
+    ) -> None:
+        """Mark a durable cancel as consumed after restart teardown observes it."""
+        consumed = CheckpointData.create(
+            seed_id=cls._cancel_checkpoint_seed(process_id),
+            phase=_CANCEL_CONSUMED_PHASE,
+            state={
+                "status": "cancel_consumed",
+                "process_id": process_id,
+                "reason": reason,
+                "consumed_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        result = store.save(consumed)
+        if result.is_err:
+            raise result.error
+
+    @staticmethod
+    def _checkpoint_artifact_exists(store: CheckpointStore, process_id: str, level: int) -> bool:
+        """Return True when a specific rollback-level checkpoint file exists."""
+        try:
+            path = store._get_checkpoint_path(process_id, level)  # noqa: SLF001
+            try:
+                path.stat()
+            except FileNotFoundError:
+                return False
+            return True
+        except Exception as exc:  # noqa: BLE001
+            raise PersistenceError(
+                f"Failed to inspect checkpoint artifact: {exc}",
+                operation="read",
+                details={"seed_id": process_id, "level": level},
+            ) from exc
 
     def failure(self) -> BaseException | None:
         """Return the exception captured from the work task, if it failed."""
@@ -716,6 +865,8 @@ class AgentProcess:
     """
 
     event_store: _AppendableEventStore | None = None
+    checkpoint_store: CheckpointStore | None = None
+    cancel_key: str | None = None
 
     async def spawn(
         self,
@@ -744,6 +895,9 @@ class AgentProcess:
             The :class:`AgentProcessHandle` wired to the work loop.
         """
         pid = process_id or _new_process_id()
+        cancel_key = self.cancel_key or pid
+        AgentProcessHandle._validate_process_id_namespace(pid)
+        AgentProcessHandle._validate_process_id_namespace(cancel_key)
         emit = self._make_emitter(intent=intent, process_id=pid)
         replay_store: _ReplayableEventStore | None = (
             self.event_store  # type: ignore[assignment]
@@ -755,7 +909,21 @@ class AgentProcess:
             _emit_directive=emit,
             _replay_store=replay_store,
             _validate_replay_against_live_status=True,
+            _checkpoint_store=self.checkpoint_store,
+            _cancel_key=cancel_key,
         )
+        persisted_cancel_found = False
+        persisted_cancel_reason: str | None = None
+        if self.checkpoint_store is not None:
+            cancelled, reason = AgentProcessHandle.load_persisted_cancel(
+                cancel_key, store=self.checkpoint_store
+            )
+            if cancelled:
+                persisted_cancel_found = True
+                persisted_cancel_reason = reason
+                handle._cancel_reason = reason or "cancel requested"
+                handle._cancel_event.set()
+                handle._paused_event.set()
         # Emit the initial RUNNING transition so projections have a
         # spawn marker even if the loop fails before the first
         # cooperative checkpoint.
@@ -794,6 +962,19 @@ class AgentProcess:
                 try:
                     if handle.should_cancel() and not handle._complete_on_return_after_cancel:
                         await handle._mark_cancelled()
+                        if self.checkpoint_store is not None and persisted_cancel_found:
+                            try:
+                                AgentProcessHandle._consume_persisted_cancel(
+                                    cancel_key,
+                                    store=self.checkpoint_store,
+                                    reason=persisted_cancel_reason,
+                                )
+                            except Exception:  # noqa: BLE001 — cleanup must not hide cancellation
+                                logger.warning(
+                                    "agent_process.spawn_cancel_consume_failed",
+                                    extra={"process_id": pid, "cancel_key": cancel_key},
+                                    exc_info=True,
+                                )
                     else:
                         await handle._mark_completed(reason="work returned")
                 except BaseException as exc:  # noqa: BLE001 — terminal durability failure
@@ -877,6 +1058,9 @@ async def run_with_agent_process[T](
     intent: str,
     work_fn: Callable[[AgentProcessHandle], Awaitable[T]],
     timeout: float | None = None,
+    checkpoint_store: CheckpointStore | None = None,
+    process_id: str | None = None,
+    cancel_key: str | None = None,
 ) -> T:
     """Run one production surface through :class:`AgentProcess.spawn`.
 
@@ -907,6 +1091,29 @@ async def run_with_agent_process[T](
             error_box.append(exc)
             raise
 
+    durable_store = checkpoint_store
+    durable_cancel_key = cancel_key or process_id
+    if durable_cancel_key is not None and durable_store is None:
+        try:
+            durable_store = CheckpointStore()
+            durable_store.initialize()
+        except Exception:  # noqa: BLE001 — durable cancel is best-effort at this boundary
+            logger.warning(
+                "agent_process.run_with_agent_process_checkpoint_unavailable",
+                extra={
+                    "process_id": process_id,
+                    "cancel_key": durable_cancel_key,
+                    "intent": intent,
+                },
+                exc_info=True,
+            )
+            durable_store = None
+
+    process = AgentProcess(
+        event_store=event_store, checkpoint_store=durable_store, cancel_key=durable_cancel_key
+    )
+    handle = await process.spawn(intent=intent, work_fn=_work, process_id=process_id)
+
     async def _request_work_cancellation() -> asyncio.Task[None] | None:
         await handle.cancel(reason="cancelled by job runner")
         work_task = handle._work_task
@@ -914,8 +1121,6 @@ async def run_with_agent_process[T](
             work_task.cancel()
         return work_task
 
-    process = AgentProcess(event_store=event_store)
-    handle = await process.spawn(intent=intent, work_fn=_work)
     try:
         final_status = await handle.wait_until_complete(timeout=timeout)
     except asyncio.CancelledError:

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -18,6 +18,7 @@ import asyncio
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
+from uuid import uuid4
 
 import pytest
 
@@ -81,6 +82,11 @@ class _CancellableJobManager:
     def __init__(self) -> None:
         self.runner_task: asyncio.Task[Any] | None = None
         self.job_types: list[str] = []
+        self._counter = 0
+
+    async def allocate_job_id(self) -> str:
+        self._counter += 1
+        return f"job_{uuid4().hex[:12]}"
 
     async def start_job(
         self,
@@ -89,11 +95,13 @@ class _CancellableJobManager:
         initial_message: str,  # noqa: ARG002 - mirrors JobManager API
         runner: Any,
         links: JobLinks | None = None,
+        job_id: str | None = None,
     ) -> _CompletedJobSnapshot:
+        job_id = job_id or await self.allocate_job_id()
         self.job_types.append(job_type)
         self.runner_task = asyncio.create_task(runner)
         return _CompletedJobSnapshot(
-            job_id=f"job_{job_type}",
+            job_id=job_id,
             links=links or JobLinks(),
             status=JobStatus.RUNNING,
         )
@@ -111,6 +119,11 @@ class _InlineJobManager:
     def __init__(self) -> None:
         self.runner_results: list[MCPToolResult] = []
         self.job_types: list[str] = []
+        self._counter = 0
+
+    async def allocate_job_id(self) -> str:
+        self._counter += 1
+        return f"job_{uuid4().hex[:12]}"
 
     async def start_job(
         self,
@@ -119,11 +132,13 @@ class _InlineJobManager:
         initial_message: str,  # noqa: ARG002 - mirrors JobManager API
         runner: Any,
         links: JobLinks | None = None,
+        job_id: str | None = None,
     ) -> _CompletedJobSnapshot:
+        job_id = job_id or await self.allocate_job_id()
         self.job_types.append(job_type)
         self.runner_results.append(await runner)
         return _CompletedJobSnapshot(
-            job_id=f"job_{job_type}",
+            job_id=job_id,
             links=links or JobLinks(),
         )
 

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -18,11 +18,13 @@ from ouroboros.mcp.tools.job_handlers import (
     _render_job_snapshot_inner,
 )
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.agent_process import AgentProcessHandle
 from ouroboros.orchestrator.heartbeat import acquire as acquire_session_lock
 from ouroboros.orchestrator.heartbeat import lock_path
 from ouroboros.orchestrator.heartbeat import release as release_session_lock
 from ouroboros.orchestrator.runner import clear_cancellation, is_cancellation_requested
 from ouroboros.orchestrator.session import SessionRepository
+from ouroboros.persistence.checkpoint import CheckpointStore
 from ouroboros.persistence.event_store import EventStore, PersistenceError
 
 
@@ -42,6 +44,25 @@ async def _cancel_manager_tasks(manager: JobManager) -> None:
             task.cancel()
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _wait_for_job_status(
+    manager: JobManager,
+    job_id: str,
+    status: JobStatus,
+    *,
+    timeout: float = 1.0,
+) -> JobSnapshot:
+    deadline = asyncio.get_running_loop().time() + timeout
+    last_snapshot: JobSnapshot | None = None
+    while asyncio.get_running_loop().time() < deadline:
+        last_snapshot = await manager.get_snapshot(job_id)
+        if last_snapshot.status is status:
+            return last_snapshot
+        await asyncio.sleep(0.01)
+    if last_snapshot is None:
+        last_snapshot = await manager.get_snapshot(job_id)
+    raise AssertionError(f"job {job_id} did not become {status}; last={last_snapshot.status}")
 
 
 class TestJobManager:
@@ -132,13 +153,93 @@ class TestJobManager:
                 links=JobLinks(),
             )
 
-            await asyncio.sleep(0.15)
-            snapshot = await manager.get_snapshot(started.job_id)
+            snapshot = await _wait_for_job_status(manager, started.job_id, JobStatus.COMPLETED)
 
             assert snapshot.status == JobStatus.COMPLETED
             assert snapshot.result_text == "done"
             assert snapshot.result_meta["kind"] == "test"
         finally:
+            await store.close()
+
+    async def test_start_job_default_allocates_job_id(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(),
+            )
+
+            assert started.job_id.startswith("job_")
+            assert len(started.job_id) == len("job_") + 12
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_start_job_accepts_preallocated_job_id_once(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                return MCPToolResult()
+
+            job_id = await manager.allocate_job_id()
+            started = await manager.start_job(
+                job_id=job_id,
+                job_type="test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(),
+            )
+
+            assert started.job_id == job_id
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_start_job_rejects_existing_job_id(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                return MCPToolResult()
+
+            job_id = await manager.allocate_job_id()
+            await manager.start_job(
+                job_id=job_id,
+                job_type="test",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(),
+            )
+
+            try:
+                runner = asyncio.get_running_loop().create_future()
+                runner.set_result(MCPToolResult())
+                await manager.start_job(
+                    job_id=job_id,
+                    job_type="test",
+                    initial_message="queued again",
+                    runner=runner,
+                    links=JobLinks(),
+                )
+            except ValueError as exc:
+                assert str(exc) == f"Job already exists: {job_id}"
+            else:
+                raise AssertionError("expected duplicate job_id to be rejected")
+        finally:
+            await _cancel_manager_tasks(manager)
             await store.close()
 
     async def test_start_job_tracks_externally_created_task(self, tmp_path) -> None:
@@ -165,8 +266,7 @@ class TestJobManager:
 
             assert manager._runner_tasks.get(started.job_id) is external_task
 
-            await asyncio.sleep(0.1)
-            snapshot = await manager.get_snapshot(started.job_id)
+            snapshot = await _wait_for_job_status(manager, started.job_id, JobStatus.COMPLETED)
             assert snapshot.status == JobStatus.COMPLETED
             assert started.job_id not in manager._runner_tasks
         finally:
@@ -197,8 +297,7 @@ class TestJobManager:
                     meta={"kind": "future"},
                 )
             )
-            await asyncio.sleep(0.05)
-            snapshot = await manager.get_snapshot(started.job_id)
+            snapshot = await _wait_for_job_status(manager, started.job_id, JobStatus.COMPLETED)
 
             assert snapshot.status == JobStatus.COMPLETED
             assert snapshot.result_text == "future"
@@ -275,6 +374,68 @@ class TestJobManager:
             assert changed is True
             assert snapshot.cursor >= started.cursor
         finally:
+            await store.close()
+
+    async def test_cancel_job_persists_job_scoped_agent_process_cancel(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        checkpoint_store = CheckpointStore(tmp_path / "checkpoints")
+        manager = JobManager(store, checkpoint_store=checkpoint_store)
+
+        try:
+            never_done = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                await never_done.wait()
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="durable_cancel",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(),
+            )
+
+            await manager.cancel_job(started.job_id)
+
+            found, reason = AgentProcessHandle.load_persisted_cancel(
+                f"mcp_job:{started.job_id}", store=checkpoint_store
+            )
+            assert found is True
+            assert reason == "Background job cancelled"
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_job_persist_failure_does_not_block_cancellation(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        def _raise_persist(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            raise RuntimeError("checkpoint unavailable")
+
+        monkeypatch.setattr(manager, "_persist_durable_cancel", _raise_persist)
+
+        try:
+            never_done = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                await never_done.wait()
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="durable_cancel_best_effort",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(),
+            )
+
+            snapshot = await manager.cancel_job(started.job_id)
+
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+        finally:
+            await _cancel_manager_tasks(manager)
             await store.close()
 
     async def test_cancel_job_cancels_non_session_task(self, tmp_path) -> None:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -640,10 +640,13 @@ class TestAsyncJobHandlers:
                 return None
 
         class FakeJobManager:
-            async def start_job(self, *, job_type, initial_message, runner, links):
+            async def allocate_job_id(self):
+                return "job_test"
+
+            async def start_job(self, *, job_type, initial_message, runner, links, job_id=None):
                 runner.close()
                 return SimpleNamespace(
-                    job_id="job_test",
+                    job_id=job_id or "job_test",
                     links=links,
                     status=SimpleNamespace(value="queued"),
                     cursor=1,

--- a/tests/unit/mcp/tools/test_job_instance_cancel_keys.py
+++ b/tests/unit/mcp/tools/test_job_instance_cancel_keys.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from ouroboros.core.types import Result
+from ouroboros.mcp.job_manager import JobLinks, JobSnapshot, JobStatus
+from ouroboros.mcp.tools import evolution_handlers, execution_handlers, ralph_handlers
+from ouroboros.mcp.tools.evolution_handlers import StartEvolveStepHandler
+from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.types import MCPToolResult
+
+
+class _EventStore:
+    async def initialize(self) -> None:
+        return None
+
+
+class _JobManager:
+    def __init__(self) -> None:
+        self._counter = 0
+        self.started: list[dict[str, Any]] = []
+
+    async def allocate_job_id(self) -> str:
+        self._counter += 1
+        return f"job_{self._counter:012d}"
+
+    async def start_job(
+        self,
+        *,
+        job_type: str,
+        initial_message: str,
+        runner: Any,
+        links: JobLinks | None = None,
+        job_id: str | None = None,
+    ) -> JobSnapshot:
+        job_id = job_id or await self.allocate_job_id()
+        self.started.append({"job_type": job_type, "job_id": job_id, "links": links})
+        try:
+            runner.close()
+        except AttributeError:
+            pass
+        now = datetime.now(UTC)
+        return JobSnapshot(
+            job_id=job_id,
+            job_type=job_type,
+            status=JobStatus.QUEUED,
+            message=initial_message,
+            created_at=now,
+            updated_at=now,
+            links=links or JobLinks(),
+        )
+
+
+class _EvolveHandler:
+    async def handle(self, arguments: dict[str, Any]) -> Result[MCPToolResult, Any]:
+        return Result.ok(MCPToolResult(meta={"lineage_id": arguments["lineage_id"]}))
+
+
+class _ExecuteHandler:
+    agent_runtime_backend: str | None = None
+    llm_backend: str | None = None
+
+    async def handle(self, *args: Any, **kwargs: Any) -> Result[MCPToolResult, Any]:
+        return Result.ok(MCPToolResult())
+
+
+def _capture_run_with_agent_process(monkeypatch, module) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_run_with_agent_process(**kwargs: Any):
+        calls.append(kwargs)
+
+        async def _runner() -> MCPToolResult:
+            return MCPToolResult()
+
+        return _runner()
+
+    monkeypatch.setattr(module, "run_with_agent_process", _fake_run_with_agent_process)
+    return calls
+
+
+async def test_ralph_jobs_on_same_lineage_use_distinct_job_scoped_cancel_keys(monkeypatch) -> None:
+    calls = _capture_run_with_agent_process(monkeypatch, ralph_handlers)
+    job_manager = _JobManager()
+    handler = RalphHandler(
+        evolve_handler=_EvolveHandler(),
+        event_store=_EventStore(),  # type: ignore[arg-type]
+        job_manager=job_manager,  # type: ignore[arg-type]
+    )
+
+    first = await handler.handle({"lineage_id": "lin_same"})
+    second = await handler.handle({"lineage_id": "lin_same"})
+
+    assert first.is_ok and second.is_ok
+    assert [call["cancel_key"] for call in calls] == [
+        "mcp_job:job_000000000001",
+        "mcp_job:job_000000000002",
+    ]
+    assert calls[0]["cancel_key"] != "ralph:lin_same"
+    assert calls[0]["process_id"] != calls[1]["process_id"]
+
+
+async def test_evolve_jobs_on_same_lineage_use_distinct_job_scoped_cancel_keys(monkeypatch) -> None:
+    calls = _capture_run_with_agent_process(monkeypatch, evolution_handlers)
+    job_manager = _JobManager()
+    handler = StartEvolveStepHandler(
+        evolve_handler=_EvolveHandler(),  # type: ignore[arg-type]
+        event_store=_EventStore(),  # type: ignore[arg-type]
+        job_manager=job_manager,  # type: ignore[arg-type]
+    )
+
+    first = await handler.handle({"lineage_id": "lin_same"})
+    second = await handler.handle({"lineage_id": "lin_same"})
+
+    assert first.is_ok and second.is_ok
+    assert [call["cancel_key"] for call in calls] == [
+        "mcp_job:job_000000000001",
+        "mcp_job:job_000000000002",
+    ]
+    assert calls[0]["cancel_key"] != "evolve_step:lin_same"
+    assert calls[0]["process_id"] != calls[1]["process_id"]
+
+
+async def test_execute_seed_uses_job_scoped_cancel_key(monkeypatch, tmp_path) -> None:
+    calls = _capture_run_with_agent_process(monkeypatch, execution_handlers)
+    job_manager = _JobManager()
+    handler = StartExecuteSeedHandler(
+        execute_handler=_ExecuteHandler(),  # type: ignore[arg-type]
+        event_store=_EventStore(),  # type: ignore[arg-type]
+        job_manager=job_manager,  # type: ignore[arg-type]
+    )
+
+    result = await handler.handle({"seed_content": "goal: test\n", "cwd": str(tmp_path)})
+
+    assert result.is_ok
+    assert calls[0]["cancel_key"] == "mcp_job:job_000000000001"
+    assert calls[0]["process_id"].startswith("execute_seed:exec_")
+    assert calls[0]["cancel_key"] != calls[0]["process_id"]

--- a/tests/unit/mcp/tools/test_start_execute_seed_idempotency.py
+++ b/tests/unit/mcp/tools/test_start_execute_seed_idempotency.py
@@ -41,9 +41,13 @@ def _make_job_manager_stub(start_calls: list[dict]) -> JobManager:
 
     counter = {"n": 0}
 
-    async def _start_job(*, job_type, initial_message, runner, links=None):  # noqa: ARG001
+    async def _allocate_job_id():
         counter["n"] += 1
         job_id = f"job_{counter['n']:012d}"
+        return job_id
+
+    async def _start_job(*, job_type, initial_message, runner, links=None, job_id=None):  # noqa: ARG001
+        job_id = job_id or await _allocate_job_id()
         start_calls.append(
             {
                 "job_type": job_type,
@@ -69,6 +73,7 @@ def _make_job_manager_stub(start_calls: list[dict]) -> JobManager:
         )
         return snapshot
 
+    job_manager.allocate_job_id = _allocate_job_id
     job_manager.start_job = _start_job
     return job_manager
 
@@ -248,9 +253,13 @@ async def test_concurrent_calls_with_same_key_dedupe(event_store, tmp_path) -> N
     job_manager = MagicMock()
     counter = {"n": 0}
 
-    async def _slow_start_job(*, job_type, initial_message, runner, links=None):  # noqa: ARG001
+    async def _allocate_job_id():
         counter["n"] += 1
         job_id = f"job_{counter['n']:012d}"
+        return job_id
+
+    async def _slow_start_job(*, job_type, initial_message, runner, links=None, job_id=None):  # noqa: ARG001
+        job_id = job_id or await _allocate_job_id()
         start_calls.append({"job_id": job_id})
         try:
             runner.close()
@@ -270,6 +279,7 @@ async def test_concurrent_calls_with_same_key_dedupe(event_store, tmp_path) -> N
             updated_at=now,
         )
 
+    job_manager.allocate_job_id = _allocate_job_id
     job_manager.start_job = _slow_start_job
 
     handler = StartExecuteSeedHandler(

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -11,6 +11,7 @@ import asyncio
 from datetime import UTC, datetime
 import hashlib
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -22,6 +23,7 @@ from ouroboros.orchestrator.agent_process import (
     AgentProcessHandle,
     AgentProcessStatus,
     project_agent_process_snapshot,
+    run_with_agent_process,
 )
 from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
 from ouroboros.persistence.event_store import EventStore
@@ -1508,3 +1510,648 @@ async def test_load_persisted_pause_returns_false_when_no_checkpoint(tmp_path: P
     fresh_process_id = "deadbeefdeadbeefdeadbeefdeadbeef"
 
     assert AgentProcessHandle.load_persisted_pause(fresh_process_id, store=ck_store) is False
+
+
+# ---------------------------------------------------------------------------
+# Slice 4 of #518 — durable cancel signal via CheckpointStore
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_persists_state_via_checkpoint_store(tmp_path) -> None:
+    """``cancel()`` must write an ``agent_process_cancelled`` checkpoint
+    so a restarted process can detect that a previous run was cancelled
+    via :meth:`AgentProcessHandle.load_persisted_cancel`."""
+    from ouroboros.orchestrator.agent_process import AgentProcessHandle
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+
+    event_store = _FakeEventStore()
+    process = AgentProcess(event_store=event_store)
+
+    async def work(handle):
+        await asyncio.sleep(0.05)
+
+    handle = await process.spawn(intent="canary", work_fn=work)
+    handle._checkpoint_store = store  # noqa: SLF001 — exercise the injection point
+    await handle.cancel(reason="quota exceeded")
+    await handle.wait_until_complete(timeout=1.0)
+
+    found, reason = AgentProcessHandle.load_persisted_cancel(handle.process_id, store=store)
+    assert found is True
+    assert reason == "quota exceeded"
+
+
+@pytest.mark.asyncio
+async def test_cancel_swallows_checkpoint_save_error() -> None:
+    """A failing CheckpointStore must NOT raise out of ``cancel()`` —
+    the in-memory flag is authoritative and the durable hint is best
+    effort."""
+    from ouroboros.core.errors import PersistenceError
+    from ouroboros.core.types import Result
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    class _ExplodingStore(CheckpointStore):
+        def __init__(self) -> None:  # noqa: D401 — minimal stub
+            self.calls: list[Any] = []
+
+        def save(self, checkpoint: Any) -> Result[None, PersistenceError]:
+            self.calls.append(checkpoint)
+            return Result.err(PersistenceError("simulated disk full"))
+
+    event_store = _FakeEventStore()
+    process = AgentProcess(event_store=event_store)
+
+    async def work(handle):
+        await asyncio.sleep(0.05)
+
+    handle = await process.spawn(intent="explode", work_fn=work)
+    bad_store = _ExplodingStore()
+    handle._checkpoint_store = bad_store  # noqa: SLF001
+    await handle.cancel(reason="boom")
+    await handle.wait_until_complete(timeout=1.0)
+
+    # cancel() did not raise; the in-memory transition still happened
+    assert handle.status() is AgentProcessStatus.CANCELLED
+    # And the store attempt was made (so we know the code path executed)
+    assert len(bad_store.calls) == 1
+    assert bad_store.calls[0].phase == "agent_process_cancelled"
+
+
+def test_load_persisted_cancel_returns_false_when_no_checkpoint(tmp_path) -> None:
+    """A fresh ``process_id`` with no prior writes returns ``(False, None)``."""
+    from ouroboros.orchestrator.agent_process import AgentProcessHandle
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    found, reason = AgentProcessHandle.load_persisted_cancel("never-seen-process", store=store)
+    assert found is False
+    assert reason is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_uses_process_checkpoint_store_public_spawn_path(tmp_path) -> None:
+    """``AgentProcess(checkpoint_store=...)`` wires durable cancel into spawned handles."""
+    from ouroboros.orchestrator.agent_process import AgentProcessHandle
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process = AgentProcess(event_store=_FakeEventStore(), checkpoint_store=store)
+
+    async def work(handle):
+        while not handle.should_cancel():
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="public-store", work_fn=work)
+    await handle.cancel(reason="operator stop")
+    await handle.wait_until_complete(timeout=1.0)
+
+    found, reason = AgentProcessHandle.load_persisted_cancel(handle.process_id, store=store)
+    assert found is True
+    assert reason == "operator stop"
+
+
+@pytest.mark.asyncio
+async def test_spawn_enters_work_fn_cancelled_when_persisted_cancel_exists(tmp_path) -> None:
+    """Restarting the same process_id must let workflow teardown observe cancel."""
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process = AgentProcess(event_store=_FakeEventStore(), checkpoint_store=store)
+    process_id = "restart-cancelled-process"
+
+    async def first_work(handle):
+        while not handle.should_cancel():
+            await asyncio.sleep(0.005)
+
+    first = await process.spawn(intent="first", process_id=process_id, work_fn=first_work)
+    await first.cancel(reason="operator stop")
+    assert await first.wait_until_complete(timeout=1.0) is AgentProcessStatus.CANCELLED
+    restart_event_offset = len(process.event_store.appended)
+
+    teardown_called = False
+    normal_work_called = False
+
+    async def restarted_work(handle):
+        nonlocal normal_work_called, teardown_called
+        if handle.should_cancel():
+            teardown_called = True
+            return
+        normal_work_called = True
+
+    restarted = await process.spawn(intent="restart", process_id=process_id, work_fn=restarted_work)
+
+    assert await restarted.wait_until_complete(timeout=1.0) is AgentProcessStatus.CANCELLED
+    assert restarted.should_cancel() is True
+    assert teardown_called is True
+    assert normal_work_called is False
+    restart_directives = _directives(process.event_store.appended[restart_event_offset:])
+    assert restart_directives == ["continue", "cancel"]
+
+    third_called = False
+
+    async def third_work(handle):
+        nonlocal third_called
+        third_called = True
+
+    third = await process.spawn(intent="third", process_id=process_id, work_fn=third_work)
+
+    assert await third.wait_until_complete(timeout=1.0) is AgentProcessStatus.COMPLETED
+    assert third_called is True
+
+
+@pytest.mark.asyncio
+async def test_spawn_rejects_process_id_in_cancel_control_namespace(tmp_path) -> None:
+    """Caller-supplied process IDs must not collide with cancel-control keys."""
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process = AgentProcess(event_store=_FakeEventStore(), checkpoint_store=store)
+
+    async def work(handle):
+        return None
+
+    with pytest.raises(ValueError):
+        await process.spawn(
+            intent="reserved",
+            process_id="__ouroboros_agent_process_cancel__:external",
+            work_fn=work,
+        )
+
+
+@pytest.mark.asyncio
+async def test_spawn_returns_cancelled_when_cancel_consumption_fails(tmp_path) -> None:
+    """Consume cleanup failure must not escape after CANCELLED is recorded."""
+    from ouroboros.core.errors import PersistenceError
+    from ouroboros.core.types import Result
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    class _ConsumeFailingStore(CheckpointStore):
+        def save(self, checkpoint: Any) -> Result[None, PersistenceError]:
+            if checkpoint.phase == "agent_process_cancel_consumed":
+                return Result.err(PersistenceError("simulated consume failure"))
+            return super().save(checkpoint)
+
+    store = _ConsumeFailingStore(base_path=tmp_path)
+    store.initialize()
+    process = AgentProcess(event_store=_FakeEventStore(), checkpoint_store=store)
+    process_id = "consume-fails-process"
+
+    async def first_work(handle):
+        while not handle.should_cancel():
+            await asyncio.sleep(0.005)
+
+    first = await process.spawn(intent="first", process_id=process_id, work_fn=first_work)
+    await first.cancel(reason="operator stop")
+    assert await first.wait_until_complete(timeout=1.0) is AgentProcessStatus.CANCELLED
+
+    teardown_called = False
+    normal_work_called = False
+
+    async def restarted_work(handle):
+        nonlocal normal_work_called, teardown_called
+        if handle.should_cancel():
+            teardown_called = True
+            return
+        normal_work_called = True
+
+    restarted = await process.spawn(intent="restart", process_id=process_id, work_fn=restarted_work)
+
+    assert await restarted.wait_until_complete(timeout=1.0) is AgentProcessStatus.CANCELLED
+    assert teardown_called is True
+    assert normal_work_called is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_survives_ordinary_checkpoint_rotation_after_cancel(tmp_path) -> None:
+    """Durable cancel must not share the ordinary process checkpoint ring."""
+    from ouroboros.orchestrator.agent_process import AgentProcessHandle
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process = AgentProcess(event_store=_FakeEventStore(), checkpoint_store=store)
+
+    async def work(handle):
+        while not handle.should_cancel():
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="rotation-proof", work_fn=work)
+    await handle.cancel(reason="operator stop")
+    await handle.wait_until_complete(timeout=1.0)
+
+    for index in range(store.MAX_ROLLBACK_DEPTH + 2):
+        ordinary_checkpoint = CheckpointData.create(
+            seed_id=handle.process_id,
+            phase="execution",
+            state={"post_cancel_checkpoint": index},
+        )
+        assert store.save(ordinary_checkpoint).is_ok
+
+    found, reason = AgentProcessHandle.load_persisted_cancel(handle.process_id, store=store)
+
+    assert found is True
+    assert reason == "operator stop"
+
+
+def test_load_persisted_cancel_finds_rotated_marker_after_partial_consume(tmp_path) -> None:
+    """If consume write fails after rotation, rollback cancel marker remains active."""
+    from ouroboros.orchestrator.agent_process import AgentProcessHandle
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process_id = "partial-consume-process"
+    seed_id = AgentProcessHandle._cancel_checkpoint_seed(process_id)  # noqa: SLF001
+    checkpoint = CheckpointData.create(
+        seed_id=seed_id,
+        phase="agent_process_cancelled",
+        state={"status": "cancelled", "reason": "operator stop"},
+    )
+    assert store.save(checkpoint).is_ok
+
+    store._rotate_checkpoints(seed_id)  # noqa: SLF001 — simulate post-rotate write failure
+
+    found, reason = AgentProcessHandle.load_persisted_cancel(process_id, store=store)
+
+    assert found is True
+    assert reason == "operator stop"
+
+
+def test_load_persisted_cancel_raises_when_checkpoint_artifact_is_corrupt(tmp_path) -> None:
+    """Restart gate must fail closed when durable state exists but is unreadable."""
+    from ouroboros.core.errors import PersistenceError
+    from ouroboros.orchestrator.agent_process import AgentProcessHandle
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process_id = "corrupt-cancel-process"
+    checkpoint = CheckpointData.create(
+        seed_id=AgentProcessHandle._cancel_checkpoint_seed(process_id),  # noqa: SLF001
+        phase="agent_process_cancelled",
+        state={"status": "cancelled", "reason": "operator stop"},
+    )
+    save_result = store.save(checkpoint)
+    assert save_result.is_ok
+
+    path = store._get_checkpoint_path(  # noqa: SLF001 — corrupt public artifact
+        AgentProcessHandle._cancel_checkpoint_seed(process_id)  # noqa: SLF001
+    )
+    path.write_text("not valid json")
+
+    with pytest.raises(PersistenceError):
+        AgentProcessHandle.load_persisted_cancel(process_id, store=store)
+
+
+def test_load_persisted_cancel_returns_false_without_store() -> None:
+    """``store=None`` means no durable state — return ``(False, None)``
+    rather than raising."""
+    from ouroboros.orchestrator.agent_process import AgentProcessHandle
+
+    found, reason = AgentProcessHandle.load_persisted_cancel("any-process", store=None)
+    assert found is False
+    assert reason is None
+
+
+def test_load_persisted_cancel_consumed_marker_beats_older_cancel(tmp_path) -> None:
+    """A current consumed marker must not resurrect an older cancel marker."""
+    from ouroboros.orchestrator.agent_process import AgentProcessHandle
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process_id = "consumed-beats-stale-cancel"
+    seed_id = AgentProcessHandle._cancel_checkpoint_seed(process_id)  # noqa: SLF001
+    cancel = CheckpointData.create(
+        seed_id=seed_id,
+        phase="agent_process_cancelled",
+        state={"status": "cancelled", "reason": "old stop"},
+    )
+    consumed = CheckpointData.create(
+        seed_id=seed_id,
+        phase="agent_process_cancel_consumed",
+        state={"status": "cancel_consumed", "reason": "old stop"},
+    )
+
+    assert store.save(cancel).is_ok
+    assert store.save(consumed).is_ok
+
+    found, reason = AgentProcessHandle.load_persisted_cancel(process_id, store=store)
+
+    assert found is False
+    assert reason is None
+
+
+@pytest.mark.asyncio
+async def test_spawn_rejects_sanitized_process_id_cancel_control_collision(tmp_path) -> None:
+    """IDs that sanitize into the reserved cancel namespace must be rejected."""
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process = AgentProcess(event_store=_FakeEventStore(), checkpoint_store=store)
+
+    async def work(handle):
+        return None
+
+    with pytest.raises(ValueError):
+        await process.spawn(
+            intent="reserved-sanitized",
+            process_id="__ouroboros/agent_process_cancel__:external",
+            work_fn=work,
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_reuses_durable_cancel_process_id(tmp_path) -> None:
+    """The production helper must expose crash-left durable cancel by stable process ID."""
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process_id = "helper:durable-cancel"
+    checkpoint = CheckpointData.create(
+        seed_id=AgentProcessHandle._cancel_checkpoint_seed(process_id),  # noqa: SLF001
+        phase="agent_process_cancelled",
+        state={"status": "cancelled", "reason": "operator stop"},
+    )
+    assert store.save(checkpoint).is_ok
+
+    teardown_called = False
+    normal_work_called = False
+
+    async def restarted_work(handle):
+        nonlocal normal_work_called, teardown_called
+        if handle.should_cancel():
+            teardown_called = True
+            return "teardown"
+        normal_work_called = True
+        return "normal"
+
+    restart_result = await run_with_agent_process(
+        event_store=_FakeEventStore(),
+        intent="helper",
+        work_fn=restarted_work,
+        checkpoint_store=store,
+        process_id=process_id,
+    )
+
+    assert restart_result == "teardown"
+    assert teardown_called is True
+    assert normal_work_called is False
+
+    fresh_called = False
+
+    async def fresh_work(handle):
+        nonlocal fresh_called
+        fresh_called = True
+        return "fresh"
+
+    fresh_result = await run_with_agent_process(
+        event_store=_FakeEventStore(),
+        intent="helper",
+        work_fn=fresh_work,
+        checkpoint_store=store,
+        process_id=process_id,
+    )
+
+    assert fresh_result == "fresh"
+    assert fresh_called is True
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_keeps_live_cancel_marker_until_restart_consumes(
+    tmp_path,
+) -> None:
+    """Live cancellation must not consume the durable marker too early.
+
+    ``JobManager.cancel_job`` writes the job-scoped marker before the runner sees
+    cancellation. If the same process crashes after live teardown but before job
+    state is durably terminal, the restart must still observe that marker.
+    """
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process_id = "helper:live-cancel"
+
+    async def cancel_work(handle):
+        await handle.cancel(reason="operator stop")
+        return "cancelled"
+
+    cancel_result = await run_with_agent_process(
+        event_store=_FakeEventStore(),
+        intent="helper",
+        work_fn=cancel_work,
+        checkpoint_store=store,
+        process_id=process_id,
+    )
+
+    assert cancel_result == "cancelled"
+    assert AgentProcessHandle.load_persisted_cancel(process_id, store=store) == (
+        True,
+        "operator stop",
+    )
+
+    restart_teardown_called = False
+
+    async def restart_work(handle):
+        nonlocal restart_teardown_called
+        if handle.should_cancel():
+            restart_teardown_called = True
+            return "teardown"
+        return "normal"
+
+    restart_result = await run_with_agent_process(
+        event_store=_FakeEventStore(),
+        intent="helper",
+        work_fn=restart_work,
+        checkpoint_store=store,
+        process_id=process_id,
+    )
+
+    assert restart_result == "teardown"
+    assert restart_teardown_called is True
+    assert AgentProcessHandle.load_persisted_cancel(process_id, store=store) == (False, None)
+
+
+@pytest.mark.asyncio
+async def test_spawn_consumes_persisted_cancel_even_without_reason(tmp_path) -> None:
+    """Missing optional reason must not make a durable cancel permanent."""
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process = AgentProcess(event_store=_FakeEventStore(), checkpoint_store=store)
+    process_id = "missing-reason-cancel"
+    checkpoint = CheckpointData.create(
+        seed_id=AgentProcessHandle._cancel_checkpoint_seed(process_id),  # noqa: SLF001
+        phase="agent_process_cancelled",
+        state={"status": "cancelled"},
+    )
+    assert store.save(checkpoint).is_ok
+
+    teardown_called = False
+
+    async def restart_work(handle):
+        nonlocal teardown_called
+        if handle.should_cancel():
+            teardown_called = True
+
+    restarted = await process.spawn(intent="restart", process_id=process_id, work_fn=restart_work)
+
+    assert await restarted.wait_until_complete(timeout=1.0) is AgentProcessStatus.CANCELLED
+    assert teardown_called is True
+
+    second_called = False
+
+    async def second_work(handle):
+        nonlocal second_called
+        second_called = True
+
+    second = await process.spawn(intent="second", process_id=process_id, work_fn=second_work)
+
+    assert await second.wait_until_complete(timeout=1.0) is AgentProcessStatus.COMPLETED
+    assert second_called is True
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_checkpoint_init_failure_is_best_effort(monkeypatch) -> None:
+    """Implicit helper durability must not make background jobs require writable home."""
+    from ouroboros.persistence.checkpoint import CheckpointStore
+
+    def fail_initialize(self):
+        raise OSError("read-only checkpoint directory")
+
+    monkeypatch.setattr(CheckpointStore, "initialize", fail_initialize)
+
+    async def work(handle):
+        return "completed"
+
+    result = await run_with_agent_process(
+        event_store=_FakeEventStore(),
+        intent="helper",
+        work_fn=work,
+        process_id="helper:init-fails",
+    )
+
+    assert result == "completed"
+
+
+def test_load_persisted_cancel_raises_when_newer_artifact_corrupt_despite_backup(
+    tmp_path,
+) -> None:
+    """A corrupt newer cancel artifact must fail closed instead of using stale rollback."""
+    from ouroboros.core.errors import PersistenceError
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process_id = "corrupt-current-with-backup"
+    seed_id = AgentProcessHandle._cancel_checkpoint_seed(process_id)  # noqa: SLF001
+    consumed = CheckpointData.create(
+        seed_id=seed_id,
+        phase="agent_process_cancel_consumed",
+        state={"status": "cancel_consumed"},
+    )
+    current = CheckpointData.create(
+        seed_id=seed_id,
+        phase="agent_process_cancelled",
+        state={"status": "cancelled", "reason": "new stop"},
+    )
+    assert store.save(consumed).is_ok
+    assert store.save(current).is_ok
+    store._get_checkpoint_path(seed_id).write_text("not valid json")  # noqa: SLF001
+
+    with pytest.raises(PersistenceError):
+        AgentProcessHandle.load_persisted_cancel(process_id, store=store)
+
+
+def test_load_persisted_cancel_raises_on_rotated_consumed_without_current_level(
+    tmp_path,
+) -> None:
+    """A rotated consumed marker with no current file is an ambiguous failed write.
+
+    ``CheckpointStore.save()`` rotates before writing level 0. If a fresh cancel
+    write fails after rotating an older consumed marker, level 0 is absent and
+    level 1 contains stale consumed state. Restart must fail closed instead of
+    treating cancellation as absent.
+    """
+    from ouroboros.core.errors import PersistenceError
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    process_id = "rotated-consumed-without-current"
+    seed_id = AgentProcessHandle._cancel_checkpoint_seed(process_id)  # noqa: SLF001
+    consumed = CheckpointData.create(
+        seed_id=seed_id,
+        phase="agent_process_cancel_consumed",
+        state={"status": "cancel_consumed"},
+    )
+    assert store.save(consumed).is_ok
+    store._rotate_checkpoints(seed_id)  # noqa: SLF001 — simulate failed fresh cancel write
+
+    with pytest.raises(PersistenceError):
+        AgentProcessHandle.load_persisted_cancel(process_id, store=store)
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_separates_lifecycle_id_from_cancel_key(tmp_path) -> None:
+    """Lifecycle process_id can be attempt-unique while cancel_key is restart-stable."""
+    from ouroboros.persistence.checkpoint import CheckpointData, CheckpointStore
+
+    store = CheckpointStore(base_path=tmp_path)
+    store.initialize()
+    cancel_key = "helper:stable-cancel-key"
+    checkpoint = CheckpointData.create(
+        seed_id=AgentProcessHandle._cancel_checkpoint_seed(cancel_key),  # noqa: SLF001
+        phase="agent_process_cancelled",
+        state={"status": "cancelled", "reason": "operator stop"},
+    )
+    assert store.save(checkpoint).is_ok
+    event_store = _FakeEventStore()
+
+    async def restarted_work(handle):
+        assert handle.process_id == "helper:attempt-1"
+        assert handle.should_cancel() is True
+        return "teardown"
+
+    restart_result = await run_with_agent_process(
+        event_store=event_store,
+        intent="helper",
+        work_fn=restarted_work,
+        checkpoint_store=store,
+        process_id="helper:attempt-1",
+        cancel_key=cancel_key,
+    )
+
+    assert restart_result == "teardown"
+    assert {event.aggregate_id for event in event_store.appended} == {"helper:attempt-1"}
+
+    fresh_called = False
+
+    async def fresh_work(handle):
+        nonlocal fresh_called
+        assert handle.process_id == "helper:attempt-2"
+        fresh_called = True
+        return "fresh"
+
+    fresh_result = await run_with_agent_process(
+        event_store=_FakeEventStore(),
+        intent="helper",
+        work_fn=fresh_work,
+        checkpoint_store=store,
+        process_id="helper:attempt-2",
+        cancel_key=cancel_key,
+    )
+
+    assert fresh_result == "fresh"
+    assert fresh_called is True


### PR DESCRIPTION
## Summary

Slice 4 of M6 (#518). Makes the cooperative cancel signal survive process restarts by persisting it through the existing ``CheckpointStore`` (#338). The in-memory flag remains the authoritative source; the durable record is a best-effort hint for the restart path.

## Behavior

- ``AgentProcessHandle.cancel(reason=..., checkpoint_store=...)`` now writes a ``agent_process_cancelled`` checkpoint keyed by ``process_id``. Save failures are logged at WARNING and never raised.
- New classmethod ``AgentProcessHandle.load_persisted_cancel(process_id, store=...)`` returns ``(True, reason)`` iff the latest checkpoint for that process_id is a cancel record. A restart loop calls this once at startup and jumps straight to teardown when True.
- Cancellation semantics remain cooperative (per #627). No forced kill, no behavior change for in-memory consumers.

## Test plan

- ``test_cancel_persists_state_via_checkpoint_store`` — cancel(reason='X'), load returns (True, 'X').
- ``test_cancel_swallows_checkpoint_save_error`` — injected store raises; in-memory transition still completes, no exception leaks.
- ``test_load_persisted_cancel_returns_false_when_no_checkpoint`` — fresh process_id.
- ``test_load_persisted_cancel_returns_false_without_store`` — ``store=None``.
- Full agent_process suite: 25 passed.
- ``ruff check`` + ``ruff format --check`` clean.

## Companion

Companion to PR-A (``feat/518-agent-process-durable-pause`` — durable pause/resume). Both share the ``CheckpointStore`` instance and the ``process_id``-as-seed-id convention. They are additive at the API level (different phase strings, different classmethods) so they can land in either order with at most a trivial textual merge.

Part of #518.