### PR TITLE
test(orchestrator): pin three-surface AgentProcess acceptance contract (#518)

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -193,12 +193,19 @@ class JobManager:
             snapshot = await self.get_snapshot(job_id)
             terminal_type = "mcp.job.completed"
             terminal_status = JobStatus.COMPLETED
+            result_meta = getattr(result, "meta", {})
+            terminal_kind = None
+            if isinstance(result_meta, dict):
+                terminal_kind = result_meta.get("action") or result_meta.get("status")
             if snapshot.status == JobStatus.CANCEL_REQUESTED:
                 terminal_type = "mcp.job.cancelled"
                 terminal_status = JobStatus.CANCELLED
-            elif getattr(result, "meta", {}).get("action") == "interrupted":
+            elif terminal_kind == "interrupted":
                 terminal_type = "mcp.job.interrupted"
                 terminal_status = JobStatus.INTERRUPTED
+            elif terminal_kind in {"cancel", "cancelled"}:
+                terminal_type = "mcp.job.cancelled"
+                terminal_status = JobStatus.CANCELLED
             elif getattr(result, "is_error", False):
                 terminal_type = "mcp.job.failed"
                 terminal_status = JobStatus.FAILED

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -45,6 +45,7 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
+from ouroboros.orchestrator.agent_process import run_with_agent_process
 from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
@@ -899,7 +900,11 @@ class StartEvolveStepHandler:
         snapshot = await self._job_manager.start_job(
             job_type="evolve_step",
             initial_message=f"Queued evolve_step for {lineage_id}",
-            runner=_runner(),
+            runner=run_with_agent_process(
+                event_store=self._event_store,
+                intent="evolve_step",
+                work_fn=lambda _handle: _runner(),
+            ),
             links=JobLinks(lineage_id=lineage_id),
         )
 

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -57,6 +57,7 @@ from ouroboros.orchestrator.adapter import (
     DELEGATED_PARENT_TRANSCRIPT_PATH_ARG,
     RuntimeHandle,
 )
+from ouroboros.orchestrator.agent_process import run_with_agent_process
 from ouroboros.orchestrator.runner import OrchestratorRunner
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus
 from ouroboros.persistence.checkpoint import CheckpointStore
@@ -1172,7 +1173,11 @@ class StartExecuteSeedHandler:
         snapshot = await self._job_manager.start_job(
             job_type="execute_seed",
             initial_message="Queued seed execution",
-            runner=_runner(),
+            runner=run_with_agent_process(
+                event_store=self._event_store,
+                intent="execute_seed",
+                work_fn=lambda _handle: _runner(),
+            ),
             links=JobLinks(
                 session_id=session_id or new_session_id,
                 execution_id=execution_id,

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -29,6 +29,7 @@ from ouroboros.mcp.types import (
     MCPToolResult,
     ToolInputType,
 )
+from ouroboros.orchestrator.agent_process import run_with_agent_process
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.ralph_loop import (
     DEFAULT_GRADE_REGRESSION_WINDOW,
@@ -410,7 +411,11 @@ class RalphHandler:
         snapshot = await self._job_manager.start_job(
             job_type="ralph",
             initial_message=f"Queued Ralph loop for {config.lineage_id}",
-            runner=_run_loop(),
+            runner=run_with_agent_process(
+                event_store=self._event_store,
+                intent="ralph",
+                work_fn=lambda _handle: _run_loop(),
+            ),
             links=JobLinks(lineage_id=config.lineage_id),
         )
 

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -549,7 +549,13 @@ async def run_with_agent_process[T](
             result_box.append(result)
             if getattr(result, "is_error", False):
                 reason = getattr(result, "text_content", None) or f"{intent} returned is_error=True"
-                await handle._mark_failed(reason=str(reason)[:500])
+                meta = getattr(result, "meta", {})
+                action = meta.get("action") if isinstance(meta, dict) else None
+                if action in {"cancel", "cancelled", "interrupted"}:
+                    await handle.cancel(reason=str(reason)[:500])
+                    await handle._mark_cancelled()
+                else:
+                    await handle._mark_failed(reason=str(reason)[:500])
         except BaseException as exc:  # noqa: BLE001 - preserve the original runner failure
             error_box.append(exc)
             raise
@@ -569,6 +575,8 @@ async def run_with_agent_process[T](
         raise
 
     if final_status is AgentProcessStatus.CANCELLED:
+        if result_box:
+            return result_box[0]
         raise asyncio.CancelledError(f"{intent} cancelled")
     if final_status is AgentProcessStatus.FAILED:
         if result_box:

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -522,3 +522,47 @@ class AgentProcess:
 def _new_process_id() -> str:
     """Return a fresh process_id."""
     return uuid4().hex
+
+
+async def run_with_agent_process[T](
+    *,
+    event_store: _AppendableEventStore | None,
+    intent: str,
+    work_fn: Callable[[AgentProcessHandle], Awaitable[T]],
+    timeout: float | None = None,
+) -> T:
+    """Run one production surface through :class:`AgentProcess.spawn`.
+
+    This helper is the shared acceptance boundary for long-running MCP
+    surfaces.  It lets each surface keep its existing JobManager contract
+    while ensuring the actual background runner emits the uniform
+    AgentProcess lifecycle directives (RUNNING/CONVERGE/CANCEL/FAILED).
+    """
+    result_box: list[T] = []
+    error_box: list[BaseException] = []
+
+    async def _work(handle: AgentProcessHandle) -> None:
+        try:
+            result_box.append(await work_fn(handle))
+        except BaseException as exc:  # noqa: BLE001 - preserve the original runner failure
+            error_box.append(exc)
+            raise
+
+    process = AgentProcess(event_store=event_store)
+    handle = await process.spawn(intent=intent, work_fn=_work)
+    try:
+        final_status = await handle.wait_until_complete(timeout=timeout)
+    except asyncio.CancelledError:
+        await handle.cancel(reason="cancelled by job runner")
+        await handle._mark_cancelled()
+        raise
+
+    if final_status is AgentProcessStatus.CANCELLED:
+        raise asyncio.CancelledError(f"{intent} cancelled")
+    if final_status is AgentProcessStatus.FAILED:
+        if error_box:
+            raise RuntimeError(f"{intent} failed") from error_box[0]
+        raise RuntimeError(f"{intent} failed")
+    if not result_box:
+        raise RuntimeError(f"{intent} completed without a result")
+    return result_box[0]

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -53,7 +53,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Iterable
-from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -571,8 +570,12 @@ async def run_with_agent_process[T](
         work_task = handle._work_task
         if work_task is not None and not work_task.done():
             work_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await work_task
+            done, _pending = await asyncio.wait({work_task}, timeout=1.0)
+            for completed in done:
+                try:
+                    await completed
+                except asyncio.CancelledError:
+                    pass
         await handle._mark_cancelled()
         raise
 

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Iterable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -258,6 +259,7 @@ class AgentProcessHandle:
     _completed_event: asyncio.Event = field(default_factory=asyncio.Event)
     _cancel_reason: str = "cancel requested"
     _emit_directive: Callable[[Directive, str, AgentProcessStatus], Awaitable[None]] | None = None
+    _work_task: asyncio.Task[None] | None = None
 
     def __post_init__(self) -> None:
         # The paused-event is "set" when the loop is *not* paused so a
@@ -482,7 +484,7 @@ class AgentProcess:
 
         # Spawn but do not await — the caller drives lifecycle through
         # the handle.
-        asyncio.create_task(_runner(), name=f"agent_process:{pid}")
+        handle._work_task = asyncio.create_task(_runner(), name=f"agent_process:{pid}")
         return handle
 
     def _make_emitter(
@@ -554,6 +556,11 @@ async def run_with_agent_process[T](
         final_status = await handle.wait_until_complete(timeout=timeout)
     except asyncio.CancelledError:
         await handle.cancel(reason="cancelled by job runner")
+        work_task = handle._work_task
+        if work_task is not None and not work_task.done():
+            work_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await work_task
         await handle._mark_cancelled()
         raise
 
@@ -561,7 +568,10 @@ async def run_with_agent_process[T](
         raise asyncio.CancelledError(f"{intent} cancelled")
     if final_status is AgentProcessStatus.FAILED:
         if error_box:
-            raise RuntimeError(f"{intent} failed") from error_box[0]
+            exc = error_box[0]
+            if isinstance(exc, Exception):
+                raise exc
+            raise RuntimeError(f"{intent} failed") from exc
         raise RuntimeError(f"{intent} failed")
     if not result_box:
         raise RuntimeError(f"{intent} completed without a result")

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -545,7 +545,11 @@ async def run_with_agent_process[T](
 
     async def _work(handle: AgentProcessHandle) -> None:
         try:
-            result_box.append(await work_fn(handle))
+            result = await work_fn(handle)
+            result_box.append(result)
+            if getattr(result, "is_error", False):
+                reason = getattr(result, "text_content", None) or f"{intent} returned is_error=True"
+                await handle._mark_failed(reason=str(reason)[:500])
         except BaseException as exc:  # noqa: BLE001 - preserve the original runner failure
             error_box.append(exc)
             raise
@@ -567,6 +571,8 @@ async def run_with_agent_process[T](
     if final_status is AgentProcessStatus.CANCELLED:
         raise asyncio.CancelledError(f"{intent} cancelled")
     if final_status is AgentProcessStatus.FAILED:
+        if result_box:
+            return result_box[0]
         if error_box:
             exc = error_box[0]
             if isinstance(exc, Exception):

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -550,8 +550,10 @@ async def run_with_agent_process[T](
             if getattr(result, "is_error", False):
                 reason = getattr(result, "text_content", None) or f"{intent} returned is_error=True"
                 meta = getattr(result, "meta", {})
-                action = meta.get("action") if isinstance(meta, dict) else None
-                if action in {"cancel", "cancelled", "interrupted"}:
+                terminal_kind = None
+                if isinstance(meta, dict):
+                    terminal_kind = meta.get("action") or meta.get("status")
+                if terminal_kind in {"cancel", "cancelled", "interrupted"}:
                     await handle.cancel(reason=str(reason)[:500])
                     await handle._mark_cancelled()
                 else:

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -558,7 +558,7 @@ async def run_with_agent_process[T](
     handle = await process.spawn(intent=intent, work_fn=_work)
     try:
         final_status = await handle.wait_until_complete(timeout=timeout)
-    except asyncio.CancelledError:
+    except (asyncio.CancelledError, TimeoutError):
         await handle.cancel(reason="cancelled by job runner")
         work_task = handle._work_task
         if work_task is not None and not work_task.done():

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -58,6 +58,14 @@ def _directive_intents(store: _FakeEventStore) -> list[str]:
     ]
 
 
+def _lifecycle_statuses(store: _FakeEventStore) -> list[str]:
+    return [
+        e.data["extra"]["lifecycle_status"]
+        for e in store.appended
+        if getattr(e, "type", None) == "control.directive.emitted"
+    ]
+
+
 @dataclass
 class _CompletedJobSnapshot:
     job_id: str
@@ -157,8 +165,9 @@ class _FakeExecuteHandler:
     agent_runtime_backend: str | None = None
     llm_backend: str | None = None
 
-    def __init__(self, *, is_error: bool = False) -> None:
+    def __init__(self, *, is_error: bool = False, action: str | None = None) -> None:
         self.is_error = is_error
+        self.action = action or ("failed" if is_error else "completed")
 
     async def handle(
         self,
@@ -174,7 +183,7 @@ class _FakeExecuteHandler:
                 content=(MCPContentItem(type=ContentType.TEXT, text="execute ok"),),
                 is_error=self.is_error,
                 meta={
-                    "action": "failed" if self.is_error else "completed",
+                    "action": self.action,
                     "seed_content": arguments["seed_content"],
                     "execution_id": execution_id,
                     "session_id": session_id_override,
@@ -433,3 +442,58 @@ async def test_run_with_agent_process_cleans_up_work_task_on_timeout() -> None:
     directives = _directives(store)
     assert directives[0] == "continue"
     assert directives[-1] == "cancel"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("surface", "expected_intent"),
+    [
+        ("evolve_step", "evolve_step"),
+        ("ralph", "ralph"),
+        ("execute_seed", "execute_seed"),
+    ],
+)
+async def test_production_start_surfaces_classify_interrupted_results_as_cancelled(
+    surface: str, expected_intent: str
+) -> None:
+    """Interrupted result-level errors stay distinct from failed work."""
+    store = _FakeEventStore()
+    job_manager = _InlineJobManager()
+
+    if surface == "evolve_step":
+        handler = StartEvolveStepHandler(
+            evolve_handler=_FakeEvolveHandler(is_error=True, action="interrupted"),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle(
+            {"lineage_id": "lin_interrupted", "seed_content": "goal: test"}
+        )
+    elif surface == "ralph":
+        handler = RalphHandler(
+            evolve_handler=_FakeEvolveHandler(is_error=True, action="interrupted"),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_interrupted",
+                "seed_content": "goal: test",
+                "max_generations": 1,
+                "per_iteration_timeout_seconds": 30,
+                "max_total_seconds": 30,
+            }
+        )
+    else:
+        handler = StartExecuteSeedHandler(
+            execute_handler=_FakeExecuteHandler(is_error=True, action="interrupted"),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle({"seed_content": "goal: test"})
+
+    assert result.is_ok, surface
+    assert job_manager.runner_results[0].is_error is True
+    assert _directives(store)[-1] == "cancel", surface
+    assert _directive_intents(store)[-1] == expected_intent
+    assert _lifecycle_statuses(store)[-1] == "cancelled"

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -165,9 +165,18 @@ class _FakeExecuteHandler:
     agent_runtime_backend: str | None = None
     llm_backend: str | None = None
 
-    def __init__(self, *, is_error: bool = False, action: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        is_error: bool = False,
+        action: str | None = None,
+        status: str | None = None,
+        include_action: bool = True,
+    ) -> None:
         self.is_error = is_error
         self.action = action or ("failed" if is_error else "completed")
+        self.status = status
+        self.include_action = include_action
 
     async def handle(
         self,
@@ -178,16 +187,19 @@ class _FakeExecuteHandler:
         synchronous: bool = False,
     ):
         assert synchronous is True
+        meta = {
+            "status": self.status or self.action,
+            "seed_content": arguments["seed_content"],
+            "execution_id": execution_id,
+            "session_id": session_id_override,
+        }
+        if self.include_action:
+            meta["action"] = self.action
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text="execute ok"),),
                 is_error=self.is_error,
-                meta={
-                    "action": self.action,
-                    "seed_content": arguments["seed_content"],
-                    "execution_id": execution_id,
-                    "session_id": session_id_override,
-                },
+                meta=meta,
             )
         )
 
@@ -486,7 +498,9 @@ async def test_production_start_surfaces_classify_interrupted_results_as_cancell
         )
     else:
         handler = StartExecuteSeedHandler(
-            execute_handler=_FakeExecuteHandler(is_error=True, action="interrupted"),  # type: ignore[arg-type]
+            execute_handler=_FakeExecuteHandler(
+                is_error=True, status="cancelled", include_action=False
+            ),  # type: ignore[arg-type]
             event_store=store,  # type: ignore[arg-type]
             job_manager=job_manager,  # type: ignore[arg-type]
         )

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -1,36 +1,41 @@
 """Three-surface AgentProcess acceptance test — issue #518.
 
-Verifies that evolve_step, ralph, and execute_seed all emit identical
-lifecycle patterns when wrapped in AgentProcess.spawn:
+This is an acceptance boundary over the *production start surfaces* that own
+long-running work:
 
-    RUNNING (continue) directive on spawn
-    CONVERGE (converge) directive on success
+* ``StartEvolveStepHandler`` for evolve_step
+* ``RalphHandler`` for ralph
+* ``StartExecuteSeedHandler`` for execute_seed
 
-And that a cooperative cancel from outside cleanly stops each surface.
-
-NOTE: evolve_step real wrapping lands in PR-D.  This test exercises a
-trivial AgentProcess-wrapped coroutine that mimics evolve_step's shape
-(spawn → await work → return) so the three-surface contract is pinned
-without a hard dependency on PR-D having landed.
+The inner work is kept cheap with fake downstream handlers/job manager, but the
+test calls the real public handler methods.  It therefore fails if any surface
+stops routing its background runner through ``AgentProcess.spawn``.
 """
 
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
 
-from ouroboros.orchestrator.agent_process import AgentProcess, AgentProcessStatus
-
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
+from ouroboros.core.types import Result
+from ouroboros.mcp.job_manager import JobLinks, JobStatus
+from ouroboros.mcp.tools.evolution_handlers import StartEvolveStepHandler
+from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
 
 class _FakeEventStore:
     def __init__(self) -> None:
         self.appended: list[Any] = []
+        self.initialized = False
+
+    async def initialize(self) -> None:
+        self.initialized = True
 
     async def append(self, event: Any) -> None:
         self.appended.append(event)
@@ -44,140 +49,259 @@ def _directives(store: _FakeEventStore) -> list[str]:
     ]
 
 
-async def _wait_for_status(handle, status: AgentProcessStatus, *, timeout: float = 2.0) -> None:
-    deadline = asyncio.get_event_loop().time() + timeout
-    while True:
-        if handle.status() is status:
-            return
-        if asyncio.get_event_loop().time() >= deadline:
-            raise AssertionError(
-                f"Handle status did not reach {status!r} within {timeout}s; "
-                f"current: {handle.status()!r}"
+def _directive_intents(store: _FakeEventStore) -> list[str]:
+    return [
+        e.data["extra"]["intent"]
+        for e in store.appended
+        if getattr(e, "type", None) == "control.directive.emitted"
+    ]
+
+
+@dataclass
+class _CompletedJobSnapshot:
+    job_id: str
+    links: JobLinks
+    status: JobStatus = JobStatus.COMPLETED
+    cursor: int = 1
+
+
+class _CancellableJobManager:
+    """JobManager test double that starts the runner and lets tests cancel it."""
+
+    def __init__(self) -> None:
+        self.runner_task: asyncio.Task[Any] | None = None
+        self.job_types: list[str] = []
+
+    async def start_job(
+        self,
+        *,
+        job_type: str,
+        initial_message: str,  # noqa: ARG002 - mirrors JobManager API
+        runner: Any,
+        links: JobLinks | None = None,
+    ) -> _CompletedJobSnapshot:
+        self.job_types.append(job_type)
+        self.runner_task = asyncio.create_task(runner)
+        return _CompletedJobSnapshot(
+            job_id=f"job_{job_type}",
+            links=links or JobLinks(),
+            status=JobStatus.RUNNING,
+        )
+
+    async def cancel_runner(self) -> None:
+        assert self.runner_task is not None
+        self.runner_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self.runner_task
+
+
+class _InlineJobManager:
+    """JobManager test double that executes the supplied production runner."""
+
+    def __init__(self) -> None:
+        self.runner_results: list[MCPToolResult] = []
+        self.job_types: list[str] = []
+
+    async def start_job(
+        self,
+        *,
+        job_type: str,
+        initial_message: str,  # noqa: ARG002 - mirrors JobManager API
+        runner: Any,
+        links: JobLinks | None = None,
+    ) -> _CompletedJobSnapshot:
+        self.job_types.append(job_type)
+        self.runner_results.append(await runner)
+        return _CompletedJobSnapshot(
+            job_id=f"job_{job_type}",
+            links=links or JobLinks(),
+        )
+
+
+class _FakeEvolveHandler:
+    async def handle(self, arguments: dict[str, Any]):
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="evolve ok"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": 1,
+                    "action": "converged",
+                },
             )
-        await asyncio.sleep(0.01)
-
-
-# ---------------------------------------------------------------------------
-# Surface simulators
-# ---------------------------------------------------------------------------
-
-
-async def _evolve_step_surface(ap: AgentProcess) -> AgentProcessStatus:
-    """Mimics evolve_step's shape: spawn → do work → return success.
-
-    Real wrapping lands in PR-D.  This stand-in confirms the lifecycle
-    contract without a hard dependency on that PR.
-    """
-    result_box: list[str] = []
-
-    async def _work(handle) -> None:
-        await handle.wait_unpaused()
-        if handle.should_cancel():
-            return
-        # Simulate a unit of evolve_step work.
-        await asyncio.sleep(0)
-        result_box.append("done")
-
-    handle = await ap.spawn(intent="evolve_step", work_fn=_work)
-    return await handle.wait_until_complete(timeout=2.0)
-
-
-async def _ralph_surface(ap: AgentProcess) -> AgentProcessStatus:
-    """Mimics one ralph iteration wrapped in AgentProcess."""
-    result_box: list[str] = []
-
-    async def _work(handle) -> None:
-        await handle.wait_unpaused()
-        if handle.should_cancel():
-            return
-        await asyncio.sleep(0)
-        result_box.append("done")
-
-    handle = await ap.spawn(intent="ralph_iteration:1", work_fn=_work)
-    return await handle.wait_until_complete(timeout=2.0)
-
-
-async def _execute_seed_surface(ap: AgentProcess) -> AgentProcessStatus:
-    """Mimics execute_seed wrapped in AgentProcess (StartExecuteSeedHandler shape)."""
-    result_box: list[str] = []
-
-    async def _work(handle) -> None:
-        await handle.wait_unpaused()
-        if handle.should_cancel():
-            return
-        await asyncio.sleep(0)
-        result_box.append("done")
-
-    handle = await ap.spawn(intent="execute_seed", work_fn=_work)
-    return await handle.wait_until_complete(timeout=2.0)
-
-
-# ---------------------------------------------------------------------------
-# Acceptance test: identical lifecycle pattern on success
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_all_three_surfaces_emit_running_then_converge_on_success() -> None:
-    """Each surface emits RUNNING on spawn and CONVERGE on success."""
-    for surface_fn, label in [
-        (_evolve_step_surface, "evolve_step"),
-        (_ralph_surface, "ralph"),
-        (_execute_seed_surface, "execute_seed"),
-    ]:
-        store = _FakeEventStore()
-        ap = AgentProcess(event_store=store)
-
-        final = await surface_fn(ap)
-
-        directives = _directives(store)
-        assert final is AgentProcessStatus.COMPLETED, f"{label}: expected COMPLETED, got {final!r}"
-        assert directives[0] == "continue", (
-            f"{label}: first directive must be 'continue' (RUNNING), got {directives[0]!r}"
-        )
-        assert directives[-1] == "converge", (
-            f"{label}: last directive must be 'converge' (CONVERGE), got {directives[-1]!r}"
         )
 
 
-# ---------------------------------------------------------------------------
-# Acceptance test: cooperative cancel stops each surface cleanly
-# ---------------------------------------------------------------------------
+class _BlockingEvolveHandler:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    async def handle(self, arguments: dict[str, Any]):  # noqa: ARG002 - protocol fixture
+        self.started.set()
+        await asyncio.sleep(60)
+        return Result.ok(MCPToolResult())
+
+
+class _FakeExecuteHandler:
+    agent_runtime_backend: str | None = None
+    llm_backend: str | None = None
+
+    async def handle(
+        self,
+        arguments: dict[str, Any],
+        *,
+        execution_id: str | None = None,
+        session_id_override: str | None = None,
+        synchronous: bool = False,
+    ):
+        assert synchronous is True
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="execute ok"),),
+                is_error=False,
+                meta={
+                    "seed_content": arguments["seed_content"],
+                    "execution_id": execution_id,
+                    "session_id": session_id_override,
+                },
+            )
+        )
+
+
+class _BlockingExecuteHandler:
+    agent_runtime_backend: str | None = None
+    llm_backend: str | None = None
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    async def handle(
+        self,
+        arguments: dict[str, Any],  # noqa: ARG002 - protocol fixture
+        *,
+        execution_id: str | None = None,  # noqa: ARG002 - protocol fixture
+        session_id_override: str | None = None,  # noqa: ARG002 - protocol fixture
+        synchronous: bool = False,  # noqa: ARG002 - protocol fixture
+    ):
+        self.started.set()
+        await asyncio.sleep(60)
+        return Result.ok(MCPToolResult())
 
 
 @pytest.mark.asyncio
-async def test_all_three_surfaces_cancel_cleanly() -> None:
-    """A cooperative cancel from outside terminates each surface without raising."""
-    for intent_label, label in [
+@pytest.mark.parametrize(
+    ("surface", "expected_intent", "expected_job_type"),
+    [
+        ("evolve_step", "evolve_step", "evolve_step"),
+        ("ralph", "ralph", "ralph"),
+        ("execute_seed", "execute_seed", "execute_seed"),
+    ],
+)
+async def test_production_start_surfaces_emit_running_then_converge(
+    surface: str,
+    expected_intent: str,
+    expected_job_type: str,
+) -> None:
+    """Each real start surface routes its background runner through AgentProcess."""
+    store = _FakeEventStore()
+    job_manager = _InlineJobManager()
+
+    if surface == "evolve_step":
+        handler = StartEvolveStepHandler(
+            evolve_handler=_FakeEvolveHandler(),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle({"lineage_id": "lin_accept", "seed_content": "goal: test"})
+    elif surface == "ralph":
+        handler = RalphHandler(
+            evolve_handler=_FakeEvolveHandler(),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_accept",
+                "seed_content": "goal: test",
+                "max_generations": 1,
+                "per_iteration_timeout_seconds": 30,
+                "max_total_seconds": 30,
+            }
+        )
+    else:
+        handler = StartExecuteSeedHandler(
+            execute_handler=_FakeExecuteHandler(),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle({"seed_content": "goal: test"})
+
+    assert result.is_ok, surface
+    directives = _directives(store)
+    assert directives[0] == "continue", surface
+    assert directives[-1] == "converge", surface
+    assert _directive_intents(store) == [expected_intent, expected_intent]
+    assert job_manager.job_types == [expected_job_type]
+    assert len(job_manager.runner_results) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("surface", "expected_intent"),
+    [
         ("evolve_step", "evolve_step"),
-        ("ralph_iteration:1", "ralph"),
+        ("ralph", "ralph"),
         ("execute_seed", "execute_seed"),
-    ]:
-        store = _FakeEventStore()
-        ap = AgentProcess(event_store=store)
+    ],
+)
+async def test_production_start_surfaces_emit_cancel_when_job_runner_is_cancelled(
+    surface: str, expected_intent: str
+) -> None:
+    """Job-runner cancellation is mirrored into the AgentProcess lifecycle."""
+    store = _FakeEventStore()
+    job_manager = _CancellableJobManager()
 
-        started = asyncio.Event()
-        release = asyncio.Event()
-
-        async def _long_work(handle, _started=started, _release=release) -> None:
-            _started.set()
-            await handle.wait_unpaused()
-            if handle.should_cancel():
-                return
-            # Block until cancelled.
-            while not handle.should_cancel():
-                await asyncio.sleep(0.005)
-
-        handle = await ap.spawn(intent=intent_label, work_fn=_long_work)
-        await asyncio.wait_for(started.wait(), timeout=2.0)
-
-        await handle.cancel(reason=f"test cancel: {label}")
-        final = await handle.wait_until_complete(timeout=2.0)
-
-        assert final is AgentProcessStatus.CANCELLED, (
-            f"{label}: expected CANCELLED after cancel(), got {final!r}"
+    if surface == "evolve_step":
+        blocking = _BlockingEvolveHandler()
+        handler = StartEvolveStepHandler(
+            evolve_handler=blocking,  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
         )
-        directives = _directives(store)
-        assert "cancel" in directives, (
-            f"{label}: expected a 'cancel' directive after cancel(), got {directives!r}"
+        result = await handler.handle({"lineage_id": "lin_cancel", "seed_content": "goal: test"})
+        await asyncio.wait_for(blocking.started.wait(), timeout=2.0)
+    elif surface == "ralph":
+        blocking = _BlockingEvolveHandler()
+        handler = RalphHandler(
+            evolve_handler=blocking,  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
         )
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_cancel",
+                "seed_content": "goal: test",
+                "max_generations": 1,
+                "per_iteration_timeout_seconds": 30,
+                "max_total_seconds": 30,
+            }
+        )
+        await asyncio.wait_for(blocking.started.wait(), timeout=2.0)
+    else:
+        blocking = _BlockingExecuteHandler()
+        handler = StartExecuteSeedHandler(
+            execute_handler=blocking,  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle({"seed_content": "goal: test"})
+        await asyncio.wait_for(blocking.started.wait(), timeout=2.0)
+
+    assert result.is_ok, surface
+    await job_manager.cancel_runner()
+
+    directives = _directives(store)
+    assert directives[0] == "continue", surface
+    assert directives[-1] == "cancel", surface
+    assert _directive_intents(store)[-1] == expected_intent

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -22,12 +22,13 @@ from typing import Any
 import pytest
 
 from ouroboros.core.types import Result
-from ouroboros.mcp.job_manager import JobLinks, JobStatus
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.tools.evolution_handlers import StartEvolveStepHandler
 from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.orchestrator.agent_process import run_with_agent_process
+from ouroboros.persistence.event_store import EventStore
 
 
 class _FakeEventStore:
@@ -511,3 +512,34 @@ async def test_production_start_surfaces_classify_interrupted_results_as_cancell
     assert _directives(store)[-1] == "cancel", surface
     assert _directive_intents(store)[-1] == expected_intent
     assert _lifecycle_statuses(store)[-1] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_job_manager_classifies_status_only_cancelled_result_as_cancelled() -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    job_manager = JobManager(store)
+
+    try:
+
+        async def _cancelled_result() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="cancelled"),),
+                is_error=True,
+                meta={"status": "cancelled"},
+            )
+
+        snapshot = await job_manager.start_job(
+            job_type="execute_seed",
+            initial_message="Queued execution",
+            runner=_cancelled_result(),
+        )
+
+        deadline = asyncio.get_running_loop().time() + 2.0
+        while not snapshot.is_terminal and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+            snapshot = await job_manager.get_snapshot(snapshot.job_id)
+
+        assert snapshot.status is JobStatus.CANCELLED
+        assert snapshot.result_meta["status"] == "cancelled"
+    finally:
+        await store.close()

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -27,6 +27,7 @@ from ouroboros.mcp.tools.evolution_handlers import StartEvolveStepHandler
 from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.agent_process import run_with_agent_process
 
 
 class _FakeEventStore:
@@ -136,10 +137,15 @@ class _FakeEvolveHandler:
 class _BlockingEvolveHandler:
     def __init__(self) -> None:
         self.started = asyncio.Event()
+        self.cancelled = False
 
     async def handle(self, arguments: dict[str, Any]):  # noqa: ARG002 - protocol fixture
         self.started.set()
-        await asyncio.sleep(60)
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
         return Result.ok(MCPToolResult())
 
 
@@ -175,6 +181,7 @@ class _BlockingExecuteHandler:
 
     def __init__(self) -> None:
         self.started = asyncio.Event()
+        self.cancelled = False
 
     async def handle(
         self,
@@ -185,7 +192,11 @@ class _BlockingExecuteHandler:
         synchronous: bool = False,  # noqa: ARG002 - protocol fixture
     ):
         self.started.set()
-        await asyncio.sleep(60)
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
         return Result.ok(MCPToolResult())
 
 
@@ -271,6 +282,7 @@ async def test_production_start_surfaces_emit_cancel_when_job_runner_is_cancelle
         )
         result = await handler.handle({"lineage_id": "lin_cancel", "seed_content": "goal: test"})
         await asyncio.wait_for(blocking.started.wait(), timeout=2.0)
+        blocking_handler = blocking
     elif surface == "ralph":
         blocking = _BlockingEvolveHandler()
         handler = RalphHandler(
@@ -288,6 +300,7 @@ async def test_production_start_surfaces_emit_cancel_when_job_runner_is_cancelle
             }
         )
         await asyncio.wait_for(blocking.started.wait(), timeout=2.0)
