### PR TITLE
fix(orchestrator): keep AgentProcess cancellation owned until work exits

### DIFF
--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -907,22 +907,50 @@ async def run_with_agent_process[T](
             error_box.append(exc)
             raise
 
-    process = AgentProcess(event_store=event_store)
-    handle = await process.spawn(intent=intent, work_fn=_work)
-    try:
-        final_status = await handle.wait_until_complete(timeout=timeout)
-    except (asyncio.CancelledError, TimeoutError):
+    async def _request_work_cancellation() -> asyncio.Task[None] | None:
         await handle.cancel(reason="cancelled by job runner")
         work_task = handle._work_task
         if work_task is not None and not work_task.done():
             work_task.cancel()
-            done, _pending = await asyncio.wait({work_task}, timeout=1.0)
+        return work_task
+
+    process = AgentProcess(event_store=event_store)
+    handle = await process.spawn(intent=intent, work_fn=_work)
+    try:
+        final_status = await handle.wait_until_complete(timeout=timeout)
+    except asyncio.CancelledError:
+        work_task = await _request_work_cancellation()
+        if work_task is not None:
+            while not work_task.done():
+                try:
+                    await asyncio.shield(work_task)
+                except asyncio.CancelledError:
+                    # The JobManager may cancel this wrapper more than once.
+                    # Do not re-cancel the work task while it is already
+                    # unwinding; a second injected CancelledError can abort
+                    # workflow cleanup and create the false-terminal state this
+                    # adapter is responsible for preventing.
+                    continue
+        if handle.status() not in _TERMINAL_STATUSES:
+            await handle._mark_cancelled()
+        raise
+    except TimeoutError:
+        work_task = await _request_work_cancellation()
+        if work_task is not None and not work_task.done():
+            done, pending = await asyncio.wait({work_task}, timeout=1.0)
             for completed in done:
                 try:
                     await completed
                 except asyncio.CancelledError:
                     pass
-        await handle._mark_cancelled()
+            if pending:
+                # Timeout callers may return, but the lifecycle must not claim
+                # terminal cancellation until the owned work task really exits.
+                # The AgentProcess runner will publish the terminal transition
+                # later if the workflow eventually honors cancellation.
+                raise
+        if handle.status() not in _TERMINAL_STATUSES:
+            await handle._mark_cancelled()
         raise
 
     await _wait_for_lifecycle_emit_drain(handle)

--- a/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
+++ b/tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py
@@ -546,7 +546,9 @@ async def test_job_manager_classifies_status_only_cancelled_result_as_cancelled(
 
 
 @pytest.mark.asyncio
-async def test_run_with_agent_process_timeout_does_not_hang_on_stubborn_worker() -> None:
+async def test_run_with_agent_process_timeout_does_not_publish_terminal_cancel_for_stubborn_worker() -> (
+    None
+):
     store = _FakeEventStore()
     release = asyncio.Event()
     swallowed_cancel = asyncio.Event()
@@ -571,6 +573,52 @@ async def test_run_with_agent_process_timeout_does_not_hang_on_stubborn_worker()
         )
 
     assert swallowed_cancel.is_set()
-    assert _directives(store)[-1] == "cancel"
+    assert _directives(store) == ["continue"]
+
     release.set()
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while _directives(store)[-1] != "cancel" and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+    assert _directives(store)[-1] == "cancel"
+    assert _lifecycle_statuses(store)[-1] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_run_with_agent_process_external_cancel_waits_for_stubborn_worker_to_stop() -> None:
+    store = _FakeEventStore()
+    release = asyncio.Event()
+    swallowed_cancel = asyncio.Event()
+
+    async def _stubborn_work(_handle: Any) -> MCPToolResult:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            swallowed_cancel.set()
+            await release.wait()
+        return MCPToolResult()
+
+    task = asyncio.create_task(
+        run_with_agent_process(
+            event_store=store,
+            intent="stubborn_cancel_surface",
+            work_fn=_stubborn_work,
+        )
+    )
     await asyncio.sleep(0)
+
+    task.cancel()
+    await asyncio.wait_for(swallowed_cancel.wait(), timeout=2.0)
+    task.cancel()
+    await asyncio.sleep(1.1)
+
+    assert not task.done()
+    assert _directives(store) == ["continue"]
+
+    release.set()
+    with suppress(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=2.0)
+
+    assert task.cancelled()
+    assert _directives(store)[-1] == "cancel"
+    assert _lifecycle_statuses(store)[-1] == "cancelled"


### PR DESCRIPTION
## Summary

Follow-up to #848. This closes the cancellation-ownership gap found after merge: `run_with_agent_process()` must not publish terminal `cancelled` lifecycle state while the underlying production work task is still alive.

## What changed

- External cancellation now keeps the wrapper task attached to the spawned AgentProcess work task until that work actually exits, then re-raises cancellation to preserve JobManager semantics.
- Timeout cleanup still requests/cancels the work task, but if the work remains pending after the bounded grace period it returns the timeout without emitting terminal `cancelled`; the AgentProcess runner will publish terminal cancellation later only when the work exits.
- Acceptance coverage now proves:
  - stubborn timeout workers do **not** get a terminal cancel directive while still running;
  - external cancellation does not complete the wrapper until stubborn work stops.

## Why

Python asyncio cannot force-kill a task that swallows `CancelledError`. The safe contract is therefore: request cancellation immediately, but do not claim terminal lifecycle completion until the owned work task has actually stopped.

## Test plan

- `PYTHONPATH=src uv run pytest tests/integration/orchestrator/test_agent_process_three_surface_acceptance.py tests/unit/orchestrator/test_agent_process.py tests/unit/mcp/tools/test_ralph_handler.py tests/unit/mcp/tools/test_start_execute_seed_idempotency.py tests/unit/mcp/tools/test_round5_fixes.py -q` — 132 passed.
- `PYTHONPATH=src uv run pytest -q` — 7985 passed, 3 skipped.
- `PYTHONPATH=src uv run ruff check .` — clean.
- `PYTHONPATH=src uv run ruff format --check .` — clean.
- `uv run mypy src` — clean.

Fixes the post-merge blocker identified on #848.
