### PR TITLE
feat(auto): first built-in coding DomainProfile + parity tests (#809 P3, PR 2/6)

### DIFF
--- a/src/ouroboros/auto/__init__.py
+++ b/src/ouroboros/auto/__init__.py
@@ -6,14 +6,24 @@ state plus deterministic quality gates that a higher-level supervisor can use
 before starting execution.
 """
 
-from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
-from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
-from ouroboros.auto.interview_driver import AutoInterviewDriver, AutoInterviewResult, InterviewTurn
-from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
-from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
-from ouroboros.auto.seed_repairer import RepairResult, SeedRepairer
-from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
-from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoPolicy, AutoStore
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
+    from ouroboros.auto.grading import GradeGate, GradeResult, SeedGrade
+    from ouroboros.auto.interview_driver import (
+        AutoInterviewDriver,
+        AutoInterviewResult,
+        InterviewTurn,
+    )
+    from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
+    from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+    from ouroboros.auto.seed_repairer import RepairResult, SeedRepairer
+    from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoPolicy, AutoStore
 
 __all__ = [
     "AutoAnswer",
@@ -40,3 +50,45 @@ __all__ = [
     "SeedGrade",
     "SeedRepairer",
 ]
+
+_EXPORTS = {
+    "AutoAnswer": "ouroboros.auto.answerer",
+    "AutoAnswerSource": "ouroboros.auto.answerer",
+    "AutoAnswerer": "ouroboros.auto.answerer",
+    "AutoInterviewDriver": "ouroboros.auto.interview_driver",
+    "AutoInterviewResult": "ouroboros.auto.interview_driver",
+    "AutoPhase": "ouroboros.auto.state",
+    "AutoPipeline": "ouroboros.auto.pipeline",
+    "AutoPipelineResult": "ouroboros.auto.pipeline",
+    "AutoPipelineState": "ouroboros.auto.state",
+    "AutoPolicy": "ouroboros.auto.state",
+    "AutoStore": "ouroboros.auto.state",
+    "GradeGate": "ouroboros.auto.grading",
+    "GradeResult": "ouroboros.auto.grading",
+    "InterviewTurn": "ouroboros.auto.interview_driver",
+    "LedgerEntry": "ouroboros.auto.ledger",
+    "LedgerSection": "ouroboros.auto.ledger",
+    "RepairResult": "ouroboros.auto.seed_repairer",
+    "ReviewFinding": "ouroboros.auto.seed_reviewer",
+    "SeedDraftLedger": "ouroboros.auto.ledger",
+    "SeedGrade": "ouroboros.auto.grading",
+    "SeedRepairer": "ouroboros.auto.seed_repairer",
+    "SeedReview": "ouroboros.auto.seed_reviewer",
+    "SeedReviewer": "ouroboros.auto.seed_reviewer",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose the public auto package API without eager submodule imports."""
+    try:
+        module_name = _EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    value = getattr(importlib.import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted((*globals(), *__all__))

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -190,12 +190,19 @@ class DomainProfileRegistry:
 
     def __init__(self, loader: Callable[[DomainProfileRegistry], None] | None = None) -> None:
         self._profiles: list[DomainProfile] = []
+        self._profile_storage = self._profiles
         self._loader = loader
         self._loaded = loader is None
 
     def _ensure_loaded(self) -> None:
         """Load built-in profiles on first read without coupling module imports."""
         if self._loaded:
+            return
+        if self._profiles is not self._profile_storage:
+            # Tests and callers may intentionally replace the private backing
+            # list to isolate the singleton registry.  Treat that replacement
+            # as an explicit opt-out from default lazy loading for this object.
+            self._loaded = True
             return
         self._loaded = True
         if self._loader is not None:
@@ -209,6 +216,7 @@ class DomainProfileRegistry:
         ValueError
             If a profile with the same ``name`` is already registered.
         """
+        self._ensure_loaded()
         if any(p.name == profile.name for p in self._profiles):
             raise ValueError(f"A DomainProfile named {profile.name!r} is already registered.")
         self._profiles.append(profile)

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -16,7 +16,7 @@ second built-in profile.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -109,7 +109,7 @@ class DomainProfile:
         Frozenset of phrases that are insufficiently precise for this domain
         (e.g. ``"clean"``, ``"easy"`` for coding).
     safe_defaults:
-        Domain-specific defaults keyed by ledger section.  PR-5 will
+        Immutable domain-specific defaults keyed by ledger section.  PR-5 will
         introduce a richer ``_DefaultSpec`` shape; ``Any`` is intentional here.
     detector:
         A callable ``(cwd: Path) -> float`` returning a confidence in
@@ -121,7 +121,7 @@ class DomainProfile:
     verifiable_predicates: tuple[VerifiablePredicate, ...]
     intent_classifier: IntentClassifier
     vague_terms: frozenset[str]
-    safe_defaults: dict[str, Any]
+    safe_defaults: Mapping[str, Any]
     detector: Callable[[Path], float]
 
     def find_verifiable_predicate(self, criterion: str) -> VerifiablePredicate | None:

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -224,7 +224,6 @@ class DomainProfileRegistry:
         ValueError
             If a profile with the same ``name`` is already registered.
         """
-        self._ensure_loaded()
         if any(p.name == profile.name for p in self._profiles):
             raise ValueError(f"A DomainProfile named {profile.name!r} is already registered.")
         self._profiles.append(profile)

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+import importlib
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -145,8 +146,18 @@ class DomainProfileRegistry:
         best = registry.detect_best(Path.cwd())
     """
 
-    def __init__(self) -> None:
+    def __init__(self, loader: Callable[[DomainProfileRegistry], None] | None = None) -> None:
         self._profiles: list[DomainProfile] = []
+        self._loader = loader
+        self._loaded = loader is None
+
+    def _ensure_loaded(self) -> None:
+        """Load built-in profiles on first read without coupling module imports."""
+        if self._loaded:
+            return
+        self._loaded = True
+        if self._loader is not None:
+            self._loader(self)
 
     def register(self, profile: DomainProfile) -> None:
         """Register *profile*.
@@ -162,6 +173,7 @@ class DomainProfileRegistry:
 
     def get(self, name: str) -> DomainProfile | None:
         """Return the profile registered under *name*, or None."""
+        self._ensure_loaded()
         for profile in self._profiles:
             if profile.name == name:
                 return profile
@@ -169,6 +181,7 @@ class DomainProfileRegistry:
 
     def all(self) -> tuple[DomainProfile, ...]:
         """Return all registered profiles in registration order."""
+        self._ensure_loaded()
         return tuple(self._profiles)
 
     def detect_best(self, cwd: Path) -> DomainProfile | None:
@@ -178,6 +191,7 @@ class DomainProfileRegistry:
         by registration order (earlier registration wins).  Returns ``None``
         when no profiles are registered or all detectors return 0.0.
         """
+        self._ensure_loaded()
         best_profile: DomainProfile | None = None
         best_confidence: float = 0.0
         for profile in self._profiles:
@@ -204,6 +218,7 @@ class DomainProfileRegistry:
             Minimum detector confidence required for a profile's predicates
             to be included.  Default is ``0.5``.
         """
+        self._ensure_loaded()
         seen_codes: set[str] = set()
         result: list[VerifiablePredicate] = []
         for profile in self._profiles:
@@ -215,13 +230,18 @@ class DomainProfileRegistry:
         return tuple(result)
 
 
-#: Module-level singleton registry.  Built-in profiles are imported below so
-#: callers that use ``DEFAULT_REGISTRY`` directly see the default registrations
-#: without needing an additional ``ouroboros.auto.profiles`` side-effect import.
-DEFAULT_REGISTRY: DomainProfileRegistry = DomainProfileRegistry()
+def _load_default_profiles(registry: DomainProfileRegistry) -> None:
+    """Register built-in profiles lazily.
 
-# Import built-ins after ``DEFAULT_REGISTRY`` exists.  The profile modules import
-# this module to access the registry and contracts, so keeping this at the end
-# avoids an incomplete-initialization cycle while still satisfying the public
-# default-registry contract.
-import ouroboros.auto.profiles  # noqa: E402,F401
+    ``domain_profile`` is the lightweight contracts module.  Importing it must
+    not drag in domain-specific adapters such as ``profiles.coding`` and their
+    transitive dependencies.  The default registry still exposes built-ins to
+    callers, but only when the registry is actually queried.
+    """
+    profiles = importlib.import_module("ouroboros.auto.profiles")
+    profiles.register_default_profiles(registry)
+
+
+#: Module-level singleton registry.  Built-in profiles are loaded lazily on
+#: first access so importing this contracts module remains dependency-light.
+DEFAULT_REGISTRY: DomainProfileRegistry = DomainProfileRegistry(loader=_load_default_profiles)

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -1,0 +1,219 @@
+"""DomainProfile contracts for the Pillar A refactor (#809 P3).
+
+ooo auto today bakes Python/coding assumptions into ``answerer.py`` and
+``safe_defaults.py``: vague-term lists, verifiable predicates,
+intent classifiers, and safe defaults all assume the user is shipping
+code. Pillar A of #809 inverts that: core only knows *that AC must
+be verifiable*; *what counts as verifiable* moves into a per-domain
+``DomainProfile``.
+
+This module ships the contracts only — no caller is wired here. PR-2
+populates the first ``coding`` profile, PR-3 adds CLI activation,
+PR-4 routes ``AutoAnswerer`` through ``intent_classifier``, PR-5
+migrates ``safe_defaults``, and PR-6 demonstrates plurality with a
+second built-in profile.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = [
+    "DEFAULT_REGISTRY",
+    "DomainProfile",
+    "DomainProfileRegistry",
+    "IntentClassifier",
+    "RepoContextExtractor",
+    "VerifiablePredicate",
+]
+
+
+@runtime_checkable
+class VerifiablePredicate(Protocol):
+    """A single verifiable predicate that can match and repair AC text.
+
+    Each predicate has a stable ``code`` identifier (e.g. ``"exit_code"``,
+    ``"wcag_contrast"``) that downstream tooling can reference without
+    coupling to predicate internals.
+    """
+
+    code: str
+    """Stable identifier — e.g. ``"exit_code"``, ``"stdout_snapshot"``."""
+
+    def matches(self, criterion: str) -> bool:
+        """Return True if *criterion* (an AC string) satisfies this predicate."""
+        ...
+
+    def repair_template(self, criterion: str) -> str:
+        """Return a repaired AC string for a criterion that failed ``matches``."""
+        ...
+
+
+@runtime_checkable
+class IntentClassifier(Protocol):
+    """Classifies a raw interview question into a canonical intent label.
+
+    ``classify`` returns a canonical label string (e.g. ``"runtime_context"``,
+    ``"acceptance_criteria"``) or ``None`` when no intent matches.
+    ``supported_intents`` advertises the full label set so callers can validate
+    routing tables without probing every possible question.
+    """
+
+    def classify(self, question: str) -> str | None:
+        """Return the canonical intent label for *question*, or None."""
+        ...
+
+    def supported_intents(self) -> frozenset[str]:
+        """Return the full set of intent labels this classifier can emit."""
+        ...
+
+
+@runtime_checkable
+class RepoContextExtractor(Protocol):
+    """Extracts minimal repository context from a working directory.
+
+    The shape of the returned dict is deliberately open (``dict[str, Any]``)
+    so PR-2 can pass through the existing ``AutoAnswerContext``-style dict
+    without forcing a schema change here.
+    """
+
+    def extract(self, cwd: Path) -> dict[str, Any]:
+        """Return a flat dict of repository facts keyed by fact name."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class DomainProfile:
+    """An immutable profile that describes how a domain verifies AC.
+
+    ``DomainProfile`` is the central unit of the Pillar A refactor: each
+    domain (``coding``, ``design``, ``data-science``, …) ships its own
+    instance.  Core logic references only this interface; domain knowledge
+    stays out of ``answerer.py`` and ``safe_defaults.py``.
+
+    Attributes
+    ----------
+    name:
+        Unique profile identifier, e.g. ``"coding"``.
+    repo_context_extractor:
+        Extracts repo facts from a working directory.
+    verifiable_predicates:
+        Ordered tuple of predicates.  ``find_verifiable_predicate`` scans
+        left-to-right and returns the first match.
+    intent_classifier:
+        Maps interview questions to canonical intent labels.
+    vague_terms:
+        Frozenset of phrases that are insufficiently precise for this domain
+        (e.g. ``"clean"``, ``"easy"`` for coding).
+    safe_defaults:
+        Domain-specific defaults keyed by ledger section.  PR-5 will
+        introduce a richer ``_DefaultSpec`` shape; ``Any`` is intentional here.
+    detector:
+        A callable ``(cwd: Path) -> float`` returning a confidence in
+        [0.0, 1.0] that *cwd* belongs to this domain.
+    """
+
+    name: str
+    repo_context_extractor: RepoContextExtractor
+    verifiable_predicates: tuple[VerifiablePredicate, ...]
+    intent_classifier: IntentClassifier
+    vague_terms: frozenset[str]
+    safe_defaults: dict[str, Any]
+    detector: Callable[[Path], float]
+
+    def find_verifiable_predicate(self, criterion: str) -> VerifiablePredicate | None:
+        """Return the first predicate whose ``matches`` returns True, or None."""
+        for predicate in self.verifiable_predicates:
+            if predicate.matches(criterion):
+                return predicate
+        return None
+
+
+class DomainProfileRegistry:
+    """A mutable registry of ``DomainProfile`` instances.
+
+    Profiles are stored in registration order, which acts as a tie-breaker
+    when ``detect_best`` finds equal confidence scores.
+
+    Usage::
+
+        registry = DomainProfileRegistry()
+        registry.register(my_coding_profile)
+        best = registry.detect_best(Path.cwd())
+    """
+
+    def __init__(self) -> None:
+        self._profiles: list[DomainProfile] = []
+
+    def register(self, profile: DomainProfile) -> None:
+        """Register *profile*.
+
+        Raises
+        ------
+        ValueError
+            If a profile with the same ``name`` is already registered.
+        """
+        if any(p.name == profile.name for p in self._profiles):
+            raise ValueError(f"A DomainProfile named {profile.name!r} is already registered.")
+        self._profiles.append(profile)
+
+    def get(self, name: str) -> DomainProfile | None:
+        """Return the profile registered under *name*, or None."""
+        for profile in self._profiles:
+            if profile.name == name:
+                return profile
+        return None
+
+    def all(self) -> tuple[DomainProfile, ...]:
+        """Return all registered profiles in registration order."""
+        return tuple(self._profiles)
+
+    def detect_best(self, cwd: Path) -> DomainProfile | None:
+        """Return the highest-confidence profile for *cwd*.
+
+        Confidence is measured by ``profile.detector(cwd)``.  Ties are broken
+        by registration order (earlier registration wins).  Returns ``None``
+        when no profiles are registered or all detectors return 0.0.
+        """
+        best_profile: DomainProfile | None = None
+        best_confidence: float = 0.0
+        for profile in self._profiles:
+            confidence = profile.detector(cwd)
+            if confidence > best_confidence:
+                best_confidence = confidence
+                best_profile = profile
+        return best_profile
+
+    def union_predicates(
+        self, cwd: Path, threshold: float = 0.5
+    ) -> tuple[VerifiablePredicate, ...]:
+        """Return the union of predicates from all profiles above *threshold*.
+
+        Useful for monorepo projects where multiple domain profiles apply.
+        Profiles are evaluated in registration order; predicates from earlier
+        profiles appear first in the result.
+
+        Parameters
+        ----------
+        cwd:
+            Working directory passed to each profile's ``detector``.
+        threshold:
+            Minimum detector confidence required for a profile's predicates
+            to be included.  Default is ``0.5``.
+        """
+        seen_codes: set[str] = set()
+        result: list[VerifiablePredicate] = []
+        for profile in self._profiles:
+            if profile.detector(cwd) >= threshold:
+                for predicate in profile.verifiable_predicates:
+                    if predicate.code not in seen_codes:
+                        seen_codes.add(predicate.code)
+                        result.append(predicate)
+        return tuple(result)
+
+
+#: Module-level singleton registry.  PR-2 will register the ``coding`` profile here.
+DEFAULT_REGISTRY: DomainProfileRegistry = DomainProfileRegistry()

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -201,8 +201,8 @@ class DomainProfileRegistry:
         if self._profiles is not self._profile_storage:
             # Tests and callers may intentionally replace the private backing
             # list to isolate the singleton registry.  Treat that replacement
-            # as an explicit opt-out from default lazy loading for this object.
-            self._loaded = True
+            # as a temporary opt-out; do not mark the loader complete because
+            # monkeypatch-style replacement may later restore the original list.
             return
         self._loaded = True
         if self._loader is not None:

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -215,5 +215,13 @@ class DomainProfileRegistry:
         return tuple(result)
 
 
-#: Module-level singleton registry.  PR-2 will register the ``coding`` profile here.
+#: Module-level singleton registry.  Built-in profiles are imported below so
+#: callers that use ``DEFAULT_REGISTRY`` directly see the default registrations
+#: without needing an additional ``ouroboros.auto.profiles`` side-effect import.
 DEFAULT_REGISTRY: DomainProfileRegistry = DomainProfileRegistry()
+
+# Import built-ins after ``DEFAULT_REGISTRY`` exists.  The profile modules import
+# this module to access the registry and contracts, so keeping this at the end
+# avoids an incomplete-initialization cycle while still satisfying the public
+# default-registry contract.
+import ouroboros.auto.profiles  # noqa: E402,F401

--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -193,10 +193,11 @@ class DomainProfileRegistry:
         self._profile_storage = self._profiles
         self._loader = loader
         self._loaded = loader is None
+        self._loading = False
 
     def _ensure_loaded(self) -> None:
         """Load built-in profiles on first read without coupling module imports."""
-        if self._loaded:
+        if self._loaded or self._loading:
             return
         if self._profiles is not self._profile_storage:
             # Tests and callers may intentionally replace the private backing
@@ -204,9 +205,16 @@ class DomainProfileRegistry:
             # as a temporary opt-out; do not mark the loader complete because
             # monkeypatch-style replacement may later restore the original list.
             return
-        self._loaded = True
-        if self._loader is not None:
+        if self._loader is None:
+            self._loaded = True
+            return
+
+        self._loading = True
+        try:
             self._loader(self)
+            self._loaded = True
+        finally:
+            self._loading = False
 
     def register(self, profile: DomainProfile) -> None:
         """Register *profile*.

--- a/src/ouroboros/auto/profiles/__init__.py
+++ b/src/ouroboros/auto/profiles/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in DomainProfile implementations."""
+
+from .coding import CODING_PROFILE
+
+__all__ = ["CODING_PROFILE"]

--- a/src/ouroboros/auto/profiles/__init__.py
+++ b/src/ouroboros/auto/profiles/__init__.py
@@ -1,5 +1,29 @@
 """Built-in DomainProfile implementations."""
 
-from .coding import CODING_PROFILE
+from __future__ import annotations
 
-__all__ = ["CODING_PROFILE"]
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ouroboros.auto.domain_profile import DomainProfileRegistry
+
+__all__ = ["CODING_PROFILE", "register_default_profiles"]
+
+
+def __getattr__(name: str):
+    if name == "CODING_PROFILE":
+        from .coding import CODING_PROFILE
+
+        return CODING_PROFILE
+    raise AttributeError(name)
+
+
+def register_default_profiles(registry: DomainProfileRegistry) -> None:
+    """Register built-in profiles into *registry* on demand."""
+    from .coding import CODING_PROFILE
+
+    try:
+        registry.register(CODING_PROFILE)
+    except ValueError:
+        # Keep repeated lazy-load/importlib scenarios idempotent.
+        pass

--- a/src/ouroboros/auto/profiles/coding.py
+++ b/src/ouroboros/auto/profiles/coding.py
@@ -213,11 +213,22 @@ def _build_safe_defaults() -> MappingProxyType[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+_CODING_MARKERS = (
+    "pyproject.toml",
+    "package.json",
+    "go.mod",
+    "Cargo.toml",
+    "pom.xml",
+    "build.gradle",
+    "settings.gradle",
+    "composer.json",
+    "Gemfile",
+)
+
+
 def _coding_detector(cwd: Path) -> float:
     """Return 1.0 if the directory looks like a coding project, else 0.0."""
-    if (cwd / "pyproject.toml").is_file():
-        return 1.0
-    return 0.0
+    return 1.0 if any((cwd / marker).is_file() for marker in _CODING_MARKERS) else 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/src/ouroboros/auto/profiles/coding.py
+++ b/src/ouroboros/auto/profiles/coding.py
@@ -24,18 +24,26 @@ from ouroboros.auto.safe_defaults import _SAFE_DEFAULTS  # noqa: PLC2701
 # ---------------------------------------------------------------------------
 
 
+def _matches_observable_pattern(criterion: str, *patterns: str) -> bool:
+    """Return True only for criteria accepted by the existing grading contract."""
+    if not _is_observable(criterion):
+        return False
+    lowered = criterion.lower()
+    return any(re.search(pattern, lowered) for pattern in patterns)
+
+
 class _ExitCodePredicate:
     """Matches AC text that references exit codes or command success/failure."""
 
     code = "exit_code"
 
     def matches(self, criterion: str) -> bool:
-        lowered = criterion.lower()
-        return bool(
-            re.search(r"\bexit\s*code\b", lowered)
-            or re.search(r"\bexit(?:s)?\s+(?:0|with|non-zero)\b", lowered)
-            or re.search(r"\breturns?\s+(?:0|non-zero|exit)\b", lowered)
-            or "exit_code" in lowered
+        return _matches_observable_pattern(
+            criterion,
+            r"\bexit\s*code\b",
+            r"\bexit(?:s)?\s+(?:0|with|non-zero)\b",
+            r"\breturns?\s+(?:0|non-zero|exit)\b",
+            r"exit_code",
         )
 
     def repair_template(self, criterion: str) -> str:
@@ -48,13 +56,13 @@ class _TestPassPredicate:
     code = "test_pass"
 
     def matches(self, criterion: str) -> bool:
-        lowered = criterion.lower()
-        return bool(
-            re.search(r"\btests?\s+pass\b", lowered)
-            or re.search(r"\ball\s+tests?\b", lowered)
-            or re.search(r"\btest\s+suite\b", lowered)
-            or re.search(r"\bpytest\b", lowered)
-            or re.search(r"\bjest\b", lowered)
+        return _matches_observable_pattern(
+            criterion,
+            r"\btests?\s+pass\b",
+            r"\ball\s+tests?\b",
+            r"\btest\s+suite\b",
+            r"\bpytest\b",
+            r"\bjest\b",
         )
 
     def repair_template(self, criterion: str) -> str:
@@ -67,14 +75,14 @@ class _LintCleanPredicate:
     code = "lint_clean"
 
     def matches(self, criterion: str) -> bool:
-        lowered = criterion.lower()
-        return bool(
-            re.search(r"\blinters?\b", lowered)
-            or re.search(r"\blint(?:s|ed|ing)\b", lowered)
-            or re.search(r"\bruff\b", lowered)
-            or re.search(r"\bflake8\b", lowered)
-            or re.search(r"\beslint\b", lowered)
-            or re.search(r"\bno\s+lint\s+errors?\b", lowered)
+        return _matches_observable_pattern(
+            criterion,
+            r"\blinters?\b",
+            r"\blint(?:s|ed|ing)\b",
+            r"\bruff\b",
+            r"\bflake8\b",
+            r"\beslint\b",
+            r"\bno\s+lint\s+errors?\b",
         )
 
     def repair_template(self, criterion: str) -> str:
@@ -87,13 +95,13 @@ class _TypeCheckCleanPredicate:
     code = "type_check_clean"
 
     def matches(self, criterion: str) -> bool:
-        lowered = criterion.lower()
-        return bool(
-            re.search(r"\btype\s*check\b", lowered)
-            or re.search(r"\bmypy\b", lowered)
-            or re.search(r"\bpyright\b", lowered)
-            or re.search(r"\btsc\b", lowered)
-            or re.search(r"\bno\s+type\s+errors?\b", lowered)
+        return _matches_observable_pattern(
+            criterion,
+            r"\btype\s*check\b",
+            r"\bmypy\b",
+            r"\bpyright\b",
+            r"\btsc\b",
+            r"\bno\s+type\s+errors?\b",
         )
 
     def repair_template(self, criterion: str) -> str:
@@ -125,17 +133,6 @@ class _CodingIntentClassifier:
     to the existing private classifier so intent routing stays in a single
     place until PR-4 migrates callers.
     """
-
-    _SUPPORTED: frozenset[str] = frozenset(
-        {
-            "non_goals",
-            "verification",
-            "acceptance_criteria",
-            "actor_io",
-            "runtime_context",
-            "product_behavior",
-        }
-    )
 
     def classify(self, question: str) -> str | None:
         # Import locally to avoid a circular import at module load time.
@@ -175,7 +172,12 @@ class _CodingIntentClassifier:
         return next(iter(intents)).value
 
     def supported_intents(self) -> frozenset[str]:
-        return self._SUPPORTED
+        # Import locally to avoid coupling this adapter's module import to
+        # answerer.py while still deriving the supported set from the source
+        # enum instead of hard-coding labels.
+        from ouroboros.auto.answerer import QuestionIntent
+
+        return frozenset(intent.value for intent in QuestionIntent)
 
 
 # ---------------------------------------------------------------------------

--- a/src/ouroboros/auto/profiles/coding.py
+++ b/src/ouroboros/auto/profiles/coding.py
@@ -14,7 +14,7 @@ import re
 from types import MappingProxyType
 from typing import Any
 
-from ouroboros.auto.domain_profile import DEFAULT_REGISTRY, DomainProfile
+from ouroboros.auto.domain_profile import DomainProfile
 from ouroboros.auto.grading import VAGUE_TERMS, _is_observable  # noqa: PLC2701
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.safe_defaults import _SAFE_DEFAULTS  # noqa: PLC2701
@@ -250,9 +250,3 @@ CODING_PROFILE: DomainProfile = DomainProfile(
     safe_defaults=_build_safe_defaults(),
     detector=_coding_detector,
 )
-
-# Register with the module-level singleton so any caller that imports this
-# module benefits from auto-registration.  The guard prevents double-
-# registration on reimport (e.g. in pytest with importmode=importlib).
-if DEFAULT_REGISTRY.get("coding") is None:
-    DEFAULT_REGISTRY.register(CODING_PROFILE)

--- a/src/ouroboros/auto/profiles/coding.py
+++ b/src/ouroboros/auto/profiles/coding.py
@@ -1,0 +1,220 @@
+"""Built-in ``coding`` DomainProfile (#809 P3, PR 2/6).
+
+Packages the existing Python/coding logic from ``answerer.py``,
+``grading.py``, and ``safe_defaults.py`` as an immutable ``DomainProfile``
+without modifying those modules.  PR-4 and PR-5 will route the callers
+through this profile; for now the profile acts as a read-only adapter so
+the parity tests can pin equality.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Any
+
+from ouroboros.auto.domain_profile import DEFAULT_REGISTRY, DomainProfile
+from ouroboros.auto.grading import VAGUE_TERMS
+from ouroboros.auto.repo_context import repo_auto_answer_context
+from ouroboros.auto.safe_defaults import _SAFE_DEFAULTS  # noqa: PLC2701
+
+# ---------------------------------------------------------------------------
+# VerifiablePredicate implementations
+# ---------------------------------------------------------------------------
+
+
+class _ExitCodePredicate:
+    """Matches AC text that references exit codes or command success/failure."""
+
+    code = "exit_code"
+
+    def matches(self, criterion: str) -> bool:
+        lowered = criterion.lower()
+        return bool(
+            re.search(r"\bexit\s*code\b", lowered)
+            or re.search(r"\bexit(?:s)?\s+(?:0|with|non-zero)\b", lowered)
+            or re.search(r"\breturns?\s+(?:0|non-zero|exit)\b", lowered)
+            or "exit_code" in lowered
+        )
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Command exits 0 on success and non-zero on failure: {criterion}"
+
+
+class _TestPassPredicate:
+    """Matches AC text that references test suites passing."""
+
+    code = "test_pass"
+
+    def matches(self, criterion: str) -> bool:
+        lowered = criterion.lower()
+        return bool(
+            re.search(r"\btests?\s+pass\b", lowered)
+            or re.search(r"\ball\s+tests?\b", lowered)
+            or re.search(r"\btest\s+suite\b", lowered)
+            or re.search(r"\bpytest\b", lowered)
+            or re.search(r"\bjest\b", lowered)
+        )
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Run test suite and all tests pass: {criterion}"
+
+
+class _LintCleanPredicate:
+    """Matches AC text that references linting passing."""
+
+    code = "lint_clean"
+
+    def matches(self, criterion: str) -> bool:
+        lowered = criterion.lower()
+        return bool(
+            re.search(r"\blinters?\b", lowered)
+            or re.search(r"\blint(?:s|ed|ing)\b", lowered)
+            or re.search(r"\bruff\b", lowered)
+            or re.search(r"\bflake8\b", lowered)
+            or re.search(r"\beslint\b", lowered)
+            or re.search(r"\bno\s+lint\s+errors?\b", lowered)
+        )
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Linter reports zero errors: {criterion}"
+
+
+class _TypeCheckCleanPredicate:
+    """Matches AC text that references type checking passing."""
+
+    code = "type_check_clean"
+
+    def matches(self, criterion: str) -> bool:
+        lowered = criterion.lower()
+        return bool(
+            re.search(r"\btype\s*check\b", lowered)
+            or re.search(r"\bmypy\b", lowered)
+            or re.search(r"\bpyright\b", lowered)
+            or re.search(r"\btsc\b", lowered)
+            or re.search(r"\bno\s+type\s+errors?\b", lowered)
+        )
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Type checker reports zero errors: {criterion}"
+
+
+# ---------------------------------------------------------------------------
+# IntentClassifier adapter
+# ---------------------------------------------------------------------------
+
+
+class _CodingIntentClassifier:
+    """Thin adapter over ``_classify_question_intents`` from ``answerer.py``.
+
+    ``supported_intents`` returns the canonical label set drawn from
+    ``QuestionIntent`` (defined in ``answerer.py``).  ``classify`` delegates
+    to the existing private classifier so intent routing stays in a single
+    place until PR-4 migrates callers.
+    """
+
+    _SUPPORTED: frozenset[str] = frozenset(
+        {
+            "non_goals",
+            "verification",
+            "acceptance_criteria",
+            "actor_io",
+            "runtime_context",
+            "product_behavior",
+        }
+    )
+
+    def classify(self, question: str) -> str | None:
+        # Import locally to avoid a circular import at module load time.
+        from ouroboros.auto.answerer import _classify_question_intents  # noqa: PLC2701
+
+        intents = _classify_question_intents(question)
+        if not intents:
+            return None
+        # Return the highest-priority intent using the same priority order
+        # as AutoAnswerer.answer().
+        priority = [
+            "non_goals",
+            "verification",
+            "acceptance_criteria",
+            "runtime_context",
+            "product_behavior",
+            "actor_io",
+        ]
+        for label in priority:
+            for intent in intents:
+                if intent.value == label:
+                    return label
+        # Fallback: return any matched intent value
+        return next(iter(intents)).value
+
+    def supported_intents(self) -> frozenset[str]:
+        return self._SUPPORTED
+
+
+# ---------------------------------------------------------------------------
+# RepoContextExtractor adapter
+# ---------------------------------------------------------------------------
+
+
+class _CodingRepoContextExtractor:
+    """Thin adapter over ``repo_auto_answer_context`` from ``repo_context.py``."""
+
+    def extract(self, cwd: Path) -> dict[str, Any]:
+        ctx = repo_auto_answer_context(cwd)
+        return dict(ctx.repo_facts)
+
+
+# ---------------------------------------------------------------------------
+# Safe defaults adapter
+# ---------------------------------------------------------------------------
+
+
+def _build_safe_defaults() -> dict[str, Any]:
+    """Return a plain ``dict[str, Any]`` mirroring ``_SAFE_DEFAULTS``.
+
+    ``_SAFE_DEFAULTS`` is ``dict[str, _DefaultSpec]`` where ``_DefaultSpec``
+    is a frozen dataclass with ``value`` and ``rationale`` fields.  We copy
+    the mapping verbatim so the ``DomainProfile.safe_defaults`` type
+    (``dict[str, Any]``) holds the same objects.  PR-5 will introduce a
+    typed ``_DefaultSpec``-aware schema; ``Any`` is intentional here.
+    """
+    return dict(_SAFE_DEFAULTS)
+
+
+# ---------------------------------------------------------------------------
+# Detector
+# ---------------------------------------------------------------------------
+
+
+def _coding_detector(cwd: Path) -> float:
+    """Return 1.0 if the directory looks like a coding project, else 0.0."""
+    if (cwd / "pyproject.toml").exists() or (cwd / "package.json").exists():
+        return 1.0
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+CODING_PROFILE: DomainProfile = DomainProfile(
+    name="coding",
+    repo_context_extractor=_CodingRepoContextExtractor(),
+    verifiable_predicates=(
+        _ExitCodePredicate(),
+        _TestPassPredicate(),
+        _LintCleanPredicate(),
+        _TypeCheckCleanPredicate(),
+    ),
+    intent_classifier=_CodingIntentClassifier(),
+    vague_terms=frozenset(VAGUE_TERMS),
+    safe_defaults=_build_safe_defaults(),
+    detector=_coding_detector,
+)
+
+# Register with the module-level singleton so any caller that imports this
+# module benefits from auto-registration.  The guard prevents double-
+# registration on reimport (e.g. in pytest with importmode=importlib).
+if DEFAULT_REGISTRY.get("coding") is None:
+    DEFAULT_REGISTRY.register(CODING_PROFILE)

--- a/src/ouroboros/auto/profiles/coding.py
+++ b/src/ouroboros/auto/profiles/coding.py
@@ -15,7 +15,7 @@ from types import MappingProxyType
 from typing import Any
 
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY, DomainProfile
-from ouroboros.auto.grading import VAGUE_TERMS
+from ouroboros.auto.grading import VAGUE_TERMS, _is_observable  # noqa: PLC2701
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.safe_defaults import _SAFE_DEFAULTS  # noqa: PLC2701
 
@@ -100,6 +100,18 @@ class _TypeCheckCleanPredicate:
         return f"Type checker reports zero errors: {criterion}"
 
 
+class _ObservableBehaviorPredicate:
+    """Fallback predicate that mirrors grading._is_observable()."""
+
+    code = "observable_behavior"
+
+    def matches(self, criterion: str) -> bool:
+        return _is_observable(criterion)
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Mention command output, file/artifact, API response, or test result: {criterion}"
+
+
 # ---------------------------------------------------------------------------
 # IntentClassifier adapter
 # ---------------------------------------------------------------------------
@@ -127,26 +139,39 @@ class _CodingIntentClassifier:
 
     def classify(self, question: str) -> str | None:
         # Import locally to avoid a circular import at module load time.
-        from ouroboros.auto.answerer import _classify_question_intents  # noqa: PLC2701
+        from ouroboros.auto.answerer import (  # noqa: PLC2701
+            QuestionIntent,
+            _classify_question_intents,
+            _has_user_verify_feature_shape,
+            _normalize_question,
+            _should_preserve_runtime_route,
+        )
 
         intents = _classify_question_intents(question)
         if not intents:
             return None
-        # Return the highest-priority intent using the same priority order
-        # as AutoAnswerer.answer().
-        priority = [
-            "non_goals",
-            "verification",
-            "acceptance_criteria",
-            "runtime_context",
-            "product_behavior",
-            "actor_io",
-        ]
-        for label in priority:
-            for intent in intents:
-                if intent.value == label:
-                    return label
-        # Fallback: return any matched intent value
+
+        # Mirror AutoAnswerer.answer()'s route order, including the
+        # user-facing verify-feature demotion that keeps questions like
+        # "Can users verify their email?" on the product_behavior path.
+        lowered = _normalize_question(question)
+        demote_for_user_verify = (
+            QuestionIntent.PRODUCT_BEHAVIOR in intents and _has_user_verify_feature_shape(lowered)
+        )
+        if QuestionIntent.NON_GOALS in intents:
+            return QuestionIntent.NON_GOALS.value
+        if QuestionIntent.VERIFICATION in intents and not demote_for_user_verify:
+            return QuestionIntent.VERIFICATION.value
+        if QuestionIntent.ACCEPTANCE_CRITERIA in intents and not demote_for_user_verify:
+            return QuestionIntent.ACCEPTANCE_CRITERIA.value
+        if QuestionIntent.RUNTIME_CONTEXT in intents and _should_preserve_runtime_route(lowered):
+            return QuestionIntent.RUNTIME_CONTEXT.value
+        if QuestionIntent.PRODUCT_BEHAVIOR in intents:
+            return QuestionIntent.PRODUCT_BEHAVIOR.value
+        if QuestionIntent.ACTOR_IO in intents:
+            return QuestionIntent.ACTOR_IO.value
+        if QuestionIntent.RUNTIME_CONTEXT in intents:
+            return QuestionIntent.RUNTIME_CONTEXT.value
         return next(iter(intents)).value
 
     def supported_intents(self) -> frozenset[str]:
@@ -207,6 +232,7 @@ CODING_PROFILE: DomainProfile = DomainProfile(
         _TestPassPredicate(),
         _LintCleanPredicate(),
         _TypeCheckCleanPredicate(),
+        _ObservableBehaviorPredicate(),
     ),
     intent_classifier=_CodingIntentClassifier(),
     vague_terms=frozenset(VAGUE_TERMS),

--- a/src/ouroboros/auto/profiles/coding.py
+++ b/src/ouroboros/auto/profiles/coding.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
+from types import MappingProxyType
 from typing import Any
 
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY, DomainProfile
@@ -170,16 +171,16 @@ class _CodingRepoContextExtractor:
 # ---------------------------------------------------------------------------
 
 
-def _build_safe_defaults() -> dict[str, Any]:
-    """Return a plain ``dict[str, Any]`` mirroring ``_SAFE_DEFAULTS``.
+def _build_safe_defaults() -> MappingProxyType[str, Any]:
+    """Return an immutable mapping mirroring ``_SAFE_DEFAULTS``.
 
     ``_SAFE_DEFAULTS`` is ``dict[str, _DefaultSpec]`` where ``_DefaultSpec``
-    is a frozen dataclass with ``value`` and ``rationale`` fields.  We copy
-    the mapping verbatim so the ``DomainProfile.safe_defaults`` type
-    (``dict[str, Any]``) holds the same objects.  PR-5 will introduce a
-    typed ``_DefaultSpec``-aware schema; ``Any`` is intentional here.
+    is a frozen dataclass with ``value`` and ``rationale`` fields.  We expose
+    a read-only copy so callers cannot mutate shared defaults on the module
+    singleton.  PR-5 will introduce a typed ``_DefaultSpec``-aware schema;
+    ``Any`` is intentional here.
     """
-    return dict(_SAFE_DEFAULTS)
+    return MappingProxyType(dict(_SAFE_DEFAULTS))
 
 
 # ---------------------------------------------------------------------------
@@ -189,7 +190,7 @@ def _build_safe_defaults() -> dict[str, Any]:
 
 def _coding_detector(cwd: Path) -> float:
     """Return 1.0 if the directory looks like a coding project, else 0.0."""
-    if (cwd / "pyproject.toml").exists() or (cwd / "package.json").exists():
+    if (cwd / "pyproject.toml").is_file():
         return 1.0
     return 0.0
 

--- a/tests/unit/auto/test_domain_profile_coding_parity.py
+++ b/tests/unit/auto/test_domain_profile_coding_parity.py
@@ -1,0 +1,190 @@
+"""Parity tests for the built-in ``coding`` DomainProfile (#809 P3, PR 2/6).
+
+These tests pin the ``coding`` DomainProfile against the existing constants
+and functions in ``answerer.py``, ``grading.py``, and ``safe_defaults.py``.
+They are the safety net for PR-4 and PR-5: as long as these pass, the
+refactored callers produce identical behaviour to the originals.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
+from ouroboros.auto.grading import VAGUE_TERMS
+from ouroboros.auto.profiles.coding import CODING_PROFILE
+from ouroboros.auto.safe_defaults import _SAFE_DEFAULTS  # noqa: PLC2701
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_coding_profile_registered_in_default_registry() -> None:
+    """Importing the profile module must auto-register it."""
+    assert DEFAULT_REGISTRY.get("coding") is CODING_PROFILE
+
+
+# ---------------------------------------------------------------------------
+# vague_terms parity
+# ---------------------------------------------------------------------------
+
+
+def test_vague_terms_match_grading_constant() -> None:
+    """CODING_PROFILE.vague_terms must equal frozenset(VAGUE_TERMS)."""
+    assert CODING_PROFILE.vague_terms == frozenset(VAGUE_TERMS)
+
+
+@pytest.mark.parametrize("term", list(VAGUE_TERMS))
+def test_each_vague_term_present_in_profile(term: str) -> None:
+    """Every term from grading.VAGUE_TERMS must be in the profile."""
+    assert term in CODING_PROFILE.vague_terms
+
+
+# ---------------------------------------------------------------------------
+# safe_defaults parity
+# ---------------------------------------------------------------------------
+
+
+def test_safe_defaults_keys_match() -> None:
+    """CODING_PROFILE.safe_defaults must have the same keys as _SAFE_DEFAULTS."""
+    assert set(CODING_PROFILE.safe_defaults.keys()) == set(_SAFE_DEFAULTS.keys())
+
+
+def test_safe_defaults_values_match() -> None:
+    """CODING_PROFILE.safe_defaults values must be the same objects as _SAFE_DEFAULTS."""
+    for key in _SAFE_DEFAULTS:
+        assert CODING_PROFILE.safe_defaults[key] is _SAFE_DEFAULTS[key], (
+            f"safe_defaults[{key!r}] diverged from _SAFE_DEFAULTS"
+        )
+
+
+# ---------------------------------------------------------------------------
+# intent_classifier parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("question", "expected_intent"),
+    [
+        ("What are the non-goals of this feature?", "non_goals"),
+        ("How do we verify the output?", "verification"),
+        ("What are the acceptance criteria?", "acceptance_criteria"),
+        ("Which framework does this project use?", "runtime_context"),
+        ("Who are the actors and what are the inputs?", "actor_io"),
+    ],
+)
+def test_intent_classifier_matches_existing_classifier(
+    question: str, expected_intent: str
+) -> None:
+    """intent_classifier.classify() must agree with _classify_question_intents."""
+    from ouroboros.auto.answerer import _classify_question_intents  # noqa: PLC2701
+
+    raw_intents = _classify_question_intents(question)
+    raw_values = {i.value for i in raw_intents}
+    profile_result = CODING_PROFILE.intent_classifier.classify(question)
+
+    # The profile must return a value that is also in the raw classifier output.
+    assert profile_result in raw_values, (
+        f"classify({question!r}) returned {profile_result!r}; "
+        f"raw classifier returned {raw_values}"
+    )
+    assert expected_intent in raw_values
+
+
+def test_intent_classifier_returns_none_for_unknown() -> None:
+    """An unclassifiable question returns None from classify()."""
+    result = CODING_PROFILE.intent_classifier.classify(
+        "The weather today is pleasant and mild."
+    )
+    assert result is None
+
+
+def test_intent_classifier_supported_intents() -> None:
+    """supported_intents() must include all QuestionIntent values."""
+    from ouroboros.auto.answerer import QuestionIntent
+
+    expected = frozenset(qi.value for qi in QuestionIntent)
+    assert expected <= CODING_PROFILE.intent_classifier.supported_intents()
+
+
+# ---------------------------------------------------------------------------
+# verifiable_predicate parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("criterion", "expected_code"),
+    [
+        ("Command exits 0 on success", "exit_code"),
+        ("exit_code must be zero", "exit_code"),
+        ("All tests pass", "test_pass"),
+        ("pytest reports no failures", "test_pass"),
+        ("Linter reports zero errors", "lint_clean"),
+        ("ruff check passes", "lint_clean"),
+        ("mypy reports no type errors", "type_check_clean"),
+        ("type check clean with pyright", "type_check_clean"),
+    ],
+)
+def test_predicate_matches_known_criteria(criterion: str, expected_code: str) -> None:
+    """find_verifiable_predicate must find the right predicate for known criteria."""
+    predicate = CODING_PROFILE.find_verifiable_predicate(criterion)
+    assert predicate is not None, f"No predicate matched {criterion!r}"
+    assert predicate.code == expected_code
+
+
+def test_predicate_repair_template_returns_string() -> None:
+    """repair_template must return a non-empty string for any criterion."""
+    for predicate in CODING_PROFILE.verifiable_predicates:
+        result = predicate.repair_template("some criterion text")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+def test_predicate_codes_are_unique() -> None:
+    """All predicate codes must be unique within the profile."""
+    codes = [p.code for p in CODING_PROFILE.verifiable_predicates]
+    assert len(codes) == len(set(codes))
+
+
+def test_predicate_no_match_returns_none() -> None:
+    """find_verifiable_predicate returns None when nothing matches."""
+    result = CODING_PROFILE.find_verifiable_predicate(
+        "The product must feel delightful to the user."
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# detector
+# ---------------------------------------------------------------------------
+
+
+def test_detector_returns_one_for_pyproject(tmp_path: Path) -> None:
+    """detector returns 1.0 when pyproject.toml exists."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+    assert CODING_PROFILE.detector(tmp_path) == 1.0
+
+
+def test_detector_returns_one_for_package_json(tmp_path: Path) -> None:
+    """detector returns 1.0 when package.json exists."""
+    (tmp_path / "package.json").write_text('{"name": "test"}\n')
+    assert CODING_PROFILE.detector(tmp_path) == 1.0
+
+
+def test_detector_returns_zero_for_empty_dir(tmp_path: Path) -> None:
+    """detector returns 0.0 when neither marker file is present."""
+    assert CODING_PROFILE.detector(tmp_path) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# repo_context_extractor smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_repo_context_extractor_returns_dict(tmp_path: Path) -> None:
+    """extract() returns a dict (possibly empty) for an empty directory."""
+    result = CODING_PROFILE.repo_context_extractor.extract(tmp_path)
+    assert isinstance(result, dict)

--- a/tests/unit/auto/test_domain_profile_coding_parity.py
+++ b/tests/unit/auto/test_domain_profile_coding_parity.py
@@ -190,10 +190,17 @@ def test_detector_returns_one_for_pyproject(tmp_path: Path) -> None:
     assert CODING_PROFILE.detector(tmp_path) == 1.0
 
 
-def test_detector_returns_zero_for_package_json_without_pyproject(tmp_path: Path) -> None:
-    """detector only scores repos the current extractor can inspect."""
+def test_detector_returns_one_for_package_json(tmp_path: Path) -> None:
+    """detector returns 1.0 for a Node/JS coding repo marker."""
     (tmp_path / "package.json").write_text('{"name": "test"}\n')
-    assert CODING_PROFILE.detector(tmp_path) == 0.0
+    assert CODING_PROFILE.detector(tmp_path) == 1.0
+
+
+@pytest.mark.parametrize("marker", ["go.mod", "Cargo.toml", "pom.xml", "Gemfile"])
+def test_detector_returns_one_for_other_coding_markers(tmp_path: Path, marker: str) -> None:
+    """detector recognizes common non-Python coding repo markers."""
+    (tmp_path / marker).write_text("module example\n")
+    assert CODING_PROFILE.detector(tmp_path) == 1.0
 
 
 def test_detector_returns_zero_for_empty_dir(tmp_path: Path) -> None:

--- a/tests/unit/auto/test_domain_profile_coding_parity.py
+++ b/tests/unit/auto/test_domain_profile_coding_parity.py
@@ -24,7 +24,7 @@ from ouroboros.auto.safe_defaults import _SAFE_DEFAULTS  # noqa: PLC2701
 
 
 def test_coding_profile_registered_in_default_registry() -> None:
-    """Importing the profile module must auto-register it."""
+    """Querying the default registry lazily registers the coding profile."""
     assert DEFAULT_REGISTRY.get("coding") is CODING_PROFILE
 
 

--- a/tests/unit/auto/test_domain_profile_coding_parity.py
+++ b/tests/unit/auto/test_domain_profile_coding_parity.py
@@ -9,6 +9,7 @@ refactored callers produce identical behaviour to the originals.
 from __future__ import annotations
 
 from pathlib import Path
+from types import MappingProxyType
 
 import pytest
 
@@ -61,6 +62,13 @@ def test_safe_defaults_values_match() -> None:
         )
 
 
+def test_safe_defaults_mapping_is_immutable() -> None:
+    """Callers must not be able to mutate shared singleton defaults."""
+    assert isinstance(CODING_PROFILE.safe_defaults, MappingProxyType)
+    with pytest.raises(TypeError):
+        CODING_PROFILE.safe_defaults["runtime_context"] = object()  # type: ignore[index]
+
+
 # ---------------------------------------------------------------------------
 # intent_classifier parity
 # ---------------------------------------------------------------------------
@@ -76,9 +84,7 @@ def test_safe_defaults_values_match() -> None:
         ("Who are the actors and what are the inputs?", "actor_io"),
     ],
 )
-def test_intent_classifier_matches_existing_classifier(
-    question: str, expected_intent: str
-) -> None:
+def test_intent_classifier_matches_existing_classifier(question: str, expected_intent: str) -> None:
     """intent_classifier.classify() must agree with _classify_question_intents."""
     from ouroboros.auto.answerer import _classify_question_intents  # noqa: PLC2701
 
@@ -88,17 +94,14 @@ def test_intent_classifier_matches_existing_classifier(
 
     # The profile must return a value that is also in the raw classifier output.
     assert profile_result in raw_values, (
-        f"classify({question!r}) returned {profile_result!r}; "
-        f"raw classifier returned {raw_values}"
+        f"classify({question!r}) returned {profile_result!r}; raw classifier returned {raw_values}"
     )
     assert expected_intent in raw_values
 
 
 def test_intent_classifier_returns_none_for_unknown() -> None:
     """An unclassifiable question returns None from classify()."""
-    result = CODING_PROFILE.intent_classifier.classify(
-        "The weather today is pleasant and mild."
-    )
+    result = CODING_PROFILE.intent_classifier.classify("The weather today is pleasant and mild.")
     assert result is None
 
 
@@ -168,10 +171,10 @@ def test_detector_returns_one_for_pyproject(tmp_path: Path) -> None:
     assert CODING_PROFILE.detector(tmp_path) == 1.0
 
 
-def test_detector_returns_one_for_package_json(tmp_path: Path) -> None:
-    """detector returns 1.0 when package.json exists."""
+def test_detector_returns_zero_for_package_json_without_pyproject(tmp_path: Path) -> None:
+    """detector only scores repos the current extractor can inspect."""
     (tmp_path / "package.json").write_text('{"name": "test"}\n')
-    assert CODING_PROFILE.detector(tmp_path) == 1.0
+    assert CODING_PROFILE.detector(tmp_path) == 0.0
 
 
 def test_detector_returns_zero_for_empty_dir(tmp_path: Path) -> None:

--- a/tests/unit/auto/test_domain_profile_coding_parity.py
+++ b/tests/unit/auto/test_domain_profile_coding_parity.py
@@ -124,13 +124,13 @@ def test_intent_classifier_supported_intents() -> None:
     ("criterion", "expected_code"),
     [
         ("Command exits 0 on success", "exit_code"),
-        ("exit_code must be zero", "exit_code"),
-        ("All tests pass", "test_pass"),
-        ("pytest reports no failures", "test_pass"),
-        ("Linter reports zero errors", "lint_clean"),
-        ("ruff check passes", "lint_clean"),
-        ("mypy reports no type errors", "type_check_clean"),
-        ("type check clean with pyright", "type_check_clean"),
+        ("Process returns with exit code 0", "exit_code"),
+        ("Test suite passes and verifies stdout output", "test_pass"),
+        ("pytest check passes and verifies stdout output", "test_pass"),
+        ("Linter check passes and verifies stdout output", "lint_clean"),
+        ("ruff check passes and verifies stdout output", "lint_clean"),
+        ("mypy type check passes and verifies stdout output", "type_check_clean"),
+        ("type check with pyright verifies stdout output", "type_check_clean"),
         ("GET /health responds with HTTP status 200", "observable_behavior"),
         ("CLI stdout contains created habits", "observable_behavior"),
         ("Export writes a JSON artifact file", "observable_behavior"),
@@ -163,6 +163,24 @@ def test_observable_predicate_matches_grading_observable_contract() -> None:
     for criterion in criteria:
         assert _is_observable(criterion), criterion
         assert CODING_PROFILE.find_verifiable_predicate(criterion) is not None, criterion
+
+
+@pytest.mark.parametrize(
+    "criterion",
+    [
+        "All tests pass",
+        "pytest reports no failures",
+        "Linter reports zero errors",
+        "ruff check passes",
+        "mypy reports no type errors",
+        "type check clean with pyright",
+        "exit_code must be zero",
+    ],
+)
+def test_predicates_do_not_widen_grading_observable_contract(criterion: str) -> None:
+    """The profile must not accept criteria rejected by the current grading gate."""
+    assert not _is_observable(criterion), criterion
+    assert CODING_PROFILE.find_verifiable_predicate(criterion) is None
 
 
 def test_predicate_codes_are_unique() -> None:

--- a/tests/unit/auto/test_domain_profile_coding_parity.py
+++ b/tests/unit/auto/test_domain_profile_coding_parity.py
@@ -14,7 +14,7 @@ from types import MappingProxyType
 import pytest
 
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
-from ouroboros.auto.grading import VAGUE_TERMS
+from ouroboros.auto.grading import VAGUE_TERMS, _is_observable  # noqa: PLC2701
 from ouroboros.auto.profiles.coding import CODING_PROFILE
 from ouroboros.auto.safe_defaults import _SAFE_DEFAULTS  # noqa: PLC2701
 
@@ -82,10 +82,11 @@ def test_safe_defaults_mapping_is_immutable() -> None:
         ("What are the acceptance criteria?", "acceptance_criteria"),
         ("Which framework does this project use?", "runtime_context"),
         ("Who are the actors and what are the inputs?", "actor_io"),
+        ("Can users verify their email?", "product_behavior"),
     ],
 )
 def test_intent_classifier_matches_existing_classifier(question: str, expected_intent: str) -> None:
-    """intent_classifier.classify() must agree with _classify_question_intents."""
+    """intent_classifier.classify() must agree with existing answer routing."""
     from ouroboros.auto.answerer import _classify_question_intents  # noqa: PLC2701
 
     raw_intents = _classify_question_intents(question)
@@ -96,6 +97,7 @@ def test_intent_classifier_matches_existing_classifier(question: str, expected_i
     assert profile_result in raw_values, (
         f"classify({question!r}) returned {profile_result!r}; raw classifier returned {raw_values}"
     )
+    assert profile_result == expected_intent
     assert expected_intent in raw_values
 
 
@@ -129,6 +131,9 @@ def test_intent_classifier_supported_intents() -> None:
         ("ruff check passes", "lint_clean"),
         ("mypy reports no type errors", "type_check_clean"),
         ("type check clean with pyright", "type_check_clean"),
+        ("GET /health responds with HTTP status 200", "observable_behavior"),
+        ("CLI stdout contains created habits", "observable_behavior"),
+        ("Export writes a JSON artifact file", "observable_behavior"),
     ],
 )
 def test_predicate_matches_known_criteria(criterion: str, expected_code: str) -> None:
@@ -144,6 +149,20 @@ def test_predicate_repair_template_returns_string() -> None:
         result = predicate.repair_template("some criterion text")
         assert isinstance(result, str)
         assert len(result) > 0
+
+
+def test_observable_predicate_matches_grading_observable_contract() -> None:
+    """The profile must accept every AC that the current grading gate accepts."""
+    criteria = (
+        "`habit list` prints stable stdout containing created habits",
+        "The API endpoint returns response status 200",
+        "The command writes an artifact file to disk",
+        "stderr contains the validation error for invalid input",
+        "DELETE /items/{id} responds with HTTP 204",
+    )
+    for criterion in criteria:
+        assert _is_observable(criterion), criterion
+        assert CODING_PROFILE.find_verifiable_predicate(criterion) is not None, criterion
 
 
 def test_predicate_codes_are_unique() -> None:

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -252,6 +252,24 @@ def test_lazy_registry_respects_replaced_profile_storage_temporarily() -> None:
     assert calls == ["loaded"]
 
 
+def test_lazy_registry_retries_after_loader_failure() -> None:
+    calls: list[str] = []
+
+    def _loader(registry: DomainProfileRegistry) -> None:
+        calls.append("called")
+        if len(calls) == 1:
+            raise RuntimeError("transient profile import failure")
+        registry.register(_make_profile(name="built-in"))
+
+    registry = DomainProfileRegistry(loader=_loader)
+
+    with pytest.raises(RuntimeError, match="transient"):
+        registry.all()
+
+    assert [profile.name for profile in registry.all()] == ["built-in"]
+    assert calls == ["called", "called"]
+
+
 def test_registry_rejects_duplicate_name() -> None:
     registry = DomainProfileRegistry()
     registry.register(_make_profile(name="coding"))

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -217,6 +217,36 @@ def test_find_verifiable_predicate_returns_first_match() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_lazy_registry_register_loads_defaults_before_custom_profile() -> None:
+    calls: list[str] = []
+
+    def _loader(registry: DomainProfileRegistry) -> None:
+        calls.append("loaded")
+        registry.register(_make_profile(name="built-in"))
+
+    registry = DomainProfileRegistry(loader=_loader)
+    custom = _make_profile(name="custom")
+
+    registry.register(custom)
+
+    assert calls == ["loaded"]
+    assert [profile.name for profile in registry.all()] == ["built-in", "custom"]
+
+
+def test_lazy_registry_respects_replaced_profile_storage() -> None:
+    calls: list[str] = []
+
+    def _loader(registry: DomainProfileRegistry) -> None:
+        calls.append("loaded")
+        registry.register(_make_profile(name="built-in"))
+
+    registry = DomainProfileRegistry(loader=_loader)
+    registry._profiles = []  # type: ignore[attr-defined]  # test-only singleton isolation hook
+
+    assert registry.all() == ()
+    assert calls == []
+
+
 def test_registry_rejects_duplicate_name() -> None:
     registry = DomainProfileRegistry()
     registry.register(_make_profile(name="coding"))

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -233,7 +233,7 @@ def test_lazy_registry_register_loads_defaults_before_custom_profile() -> None:
     assert [profile.name for profile in registry.all()] == ["built-in", "custom"]
 
 
-def test_lazy_registry_respects_replaced_profile_storage() -> None:
+def test_lazy_registry_respects_replaced_profile_storage_temporarily() -> None:
     calls: list[str] = []
 
     def _loader(registry: DomainProfileRegistry) -> None:
@@ -241,10 +241,15 @@ def test_lazy_registry_respects_replaced_profile_storage() -> None:
         registry.register(_make_profile(name="built-in"))
 
     registry = DomainProfileRegistry(loader=_loader)
+    original_profiles = registry._profiles  # type: ignore[attr-defined]
     registry._profiles = []  # type: ignore[attr-defined]  # test-only singleton isolation hook
 
     assert registry.all() == ()
     assert calls == []
+
+    registry._profiles = original_profiles  # type: ignore[attr-defined]
+    assert [profile.name for profile in registry.all()] == ["built-in"]
+    assert calls == ["loaded"]
 
 
 def test_registry_rejects_duplicate_name() -> None:

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -218,8 +218,15 @@ def test_registry_union_predicates_applies_threshold() -> None:
     assert "wcag_contrast" not in codes
 
 
-def test_default_registry_starts_empty() -> None:
-    # DEFAULT_REGISTRY is a module-level singleton; PR-2 registers coding here.
-    # At this point (PR-1) it must be empty.
-    assert DEFAULT_REGISTRY.all() == ()
-    assert DEFAULT_REGISTRY.detect_best(Path("/tmp")) is None
+def test_default_registry_contains_coding_after_pr2(tmp_path: Path) -> None:
+    # DEFAULT_REGISTRY is a module-level singleton.  PR-2 registers the
+    # built-in ``coding`` profile; importing the profiles package is enough.
+    import ouroboros.auto.profiles  # noqa: F401 — trigger registration
+
+    from ouroboros.auto.profiles.coding import CODING_PROFILE
+
+    assert DEFAULT_REGISTRY.get("coding") is CODING_PROFILE
+    # detect_best only returns a profile when the detector scores > 0.0;
+    # create a pyproject.toml marker so the coding detector fires.
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='t'\n")
+    assert DEFAULT_REGISTRY.detect_best(tmp_path) is CODING_PROFILE

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
 from pathlib import Path
+import subprocess
+import sys
 from typing import Any
 
 import pytest
@@ -218,9 +220,19 @@ def test_registry_union_predicates_applies_threshold() -> None:
     assert "wcag_contrast" not in codes
 
 
+def test_importing_contracts_module_does_not_import_builtin_profiles() -> None:
+    code = (
+        "import sys; "
+        "import ouroboros.auto.domain_profile; "
+        "assert 'ouroboros.auto.profiles.coding' not in sys.modules"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
 def test_default_registry_contains_coding_after_pr2(tmp_path: Path) -> None:
-    # DEFAULT_REGISTRY is a module-level singleton.  Importing domain_profile
-    # alone should expose built-in default profiles to callers.
+    # DEFAULT_REGISTRY is a module-level singleton.  Querying it should lazily
+    # expose built-in default profiles without importing them at contract-module
+    # import time.
     from ouroboros.auto.profiles.coding import CODING_PROFILE
 
     assert DEFAULT_REGISTRY.get("coding") is CODING_PROFILE

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -217,7 +217,7 @@ def test_find_verifiable_predicate_returns_first_match() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_lazy_registry_register_loads_defaults_before_custom_profile() -> None:
+def test_lazy_registry_preserves_custom_registration_order_before_defaults() -> None:
     calls: list[str] = []
 
     def _loader(registry: DomainProfileRegistry) -> None:
@@ -229,8 +229,9 @@ def test_lazy_registry_register_loads_defaults_before_custom_profile() -> None:
 
     registry.register(custom)
 
+    assert calls == []
+    assert [profile.name for profile in registry.all()] == ["custom", "built-in"]
     assert calls == ["loaded"]
-    assert [profile.name for profile in registry.all()] == ["built-in", "custom"]
 
 
 def test_lazy_registry_respects_replaced_profile_storage_temporarily() -> None:

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -222,7 +222,6 @@ def test_default_registry_contains_coding_after_pr2(tmp_path: Path) -> None:
     # DEFAULT_REGISTRY is a module-level singleton.  PR-2 registers the
     # built-in ``coding`` profile; importing the profiles package is enough.
     import ouroboros.auto.profiles  # noqa: F401 — trigger registration
-
     from ouroboros.auto.profiles.coding import CODING_PROFILE
 
     assert DEFAULT_REGISTRY.get("coding") is CODING_PROFILE

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -219,9 +219,8 @@ def test_registry_union_predicates_applies_threshold() -> None:
 
 
 def test_default_registry_contains_coding_after_pr2(tmp_path: Path) -> None:
-    # DEFAULT_REGISTRY is a module-level singleton.  PR-2 registers the
-    # built-in ``coding`` profile; importing the profiles package is enough.
-    import ouroboros.auto.profiles  # noqa: F401 — trigger registration
+    # DEFAULT_REGISTRY is a module-level singleton.  Importing domain_profile
+    # alone should expose built-in default profiles to callers.
     from ouroboros.auto.profiles.coding import CODING_PROFILE
 
     assert DEFAULT_REGISTRY.get("coding") is CODING_PROFILE

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -394,7 +394,20 @@ def test_importing_contracts_module_does_not_import_builtin_profiles() -> None:
     code = (
         "import sys; "
         "import ouroboros.auto.domain_profile; "
-        "assert 'ouroboros.auto.profiles.coding' not in sys.modules"
+        "assert 'ouroboros.auto.profiles.coding' not in sys.modules; "
+        "assert 'ouroboros.auto.grading' not in sys.modules; "
+        "assert 'ouroboros.auto.pipeline' not in sys.modules"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_auto_package_exports_are_lazy() -> None:
+    code = (
+        "import sys; "
+        "import ouroboros.auto as auto; "
+        "assert 'ouroboros.auto.grading' not in sys.modules; "
+        "assert auto.GradeGate.__name__ == 'GradeGate'; "
+        "assert 'ouroboros.auto.grading' in sys.modules"
     )
     subprocess.run([sys.executable, "-c", code], check=True)
 

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -1,0 +1,225 @@
+"""Contract tests for DomainProfile and VerifiablePredicate (#809 P3, PR 1/6).
+
+These tests verify the Protocol stubs, dataclass invariants, and registry
+semantics introduced in ``domain_profile.py``.  No real domain profiles are
+imported; every fixture is a minimal inline stub.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.domain_profile import (
+    DEFAULT_REGISTRY,
+    DomainProfile,
+    DomainProfileRegistry,
+    IntentClassifier,
+    RepoContextExtractor,
+    VerifiablePredicate,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal stubs
+# ---------------------------------------------------------------------------
+
+
+class _ExitCodePredicate:
+    code = "exit_code"
+
+    def matches(self, criterion: str) -> bool:
+        return "exit" in criterion.lower()
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Command exits 0 when: {criterion}"
+
+
+class _ContrastPredicate:
+    code = "wcag_contrast"
+
+    def matches(self, criterion: str) -> bool:
+        return "contrast" in criterion.lower()
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Contrast ratio ≥ 4.5:1 for: {criterion}"
+
+
+class _SimpleClassifier:
+    def classify(self, question: str) -> str | None:
+        if "runtime" in question.lower():
+            return "runtime_context"
+        return None
+
+    def supported_intents(self) -> frozenset[str]:
+        return frozenset({"runtime_context", "acceptance_criteria"})
+
+
+class _SimpleExtractor:
+    def extract(self, cwd: Path) -> dict[str, Any]:
+        return {"cwd": str(cwd)}
+
+
+def _make_profile(
+    name: str = "coding",
+    confidence: float = 0.8,
+    predicates: tuple[VerifiablePredicate, ...] = (),
+) -> DomainProfile:
+    return DomainProfile(
+        name=name,
+        repo_context_extractor=_SimpleExtractor(),
+        verifiable_predicates=predicates,
+        intent_classifier=_SimpleClassifier(),
+        vague_terms=frozenset({"easy", "clean"}),
+        safe_defaults={"runtime_context": "existing project"},
+        detector=lambda _cwd: confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_verifiable_predicate_protocol_smoke() -> None:
+    pred = _ExitCodePredicate()
+    assert isinstance(pred, VerifiablePredicate)
+    assert pred.code == "exit_code"
+    assert pred.matches("command exits 0")
+    assert not pred.matches("stdout snapshot")
+    assert "exit" in pred.repair_template("some criterion").lower()
+
+
+def test_intent_classifier_protocol_smoke() -> None:
+    clf = _SimpleClassifier()
+    assert isinstance(clf, IntentClassifier)
+    assert clf.classify("Which runtime should we use?") == "runtime_context"
+    assert clf.classify("something unrelated") is None
+    assert "runtime_context" in clf.supported_intents()
+
+
+def test_repo_context_extractor_protocol_smoke() -> None:
+    extractor = _SimpleExtractor()
+    assert isinstance(extractor, RepoContextExtractor)
+    result = extractor.extract(Path("/tmp"))
+    assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# DomainProfile invariants
+# ---------------------------------------------------------------------------
+
+
+def test_domain_profile_is_frozen() -> None:
+    profile = _make_profile()
+    with pytest.raises(FrozenInstanceError):
+        profile.name = "mutated"  # type: ignore[misc]
+
+
+def test_find_verifiable_predicate_returns_first_match() -> None:
+    exit_pred = _ExitCodePredicate()
+    contrast_pred = _ContrastPredicate()
+    profile = _make_profile(predicates=(exit_pred, contrast_pred))
+
+    result = profile.find_verifiable_predicate("command exits 0 on success")
+    assert result is exit_pred
+
+    result2 = profile.find_verifiable_predicate("color contrast check")
+    assert result2 is contrast_pred
+
+    result3 = profile.find_verifiable_predicate("stdout contains expected output")
+    assert result3 is None
+
+
+# ---------------------------------------------------------------------------
+# DomainProfileRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_rejects_duplicate_name() -> None:
+    registry = DomainProfileRegistry()
+    registry.register(_make_profile(name="coding"))
+    with pytest.raises(ValueError, match="coding"):
+        registry.register(_make_profile(name="coding"))
+
+
+def test_registry_get_returns_none_for_unknown() -> None:
+    registry = DomainProfileRegistry()
+    assert registry.get("nonexistent") is None
+
+
+def test_registry_get_returns_registered_profile() -> None:
+    registry = DomainProfileRegistry()
+    profile = _make_profile(name="coding")
+    registry.register(profile)
+    assert registry.get("coding") is profile
+
+
+def test_registry_detect_best_picks_highest_confidence() -> None:
+    registry = DomainProfileRegistry()
+    low = _make_profile(name="low", confidence=0.2)
+    high = _make_profile(name="high", confidence=0.9)
+    registry.register(low)
+    registry.register(high)
+
+    best = registry.detect_best(Path("/tmp"))
+    assert best is not None
+    assert best.name == "high"
+
+
+def test_registry_detect_best_breaks_ties_by_registration_order() -> None:
+    registry = DomainProfileRegistry()
+    first = _make_profile(name="first", confidence=0.7)
+    second = _make_profile(name="second", confidence=0.7)
+    registry.register(first)
+    registry.register(second)
+
+    best = registry.detect_best(Path("/tmp"))
+    assert best is not None
+    assert best.name == "first"
+
+
+def test_registry_detect_best_returns_none_when_empty() -> None:
+    registry = DomainProfileRegistry()
+    assert registry.detect_best(Path("/tmp")) is None
+
+
+def test_registry_union_predicates_applies_threshold() -> None:
+    registry = DomainProfileRegistry()
+    exit_pred = _ExitCodePredicate()
+    contrast_pred = _ContrastPredicate()
+
+    above = DomainProfile(
+        name="above",
+        repo_context_extractor=_SimpleExtractor(),
+        verifiable_predicates=(exit_pred,),
+        intent_classifier=_SimpleClassifier(),
+        vague_terms=frozenset(),
+        safe_defaults={},
+        detector=lambda _: 0.8,
+    )
+    below = DomainProfile(
+        name="below",
+        repo_context_extractor=_SimpleExtractor(),
+        verifiable_predicates=(contrast_pred,),
+        intent_classifier=_SimpleClassifier(),
+        vague_terms=frozenset(),
+        safe_defaults={},
+        detector=lambda _: 0.3,
+    )
+    registry.register(above)
+    registry.register(below)
+
+    predicates = registry.union_predicates(Path("/tmp"), threshold=0.5)
+    codes = [p.code for p in predicates]
+    assert "exit_code" in codes
+    assert "wcag_contrast" not in codes
+
+
+def test_default_registry_starts_empty() -> None:
+    # DEFAULT_REGISTRY is a module-level singleton; PR-2 registers coding here.
+    # At this point (PR-1) it must be empty.
+    assert DEFAULT_REGISTRY.all() == ()
+    assert DEFAULT_REGISTRY.detect_best(Path("/tmp")) is None


### PR DESCRIPTION
## Summary

- Creates `src/ouroboros/auto/profiles/` package with the first built-in `DomainProfile`: **`coding`**
- Surfaces existing logic from `answerer.py`, `grading.py`, and `safe_defaults.py` as adapters — **does not modify those files**
- Registers `CODING_PROFILE` in `DEFAULT_REGISTRY` at import time (guard against double-registration on reimport)
- Adds 35 parity tests that pin equality between the profile and the originals, providing a regression safety net for PR-4 and PR-5

## Why parity-only

PR-4 will route `AutoAnswerer` through `intent_classifier`; PR-5 will migrate `safe_defaults`. As long as these parity tests pass, those refactors cannot silently diverge from today's behaviour. The profile is a read-only adapter until then.

## What's in `CODING_PROFILE`

| Field | Source |
|---|---|
| `vague_terms` | `grading.VAGUE_TERMS` (frozenset) |
| `safe_defaults` | `safe_defaults._SAFE_DEFAULTS` verbatim (`Any` values; PR-5 tightens) |
| `intent_classifier` | thin adapter over `_classify_question_intents` |
| `verifiable_predicates` | `exit_code`, `test_pass`, `lint_clean`, `type_check_clean` |
| `repo_context_extractor` | delegates to `repo_auto_answer_context` |
| `detector` | 1.0 if `pyproject.toml` or `package.json` present, else 0.0 |

`test_domain_profile_contracts.py` updated: `test_default_registry_starts_empty` replaced by `test_default_registry_contains_coding_after_pr2` (the PR-1 comment on that test already anticipated this change).

## Stacks on

PR #849 (`feat/p3-domain-profile-contracts`) — base branch is `feat/p3-domain-profile-contracts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)