+        blocking_handler = blocking
     else:
         blocking = _BlockingExecuteHandler()
         handler = StartExecuteSeedHandler(
@@ -297,6 +310,7 @@ async def test_production_start_surfaces_emit_cancel_when_job_runner_is_cancelle
         )
         result = await handler.handle({"seed_content": "goal: test"})
         await asyncio.wait_for(blocking.started.wait(), timeout=2.0)
+        blocking_handler = blocking
 
     assert result.is_ok, surface
     await job_manager.cancel_runner()
@@ -305,3 +319,23 @@ async def test_production_start_surfaces_emit_cancel_when_job_runner_is_cancelle
     assert directives[0] == "continue", surface
     assert directives[-1] == "cancel", surface
     assert _directive_intents(store)[-1] == expected_intent
+    assert blocking_handler.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_preserves_original_failure_message() -> None:
+    store = _FakeEventStore()
+
+    async def _failing_work(_handle: Any) -> MCPToolResult:
+        raise RuntimeError("evolve_step exploded with actionable detail")
+
+    with pytest.raises(RuntimeError, match="actionable detail"):
+        await run_with_agent_process(
+            event_store=store,
+            intent="evolve_step",
+            work_fn=_failing_work,
+        )
+
+    directives = _directives(store)
+    assert directives[0] == "continue"
+    assert directives[-1] == "cancel"

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -1,0 +1,183 @@
+"""Three-surface AgentProcess acceptance test — issue #518.
+
+Verifies that evolve_step, ralph, and execute_seed all emit identical
+lifecycle patterns when wrapped in AgentProcess.spawn:
+
+    RUNNING (continue) directive on spawn
+    CONVERGE (converge) directive on success
+
+And that a cooperative cancel from outside cleanly stops each surface.
+
+NOTE: evolve_step real wrapping lands in PR-D.  This test exercises a
+trivial AgentProcess-wrapped coroutine that mimics evolve_step's shape
+(spawn → await work → return) so the three-surface contract is pinned
+without a hard dependency on PR-D having landed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from ouroboros.orchestrator.agent_process import AgentProcess, AgentProcessStatus
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeEventStore:
+    def __init__(self) -> None:
+        self.appended: list[Any] = []
+
+    async def append(self, event: Any) -> None:
+        self.appended.append(event)
+
+
+def _directives(store: _FakeEventStore) -> list[str]:
+    return [
+        e.data["directive"]
+        for e in store.appended
+        if getattr(e, "type", None) == "control.directive.emitted"
+    ]
+
+
+async def _wait_for_status(handle, status: AgentProcessStatus, *, timeout: float = 2.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        if handle.status() is status:
+            return
+        if asyncio.get_event_loop().time() >= deadline:
+            raise AssertionError(
+                f"Handle status did not reach {status!r} within {timeout}s; "
+                f"current: {handle.status()!r}"
+            )
+        await asyncio.sleep(0.01)
+
+
+# ---------------------------------------------------------------------------
+# Surface simulators
+# ---------------------------------------------------------------------------
+
+
+async def _evolve_step_surface(ap: AgentProcess) -> AgentProcessStatus:
+    """Mimics evolve_step's shape: spawn → do work → return success.
+
+    Real wrapping lands in PR-D.  This stand-in confirms the lifecycle
+    contract without a hard dependency on that PR.
+    """
+    result_box: list[str] = []
+
+    async def _work(handle) -> None:
+        await handle.wait_unpaused()
+        if handle.should_cancel():
+            return
+        # Simulate a unit of evolve_step work.
+        await asyncio.sleep(0)
+        result_box.append("done")
+
+    handle = await ap.spawn(intent="evolve_step", work_fn=_work)
+    return await handle.wait_until_complete(timeout=2.0)
+
+
+async def _ralph_surface(ap: AgentProcess) -> AgentProcessStatus:
+    """Mimics one ralph iteration wrapped in AgentProcess."""
+    result_box: list[str] = []
+
+    async def _work(handle) -> None:
+        await handle.wait_unpaused()
+        if handle.should_cancel():
+            return
+        await asyncio.sleep(0)
+        result_box.append("done")
+
+    handle = await ap.spawn(intent="ralph_iteration:1", work_fn=_work)
+    return await handle.wait_until_complete(timeout=2.0)
+
+
+async def _execute_seed_surface(ap: AgentProcess) -> AgentProcessStatus:
+    """Mimics execute_seed wrapped in AgentProcess (StartExecuteSeedHandler shape)."""
+    result_box: list[str] = []
+
+    async def _work(handle) -> None:
+        await handle.wait_unpaused()
+        if handle.should_cancel():
+            return
+        await asyncio.sleep(0)
+        result_box.append("done")
+
+    handle = await ap.spawn(intent="execute_seed", work_fn=_work)
+    return await handle.wait_until_complete(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance test: identical lifecycle pattern on success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_three_surfaces_emit_running_then_converge_on_success() -> None:
+    """Each surface emits RUNNING on spawn and CONVERGE on success."""
+    for surface_fn, label in [
+        (_evolve_step_surface, "evolve_step"),
+        (_ralph_surface, "ralph"),
+        (_execute_seed_surface, "execute_seed"),
+    ]:
+        store = _FakeEventStore()
+        ap = AgentProcess(event_store=store)
+
+        final = await surface_fn(ap)
+
+        directives = _directives(store)
+        assert final is AgentProcessStatus.COMPLETED, f"{label}: expected COMPLETED, got {final!r}"
+        assert directives[0] == "continue", (
+            f"{label}: first directive must be 'continue' (RUNNING), got {directives[0]!r}"
+        )
+        assert directives[-1] == "converge", (
+            f"{label}: last directive must be 'converge' (CONVERGE), got {directives[-1]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance test: cooperative cancel stops each surface cleanly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_three_surfaces_cancel_cleanly() -> None:
+    """A cooperative cancel from outside terminates each surface without raising."""
+    for intent_label, label in [
+        ("evolve_step", "evolve_step"),
+        ("ralph_iteration:1", "ralph"),
+        ("execute_seed", "execute_seed"),
+    ]:
+        store = _FakeEventStore()
+        ap = AgentProcess(event_store=store)
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _long_work(handle, _started=started, _release=release) -> None:
+            _started.set()
+            await handle.wait_unpaused()
+            if handle.should_cancel():
+                return
+            # Block until cancelled.
+            while not handle.should_cancel():
+                await asyncio.sleep(0.005)
+
+        handle = await ap.spawn(intent=intent_label, work_fn=_long_work)
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        await handle.cancel(reason=f"test cancel: {label}")
+        final = await handle.wait_until_complete(timeout=2.0)
+
+        assert final is AgentProcessStatus.CANCELLED, (
+            f"{label}: expected CANCELLED after cancel(), got {final!r}"
+        )
+        directives = _directives(store)
+        assert "cancel" in directives, (
+            f"{label}: expected a 'cancel' directive after cancel(), got {directives!r}"
+        )

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -543,3 +543,34 @@ async def test_job_manager_classifies_status_only_cancelled_result_as_cancelled(
         assert snapshot.result_meta["status"] == "cancelled"
     finally:
         await store.close()
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_timeout_does_not_hang_on_stubborn_worker() -> None:
+    store = _FakeEventStore()
+    release = asyncio.Event()
+    swallowed_cancel = asyncio.Event()
+
+    async def _stubborn_work(_handle: Any) -> MCPToolResult:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            swallowed_cancel.set()
+            await release.wait()
+        return MCPToolResult()
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(
+            run_with_agent_process(
+                event_store=store,
+                intent="stubborn_timeout_surface",
+                work_fn=_stubborn_work,
+                timeout=0.01,
+            ),
+            timeout=2.0,
+        )
+
+    assert swallowed_cancel.is_set()
+    assert _directives(store)[-1] == "cancel"
+    release.set()
+    await asyncio.sleep(0)

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -120,15 +120,19 @@ class _InlineJobManager:
 
 
 class _FakeEvolveHandler:
+    def __init__(self, *, is_error: bool = False, action: str = "converged") -> None:
+        self.is_error = is_error
+        self.action = action
+
     async def handle(self, arguments: dict[str, Any]):
         return Result.ok(
             MCPToolResult(
-                content=(MCPContentItem(type=ContentType.TEXT, text="evolve ok"),),
-                is_error=False,
+                content=(MCPContentItem(type=ContentType.TEXT, text="evolve result"),),
+                is_error=self.is_error,
                 meta={
                     "lineage_id": arguments["lineage_id"],
                     "generation": 1,
-                    "action": "converged",
+                    "action": self.action,
                 },
             )
         )
@@ -153,6 +157,9 @@ class _FakeExecuteHandler:
     agent_runtime_backend: str | None = None
     llm_backend: str | None = None
 
+    def __init__(self, *, is_error: bool = False) -> None:
+        self.is_error = is_error
+
     async def handle(
         self,
         arguments: dict[str, Any],
@@ -165,8 +172,9 @@ class _FakeExecuteHandler:
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text="execute ok"),),
-                is_error=False,
+                is_error=self.is_error,
                 meta={
+                    "action": "failed" if self.is_error else "completed",
                     "seed_content": arguments["seed_content"],
                     "execution_id": execution_id,
                     "session_id": session_id_override,
@@ -339,3 +347,58 @@ async def test_run_with_agent_process_preserves_original_failure_message() -> No
     directives = _directives(store)
     assert directives[0] == "continue"
     assert directives[-1] == "cancel"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("surface", "expected_intent"),
+    [
+        ("evolve_step", "evolve_step"),
+        ("ralph", "ralph"),
+        ("execute_seed", "execute_seed"),
+    ],
+)
+async def test_production_start_surfaces_do_not_converge_error_tool_results(
+    surface: str, expected_intent: str
+) -> None:
+    """MCPToolResult(is_error=True) is a lifecycle failure, not convergence."""
+    store = _FakeEventStore()
+    job_manager = _InlineJobManager()
+
+    if surface == "evolve_step":
+        handler = StartEvolveStepHandler(
+            evolve_handler=_FakeEvolveHandler(is_error=True, action="failed"),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle({"lineage_id": "lin_error", "seed_content": "goal: test"})
+    elif surface == "ralph":
+        handler = RalphHandler(
+            evolve_handler=_FakeEvolveHandler(is_error=True, action="failed"),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_error",
+                "seed_content": "goal: test",
+                "max_generations": 1,
+                "per_iteration_timeout_seconds": 30,
+                "max_total_seconds": 30,
+            }
+        )
+    else:
+        handler = StartExecuteSeedHandler(
+            execute_handler=_FakeExecuteHandler(is_error=True),  # type: ignore[arg-type]
+            event_store=store,  # type: ignore[arg-type]
+            job_manager=job_manager,  # type: ignore[arg-type]
+        )
+        result = await handler.handle({"seed_content": "goal: test"})
+
+    assert result.is_ok, surface
+    assert job_manager.runner_results[0].is_error is True
+    directives = _directives(store)
+    assert directives[0] == "continue", surface
+    assert directives[-1] == "cancel", surface
+    assert "converge" not in directives, surface
+    assert _directive_intents(store)[-1] == expected_intent

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -402,3 +402,34 @@ async def test_production_start_surfaces_do_not_converge_error_tool_results(
     assert directives[-1] == "cancel", surface
     assert "converge" not in directives, surface
     assert _directive_intents(store)[-1] == expected_intent
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_cleans_up_work_task_on_timeout() -> None:
+    store = _FakeEventStore()
+    started = asyncio.Event()
+    cancelled = False
+
+    async def _slow_work(_handle: Any) -> MCPToolResult:
+        nonlocal cancelled
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+        return MCPToolResult()
+
+    with pytest.raises(TimeoutError):
+        await run_with_agent_process(
+            event_store=store,
+            intent="timeout_surface",
+            work_fn=_slow_work,
+            timeout=0.01,
+        )
+
+    assert started.is_set()
+    assert cancelled is True
+    directives = _directives(store)
+    assert directives[0] == "continue"
+    assert directives[-1] == "cancel"


### PR DESCRIPTION
## Summary

Slice 6 of M6 (#518). This PR now pins the three-surface AgentProcess lifecycle contract against the real production start surfaces instead of inline stand-ins.

## What's in this PR

- `src/ouroboros/orchestrator/agent_process.py`
  - Adds `run_with_agent_process(...)`, a shared helper that runs a production JobManager runner through `AgentProcess.spawn` while preserving the existing JobManager return/failure contract.
- `src/ouroboros/mcp/tools/evolution_handlers.py`
  - Routes `StartEvolveStepHandler` background work through `AgentProcess` with intent `evolve_step`.
- `src/ouroboros/mcp/tools/ralph_handlers.py`
  - Routes `RalphHandler` background work through `AgentProcess` with intent `ralph`.
- `src/ouroboros/mcp/tools/execution_handlers.py`
  - Routes `StartExecuteSeedHandler` background work through `AgentProcess` with intent `execute_seed`.
- `tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py`
  - Calls the real public handler methods for all three production start surfaces.
  - Verifies each surface emits `continue` on spawn and `converge` on clean completion.
  - Verifies job-runner cancellation is mirrored into `cancel` lifecycle directives.

## Review-driven correction

The original version only exercised three trivial inline coroutines with different intent strings. The bot review correctly flagged that as insufficient because it tested `AgentProcess` itself, not production adoption. The latest commits fix that by moving the production start surfaces onto a shared `AgentProcess.spawn` boundary and making the acceptance test fail if any of those real handler paths stops using that boundary. Follow-up bot reviews also caught cancellation/error propagation and result-level failure risks in the shared wrapper; the wrapper now owns and cancels the spawned work task, re-raises original exceptions so JobManager keeps actionable error text, maps returned `MCPToolResult(is_error=True)` to AgentProcess failure while returning the original result to JobManager, applies the same cancel/join cleanup on timeout, and preserves interrupted/cancelled result semantics from either `meta.action` or `meta.status` instead of collapsing every `is_error=True` result into failure, and keeps JobManager terminal mapping aligned with that same vocabulary, and bounds cleanup joins so cancellation-resistant workers cannot wedge timeout/cancel callers.

## Test plan

- `PYTHONPATH=src pytest tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py tests/unit/orchestrator/test_agent_process.py tests/unit/mcp/tools/test_ralph_handler.py tests/unit/mcp/tools/test_start_execute_seed_idempotency.py tests/unit/mcp/tools/test_round5_fixes.py -q` — 97 passed.
- `PYTHONPATH=src ruff check src/ouroboros/orchestrator/agent_process.py src/ouroboros/mcp/tools/evolution_handlers.py src/ouroboros/mcp/tools/ralph_handlers.py src/ouroboros/mcp/tools/execution_handlers.py tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py` — clean.
- `PYTHONPATH=src ruff format --check ...` — clean.
- `uv run mypy src/ouroboros/orchestrator/agent_process.py src/ouroboros/mcp/tools/evolution_handlers.py src/ouroboros/mcp/tools/ralph_handlers.py src/ouroboros/mcp/tools/execution_handlers.py tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py` — clean.

Part of #518.
