### PR TITLE
fix(cli/plugin): make trust and disable transitions atomic

### DIFF
--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -2473,6 +2473,7 @@ def trust_command(
     # MUST surface that state's own corruption clearly.
     try:
         was_disabled = trust.is_disabled(name)
+        existing_record = trust.read(name) if scopes else None
     except (ValueError, OSError) as exc:
         print_error(
             f"trust state for {name!r} is unreadable: {exc}. "
@@ -2480,6 +2481,17 @@ def trust_command(
             f"then re-run `ooo plugin trust {name} --scope <...>`."
         )
         raise typer.Exit(code=1) from exc
+    prior_granted_scopes = (
+        {g.scope for g in existing_record.granted_scopes}
+        if existing_record is not None
+        and existing_record.matches_subject(
+            version=manifest.version,
+            source_type=entry.source_type,
+            source_identity=entry.source_identity,
+            artifact_digest=entry.artifact_digest,
+        )
+        else set()
+    )
 
     # ``--audit-log`` is operator-supplied and routinely points at a
     # path the user expects to exist (e.g. inside a pre-created log
@@ -2519,9 +2531,11 @@ def trust_command(
                     f"re-run `ooo plugin trust {name} --scope <...>`."
                 )
                 raise typer.Exit(code=1) from exc
+        granted_for_event = set(prior_granted_scopes)
         for scope in scopes:
             assert record is not None
             print_success(f"Granted: {scope} ({len(record.granted_scopes)} total scope(s))")
+            granted_for_event.add(scope)
 
             # Audit `trust_state` must mirror the firewall's invokability
             # view, not the fact that *some* grant was just written. A
@@ -2534,11 +2548,10 @@ def trust_command(
             # one optional scope, where the user grants only the
             # optional one. Compute the same predicate the firewall
             # uses post-grant.
-            granted_after = {g.scope for g in record.granted_scopes}
             required_scopes = {p.scope for p in manifest.permissions if p.required}
             event_trust_state = (
                 "trusted"
-                if granted_after and not (required_scopes - granted_after)
+                if granted_for_event and not (required_scopes - granted_for_event)
                 else "installed"
             )
 

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -2667,7 +2667,7 @@ def disable_command(
     # a recovery hint instead of a raw traceback in the very command
     # operators run to repair that state.
     try:
-        removed_trust = (trust.root / name / "trust.json").is_file()
+        removed_trust = trust.has_trust_record(name)
         if not removed_trust:
             # Disabling an already-untrusted plugin is valid: the disable
             # record is an independent revocation signal. However, when
@@ -2682,7 +2682,7 @@ def disable_command(
                 candidate_root = candidate_root.expanduser()
                 if candidate_root == trust.root.expanduser():
                     continue
-                if (candidate_root / name / "trust.json").is_file():
+                if TrustStore(root=candidate_root).has_trust_record(name):
                     print_error(
                         f"no trust grant for {name!r} exists under {trust.root}, "
                         f"but a grant exists under {candidate_root}; pass the "

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -2500,12 +2500,13 @@ def trust_command(
         )
         raise typer.Exit(code=1) from exc
     try:
-        for scope in scopes:
+        record = None
+        if scopes:
             try:
-                record = trust.grant(
+                record = trust.grant_many_and_clear_disable(
                     plugin=name,
                     version=manifest.version,
-                    scope=scope,
+                    scopes=scopes,
                     granted_by=granted_by,
                     source_type=entry.source_type,
                     source_identity=entry.source_identity,
@@ -2518,6 +2519,8 @@ def trust_command(
                     f"re-run `ooo plugin trust {name} --scope <...>`."
                 )
                 raise typer.Exit(code=1) from exc
+        for scope in scopes:
+            assert record is not None
             print_success(f"Granted: {scope} ({len(record.granted_scopes)} total scope(s))")
 
             # Audit `trust_state` must mirror the firewall's invokability
@@ -2600,26 +2603,19 @@ def trust_command(
                 # with a teardown failure.
                 pass
 
-    # Clear the disable record only after all fallible writes above
-    # have succeeded. ``clear_disable`` is idempotent and the
-    # *last* state-changing step the command makes. Wrap so a
-    # filesystem failure (permissions, etc.) on ``unlink(disabled.json)``
-    # does NOT crash after the user has already seen ``Granted: ...``
-    # — that left a partial-commit at the trust boundary where the
-    # trust file looked updated while the plugin was still disabled.
-    # The recovery hint instructs the user to re-run ``trust`` after
-    # repairing the underlying filesystem condition.
-    try:
-        trust.clear_disable(name)
-    except (ValueError, OSError) as exc:
-        print_error(
-            f"grants for {name!r} were written, but clearing the disable "
-            f"record failed: {exc}. The plugin remains disabled until "
-            f"`ooo plugin disable {name}` is unwound — re-run "
-            f"`ooo plugin trust {name} ...` after the underlying "
-            f"filesystem issue is fixed."
-        )
-        raise typer.Exit(code=1) from exc
+    # Scope grants clear disable atomically via grant_many_and_clear_disable().
+    # A bare re-enable still has no grant to combine with, so keep the
+    # idempotent clear-only path for zero-required-permission plugins.
+    if not scopes:
+        try:
+            trust.clear_disable(name)
+        except (ValueError, OSError) as exc:
+            print_error(
+                f"clearing the disable record for {name!r} failed: {exc}. "
+                f"The plugin remains disabled until `ooo plugin trust {name}` "
+                "is re-run after the underlying filesystem issue is fixed."
+            )
+            raise typer.Exit(code=1) from exc
     if not scopes and was_disabled:
         # Bare `ooo plugin trust <zero-perm-plugin>` (or all-optional)
         # against a disabled subject — the only effective change is
@@ -2671,7 +2667,7 @@ def disable_command(
     # a recovery hint instead of a raw traceback in the very command
     # operators run to repair that state.
     try:
-        removed_trust = trust.remove(name)
+        removed_trust = (trust.root / name / "trust.json").is_file()
         if not removed_trust:
             # Disabling an already-untrusted plugin is valid: the disable
             # record is an independent revocation signal. However, when
@@ -2693,7 +2689,7 @@ def disable_command(
                         "same --trust-root used for the grant before disabling."
                     )
                     raise typer.Exit(code=1)
-        trust.write_disable(
+        trust.apply_disable(
             name,
             source_type=entry.source_type
             or ("plugin_home" if entry.source_kind == "git" else "local_path"),

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -494,6 +494,16 @@ class TrustStore:
     def reset_for_version_bump(self, plugin: str, new_version: str) -> None:
         self.reset_for_subject_change(plugin, new_version=new_version)
 
+    def has_trust_record(self, plugin: str) -> bool:
+        """True if a trust record file exists for `plugin`.
+
+        This intentionally validates before deriving the path so CLI
+        preflight checks do not bypass the TrustStore path-boundary
+        guard when inspecting whether a grant exists.
+        """
+        _validate_plugin_name(plugin)
+        return self._path(plugin).is_file()
+
     def remove(self, plugin: str) -> bool:
         """Remove the trust file for `plugin`. Returns True if removed.
 

--- a/src/ouroboros/plugin/trust_store.py
+++ b/src/ouroboros/plugin/trust_store.py
@@ -365,9 +365,35 @@ class TrustStore:
         artifact_digest: str = "",
         when: datetime | None = None,
     ) -> TrustRecord:
-        """Atomic ``ooo plugin trust`` step: grant ``scope`` AND clear
-        any existing disable record inside a single per-plugin
-        critical section.
+        """Atomic ``ooo plugin trust`` step for one scope.
+
+        See :meth:`grant_many_and_clear_disable` for the multi-scope
+        variant used by the CLI.
+        """
+        return self.grant_many_and_clear_disable(
+            plugin=plugin,
+            version=version,
+            scopes=(scope,),
+            granted_by=granted_by,
+            source_type=source_type,
+            source_identity=source_identity,
+            artifact_digest=artifact_digest,
+            when=when,
+        )
+
+    def grant_many_and_clear_disable(
+        self,
+        *,
+        plugin: str,
+        version: str,
+        scopes: Iterable[str],
+        granted_by: str,
+        source_type: str = "",
+        source_identity: str = "",
+        artifact_digest: str = "",
+        when: datetime | None = None,
+    ) -> TrustRecord:
+        """Grant one or more scopes and clear disable atomically.
 
         Calling ``grant()`` then ``clear_disable()`` from the CLI takes
         and releases the lock twice. A concurrent ``ooo plugin
@@ -378,10 +404,12 @@ class TrustStore:
         ``disabled.json`` — leaving a "trust gone AND disable gone"
         final state where ``ooo plugin trust`` reported success but
         the plugin is invocable without any consented scopes. Doing
-        both writes inside one critical section closes that
-        interleaving.
+        all grant writes and the disable clear inside one critical
+        section closes that interleaving, including repeatable
+        ``--scope`` invocations.
         """
         _validate_plugin_name(plugin)
+        scope_list = list(scopes)
         when = when or datetime.now(tz=UTC)
         ts = when.strftime("%Y-%m-%dT%H:%M:%SZ")
         with self._grant_lock(plugin):
@@ -395,8 +423,9 @@ class TrustStore:
             ):
                 existing = None
             granted = list(existing.granted_scopes) if existing else []
-            if all(g.scope != scope for g in granted):
-                granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
+            for scope in scope_list:
+                if all(g.scope != scope for g in granted):
+                    granted.append(GrantedScope(scope=scope, granted_at=ts, granted_by=granted_by))
             payload: dict = {
                 "schema_version": TRUST_SCHEMA_VERSION,
                 "plugin": plugin,

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -1597,6 +1597,100 @@ def test_trust_clears_disable_record(runner: CliRunner, tmp_path: Path) -> None:
     assert rec is not None and rec.has_scope("github:read")
 
 
+def test_trust_command_uses_atomic_multi_scope_grant_and_clear_disable(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`ooo plugin trust` must not split grant and re-enable into
+    separate TrustStore critical sections.
+    """
+    paths = _common_paths(tmp_path)
+    src = tmp_path / "src"
+    _install_reference_plugin(runner, plugin_dir=src, paths=paths)
+    TrustStore(root=paths["trust_root"]).write_disable(
+        "github-pr-ops",
+        source_type="local_path",
+        source_identity=str(src),
+        disabled_by="user:test",
+    )
+
+    calls: list[dict[str, object]] = []
+    original = TrustStore.grant_many_and_clear_disable
+
+    def _spy(self: TrustStore, **kwargs):  # noqa: ANN001
+        calls.append(dict(kwargs))
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(TrustStore, "grant_many_and_clear_disable", _spy)
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "trust",
+            "github-pr-ops",
+            "--scope",
+            "github:read",
+            "--granted-by",
+            "user:test",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    assert calls[0]["scopes"] == ["github:read"]
+    trust = TrustStore(root=paths["trust_root"])
+    assert trust.read("github-pr-ops") is not None
+    assert not trust.is_disabled("github-pr-ops")
+
+
+def test_disable_command_uses_atomic_apply_disable(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`ooo plugin disable` must write disabled.json and revoke trust
+    through the TrustStore atomic disable primitive.
+    """
+    paths = _common_paths(tmp_path)
+    src = tmp_path / "src"
+    _install_reference_plugin(runner, plugin_dir=src, paths=paths)
+    TrustStore(root=paths["trust_root"]).grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+
+    calls: list[tuple[str, dict[str, object]]] = []
+    original = TrustStore.apply_disable
+
+    def _spy(self: TrustStore, plugin: str, **kwargs):  # noqa: ANN001
+        calls.append((plugin, dict(kwargs)))
+        return original(self, plugin, **kwargs)
+
+    monkeypatch.setattr(TrustStore, "apply_disable", _spy)
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "disable",
+            "github-pr-ops",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    assert calls[0][0] == "github-pr-ops"
+    trust = TrustStore(root=paths["trust_root"])
+    assert trust.read("github-pr-ops") is None
+    assert trust.is_disabled("github-pr-ops")
+
+
 def test_list_reflects_disabled_state(runner: CliRunner, tmp_path: Path) -> None:
     """`ooo plugin list --json` must surface `trust_state="disabled"` for a
     plugin with a disable record, regardless of whether it has a trust
@@ -3278,7 +3372,27 @@ def test_trust_friendly_error_on_clear_disable_failure(
     """
     paths = _common_paths(tmp_path)
     src = tmp_path / "src"
-    _install_reference_plugin(runner, plugin_dir=src, paths=paths)
+    optional_manifest = {
+        **REFERENCE_MANIFEST,
+        "permissions": [
+            {"scope": "github:read", "risk": "read_only", "required": False},
+        ],
+    }
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "ouroboros.plugin.json").write_text(json.dumps(optional_manifest))
+    runner.invoke(
+        plugin_app,
+        [
+            "install",
+            str(src),
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+    )
 
     runner.invoke(
         plugin_app,
@@ -3302,8 +3416,6 @@ def test_trust_friendly_error_on_clear_disable_failure(
         [
             "trust",
             "github-pr-ops",
-            "--scope",
-            "github:read",
             "--lockfile",
             str(paths["lockfile"]),
             "--trust-root",
@@ -3520,14 +3632,14 @@ def test_trust_failure_after_disable_check_keeps_disable_record(
     trust = TrustStore(root=paths["trust_root"])
     assert trust.is_disabled("github-pr-ops")
 
-    # Make the grant write fail. With the new ordering, the failure
-    # must NOT clear the disable record.
-    original_grant = TrustStore.grant
+    # Make the atomic grant/re-enable write fail. The failure must NOT
+    # clear the disable record.
+    original_grant_many = TrustStore.grant_many_and_clear_disable
 
-    def _failing_grant(self, **kwargs):  # noqa: ANN001 — pytest patch shape
+    def _failing_grant_many(self, **kwargs):  # noqa: ANN001 — pytest patch shape
         raise OSError("disk full simulating mid-grant failure")
 
-    monkeypatch.setattr(TrustStore, "grant", _failing_grant)
+    monkeypatch.setattr(TrustStore, "grant_many_and_clear_disable", _failing_grant_many)
 
     result = runner.invoke(
         plugin_app,
@@ -3546,7 +3658,7 @@ def test_trust_failure_after_disable_check_keeps_disable_record(
     )
     assert result.exit_code != 0, result.output
     # Re-read trust state with the original grant restored.
-    monkeypatch.setattr(TrustStore, "grant", original_grant)
+    monkeypatch.setattr(TrustStore, "grant_many_and_clear_disable", original_grant_many)
     assert trust.is_disabled("github-pr-ops"), (
         "trust command failed mid-grant; the disable record MUST remain "
         "in place so the plugin stays gated until the user re-runs"

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -428,6 +428,75 @@ def test_trust_partial_grant_records_installed_in_audit_event(
     )
 
 
+def test_trust_multi_scope_audit_events_reflect_incremental_grant_state(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Multi-scope trust persists atomically, but the audit stream is still
+    one event per requested scope. Each event's trust_state must describe
+    the conceptual grant step for that event, not the final batched result.
+    """
+    manifest_with_two_required = {
+        **REFERENCE_MANIFEST,
+        "permissions": [
+            {"scope": "github:read", "risk": "read_only", "required": True},
+            {
+                "scope": "github:pull_request:write",
+                "risk": "destructive",
+                "required": True,
+            },
+        ],
+    }
+    plugin_dir = tmp_path / "github-pr-ops"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "ouroboros.plugin.json").write_text(json.dumps(manifest_with_two_required))
+    paths = _common_paths(tmp_path)
+    install = runner.invoke(
+        plugin_app,
+        [
+            "install",
+            str(plugin_dir),
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+        ],
+    )
+    assert install.exit_code == 0, install.output
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "trust",
+            "github-pr-ops",
+            "--scope",
+            "github:read",
+            "--scope",
+            "github:pull_request:write",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+            "--audit-log",
+            str(paths["audit_log"]),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    payloads = [json.loads(line)["payload"] for line in paths["audit_log"].read_text().splitlines()]
+    assert [payload["provenance"]["granted_scope"] for payload in payloads] == [
+        "github:read",
+        "github:pull_request:write",
+    ]
+    assert [payload["trust_state"] for payload in payloads] == ["installed", "trusted"]
+
+    record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
+    assert record is not None
+    assert {g.scope for g in record.granted_scopes} == {
+        "github:read",
+        "github:pull_request:write",
+    }
+
+
 def test_trust_full_required_grant_records_trusted_in_audit_event(
     runner: CliRunner, tmp_path: Path
 ) -> None:

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -217,6 +217,8 @@ def test_invalid_plugin_name_rejected(tmp_path: Path, bad_name: str) -> None:
     with pytest.raises(ValueError, match="invalid plugin name"):
         store.reset_for_version_bump(bad_name, new_version="0.2.0")
     with pytest.raises(ValueError, match="invalid plugin name"):
+        store.has_trust_record(bad_name)
+    with pytest.raises(ValueError, match="invalid plugin name"):
         store.remove(bad_name)
 
 

--- a/tests/unit/plugin/test_trust_store.py
+++ b/tests/unit/plugin/test_trust_store.py
@@ -388,6 +388,35 @@ def test_grant_and_clear_disable_is_atomic(tmp_path: Path) -> None:
     assert not store.is_disabled(plugin)
 
 
+def test_grant_many_and_clear_disable_is_atomic(tmp_path: Path) -> None:
+    """CLI-shaped multi-scope re-trust must also be one atomic trust
+    transition: all requested grants are persisted and the disable
+    record is cleared under the same per-plugin lock.
+    """
+    store = TrustStore(root=tmp_path)
+    plugin = "atomic-trust-many"
+    store.write_disable(
+        plugin,
+        source_type="local_path",
+        source_identity="/tmp/installs/atomic-trust-many",
+        disabled_by="user:test",
+    )
+    assert store.is_disabled(plugin)
+
+    record = store.grant_many_and_clear_disable(
+        plugin=plugin,
+        version="0.1.0",
+        scopes=("github:read", "github:write"),
+        granted_by="user:test",
+        source_type="local_path",
+        source_identity="/tmp/installs/atomic-trust-many",
+        artifact_digest="sha256:" + "0" * 64,
+    )
+
+    assert [g.scope for g in record.granted_scopes] == ["github:read", "github:write"]
+    assert not store.is_disabled(plugin)
+
+
 def test_grant_resets_legacy_unbound_record_on_subject_bound_grant(tmp_path: Path) -> None:
     """A pre-RFC ``trust.json`` has blank ``source_type`` /
     ``source_identity`` / ``artifact_digest`` columns. Without


### PR DESCRIPTION
## Summary

- Route scoped `ooo plugin trust` through one TrustStore transition that grants all requested scopes and clears `disabled.json` under the same per-plugin lock.
- Route `ooo plugin disable` through `TrustStore.apply_disable(...)` so `disabled.json` write and `trust.json` removal stay atomic.
- Add TrustStore and CLI regression tests that pin trust/disable command paths to the atomic primitives.

Closes #867.

## Rationale

Recent plugin-security merges keep this area narrow and contract-driven: small fail-closed changes with explicit regression coverage around the user-level plugin trust boundary. This PR follows that pattern rather than broadening the plugin trust model.

The bug is a split-transition race: `trust` can write `trust.json`, a concurrent `disable` can atomically write `disabled.json` and remove `trust.json`, then `trust` can clear the disable record as a late separate step. The final state has neither trust nor disable state. Keeping each logical command transition inside one TrustStore critical section removes that interleaving.

I kept this as one PR because the store method and CLI call-site changes form one atomicity boundary; splitting them would either leave the CLI unprotected or add unused API surface without the caller that closes the bug.

## Tests

- `uv run pytest tests/unit/plugin/test_trust_store.py tests/unit/cli/test_plugin_command_mutating.py -q`
- `uv run ruff check src/ouroboros/plugin/trust_store.py src/ouroboros/cli/commands/plugin.py tests/unit/plugin/test_trust_store.py tests/unit/cli/test_plugin_command_mutating.py`
- `git diff --check`
