### PR TITLE
fix(interview): close parent-context leaks in sub-CLI envelope (#869)

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -738,6 +738,39 @@ class ClaudeCodeAdapter:
                     },
                 )
 
+            # Pure-interviewer envelope: close every parent-context leak path
+            # the SDK exposes.  ``strict_mcp_config`` only blocks MCP-server
+            # discovery; skills / sub-agents / plugins / settings / hooks
+            # still inherit from the parent Claude Code session, so the
+            # spawned sub-CLI's system prompt grows tool descriptors that
+            # tempt the model into emitting a ``ToolUseBlock`` on the only
+            # allowed turn.  When ``max_turns=1`` that consumes the budget
+            # before any text streams and the CLI emits a ``{"type":
+            # "error"}`` control message which the SDK re-raises as a bare
+            # ``Exception`` before any ``ResultMessage`` reaches the
+            # adapter (see ``claude_agent_sdk/_internal/query.py``).  Each
+            # override is gated by SDK field presence so older releases
+            # that have not yet introduced the field stay no-op.  See
+            # https://github.com/Q00/ouroboros/issues/869.
+            _ISOLATION_OVERRIDES: tuple[tuple[str, object], ...] = (
+                ("setting_sources", []),
+                ("skills", []),
+                ("agents", []),
+                ("plugins", []),
+                ("hooks", {}),
+                ("include_hook_events", False),
+            )
+            applied_isolation: list[str] = []
+            for option_name, isolated_value in _ISOLATION_OVERRIDES:
+                if option_name in field_names:
+                    options_kwargs[option_name] = isolated_value
+                    applied_isolation.append(option_name)
+            log.debug(
+                "claude_code_adapter.strict_mcp_isolation_applied",
+                applied=applied_isolation,
+                skipped=sorted(name for name, _ in _ISOLATION_OVERRIDES if name not in field_names),
+            )
+
         # Pass model from CompletionConfig if specified
         # "default" is not a valid SDK model — treat it as None (use SDK default)
         if config.model and config.model != "default":

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -966,6 +966,200 @@ class TestJsonSchemaHandling:
         assert "strict_mcp_config" not in options_call_kwargs
         assert "strict-mcp-config" not in (options_call_kwargs.get("extra_args") or {})
 
