### PR TITLE
fix(security): contain auto Seed persistence paths

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+import re
 from typing import Any
 
 import yaml
@@ -21,6 +22,8 @@ from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import MCPToolResult
 from ouroboros.resilience.lateral import ThinkingPersona
+
+_SAFE_SEED_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 class HandlerError(RuntimeError):
@@ -596,12 +599,32 @@ def save_seed(seed: Seed, *, seeds_dir: Path | None = None) -> str:
     """Persist an auto-generated Seed in the standard seed directory."""
     directory = seeds_dir or (Path.home() / ".ouroboros" / "seeds")
     directory.mkdir(parents=True, exist_ok=True)
-    path = directory / f"{seed.metadata.seed_id}.yaml"
+    seed_id = _safe_seed_id_for_filename(seed.metadata.seed_id)
+    path = directory / f"{seed_id}.yaml"
+    _require_path_inside_directory(path, directory)
     path.write_text(
         yaml.dump(seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False),
         encoding="utf-8",
     )
     return str(path)
+
+
+def _safe_seed_id_for_filename(seed_id: str) -> str:
+    """Return a seed id that is safe to interpolate into a filename."""
+    candidate = seed_id.strip()
+    if not candidate or not _SAFE_SEED_ID_PATTERN.fullmatch(candidate):
+        msg = f"Seed id is not safe for persistence filename: {seed_id!r}"
+        raise HandlerError(msg)
+    return candidate
+
+
+def _require_path_inside_directory(path: Path, directory: Path) -> None:
+    """Fail closed if a computed seed path escapes the seed directory."""
+    resolved_directory = directory.resolve()
+    resolved_path = path.resolve()
+    if resolved_path.parent != resolved_directory:
+        msg = f"Seed path escapes seed directory: {resolved_path}"
+        raise HandlerError(msg)
 
 
 def _turn_from_result(

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -6,7 +6,6 @@ import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-import re
 from typing import Any
 
 import yaml
@@ -23,7 +22,14 @@ from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.types import MCPToolResult
 from ouroboros.resilience.lateral import ThinkingPersona
 
-_SAFE_SEED_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_SAFE_SEED_ID_FILENAME_CHARS = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
+)
+_WINDOWS_RESERVED_FILENAME_STEMS = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{index}" for index in range(1, 10)}
+    | {f"LPT{index}" for index in range(1, 10)}
+)
 
 
 class HandlerError(RuntimeError):
@@ -610,12 +616,26 @@ def save_seed(seed: Seed, *, seeds_dir: Path | None = None) -> str:
 
 
 def _safe_seed_id_for_filename(seed_id: str) -> str:
-    """Return a seed id that is safe to interpolate into a filename."""
-    candidate = seed_id.strip()
-    if not candidate or not _SAFE_SEED_ID_PATTERN.fullmatch(candidate):
-        msg = f"Seed id is not safe for persistence filename: {seed_id!r}"
-        raise HandlerError(msg)
-    return candidate
+    """Return a filesystem-safe filename stem for a Seed id.
+
+    Seed ids are semantic identifiers, not a filesystem trust boundary.  Keep
+    common generated ids readable, but percent-encode every other UTF-8 byte so
+    traversal separators, whitespace, dots, and path-sensitive characters cannot
+    become path syntax while the persisted Seed metadata remains intact.
+    """
+    if seed_id == "":
+        return "%EMPTY%"
+    parts: list[str] = []
+    for char in seed_id:
+        if char in _SAFE_SEED_ID_FILENAME_CHARS:
+            parts.append(char)
+        else:
+            parts.extend(f"%{byte:02X}" for byte in char.encode("utf-8"))
+    stem = "".join(parts)
+    if stem.upper() in _WINDOWS_RESERVED_FILENAME_STEMS:
+        first_byte = stem[0].encode("utf-8")[0]
+        stem = f"%{first_byte:02X}{stem[1:]}"
+    return stem
 
 
 def _require_path_inside_directory(path: Path, directory: Path) -> None:

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1958,3 +1958,37 @@ async def test_auto_handler_meta_always_emits_provenance_keys_when_empty(monkeyp
     assert meta["ledger_provenance"] == {}
     assert meta["evidence_backed_sections"] == []
     assert meta["assumption_only_sections"] == []
+
+
+def test_auto_save_seed_rejects_path_traversal_seed_id(tmp_path: Path) -> None:
+    from ouroboros.auto.adapters import HandlerError, save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    seed = Seed(
+        goal="Demo goal",
+        ontology_schema=OntologySchema(name="demo", description="demo ontology"),
+        metadata=SeedMetadata(seed_id="../outside"),
+    )
+
+    with pytest.raises(HandlerError, match="not safe"):
+        save_seed(seed, seeds_dir=seeds_dir)
+
+    assert not (tmp_path / "outside.yaml").exists()
+
+
+def test_auto_save_seed_accepts_default_seed_id_inside_seed_dir(tmp_path: Path) -> None:
+    from ouroboros.auto.adapters import save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    seed = Seed(
+        goal="Demo goal",
+        ontology_schema=OntologySchema(name="demo", description="demo ontology"),
+        metadata=SeedMetadata(seed_id="seed_safe_123"),
+    )
+
+    path = Path(save_seed(seed, seeds_dir=seeds_dir)).resolve()
+
+    assert path == (seeds_dir / "seed_safe_123.yaml").resolve()
+    assert path.exists()

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1960,8 +1960,10 @@ async def test_auto_handler_meta_always_emits_provenance_keys_when_empty(monkeyp
     assert meta["assumption_only_sections"] == []
 
 
-def test_auto_save_seed_rejects_path_traversal_seed_id(tmp_path: Path) -> None:
-    from ouroboros.auto.adapters import HandlerError, save_seed
+def test_auto_save_seed_encodes_path_traversal_seed_id_inside_seed_dir(
+    tmp_path: Path,
+) -> None:
+    from ouroboros.auto.adapters import load_seed, save_seed
     from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 
     seeds_dir = tmp_path / "seeds"
@@ -1971,14 +1973,78 @@ def test_auto_save_seed_rejects_path_traversal_seed_id(tmp_path: Path) -> None:
         metadata=SeedMetadata(seed_id="../outside"),
     )
 
-    with pytest.raises(HandlerError, match="not safe"):
-        save_seed(seed, seeds_dir=seeds_dir)
+    path = Path(save_seed(seed, seeds_dir=seeds_dir)).resolve()
 
+    assert path == (seeds_dir / "%2E%2E%2Foutside.yaml").resolve()
+    assert path.exists()
     assert not (tmp_path / "outside.yaml").exists()
+    assert load_seed(path).metadata.seed_id == "../outside"
+
+
+def test_auto_save_seed_encodes_whitespace_padded_seed_id_without_metadata_drift(
+    tmp_path: Path,
+) -> None:
+    from ouroboros.auto.adapters import load_seed, save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    seed = Seed(
+        goal="Demo goal",
+        ontology_schema=OntologySchema(name="demo", description="demo ontology"),
+        metadata=SeedMetadata(seed_id="seed_safe_123 "),
+    )
+
+    path = Path(save_seed(seed, seeds_dir=seeds_dir)).resolve()
+
+    assert path == (seeds_dir / "seed_safe_123%20.yaml").resolve()
+    assert path.exists()
+    assert not (seeds_dir / "seed_safe_123.yaml").exists()
+    assert load_seed(path).metadata.seed_id == "seed_safe_123 "
+
+
+def test_auto_save_seed_encodes_previously_accepted_punctuation_seed_id(
+    tmp_path: Path,
+) -> None:
+    from ouroboros.auto.adapters import load_seed, save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    seed = Seed(
+        goal="Demo goal",
+        ontology_schema=OntologySchema(name="demo", description="demo ontology"),
+        metadata=SeedMetadata(seed_id="seed.v1"),
+    )
+
+    path = Path(save_seed(seed, seeds_dir=seeds_dir)).resolve()
+
+    assert path == (seeds_dir / "seed%2Ev1.yaml").resolve()
+    assert path.exists()
+    assert load_seed(path).metadata.seed_id == "seed.v1"
+
+
+def test_auto_save_seed_encodes_windows_reserved_basename_seed_id(
+    tmp_path: Path,
+) -> None:
+    from ouroboros.auto.adapters import load_seed, save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    seed = Seed(
+        goal="Demo goal",
+        ontology_schema=OntologySchema(name="demo", description="demo ontology"),
+        metadata=SeedMetadata(seed_id="CON"),
+    )
+
+    path = Path(save_seed(seed, seeds_dir=seeds_dir)).resolve()
+
+    assert path == (seeds_dir / "%43ON.yaml").resolve()
+    assert path.exists()
+    assert not (seeds_dir / "CON.yaml").exists()
+    assert load_seed(path).metadata.seed_id == "CON"
 
 
 def test_auto_save_seed_accepts_default_seed_id_inside_seed_dir(tmp_path: Path) -> None:
-    from ouroboros.auto.adapters import save_seed
+    from ouroboros.auto.adapters import load_seed, save_seed
     from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 
     seeds_dir = tmp_path / "seeds"
@@ -1992,3 +2058,4 @@ def test_auto_save_seed_accepts_default_seed_id_inside_seed_dir(tmp_path: Path) 
 
     assert path == (seeds_dir / "seed_safe_123.yaml").resolve()
     assert path.exists()
+    assert load_seed(path).metadata.seed_id == "seed_safe_123"


### PR DESCRIPTION
## Summary

Fixes #861.

`ooo auto` saves generated Seeds under `~/.ouroboros/seeds`, but the filename was derived directly from `seed.metadata.seed_id`. Since generated/imported Seed metadata is not a filesystem trust boundary, this PR now separates the semantic Seed ID from the filesystem filename: the persisted YAML keeps the original `metadata.seed_id`, while the filename stem percent-encodes path-sensitive bytes before writing.

## Why this shape

Recent security fixes in this repo are narrow, boundary-focused, and regression-tested:

- #413 sanitized `CheckpointStore` seed IDs and enforced containment.
- #631 enforced containment for seed-encoded project paths.
- Recent plugin/firewall changes fail closed when trust inputs are malformed.

This PR applies the same boundary policy to the auto Seed persistence surface without changing the Seed schema or narrowing the existing `SeedMetadata.seed_id` contract.

## Changes

- Encode unsafe Seed ID bytes for the YAML filename instead of interpolating raw metadata into a path.
- Preserve the original semantic `metadata.seed_id` in the persisted YAML.
- Verify the resolved output path stays directly under the Seed directory before writing.
- Add regression coverage for traversal encoding, whitespace/metadata consistency, punctuation compatibility, Windows reserved basename handling, and normal generated Seed persistence.

## Verification

- `uv run pytest -q tests/unit/auto/test_surface.py::test_auto_save_seed_encodes_path_traversal_seed_id_inside_seed_dir tests/unit/auto/test_surface.py::test_auto_save_seed_encodes_whitespace_padded_seed_id_without_metadata_drift tests/unit/auto/test_surface.py::test_auto_save_seed_encodes_previously_accepted_punctuation_seed_id tests/unit/auto/test_surface.py::test_auto_save_seed_encodes_windows_reserved_basename_seed_id tests/unit/auto/test_surface.py::test_auto_save_seed_accepts_default_seed_id_inside_seed_dir`
- `uv run pytest -q tests/unit/auto/test_surface.py tests/unit/auto/test_interview_pipeline.py`
- `uv run pytest -q tests/unit/auto tests/unit/mcp/tools/test_definitions.py`
- `uv run ruff check src/ouroboros/auto/adapters.py tests/unit/auto/test_surface.py`
- `uv run ruff format --check src/ouroboros/auto/adapters.py tests/unit/auto/test_surface.py`
