### PR TITLE
fix(security): redact secret-shaped event resource payloads

### DIFF
--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 import structlog
@@ -23,6 +24,31 @@ from ouroboros.orchestrator.session import SessionRepository, SessionTracker
 from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
+
+_REDACTED = "[redacted]"
+_SECRET_FIELD_NAMES = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "auth_token",
+        "authorization",
+        "bearer_token",
+        "client_secret",
+        "credential",
+        "credentials",
+        "password",
+        "private_key",
+        "secret",
+        "token",
+    }
+)
+_SECRET_FLAG_PATTERN = re.compile(
+    r"(?i)(--(?:api[-_]?key|token|password|secret|private[-_]?key)(?:=|\s+))([^\s,;]+)"
+)
+_BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
+_HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(
+    r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9][A-Za-z0-9_-]{8,}|AKIA[0-9A-Z]{16})\b"
+)
 
 
 @dataclass
@@ -463,10 +489,41 @@ def _event_to_dict(event: Any) -> dict[str, Any]:
         "timestamp": event.timestamp.isoformat() if event.timestamp else None,
         "aggregate_type": event.aggregate_type,
         "aggregate_id": event.aggregate_id,
-        "data": event.data,
+        "data": _redact_event_resource_value(event.data),
         "consensus_id": event.consensus_id,
         "event_version": event.event_version,
     }
+
+
+def _redact_event_resource_value(value: Any, *, key: str | None = None) -> Any:
+    """Project event data through a conservative MCP-resource redaction layer."""
+    if _is_secret_field_name(key):
+        return _REDACTED
+    if isinstance(value, dict):
+        return {
+            item_key: _redact_event_resource_value(item, key=str(item_key))
+            for item_key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_event_resource_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_event_resource_value(item) for item in value]
+    if isinstance(value, str):
+        return _redact_secret_shaped_text(value)
+    return value
+
+
+def _is_secret_field_name(key: str | None) -> bool:
+    if key is None:
+        return False
+    normalized = key.strip().lower().replace("-", "_")
+    return normalized in _SECRET_FIELD_NAMES or normalized.endswith(("_api_key", "_secret"))
+
+
+def _redact_secret_shaped_text(value: str) -> str:
+    redacted = _SECRET_FLAG_PATTERN.sub(lambda match: f"{match.group(1)}{_REDACTED}", value)
+    redacted = _BEARER_PATTERN.sub(f"Bearer {_REDACTED}", redacted)
+    return _HIGH_CONFIDENCE_SECRET_PATTERN.sub(_REDACTED, redacted)
 
 
 def _timestamp_to_string(value: object) -> str:

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -523,7 +523,7 @@ def _redact_event_resource_value(value: Any, *, key: str | None = None) -> Any:
 def _is_secret_field_name(key: str | None) -> bool:
     if key is None:
         return False
