### PR TITLE
fix(plugin): bound firewall subprocess invocation time

### DIFF
--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -50,6 +50,7 @@ from ouroboros.plugin.trust_store import TrustRecord
 from ouroboros.plugin.userlevel_registry import RegisteredProgram
 
 SCHEMA_VERSION = "0.1"
+DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS = 300.0
 
 EventSink = Callable[[dict], None]
 ConfirmFn = Callable[[str], bool]
@@ -815,6 +816,7 @@ def invoke_plugin(
     run_kwargs: dict = {
         "capture_output": True,
         "check": False,
+        "timeout": DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS,
     }
     if plugin_home is not None:
         run_kwargs["cwd"] = str(plugin_home)
@@ -839,6 +841,39 @@ def invoke_plugin(
         return InvocationResult(
             status="failed",
             exit_code=127,
+            message=message,
+            events=tuple(emitted),
+        )
+    except subprocess.TimeoutExpired as exc:
+        # A plugin command is an external process under the firewall's
+        # control boundary. Bound its lifetime the same way the Auto and
+        # Ralph runtimes bound their agent loops, and always close the
+        # audit sequence with a terminal ``plugin.failed`` event rather
+        # than leaving the caller hung indefinitely.
+        message = (
+            f"entrypoint timed out after "
+            f"{DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS:g}s: {cmd_argv[0]!r}"
+        )
+        _emit(
+            _event_envelope(
+                event_type="plugin.failed",
+                manifest=manifest,
+                namespace=namespace,
+                command_name=command_name,
+                argv=argv,
+                trust_state=trust_state,
+                result={"status": "failed", "message": message},
+                provenance={
+                    "correlation_id": correlation_id,
+                    "reason": "timeout",
+                    "exception_type": type(exc).__name__,
+                    "timeout_seconds": f"{DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS:g}",
+                },
+            )
+        )
+        return InvocationResult(
+            status="failed",
+            exit_code=124,
             message=message,
             events=tuple(emitted),
         )

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -820,6 +820,24 @@ def invoke_plugin(
     }
     if plugin_home is not None:
         run_kwargs["cwd"] = str(plugin_home)
+
+    # Coerce stdout/stderr to bytes for hashing, regardless of whether
+    # the runner returned ``bytes`` (real subprocess.run without
+    # ``text=True``) or ``str`` (test fakes that pre-decode). This also
+    # handles partial buffers attached to ``subprocess.TimeoutExpired``.
+    # ``surrogateescape`` round-trips arbitrary byte sequences through
+    # str without raising, matching how Python decodes filesystem paths.
+    def _to_bytes(value: object) -> bytes:
+        if value is None:
+            return b""
+        if isinstance(value, bytes):
+            return value
+        if isinstance(value, str):
+            return value.encode("utf-8", errors="surrogateescape")
+        # Defensive: any other type is treated as empty so we never
+        # crash on an unexpected runner return shape.
+        return b""
+
     try:
         completed = runner(cmd_argv, **run_kwargs)
     except FileNotFoundError as exc:
@@ -850,6 +868,10 @@ def invoke_plugin(
         # Ralph runtimes bound their agent loops, and always close the
         # audit sequence with a terminal ``plugin.failed`` event rather
         # than leaving the caller hung indefinitely.
+        stdout_bytes = _to_bytes(exc.stdout)
+        stderr_bytes = _to_bytes(exc.stderr)
+        stdout_hash = hashlib.sha256(stdout_bytes).hexdigest()
+        stderr_hash = hashlib.sha256(stderr_bytes).hexdigest()
         message = (
             f"entrypoint timed out after "
             f"{DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS:g}s: {cmd_argv[0]!r}"
@@ -868,6 +890,8 @@ def invoke_plugin(
                     "reason": "timeout",
                     "exception_type": type(exc).__name__,
                     "timeout_seconds": f"{DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS:g}",
+                    "stdout_sha256": stdout_hash,
+                    "stderr_sha256": stderr_hash,
                 },
             )
         )
@@ -875,6 +899,10 @@ def invoke_plugin(
             status="failed",
             exit_code=124,
             message=message,
+            stdout_sha256=stdout_hash,
+            stderr_sha256=stderr_hash,
+            stdout_bytes=stdout_bytes,
+            stderr_bytes=stderr_bytes,
             events=tuple(emitted),
         )
     except OSError as exc:
@@ -907,22 +935,6 @@ def invoke_plugin(
             message=message,
             events=tuple(emitted),
         )
-
-    # Coerce stdout/stderr to bytes for hashing, regardless of whether
-    # the runner returned ``bytes`` (real subprocess.run without
-    # ``text=True``) or ``str`` (test fakes that pre-decode).
-    # ``surrogateescape`` round-trips arbitrary byte sequences through
-    # str without raising, matching how Python decodes filesystem paths.
-    def _to_bytes(value: object) -> bytes:
-        if value is None:
-            return b""
-        if isinstance(value, bytes):
-            return value
-        if isinstance(value, str):
-            return value.encode("utf-8", errors="surrogateescape")
-        # Defensive: any other type is treated as empty so we never
-        # crash on an unexpected runner return shape.
-        return b""
 
     stdout_bytes = _to_bytes(completed.stdout)
     stderr_bytes = _to_bytes(completed.stderr)

--- a/tests/unit/evolution/test_generation_watchdog.py
+++ b/tests/unit/evolution/test_generation_watchdog.py
@@ -318,8 +318,12 @@ async def test_parent_execution_child_events_reset_idle_timeout() -> None:
 
 
 @pytest.mark.asyncio
-async def test_session_scoped_decomposition_events_reset_material_progress_timeout() -> None:
+async def test_session_scoped_decomposition_events_reset_material_progress_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Decomposition level progress is stored as execution events keyed by session ID."""
+    clock = _FakeMonotonicClock()
+    monkeypatch.setattr(watchdog_module, "time", SimpleNamespace(monotonic=clock))
     event_store = await _store()
     session_id = "session-levels"
     execution_id = "exec-levels"
@@ -333,6 +337,7 @@ async def test_session_scoped_decomposition_events_reset_material_progress_timeo
     async def decomposition_work() -> str:
         await event_store.append(_session_started(session_id, execution_id))
         await asyncio.sleep(0.04)
+        clock.advance(0.04)
         await event_store.append(
             _decomposition_level_event(
                 session_id,
@@ -341,6 +346,7 @@ async def test_session_scoped_decomposition_events_reset_material_progress_timeo
             )
         )
         await asyncio.sleep(0.04)
+        clock.advance(0.04)
         await event_store.append(
             _decomposition_level_event(
                 session_id,
@@ -349,6 +355,7 @@ async def test_session_scoped_decomposition_events_reset_material_progress_timeo
             )
         )
         await asyncio.sleep(0.04)
+        clock.advance(0.04)
         return "done"
 
     assert await watchdog.watch(decomposition_work()) == "done"

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -9,6 +9,7 @@ import subprocess
 import pytest
 
 from ouroboros.plugin.firewall import (
+    DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS,
     invoke_plugin,
 )
 from ouroboros.plugin.manifest import load_manifest
@@ -1163,3 +1164,72 @@ def test_entrypoint_missing_emits_failed_127(tmp_path: Path) -> None:
     types = [e["event_type"] for e in events]
     assert types == ["plugin.invoked", "plugin.permission_used", "plugin.failed"]
     assert "not found" in result.message.lower()
+
+
+def test_subprocess_invocation_uses_default_timeout(tmp_path: Path) -> None:
+    """The firewall owns the external plugin process boundary, so the
+    subprocess launch must always carry a finite timeout."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    observed_kwargs: dict = {}
+
+    def _spy_runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:  # noqa: ARG001
+        observed_kwargs.update(kwargs)
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="ok", stderr="")
+
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=lambda _event: None,
+        correlation_id="corr-timeout-kw",
+        subprocess_runner=_spy_runner,
+    )
+
+    assert result.status == "success"
+    assert observed_kwargs["timeout"] == DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS
+
+
+def test_subprocess_timeout_emits_terminal_failed_event(tmp_path: Path) -> None:
+    """TimeoutExpired must not escape the firewall or leave the audit
+    sequence without a terminal plugin.failed event."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+
+    def _timeout_runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:  # noqa: ARG001
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs["timeout"])
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-timeout",
+        subprocess_runner=_timeout_runner,
+    )
+
+    assert result.status == "failed"
+    assert result.exit_code == 124
+    assert "timed out" in result.message
+    assert [event["event_type"] for event in events] == [
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.failed",
+    ]
+    failed = events[-1]
+    assert failed["result"]["status"] == "failed"
+    assert failed["provenance"]["reason"] == "timeout"
+    assert failed["provenance"]["exception_type"] == "TimeoutExpired"

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 import subprocess
@@ -1233,3 +1234,63 @@ def test_subprocess_timeout_emits_terminal_failed_event(tmp_path: Path) -> None:
     assert failed["result"]["status"] == "failed"
     assert failed["provenance"]["reason"] == "timeout"
     assert failed["provenance"]["exception_type"] == "TimeoutExpired"
+
+
+def test_subprocess_timeout_preserves_partial_output_hashes_only_in_events(
+    tmp_path: Path,
+) -> None:
+    """TimeoutExpired may carry partial stdout/stderr buffers. The
+    firewall must return those bytes to in-process callers and put only
+    their hashes in the terminal audit event."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    partial_stdout = b"partial stdout before timeout\n"
+    partial_stderr = b"partial stderr before timeout\n"
+
+    def _timeout_runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:  # noqa: ARG001
+        raise subprocess.TimeoutExpired(
+            cmd=argv,
+            timeout=kwargs["timeout"],
+            output=partial_stdout,
+            stderr=partial_stderr,
+        )
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["url"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-timeout-partial",
+        subprocess_runner=_timeout_runner,
+    )
+
+    expected_stdout_hash = hashlib.sha256(partial_stdout).hexdigest()
+    expected_stderr_hash = hashlib.sha256(partial_stderr).hexdigest()
+    assert result.status == "failed"
+    assert result.exit_code == 124
+    assert result.stdout_bytes == partial_stdout
+    assert result.stderr_bytes == partial_stderr
+    assert result.stdout_sha256 == expected_stdout_hash
+    assert result.stderr_sha256 == expected_stderr_hash
+
+    assert [event["event_type"] for event in events] == [
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.failed",
+    ]
+    failed = events[-1]
+    assert failed["result"]["status"] == "failed"
+    assert failed["provenance"]["reason"] == "timeout"
+    assert failed["provenance"]["stdout_sha256"] == expected_stdout_hash
+    assert failed["provenance"]["stderr_sha256"] == expected_stderr_hash
+
+    serialized = json.dumps(events)
+    assert "partial stdout before timeout" not in serialized
+    assert "partial stderr before timeout" not in serialized


