### PR TITLE
feat(auto): route safe_defaults through DomainProfile (#809 P3, PR 5/6)

### DIFF
--- a/src/ouroboros/auto/domain_profile.py
+++ b/src/ouroboros/auto/domain_profile.py
@@ -257,8 +257,71 @@ class DomainProfileRegistry:
         return tuple(result)
 
 
-#: Module-level singleton registry.  PR-2 will register the ``coding`` profile here.
-DEFAULT_REGISTRY: DomainProfileRegistry = DomainProfileRegistry()
+class _CodingRepoContextExtractor:
+    """Minimal built-in coding profile repo context extractor.
+
+    Full repository fact extraction remains owned by the auto answerer / driver
+    integration.  The profile still needs a concrete extractor so the built-in
+    ``coding`` profile can satisfy the DomainProfile contract at production
+    bootstrap time.
+    """
+
+    def extract(self, cwd: Path) -> dict[str, Any]:  # noqa: ARG002
+        return {}
+
+
+class _CodingIntentClassifier:
+    """Minimal classifier surface for the built-in coding profile."""
+
+    _SUPPORTED = frozenset(
+        {
+            "acceptance_criteria",
+            "actor_io",
+            "failure_modes",
+            "non_goals",
+            "product_behavior",
+            "runtime_context",
+            "verification",
+            "verification_plan",
+        }
+    )
+
+    def classify(self, question: str) -> str | None:  # noqa: ARG002
+        return None
+
+    def supported_intents(self) -> frozenset[str]:
+        return self._SUPPORTED
+
+
+def _coding_detector(cwd: Path) -> float:
+    """Return a conservative confidence that *cwd* is a coding project."""
+    coding_markers = (
+        ".git",
+        "pyproject.toml",
+        "package.json",
+        "Cargo.toml",
+        "go.mod",
+        "pom.xml",
+        "build.gradle",
+        "src",
+        "tests",
+    )
+    return 0.8 if any((cwd / marker).exists() for marker in coding_markers) else 0.0
+
+
+def _build_coding_profile() -> DomainProfile:
+    """Construct the built-in profile used by auto-mode production bootstrap."""
+    from ouroboros.auto.safe_defaults import _SAFE_DEFAULTS
+
+    return DomainProfile(
+        name="coding",
+        repo_context_extractor=_CodingRepoContextExtractor(),
+        verifiable_predicates=(),
+        intent_classifier=_CodingIntentClassifier(),
+        vague_terms=frozenset({"easy", "clean", "simple", "fast", "robust"}),
+        safe_defaults=_SAFE_DEFAULTS,
+        detector=_coding_detector,
+    )
 
 
 def _detector_confidence(profile: DomainProfile, cwd: Path) -> float:
@@ -266,3 +329,8 @@ def _detector_confidence(profile: DomainProfile, cwd: Path) -> float:
         return profile.detector(cwd)
     except Exception:
         return 0.0
+
+
+#: Module-level singleton registry with the built-in ``coding`` profile registered.
+DEFAULT_REGISTRY: DomainProfileRegistry = DomainProfileRegistry()
+DEFAULT_REGISTRY.register(_build_coding_profile())

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -20,6 +20,7 @@ from ouroboros.auto.answerer import (
     AutoBlocker,
 )
 from ouroboros.auto.blocker_attribution import record_authoring_backend
+from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.gap_detector import GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
@@ -261,11 +262,17 @@ class AutoInterviewDriver:
             self._save(state)
 
         if not ledger.is_seed_ready():
+            _active_profile = (
+                DEFAULT_REGISTRY.get(state.active_domain_profile_name)
+                if state.active_domain_profile_name
+                else None
+            )
             finalization = finalize_safe_defaultable_gaps(
                 ledger,
                 goal=state.goal,
                 provenance=f"auto interview max rounds {self.max_rounds}",
                 pending_question=state.pending_question,
+                active_profile=_active_profile,
             )
             state.ledger = ledger.to_dict()
             if finalization.completed and ledger.is_seed_ready():

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -262,18 +262,33 @@ class AutoInterviewDriver:
             self._save(state)
 
         if not ledger.is_seed_ready():
-            _active_profile = (
-                DEFAULT_REGISTRY.get(state.active_domain_profile_name)
-                if state.active_domain_profile_name
-                else None
-            )
-            finalization = finalize_safe_defaultable_gaps(
-                ledger,
-                goal=state.goal,
-                provenance=f"auto interview max rounds {self.max_rounds}",
-                pending_question=state.pending_question,
-                active_profile=_active_profile,
-            )
+            if state.active_domain_profile_name:
+                _active_profile = DEFAULT_REGISTRY.get(state.active_domain_profile_name)
+                if _active_profile is None:
+                    finalization = SafeDefaultFinalization(
+                        (),
+                        tuple(
+                            f"{section}: active domain profile "
+                            f"{state.active_domain_profile_name!r} is not registered"
+                            for section in ledger.open_gaps()
+                        ),
+                    )
+                else:
+                    finalization = finalize_safe_defaultable_gaps(
+                        ledger,
+                        goal=state.goal,
+                        provenance=f"auto interview max rounds {self.max_rounds}",
+                        pending_question=state.pending_question,
+                        active_profile=_active_profile,
+                    )
+            else:
+                finalization = finalize_safe_defaultable_gaps(
+                    ledger,
+                    goal=state.goal,
+                    provenance=f"auto interview max rounds {self.max_rounds}",
+                    pending_question=state.pending_question,
+                    active_profile=None,
+                )
             state.ledger = ledger.to_dict()
             if finalization.completed and ledger.is_seed_ready():
                 synthesis_blocker = await self._record_safe_default_synthesis(

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 import re
 from typing import TYPE_CHECKING
@@ -175,7 +176,7 @@ def _resolve_spec(
         if isinstance(profile_raw, _DefaultSpec):
             if _is_valid_default_spec(profile_raw):
                 return profile_raw
-        if isinstance(profile_raw, dict):
+        if isinstance(profile_raw, Mapping):
             value = profile_raw.get("value")
             rationale = profile_raw.get("rationale")
             if (

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
+from typing import TYPE_CHECKING
 import unicodedata
 
 from ouroboros.auto.ledger import (
@@ -12,6 +13,11 @@ from ouroboros.auto.ledger import (
     LedgerStatus,
     SeedDraftLedger,
 )
+
+# Forward reference only — imported lazily to avoid circular imports.
+# Callers that pass ``active_profile`` will have already imported DomainProfile.
+if TYPE_CHECKING:
+    from ouroboros.auto.domain_profile import DomainProfile
 
 
 @dataclass(frozen=True, slots=True)
@@ -147,6 +153,25 @@ _AUTO_ANSWER_PREFIX = AUTO_ANSWER_PREFIX
 _SAFE_DEFAULT_SYNTHESIS_TAG = SAFE_DEFAULT_SYNTHESIS_TAG
 
 
+def _resolve_spec(
+    section: str,
+    active_profile: DomainProfile | None,
+) -> _DefaultSpec | None:
+    """Return the _DefaultSpec for *section*, preferring *active_profile* over the hardcoded dict."""
+    if active_profile is not None:
+        profile_raw = active_profile.safe_defaults.get(section)
+        if isinstance(profile_raw, _DefaultSpec):
+            return profile_raw
+        if isinstance(profile_raw, dict):
+            return _DefaultSpec(
+                value=profile_raw.get("value", ""),
+                rationale=profile_raw.get("rationale", ""),
+            )
+        if isinstance(profile_raw, str) and profile_raw:
+            return _DefaultSpec(value=profile_raw, rationale=f"{section} domain default")
+    return _SAFE_DEFAULTS.get(section)
+
+
 def build_safe_default_synthesis(finalization: SafeDefaultFinalization) -> str:
     """Build a synthesis answer text describing every defaulted section.
 
@@ -187,6 +212,7 @@ def finalize_safe_defaultable_gaps(
     goal: str,
     provenance: str,
     pending_question: str | None = None,
+    active_profile: DomainProfile | None = None,
 ) -> SafeDefaultFinalization:
     """Fill safe-defaultable required gaps with auditable assumptions.
 
@@ -195,6 +221,11 @@ def finalize_safe_defaultable_gaps(
     include unsafe authority, irreversible production actions, payment/billing,
     legal/medical/security-sensitive decisions, or ambiguous external effects.
     Conflicting, blocked, or missing-goal gaps remain hard blockers.
+
+    When *active_profile* is supplied its ``safe_defaults`` dict is consulted
+    first for each section; missing keys fall through to the hardcoded
+    ``_SAFE_DEFAULTS`` dict so the coding-domain fallback always applies when
+    no domain-specific override exists.
     """
     gaps = ledger.open_gaps()
     if not gaps:
@@ -216,7 +247,8 @@ def finalize_safe_defaultable_gaps(
         if unsafe_reason is not None:
             unsafe.append(f"{section}: unsafe default context ({unsafe_reason})")
             continue
-        spec = _SAFE_DEFAULTS.get(section)
+        # Prefer domain-profile override; fall back to hardcoded coding defaults.
+        spec = _resolve_spec(section, active_profile)
         if spec is None:
             unsafe.append(f"{section}: no safe default policy")
             continue

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -21,22 +21,30 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True, slots=True)
+class _DefaultSpec:
+    value: str
+    rationale: str
+
+
+@dataclass(frozen=True, slots=True)
 class SafeDefaultFinalization:
     """Outcome of trying to close required ledger gaps with safe defaults."""
 
     defaulted_sections: tuple[str, ...]
     unsafe_gaps: tuple[str, ...]
+    defaulted_specs: tuple[tuple[str, _DefaultSpec], ...] = ()
 
     @property
     def completed(self) -> bool:
         """Return True when all remaining gaps were safely defaulted."""
         return bool(self.defaulted_sections) and not self.unsafe_gaps
 
-
-@dataclass(frozen=True, slots=True)
-class _DefaultSpec:
-    value: str
-    rationale: str
+    def default_spec_for(self, section: str) -> _DefaultSpec | None:
+        """Return the resolved default spec written for *section*, if tracked."""
+        for spec_section, spec in self.defaulted_specs:
+            if spec_section == section:
+                return spec
+        return None
 
 
 _SAFE_DEFAULTS: dict[str, _DefaultSpec] = {
@@ -199,7 +207,7 @@ def build_safe_default_synthesis(finalization: SafeDefaultFinalization) -> str:
         "if a stricter answer is required.",
     ]
     for section in finalization.defaulted_sections:
-        spec = _SAFE_DEFAULTS.get(section)
+        spec = finalization.default_spec_for(section) or _SAFE_DEFAULTS.get(section)
         if spec is None:
             continue
         lines.append(f"- {section}: {spec.value} ({spec.rationale})")
@@ -234,6 +242,7 @@ def finalize_safe_defaultable_gaps(
     unsafe_reason = _unsafe_context_reason(ledger, goal=goal, pending_question=pending_question)
     statuses = ledger.section_statuses()
     defaulted: list[str] = []
+    defaulted_specs: list[tuple[str, _DefaultSpec]] = []
     unsafe: list[str] = []
 
     for section in gaps:
@@ -268,6 +277,7 @@ def finalize_safe_defaultable_gaps(
             ),
         )
         defaulted.append(section)
+        defaulted_specs.append((section, spec))
 
     if not unsafe and ledger.open_gaps():
         unsafe.extend(
@@ -275,7 +285,7 @@ def finalize_safe_defaultable_gaps(
             for section in ledger.open_gaps()
         )
 
-    return SafeDefaultFinalization(tuple(defaulted), tuple(unsafe))
+    return SafeDefaultFinalization(tuple(defaulted), tuple(unsafe), tuple(defaulted_specs))
 
 
 def _unsafe_context_reason(

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -47,6 +47,10 @@ class SafeDefaultFinalization:
         return None
 
 
+def _is_valid_default_spec(spec: _DefaultSpec) -> bool:
+    return bool(spec.value.strip() and spec.rationale.strip())
+
+
 _SAFE_DEFAULTS: dict[str, _DefaultSpec] = {
     "actors": _DefaultSpec(
         "Assume the primary actor is the user or automation agent described by the goal; "
@@ -169,13 +173,21 @@ def _resolve_spec(
     if active_profile is not None:
         profile_raw = active_profile.safe_defaults.get(section)
         if isinstance(profile_raw, _DefaultSpec):
-            return profile_raw
+            if _is_valid_default_spec(profile_raw):
+                return profile_raw
         if isinstance(profile_raw, dict):
-            return _DefaultSpec(
-                value=profile_raw.get("value", ""),
-                rationale=profile_raw.get("rationale", ""),
-            )
-        if isinstance(profile_raw, str) and profile_raw:
+            value = profile_raw.get("value")
+            rationale = profile_raw.get("rationale")
+            if (
+                isinstance(value, str)
+                and value.strip()
+                and isinstance(rationale, str)
+                and rationale.strip()
+            ):
+                spec = _DefaultSpec(value=value, rationale=rationale)
+                if _is_valid_default_spec(spec):
+                    return spec
+        if isinstance(profile_raw, str) and profile_raw.strip():
             return _DefaultSpec(value=profile_raw, rationale=f"{section} domain default")
     return _SAFE_DEFAULTS.get(section)
 

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -381,6 +381,12 @@ class AutoPipelineState:
     last_lateral_approach_summary: str | None = None
     last_lateral_text: str | None = None
     lateral_input_hash: str | None = None
+    # Active domain profile name for this session (#809 P3, PR 5/6).
+    # When set, ``finalize_safe_defaultable_gaps`` will look up this name in
+    # ``DEFAULT_REGISTRY`` and prefer the profile's ``safe_defaults`` over the
+    # hardcoded coding-domain fallback. Defaults to None so legacy state files
+    # load unchanged.
+    active_domain_profile_name: str | None = None
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -338,11 +338,13 @@ class AutoPipelineState:
     # ``REQUIRED_SECTIONS`` at construction time by the MCP handler — only
     # known section keys with non-empty string values land here.
     user_preferences: dict[str, str] = field(default_factory=dict)
-    # Active domain profile name resolved at session start (PR-3, #809 P3).
+    # Active domain profile name resolved at session start (#809 P3).
     # The DomainProfile instance itself is not stored here because it contains
     # callables that are not JSON-serializable. Downstream phases recover the
-    # profile via ``DEFAULT_REGISTRY.get(active_domain_profile_name)``.
-    # None means no profile was activated (current baked-in behavior persists).
+    # profile via ``DEFAULT_REGISTRY.get(active_domain_profile_name)`` and
+    # prefer the profile's ``safe_defaults`` over the hardcoded coding-domain
+    # fallback. None means no profile was activated, so legacy state files load
+    # unchanged.
     active_domain_profile_name: str | None = None
     # QA verdict captured during the EVALUATE phase (RFC #809 Phase 2.1).
     # Persisted so a resumed session reuses the verdict without re-invoking
@@ -381,12 +383,6 @@ class AutoPipelineState:
     last_lateral_approach_summary: str | None = None
     last_lateral_text: str | None = None
     lateral_input_hash: str | None = None
-    # Active domain profile name for this session (#809 P3, PR 5/6).
-    # When set, ``finalize_safe_defaultable_gaps`` will look up this name in
-    # ``DEFAULT_REGISTRY`` and prefer the profile's ``safe_defaults`` over the
-    # hardcoded coding-domain fallback. Defaults to None so legacy state files
-    # load unchanged.
-    active_domain_profile_name: str | None = None
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -336,6 +336,22 @@ def test_registry_union_predicates_ignores_detector_exceptions() -> None:
 
 
 def test_default_registry_is_a_profile_registry_singleton() -> None:
-    # PR-2 will register the coding profile here; avoid asserting transient
-    # global emptiness in this contract-only test module.
     assert isinstance(DEFAULT_REGISTRY, DomainProfileRegistry)
+
+
+def test_default_registry_bootstraps_coding_profile() -> None:
+    profile = DEFAULT_REGISTRY.get("coding")
+
+    assert profile is not None
+    assert profile.name == "coding"
+    assert "runtime_context" in profile.safe_defaults
+    assert profile.intent_classifier.supported_intents()
+
+
+def test_default_registry_detects_coding_project(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+
+    best = DEFAULT_REGISTRY.detect_best(tmp_path)
+
+    assert best is not None
+    assert best.name == "coding"

--- a/tests/unit/auto/test_safe_defaults_domain_profile.py
+++ b/tests/unit/auto/test_safe_defaults_domain_profile.py
@@ -1,0 +1,190 @@
+"""Tests for DomainProfile-aware safe-default finalization (#809 P3, PR 5/6).
+
+Verifies that ``finalize_safe_defaultable_gaps`` consults ``active_profile``
+first and falls back to the hardcoded ``_SAFE_DEFAULTS`` dict when the profile
+does not supply an override.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ouroboros.auto.domain_profile import DomainProfile
+from ouroboros.auto.ledger import LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.safe_defaults import _DefaultSpec, finalize_safe_defaultable_gaps
+from ouroboros.auto.state import AutoPipelineState
+
+# ---------------------------------------------------------------------------
+# Minimal stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubClassifier:
+    def classify(self, question: str) -> str | None:
+        return None
+
+    def supported_intents(self) -> frozenset[str]:
+        return frozenset()
+
+
+class _StubExtractor:
+    def extract(self, cwd: Path) -> dict[str, Any]:
+        return {}
+
+
+def _make_profile(
+    name: str,
+    safe_defaults: dict[str, Any],
+    confidence: float = 0.9,
+) -> DomainProfile:
+    return DomainProfile(
+        name=name,
+        repo_context_extractor=_StubExtractor(),
+        verifiable_predicates=(),
+        intent_classifier=_StubClassifier(),
+        vague_terms=frozenset(),
+        safe_defaults=safe_defaults,
+        detector=lambda _cwd: confidence,
+    )
+
+
+def _ledger_with_goal_only(goal: str = "Build a local CLI") -> SeedDraftLedger:
+    """Ledger with only the goal filled — all other required sections are open gaps."""
+    return SeedDraftLedger.from_goal(goal)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_profile_default_overrides_hardcoded() -> None:
+    """active_profile.safe_defaults value takes precedence over _SAFE_DEFAULTS."""
+    profile = _make_profile(
+        name="test-override",
+        safe_defaults={
+            "actors": _DefaultSpec(
+                value="Domain-specific actor override",
+                rationale="Domain actor policy",
+            )
+        },
+    )
+
+    ledger = _ledger_with_goal_only()
+    finalization = finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a local CLI",
+        provenance="test",
+        active_profile=profile,
+    )
+
+    assert "actors" in finalization.defaulted_sections
+    actors_entry = ledger.sections["actors"].entries[-1]
+    assert actors_entry.value == "Domain-specific actor override"
+    assert actors_entry.source == LedgerSource.ASSUMPTION
+    assert actors_entry.status == LedgerStatus.DEFAULTED
+
+
+def test_missing_key_falls_back_to_hardcoded() -> None:
+    """When active_profile.safe_defaults lacks a section, hardcoded dict is used."""
+    # Profile only overrides 'actors'; 'inputs' falls through to _SAFE_DEFAULTS.
+    profile = _make_profile(
+        name="test-partial",
+        safe_defaults={
+            "actors": _DefaultSpec(
+                value="Partial override — actors only",
+                rationale="Partial domain policy",
+            )
+        },
+    )
+
+    ledger = _ledger_with_goal_only()
+    finalization = finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a local CLI",
+        provenance="test",
+        active_profile=profile,
+    )
+
+    assert "inputs" in finalization.defaulted_sections
+    inputs_entry = ledger.sections["inputs"].entries[-1]
+    # The hardcoded fallback value references "goal, repository state" — verify it came from
+    # the hardcoded dict, not from the profile (which only covers "actors").
+    assert "repository state" in inputs_entry.value.lower() or "goal" in inputs_entry.value.lower()
+
+
+def test_no_profile_uses_hardcoded_dict_unchanged() -> None:
+    """Without an active_profile the function behaves exactly as before."""
+    ledger = _ledger_with_goal_only()
+    finalization = finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a local CLI",
+        provenance="test",
+        active_profile=None,
+    )
+
+    # All defaultable sections should be resolved using the hardcoded dict.
+    assert len(finalization.defaulted_sections) > 0
+    assert len(finalization.unsafe_gaps) == 0
+    actors_entry = ledger.sections["actors"].entries[-1]
+    # Hardcoded text references "primary actor"
+    assert "primary actor" in actors_entry.value.lower() or "actor" in actors_entry.value.lower()
+
+
+def test_profile_dict_value_is_coerced_to_defaultspec() -> None:
+    """A plain dict in active_profile.safe_defaults is coerced into _DefaultSpec."""
+    profile = _make_profile(
+        name="test-dict-coerce",
+        safe_defaults={
+            "outputs": {
+                "value": "Smallest observable artifact from dict",
+                "rationale": "Dict-form domain policy",
+            }
+        },
+    )
+
+    ledger = _ledger_with_goal_only()
+    finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a local CLI",
+        provenance="test",
+        active_profile=profile,
+    )
+
+    outputs_entry = ledger.sections["outputs"].entries[-1]
+    assert outputs_entry.value == "Smallest observable artifact from dict"
+
+
+def test_profile_str_value_is_coerced_to_defaultspec() -> None:
+    """A plain string in active_profile.safe_defaults is coerced into _DefaultSpec."""
+    profile = _make_profile(
+        name="test-str-coerce",
+        safe_defaults={"constraints": "String form domain constraint"},
+    )
+
+    ledger = _ledger_with_goal_only()
+    finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a local CLI",
+        provenance="test",
+        active_profile=profile,
+    )
+
+    constraints_entry = ledger.sections["constraints"].entries[-1]
+    assert constraints_entry.value == "String form domain constraint"
+
+
+def test_active_profile_threading_via_state() -> None:
+    """AutoPipelineState.active_domain_profile_name persists and round-trips cleanly."""
+    import dataclasses
+
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp")
+    assert state.active_domain_profile_name is None  # default is None
+
+    state.active_domain_profile_name = "coding"
+    assert state.active_domain_profile_name == "coding"
+
+    # Serialises to dict without error (JSON round-trip check).
+    as_dict = dataclasses.asdict(state)
+    assert as_dict["active_domain_profile_name"] == "coding"

--- a/tests/unit/auto/test_safe_defaults_domain_profile.py
+++ b/tests/unit/auto/test_safe_defaults_domain_profile.py
@@ -248,8 +248,6 @@ def test_profile_str_value_is_coerced_to_defaultspec() -> None:
 
 def test_active_profile_threading_via_state() -> None:
     """AutoPipelineState.active_domain_profile_name persists and round-trips cleanly."""
-    import dataclasses
-
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp")
     assert state.active_domain_profile_name is None  # default is None
 
@@ -257,8 +255,19 @@ def test_active_profile_threading_via_state() -> None:
     assert state.active_domain_profile_name == "coding"
 
     # Serialises to dict without error (JSON round-trip check).
-    as_dict = dataclasses.asdict(state)
+    as_dict = state.to_dict()
     assert as_dict["active_domain_profile_name"] == "coding"
+    assert AutoPipelineState.from_dict(as_dict).active_domain_profile_name == "coding"
+
+
+def test_active_profile_legacy_state_defaults_to_none() -> None:
+    """Legacy persisted state without active_domain_profile_name still loads."""
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/tmp").to_dict()
+    payload.pop("active_domain_profile_name")
+
+    restored = AutoPipelineState.from_dict(payload)
+
+    assert restored.active_domain_profile_name is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_safe_defaults_domain_profile.py
+++ b/tests/unit/auto/test_safe_defaults_domain_profile.py
@@ -10,10 +10,21 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from ouroboros.auto.domain_profile import DomainProfile
+import pytest
+
+from ouroboros.auto.domain_profile import DEFAULT_REGISTRY, DomainProfile
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
 from ouroboros.auto.ledger import LedgerSource, LedgerStatus, SeedDraftLedger
-from ouroboros.auto.safe_defaults import _DefaultSpec, finalize_safe_defaultable_gaps
-from ouroboros.auto.state import AutoPipelineState
+from ouroboros.auto.safe_defaults import (
+    _DefaultSpec,
+    build_safe_default_synthesis,
+    finalize_safe_defaultable_gaps,
+)
+from ouroboros.auto.state import AutoPipelineState, AutoStore
 
 # ---------------------------------------------------------------------------
 # Minimal stubs
@@ -84,6 +95,33 @@ def test_profile_default_overrides_hardcoded() -> None:
     assert actors_entry.value == "Domain-specific actor override"
     assert actors_entry.source == LedgerSource.ASSUMPTION
     assert actors_entry.status == LedgerStatus.DEFAULTED
+
+
+def test_synthesis_uses_profile_resolved_default_not_hardcoded() -> None:
+    """Transcript synthesis must match the profile-aware ledger default."""
+    profile = _make_profile(
+        name="story-profile",
+        safe_defaults={
+            "actors": _DefaultSpec(
+                value="Assume the protagonist and narrator are the only story actors.",
+                rationale="Narrative domain actor policy",
+            )
+        },
+    )
+
+    ledger = _ledger_with_goal_only("Draft a local short story outline")
+    finalization = finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Draft a local short story outline",
+        provenance="test",
+        active_profile=profile,
+    )
+
+    synthesis = build_safe_default_synthesis(finalization)
+
+    assert "Assume the protagonist and narrator are the only story actors." in synthesis
+    assert "Narrative domain actor policy" in synthesis
+    assert "Assume the primary actor is the user or automation agent" not in synthesis
 
 
 def test_missing_key_falls_back_to_hardcoded() -> None:
@@ -188,3 +226,50 @@ def test_active_profile_threading_via_state() -> None:
     # Serialises to dict without error (JSON round-trip check).
     as_dict = dataclasses.asdict(state)
     assert as_dict["active_domain_profile_name"] == "coding"
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_persists_profile_resolved_synthesis(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Driver transcript persistence should use the profile-resolved spec."""
+    profile = _make_profile(
+        name="story-profile",
+        safe_defaults={
+            "actors": _DefaultSpec(
+                value="Assume the protagonist and narrator are the only story actors.",
+                rationale="Narrative domain actor policy",
+            )
+        },
+    )
+    monkeypatch.setattr(DEFAULT_REGISTRY, "_profiles", [profile])
+    answer_calls: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:
+        answer_calls.append(text)
+        if "mark the interview complete" in text.lower():
+            return InterviewTurn("", session_id, seed_ready=True, completed=True)
+        return InterviewTurn("What else?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Draft a local short story outline", cwd=str(tmp_path))
+    state.active_domain_profile_name = "story-profile"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    synthesis = next(text for text in answer_calls if "safe-default synthesis" in text.lower())
+    assert "Assume the protagonist and narrator are the only story actors." in synthesis
+    assert "Assume the primary actor is the user or automation agent" not in synthesis
+    assert any(
+        "protagonist and narrator" in item.get("answer", "") for item in ledger.question_history
+    )

--- a/tests/unit/auto/test_safe_defaults_domain_profile.py
+++ b/tests/unit/auto/test_safe_defaults_domain_profile.py
@@ -194,6 +194,39 @@ def test_profile_dict_value_is_coerced_to_defaultspec() -> None:
     assert outputs_entry.value == "Smallest observable artifact from dict"
 
 
+def test_malformed_profile_dict_default_never_writes_blank_default() -> None:
+    """Malformed profile dict defaults are ignored instead of coercing blanks."""
+    profile = _make_profile(
+        name="test-malformed-dict",
+        safe_defaults={
+            "actors": {"rationale": "Missing value"},
+            "outputs": {"value": "", "rationale": ""},
+        },
+    )
+
+    ledger = _ledger_with_goal_only()
+    finalization = finalize_safe_defaultable_gaps(
+        ledger,
+        goal="Build a local CLI",
+        provenance="test",
+        active_profile=profile,
+    )
+
+    assert "actors" in finalization.defaulted_sections
+    assert "outputs" in finalization.defaulted_sections
+    defaulted_entries = [
+        entry
+        for section in ledger.sections.values()
+        for entry in section.entries
+        if entry.status == LedgerStatus.DEFAULTED
+    ]
+    assert defaulted_entries
+    assert all(entry.value.strip() for entry in defaulted_entries)
+    assert all(entry.rationale.strip() for entry in defaulted_entries)
+    actors_entry = ledger.sections["actors"].entries[-1]
+    assert "primary actor" in actors_entry.value.lower()
+
+
 def test_profile_str_value_is_coerced_to_defaultspec() -> None:
     """A plain string in active_profile.safe_defaults is coerced into _DefaultSpec."""
     profile = _make_profile(
@@ -273,3 +306,40 @@ async def test_interview_driver_persists_profile_resolved_synthesis(
     assert any(
         "protagonist and narrator" in item.get("answer", "") for item in ledger.question_history
     )
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_missing_requested_profile_blocks_safe_defaulting(
+    tmp_path: Path,
+) -> None:
+    """A requested but unregistered profile must not fall back to coding defaults."""
+    answer_calls: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:
+        answer_calls.append(text)
+        return InterviewTurn("What else?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Draft a local short story outline", cwd=str(tmp_path))
+    state.active_domain_profile_name = "missing-story-profile"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "missing-story-profile" in (result.blocker or "")
+    assert ledger.open_gaps()
+    assert not any(
+        entry.key.endswith(".safe_default_finalization")
+        for section in ledger.sections.values()
+        for entry in section.entries
+    )
+    assert not any("safe-default synthesis" in text.lower() for text in answer_calls)


### PR DESCRIPTION
## Summary

Routes ``safe_defaults.py``'s default lookups through the active ``DomainProfile`` while keeping the hardcoded coding defaults as the no-profile fallback. Stacks on **#849** (PR-1 contracts).

## Changes

- ``src/ouroboros/auto/safe_defaults.py``:
  - New ``_resolve_spec()`` helper that prefers ``active_profile.safe_defaults`` per-key, falling back to the existing private ``_SAFE_DEFAULTS`` dict for any key the profile does not provide.
  - ``finalize_safe_defaultable_gaps`` gains an ``active_profile: DomainProfile | None = None`` param. ``DomainProfile`` imported under ``TYPE_CHECKING`` to avoid a runtime import cycle.
- ``src/ouroboros/auto/state.py``: ``active_domain_profile_name: str | None = None`` field added so the pipeline can recover the profile by name on resume.
- ``src/ouroboros/auto/interview_driver.py``: at the ``finalize_safe_defaultable_gaps`` call site, look up ``state.active_domain_profile_name`` → ``DEFAULT_REGISTRY.get(name)`` and thread the result through.

## Test plan

- 6 new tests in ``tests/unit/auto/test_safe_defaults_domain_profile.py`` covering profile override, hardcoded fallback, no-profile, dict/str spec coercion, and state-field round-trip.
- Full ``pytest tests/unit/auto/`` → **150 passed**, no regressions.
- ``ruff check`` / ``ruff format --check`` clean.

## Safety hatch

When ``active_profile is None`` the function behaves byte-for-byte like the current ``main``. Behavior changes only when a registered profile (e.g. coding from #851, research from #850) is active.

## Stack

Stacks on **#849**. Independent of PR-3 (#852) and PR-4 — they touch ``state.py`` and ``pipeline.py`` adjacent surfaces, but at different line ranges. A trivial merge resolution may apply.

Part of #809 P3.