### PR TITLE
fix(auto): bound encoded Seed filenames

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +31,13 @@ _WINDOWS_RESERVED_FILENAME_STEMS = frozenset(
     {"CON", "PRN", "AUX", "NUL"}
     | {f"COM{index}" for index in range(1, 10)}
     | {f"LPT{index}" for index in range(1, 10)}
+)
+_SEED_FILENAME_SUFFIX = ".yaml"
+_SEED_FILENAME_COMPONENT_MAX_BYTES = 255
+_SEED_FILENAME_DIGEST_HEX_LENGTH = 24
+_SEED_FILENAME_DIGEST_SEPARATOR = "--"
+_SEED_FILENAME_STEM_MAX_BYTES = _SEED_FILENAME_COMPONENT_MAX_BYTES - len(
+    _SEED_FILENAME_SUFFIX.encode("utf-8")
 )
 
 
@@ -736,7 +744,7 @@ def save_seed(seed: Seed, *, seeds_dir: Path | None = None) -> str:
     directory = seeds_dir or (Path.home() / ".ouroboros" / "seeds")
     directory.mkdir(parents=True, exist_ok=True)
     seed_id = _safe_seed_id_for_filename(seed.metadata.seed_id)
-    path = directory / f"{seed_id}.yaml"
+    path = directory / f"{seed_id}{_SEED_FILENAME_SUFFIX}"
     _require_path_inside_directory(path, directory)
     path.write_text(
         yaml.dump(seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False),
@@ -765,7 +773,25 @@ def _safe_seed_id_for_filename(seed_id: str) -> str:
     if stem.upper() in _WINDOWS_RESERVED_FILENAME_STEMS:
         first_byte = stem[0].encode("utf-8")[0]
         stem = f"%{first_byte:02X}{stem[1:]}"
-    return stem
+    return _bound_seed_filename_stem(stem, seed_id)
+
+
+def _bound_seed_filename_stem(stem: str, seed_id: str) -> str:
+    """Keep the encoded Seed filename stem under common component limits.
+
+    The encoded stem is ASCII-only, so character count equals byte count.  When
+    percent-encoding would inflate a valid semantic Seed id beyond common
+    255-byte filename component limits, preserve a readable prefix and append a
+    digest of the original semantic id.
+    """
+    if len(stem.encode("utf-8")) <= _SEED_FILENAME_STEM_MAX_BYTES:
+        return stem
+
+    digest = hashlib.sha256(seed_id.encode("utf-8")).hexdigest()[:_SEED_FILENAME_DIGEST_HEX_LENGTH]
+    suffix = f"{_SEED_FILENAME_DIGEST_SEPARATOR}{digest}"
+    prefix_budget = _SEED_FILENAME_STEM_MAX_BYTES - len(suffix.encode("utf-8"))
+    prefix = stem[:prefix_budget]
+    return f"{prefix}{suffix}"
 
 
 def _require_path_inside_directory(path: Path, directory: Path) -> None:

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -35,7 +35,7 @@ _WINDOWS_RESERVED_FILENAME_STEMS = frozenset(
 _SEED_FILENAME_SUFFIX = ".yaml"
 _SEED_FILENAME_COMPONENT_MAX_BYTES = 255
 _SEED_FILENAME_DIGEST_HEX_LENGTH = 24
-_SEED_FILENAME_DIGEST_SEPARATOR = "--"
+_SEED_FILENAME_TRUNCATION_MARKER = "--%TRUNC%"
 _SEED_FILENAME_STEM_MAX_BYTES = _SEED_FILENAME_COMPONENT_MAX_BYTES - len(
     _SEED_FILENAME_SUFFIX.encode("utf-8")
 )
@@ -788,7 +788,7 @@ def _bound_seed_filename_stem(stem: str, seed_id: str) -> str:
         return stem
 
     digest = hashlib.sha256(seed_id.encode("utf-8")).hexdigest()[:_SEED_FILENAME_DIGEST_HEX_LENGTH]
-    suffix = f"{_SEED_FILENAME_DIGEST_SEPARATOR}{digest}"
+    suffix = f"{_SEED_FILENAME_TRUNCATION_MARKER}{digest}"
     prefix_budget = _SEED_FILENAME_STEM_MAX_BYTES - len(suffix.encode("utf-8"))
     prefix = stem[:prefix_budget]
     return f"{prefix}{suffix}"

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2094,6 +2094,37 @@ def test_auto_save_seed_long_unicode_filename_digest_avoids_prefix_collision(
     assert len(second_path.name.encode("utf-8")) <= 255
 
 
+def test_auto_save_seed_truncated_filename_namespace_cannot_overwrite_untruncated_id(
+    tmp_path: Path,
+) -> None:
+    from ouroboros.auto.adapters import load_seed, save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    ontology = OntologySchema(name="demo", description="demo ontology")
+    long_seed = Seed(
+        goal="Long Unicode goal",
+        ontology_schema=ontology,
+        metadata=SeedMetadata(seed_id="漢" * 80),
+    )
+
+    long_path = Path(save_seed(long_seed, seeds_dir=seeds_dir)).resolve()
+    colliding_semantic_id = long_path.stem
+    safe_ascii_seed = Seed(
+        goal="Safe ASCII goal",
+        ontology_schema=ontology,
+        metadata=SeedMetadata(seed_id=colliding_semantic_id),
+    )
+
+    safe_ascii_path = Path(save_seed(safe_ascii_seed, seeds_dir=seeds_dir)).resolve()
+
+    assert long_path != safe_ascii_path
+    assert long_path.exists()
+    assert safe_ascii_path.exists()
+    assert load_seed(long_path).metadata.seed_id == "漢" * 80
+    assert load_seed(safe_ascii_path).metadata.seed_id == colliding_semantic_id
+
+
 def test_auto_save_seed_accepts_default_seed_id_inside_seed_dir(tmp_path: Path) -> None:
     from ouroboros.auto.adapters import load_seed, save_seed
     from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2043,6 +2043,57 @@ def test_auto_save_seed_encodes_windows_reserved_basename_seed_id(
     assert load_seed(path).metadata.seed_id == "CON"
 
 
+def test_auto_save_seed_bounds_long_unicode_seed_id_filename_without_metadata_drift(
+    tmp_path: Path,
+) -> None:
+    from ouroboros.auto.adapters import load_seed, save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    seed_id = "漢" * 80
+    seed = Seed(
+        goal="Demo goal",
+        ontology_schema=OntologySchema(name="demo", description="demo ontology"),
+        metadata=SeedMetadata(seed_id=seed_id),
+    )
+
+    path = Path(save_seed(seed, seeds_dir=seeds_dir)).resolve()
+
+    assert path.parent == seeds_dir.resolve()
+    assert path.exists()
+    assert len(path.name.encode("utf-8")) <= 255
+    assert path.name.endswith(".yaml")
+    assert "--" in path.stem
+    assert load_seed(path).metadata.seed_id == seed_id
+
+
+def test_auto_save_seed_long_unicode_filename_digest_avoids_prefix_collision(
+    tmp_path: Path,
+) -> None:
+    from ouroboros.auto.adapters import save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    ontology = OntologySchema(name="demo", description="demo ontology")
+    first = Seed(
+        goal="Demo goal", ontology_schema=ontology, metadata=SeedMetadata(seed_id="漢" * 80)
+    )
+    second = Seed(
+        goal="Demo goal",
+        ontology_schema=ontology,
+        metadata=SeedMetadata(seed_id=("漢" * 79) + "字"),
+    )
+
+    first_path = Path(save_seed(first, seeds_dir=seeds_dir)).resolve()
+    second_path = Path(save_seed(second, seeds_dir=seeds_dir)).resolve()
+
+    assert first_path != second_path
+    assert first_path.exists()
+    assert second_path.exists()
+    assert len(first_path.name.encode("utf-8")) <= 255
+    assert len(second_path.name.encode("utf-8")) <= 255
+
+
 def test_auto_save_seed_accepts_default_seed_id_inside_seed_dir(tmp_path: Path) -> None:
     from ouroboros.auto.adapters import load_seed, save_seed
     from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2067,6 +2067,29 @@ def test_auto_save_seed_bounds_long_unicode_seed_id_filename_without_metadata_dr
     assert load_seed(path).metadata.seed_id == seed_id
 
 
+def test_auto_save_seed_bounds_long_ascii_seed_id_filename_without_metadata_drift(
+    tmp_path: Path,
+) -> None:
+    from ouroboros.auto.adapters import load_seed, save_seed
+    from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+    seeds_dir = tmp_path / "seeds"
+    seed_id = "seed_" + ("a" * 300)
+    seed = Seed(
+        goal="Demo goal",
+        ontology_schema=OntologySchema(name="demo", description="demo ontology"),
+        metadata=SeedMetadata(seed_id=seed_id),
+    )
+
+    path = Path(save_seed(seed, seeds_dir=seeds_dir)).resolve()
+
+    assert path.parent == seeds_dir.resolve()
+    assert path.exists()
+    assert len(path.name.encode("utf-8")) <= 255
+    assert "--%TRUNC%" in path.stem
+    assert load_seed(path).metadata.seed_id == seed_id
+
+
 def test_auto_save_seed_long_unicode_filename_digest_avoids_prefix_collision(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #865.

#865 correctly separated semantic `SeedMetadata.seed_id` from the filesystem filename and fixed the traversal boundary from #861, but the final bot review identified a compatibility regression: percent-encoding every non-ASCII UTF-8 byte can inflate a previously valid seed id beyond common 255-byte filename component limits.

This PR keeps the #865 security boundary and adds a bounded filename-stem fallback:

- short/readable generated ids still persist as before;
- unsafe bytes are still encoded so traversal and path syntax cannot escape the managed seed directory;
- if the encoded stem would exceed the filename component budget, the adapter preserves a readable prefix and appends a SHA-256 digest suffix derived from the original semantic seed id;
- persisted YAML still keeps the original `metadata.seed_id` unchanged.

## Why this shape

`SeedMetadata.seed_id` remains semantic data, not a filesystem trust boundary. The adapter should therefore bound the filename at the filesystem edge rather than mutating, truncating, or rejecting the semantic id.

## Regression coverage

Adds tests that:

- save an 80-character CJK seed id without `ENAMETOOLONG`;
- assert the resulting filename stays within a 255-byte component limit;
- verify the YAML metadata still contains the original Unicode seed id;
- verify digest suffixes distinguish long ids with the same encoded prefix.

Existing #865 traversal, whitespace, punctuation, Windows-reserved basename, and default-id tests continue to pass.

## Validation

- `PYTHONPATH=src pytest -q` on the seven targeted `save_seed` regression tests → passed
- `PYTHONPATH=src pytest -q tests/unit/auto/test_surface.py tests/unit/auto/test_interview_pipeline.py` → `209 passed`
- `PYTHONPATH=src ruff check src/ouroboros/auto/adapters.py tests/unit/auto/test_surface.py` → passed
- `PYTHONPATH=src ruff format --check src/ouroboros/auto/adapters.py tests/unit/auto/test_surface.py` → passed
- `PYTHONPATH=src uv run mypy src/ouroboros/auto/adapters.py` → passed

Refs #865.