-    normalized = key.strip().lower().replace("-", "_")
+    normalized = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key.strip()).lower().replace("-", "_")
     field_parts = tuple(filter(None, normalized.split("_")))
     secret_terminal_parts = {
         "credential",

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -54,6 +54,20 @@ _SECRET_FLAG_PATTERN = re.compile(
     r")(?:=|\s+))"
     r"(\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|[^\s,;]+)"
 )
+_SECRET_LABEL_PATTERN = re.compile(
+    r"(?i)(\b(?:"
+    r"api[-_]?key"
+    r"|(?:access|auth|bearer|github|gh|refresh)[-_]?token"
+    r"|token"
+    r"|password"
+    r"|(?:client[-_]?)?secret"
+    r"|credentials?"
+    r"|private[-_]?key"
+    r"|(?:aws[-_])?secret[-_]access[-_]key"
+    r"|authorization"
+    r")\b\s*[:=]\s*)"
+    r"(\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|[^,;\n]+)"
+)
 _BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
 _HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(
     r"\b(?:"
@@ -546,12 +560,17 @@ def _is_secret_field_name(key: str | None) -> bool:
         normalized in _SECRET_FIELD_NAMES
         or normalized.endswith(("_api_key", "_private_key"))
         or (bool(field_parts) and field_parts[-1] in secret_terminal_parts)
-        or (bool(field_parts) and field_parts[-1] == "key" and bool(set(field_parts) & secret_key_context_parts))
+        or (
+            bool(field_parts)
+            and field_parts[-1] == "key"
+            and bool(set(field_parts) & secret_key_context_parts)
+        )
     )
 
 
 def _redact_secret_shaped_text(value: str) -> str:
     redacted = _SECRET_FLAG_PATTERN.sub(lambda match: f"{match.group(1)}{_REDACTED}", value)
+    redacted = _SECRET_LABEL_PATTERN.sub(lambda match: f"{match.group(1)}{_REDACTED}", redacted)
     redacted = _BEARER_PATTERN.sub(f"Bearer {_REDACTED}", redacted)
     return _HIGH_CONFIDENCE_SECRET_PATTERN.sub(_REDACTED, redacted)
 

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -528,13 +528,14 @@ def _is_secret_field_name(key: str | None) -> bool:
     secret_terminal_parts = {
         "credential",
         "credentials",
-        "key",
         "password",
         "secret",
         "token",
     }
-    return normalized in _SECRET_FIELD_NAMES or (
-        bool(field_parts) and field_parts[-1] in secret_terminal_parts
+    return (
+        normalized in _SECRET_FIELD_NAMES
+        or normalized.endswith(("_api_key", "_private_key"))
+        or (bool(field_parts) and field_parts[-1] in secret_terminal_parts)
     )
 
 

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -43,7 +43,8 @@ _SECRET_FIELD_NAMES = frozenset(
     }
 )
 _SECRET_FLAG_PATTERN = re.compile(
-    r"(?i)(--(?:api[-_]?key|token|password|secret|private[-_]?key)(?:=|\s+))([^\s,;]+)"
+    r"(?i)(--(?:api[-_]?key|token|password|secret|private[-_]?key)(?:=|\s+))"
+    r"(\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|[^\s,;]+)"
 )
 _BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
 _HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -43,7 +43,15 @@ _SECRET_FIELD_NAMES = frozenset(
     }
 )
 _SECRET_FLAG_PATTERN = re.compile(
-    r"(?i)(--(?:api[-_]?key|token|password|secret|private[-_]?key)(?:=|\s+))"
+    r"(?i)(--(?:"
+    r"api[-_]?key"
+    r"|(?:access|auth|bearer|github|gh|refresh)[-_]?token"
+    r"|token"
+    r"|password"
+    r"|(?:client[-_]?)?secret"
+    r"|credentials?"
+    r"|private[-_]?key"
+    r")(?:=|\s+))"
     r"(\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|[^\s,;]+)"
 )
 _BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -534,16 +534,19 @@ def _is_secret_field_name(key: str | None) -> bool:
     normalized = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key.strip()).lower().replace("-", "_")
     field_parts = tuple(filter(None, normalized.split("_")))
     secret_terminal_parts = {
+        "authorization",
         "credential",
         "credentials",
         "password",
         "secret",
         "token",
     }
+    secret_key_context_parts = {"access", "api", "private", "secret"}
     return (
         normalized in _SECRET_FIELD_NAMES
         or normalized.endswith(("_api_key", "_private_key"))
         or (bool(field_parts) and field_parts[-1] in secret_terminal_parts)
+        or (bool(field_parts) and field_parts[-1] == "key" and bool(set(field_parts) & secret_key_context_parts))
     )
 
 

--- a/src/ouroboros/mcp/resources/handlers.py
+++ b/src/ouroboros/mcp/resources/handlers.py
@@ -48,7 +48,13 @@ _SECRET_FLAG_PATTERN = re.compile(
 )
 _BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
 _HIGH_CONFIDENCE_SECRET_PATTERN = re.compile(
-    r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9][A-Za-z0-9_-]{8,}|AKIA[0-9A-Z]{16})\b"
+    r"\b(?:"
+    r"gh[pousr]_[A-Za-z0-9_]{20,}"
+    r"|sk-[A-Za-z0-9][A-Za-z0-9_-]{8,}"
+    r"|AIza[A-Za-z0-9_-]{35}"
+    r"|AKIA[0-9A-Z]{16}"
+    r"|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
+    r")\b"
 )
 
 