+    @pytest.mark.asyncio
+    async def test_strict_mcp_config_closes_parent_context_leak_paths(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``strict_mcp_config=True`` must also zero out every parent-context
+        leak surface the SDK exposes (skills / sub-agents / plugins /
+        settings / hooks).
+
+        ``--strict-mcp-config`` alone only blocks MCP-server discovery,
+        not the other descriptor sources that the parent Claude Code
+        session leaks into the spawned subprocess.  Leaving them open
+        gives the sub-CLI's model enough tool descriptors that it
+        emits a ``ToolUseBlock`` on the only allowed turn, exhausts
+        ``max_turns=1`` before any text streams, and ultimately surfaces
+        as the bare-``Exception`` failure path described in #869.
+        """
+        from ouroboros.providers import claude_code_adapter as adapter_mod
+
+        monkeypatch.setattr(
+            adapter_mod,
+            "_claude_options_field_names",
+            lambda: frozenset(
+                {
+                    "extra_args",
+                    "allowed_tools",
+                    "tools",
+                    "strict_mcp_config",
+                    "setting_sources",
+                    "skills",
+                    "agents",
+                    "plugins",
+                    "hooks",
+                    "include_hook_events",
+                }
+            ),
+        )
+
+        adapter = ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        assert options_call_kwargs.get("strict_mcp_config") is True
+        assert options_call_kwargs.get("setting_sources") == []
+        assert options_call_kwargs.get("skills") == []
+        assert options_call_kwargs.get("agents") == []
+        assert options_call_kwargs.get("plugins") == []
+        assert options_call_kwargs.get("hooks") == {}
+        assert options_call_kwargs.get("include_hook_events") is False
+
+    @pytest.mark.asyncio
+    async def test_strict_mcp_config_isolation_is_noop_when_sdk_lacks_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each isolation override must be gated by SDK field presence.
+
+        Older SDK releases predate ``skills`` / ``agents`` / ``plugins`` /
+        ``setting_sources`` / ``hooks`` / ``include_hook_events`` on
+        ``ClaudeAgentOptions``.  Forwarding them unconditionally would
+        crash with ``TypeError`` at ``ClaudeAgentOptions(**options_kwargs)``.
+        On those releases the adapter still forwards ``strict_mcp_config``
+        (or its ``extra_args`` fallback) and simply omits the rest.
+        """
+        from ouroboros.providers import claude_code_adapter as adapter_mod
+
+        monkeypatch.setattr(
+            adapter_mod,
+            "_claude_options_field_names",
+            lambda: frozenset({"extra_args", "allowed_tools", "tools", "strict_mcp_config"}),
+        )
+
+        adapter = ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        assert options_call_kwargs.get("strict_mcp_config") is True
+        for absent in (
+            "setting_sources",
+            "skills",
+            "agents",
+            "plugins",
+            "hooks",
+            "include_hook_events",
+        ):
+            assert absent not in options_call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_isolation_overrides_skipped_without_strict_mcp_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-isolation callers must keep parent context (skills, plugins,
+        settings) intact.  The isolation overrides are scoped to opt-in
+        ``strict_mcp_config=True`` callers only — generic explicit
+        envelopes that need ``mcp__*`` tool access or project-scoped
+        skills/agents must not silently lose them.
+        """
+        from ouroboros.providers import claude_code_adapter as adapter_mod
+
+        monkeypatch.setattr(
+            adapter_mod,
+            "_claude_options_field_names",
+            lambda: frozenset(
+                {
+                    "extra_args",
+                    "allowed_tools",
+                    "tools",
+                    "strict_mcp_config",
+                    "setting_sources",
+                    "skills",
+                    "agents",
+                    "plugins",
+                    "hooks",
+                    "include_hook_events",
+                }
+            ),
+        )
+
+        adapter = ClaudeCodeAdapter(allowed_tools=["Read", "mcp__ouroboros__qa"])
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            msg = MagicMock()
+            type(msg).__name__ = "ResultMessage"
+            msg.structured_output = None
+            msg.result = "test response"
+            msg.is_error = False
+            yield msg
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            await adapter._execute_single_request("test prompt", config)
+
+        options_call_kwargs = mock_options_cls.call_args.kwargs
+        for absent in (
+            "strict_mcp_config",
+            "setting_sources",
+            "skills",
+            "agents",
+            "plugins",
+            "hooks",
+            "include_hook_events",
+        ):
+            assert absent not in options_call_kwargs
+
 
 class TestErrorDiagnostics:
     """Tests for error diagnostic paths in _execute_single_request."""


### PR DESCRIPTION
## Summary

Closes the root-cause leak that surfaced in #869 as `Reached maximum number of turns (1)` raised as a bare `Exception` from `claude_agent_sdk._internal.query` before any `ResultMessage` reaches the adapter.

## RCA

`strict_mcp_config=True` (introduced in #754) only blocks **MCP-server discovery**. The other parent-context surfaces the SDK exposes were left at SDK defaults, so a Claude Code-hosted parent session leaks them into the spawned sub-CLI:

| Surface | Was leaked? | Effect on sub-CLI prompt |
|---|---|---|
| MCP servers | ❌ blocked by `strict_mcp_config` | — |
| `skills` | ✅ leaked | Tens of user/plugin skill descriptors visible |
| `agents` | ✅ leaked | Sub-agent registry visible |
| `plugins` | ✅ leaked | Plugin-bundled tools/skills visible |
| `setting_sources` | ✅ leaked | user/project/local `settings.json` all loaded |
| `hooks` / `include_hook_events` | ✅ leaked | Parent hooks fire inside sub-CLI |

With those descriptors visible the sub-CLI's model emits a `ToolUseBlock` on its only allowed turn for a `max_turns=1` request. That consumes the budget before any text streams, and the CLI sends `{"type": "error", "error": "Reached maximum number of turns (1)"}` over the control protocol. The SDK then re-raises it as a bare `Exception` from `claude_agent_sdk/_internal/query.py:813` *before* any `ResultMessage(subtype="error_max_turns")` is yielded — so the existing `_is_usable_max_turns_partial` recovery path (#587, #786, #834) never fires.

## Reproduction note

I could confirm the SDK code path locally by monkey-patching the SDK's message receive stream to emit a single `{"type": "error", ...}` envelope. The traceback then matches the one in the issue exactly:

```
Exception: Reached maximum number of turns (1)
  File ".../claude_agent_sdk/_internal/query.py", line 813, in receive_messages
    raise Exception(message.get("error", "Unknown error"))
  File "ouroboros/providers/claude_code_adapter.py", line 806, in _execute_single_request
```

Natural reproduction is environment-dependent (the issue author reports Linux + CLI 2.1.138; on macOS + CLI 2.1.138 + SDK 0.1.76 the parent session's specific skill/plugin inventory determines whether the model emits a tool-use block on turn 1). The fix targets the structural cause regardless of which side of that boundary a given environment falls on.

## Change

`claude_code_adapter.py` — inside the existing `strict_mcp_config` block, after the typed-field / `extra_args` branch, zero out every parent-context override the SDK exposes. Each field is gated by `_claude_options_field_names` so older SDK releases that predate the field stay a no-op.

```python
_ISOLATION_OVERRIDES = (
    ("setting_sources", []),
    ("skills", []),
    ("agents", []),
    ("plugins", []),
    ("hooks", {}),
    ("include_hook_events", False),
)
```

A debug log line (`claude_code_adapter.strict_mcp_isolation_applied`) records exactly which fields were applied vs. skipped per release.

## Scope guarantee

- Only callers that opt in to `strict_mcp_config=True` (currently: `InterviewHandler.handle`, generate-seed's interview-engine path, and adapter clones via `with_strict_mcp_config()`) get the isolation overrides.
- Generic explicit envelopes that pass an `allowed_tools=["mcp__ouroboros__qa", ...]` list — i.e. non-interview callers that legitimately need MCP-tool access or project-scoped skills/agents — are unchanged. A regression test (`test_isolation_overrides_skipped_without_strict_mcp_config`) locks this.

## Test plan

- [x] `pytest tests/unit/providers/test_claude_code_adapter.py` → 49 passed (added 3 cases).
- [x] `pytest tests/unit/providers/ tests/unit/mcp/tools/test_interview_*_wiring.py tests/unit/mcp/tools/test_interview_response_diagnostics.py` → 382 passed.
- [x] `ruff check`, `ruff format --check`, `mypy` clean on touched files.
- [x] Live SDK 0.1.76 verification: forwards all six isolation fields with the expected values; emits `applied=['setting_sources','skills','agents','plugins','hooks','include_hook_events']` debug log.
- [ ] Reviewer: confirm the override list is what we want — in particular whether `add_dirs=[]` should also be zeroed to close the CLAUDE.md auto-discovery path (kept out of this PR because it has UX implications for the interview CLI entrypoints, which intentionally inherit project CLAUDE.md).
- [ ] Reviewer: confirm that PM-interview / generate-seed paths still produce questions after this change in a real Claude Code-hosted session.

## Related

- #869 — the bug
- #754 — original MCP-server isolation (this PR builds on it)
- #587 / #786 / #834 — `error_max_turns` partial-extraction (still relevant for the case where the CLI does emit a `ResultMessage`, which this PR does not touch)
- #837 — diagnostic event for interview response shape (complementary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)