### PR TITLE
docs: clarify source checkout Python defaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ uv run pytest tests/unit/ -q # run tests
 
 **Requirements**: Python >= 3.12, [uv](https://github.com/astral-sh/uv)
 
+> This repository's `.python-version` defaults source checkouts to **stable Python 3.14** for local development. Python 3.12 and 3.13 remain supported. If your local 3.14 interpreter is a beta/RC build or hits dependency compatibility issues, rerun the contributor commands with an explicit stable interpreter, for example `uv run --python 3.12 ouroboros --version` and `uv run --python 3.12 pytest tests/unit/ -q`.
+
 ---
 
 ## Development Workflow
@@ -324,8 +326,10 @@ uv run ruff check src/ tests/
 
 ### Python Version
 
-- **Minimum**: Python 3.12
-- **Target**: Python >= 3.12
+- **Minimum supported**: Python 3.12
+- **Supported CI range**: Python 3.12, 3.13, and 3.14
+- **Source-checkout default**: `.python-version` selects stable Python 3.14 for local development
+- Use `uv run --python 3.12 ...` or another supported stable interpreter when validating compatibility below the checkout default or when a local 3.14 prerelease/dependency combination fails before the CLI starts.
 - Use modern Python features (type unions `|`, match statements, etc.)
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,6 +138,13 @@ uv sync --all-extras                  # or: include all optional extras
 uv run ouroboros --version            # verify CLI
 ```
 
+Source checkouts use the repository `.python-version`, which currently defaults to **stable Python 3.14**. Ouroboros still supports Python 3.12+, so if your local 3.14 interpreter is a prerelease build or hits dependency compatibility issues before the CLI starts, pin a supported stable interpreter explicitly:
+
+```bash
+uv run --python 3.12 ouroboros --version
+uv run --python 3.12 pytest tests/unit/ -q
+```
+
 > See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor setup (linting, testing, pre-commit hooks).
 
 ### Prerequisites
@@ -369,10 +376,12 @@ claude plugin install ouroboros@ouroboros --force
 ### Python / CLI issues
 
 ```bash
-python --version            # Must be >= 3.12
+python --version            # Must be >= 3.12 and should be a stable release
 pip install --force-reinstall ouroboros-ai
 ouroboros --version
 ```
+
+For source checkouts, `uv run ...` follows `.python-version` and may choose Python 3.14. If that local interpreter is a beta/RC build or dependency-sensitive environment, retry with an explicit supported stable interpreter, for example `uv run --python 3.12 ouroboros --version`.
 
 ### API key not found
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -57,7 +57,8 @@ If you encounter Windows-specific issues, please [open an issue](https://github.
 |----------------|---------------|
 | 3.12           | Supported     |
 | 3.13           | Supported     |
-| 3.14+          | Supported     |
+| 3.14           | Supported     |
+| 3.14 beta/RC   | Best effort   |
 | < 3.12         | Not supported |
 
-The minimum required version is **Python >= 3.12** as specified in `pyproject.toml`.
+The minimum required version is **Python >= 3.12** as specified in `pyproject.toml`. Source checkouts default to **stable Python 3.14** through `.python-version`; that default does not narrow the supported runtime range to 3.14-only. If a local 3.14 prerelease or dependency combination fails during contributor setup, rerun the command with an explicit supported stable interpreter such as `uv run --python 3.12 ...`.


### PR DESCRIPTION
## Summary

- Clarifies that Ouroboros supports Python >=3.12 while source checkouts default to stable Python 3.14 via `.python-version`.
- Adds explicit `uv run --python 3.12 ...` fallback commands for contributors whose local 3.14 prerelease/dependency combination fails before the CLI starts.
- Updates platform support wording to distinguish stable 3.14 support from beta/RC best-effort behavior.

Closes #873.

## Validation

- `git diff --check`
- Grepped touched docs for Python version policy mentions
