### PR TITLE
feat(auto): DomainProfile and VerifiablePredicate contracts (#809 P3, PR 1/6)

### DIFF
--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -1,0 +1,219 @@
+"""DomainProfile contracts for the Pillar A refactor (#809 P3).
+
+ooo auto today bakes Python/coding assumptions into ``answerer.py`` and
+``safe_defaults.py``: vague-term lists, verifiable predicates,
+intent classifiers, and safe defaults all assume the user is shipping
+code. Pillar A of #809 inverts that: core only knows *that AC must
+be verifiable*; *what counts as verifiable* moves into a per-domain
+``DomainProfile``.
+
+This module ships the contracts only — no caller is wired here. PR-2
+populates the first ``coding`` profile, PR-3 adds CLI activation,
+PR-4 routes ``AutoAnswerer`` through ``intent_classifier``, PR-5
+migrates ``safe_defaults``, and PR-6 demonstrates plurality with a
+second built-in profile.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = [
+    "DEFAULT_REGISTRY",
+    "DomainProfile",
+    "DomainProfileRegistry",
+    "IntentClassifier",
+    "RepoContextExtractor",
+    "VerifiablePredicate",
+]
+
+
+@runtime_checkable
+class VerifiablePredicate(Protocol):
+    """A single verifiable predicate that can match and repair AC text.
+
+    Each predicate has a stable ``code`` identifier (e.g. ``"exit_code"``,
+    ``"wcag_contrast"``) that downstream tooling can reference without
+    coupling to predicate internals.
+    """
+
+    code: str
+    """Stable identifier — e.g. ``"exit_code"``, ``"stdout_snapshot"``."""
+
+    def matches(self, criterion: str) -> bool:
+        """Return True if *criterion* (an AC string) satisfies this predicate."""
+        ...
+
+    def repair_template(self, criterion: str) -> str:
+        """Return a repaired AC string for a criterion that failed ``matches``."""
+        ...
+
+
+@runtime_checkable
+class IntentClassifier(Protocol):
+    """Classifies a raw interview question into a canonical intent label.
+
+    ``classify`` returns a canonical label string (e.g. ``"runtime_context"``,
+    ``"acceptance_criteria"``) or ``None`` when no intent matches.
+    ``supported_intents`` advertises the full label set so callers can validate
+    routing tables without probing every possible question.
+    """
+
+    def classify(self, question: str) -> str | None:
+        """Return the canonical intent label for *question*, or None."""
+        ...
+
+    def supported_intents(self) -> frozenset[str]:
+        """Return the full set of intent labels this classifier can emit."""
+        ...
+
+
+@runtime_checkable
+class RepoContextExtractor(Protocol):
+    """Extracts minimal repository context from a working directory.
+
+    The shape of the returned dict is deliberately open (``dict[str, Any]``)
+    so PR-2 can pass through the existing ``AutoAnswerContext``-style dict
+    without forcing a schema change here.
+    """
+
+    def extract(self, cwd: Path) -> dict[str, Any]:
+        """Return a flat dict of repository facts keyed by fact name."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class DomainProfile:
+    """An immutable profile that describes how a domain verifies AC.
+
+    ``DomainProfile`` is the central unit of the Pillar A refactor: each
+    domain (``coding``, ``design``, ``data-science``, …) ships its own
+    instance.  Core logic references only this interface; domain knowledge
+    stays out of ``answerer.py`` and ``safe_defaults.py``.
+
+    Attributes
+    ----------
+    name:
+        Unique profile identifier, e.g. ``"coding"``.
+    repo_context_extractor:
+        Extracts repo facts from a working directory.
+    verifiable_predicates:
+        Ordered tuple of predicates.  ``find_verifiable_predicate`` scans
+        left-to-right and returns the first match.
+    intent_classifier:
+        Maps interview questions to canonical intent labels.
+    vague_terms:
+        Frozenset of phrases that are insufficiently precise for this domain
+        (e.g. ``"clean"``, ``"easy"`` for coding).
+    safe_defaults:
+        Domain-specific defaults keyed by ledger section.  PR-5 will
+        introduce a richer ``_DefaultSpec`` shape; ``Any`` is intentional here.
+    detector:
+        A callable ``(cwd: Path) -> float`` returning a confidence in
+        [0.0, 1.0] that *cwd* belongs to this domain.
+    """
+
+    name: str
+    repo_context_extractor: RepoContextExtractor
+    verifiable_predicates: tuple[VerifiablePredicate, ...]
+    intent_classifier: IntentClassifier
+    vague_terms: frozenset[str]
+    safe_defaults: dict[str, Any]
+    detector: Callable[[Path], float]
+
+    def find_verifiable_predicate(self, criterion: str) -> VerifiablePredicate | None:
+        """Return the first predicate whose ``matches`` returns True, or None."""
+        for predicate in self.verifiable_predicates:
+            if predicate.matches(criterion):
+                return predicate
+        return None
+
+
+class DomainProfileRegistry:
+    """A mutable registry of ``DomainProfile`` instances.
+
+    Profiles are stored in registration order, which acts as a tie-breaker
+    when ``detect_best`` finds equal confidence scores.
+
+    Usage::
+
+        registry = DomainProfileRegistry()
+        registry.register(my_coding_profile)
+        best = registry.detect_best(Path.cwd())
+    """
+
+    def __init__(self) -> None:
+        self._profiles: list[DomainProfile] = []
+
+    def register(self, profile: DomainProfile) -> None:
+        """Register *profile*.
+
+        Raises
+        ------
+        ValueError
+            If a profile with the same ``name`` is already registered.
+        """
+        if any(p.name == profile.name for p in self._profiles):
+            raise ValueError(f"A DomainProfile named {profile.name!r} is already registered.")
+        self._profiles.append(profile)
+
+    def get(self, name: str) -> DomainProfile | None:
+        """Return the profile registered under *name*, or None."""
+        for profile in self._profiles:
+            if profile.name == name:
+                return profile
+        return None
+
+    def all(self) -> tuple[DomainProfile, ...]:
+        """Return all registered profiles in registration order."""
+        return tuple(self._profiles)
+
+    def detect_best(self, cwd: Path) -> DomainProfile | None:
+        """Return the highest-confidence profile for *cwd*.
+
+        Confidence is measured by ``profile.detector(cwd)``.  Ties are broken
+        by registration order (earlier registration wins).  Returns ``None``
+        when no profiles are registered or all detectors return 0.0.
+        """
+        best_profile: DomainProfile | None = None
+        best_confidence: float = 0.0
+        for profile in self._profiles:
+            confidence = profile.detector(cwd)
+            if confidence > best_confidence:
+                best_confidence = confidence
+                best_profile = profile
+        return best_profile
+
+    def union_predicates(
+        self, cwd: Path, threshold: float = 0.5
+    ) -> tuple[VerifiablePredicate, ...]:
+        """Return the union of predicates from all profiles above *threshold*.
+
+        Useful for monorepo projects where multiple domain profiles apply.
+        Profiles are evaluated in registration order; predicates from earlier
+        profiles appear first in the result.
+
+        Parameters
+        ----------
+        cwd:
+            Working directory passed to each profile's ``detector``.
+        threshold:
+            Minimum detector confidence required for a profile's predicates
+            to be included.  Default is ``0.5``.
+        """
+        seen_codes: set[str] = set()
+        result: list[VerifiablePredicate] = []
+        for profile in self._profiles:
+            if profile.detector(cwd) >= threshold:
+                for predicate in profile.verifiable_predicates:
+                    if predicate.code not in seen_codes:
+                        seen_codes.add(predicate.code)
+                        result.append(predicate)
+        return tuple(result)
+
+
+#: Module-level singleton registry.  PR-2 will register the ``coding`` profile here.
+DEFAULT_REGISTRY: DomainProfileRegistry = DomainProfileRegistry()

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -16,9 +16,10 @@ second built-in profile.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Protocol, runtime_checkable
 
 __all__ = [
@@ -29,6 +30,27 @@ __all__ = [
     "RepoContextExtractor",
     "VerifiablePredicate",
 ]
+
+
+def _freeze_safe_default_value(value: Any) -> Any:
+    """Recursively freeze common mutable containers used by safe defaults."""
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {key: _freeze_safe_default_value(nested) for key, nested in value.items()}
+        )
+    if isinstance(value, tuple):
+        return tuple(_freeze_safe_default_value(item) for item in value)
+    if isinstance(value, list):
+        return tuple(_freeze_safe_default_value(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_safe_default_value(item) for item in value)
+    return value
+
+
+def _freeze_safe_defaults(safe_defaults: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType(
+        {key: _freeze_safe_default_value(value) for key, value in safe_defaults.items()}
+    )
 
 
 @runtime_checkable
@@ -111,6 +133,7 @@ class DomainProfile:
     safe_defaults:
         Domain-specific defaults keyed by ledger section.  PR-5 will
         introduce a richer ``_DefaultSpec`` shape; ``Any`` is intentional here.
+        Common mutable containers are recursively frozen at construction time.
     detector:
         A callable ``(cwd: Path) -> float`` returning a confidence in
         [0.0, 1.0] that *cwd* belongs to this domain.
@@ -121,8 +144,11 @@ class DomainProfile:
     verifiable_predicates: tuple[VerifiablePredicate, ...]
     intent_classifier: IntentClassifier
     vague_terms: frozenset[str]
-    safe_defaults: dict[str, Any]
+    safe_defaults: Mapping[str, Any]
     detector: Callable[[Path], float]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "safe_defaults", _freeze_safe_defaults(self.safe_defaults))
 
     def find_verifiable_predicate(self, criterion: str) -> VerifiablePredicate | None:
         """Return the first predicate whose ``matches`` returns True, or None."""

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -16,7 +16,7 @@ second built-in profile.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -107,7 +107,7 @@ class RepoContextExtractor(Protocol):
         ...
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, init=False)
 class DomainProfile:
     """An immutable profile that describes how a domain verifies AC.
 
@@ -147,8 +147,24 @@ class DomainProfile:
     safe_defaults: Mapping[str, Any]
     detector: Callable[[Path], float]
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "safe_defaults", _freeze_safe_defaults(self.safe_defaults))
+    def __init__(
+        self,
+        *,
+        name: str,
+        repo_context_extractor: RepoContextExtractor,
+        verifiable_predicates: Iterable[VerifiablePredicate],
+        intent_classifier: IntentClassifier,
+        vague_terms: Iterable[str],
+        safe_defaults: Mapping[str, Any],
+        detector: Callable[[Path], float],
+    ) -> None:
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "repo_context_extractor", repo_context_extractor)
+        object.__setattr__(self, "verifiable_predicates", tuple(verifiable_predicates))
+        object.__setattr__(self, "intent_classifier", intent_classifier)
+        object.__setattr__(self, "vague_terms", frozenset(vague_terms))
+        object.__setattr__(self, "safe_defaults", _freeze_safe_defaults(safe_defaults))
+        object.__setattr__(self, "detector", detector)
 
     def find_verifiable_predicate(self, criterion: str) -> VerifiablePredicate | None:
         """Return the first predicate whose ``matches`` returns True, or None."""

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -7,6 +7,7 @@ imported; every fixture is a minimal inline stub.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from typing import Any
@@ -66,6 +67,7 @@ def _make_profile(
     name: str = "coding",
     confidence: float = 0.8,
     predicates: tuple[VerifiablePredicate, ...] = (),
+    safe_defaults: Mapping[str, Any] | None = None,
 ) -> DomainProfile:
     return DomainProfile(
         name=name,
@@ -73,7 +75,9 @@ def _make_profile(
         verifiable_predicates=predicates,
         intent_classifier=_SimpleClassifier(),
         vague_terms=frozenset({"easy", "clean"}),
-        safe_defaults={"runtime_context": "existing project"},
+        safe_defaults=(
+            safe_defaults if safe_defaults is not None else {"runtime_context": "existing project"}
+        ),
         detector=lambda _cwd: confidence,
     )
 
@@ -116,6 +120,37 @@ def test_domain_profile_is_frozen() -> None:
     profile = _make_profile()
     with pytest.raises(FrozenInstanceError):
         profile.name = "mutated"  # type: ignore[misc]
+
+
+def test_domain_profile_safe_defaults_are_deeply_frozen() -> None:
+    source_defaults: dict[str, Any] = {
+        "runtime_context": {
+            "summary": "existing project",
+            "commands": ["pytest"],
+            "tags": {"contract"},
+        },
+    }
+    profile = _make_profile(safe_defaults=source_defaults)
+
+    with pytest.raises(TypeError):
+        profile.safe_defaults["acceptance_criteria"] = "specific"  # type: ignore[index]
+
+    runtime_context = profile.safe_defaults["runtime_context"]
+    assert isinstance(runtime_context, Mapping)
+    with pytest.raises(TypeError):
+        runtime_context["summary"] = "mutated"  # type: ignore[index]
+
+    commands = runtime_context["commands"]
+    assert commands == ("pytest",)
+    with pytest.raises(TypeError):
+        commands[0] = "ruff"  # type: ignore[index]
+
+    assert runtime_context["tags"] == frozenset({"contract"})
+
+    source_defaults["runtime_context"]["summary"] = "mutated outside profile"
+    source_defaults["runtime_context"]["commands"].append("ruff")
+    assert runtime_context["summary"] == "existing project"
+    assert runtime_context["commands"] == ("pytest",)
 
 
 def test_find_verifiable_predicate_returns_first_match() -> None:
@@ -218,8 +253,7 @@ def test_registry_union_predicates_applies_threshold() -> None:
     assert "wcag_contrast" not in codes
 
 
-def test_default_registry_starts_empty() -> None:
-    # DEFAULT_REGISTRY is a module-level singleton; PR-2 registers coding here.
-    # At this point (PR-1) it must be empty.
-    assert DEFAULT_REGISTRY.all() == ()
-    assert DEFAULT_REGISTRY.detect_best(Path("/tmp")) is None
+def test_default_registry_is_a_profile_registry_singleton() -> None:
+    # PR-2 will register the coding profile here; avoid asserting transient
+    # global emptiness in this contract-only test module.
+    assert isinstance(DEFAULT_REGISTRY, DomainProfileRegistry)

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -7,7 +7,7 @@ imported; every fixture is a minimal inline stub.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from typing import Any
@@ -66,7 +66,7 @@ class _SimpleExtractor:
 def _make_profile(
     name: str = "coding",
     confidence: float = 0.8,
-    predicates: tuple[VerifiablePredicate, ...] = (),
+    predicates: Iterable[VerifiablePredicate] = (),
     safe_defaults: Mapping[str, Any] | None = None,
 ) -> DomainProfile:
     return DomainProfile(
@@ -151,6 +151,47 @@ def test_domain_profile_safe_defaults_are_deeply_frozen() -> None:
     source_defaults["runtime_context"]["commands"].append("ruff")
     assert runtime_context["summary"] == "existing project"
     assert runtime_context["commands"] == ("pytest",)
+
+
+def test_domain_profile_coerces_predicate_inputs_to_immutable_tuple() -> None:
+    registry = DomainProfileRegistry()
+    exit_pred = _ExitCodePredicate()
+    contrast_pred = _ContrastPredicate()
+    source_predicates: list[VerifiablePredicate] = [exit_pred]
+    profile = _make_profile(predicates=source_predicates)
+    registry.register(profile)
+
+    source_predicates.clear()
+    source_predicates.append(contrast_pred)
+
+    registered = registry.get("coding")
+    assert registered is profile
+    assert registered.verifiable_predicates == (exit_pred,)
+    assert registered.find_verifiable_predicate("command exits 0") is exit_pred
+    assert registered.find_verifiable_predicate("color contrast check") is None
+
+
+def test_domain_profile_coerces_vague_terms_to_immutable_frozenset() -> None:
+    registry = DomainProfileRegistry()
+    source_vague_terms = {"easy", "clean"}
+    profile = DomainProfile(
+        name="coding",
+        repo_context_extractor=_SimpleExtractor(),
+        verifiable_predicates=(),
+        intent_classifier=_SimpleClassifier(),
+        vague_terms=source_vague_terms,
+        safe_defaults={},
+        detector=lambda _cwd: 0.8,
+    )
+    registry.register(profile)
+
+    source_vague_terms.clear()
+    source_vague_terms.add("later")
+
+    registered = registry.get("coding")
+    assert registered is profile
+    assert registered.vague_terms == frozenset({"easy", "clean"})
+    assert "later" not in registered.vague_terms
 
 
 def test_find_verifiable_predicate_returns_first_match() -> None:

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -1,0 +1,225 @@
+"""Contract tests for DomainProfile and VerifiablePredicate (#809 P3, PR 1/6).
+
+These tests verify the Protocol stubs, dataclass invariants, and registry
+semantics introduced in ``domain_profile.py``.  No real domain profiles are
+imported; every fixture is a minimal inline stub.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.domain_profile import (
+    DEFAULT_REGISTRY,
+    DomainProfile,
+    DomainProfileRegistry,
+    IntentClassifier,
+    RepoContextExtractor,
+    VerifiablePredicate,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal stubs
+# ---------------------------------------------------------------------------
+
+
+class _ExitCodePredicate:
+    code = "exit_code"
+
+    def matches(self, criterion: str) -> bool:
+        return "exit" in criterion.lower()
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Command exits 0 when: {criterion}"
+
+
+class _ContrastPredicate:
+    code = "wcag_contrast"
+
+    def matches(self, criterion: str) -> bool:
+        return "contrast" in criterion.lower()
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Contrast ratio ≥ 4.5:1 for: {criterion}"
+
+
+class _SimpleClassifier:
+    def classify(self, question: str) -> str | None:
+        if "runtime" in question.lower():
+            return "runtime_context"
+        return None
+
+    def supported_intents(self) -> frozenset[str]:
+        return frozenset({"runtime_context", "acceptance_criteria"})
+
+
+class _SimpleExtractor:
+    def extract(self, cwd: Path) -> dict[str, Any]:
+        return {"cwd": str(cwd)}
+
+
+def _make_profile(
+    name: str = "coding",
+    confidence: float = 0.8,
+    predicates: tuple[VerifiablePredicate, ...] = (),
+) -> DomainProfile:
+    return DomainProfile(
+        name=name,
+        repo_context_extractor=_SimpleExtractor(),
+        verifiable_predicates=predicates,
+        intent_classifier=_SimpleClassifier(),
+        vague_terms=frozenset({"easy", "clean"}),
+        safe_defaults={"runtime_context": "existing project"},
+        detector=lambda _cwd: confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_verifiable_predicate_protocol_smoke() -> None:
+    pred = _ExitCodePredicate()
+    assert isinstance(pred, VerifiablePredicate)
+    assert pred.code == "exit_code"
+    assert pred.matches("command exits 0")
+    assert not pred.matches("stdout snapshot")
+    assert "exit" in pred.repair_template("some criterion").lower()
+
+
+def test_intent_classifier_protocol_smoke() -> None:
+    clf = _SimpleClassifier()
+    assert isinstance(clf, IntentClassifier)
+    assert clf.classify("Which runtime should we use?") == "runtime_context"
+    assert clf.classify("something unrelated") is None
+    assert "runtime_context" in clf.supported_intents()
+
+
+def test_repo_context_extractor_protocol_smoke() -> None:
+    extractor = _SimpleExtractor()
+    assert isinstance(extractor, RepoContextExtractor)
+    result = extractor.extract(Path("/tmp"))
+    assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# DomainProfile invariants
+# ---------------------------------------------------------------------------
+
+
+def test_domain_profile_is_frozen() -> None:
+    profile = _make_profile()
+    with pytest.raises(FrozenInstanceError):
+        profile.name = "mutated"  # type: ignore[misc]
+
+
+def test_find_verifiable_predicate_returns_first_match() -> None:
+    exit_pred = _ExitCodePredicate()
+    contrast_pred = _ContrastPredicate()
+    profile = _make_profile(predicates=(exit_pred, contrast_pred))
+
+    result = profile.find_verifiable_predicate("command exits 0 on success")
+    assert result is exit_pred
+
+    result2 = profile.find_verifiable_predicate("color contrast check")
+    assert result2 is contrast_pred
+
+    result3 = profile.find_verifiable_predicate("stdout contains expected output")
+    assert result3 is None
+
+
+# ---------------------------------------------------------------------------
+# DomainProfileRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_rejects_duplicate_name() -> None:
+    registry = DomainProfileRegistry()
+    registry.register(_make_profile(name="coding"))
+    with pytest.raises(ValueError, match="coding"):
+        registry.register(_make_profile(name="coding"))
+
+
+def test_registry_get_returns_none_for_unknown() -> None:
+    registry = DomainProfileRegistry()
+    assert registry.get("nonexistent") is None
+
+
+def test_registry_get_returns_registered_profile() -> None:
+    registry = DomainProfileRegistry()
+    profile = _make_profile(name="coding")
+    registry.register(profile)
+    assert registry.get("coding") is profile
+
+
+def test_registry_detect_best_picks_highest_confidence() -> None:
+    registry = DomainProfileRegistry()
+    low = _make_profile(name="low", confidence=0.2)
+    high = _make_profile(name="high", confidence=0.9)
+    registry.register(low)
+    registry.register(high)
+
+    best = registry.detect_best(Path("/tmp"))
+    assert best is not None
+    assert best.name == "high"
+
+
+def test_registry_detect_best_breaks_ties_by_registration_order() -> None:
+    registry = DomainProfileRegistry()
+    first = _make_profile(name="first", confidence=0.7)
+    second = _make_profile(name="second", confidence=0.7)
+    registry.register(first)
+    registry.register(second)
+
+    best = registry.detect_best(Path("/tmp"))
+    assert best is not None
+    assert best.name == "first"
+
+
+def test_registry_detect_best_returns_none_when_empty() -> None:
+    registry = DomainProfileRegistry()
+    assert registry.detect_best(Path("/tmp")) is None
+
+
+def test_registry_union_predicates_applies_threshold() -> None:
+    registry = DomainProfileRegistry()
+    exit_pred = _ExitCodePredicate()
+    contrast_pred = _ContrastPredicate()
+
+    above = DomainProfile(
+        name="above",
+        repo_context_extractor=_SimpleExtractor(),
+        verifiable_predicates=(exit_pred,),
+        intent_classifier=_SimpleClassifier(),
+        vague_terms=frozenset(),
+        safe_defaults={},
+        detector=lambda _: 0.8,
+    )
+    below = DomainProfile(
+        name="below",
+        repo_context_extractor=_SimpleExtractor(),
+        verifiable_predicates=(contrast_pred,),
+        intent_classifier=_SimpleClassifier(),
+        vague_terms=frozenset(),
+        safe_defaults={},
+        detector=lambda _: 0.3,
+    )
+    registry.register(above)
+    registry.register(below)
+
+    predicates = registry.union_predicates(Path("/tmp"), threshold=0.5)
+    codes = [p.code for p in predicates]
+    assert "exit_code" in codes
+    assert "wcag_contrast" not in codes
+
+
+def test_default_registry_starts_empty() -> None:
+    # DEFAULT_REGISTRY is a module-level singleton; PR-2 registers coding here.
+    # At this point (PR-1) it must be empty.
+    assert DEFAULT_REGISTRY.all() == ()
+    assert DEFAULT_REGISTRY.detect_best(Path("/tmp")) is None


### PR DESCRIPTION
## Summary

- Introduces `DomainProfile`, `VerifiablePredicate`, `IntentClassifier`, and `RepoContextExtractor` as the contract layer for the Pillar A refactor (#809 P3).
- Adds `DomainProfileRegistry` with `register`, `get`, `all`, `detect_best` (highest confidence, ties by registration order), and `union_predicates` (monorepo support).
- Exposes `DEFAULT_REGISTRY` as the module-level singleton that PR-2 will populate with the `coding` profile.
- **No existing caller is modified** — `answerer.py`, `safe_defaults.py`, and all other modules are untouched.

## Exported surface (`src/ouroboros/auto/domain_profile.py`)

| Symbol | Kind |
|---|---|
| `VerifiablePredicate` | `Protocol` (`code`, `matches`, `repair_template`) |
| `IntentClassifier` | `Protocol` (`classify`, `supported_intents`) |
| `RepoContextExtractor` | `Protocol` (`extract`) |
| `DomainProfile` | `frozen dataclass` (7 fields + `find_verifiable_predicate`) |
| `DomainProfileRegistry` | class (`register`, `get`, `all`, `detect_best`, `union_predicates`) |
| `DEFAULT_REGISTRY` | module-level singleton |

## Test plan

- [x] `test_verifiable_predicate_protocol_smoke` — minimal stub satisfies Protocol
- [x] `test_intent_classifier_protocol_smoke`
- [x] `test_repo_context_extractor_protocol_smoke`
- [x] `test_domain_profile_is_frozen` — mutation raises `FrozenInstanceError`
- [x] `test_find_verifiable_predicate_returns_first_match`
- [x] `test_registry_rejects_duplicate_name`
- [x] `test_registry_get_returns_none_for_unknown`
- [x] `test_registry_get_returns_registered_profile`
- [x] `test_registry_detect_best_picks_highest_confidence`
- [x] `test_registry_detect_best_breaks_ties_by_registration_order`
- [x] `test_registry_detect_best_returns_none_when_empty`
- [x] `test_registry_union_predicates_applies_threshold`
- [x] `test_default_registry_starts_empty` — singleton is empty at PR-1

All 13 tests pass; `ruff check` and `ruff format --check` clean.

## Why observational

This PR only *defines* interfaces — it imports nothing from `answerer.py`, `safe_defaults.py`, or any other `auto/` module.  The module is dependency-free so it can be safely imported from anywhere in the stack.

## Stack note

PRs 2–6 will base off this branch in sequence:
- **PR-2**: register `coding` `DomainProfile` into `DEFAULT_REGISTRY`
- **PR-3**: CLI activation routes through `DomainProfileRegistry`
- **PR-4**: `AutoAnswerer` routed through `intent_classifier`
- **PR-5**: `safe_defaults` migrated to `DomainProfile.safe_defaults`
- **PR-6**: second built-in profile demonstrating plurality

🤖 Generated with [Claude Code](https://claude.com/claude-code)