### PR TITLE
feat(auto): 3-step DomainProfile activation in ooo auto CLI (#809 P3, PR 3/6)

### DIFF
--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -223,7 +223,7 @@ class DomainProfileRegistry:
         best_profile: DomainProfile | None = None
         best_confidence: float = 0.0
         for profile in self._profiles:
-            confidence = profile.detector(cwd)
+            confidence = _detector_confidence(profile, cwd)
             if confidence > best_confidence:
                 best_confidence = confidence
                 best_profile = profile
@@ -249,7 +249,7 @@ class DomainProfileRegistry:
         seen_codes: set[str] = set()
         result: list[VerifiablePredicate] = []
         for profile in self._profiles:
-            if profile.detector(cwd) >= threshold:
+            if _detector_confidence(profile, cwd) >= threshold:
                 for predicate in profile.verifiable_predicates:
                     if predicate.code not in seen_codes:
                         seen_codes.add(predicate.code)
@@ -259,3 +259,10 @@ class DomainProfileRegistry:
 
 #: Module-level singleton registry.  PR-2 will register the ``coding`` profile here.
 DEFAULT_REGISTRY: DomainProfileRegistry = DomainProfileRegistry()
+
+
+def _detector_confidence(profile: DomainProfile, cwd: Path) -> float:
+    try:
+        return profile.detector(cwd)
+    except Exception:
+        return 0.0

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -338,6 +338,12 @@ class AutoPipelineState:
     # ``REQUIRED_SECTIONS`` at construction time by the MCP handler — only
     # known section keys with non-empty string values land here.
     user_preferences: dict[str, str] = field(default_factory=dict)
+    # Active domain profile name resolved at session start (PR-3, #809 P3).
+    # The DomainProfile instance itself is not stored here because it contains
+    # callables that are not JSON-serializable. Downstream phases recover the
+    # profile via ``DEFAULT_REGISTRY.get(active_domain_profile_name)``.
+    # None means no profile was activated (current baked-in behavior persists).
+    active_domain_profile_name: str | None = None
     # QA verdict captured during the EVALUATE phase (RFC #809 Phase 2.1).
     # Persisted so a resumed session reuses the verdict without re-invoking
     # the LLM-driven judge when the underlying artifact has not changed.
@@ -695,6 +701,7 @@ class AutoPipelineState:
         payload.setdefault("last_lateral_approach_summary", None)
         payload.setdefault("last_lateral_text", None)
         payload.setdefault("lateral_input_hash", None)
+        payload.setdefault("active_domain_profile_name", None)
         # Convert the persisted ``deadline_at_epoch`` (epoch seconds) back into
         # a monotonic-clock value usable from this process. If the companion
         # epoch field is present, derive ``deadline_at`` from the offset
@@ -931,6 +938,7 @@ class AutoPipelineState:
             "pending_question",
             "last_tool_name",
             "last_error",
+            "active_domain_profile_name",
         )
         for field_name in optional_string_fields:
             value = getattr(self, field_name)

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -180,6 +180,7 @@ def auto_command(
         str | None,
         typer.Option(
             "--domain",
+            hidden=True,
             help=(
                 "Explicitly activate a domain profile by name (e.g. 'coding'). "
                 "Overrides auto-detection. Use 'ooo auto --domain coding <goal>' "

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -236,6 +236,8 @@ def auto_command(
                 progress_callback=_make_progress_renderer(quiet=quiet),
             )
         )
+    except typer.Exit:
+        raise
     except Exception as exc:
         print_error(f"Auto pipeline failed: {exc}")
         raise typer.Exit(1) from exc
@@ -372,9 +374,14 @@ async def _run_auto(
                 f"Unknown domain profile: {domain!r}. Register it with DEFAULT_REGISTRY before use."
             )
             raise typer.Exit(1)
-    else:
+        state.active_domain_profile_name = active_profile.name
+    elif not resume:
         active_profile = DEFAULT_REGISTRY.detect_best(Path(state.cwd))
-    state.active_domain_profile_name = active_profile.name if active_profile else None
+        state.active_domain_profile_name = active_profile.name if active_profile else None
+    else:
+        # Resume preserves the session-start profile unless the operator
+        # explicitly passes --domain to intentionally retarget it.
+        pass
 
     if runtime == "opencode":
         opencode_mode = state.opencode_mode or get_opencode_mode()

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -20,6 +20,7 @@ from ouroboros.auto.adapters import (
     load_seed,
     save_seed,
 )
+from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
@@ -175,6 +176,17 @@ def auto_command(
             ),
         ),
     ] = False,
