### PR TITLE
fix(plugin): prevent argv secret leaks across firewall outputs

### DIFF
--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -167,18 +167,28 @@ def _redact_argv(argv: list[str]) -> tuple[list[str], bool]:
     redacted: list[str] = []
     fired = False
     pending_value_redact = False
+    pending_bearer_tail_redact = False
     for token in argv:
+        if pending_bearer_tail_redact:
+            redacted.append(_REDACTED)
+            fired = True
+            pending_bearer_tail_redact = False
+            continue
         if pending_value_redact:
             redacted.append(_REDACTED)
             fired = True
             pending_value_redact = False
+            if token == "Bearer":
+                pending_bearer_tail_redact = True
             continue
         # `--flag=value` form: split on first `=`.
         if token.startswith("-") and "=" in token:
-            flag, _, _ = token.partition("=")
+            flag, _, value = token.partition("=")
             if flag in _SECRET_FLAG_NAMES:
                 redacted.append(f"{flag}={_REDACTED}")
                 fired = True
+                if value == "Bearer":
+                    pending_bearer_tail_redact = True
                 continue
         # Bare flag form: value is the next argv element.
         if token in _SECRET_FLAG_NAMES:
@@ -186,7 +196,15 @@ def _redact_argv(argv: list[str]) -> tuple[list[str], bool]:
             pending_value_redact = True
             continue
         # High-confidence value-shaped match (Bearer …, gh*_…, sk-…,
-        # AKIA…, JWT-shaped).
+        # AKIA…, JWT-shaped).  Shells commonly split an Authorization
+        # header into ``Bearer`` and the opaque credential tail; redact
+        # both adjacent tokens as the same logical secret rather than
+        # letting the tail land in audit events.
+        if token == "Bearer":
+            redacted.append(_REDACTED)
+            fired = True
+            pending_bearer_tail_redact = True
+            continue
         if _is_secret_value(token):
             redacted.append(_REDACTED)
             fired = True
@@ -195,6 +213,10 @@ def _redact_argv(argv: list[str]) -> tuple[list[str], bool]:
     if pending_value_redact:
         # Trailing `--token` with no value: nothing to redact, but the
         # plugin will reject it at parse-time anyway. Emit it as-is.
+        pass
+    if pending_bearer_tail_redact:
+        # Trailing `Bearer` without a credential tail was already
+        # redacted above. Nothing else to consume.
         pass
     return redacted, fired
 