@@ -518,7 +524,18 @@ def _is_secret_field_name(key: str | None) -> bool:
     if key is None:
         return False
     normalized = key.strip().lower().replace("-", "_")
-    return normalized in _SECRET_FIELD_NAMES or normalized.endswith(("_api_key", "_secret"))
+    field_parts = tuple(filter(None, normalized.split("_")))
+    secret_terminal_parts = {
+        "credential",
+        "credentials",
+        "key",
+        "password",
+        "secret",
+        "token",
+    }
+    return normalized in _SECRET_FIELD_NAMES or (
+        bool(field_parts) and field_parts[-1] in secret_terminal_parts
+    )
 
 
 def _redact_secret_shaped_text(value: str) -> str:

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -446,6 +446,7 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
                 "quoted_password_preview": 'command: login --password "correct horse battery staple"',
                 "quoted_secret_preview": "command: run --secret 'multi word value'",
                 "client_secret_preview": "command: deploy --client-secret supersecret-value",
+                "label_preview": "api_key: my-test-secret, password: hunter2, authorization: Token abc123",
                 "access_token": "opaque-access-token-value",
                 "refresh_token": "opaque-refresh-token-value",
                 "github_token": "opaque-github-token-value",
@@ -473,6 +474,9 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert "sk-live-SECRET123" not in text
     assert "multi word value" not in text
     assert "supersecret-value" not in text
+    assert "my-test-secret" not in text
+    assert "hunter2" not in text
+    assert "Token abc123" not in text
     assert "opaque-access-token-value" not in text
     assert "opaque-refresh-token-value" not in text
     assert "opaque-github-token-value" not in text
@@ -493,6 +497,10 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert data["quoted_password_preview"] == "command: login --password [redacted]"
     assert data["quoted_secret_preview"] == "command: run --secret [redacted]"
     assert data["client_secret_preview"] == "command: deploy --client-secret [redacted]"
+    assert (
+        data["label_preview"]
+        == "api_key: [redacted], password: [redacted], authorization: [redacted]"
+    )
     assert data["access_token"] == "[redacted]"
     assert data["refresh_token"] == "[redacted]"
     assert data["github_token"] == "[redacted]"

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -449,6 +449,9 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
                 "refresh_token": "opaque-refresh-token-value",
                 "github_token": "opaque-github-token-value",
                 "db_password": "opaque-db-password-value",
+                "accessToken": "opaque-camel-access-token-value",
+                "clientSecret": "opaque-camel-client-secret-value",
+                "privateKey": "opaque-camel-private-key-value",
                 "google_preview": "key=AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "idempotency_key": "event-correlation-key-123",
                 "safe_count": 3,
@@ -469,6 +472,9 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert "opaque-refresh-token-value" not in text
     assert "opaque-github-token-value" not in text
     assert "opaque-db-password-value" not in text
+    assert "opaque-camel-access-token-value" not in text
+    assert "opaque-camel-client-secret-value" not in text
+    assert "opaque-camel-private-key-value" not in text
     assert "AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" not in text
 
     payload = json.loads(text)
@@ -482,6 +488,9 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert data["refresh_token"] == "[redacted]"
     assert data["github_token"] == "[redacted]"
     assert data["db_password"] == "[redacted]"
+    assert data["accessToken"] == "[redacted]"
+    assert data["clientSecret"] == "[redacted]"
+    assert data["privateKey"] == "[redacted]"
     assert data["google_preview"] == "key=[redacted]"
     assert data["idempotency_key"] == "event-correlation-key-123"
     assert data["safe_count"] == 3

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -453,6 +453,9 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
                 "accessToken": "opaque-camel-access-token-value",
                 "clientSecret": "opaque-camel-client-secret-value",
                 "privateKey": "opaque-camel-private-key-value",
+                "aws_secret_access_key": "opaque-aws-secret-access-key-value",
+                "secret_access_key": "opaque-secret-access-key-value",
+                "request_authorization": "opaque-request-authorization-value",
                 "google_preview": "key=AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "idempotency_key": "event-correlation-key-123",
                 "safe_count": 3,
@@ -477,6 +480,9 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert "opaque-camel-access-token-value" not in text
     assert "opaque-camel-client-secret-value" not in text
     assert "opaque-camel-private-key-value" not in text
