### PR TITLE
test(orchestrator): isolate codex_cli profile tests from user config

### DIFF
--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -475,7 +475,11 @@ class TestCodexCliRuntime:
         """Default runtime_profile=None preserves existing command shape (regression)."""
         runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp/project")
 
-        command = runtime._build_command(output_last_message_path="/tmp/out.txt")
+        with patch(
+            "ouroboros.providers.profiles.load_config",
+            return_value=OuroborosConfig(),
+        ):
+            command = runtime._build_command(output_last_message_path="/tmp/out.txt")
 
         assert "--profile" not in command
 
@@ -505,7 +509,11 @@ class TestCodexCliRuntime:
                 runtime_profile="future-tier",
             )
 
-        command = runtime._build_command(output_last_message_path="/tmp/out.txt")
+        with patch(
+            "ouroboros.providers.profiles.load_config",
+            return_value=OuroborosConfig(),
+        ):
+            command = runtime._build_command(output_last_message_path="/tmp/out.txt")
 
         assert "--profile" not in command
         mock_warning.assert_called_once()


### PR DESCRIPTION
## Summary
- Two `test_codex_cli_runtime.py` tests (`test_build_command_omits_profile_flag_when_runtime_profile_unset`, `test_build_command_skips_unknown_runtime_profile_with_warning`) fail locally for any developer whose `~/.ouroboros/config.yaml` maps `llm_role_profiles.agent_runtime` to a profile with a `providers.codex.profile` entry.
- Root cause: both tests call `_build_command()` without mocking `ouroboros.providers.profiles.load_config`, so the user's local `OuroborosConfig` leaks through `_resolve_runtime_codex_config()` → `resolve_completion_profile(role="agent_runtime", backend="codex")` and injects a `--profile <name>` the assertions don't expect. CI passes because CI environments have no user config.
- Fix: wrap each `_build_command()` call in `patch("ouroboros.providers.profiles.load_config", return_value=OuroborosConfig())` — the same isolation pattern every other `_build_command` test in this file already uses.

Discovered while running `/release 0.37.0` — these were reported as failures during release validation but on inspection are purely test-isolation bugs, not production regressions.

## Test plan
- [x] `uv run pytest tests/unit/orchestrator/test_codex_cli_runtime.py` → 51 passed
- [x] `uv run ruff format tests/unit/orchestrator/test_codex_cli_runtime.py` clean
- [x] `uv run ruff check tests/unit/orchestrator/test_codex_cli_runtime.py` clean
- [x] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)