### PR TITLE
fix(copilot): keep tool events from replacing provider completions

### DIFF
--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -359,6 +359,11 @@ class CopilotCliLLMAdapter:
                 return value.strip()
         return None
 
+    @staticmethod
+    def _is_completion_content_event(event: dict[str, Any]) -> bool:
+        event_type = event.get("type")
+        return event_type in {"agent.message", "message"}
+
     def _emit_callback_for_event(self, event: dict[str, Any]) -> None:
         if self._on_message is None:
             return
@@ -494,9 +499,10 @@ class CopilotCliLLMAdapter:
             if extracted:
                 session_id = extracted
             self._emit_callback_for_event(event)
-            event_content = self._extract_text(event)
-            if event_content:
-                last_content = event_content
+            if self._is_completion_content_event(event):
+                event_content = self._extract_text(event)
+                if event_content:
+                    last_content = event_content
 
         return stdout_lines, stderr_lines, session_id, last_content
 
@@ -655,9 +661,10 @@ class CopilotCliLLMAdapter:
                     session_id = event_session_id
 
                 self._emit_callback_for_event(event)
-                event_content = self._extract_text(event)
-                if event_content:
-                    last_content = event_content
+                if self._is_completion_content_event(event):
+                    event_content = self._extract_text(event)
+                    if event_content:
+                        last_content = event_content
 
         stdout_task = asyncio.create_task(_read_stdout())
 

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -553,3 +553,33 @@ class TestComplete:
         assert result.is_err
         assert "nesting depth" in result.error.message
         assert spawn_calls == 0
+
+
+class TestRegressionToolEventDoesNotReplaceAssistantContent:
+    @pytest.mark.asyncio
+    async def test_tool_event_after_assistant_does_not_become_completion_content(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-reg"}),
+                json.dumps(
+                    {"type": "agent.message", "message": {"text": "Final assistant answer."}}
+                ),
+                json.dumps({"type": "tool_use", "name": "shell", "command": "cat ~/.ssh/id_rsa"}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Please answer")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_ok
+        assert result.value.content == "Final assistant answer."


### PR DESCRIPTION
Closes #859.

## Summary

Fixes Copilot provider completion extraction so trailing tool events cannot replace the assistant answer.

`CopilotCliLLMAdapter` reads Copilot JSONL output where assistant messages and tool events share the same stdout stream. Before this PR, both the streaming and legacy collection paths updated `last_content` from every parseable event. That meant a later `tool_use` event could become `CompletionResponse.content` even after a valid `agent.message` had already arrived.

## Root cause

The provider had one generic `_extract_text(event)` path and used it for completion content regardless of event type. `_emit_callback_for_event()` already treats `tool_use` / `tool.start` / `tool_call` as tool-callback data, but the same event could still overwrite `last_content` immediately afterwards.

That crosses the intended boundary:

- assistant/message events define completion content;
- tool events remain observable through callbacks/audit surfaces;
- tool event payloads should not become the returned LLM answer.

## What changed

- Add `_is_completion_content_event()` for Copilot provider JSONL events.
- Update `last_content` only for `agent.message` / `message` events in both collection paths.
- Preserve existing callback behavior for reasoning and tool events.
- Add a regression test where `agent.message` is followed by `tool_use`; the completion must remain the assistant answer.

## Why this scope

This keeps the fix provider-local and per-site, matching recent merged PR patterns:

- #647 made Copilot JSONL handling preserve actual assistant output on the runtime side.
- #770 and #786 fixed tool-envelope/single-shot regressions with narrow, test-locked changes rather than broad policy rewrites.

I intentionally did not change process IO, callback emission, or model/tool envelope construction.

## Reproduction locked by test

The new regression test feeds this stdout sequence:

1. `session.started` with `sess-reg`
2. `agent.message` with `Final assistant answer.`
3. `tool_use` with `command = "cat ~/.ssh/id_rsa"`

Before the fix, the test fails with:

```text
AssertionError: assert 'cat ~/.ssh/id_rsa' == 'Final assistant answer.'
```

After the fix, the provider returns `Final assistant answer.`.

## Duplicate check

Before opening this PR, I checked current open issues/PRs for Copilot/provider/tool-use/JSONL terms. The only related open items were #831, #834, and #837, which are about Claude/interview MCP response-shape hangs and diagnostics. They are related in theme but do not cover Copilot provider completion extraction.

## Validation

- `uv run pytest tests/unit/providers/test_copilot_cli_adapter.py -q`
- `uv run ruff check src/ouroboros/providers/copilot_cli_adapter.py tests/unit/providers/test_copilot_cli_adapter.py`
- `uv run ruff format --check src/ouroboros/providers/copilot_cli_adapter.py tests/unit/providers/test_copilot_cli_adapter.py`

## Not tested

- Live Copilot CLI invocation against GitHub service.