@@ -685,10 +707,11 @@ def invoke_plugin(
 
     # 2. Confirmation gate (locked Q2 — ONE prompt, command-level).
     if command.requires_confirmation:
+        redacted_prompt_argv, _ = _redact_argv(list(argv))
         prompt = (
             f"This command is destructive and requires confirmation.\n"
             f"Plugin: {manifest.name} {manifest.version}\n"
-            f"Action: {command_name} {' '.join(argv)}\n"
+            f"Action: {command_name} {' '.join(redacted_prompt_argv)}\n"
             f"Continue?"
         )
         if not confirm(prompt):

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -196,15 +196,10 @@ def _redact_argv(argv: list[str]) -> tuple[list[str], bool]:
             pending_value_redact = True
             continue
         # High-confidence value-shaped match (Bearer …, gh*_…, sk-…,
-        # AKIA…, JWT-shaped).  Shells commonly split an Authorization
-        # header into ``Bearer`` and the opaque credential tail; redact
-        # both adjacent tokens as the same logical secret rather than
-        # letting the tail land in audit events.
-        if token == "Bearer":
-            redacted.append(_REDACTED)
-            fired = True
-            pending_bearer_tail_redact = True
-            continue
+        # AKIA…, JWT-shaped).  Split ``Bearer`` auth values are only
+        # treated as secret context when introduced by a known secret flag
+        # above; a standalone literal ``Bearer`` may be ordinary user input
+        # and must not hide subsequent real flags from prompts/audit logs.
         if _is_secret_value(token):
             redacted.append(_REDACTED)
             fired = True

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -326,6 +326,35 @@ def test_confirmation_declined_blocks_with_no_subprocess(tmp_path: Path) -> None
     assert "user declined" in result.message
 
 
+def test_confirmation_prompt_uses_redacted_argv(tmp_path: Path) -> None:
+    """The one destructive-command prompt is user-visible output, so it
+    must not echo argv secrets that the audit envelope would redact."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    prompts: list[str] = []
+
+    result = invoke_plugin(
+        program,
+        command_name="merge",
+        argv=["--token", "hunter2-supersecret"],
+        trust_record=trust,
+        event_sink=lambda _event: None,
+        correlation_id="corr-confirm-redact",
+        confirm=lambda prompt: prompts.append(prompt) or False,
+        subprocess_runner=_fake_runner(),
+    )
+
+    assert result.status == "blocked"
+    assert prompts
+    assert "hunter2-supersecret" not in prompts[0]
+    assert "Action: merge --token [redacted]" in prompts[0]
+
+
 def test_confirmation_accepted_proceeds(tmp_path: Path) -> None:
     """Test 6: requires_confirmation=true + confirm()=True → normal flow."""
     program = _make_program(tmp_path)
@@ -848,6 +877,11 @@ def test_argv_redacts_secret_flags_and_high_confidence_tokens(tmp_path: Path) ->
         "--password",  # bare flag
         "hunter2-supersecret",  # value follows
         "Bearer eyJhbGciOiJIUzI1NiJ9.payload",  # high-confidence
+        "--authorization",
+        "Bearer",
+        "opaqueSecret123",
+        "--bearer=Bearer",
+        "opaqueSecret456",
         "AKIAIOSFODNN7EXAMPLE",  # AWS access key id
         "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature",  # JWT
         "plain-arg",  # not secret
@@ -872,16 +906,24 @@ def test_argv_redacts_secret_flags_and_high_confidence_tokens(tmp_path: Path) ->
     assert redacted[3] == "[redacted]"
     # Bearer / AWS / JWT all match high-confidence patterns.
     assert redacted[4] == "[redacted]"
-    assert redacted[5] == "[redacted]"
+    # Split Bearer forms redact both the marker and opaque tail.
+    assert redacted[5] == "--authorization"
     assert redacted[6] == "[redacted]"
+    assert redacted[7] == "[redacted]"
+    assert redacted[8] == "--bearer=[redacted]"
+    assert redacted[9] == "[redacted]"
+    assert redacted[10] == "[redacted]"
+    assert redacted[11] == "[redacted]"
     # Non-secret string passed through unchanged.
-    assert redacted[7] == "plain-arg"
+    assert redacted[12] == "plain-arg"
     # No raw secret bytes anywhere in the serialized event stream.
     serialized = json.dumps(events)
     for needle in (
         "ghp_thisIsClearlyASecret",
         "hunter2-supersecret",
         "eyJhbGciOiJIUzI1NiJ9.payload",
+        "opaqueSecret123",
+        "opaqueSecret456",
         "AKIAIOSFODNN7EXAMPLE",
     ):
         assert needle not in serialized, needle

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -942,19 +942,57 @@ def test_argv_no_redaction_keeps_argv_verbatim(tmp_path: Path) -> None:
         scope="github:read",
         granted_by="u",
     )
+    clean_argv = ["https://example.com/pr/1", "Bearer", "--force", "plain-tail"]
     events: list[dict] = []
     invoke_plugin(
         program,
         command_name="review",
-        argv=["https://example.com/pr/1", "--verbose"],
+        argv=clean_argv,
         trust_record=trust,
         event_sink=events.append,
         correlation_id="corr-clean",
         subprocess_runner=_fake_runner(stdout="ok"),
     )
     invoked = next(e for e in events if e["event_type"] == "plugin.invoked")
-    assert invoked["command"]["argv"] == ["https://example.com/pr/1", "--verbose"]
+    assert invoked["command"]["argv"] == clean_argv
     assert "argv_sha256" not in invoked.get("provenance", {})
+
+
+def test_confirmation_prompt_keeps_standalone_bearer_arguments(
+    tmp_path: Path,
+) -> None:
+    """A literal ``Bearer`` token is not secret context by itself.
+
+    Regression catch for the bot design note on PR #857: over-redacting
+    ``["Bearer", "--force"]`` would hide real destructive flags from the
+    user-visible confirmation prompt and from audit argv.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    prompts: list[str] = []
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="merge",
+        argv=["Bearer", "--force"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-standalone-bearer",
+        confirm=lambda prompt: prompts.append(prompt) or False,
+        subprocess_runner=_fake_runner(),
+    )
+
+    assert result.status == "blocked"
+    assert prompts
+    assert "Action: merge Bearer --force" in prompts[0]
+    failed = next(e for e in events if e["event_type"] == "plugin.failed")
+    assert failed["command"]["argv"] == ["Bearer", "--force"]
+    assert "argv_sha256" not in failed.get("provenance", {})
 
 
 def test_subprocess_invoked_with_plugin_home_as_cwd(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #855.

## Summary

- Reuse the firewall's redacted argv when rendering the destructive-command confirmation prompt, so `--token <value>` is not echoed to terminal/session logs before the user answers.
- Extend `_redact_argv` to treat shell-tokenized `Bearer <opaque>` as one logical secret, including after secret flags such as `--authorization` and `--bearer=Bearer`.
- Preserve the existing observation-first audit shape: argv is still present, but secret-shaped values are replaced with `[redacted]` and `argv_summary` describes the redacted payload that lands in the ledger.

## Why this fits the contract

`docs/rfc/userlevel-plugins.md` says plugin argv secret handling is defense-in-depth: plugins must not accept secrets via argv, but the firewall still redacts known secret shapes before persistence. A confirmation prompt is not the ledger, yet it is still a durable output surface in tmux logs, terminal transcripts, CI captures, and screenshots. It should not be weaker than audit events.

## What this does not do

- Does not make argv a supported secret transport.
- Does not add argv truncation, spill storage, or arbitrary caps. #805 intentionally kept size policy observation-first; this PR only fixes redaction correctness.

## Test plan

- [x] `uv run pytest tests/unit/plugin/test_firewall.py tests/unit/cli/test_plugin_dispatch.py -q` — 37 passed
- [x] `uv run ruff check src/ouroboros/plugin/firewall.py tests/unit/plugin/test_firewall.py` — clean
- [x] `uv run ruff format --check src/ouroboros/plugin/firewall.py tests/unit/plugin/test_firewall.py` — clean

## Regression coverage

- `test_confirmation_prompt_uses_redacted_argv` proves destructive confirmation text no longer contains the raw token value.
- Extended `test_argv_redacts_secret_flags_and_high_confidence_tokens` proves split Bearer marker + opaque tails are redacted and do not appear anywhere in serialized audit events.
