### PR TITLE
fix(copilot): ignore telemetry JSON in success fallback

### DIFF
--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -86,6 +86,27 @@ _AUTH_ERROR_PATTERNS = (
     "authentication required",
 )
 
+_COPILOT_EVENT_TYPES = frozenset(
+    {
+        "agent.message",
+        "error",
+        "fatal",
+        "message",
+        "reasoning",
+        "run.completed",
+        "session.created",
+        "session.ended",
+        "session.ready",
+        "session.started",
+        "thinking",
+        "tool.start",
+        "tool_call",
+        "tool_use",
+        "turn.completed",
+        "turn.failed",
+    }
+)
+
 _JSON_OBJECT_DIRECTIVE = (
     "Respond with a single JSON object. Do not include prose, "
     "Markdown fences, or commentary outside the JSON value."
@@ -320,6 +341,17 @@ class CopilotCliLLMAdapter:
             return None
         return event if isinstance(event, dict) else None
 
+    @staticmethod
+    def _is_copilot_event_envelope(event: dict[str, Any]) -> bool:
+        event_type = event.get("type")
+        return isinstance(event_type, str) and event_type in _COPILOT_EVENT_TYPES
+
+    @staticmethod
+    def _is_structured_response_format(response_format: dict[str, object] | None) -> bool:
+        if not response_format:
+            return False
+        return response_format.get("type") in {"json_object", "json_schema"}
+
     def _extract_text(self, value: object) -> str:
         if isinstance(value, str):
             return value.strip()
@@ -416,11 +448,32 @@ class CopilotCliLLMAdapter:
         text = "\n".join(line for line in stdout_lines if line.strip())
         return text or stderr.strip()
 
-    def _plain_text_stdout_fallback(self, stdout_lines: list[str]) -> str:
-        """Use only non-JSON stdout as successful fallback completion content."""
-        return "\n".join(
-            line for line in stdout_lines if line.strip() and self._parse_json_event(line) is None
+    def _plain_text_stdout_fallback(
+        self,
+        stdout_lines: list[str],
+        *,
+        preserve_structured_json: bool = False,
+    ) -> str:
+        """Use stdout lines that are not known Copilot event envelopes."""
+        content_lines: list[str] = []
+        nonempty_lines = [line for line in stdout_lines if line.strip()]
+        has_stream_context = len(nonempty_lines) > 1 and any(
+            self._is_copilot_event_envelope(event)
+            for line in nonempty_lines
+            if (event := self._parse_json_event(line)) is not None
         )
+
+        for line in stdout_lines:
+            if not line.strip():
+                continue
+            event = self._parse_json_event(line)
+            if preserve_structured_json and event is not None and not has_stream_context:
+                content_lines.append(line)
+                continue
+            if event is not None and self._is_copilot_event_envelope(event):
+                continue
+            content_lines.append(line)
+        return "\n".join(content_lines)
 
     # ------------------------------------------------------ stream/process io
 
@@ -583,11 +636,13 @@ class CopilotCliLLMAdapter:
             return await self._handle_legacy_process(
                 process,
                 normalized_model=normalized_model,
+                response_format=config.response_format,
             )
 
         return await self._handle_streaming_process(
             process,
             normalized_model=normalized_model,
+            response_format=config.response_format,
         )
 
     async def _handle_legacy_process(
@@ -595,6 +650,7 @@ class CopilotCliLLMAdapter:
         process: Any,
         *,
         normalized_model: str | None,
+        response_format: dict[str, object] | None,
     ) -> Result[CompletionResponse, ProviderError]:
         (
             stdout_lines,
@@ -602,8 +658,16 @@ class CopilotCliLLMAdapter:
             session_id,
             last_content,
         ) = await self._collect_legacy_process_output(process)
-
-        content = last_content or self._plain_text_stdout_fallback(stdout_lines)
+        preserve_structured_json = self._is_structured_response_format(response_format)
+        fallback_content = self._plain_text_stdout_fallback(
+            stdout_lines,
+            preserve_structured_json=preserve_structured_json,
+        )
+        content = (
+            fallback_content or last_content
+            if preserve_structured_json
+            else last_content or fallback_content
+        )
 
         if process.returncode != 0:
             return self._error_from_process(
@@ -643,6 +707,7 @@ class CopilotCliLLMAdapter:
         process: Any,
         *,
         normalized_model: str | None,
+        response_format: dict[str, object] | None,
     ) -> Result[CompletionResponse, ProviderError]:
         stdout_lines: list[str] = []
         stderr_lines: list[str] = []
@@ -721,7 +786,16 @@ class CopilotCliLLMAdapter:
             await self._cancel_tasks(stdout_task, stderr_task)
             raise
 
-        content = last_content or self._plain_text_stdout_fallback(stdout_lines)
+        preserve_structured_json = self._is_structured_response_format(response_format)
+        fallback_content = self._plain_text_stdout_fallback(
+            stdout_lines,
+            preserve_structured_json=preserve_structured_json,
+        )
+        content = (
+            fallback_content or last_content
+            if preserve_structured_json
+            else last_content or fallback_content
+        )
 
         if process.returncode != 0:
             return self._error_from_process(

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -416,6 +416,12 @@ class CopilotCliLLMAdapter:
         text = "\n".join(line for line in stdout_lines if line.strip())
         return text or stderr.strip()
 
+    def _plain_text_stdout_fallback(self, stdout_lines: list[str]) -> str:
+        """Use only non-JSON stdout as successful fallback completion content."""
+        return "\n".join(
+            line for line in stdout_lines if line.strip() and self._parse_json_event(line) is None
+        )
+
     # ------------------------------------------------------ stream/process io
 
     async def _iter_stream_lines(
@@ -597,7 +603,7 @@ class CopilotCliLLMAdapter:
             last_content,
         ) = await self._collect_legacy_process_output(process)
 
-        content = last_content or self._fallback_content(stdout_lines, "\n".join(stderr_lines))
+        content = last_content or self._plain_text_stdout_fallback(stdout_lines)
 
         if process.returncode != 0:
             return self._error_from_process(
@@ -715,7 +721,7 @@ class CopilotCliLLMAdapter:
             await self._cancel_tasks(stdout_task, stderr_task)
             raise
 
-        content = last_content or self._fallback_content(stdout_lines, "\n".join(stderr_lines))
+        content = last_content or self._plain_text_stdout_fallback(stdout_lines)
 
         if process.returncode != 0:
             return self._error_from_process(

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -400,10 +400,10 @@ class CopilotCliLLMAdapter:
         if not content.strip():
             return False
         try:
-            parsed = json.loads(content)
+            json.loads(content)
         except json.JSONDecodeError:
             return False
-        return isinstance(parsed, dict | list)
+        return True
 
     def _should_preserve_structured_event_line(self, event: dict[str, Any]) -> bool:
         event_type = event.get("type")

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -373,9 +373,7 @@ class CopilotCliLLMAdapter:
         event_type = event.get("type")
         if not isinstance(event_type, str):
             return False
-        return "." in event_type or any(
-            key in event for key in ("payload", "usage", "session_id", "sessionId")
-        )
+        return "." in event_type
 
     @staticmethod
     def _is_structured_response_format(response_format: dict[str, object] | None) -> bool:

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -384,7 +384,7 @@ class CopilotCliLLMAdapter:
     @staticmethod
     def _looks_like_future_event_envelope(event: dict[str, Any]) -> bool:
         event_type = event.get("type")
-        if not isinstance(event_type, str):
+        if not isinstance(event_type, str) or event_type in _COPILOT_EVENT_TYPES:
             return False
         prefix, separator, suffix = event_type.partition(".")
         return separator == "." and bool(suffix) and prefix in _COPILOT_FUTURE_EVENT_PREFIXES
@@ -394,6 +394,42 @@ class CopilotCliLLMAdapter:
         if not response_format:
             return False
         return response_format.get("type") in {"json_object", "json_schema"}
+
+    @staticmethod
+    def _is_structured_json_payload(content: str) -> bool:
+        if not content.strip():
+            return False
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            return False
+        return isinstance(parsed, dict | list)
+
+    def _should_preserve_structured_event_line(self, event: dict[str, Any]) -> bool:
+        event_type = event.get("type")
+        if event_type in {"agent.message", "message"}:
+            return True
+        if event_type == "tool_use" and not any(key in event for key in _COPILOT_TOOL_EVENT_KEYS):
+            return True
+        return not self._is_copilot_event_envelope(event)
+
+    def _select_success_content(
+        self,
+        *,
+        stdout_lines: list[str],
+        last_content: str,
+        fallback_content: str,
+        preserve_structured_json: bool,
+    ) -> str:
+        if not preserve_structured_json:
+            return last_content or fallback_content
+        if not self._has_copilot_stream_context(stdout_lines):
+            return fallback_content or last_content
+        fallback_is_structured = self._is_structured_json_payload(fallback_content)
+        last_is_structured = self._is_structured_json_payload(last_content)
+        if fallback_is_structured and not last_is_structured:
+            return fallback_content
+        return last_content or fallback_content
 
     def _extract_text(self, value: object) -> str:
         if isinstance(value, str):
@@ -514,13 +550,16 @@ class CopilotCliLLMAdapter:
             if preserve_structured_json and event is not None and not has_stream_context:
                 content_lines.append(line)
                 continue
-            if event is not None and (
-                self._is_copilot_event_envelope(event)
-                or (has_stream_context and self._looks_like_future_event_envelope(event))
-            ):
-                continue
-            if event is not None and not preserve_structured_json:
-                continue
+            if event is not None:
+                if has_stream_context and self._looks_like_future_event_envelope(event):
+                    continue
+                if preserve_structured_json and self._should_preserve_structured_event_line(event):
+                    content_lines.append(line)
+                    continue
+                if self._is_copilot_event_envelope(event):
+                    continue
+                if not preserve_structured_json:
+                    continue
             content_lines.append(line)
         return "\n".join(content_lines)
 
@@ -712,10 +751,11 @@ class CopilotCliLLMAdapter:
             stdout_lines,
             preserve_structured_json=preserve_structured_json,
         )
-        content = (
-            fallback_content or last_content
-            if preserve_structured_json and not self._has_copilot_stream_context(stdout_lines)
-            else last_content or fallback_content
+        content = self._select_success_content(
+            stdout_lines=stdout_lines,
+            last_content=last_content,
+            fallback_content=fallback_content,
+            preserve_structured_json=preserve_structured_json,
         )
 
         if process.returncode != 0:
@@ -840,10 +880,11 @@ class CopilotCliLLMAdapter:
             stdout_lines,
             preserve_structured_json=preserve_structured_json,
         )
-        content = (
-            fallback_content or last_content
-            if preserve_structured_json and not self._has_copilot_stream_context(stdout_lines)
-            else last_content or fallback_content
+        content = self._select_success_content(
+            stdout_lines=stdout_lines,
+            last_content=last_content,
+            fallback_content=fallback_content,
+            preserve_structured_json=preserve_structured_json,
         )
 
         if process.returncode != 0:

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -455,7 +455,7 @@ class CopilotCliLLMAdapter:
         *,
         preserve_structured_json: bool = False,
     ) -> str:
-        """Use stdout lines that are not known Copilot event envelopes."""
+        """Use stdout lines that are not Copilot JSONL event envelopes."""
         content_lines: list[str] = []
         nonempty_lines = [line for line in stdout_lines if line.strip()]
         has_stream_context = len(nonempty_lines) > 1 and any(
@@ -471,7 +471,10 @@ class CopilotCliLLMAdapter:
             if preserve_structured_json and event is not None and not has_stream_context:
                 content_lines.append(line)
                 continue
-            if event is not None and self._is_copilot_event_envelope(event):
+            if event is not None and (
+                self._is_copilot_event_envelope(event)
+                or (has_stream_context and isinstance(event.get("type"), str))
+            ):
                 continue
             content_lines.append(line)
         return "\n".join(content_lines)

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -98,6 +98,7 @@ _COPILOT_EVENT_TYPES = frozenset(
         "session.ended",
         "session.ready",
         "session.started",
+        "telemetry",
         "thinking",
         "tool.start",
         "tool_call",
@@ -663,11 +664,7 @@ class CopilotCliLLMAdapter:
             stdout_lines,
             preserve_structured_json=preserve_structured_json,
         )
-        content = (
-            fallback_content or last_content
-            if preserve_structured_json
-            else last_content or fallback_content
-        )
+        content = last_content or fallback_content
 
         if process.returncode != 0:
             return self._error_from_process(
@@ -791,11 +788,7 @@ class CopilotCliLLMAdapter:
             stdout_lines,
             preserve_structured_json=preserve_structured_json,
         )
-        content = (
-            fallback_content or last_content
-            if preserve_structured_json
-            else last_content or fallback_content
-        )
+        content = last_content or fallback_content
 
         if process.returncode != 0:
             return self._error_from_process(

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -109,6 +109,19 @@ _COPILOT_EVENT_TYPES = frozenset(
 )
 
 _COPILOT_ALWAYS_EVENT_TYPES = _COPILOT_EVENT_TYPES - {"agent.message", "message", "tool_use"}
+_COPILOT_FUTURE_EVENT_PREFIXES = frozenset(
+    {
+        "agent",
+        "message",
+        "reasoning",
+        "run",
+        "session",
+        "telemetry",
+        "thinking",
+        "tool",
+        "turn",
+    }
+)
 _COPILOT_MESSAGE_CONTENT_KEYS = frozenset({"content", "message", "text"})
 _COPILOT_TOOL_EVENT_KEYS = frozenset(
     {"args", "arguments", "command", "id", "input", "name", "parameters", "tool"}
@@ -373,7 +386,8 @@ class CopilotCliLLMAdapter:
         event_type = event.get("type")
         if not isinstance(event_type, str):
             return False
-        return "." in event_type
+        prefix, separator, suffix = event_type.partition(".")
+        return separator == "." and bool(suffix) and prefix in _COPILOT_FUTURE_EVENT_PREFIXES
 
     @staticmethod
     def _is_structured_response_format(response_format: dict[str, object] | None) -> bool:

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -550,7 +550,10 @@ class CopilotCliLLMAdapter:
                 continue
             event = self._parse_json_event(line)
             if preserve_structured_json and event is not None and not has_stream_context:
-                content_lines.append(line)
+                if self._should_preserve_structured_event_line(
+                    event
+                ) and not self._looks_like_future_event_envelope(event):
+                    content_lines.append(line)
                 continue
             if event is not None:
                 if has_stream_context and self._looks_like_future_event_envelope(event):

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -423,10 +423,12 @@ class CopilotCliLLMAdapter:
     ) -> str:
         if not preserve_structured_json:
             return last_content or fallback_content
-        if not self._has_copilot_stream_context(stdout_lines):
-            return fallback_content or last_content
         fallback_is_structured = self._is_structured_json_payload(fallback_content)
         last_is_structured = self._is_structured_json_payload(last_content)
+        if not self._has_copilot_stream_context(stdout_lines):
+            if last_is_structured:
+                return last_content
+            return fallback_content or last_content
         if fallback_is_structured and not last_is_structured:
             return fallback_content
         return last_content or fallback_content

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -108,6 +108,12 @@ _COPILOT_EVENT_TYPES = frozenset(
     }
 )
 
+_COPILOT_ALWAYS_EVENT_TYPES = _COPILOT_EVENT_TYPES - {"agent.message", "message", "tool_use"}
+_COPILOT_MESSAGE_CONTENT_KEYS = frozenset({"content", "message", "text"})
+_COPILOT_TOOL_EVENT_KEYS = frozenset(
+    {"args", "arguments", "command", "id", "input", "name", "parameters", "tool"}
+)
+
 _JSON_OBJECT_DIRECTIVE = (
     "Respond with a single JSON object. Do not include prose, "
     "Markdown fences, or commentary outside the JSON value."
@@ -342,10 +348,34 @@ class CopilotCliLLMAdapter:
             return None
         return event if isinstance(event, dict) else None
 
-    @staticmethod
-    def _is_copilot_event_envelope(event: dict[str, Any]) -> bool:
+    def _is_copilot_event_envelope(self, event: dict[str, Any]) -> bool:
         event_type = event.get("type")
-        return isinstance(event_type, str) and event_type in _COPILOT_EVENT_TYPES
+        if not isinstance(event_type, str):
+            return False
+        if event_type in _COPILOT_ALWAYS_EVENT_TYPES:
+            return True
+        if event_type in {"agent.message", "message"}:
+            return any(key in event for key in _COPILOT_MESSAGE_CONTENT_KEYS)
+        if event_type == "tool_use":
+            return any(key in event for key in _COPILOT_TOOL_EVENT_KEYS)
+        return False
+
+    def _has_copilot_stream_context(self, stdout_lines: list[str]) -> bool:
+        nonempty_lines = [line for line in stdout_lines if line.strip()]
+        return len(nonempty_lines) > 1 and any(
+            self._is_copilot_event_envelope(event)
+            for line in nonempty_lines
+            if (event := self._parse_json_event(line)) is not None
+        )
+
+    @staticmethod
+    def _looks_like_future_event_envelope(event: dict[str, Any]) -> bool:
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            return False
+        return "." in event_type or any(
+            key in event for key in ("payload", "usage", "session_id", "sessionId")
+        )
 
     @staticmethod
     def _is_structured_response_format(response_format: dict[str, object] | None) -> bool:
@@ -395,7 +425,9 @@ class CopilotCliLLMAdapter:
     @staticmethod
     def _is_completion_content_event(event: dict[str, Any]) -> bool:
         event_type = event.get("type")
-        return event_type in {"agent.message", "message"}
+        return event_type in {"agent.message", "message"} and any(
+            key in event for key in _COPILOT_MESSAGE_CONTENT_KEYS
+        )
 
     def _emit_callback_for_event(self, event: dict[str, Any]) -> None:
         if self._on_message is None:
@@ -405,13 +437,17 @@ class CopilotCliLLMAdapter:
         if not isinstance(event_type, str):
             return
 
-        if event_type in {"reasoning", "thinking", "agent.message", "message"}:
+        if event_type in {"reasoning", "thinking"} or self._is_completion_content_event(event):
             content = self._extract_text(event)
             if content:
                 self._on_message("thinking", content)
             return
 
-        if event_type in {"tool_use", "tool.start", "tool_call"}:
+        if event_type in {
+            "tool_use",
+            "tool.start",
+            "tool_call",
+        } and self._is_copilot_event_envelope(event):
             tool_name = event.get("name") or event.get("tool") or "tool"
             self._on_message("tool", str(tool_name))
 
@@ -457,12 +493,7 @@ class CopilotCliLLMAdapter:
     ) -> str:
         """Use stdout lines that are not Copilot JSONL event envelopes."""
         content_lines: list[str] = []
-        nonempty_lines = [line for line in stdout_lines if line.strip()]
-        has_stream_context = len(nonempty_lines) > 1 and any(
-            self._is_copilot_event_envelope(event)
-            for line in nonempty_lines
-            if (event := self._parse_json_event(line)) is not None
-        )
+        has_stream_context = self._has_copilot_stream_context(stdout_lines)
 
         for line in stdout_lines:
             if not line.strip():
@@ -473,8 +504,10 @@ class CopilotCliLLMAdapter:
                 continue
             if event is not None and (
                 self._is_copilot_event_envelope(event)
-                or (has_stream_context and isinstance(event.get("type"), str))
+                or (has_stream_context and self._looks_like_future_event_envelope(event))
             ):
+                continue
+            if event is not None and not preserve_structured_json:
                 continue
             content_lines.append(line)
         return "\n".join(content_lines)
@@ -667,7 +700,11 @@ class CopilotCliLLMAdapter:
             stdout_lines,
             preserve_structured_json=preserve_structured_json,
         )
-        content = last_content or fallback_content
+        content = (
+            fallback_content or last_content
+            if preserve_structured_json and not self._has_copilot_stream_context(stdout_lines)
+            else last_content or fallback_content
+        )
 
         if process.returncode != 0:
             return self._error_from_process(
@@ -791,7 +828,11 @@ class CopilotCliLLMAdapter:
             stdout_lines,
             preserve_structured_json=preserve_structured_json,
         )
-        content = last_content or fallback_content
+        content = (
+            fallback_content or last_content
+            if preserve_structured_json and not self._has_copilot_stream_context(stdout_lines)
+            else last_content or fallback_content
+        )
 
         if process.returncode != 0:
             return self._error_from_process(

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -578,6 +578,47 @@ class TestComplete:
         assert result.value.content == '{"type": "message", "body": "ok"}'
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "answer",
+        [
+            {"type": "result", "payload": {"value": "ok"}},
+            {"type": "result", "usage": {"completion_tokens": 4}},
+            {"type": "result", "session_id": "model-session"},
+            {"type": "result", "sessionId": "model-session"},
+        ],
+    )
+    async def test_structured_fallback_preserves_result_answer_with_metadata_keys_in_stream_context(
+        self,
+        answer: dict[str, Any],
+    ) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-json"}),
+                json.dumps(answer),
+                json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return a result JSON object")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == json.dumps(answer)
+
+    @pytest.mark.asyncio
     async def test_structured_fallback_still_ignores_copilot_tool_events(self) -> None:
         adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
         stdout = "\n".join(

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -313,6 +313,16 @@ class TestEventParsing:
         errors = adapter._extract_stdout_errors(lines)
         assert errors == ["rate limit reached", "auth missing"]
 
+    def test_future_event_envelope_heuristic_is_limited_to_copilot_namespaces(
+        self,
+    ) -> None:
+        assert CopilotCliLLMAdapter._looks_like_future_event_envelope(
+            {"type": "run.progress", "payload": {"phase": "future"}}
+        )
+        assert not CopilotCliLLMAdapter._looks_like_future_event_envelope(
+            {"type": "com.acme.result", "value": 1}
+        )
+
 
 class TestRetryLogic:
     def test_is_retryable_error_matches_known_patterns(self) -> None:
@@ -609,6 +619,38 @@ class TestComplete:
         ):
             result = await adapter.complete(
                 [Message(role=MessageRole.USER, content="Return a result JSON object")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == json.dumps(answer)
+
+    @pytest.mark.asyncio
+    async def test_structured_fallback_preserves_dotted_application_type_in_stream_context(
+        self,
+    ) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        answer = {"type": "com.acme.result", "value": 1}
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-json"}),
+                json.dumps(answer),
+                json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return application JSON")],
                 CompletionConfig(
                     model="default",
                     response_format={"type": "json_object"},

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -495,6 +495,89 @@ class TestComplete:
         assert result.value.content == '{"type": "tool_use", "value": "ok"}'
 
     @pytest.mark.asyncio
+    async def test_fallback_preserves_single_raw_message_json_object(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = json.dumps({"type": "message", "content": "ok"})
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return a typed JSON object")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == '{"type": "message", "content": "ok"}'
+
+    @pytest.mark.asyncio
+    async def test_structured_fallback_preserves_typed_answer_in_stream_context(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-json"}),
+                json.dumps({"type": "tool_use", "value": "ok"}),
+                json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return a typed JSON object")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == '{"type": "tool_use", "value": "ok"}'
+
+    @pytest.mark.asyncio
+    async def test_structured_fallback_preserves_message_shaped_answer_in_stream_context(
+        self,
+    ) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-json"}),
+                json.dumps({"type": "message", "body": "ok"}),
+                json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return a typed JSON object")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == '{"type": "message", "body": "ok"}'
+
+    @pytest.mark.asyncio
     async def test_structured_fallback_still_ignores_copilot_tool_events(self) -> None:
         adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
         stdout = "\n".join(

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -588,6 +588,40 @@ class TestComplete:
         assert result.value.content == '{"type": "message", "body": "ok"}'
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("event_type", ["message", "agent.message"])
+    async def test_structured_fallback_preserves_completion_shaped_json_answer_in_stream_context(
+        self,
+        event_type: str,
+    ) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        answer = {"type": event_type, "content": {"answer": "ok"}}
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-json"}),
+                json.dumps(answer),
+                json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return a typed JSON object")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == json.dumps(answer)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "answer",
         [

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -502,6 +502,7 @@ class TestComplete:
                 json.dumps({"type": "session.started", "session_id": "sess-json"}),
                 json.dumps({"type": "tool_use", "name": "shell", "command": "pwd"}),
                 json.dumps({"type": "telemetry", "payload": {"phase": "done"}}),
+                json.dumps({"type": "run.progress", "payload": {"phase": "future"}}),
                 json.dumps({"answer": "ok"}),
                 json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
             ]
@@ -527,6 +528,7 @@ class TestComplete:
         assert result.value.raw_response["session_id"] == "sess-json"
         assert "tool_use" not in result.value.content
         assert "telemetry" not in result.value.content
+        assert "run.progress" not in result.value.content
 
     @pytest.mark.asyncio
     async def test_structured_completion_event_wins_over_stray_stdout(self) -> None:

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -622,9 +622,13 @@ class TestComplete:
         assert result.value.content == json.dumps(answer)
 
     @pytest.mark.asyncio
-    async def test_single_structured_completion_event_returns_assistant_payload(self) -> None:
+    @pytest.mark.parametrize("payload", ['{"answer":"ok"}', "42", "true", "null", '"foo"'])
+    async def test_single_structured_completion_event_returns_assistant_payload(
+        self,
+        payload: str,
+    ) -> None:
         adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
-        stdout = json.dumps({"type": "message", "content": '{"answer":"ok"}'})
+        stdout = json.dumps({"type": "message", "content": payload})
 
         async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
             return _FakeProcess(stdout=stdout, returncode=0)
@@ -642,7 +646,7 @@ class TestComplete:
             )
 
         assert result.is_ok
-        assert result.value.content == '{"answer":"ok"}'
+        assert result.value.content == payload
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -622,6 +622,29 @@ class TestComplete:
         assert result.value.content == json.dumps(answer)
 
     @pytest.mark.asyncio
+    async def test_single_structured_completion_event_returns_assistant_payload(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = json.dumps({"type": "message", "content": '{"answer":"ok"}'})
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return JSON")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == '{"answer":"ok"}'
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "answer",
         [

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -501,6 +501,7 @@ class TestComplete:
             [
                 json.dumps({"type": "session.started", "session_id": "sess-json"}),
                 json.dumps({"type": "tool_use", "name": "shell", "command": "pwd"}),
+                json.dumps({"type": "telemetry", "payload": {"phase": "done"}}),
                 json.dumps({"answer": "ok"}),
                 json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
             ]
@@ -525,6 +526,37 @@ class TestComplete:
         assert result.value.content == '{"answer": "ok"}'
         assert result.value.raw_response["session_id"] == "sess-json"
         assert "tool_use" not in result.value.content
+        assert "telemetry" not in result.value.content
+
+    @pytest.mark.asyncio
+    async def test_structured_completion_event_wins_over_stray_stdout(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-json"}),
+                json.dumps({"type": "message", "content": '{"answer":"from-event"}'}),
+                "stray diagnostic text",
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return JSON")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == '{"answer":"from-event"}'
+        assert "stray diagnostic text" not in result.value.content
 
     @pytest.mark.asyncio
     async def test_nonzero_exit_returns_provider_error(self) -> None:

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -414,6 +414,37 @@ class TestComplete:
         assert "Hello there!" in result.value.content
 
     @pytest.mark.asyncio
+    async def test_fallback_plain_text_ignores_json_metadata_and_tool_events(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-mixed"}),
+                json.dumps({"type": "tool_use", "name": "shell", "command": "pwd"}),
+                "Plain text fallback answer.",
+                json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Answer plainly")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_ok
+        assert result.value.content == "Plain text fallback answer."
+        assert result.value.raw_response["session_id"] == "sess-mixed"
+        assert "session.started" not in result.value.content
+        assert "tool_use" not in result.value.content
+        assert "turn.completed" not in result.value.content
+
+    @pytest.mark.asyncio
     async def test_nonzero_exit_returns_provider_error(self) -> None:
         adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
 

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -650,6 +650,40 @@ class TestComplete:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
+        "event",
+        [
+            {"type": "session.started", "session_id": "sess-json"},
+            {"type": "telemetry", "payload": {"phase": "done"}},
+            {"type": "run.progress", "payload": {"phase": "future"}},
+        ],
+    )
+    async def test_single_structured_transport_envelope_is_not_returned_as_content(
+        self,
+        event: dict[str, Any],
+    ) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = json.dumps(event)
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return JSON")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_err
+        assert "empty response" in result.error.message.lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
         "answer",
         [
             {"type": "result", "payload": {"value": "ok"}},

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -445,6 +445,88 @@ class TestComplete:
         assert "turn.completed" not in result.value.content
 
     @pytest.mark.asyncio
+    async def test_fallback_preserves_raw_json_object_stdout(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = json.dumps({"answer": "ok"})
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            prompt = command[command.index("-p") + 1]
+            assert "single JSON object" in prompt
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return JSON")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == '{"answer": "ok"}'
+
+    @pytest.mark.asyncio
+    async def test_fallback_preserves_raw_json_object_with_type_discriminator(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = json.dumps({"type": "tool_use", "value": "ok"})
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            prompt = command[command.index("-p") + 1]
+            assert "single JSON object" in prompt
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return a typed JSON object")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == '{"type": "tool_use", "value": "ok"}'
+
+    @pytest.mark.asyncio
+    async def test_structured_fallback_still_ignores_copilot_tool_events(self) -> None:
+        adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-json"}),
+                json.dumps({"type": "tool_use", "name": "shell", "command": "pwd"}),
+                json.dumps({"answer": "ok"}),
+                json.dumps({"type": "turn.completed", "usage": {"input_tokens": 12}}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Return JSON")],
+                CompletionConfig(
+                    model="default",
+                    response_format={"type": "json_object"},
+                ),
+            )
+
+        assert result.is_ok
+        assert result.value.content == '{"answer": "ok"}'
+        assert result.value.raw_response["session_id"] == "sess-json"
+        assert "tool_use" not in result.value.content
+
+    @pytest.mark.asyncio
     async def test_nonzero_exit_returns_provider_error(self) -> None:
         adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
 

--- a/tests/unit/providers/test_copilot_cli_adapter.py
+++ b/tests/unit/providers/test_copilot_cli_adapter.py
@@ -83,6 +83,17 @@ class _FakeProcess:
         self.returncode = self._final_returncode
 
 
+class _FakeLegacyProcess:
+    def __init__(self, *, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdin = _FakeStdin()
+        self.returncode = returncode
+        self._stdout = stdout.encode("utf-8")
+        self._stderr = stderr.encode("utf-8")
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+
 class TestPromptBuilding:
     def test_preserves_system_and_roles(self) -> None:
         adapter = CopilotCliLLMAdapter(cli_path="copilot", cwd=os.getcwd())
@@ -583,3 +594,73 @@ class TestRegressionToolEventDoesNotReplaceAssistantContent:
 
         assert result.is_ok
         assert result.value.content == "Final assistant answer."
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_events_without_completion_return_empty_response_error(
+        self,
+    ) -> None:
+        messages: list[tuple[str, str]] = []
+        adapter = CopilotCliLLMAdapter(
+            cli_path="copilot",
+            cwd=os.getcwd(),
+            on_message=lambda message_type, content: messages.append((message_type, content)),
+        )
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-tool-only"}),
+                json.dumps({"type": "tool_use", "name": "shell", "command": "cat ~/.ssh/id_rsa"}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+            return _FakeProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Please answer")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert "Empty response from GitHub Copilot CLI" in result.error.message
+        assert result.error.details["session_id"] == "sess-tool-only"
+        assert "cat ~/.ssh/id_rsa" not in result.error.message
+        assert messages == [("tool", "shell")]
+
+    @pytest.mark.asyncio
+    async def test_legacy_tool_events_without_completion_return_empty_response_error(
+        self,
+    ) -> None:
+        messages: list[tuple[str, str]] = []
+        adapter = CopilotCliLLMAdapter(
+            cli_path="copilot",
+            cwd=os.getcwd(),
+            on_message=lambda message_type, content: messages.append((message_type, content)),
+        )
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "session.started", "session_id": "sess-legacy-tool-only"}),
+                json.dumps({"type": "tool_call", "name": "shell", "command": "cat ~/.ssh/id_rsa"}),
+            ]
+        )
+
+        async def fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeLegacyProcess:
+            return _FakeLegacyProcess(stdout=stdout, returncode=0)
+
+        with patch(
+            "ouroboros.providers.copilot_cli_adapter.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="Please answer")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert "Empty response from GitHub Copilot CLI" in result.error.message
+        assert result.error.details["session_id"] == "sess-legacy-tool-only"
+        assert "cat ~/.ssh/id_rsa" not in result.error.message
+        assert messages == [("tool", "shell")]


### PR DESCRIPTION
Follow-up to #860.

## Summary
- keep successful Copilot completion fallback limited to non-JSON stdout when no completion event was observed
- prevent tool/session telemetry JSON from becoming `CompletionResponse.content` on exit 0
- add streaming and legacy-process regression coverage while preserving `on_message` tool callbacks

## Validation
- `env PYTHONPATH=src /opt/hermes/.venv/bin/pytest tests/unit/providers/test_copilot_cli_adapter.py -q`
- `env PYTHONPATH=src /opt/hermes/.venv/bin/ruff check src/ouroboros/providers/copilot_cli_adapter.py tests/unit/providers/test_copilot_cli_adapter.py`
- `env PYTHONPATH=src /opt/hermes/.venv/bin/ruff format --check src/ouroboros/providers/copilot_cli_adapter.py tests/unit/providers/test_copilot_cli_adapter.py`
- `git diff --check HEAD~1..HEAD -- src/ouroboros/providers/copilot_cli_adapter.py tests/unit/providers/test_copilot_cli_adapter.py`