+    assert "opaque-aws-secret-access-key-value" not in text
+    assert "opaque-secret-access-key-value" not in text
+    assert "opaque-request-authorization-value" not in text
     assert "AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" not in text
 
     payload = json.loads(text)
@@ -494,6 +500,9 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert data["accessToken"] == "[redacted]"
     assert data["clientSecret"] == "[redacted]"
     assert data["privateKey"] == "[redacted]"
+    assert data["aws_secret_access_key"] == "[redacted]"
+    assert data["secret_access_key"] == "[redacted]"
+    assert data["request_authorization"] == "[redacted]"
     assert data["google_preview"] == "key=[redacted]"
     assert data["idempotency_key"] == "event-correlation-key-123"
     assert data["safe_count"] == 3

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -445,6 +445,11 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
                 "tool_input_preview": "command: deploy --api-key sk-live-SECRET123",
                 "quoted_password_preview": 'command: login --password "correct horse battery staple"',
                 "quoted_secret_preview": "command: run --secret 'multi word value'",
+                "access_token": "opaque-access-token-value",
+                "refresh_token": "opaque-refresh-token-value",
+                "github_token": "opaque-github-token-value",
+                "db_password": "opaque-db-password-value",
+                "google_preview": "key=AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "safe_count": 3,
             },
         )
@@ -459,6 +464,11 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert "correct horse battery staple" not in text
     assert "sk-live-SECRET123" not in text
     assert "multi word value" not in text
+    assert "opaque-access-token-value" not in text
+    assert "opaque-refresh-token-value" not in text
+    assert "opaque-github-token-value" not in text
+    assert "opaque-db-password-value" not in text
+    assert "AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" not in text
 
     payload = json.loads(text)
     data = payload["events"][0]["data"]
@@ -467,6 +477,11 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert data["tool_input_preview"] == "command: deploy --api-key [redacted]"
     assert data["quoted_password_preview"] == "command: login --password [redacted]"
     assert data["quoted_secret_preview"] == "command: run --secret [redacted]"
+    assert data["access_token"] == "[redacted]"
+    assert data["refresh_token"] == "[redacted]"
+    assert data["github_token"] == "[redacted]"
+    assert data["db_password"] == "[redacted]"
+    assert data["google_preview"] == "key=[redacted]"
     assert data["safe_count"] == 3
 
     await store.close()

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -445,6 +445,7 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
                 "tool_input_preview": "command: deploy --api-key sk-live-SECRET123",
                 "quoted_password_preview": 'command: login --password "correct horse battery staple"',
                 "quoted_secret_preview": "command: run --secret 'multi word value'",
+                "client_secret_preview": "command: deploy --client-secret supersecret-value",
                 "access_token": "opaque-access-token-value",
                 "refresh_token": "opaque-refresh-token-value",
                 "github_token": "opaque-github-token-value",
@@ -468,6 +469,7 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert "correct horse battery staple" not in text
     assert "sk-live-SECRET123" not in text
     assert "multi word value" not in text
+    assert "supersecret-value" not in text
     assert "opaque-access-token-value" not in text
     assert "opaque-refresh-token-value" not in text
     assert "opaque-github-token-value" not in text
@@ -484,6 +486,7 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert data["tool_input_preview"] == "command: deploy --api-key [redacted]"
     assert data["quoted_password_preview"] == "command: login --password [redacted]"
     assert data["quoted_secret_preview"] == "command: run --secret [redacted]"
