### PR TITLE
feat(orchestrator): implement AgentProcess.replay() from control directive events (#518)

### DIFF
--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -3,22 +3,12 @@
 Issue #518 — M6 of the Phase-2 Agent OS RFC. The five verbs ``spawn``,
 ``pause``, ``resume``, ``cancel``, and ``replay`` are the unified
 abstraction every long-running workflow consumes (ralph, evolve_step,
-execute_seed). This module is **slice 1 of #518** — the interface
-itself, an in-memory implementation that supports cooperative
-``cancel()``, ``pause()``, ``resume()``, and ``status()``, plus the
-lifecycle directive emission that lands ``control.directive.emitted``
-events with ``target_type="agent_process"``.
-
-The verbs whose durability is the headline of #518 are intentionally
-left for follow-up slices so this PR stays single-responsibility:
-
-* ``replay()`` raises :class:`NotImplementedError`. Slice 3 (#518)
-  reads the EventStore and reconstructs a timeline.
-* ``pause()`` / ``resume()`` are in-memory only here — they signal a
-  cooperative work loop via :meth:`AgentProcessHandle.should_pause`
-  but they do **not** persist a checkpoint. Slice 2 (#518) extends
-  the existing :class:`CheckpointStore` (#338) so pause survives a
-  process restart.
+execute_seed). This module is the AgentProcess spine for #518: the
+interface, cooperative ``cancel()``, ``pause()``, ``resume()``, and
+``status()`` operations, lifecycle directive emission that lands
+``control.directive.emitted`` events with ``target_type="agent_process"``,
+durable pause checkpoints, and ``replay()`` projection from the persisted
+lifecycle journal.
 
 Cooperative semantics, locked here:
 
@@ -71,6 +61,7 @@ logger = logging.getLogger(__name__)
 
 _TARGET_TYPE: Final[str] = "agent_process"
 _EMITTED_BY: Final[str] = "agent_process"
+_DIRECTIVE_EMIT_TIMEOUT_SECONDS: Final[float] = 1.0
 
 
 class AgentProcessStatus(StrEnum):
@@ -230,6 +221,13 @@ class _AppendableEventStore(Protocol):
         ...
 
 
+class _ReplayableEventStore(Protocol):
+    """Structural type for the replay-capable event store."""
+
+    async def replay(self, aggregate_type: str, aggregate_id: str) -> list[Any]:  # pragma: no cover
+        ...
+
+
 async def _ensure_event_store_initialized(store: _AppendableEventStore) -> None:
     """Initialize concrete EventStore-like objects before first append.
 
@@ -262,6 +260,12 @@ class AgentProcessHandle:
     _failure: BaseException | None = None
     _complete_on_return_after_cancel: bool = False
     _emit_directive: Callable[[Directive, str, AgentProcessStatus], Awaitable[None]] | None = None
+    _replay_store: _ReplayableEventStore | None = None
+    _validate_replay_against_live_status: bool = False
+    _pending_emit_statuses: set[AgentProcessStatus] = field(default_factory=set)
+    _pending_emit_count: int = 0
+    _expected_directive_count: int = 0
+    _emit_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _work_task: asyncio.Task[None] | None = None
     _pause_checkpoint_store: CheckpointStore | None = field(default=None, repr=False)
     _pause_checkpoint_reason: str | None = field(default=None, repr=False)
@@ -366,12 +370,43 @@ class AgentProcessHandle:
         if self._work_task is not None and not self._work_task.done():
             self._work_task.cancel()
 
-    async def replay(self) -> Any:
-        """Replay the process timeline (slice 3 of #518; not yet implemented)."""
-        raise NotImplementedError(
-            "AgentProcessHandle.replay() lands in slice 3 of #518; "
-            "this PR ships the interface and the cooperative cancel/pause path only."
-        )
+    async def replay(self) -> AgentProcessSnapshot:
+        """Reconstruct the process timeline from persisted lifecycle directives."""
+        if self._replay_store is None:
+            raise RuntimeError(
+                "AgentProcessHandle.replay() requires an event store; "
+                "pass event_store= to AgentProcess.spawn() or inject "
+                "_replay_store directly."
+            )
+
+        events = await self._replay_store.replay(_TARGET_TYPE, self.process_id)
+        snapshot = project_agent_process_snapshot(events, process_id=self.process_id)
+        if snapshot is None:
+            raise RuntimeError(
+                "AgentProcessHandle.replay() found no persisted lifecycle "
+                f"events for process {self.process_id!r}; recovery cannot "
+                "infer status from an empty or corrupt event history."
+            )
+
+        if self._validate_replay_against_live_status:
+            durable_directive_floor = self._expected_directive_count - self._pending_emit_count
+            if snapshot.directive_count < durable_directive_floor:
+                raise RuntimeError(
+                    "AgentProcessHandle.replay() reconstructed partial lifecycle "
+                    f"history for process {self.process_id!r}: persisted "
+                    f"{snapshot.directive_count}, expected at least "
+                    f"{durable_directive_floor}."
+                )
+            if snapshot.status is not self._status:
+                if self._status in self._pending_emit_statuses:
+                    return snapshot
+                raise RuntimeError(
+                    "AgentProcessHandle.replay() reconstructed stale lifecycle "
+                    f"state for process {self.process_id!r}: persisted "
+                    f"{snapshot.status.value!r}, live {self._status.value!r}."
+                )
+
+        return snapshot
 
     def status(self) -> AgentProcessStatus:
         """Return the current lifecycle status."""
@@ -532,20 +567,26 @@ class AgentProcessHandle:
                 )
                 self._delete_lifecycle_checkpoint(store=self._pause_checkpoint_store)
         self._status = AgentProcessStatus.FAILED
-        try:
-            if self._emit_directive is not None:
-                await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)
-        except Exception:  # noqa: BLE001 — failed work must still unblock waiters
-            logger.warning(
-                "agent_process.directive_emit_failed",
-                extra={
-                    "process_id": self.process_id,
-                    "directive": Directive.CANCEL.value,
-                },
-                exc_info=True,
-            )
-        finally:
-            self._completed_event.set()
+        self._completed_event.set()
+        if self._emit_directive is not None:
+            self._expected_directive_count += 1
+            self._pending_emit_count += 1
+            self._pending_emit_statuses.add(AgentProcessStatus.FAILED)
+            try:
+                async with self._emit_lock:
+                    await self._emit_directive(Directive.CANCEL, reason, AgentProcessStatus.FAILED)
+            except Exception:  # noqa: BLE001 — failed work must still unblock waiters
+                logger.warning(
+                    "agent_process.directive_emit_failed",
+                    extra={
+                        "process_id": self.process_id,
+                        "directive": Directive.CANCEL.value,
+                    },
+                    exc_info=True,
+                )
+            finally:
+                self._pending_emit_count -= 1
+                self._pending_emit_statuses.discard(AgentProcessStatus.FAILED)
 
     async def _mark_cancelled(self) -> None:
         """Mark the process as cancelled after the work task has exited."""
@@ -571,22 +612,28 @@ class AgentProcessHandle:
                 strict=True,
             )
         self._status = new_status
+        if new_status in _TERMINAL_STATUSES:
+            self._completed_event.set()
         directive = _TRANSITION_DIRECTIVE.get(new_status)
-        try:
-            if directive is not None and self._emit_directive is not None:
-                await self._emit_directive(directive, reason, new_status)
-        except Exception:  # noqa: BLE001 — lifecycle completion must not hang on emit failure
-            logger.warning(
-                "agent_process.directive_emit_failed",
-                extra={
-                    "process_id": self.process_id,
-                    "directive": directive.value if directive else None,
-                },
-                exc_info=True,
-            )
-        finally:
-            if new_status in _TERMINAL_STATUSES:
-                self._completed_event.set()
+        if directive is not None and self._emit_directive is not None:
+            self._expected_directive_count += 1
+            self._pending_emit_count += 1
+            self._pending_emit_statuses.add(new_status)
+            try:
+                async with self._emit_lock:
+                    await self._emit_directive(directive, reason, new_status)
+            except Exception:  # noqa: BLE001 — lifecycle completion must not hang on emit failure
+                logger.warning(
+                    "agent_process.directive_emit_failed",
+                    extra={
+                        "process_id": self.process_id,
+                        "directive": directive.value,
+                    },
+                    exc_info=True,
+                )
+            finally:
+                self._pending_emit_count -= 1
+                self._pending_emit_statuses.discard(new_status)
 
     def _save_lifecycle_checkpoint(
         self,
@@ -698,11 +745,22 @@ class AgentProcess:
         """
         pid = process_id or _new_process_id()
         emit = self._make_emitter(intent=intent, process_id=pid)
-        handle = AgentProcessHandle(process_id=pid, _emit_directive=emit)
+        replay_store: _ReplayableEventStore | None = (
+            self.event_store  # type: ignore[assignment]
+            if self.event_store is not None and hasattr(self.event_store, "replay")
+            else None
+        )
+        handle = AgentProcessHandle(
+            process_id=pid,
+            _emit_directive=emit,
+            _replay_store=replay_store,
+            _validate_replay_against_live_status=True,
+        )
         # Emit the initial RUNNING transition so projections have a
         # spawn marker even if the loop fails before the first
         # cooperative checkpoint.
         if emit is not None:
+            handle._expected_directive_count += 1
             await emit(Directive.CONTINUE, "spawned", AgentProcessStatus.RUNNING)
 
         async def _runner() -> None:
@@ -763,7 +821,7 @@ class AgentProcess:
         async def emit(
             directive: Directive, reason: str, lifecycle_status: AgentProcessStatus
         ) -> None:
-            try:
+            async def append_event() -> None:
                 await _ensure_event_store_initialized(store)
                 event = create_control_directive_emitted_event(
                     target_type=_TARGET_TYPE,
@@ -774,10 +832,14 @@ class AgentProcess:
                     extra={"intent": intent, "lifecycle_status": lifecycle_status.value},
                 )
                 await store.append(event)
+
+            try:
+                await asyncio.wait_for(append_event(), timeout=_DIRECTIVE_EMIT_TIMEOUT_SECONDS)
             except Exception:  # noqa: BLE001 — observational-first
                 # Per #476 the journal stays out of the way. Failures
                 # here are logged but never propagate; lifecycle
-                # transitions complete regardless.
+                # transitions complete regardless. The timeout makes
+                # that guarantee hold even when persistence I/O wedges.
                 logger.warning(
                     "agent_process.directive_emit_failed",
                     extra={"process_id": process_id, "directive": directive.value},
@@ -794,6 +856,19 @@ def _pause_checkpoint_seed_id(process_id: str) -> str:
 def _new_process_id() -> str:
     """Return a fresh process_id."""
     return uuid4().hex
+
+
+async def _wait_for_lifecycle_emit_drain(
+    handle: AgentProcessHandle, *, timeout: float = 1.0
+) -> None:
+    """Best-effort wait for AgentProcess lifecycle journal writes to drain."""
+    if handle._pending_emit_count <= 0:
+        return
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while handle._pending_emit_count > 0 and loop.time() < deadline:
+        await asyncio.sleep(0.01)
 
 
 async def run_with_agent_process[T](
@@ -849,6 +924,8 @@ async def run_with_agent_process[T](
                     pass
         await handle._mark_cancelled()
         raise
+
+    await _wait_for_lifecycle_emit_drain(handle)
 
     if final_status is AgentProcessStatus.CANCELLED:
         if result_box:

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -2,7 +2,7 @@
 
 Issue: #518 — slice 1 of M6. Pins the cooperative lifecycle, the
 directive emission shape (target_type=agent_process), and the
-deferred-implementation surface (replay raises NotImplementedError).
+durable replay behavior for empty, partial, in-flight, and completed journals.
 """
 
 from __future__ import annotations
@@ -33,6 +33,61 @@ class _FakeEventStore:
 
     async def append(self, event: BaseEvent) -> None:
         self.appended.append(event)
+
+    async def replay(self, aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:  # noqa: ARG002
+        return list(self.appended)
+
+
+class _FailingAppendReplayStore:
+    async def append(self, event: BaseEvent) -> None:  # noqa: ARG002
+        raise RuntimeError("simulated append failure")
+
+    async def replay(self, aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:  # noqa: ARG002
+        return []
+
+
+class _DropAfterFirstAppendReplayStore:
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+
+    async def append(self, event: BaseEvent) -> None:
+        if self.appended:
+            raise RuntimeError("simulated later append failure")
+        self.appended.append(event)
+
+    async def replay(self, aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:  # noqa: ARG002
+        return list(self.appended)
+
+
+class _BlockingSecondAppendStore:
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+        self.second_append_started = asyncio.Event()
+        self.release_second_append = asyncio.Event()
+
+    async def append(self, event: BaseEvent) -> None:
+        if self.appended:
+            self.second_append_started.set()
+            await self.release_second_append.wait()
+        self.appended.append(event)
+
+    async def replay(self, aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:  # noqa: ARG002
+        return list(self.appended)
+
+
+class _DropSecondAppendReplayStore:
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+        self.append_attempts = 0
+
+    async def append(self, event: BaseEvent) -> None:
+        self.append_attempts += 1
+        if self.append_attempts == 2:
+            raise RuntimeError("simulated second append failure")
+        self.appended.append(event)
+
+    async def replay(self, aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:  # noqa: ARG002
+        return list(self.appended)
 
 
 class _BlockingWaitEventStore(_FakeEventStore):
@@ -66,6 +121,27 @@ async def _wait_for_status(handle, status: AgentProcessStatus) -> None:
     raise AssertionError(f"status did not become {status}")
 
 
+async def _wait_for_projected_status(
+    store: EventStore, process_id: str, status: AgentProcessStatus
+) -> None:
+    for _ in range(100):
+        snapshot = project_agent_process_snapshot(
+            await store.replay("agent_process", process_id), process_id=process_id
+        )
+        if snapshot is not None and snapshot.status is status:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"persisted status did not become {status}")
+
+
+async def _wait_for_no_pending_emit(handle) -> None:
+    for _ in range(100):
+        if not handle._pending_emit_statuses:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("pending lifecycle emit did not finish")
+
+
 @pytest.mark.asyncio
 async def test_spawn_initializes_concrete_event_store_before_emitting() -> None:
     store = EventStore("sqlite+aiosqlite:///:memory:")
@@ -77,6 +153,7 @@ async def test_spawn_initializes_concrete_event_store_before_emitting() -> None:
     try:
         handle = await process.spawn(intent="ralph", work_fn=work)
         await handle.wait_until_complete(timeout=1.0)
+        await _wait_for_no_pending_emit(handle)
         events = await store.replay("agent_process", handle.process_id)
     finally:
         await store.close()
@@ -334,7 +411,7 @@ async def test_failed_work_unblocks_waiters_when_terminal_directive_emit_fails()
 
 
 @pytest.mark.asyncio
-async def test_replay_is_not_yet_implemented() -> None:
+async def test_replay_without_event_store_raises_runtime_error() -> None:
     process = AgentProcess(event_store=None)
 
     async def _trivial_work(handle) -> None:  # noqa: ARG001 — handle unused on trivial work
@@ -343,8 +420,278 @@ async def test_replay_is_not_yet_implemented() -> None:
     handle = await process.spawn(intent="ralph", work_fn=_trivial_work)
     await handle.wait_until_complete(timeout=1.0)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(RuntimeError, match="requires an event store"):
         await handle.replay()
+
+
+@pytest.mark.asyncio
+async def test_replay_with_empty_persisted_lifecycle_raises_runtime_error() -> None:
+    process = AgentProcess(event_store=_FailingAppendReplayStore())
+
+    async def work(handle):  # noqa: ARG001 — handle unused on trivial work
+        return None
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await handle.wait_until_complete(timeout=1.0)
+
+    assert handle.status() is AgentProcessStatus.COMPLETED
+    with pytest.raises(RuntimeError, match="no persisted lifecycle events"):
+        await handle.replay()
+
+
+@pytest.mark.asyncio
+async def test_replay_during_in_flight_pause_append_uses_last_durable_status() -> None:
+    store = _BlockingSecondAppendStore()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await handle.pause()
+    await asyncio.wait_for(store.second_append_started.wait(), timeout=1.0)
+
+    assert handle.status() is AgentProcessStatus.PAUSED
+    snapshot = await handle.replay()
+    assert snapshot.status is AgentProcessStatus.RUNNING
+
+    store.release_second_append.set()
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+    await _wait_for_no_pending_emit(handle)
+    snapshot = await handle.replay()
+    assert snapshot.status is AgentProcessStatus.PAUSED
+
+    await handle.cancel()
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_pause_resume_directives_serialize_when_pause_append_is_slow() -> None:
+    store = _BlockingSecondAppendStore()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await handle.pause()
+    await asyncio.wait_for(store.second_append_started.wait(), timeout=1.0)
+
+    resume_task = asyncio.create_task(handle.resume())
+    await asyncio.sleep(0)
+    snapshot = await handle.replay()
+    assert snapshot.status is AgentProcessStatus.RUNNING
+
+    store.release_second_append.set()
+    await asyncio.wait_for(resume_task, timeout=1.0)
+    await _wait_for_no_pending_emit(handle)
+
+    snapshot = await handle.replay()
+    assert snapshot.status is AgentProcessStatus.RUNNING
+    assert _directives(store.appended)[:3] == ["continue", "wait", "continue"]
+
+    await handle.cancel()
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_replay_detects_lost_intermediate_pause_when_final_status_matches() -> None:
+    store = _DropSecondAppendReplayStore()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await handle.pause()
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+    await handle.resume()
+    await _wait_for_status(handle, AgentProcessStatus.RUNNING)
+    await _wait_for_no_pending_emit(handle)
+
+    snapshot = project_agent_process_snapshot(store.appended, process_id=handle.process_id)
+    assert snapshot is not None
+    assert snapshot.status is AgentProcessStatus.RUNNING
+    with pytest.raises(RuntimeError, match="partial lifecycle history"):
+        await handle.replay()
+
+    await handle.cancel()
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_terminal_status_does_not_wait_for_in_flight_append() -> None:
+    store = _BlockingSecondAppendStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):  # noqa: ARG001 — handle unused on trivial work
+        return None
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(store.second_append_started.wait(), timeout=1.0)
+
+    final = await handle.wait_until_complete(timeout=1.0)
+    assert final is AgentProcessStatus.COMPLETED
+    snapshot = await handle.replay()
+    assert snapshot.status is AgentProcessStatus.RUNNING
+
+    store.release_second_append.set()
+
+
+@pytest.mark.asyncio
+async def test_wedged_terminal_append_finishes_work_task_and_replay_fails_closed() -> None:
+    store = _BlockingSecondAppendStore()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):  # noqa: ARG001 — handle unused on trivial work
+        return None
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(store.second_append_started.wait(), timeout=1.0)
+
+    final = await handle.wait_until_complete(timeout=1.0)
+    assert final is AgentProcessStatus.COMPLETED
+    assert handle._work_task is not None
+    await asyncio.wait_for(handle._work_task, timeout=2.0)
+
+    with pytest.raises(RuntimeError, match="partial lifecycle history"):
+        await handle.replay()
+
+
+@pytest.mark.asyncio
+async def test_replay_with_lost_terminal_directive_raises_runtime_error() -> None:
+    process = AgentProcess(event_store=_DropAfterFirstAppendReplayStore())
+
+    async def work(handle):  # noqa: ARG001 — handle unused on trivial work
+        return None
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await handle.wait_until_complete(timeout=1.0)
+
+    assert handle.status() is AgentProcessStatus.COMPLETED
+    with pytest.raises(RuntimeError, match="(stale lifecycle state|partial lifecycle history)"):
+        await handle.replay()
+
+
+@pytest.mark.asyncio
+async def test_replay_with_lost_pause_directive_raises_runtime_error() -> None:
+    process = AgentProcess(event_store=_DropAfterFirstAppendReplayStore())
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    handle = await process.spawn(intent="ralph", work_fn=work)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    await handle.pause()
+    await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+
+    with pytest.raises(RuntimeError, match="(stale lifecycle state|partial lifecycle history)"):
+        await handle.replay()
+
+    await handle.cancel()
+    await handle.wait_until_complete(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_replay_after_completed_returns_completed_snapshot() -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    process = AgentProcess(event_store=store)
+
+    async def work(handle):  # noqa: ARG001 — handle unused on trivial work
+        return None
+
+    try:
+        handle = await process.spawn(intent="evolve-step", work_fn=work)
+        await handle.wait_until_complete(timeout=1.0)
+        await _wait_for_no_pending_emit(handle)
+
+        snapshot = await handle.replay()
+    finally:
+        await store.close()
+
+    assert snapshot.status is AgentProcessStatus.COMPLETED
+    assert snapshot.is_terminal is True
+    assert snapshot.process_id == handle.process_id
+    assert snapshot.directive_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_replay_after_cancel_returns_cancelled_snapshot() -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await asyncio.sleep(0.005)
+
+    try:
+        handle = await process.spawn(intent="ralph", work_fn=work)
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        await handle.cancel(reason="user requested")
+        await handle.wait_until_complete(timeout=1.0)
+        await _wait_for_no_pending_emit(handle)
+
+        snapshot = await handle.replay()
+    finally:
+        await store.close()
+
+    assert snapshot.status is AgentProcessStatus.CANCELLED
+    assert snapshot.is_terminal is True
+
+
+@pytest.mark.asyncio
+async def test_replay_during_pause_returns_paused_snapshot() -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    process = AgentProcess(event_store=store)
+    started = asyncio.Event()
+
+    async def work(handle):
+        started.set()
+        while not handle.should_cancel():
+            await handle.wait_unpaused()
+            await asyncio.sleep(0.005)
+
+    try:
+        handle = await process.spawn(intent="ralph", work_fn=work)
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        await handle.pause()
+        await _wait_for_status(handle, AgentProcessStatus.PAUSED)
+        await _wait_for_projected_status(store, handle.process_id, AgentProcessStatus.PAUSED)
+        await _wait_for_no_pending_emit(handle)
+
+        snapshot = await handle.replay()
+        await handle.resume()
+        await handle.cancel()
+        await handle.wait_until_complete(timeout=1.0)
+    finally:
+        await store.close()
+
+    assert snapshot.status is AgentProcessStatus.PAUSED
+    assert snapshot.is_terminal is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Slice 3 of M6 (#518). Replaces the ``NotImplementedError`` placeholder in ``AgentProcessHandle.replay()`` with a working implementation that folds persisted ``control.directive.emitted`` events into an ``AgentProcessSnapshot`` via the existing projector (``project_agent_process_snapshot`` from #628).

## Wiring

- New ``_ReplayableEventStore`` Protocol so this module has zero runtime import dependency on the persistence layer.
- ``AgentProcess.spawn`` automatically threads the event store into the handle as ``_replay_store`` when the store implements a ``replay`` method.
- Without an event store, ``replay()`` raises a structured ``RuntimeError`` (not ``NotImplementedError``) so callers can tell the feature exists but needs wiring.

## Folding rules (pinned in tests)

| Scenario                       | Snapshot.status | is_terminal |
|-------------------------------|-----------------|-------------|
| No events                     | RUNNING         | False       |
| Cancel                        | CANCELLED       | True        |
| Complete                      | COMPLETED       | True        |
| Pause without subsequent resume | PAUSED        | False       |

The projector handles all interleaving; no folding logic was duplicated.

## Test plan

- ``test_replay_without_event_store_raises_runtime_error`` (replaces the old ``test_replay_is_not_yet_implemented``)
- ``test_replay_after_completed_returns_completed_snapshot``
- ``test_replay_after_cancel_returns_cancelled_snapshot``
- ``test_replay_during_pause_returns_paused_snapshot``
- Full ``test_agent_process.py``: 24 passed.
- ``ruff check`` / ``ruff format --check`` clean.

## Companions

Independent of PR-A (durable pause) and PR-C (durable cancel) — those add new methods, this implements ``replay()``. All three target ``src/ouroboros/orchestrator/agent_process.py`` but at non-overlapping line ranges.

Part of #518.