### PR TITLE
fix(auto): restore coding profile lazy import boundary

### DIFF
--- a/tests/integration/auto/test_domain_profile_plurality.py
+++ b/tests/integration/auto/test_domain_profile_plurality.py
@@ -26,11 +26,17 @@ def test_both_profiles_registered() -> None:
         assert "coding" in names
 
 
-def test_detect_best_returns_research_for_bib_repo(tmp_path: Path) -> None:
-    """A repo with references.bib is detected as the research domain."""
+@pytest.mark.parametrize("with_generic_code_layout", [False, True])
+def test_detect_best_returns_research_for_bib_repo(
+    tmp_path: Path, with_generic_code_layout: bool
+) -> None:
+    """Bibliography evidence beats generic coding-layout directories."""
     repo = tmp_path / "research_repo_with_bib"
     repo.mkdir()
     (repo / "references.bib").write_text("")
+    if with_generic_code_layout:
+        (repo / "src").mkdir()
+        (repo / "tests").mkdir()
 
     best = DEFAULT_REGISTRY.detect_best(repo)
     assert best is not None

--- a/tests/unit/auto/test_domain_profile_coding_parity.py
+++ b/tests/unit/auto/test_domain_profile_coding_parity.py
@@ -241,6 +241,26 @@ def test_detector_scores_linked_worktree_when_source_layout_exists(tmp_path: Pat
     assert 0.0 < CODING_PROFILE.detector(tmp_path) < 0.6
 
 
+def test_research_profile_beats_generic_src_and_tests_layout(tmp_path: Path) -> None:
+    """Research evidence must beat generic source-layout directory signals."""
+    from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "references.bib").write_text("@article{demo}\n")
+
+    best = DEFAULT_REGISTRY.detect_best(tmp_path)
+
+    assert best is not None
+    assert best.name == "research"
+
+
+def test_detector_ignores_plain_files_named_like_directory_markers(tmp_path: Path) -> None:
+    """Directory markers must be directories, not arbitrary regular files."""
+    (tmp_path / "tests").write_text("not a directory")
+    assert CODING_PROFILE.detector(tmp_path) == 0.0
+
+
 def test_detector_returns_zero_for_empty_dir(tmp_path: Path) -> None:
     """detector returns 0.0 when neither marker file nor marker directory is present."""
     assert CODING_PROFILE.detector(tmp_path) == 0.0

--- a/tests/unit/auto/test_domain_profile_contracts.py
+++ b/tests/unit/auto/test_domain_profile_contracts.py
@@ -413,6 +413,21 @@ def test_auto_package_exports_are_lazy() -> None:
     subprocess.run([sys.executable, "-c", code], check=True)
 
 
+def test_domain_profile_freezes_mapping_even_if_mapping_claims_frozen() -> None:
+    class _SpoofedFrozenMapping(dict):
+        __domain_profile_frozen__ = True
+
+    source = _SpoofedFrozenMapping({"runtime_context": ["pytest"]})
+    profile = _make_profile(safe_defaults=source)
+
+    source["runtime_context"].append("ruff")
+
+    commands = profile.safe_defaults["runtime_context"]
+    assert commands == ("pytest",)
+    with pytest.raises(AttributeError):
+        commands.append("ruff")
+
+
 def test_default_registry_get_returns_existing_profile_without_loading_builtins() -> None:
     registry = DomainProfileRegistry(
         loader=lambda _registry: (_ for _ in ()).throw(RuntimeError("boom"))


### PR DESCRIPTION
## Summary

Fixes the unresolved blocker from merged PR #851: the built-in `coding` DomainProfile was still too heavy to import through `DEFAULT_REGISTRY.get("coding")`, and its detector had lost directory-marker parity.

Changes:
- Defers `grading._is_observable`, `repo_auto_answer_context`, and `_SAFE_DEFAULTS` imports until the corresponding coding-profile adapter is actually used.
- Keeps `DEFAULT_REGISTRY.get("coding")` dependency-light: it no longer imports `grading`, `core.seed`, or `pydantic` just to return the profile singleton.
- Restores `.git`, `src`, and `tests` directory markers to coding repo detection.
- Adds regression coverage for dependency-light `get("coding")` and directory-marker detection.

## Validation

Local:
- `PYTHONPATH=src python` smoke: `DEFAULT_REGISTRY.get("coding")` does not import `ouroboros.auto.grading`, `ouroboros.core.seed`, or `pydantic`
- `PYTHONPATH=src python` smoke: `DEFAULT_REGISTRY.detect_best()` selects `coding` for a repo with only `src/`
- `PYTHONPATH=src pytest tests/unit/auto/test_domain_profile_contracts.py tests/unit/auto/test_domain_profile_coding_parity.py tests/unit/auto/test_research_profile.py tests/integration/auto/test_domain_profile_plurality.py tests/unit/cli/test_auto_domain_activation.py -q`
- `uv run mypy src/ouroboros/auto/domain_profile.py src/ouroboros/auto/profiles src/ouroboros/auto/__init__.py tests/unit/auto/test_domain_profile_contracts.py tests/unit/auto/test_domain_profile_coding_parity.py tests/unit/auto/test_research_profile.py`
- `uv run ruff format --check ...`
- `uv run ruff check ...`

## Context

This is a follow-up to #851, which was merged before the latest bot REQUEST_CHANGES finding was resolved.