### PR DESCRIPTION
Closes #856.

## Summary

- Add `DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS = 300.0` at the plugin firewall boundary.
- Pass that finite timeout into the plugin entrypoint `subprocess.run(...)` call.
- Catch `subprocess.TimeoutExpired` and close the audit sequence with a terminal `plugin.failed` event carrying timeout provenance instead of letting the CLI hang indefinitely.

## Why this fits the current direction

Recent runtime work consistently makes external/agent execution bounded and observable:

- #784: per-iteration Ralph timeout
- #789: total Ralph wall-clock budget
- #790: AutoPipeline top-level deadline
- #578: broader RuntimeControls watchdog umbrella

Plugin entrypoints are also external processes under a runtime boundary. The firewall already fail-closes trust and digest drift; subprocess lifetime should have the same bounded-control shape.

## Scope boundary

This PR intentionally handles timeout only. It does not add stdout/stderr truncation caps. #801 showed that unmeasured caps can hide audit evidence, and #805 moved argv sizing toward observation-first metadata. Output streaming/hash caps may be useful later, but they should be measurement-backed and reviewed separately.

## Test plan

- [x] `uv run pytest tests/unit/plugin/test_firewall.py tests/unit/cli/test_plugin_dispatch.py -q` — 38 passed
- [x] `uv run ruff check src/ouroboros/plugin/firewall.py tests/unit/plugin/test_firewall.py` — clean
- [x] `uv run ruff format --check src/ouroboros/plugin/firewall.py tests/unit/plugin/test_firewall.py` — clean

## Regression coverage

- `test_subprocess_invocation_uses_default_timeout` proves every plugin subprocess launch receives a finite timeout.
- `test_subprocess_timeout_emits_terminal_failed_event` proves timeout produces `plugin.invoked → plugin.permission_used → plugin.failed` with timeout provenance and exit code 124.