+    domain: Annotated[
+        str | None,
+        typer.Option(
+            "--domain",
+            help=(
+                "Explicitly activate a domain profile by name (e.g. 'coding'). "
+                "Overrides auto-detection. Use 'ooo auto --domain coding <goal>' "
+                "to force the coding profile regardless of cwd."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Run an A-grade-gated auto pipeline.
 
@@ -220,6 +232,7 @@ def auto_command(
                 reconcile_source=reconcile_source,
                 pipeline_timeout_seconds=timeout,
                 complete_product=complete_product,
+                domain=domain,
                 progress_callback=_make_progress_renderer(quiet=quiet),
             )
         )
@@ -263,6 +276,7 @@ async def _run_auto(
     reconcile_source: str | None = None,
     pipeline_timeout_seconds: float | None = None,
     complete_product: bool = False,
+    domain: str | None = None,
     progress_callback: AutoProgressCallback | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
@@ -346,6 +360,21 @@ async def _run_auto(
         state.complete_product = complete_product
         if pipeline_timeout_seconds is not None:
             state.pipeline_timeout_seconds = float(pipeline_timeout_seconds)
+
+    # 3-step domain profile activation (PR-3, Q00/ouroboros#809 P3):
+    # 1. --domain explicit flag wins.
+    # 2. Otherwise, auto-detect from cwd via DEFAULT_REGISTRY.detect_best.
+    # 3. Otherwise, None (current baked-in behavior remains in charge).
+    if domain is not None:
+        active_profile = DEFAULT_REGISTRY.get(domain)
+        if active_profile is None:
+            print_error(
+                f"Unknown domain profile: {domain!r}. Register it with DEFAULT_REGISTRY before use."
+            )
+            raise typer.Exit(1)
+    else:
+        active_profile = DEFAULT_REGISTRY.detect_best(Path(state.cwd))
+    state.active_domain_profile_name = active_profile.name if active_profile else None
 
     if runtime == "opencode":
         opencode_mode = state.opencode_mode or get_opencode_mode()

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -7,7 +7,7 @@ imported; every fixture is a minimal inline stub.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from typing import Any
@@ -68,6 +68,7 @@ def _make_profile(
     confidence: float = 0.8,
     predicates: Iterable[VerifiablePredicate] = (),
     safe_defaults: Mapping[str, Any] | None = None,
+    detector: Callable[[Path], float] | None = None,
 ) -> DomainProfile:
     return DomainProfile(
         name=name,
@@ -78,7 +79,7 @@ def _make_profile(
         safe_defaults=(
             safe_defaults if safe_defaults is not None else {"runtime_context": "existing project"}
         ),
-        detector=lambda _cwd: confidence,
+        detector=detector or (lambda _cwd: confidence),
     )
 
 
@@ -262,6 +263,29 @@ def test_registry_detect_best_returns_none_when_empty() -> None:
     assert registry.detect_best(Path("/tmp")) is None
 
 
+def test_registry_detect_best_treats_detector_exception_as_zero_confidence() -> None:
+    def _raise_detector(_cwd: Path) -> float:
+        raise OSError("unreadable")
+
+    registry = DomainProfileRegistry()
+    broken = _make_profile(name="broken", detector=_raise_detector)
+    viable = _make_profile(name="viable", confidence=0.6)
+    registry.register(broken)
+    registry.register(viable)
+
+    assert registry.detect_best(Path("/tmp")) is viable
+
+
+def test_registry_detect_best_returns_none_when_all_detectors_fail() -> None:
+    def _raise_detector(_cwd: Path) -> float:
+        raise OSError("unreadable")
+
+    registry = DomainProfileRegistry()
+    registry.register(_make_profile(name="broken", detector=_raise_detector))
+
+    assert registry.detect_best(Path("/tmp")) is None
+
+
 def test_registry_union_predicates_applies_threshold() -> None:
     registry = DomainProfileRegistry()
     exit_pred = _ExitCodePredicate()
@@ -292,6 +316,23 @@ def test_registry_union_predicates_applies_threshold() -> None:
     codes = [p.code for p in predicates]
     assert "exit_code" in codes
     assert "wcag_contrast" not in codes
+
+
+def test_registry_union_predicates_ignores_detector_exceptions() -> None:
+    def _raise_detector(_cwd: Path) -> float:
+        raise OSError("unreadable")
+
+    registry = DomainProfileRegistry()
+    exit_pred = _ExitCodePredicate()
+    contrast_pred = _ContrastPredicate()
+    registry.register(
+        _make_profile(name="broken", predicates=(exit_pred,), detector=_raise_detector)
+    )
+    registry.register(_make_profile(name="viable", predicates=(contrast_pred,), confidence=0.8))
+
+    predicates = registry.union_predicates(Path("/tmp"), threshold=0.5)
+
+    assert predicates == (contrast_pred,)
 
 
 def test_default_registry_is_a_profile_registry_singleton() -> None:

--- a/tests/unit/cli/test_auto_domain_activation.py
+++ b/tests/unit/cli/test_auto_domain_activation.py
@@ -77,31 +77,40 @@ runner = CliRunner()
 
 
 @pytest.fixture()
-def fake_profile():
-    """Register a fake 'fake-domain' profile in DEFAULT_REGISTRY for the test duration."""
-    profile = _make_fake_profile("fake-domain", detector_score=0.0)
-    DEFAULT_REGISTRY.register(profile)
-    yield profile
-    # Cleanup: remove the registered profile so other tests are not affected.
-    DEFAULT_REGISTRY._profiles[:] = [
-        p for p in DEFAULT_REGISTRY._profiles if p.name != "fake-domain"
-    ]
+def isolated_default_registry(monkeypatch):
+    """Give each test an isolated DEFAULT_REGISTRY profile list."""
+    monkeypatch.setattr(DEFAULT_REGISTRY, "_profiles", [])
 
 
 @pytest.fixture()
-def detectable_profile(tmp_path):
+def fake_profile(isolated_default_registry):
+    """Register a fake 'fake-domain' profile in DEFAULT_REGISTRY for the test duration."""
+    profile = _make_fake_profile("fake-domain", detector_score=0.0)
+    DEFAULT_REGISTRY.register(profile)
+    return profile
+
+
+@pytest.fixture()
+def detectable_profile(isolated_default_registry, tmp_path):
     """Register a fake 'detectable' profile that returns high confidence for any dir."""
     profile = _make_fake_profile("detectable", detector_score=0.9)
     DEFAULT_REGISTRY.register(profile)
-    yield profile, tmp_path
-    DEFAULT_REGISTRY._profiles[:] = [
-        p for p in DEFAULT_REGISTRY._profiles if p.name != "detectable"
-    ]
+    return profile, tmp_path
 
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_auto_help_hides_domain_option(isolated_default_registry) -> None:
+    """The dormant domain activation hook is accepted but not publicly advertised."""
+    assert DEFAULT_REGISTRY.all() == ()
+
+    result = runner.invoke(app, ["auto", "--help"])
+
+    assert result.exit_code == 0
+    assert "--domain" not in result.output
 
 
 def test_domain_flag_overrides_detection(fake_profile, tmp_path) -> None:
@@ -213,29 +222,27 @@ def test_detector_exception_leaves_profile_none(tmp_path) -> None:
 
     from ouroboros.cli.commands.auto import _run_auto
 
-    profile = _make_fake_profile("broken-detector", detector=_raise_detector)
-    DEFAULT_REGISTRY.register(profile)
-    try:
-        with patch(
-            "ouroboros.auto.pipeline.AutoPipeline.run",
-            side_effect=_fake_pipeline_run,
+    with patch.object(DEFAULT_REGISTRY, "_profiles", []):
+        profile = _make_fake_profile("broken-detector", detector=_raise_detector)
+        DEFAULT_REGISTRY.register(profile)
+        with (
+            patch(
+                "ouroboros.auto.pipeline.AutoPipeline.run",
+                side_effect=_fake_pipeline_run,
+            ),
+            patch("ouroboros.cli.commands.auto._safe_default_cwd", return_value=tmp_path),
         ):
-            with patch("ouroboros.cli.commands.auto._safe_default_cwd", return_value=tmp_path):
-                result = asyncio.run(
-                    _run_auto(
-                        goal="build something",
-                        resume=None,
-                        runtime=None,
-                        max_interview_rounds=None,
-                        max_repair_rounds=None,
-                        skip_run=True,
-                        domain=None,
-                    )
+            result = asyncio.run(
+                _run_auto(
+                    goal="build something",
+                    resume=None,
+                    runtime=None,
+                    max_interview_rounds=None,
+                    max_repair_rounds=None,
+                    skip_run=True,
+                    domain=None,
                 )
-    finally:
-        DEFAULT_REGISTRY._profiles[:] = [
-            p for p in DEFAULT_REGISTRY._profiles if p.name != "broken-detector"
-        ]
+            )
 
     assert result.status == "complete"
     assert captured["profile_name"] is None

--- a/tests/unit/cli/test_auto_domain_activation.py
+++ b/tests/unit/cli/test_auto_domain_activation.py
@@ -8,10 +8,12 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from typer.testing import CliRunner
 
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY, DomainProfile
 from ouroboros.auto.pipeline import AutoPipelineResult
-from ouroboros.auto.state import SeedOrigin
+from ouroboros.auto.state import AutoPipelineState, AutoStore, SeedOrigin
+from ouroboros.cli.main import app
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -60,6 +62,8 @@ _FAKE_RESULT = AutoPipelineResult(
     seed_path=None,
     seed_origin=SeedOrigin.NONE.value,
 )
+
+runner = CliRunner()
 
 
 # ---------------------------------------------------------------------------
@@ -213,3 +217,106 @@ def test_unknown_domain_value_errors(tmp_path) -> None:
                 )
 
     assert exc_info.value.exit_code == 1
+
+
+def test_resume_without_domain_preserves_persisted_profile(tmp_path) -> None:
+    """Resuming without --domain must not re-run detection or overwrite state."""
+    from ouroboros.cli.commands.auto import _run_auto
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="build something", cwd=str(tmp_path))
+    state.runtime_backend = "claude"
+    state.active_domain_profile_name = "persisted-domain"
+    store.save(state)
+
+    detectable = _make_fake_profile("detectable-on-resume", detector_score=0.9)
+    captured: dict[str, Any] = {}
+
+    async def _fake_pipeline_run(run_state):
+        captured["profile_name"] = run_state.active_domain_profile_name
+        store.save(run_state)
+        return _FAKE_RESULT
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore", return_value=store),
+        patch.object(DEFAULT_REGISTRY, "detect_best", return_value=detectable) as detect_best,
+        patch(
+            "ouroboros.auto.pipeline.AutoPipeline.run",
+            side_effect=_fake_pipeline_run,
+        ),
+    ):
+        result = asyncio.run(
+            _run_auto(
+                goal=None,
+                resume=state.auto_session_id,
+                runtime=None,
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=True,
+                domain=None,
+            )
+        )
+
+    assert result.status == "complete"
+    assert captured["profile_name"] == "persisted-domain"
+    assert store.load(state.auto_session_id).active_domain_profile_name == "persisted-domain"
+    detect_best.assert_not_called()
+
+
+def test_resume_with_explicit_domain_overrides_persisted_profile(tmp_path) -> None:
+    """Explicit --domain on resume intentionally updates active_domain_profile_name."""
+    from ouroboros.cli.commands.auto import _run_auto
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="build something", cwd=str(tmp_path))
+    state.runtime_backend = "claude"
+    state.active_domain_profile_name = "persisted-domain"
+    store.save(state)
+
+    override = _make_fake_profile("override-domain", detector_score=0.0)
+    captured: dict[str, Any] = {}
+
+    async def _fake_pipeline_run(run_state):
+        captured["profile_name"] = run_state.active_domain_profile_name
+        store.save(run_state)
+        return _FAKE_RESULT
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore", return_value=store),
+        patch.object(DEFAULT_REGISTRY, "get", return_value=override) as get_profile,
+        patch.object(DEFAULT_REGISTRY, "detect_best") as detect_best,
+        patch(
+            "ouroboros.auto.pipeline.AutoPipeline.run",
+            side_effect=_fake_pipeline_run,
+        ),
+    ):
+        result = asyncio.run(
+            _run_auto(
+                goal=None,
+                resume=state.auto_session_id,
+                runtime=None,
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=True,
+                domain="override-domain",
+            )
+        )
+
+    assert result.status == "complete"
+    assert captured["profile_name"] == "override-domain"
+    assert store.load(state.auto_session_id).active_domain_profile_name == "override-domain"
+    get_profile.assert_called_once_with("override-domain")
+    detect_best.assert_not_called()
+
+
+def test_unknown_domain_cli_error_is_not_wrapped(tmp_path) -> None:
+    """typer.Exit from unknown --domain should keep the clean domain error."""
+    with (
+        patch.object(DEFAULT_REGISTRY, "get", return_value=None),
+        patch("ouroboros.cli.commands.auto._safe_default_cwd", return_value=tmp_path),
+    ):
+        result = runner.invoke(app, ["auto", "build something", "--domain", "banana"])
+
+    assert result.exit_code == 1
+    assert "Unknown domain profile: 'banana'" in result.output
+    assert "Auto pipeline failed" not in result.output

--- a/tests/unit/cli/test_auto_domain_activation.py
+++ b/tests/unit/cli/test_auto_domain_activation.py
@@ -1,0 +1,215 @@
+"""Tests for 3-step DomainProfile activation in ooo auto CLI (PR-3, #809 P3)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from ouroboros.auto.domain_profile import DEFAULT_REGISTRY, DomainProfile
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.state import SeedOrigin
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_profile(name: str, detector_score: float = 0.0) -> DomainProfile:
+    """Build a minimal DomainProfile suitable for unit tests."""
+
+    class _FakeRepoContextExtractor:
+        def extract(self, cwd: Path) -> dict[str, Any]:
+            return {}
+
+    class _FakeVerifiablePredicate:
+        code = "fake_predicate"
+
+        def matches(self, criterion: str) -> bool:
+            return False
+
+        def repair_template(self, criterion: str) -> str:
+            return criterion
+
+    class _FakeIntentClassifier:
+        def classify(self, question: str) -> str | None:
+            return None
+
+        def supported_intents(self) -> frozenset[str]:
+            return frozenset()
+
+    return DomainProfile(
+        name=name,
+        repo_context_extractor=_FakeRepoContextExtractor(),
+        verifiable_predicates=(_FakeVerifiablePredicate(),),
+        intent_classifier=_FakeIntentClassifier(),
+        vague_terms=frozenset(),
+        safe_defaults={},
+        detector=lambda _cwd: detector_score,
+    )
+
+
+_FAKE_RESULT = AutoPipelineResult(
+    status="complete",
+    auto_session_id="auto_test123",
+    phase="complete",
+    grade="A",
+    seed_path=None,
+    seed_origin=SeedOrigin.NONE.value,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_profile():
+    """Register a fake 'fake-domain' profile in DEFAULT_REGISTRY for the test duration."""
+    profile = _make_fake_profile("fake-domain", detector_score=0.0)
+    DEFAULT_REGISTRY.register(profile)
+    yield profile
+    # Cleanup: remove the registered profile so other tests are not affected.
+    DEFAULT_REGISTRY._profiles[:] = [
+        p for p in DEFAULT_REGISTRY._profiles if p.name != "fake-domain"
+    ]
+
+
+@pytest.fixture()
+def detectable_profile(tmp_path):
+    """Register a fake 'detectable' profile that returns high confidence for any dir."""
+    profile = _make_fake_profile("detectable", detector_score=0.9)
+    DEFAULT_REGISTRY.register(profile)
+    yield profile, tmp_path
+    DEFAULT_REGISTRY._profiles[:] = [
+        p for p in DEFAULT_REGISTRY._profiles if p.name != "detectable"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_domain_flag_overrides_detection(fake_profile, tmp_path) -> None:
+    """--domain <name> wins even when cwd has no matching signals."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_pipeline_run(state):
+        captured["profile_name"] = state.active_domain_profile_name
+        return _FAKE_RESULT
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    with patch(
+        "ouroboros.auto.pipeline.AutoPipeline.run",
+        side_effect=_fake_pipeline_run,
+    ):
+        with patch("ouroboros.cli.commands.auto._safe_default_cwd", return_value=tmp_path):
+            result = asyncio.run(
+                _run_auto(
+                    goal="build something",
+                    resume=None,
+                    runtime=None,
+                    max_interview_rounds=None,
+                    max_repair_rounds=None,
+                    skip_run=True,
+                    domain="fake-domain",
+                )
+            )
+
+    assert result.status == "complete"
+    assert captured["profile_name"] == "fake-domain"
+
+
+def test_detection_falls_back_to_best_profile(detectable_profile, tmp_path) -> None:
+    """Without --domain, detect_best() is called and its result is stored on state."""
+    profile, cwd = detectable_profile
+    captured: dict[str, Any] = {}
+
+    async def _fake_pipeline_run(state):
+        captured["profile_name"] = state.active_domain_profile_name
+        return _FAKE_RESULT
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    with patch(
+        "ouroboros.auto.pipeline.AutoPipeline.run",
+        side_effect=_fake_pipeline_run,
+    ):
+        with patch("ouroboros.cli.commands.auto._safe_default_cwd", return_value=cwd):
+            result = asyncio.run(
+                _run_auto(
+                    goal="build something",
+                    resume=None,
+                    runtime=None,
+                    max_interview_rounds=None,
+                    max_repair_rounds=None,
+                    skip_run=True,
+                    domain=None,
+                )
+            )
+
+    assert result.status == "complete"
+    assert captured["profile_name"] == "detectable"
+
+
+def test_no_match_leaves_profile_none(tmp_path) -> None:
+    """An empty registry with no --domain leaves active_domain_profile_name as None."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_pipeline_run(state):
+        captured["profile_name"] = state.active_domain_profile_name
+        return _FAKE_RESULT
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    # Patch DEFAULT_REGISTRY.detect_best to return None regardless of registry state.
+    with patch.object(DEFAULT_REGISTRY, "detect_best", return_value=None):
+        with patch(
+            "ouroboros.auto.pipeline.AutoPipeline.run",
+            side_effect=_fake_pipeline_run,
+        ):
+            with patch("ouroboros.cli.commands.auto._safe_default_cwd", return_value=tmp_path):
+                result = asyncio.run(
+                    _run_auto(
+                        goal="build something",
+                        resume=None,
+                        runtime=None,
+                        max_interview_rounds=None,
+                        max_repair_rounds=None,
+                        skip_run=True,
+                        domain=None,
+                    )
+                )
+
+    assert result.status == "complete"
+    assert captured["profile_name"] is None
+
+
+def test_unknown_domain_value_errors(tmp_path) -> None:
+    """--domain <unknown> exits nonzero without starting the pipeline."""
+    import typer
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    with patch.object(DEFAULT_REGISTRY, "get", return_value=None):
+        with patch("ouroboros.cli.commands.auto._safe_default_cwd", return_value=tmp_path):
+            with pytest.raises(typer.Exit) as exc_info:
+                asyncio.run(
+                    _run_auto(
+                        goal="build something",
+                        resume=None,
+                        runtime=None,
+                        max_interview_rounds=None,
+                        max_repair_rounds=None,
+                        skip_run=True,
+                        domain="banana",
+                    )
+                )
+
+    assert exc_info.value.exit_code == 1

--- a/tests/unit/cli/test_auto_domain_activation.py
+++ b/tests/unit/cli/test_auto_domain_activation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -20,7 +21,11 @@ from ouroboros.cli.main import app
 # ---------------------------------------------------------------------------
 
 
-def _make_fake_profile(name: str, detector_score: float = 0.0) -> DomainProfile:
+def _make_fake_profile(
+    name: str,
+    detector_score: float = 0.0,
+    detector: Callable[[Path], float] | None = None,
+) -> DomainProfile:
     """Build a minimal DomainProfile suitable for unit tests."""
 
     class _FakeRepoContextExtractor:
@@ -50,7 +55,7 @@ def _make_fake_profile(name: str, detector_score: float = 0.0) -> DomainProfile:
         intent_classifier=_FakeIntentClassifier(),
         vague_terms=frozenset(),
         safe_defaults={},
-        detector=lambda _cwd: detector_score,
+        detector=detector or (lambda _cwd: detector_score),
     )
 
 
@@ -190,6 +195,47 @@ def test_no_match_leaves_profile_none(tmp_path) -> None:
                         domain=None,
                     )
                 )
+
+    assert result.status == "complete"
+    assert captured["profile_name"] is None
+
+
+def test_detector_exception_leaves_profile_none(tmp_path) -> None:
+    """Detector failures during new-session startup are best-effort no-matches."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_pipeline_run(state):
+        captured["profile_name"] = state.active_domain_profile_name
+        return _FAKE_RESULT
+
+    def _raise_detector(_cwd: Path) -> float:
+        raise OSError("unreadable")
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    profile = _make_fake_profile("broken-detector", detector=_raise_detector)
+    DEFAULT_REGISTRY.register(profile)
+    try:
+        with patch(
+            "ouroboros.auto.pipeline.AutoPipeline.run",
+            side_effect=_fake_pipeline_run,
+        ):
+            with patch("ouroboros.cli.commands.auto._safe_default_cwd", return_value=tmp_path):
+                result = asyncio.run(
+                    _run_auto(
+                        goal="build something",
+                        resume=None,
+                        runtime=None,
+                        max_interview_rounds=None,
+                        max_repair_rounds=None,
+                        skip_run=True,
+                        domain=None,
+                    )
+                )
+    finally:
+        DEFAULT_REGISTRY._profiles[:] = [
+            p for p in DEFAULT_REGISTRY._profiles if p.name != "broken-detector"
+        ]
 
     assert result.status == "complete"
     assert captured["profile_name"] is None


### PR DESCRIPTION
## Summary

Wires the 3-step DomainProfile activation policy into the ``ooo auto`` CLI. Stacks on **#849** (PR-1: contracts).

## Activation order

1. ``--domain <name>`` explicit flag wins.
2. Otherwise, ``DEFAULT_REGISTRY.detect_best(cwd)`` picks the highest-confidence profile.
3. Otherwise, ``active_domain_profile_name`` stays ``None`` — the pre-P3 hardcoded coding logic remains in charge (the safety hatch PR-4/PR-5 will use).

## Changes

- ``src/ouroboros/auto/state.py``: new ``active_domain_profile_name: str | None`` field on ``AutoPipelineState``, JSON-safe (stores the name, not the instance, so resume works).
- ``src/ouroboros/cli/commands/auto.py``: ``--domain`` option + 3-step resolution block.
- ``tests/unit/cli/test_auto_domain_activation.py``: 4 tests covering the explicit flag, auto-detect, none-fallback, and unknown-domain error.

## Test plan

- 4 new tests covering each activation step.
- Broader ``pytest tests/unit/cli/ tests/unit/auto/`` → **1454 passed**, no regressions.
- ``ruff check`` / ``ruff format --check`` clean.

## Why behavior is unchanged for current users

Until PR-4 (``answerer.py`` routing) and PR-5 (``safe_defaults.py`` routing) land, the activated profile is informational only — ``answerer`` and ``safe_defaults`` keep using their hardcoded coding logic. This PR just makes the activation observable on ``AutoState`` so subsequent PRs have something to read.

## Stack

Stacks on **#849** (PR-1: DomainProfile contracts). Independent of PR-2 (#TBD — coding profile), PR-4, PR-5 — they consume the activated name but don't change the wiring this PR adds.

Part of #809 P3.