+    assert data["client_secret_preview"] == "command: deploy --client-secret [redacted]"
     assert data["access_token"] == "[redacted]"
     assert data["refresh_token"] == "[redacted]"
     assert data["github_token"] == "[redacted]"

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -427,3 +427,41 @@ async def test_events_handler_reads_session_related_events(tmp_path: Path) -> No
     }
 
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: Path) -> None:
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'events.db'}")
+    await store.initialize()
+
+    await store.append(
+        BaseEvent(
+            type="demo.secret.persisted",
+            aggregate_type="session",
+            aggregate_id="orch_secret",
+            data={
+                "api_key": "sk-live-SECRET456",
+                "nested": {"password": "correct horse battery staple"},
+                "tool_input_preview": "command: deploy --api-key sk-live-SECRET123",
+                "safe_count": 3,
+            },
+        )
+    )
+
+    handler = EventsResourceHandler(event_store=store)
+    result = await handler.handle("ouroboros://events/orch_secret")
+
+    assert result.is_ok
+    text = result.value.text or ""
+    assert "sk-live-SECRET456" not in text
+    assert "correct horse battery staple" not in text
+    assert "sk-live-SECRET123" not in text
+
+    payload = json.loads(text)
+    data = payload["events"][0]["data"]
+    assert data["api_key"] == "[redacted]"
+    assert data["nested"]["password"] == "[redacted]"
+    assert data["tool_input_preview"] == "command: deploy --api-key [redacted]"
+    assert data["safe_count"] == 3
+
+    await store.close()

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -443,6 +443,8 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
                 "api_key": "sk-live-SECRET456",
                 "nested": {"password": "correct horse battery staple"},
                 "tool_input_preview": "command: deploy --api-key sk-live-SECRET123",
+                "quoted_password_preview": 'command: login --password "correct horse battery staple"',
+                "quoted_secret_preview": "command: run --secret 'multi word value'",
                 "safe_count": 3,
             },
         )
@@ -456,12 +458,15 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert "sk-live-SECRET456" not in text
     assert "correct horse battery staple" not in text
     assert "sk-live-SECRET123" not in text
+    assert "multi word value" not in text
 
     payload = json.loads(text)
     data = payload["events"][0]["data"]
     assert data["api_key"] == "[redacted]"
     assert data["nested"]["password"] == "[redacted]"
     assert data["tool_input_preview"] == "command: deploy --api-key [redacted]"
+    assert data["quoted_password_preview"] == "command: login --password [redacted]"
+    assert data["quoted_secret_preview"] == "command: run --secret [redacted]"
     assert data["safe_count"] == 3
 
     await store.close()

--- a/tests/unit/mcp/resources/test_handlers.py
+++ b/tests/unit/mcp/resources/test_handlers.py
@@ -450,6 +450,7 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
                 "github_token": "opaque-github-token-value",
                 "db_password": "opaque-db-password-value",
                 "google_preview": "key=AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "idempotency_key": "event-correlation-key-123",
                 "safe_count": 3,
             },
         )
@@ -482,6 +483,7 @@ async def test_events_handler_redacts_secret_shaped_resource_payloads(tmp_path: 
     assert data["github_token"] == "[redacted]"
     assert data["db_password"] == "[redacted]"
     assert data["google_preview"] == "key=[redacted]"
+    assert data["idempotency_key"] == "event-correlation-key-123"
     assert data["safe_count"] == 3
 
     await store.close()


### PR DESCRIPTION
## Summary

Fixes #862.

MCP event resources intentionally expose event history for observability, but the resource projection returned `event.data` verbatim. That made secret-shaped values visible through `ouroboros://events` and `ouroboros://events/{session_id}`.

This PR keeps event structure intact and redacts only secret-shaped values at the resource projection boundary.

## Why this shape

Recent merged work preserves diagnostics while narrowing risky payloads:

- #585 scopes observability records to the active MCP call.
- #701 allowlists provenance fields before persistence/reporting.
- #855/#857 establish that secret-looking argv values must be redacted rather than echoed back.

A resource projection redaction layer matches that direction better than removing `event.data` entirely.

## Changes

- Redact well-known secret field names in event resource output (`api_key`, `password`, `token`, `secret`, etc.).
- Redact secret CLI flag values in string payloads (`--api-key ...`, `--token=...`, etc.).
- Redact high-confidence token shapes (`Bearer ...`, GitHub PAT-like values, OpenAI-style `sk-...`, AWS access key IDs).
- Preserve non-sensitive event structure and values.

## Verification

- `uv run pytest -q tests/unit/mcp/resources/test_handlers.py`
- `uv run pytest -q tests/unit/mcp/resources/test_handlers.py tests/unit/persistence/test_event_store.py`
- `uv run ruff check src/ouroboros/mcp/resources/handlers.py tests/unit/mcp/resources/test_handlers.py`
