### PR TITLE
feat(orchestrator): profile YAML schema + loader (#830 PR 1/9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ exclude = [
 # so they must reach the installed wheel as package data, not just the
 # source tree.
 "src/ouroboros/plugin/schemas" = "ouroboros/plugin/schemas"
+# Execution profile YAMLs (RFC v2 #830). The loader resolves them via
+# Path(__file__).parent.parent / "profiles", so they must ship with the wheel.
+"src/ouroboros/profiles" = "ouroboros/profiles"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ packages = ["src/ouroboros"]
 exclude = [
     "src/ouroboros/opencode/plugin/**",
     "src/ouroboros/plugin/schemas/**",
+    "src/ouroboros/profiles/**",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+markers = [
+    "slow: integration tests that build artifacts or call subprocesses",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -1,0 +1,160 @@
+"""Execution profile YAML loader (RFC v2 H4).
+
+Loads structured per-domain profiles consumed by harness invariants
+(verifier focus, decomposition axis, evidence schema, suggested tools).
+
+This module is wiring-only: it defines the schema and loads YAML files.
+No existing caller is modified by this module — downstream PRs wire the
+loaded profile into `execution_strategy`, `parallel_executor`, and the
+forthcoming verifier loop.
+
+Usage:
+    from ouroboros.orchestrator.profile_loader import load_profile
+
+    profile = load_profile("code")
+    profile.axis        # "testable_unit"
+    profile.suggested_tools  # ["Read", "Edit", ...]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+import yaml
+
+_PROFILES_DIR: Final[Path] = Path(__file__).resolve().parent.parent / "profiles"
+
+
+class EvidenceSchema(BaseModel):
+    """Schema describing required evidence fields and rejection rules.
+
+    Consumed by H2 (typed evidence record) in a follow-up PR.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required: tuple[str, ...] = Field(
+        default=(),
+        description="Evidence field names that every leaf result must include.",
+    )
+    rejected_if: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Reject expressions evaluated against the evidence record "
+            "(e.g. 'tests_passed == []'). Free-form for now; the verifier "
+            "PR will define an evaluator."
+        ),
+    )
+
+
+class ExecutionProfile(BaseModel):
+    """Per-domain execution profile (RFC v2 thin skill).
+
+    See https://github.com/Q00/ouroboros/issues/830 for the v2 spec.
+    Field shape matches shaun0927's H4 sketch (axis, min_unit, evidence_schema,
+    verifier_focus, suggested_tools).
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    profile: str = Field(
+        ...,
+        min_length=1,
+        description="Profile identifier (e.g. 'code'). Must match filename stem.",
+    )
+    axis: str = Field(
+        ...,
+        min_length=1,
+        description="Decomposition axis (e.g. 'testable_unit', 'subtopic').",
+    )
+    min_unit: str = Field(
+        ...,
+        min_length=1,
+        description="Smallest dispatchable unit description for the decomposer.",
+    )
+    cut_signal: str = Field(
+        default="",
+        description="Heuristic signal that a sub-AC is small enough to stop splitting.",
+    )
+    evidence_schema: EvidenceSchema = Field(default_factory=EvidenceSchema)
+    verifier_focus: str = Field(
+        ...,
+        min_length=1,
+        description="Instruction passed to the external verifier subagent (H1).",
+    )
+    suggested_tools: tuple[str, ...] = Field(
+        default=(),
+        description="Tool names the leaf executor may use; harness still gates.",
+    )
+
+
+class ProfileError(ValueError):
+    """Raised when a profile cannot be located or parsed."""
+
+
+def _candidate_path(name: str, profiles_dir: Path) -> Path:
+    if not name or "/" in name or "\\" in name or name.startswith("."):
+        msg = f"Invalid profile name: {name!r}"
+        raise ProfileError(msg)
+    return profiles_dir / f"{name}.yaml"
+
+
+def load_profile(name: str, *, profiles_dir: Path | None = None) -> ExecutionProfile:
+    """Load and validate an execution profile by name.
+
+    Args:
+        name: Profile identifier (filename stem, e.g. 'code').
+        profiles_dir: Override the default profiles directory (tests use this).
+
+    Returns:
+        Validated ExecutionProfile instance.
+
+    Raises:
+        ProfileError: If the file is missing, malformed, or violates the schema.
+    """
+    base = profiles_dir if profiles_dir is not None else _PROFILES_DIR
+    path = _candidate_path(name, base)
+    if not path.is_file():
+        msg = f"Profile not found: {name!r} (looked in {base})"
+        raise ProfileError(msg)
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        msg = f"Profile {name!r} is not valid YAML: {exc}"
+        raise ProfileError(msg) from exc
+
+    if not isinstance(raw, dict):
+        msg = f"Profile {name!r} must be a YAML mapping at the top level, got {type(raw).__name__}"
+        raise ProfileError(msg)
+
+    try:
+        profile = ExecutionProfile.model_validate(raw)
+    except ValidationError as exc:
+        msg = f"Profile {name!r} failed schema validation: {exc}"
+        raise ProfileError(msg) from exc
+
+    if profile.profile != name:
+        msg = f"Profile name mismatch: file {name!r} declares profile={profile.profile!r}"
+        raise ProfileError(msg)
+
+    return profile
+
+
+def available_profiles(profiles_dir: Path | None = None) -> tuple[str, ...]:
+    """Return sorted list of profile names discoverable in the profiles dir."""
+    base = profiles_dir if profiles_dir is not None else _PROFILES_DIR
+    if not base.is_dir():
+        return ()
+    return tuple(sorted(p.stem for p in base.glob("*.yaml")))
+
+
+__all__ = [
+    "EvidenceSchema",
+    "ExecutionProfile",
+    "ProfileError",
+    "available_profiles",
+    "load_profile",
+]

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -120,8 +120,20 @@ def load_profile(name: str, *, profiles_dir: Path | None = None) -> ExecutionPro
         msg = f"Profile not found: {name!r} (looked in {base})"
         raise ProfileError(msg)
 
+    # Normalize filesystem + decoding errors into ProfileError so the
+    # documented contract holds — callers should never see a raw OSError
+    # or UnicodeDecodeError leak from the production loader.
     try:
-        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = f"Profile {name!r} could not be read from {path}: {exc}"
+        raise ProfileError(msg) from exc
+    except UnicodeDecodeError as exc:
+        msg = f"Profile {name!r} at {path} is not valid UTF-8: {exc.reason} (byte {exc.start})"
+        raise ProfileError(msg) from exc
+
+    try:
+        raw = yaml.safe_load(text)
     except yaml.YAMLError as exc:
         msg = f"Profile {name!r} is not valid YAML: {exc}"
         raise ProfileError(msg) from exc

--- a/src/ouroboros/profiles/analysis.yaml
+++ b/src/ouroboros/profiles/analysis.yaml
@@ -1,0 +1,20 @@
+profile: analysis
+axis: perspective
+min_unit: "single perspective compared against at least one contrasting view"
+cut_signal: "sub-AC produces a standalone comparison with explicit tradeoffs"
+evidence_schema:
+  required:
+    - claims
+    - perspectives_compared
+  rejected_if:
+    - "perspectives_compared == []"
+verifier_focus: >
+  Confirm every conclusion is supported by an explicit comparison of
+  perspectives. Reject one-sided analyses that omit contrasting views or
+  fail to make tradeoffs explicit.
+suggested_tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep

--- a/src/ouroboros/profiles/code.yaml
+++ b/src/ouroboros/profiles/code.yaml
@@ -1,0 +1,21 @@
+profile: code
+axis: testable_unit
+min_unit: "single function or module with at least one runnable test"
+cut_signal: "sub-AC produces an independently runnable test"
+evidence_schema:
+  required:
+    - files_touched
+    - commands_run
+    - tests_passed
+  rejected_if:
+    - "tests_passed == []"
+verifier_focus: >
+  Run the project's test command. Confirm tests_passed list matches reality.
+  Reject claims about files or symbols that do not exist on disk.
+suggested_tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+  - Glob
+  - Grep

--- a/src/ouroboros/profiles/research.yaml
+++ b/src/ouroboros/profiles/research.yaml
@@ -1,0 +1,22 @@
+profile: research
+axis: subtopic
+min_unit: "single question answerable from independently cited sources"
+cut_signal: "sub-AC produces a standalone markdown section with citations"
+evidence_schema:
+  required:
+    - external_sources
+    - claims
+    - triangulated_sources
+  rejected_if:
+    - "external_sources == []"
+    - "triangulated_sources == []"
+verifier_focus: >
+  Confirm each claim is anchored to at least one external source URL or
+  document. Reject claims that cite no source or that rely on a single
+  unsupported reference.
+suggested_tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -1,0 +1,107 @@
+"""Tests for ouroboros.orchestrator.profile_loader (RFC v2 #830, PR 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ouroboros.orchestrator.profile_loader import (
+    ExecutionProfile,
+    ProfileError,
+    available_profiles,
+    load_profile,
+)
+
+BUILTIN_PROFILES = ("analysis", "code", "research")
+
+
+class TestBuiltinProfiles:
+    """Bundled profiles must load and expose the H4 surface."""
+
+    @pytest.mark.parametrize("name", BUILTIN_PROFILES)
+    def test_loads(self, name: str) -> None:
+        profile = load_profile(name)
+        assert isinstance(profile, ExecutionProfile)
+        assert profile.profile == name
+        assert profile.axis
+        assert profile.min_unit
+        assert profile.verifier_focus
+
+    def test_available_lists_all_builtins(self) -> None:
+        discovered = available_profiles()
+        for name in BUILTIN_PROFILES:
+            assert name in discovered
+
+    def test_code_profile_has_test_evidence(self) -> None:
+        profile = load_profile("code")
+        assert "tests_passed" in profile.evidence_schema.required
+        assert "Read" in profile.suggested_tools
+
+    def test_research_profile_requires_triangulation(self) -> None:
+        profile = load_profile("research")
+        assert "triangulated_sources" in profile.evidence_schema.required
+
+    def test_analysis_profile_requires_perspectives(self) -> None:
+        profile = load_profile("analysis")
+        assert "perspectives_compared" in profile.evidence_schema.required
+
+
+class TestSchemaValidation:
+    """Loader rejects ill-formed profile files."""
+
+    def _write(self, dir_: Path, name: str, body: str) -> Path:
+        path = dir_ / f"{name}.yaml"
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def test_missing_required_field(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "broken",
+            "profile: broken\naxis: x\nmin_unit: y\n",  # no verifier_focus
+        )
+        with pytest.raises(ProfileError, match="schema validation"):
+            load_profile("broken", profiles_dir=tmp_path)
+
+    def test_extra_field_rejected(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "extra",
+            ("profile: extra\naxis: x\nmin_unit: y\nverifier_focus: z\nunknown_field: oops\n"),
+        )
+        with pytest.raises(ProfileError, match="schema validation"):
+            load_profile("extra", profiles_dir=tmp_path)
+
+    def test_filename_must_match_profile_field(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "alpha",
+            "profile: beta\naxis: x\nmin_unit: y\nverifier_focus: z\n",
+        )
+        with pytest.raises(ProfileError, match="name mismatch"):
+            load_profile("alpha", profiles_dir=tmp_path)
+
+    def test_non_mapping_top_level(self, tmp_path: Path) -> None:
+        self._write(tmp_path, "list", "- a\n- b\n")
+        with pytest.raises(ProfileError, match="mapping"):
+            load_profile("list", profiles_dir=tmp_path)
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        self._write(tmp_path, "bad", "profile: [unterminated\n")
+        with pytest.raises(ProfileError, match="not valid YAML"):
+            load_profile("bad", profiles_dir=tmp_path)
+
+    def test_unknown_profile(self, tmp_path: Path) -> None:
+        with pytest.raises(ProfileError, match="not found"):
+            load_profile("ghost", profiles_dir=tmp_path)
+
+    def test_invalid_name_rejected(self, tmp_path: Path) -> None:
+        for bad in ("../etc/passwd", "a/b", ".hidden", ""):
+            with pytest.raises(ProfileError, match="Invalid profile name"):
+                load_profile(bad, profiles_dir=tmp_path)
+
+    def test_profile_is_frozen(self) -> None:
+        profile = load_profile("code")
+        with pytest.raises(ValueError, match="frozen"):
+            profile.axis = "mutated"  # type: ignore[misc]

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -177,19 +177,30 @@ class TestWheelPackaging:
             timeout=120,
             check=False,
         )
-        if result.returncode != 0:
-            pytest.skip(f"uv build did not produce a wheel: {result.stderr}")
+        # The whole point of this test is to catch packaging regressions —
+        # a non-zero build status is the regression signal, not a skip.
+        assert result.returncode == 0, (
+            f"uv build failed (rc={result.returncode}):\n"
+            f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+        )
 
         wheels = list(out.glob("*.whl"))
         assert wheels, f"no wheel produced in {out}"
         wheel = wheels[0]
         with zipfile.ZipFile(wheel) as zf:
-            names = set(zf.namelist())
+            # Keep the list — not a set — so duplicate ZIP entries (which
+            # PyPI rejects) are caught here. The exclude/force-include
+            # pairing in pyproject.toml is fragile; this is the guard.
+            names = zf.namelist()
 
         for stem in ("code", "research", "analysis"):
             expected = f"ouroboros/profiles/{stem}.yaml"
-            assert expected in names, (
-                f"{expected!r} missing from wheel; force-include in "
-                f"pyproject.toml probably regressed. Wheel contents (sample): "
+            occurrences = sum(1 for n in names if n == expected)
+            assert occurrences == 1, (
+                f"{expected!r} appears {occurrences} times in wheel "
+                f"(should be exactly 1). Duplicate entries usually mean "
+                f"the wheel `exclude` for src/ouroboros/profiles is "
+                f"missing alongside the `force-include`. Wheel contents "
+                f"(profiles sample): "
                 f"{sorted(n for n in names if 'profile' in n)}"
             )

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -105,3 +105,91 @@ class TestSchemaValidation:
         profile = load_profile("code")
         with pytest.raises(ValueError, match="frozen"):
             profile.axis = "mutated"  # type: ignore[misc]
+
+
+class TestIoErrorNormalization:
+    """Filesystem + decoding errors must surface as ProfileError.
+
+    The loader documents that callers see ProfileError on every failure
+    mode, but the read-text call could leak OSError / UnicodeDecodeError
+    (bot finding on PR #881). Normalize both to ProfileError so the
+    contract holds in production.
+    """
+
+    def test_invalid_utf8_raises_profile_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "garbled.yaml"
+        # 0xff is not a valid first byte in any UTF-8 sequence.
+        path.write_bytes(b"\xff\xfe garbage\n")
+        with pytest.raises(ProfileError, match="not valid UTF-8"):
+            load_profile("garbled", profiles_dir=tmp_path)
+
+    def test_unreadable_file_raises_profile_error(self, tmp_path: Path) -> None:
+        import os
+        import stat
+
+        path = tmp_path / "locked.yaml"
+        path.write_text(
+            "profile: locked\naxis: x\nmin_unit: y\nverifier_focus: z\n",
+            encoding="utf-8",
+        )
+        path.chmod(0)
+        try:
+            # Root can bypass the permission denial — skip if so.
+            if os.geteuid() == 0:
+                pytest.skip("root bypasses permission denial")
+            with pytest.raises(ProfileError, match="could not be read"):
+                load_profile("locked", profiles_dir=tmp_path)
+        finally:
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+class TestWheelPackaging:
+    """The bundled profile YAMLs must reach the installed wheel.
+
+    The loader resolves YAMLs via ``Path(__file__).parent.parent /
+    "profiles"``. If the ``pyproject.toml`` ``force-include`` entry for
+    ``src/ouroboros/profiles`` is dropped, the source tree still works
+    but ``pip install`` of the wheel ships a loader that cannot find
+    any profile.
+
+    This regression test builds the wheel in a tmpdir and asserts every
+    bundled profile is present at the expected path inside the .whl.
+    Skipped if ``uv`` is not available on PATH (CI sandboxes that
+    cannot spawn external builds).
+    """
+
+    @pytest.mark.slow
+    def test_wheel_contains_profile_yamls(self, tmp_path: Path) -> None:
+        import shutil
+        import subprocess
+        import zipfile
+
+        if shutil.which("uv") is None:
+            pytest.skip("uv is not on PATH; cannot build the wheel here")
+
+        repo_root = Path(__file__).resolve().parents[3]
+        out = tmp_path / "dist"
+        result = subprocess.run(
+            ["uv", "build", "--wheel", "--out-dir", str(out)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"uv build did not produce a wheel: {result.stderr}")
+
+        wheels = list(out.glob("*.whl"))
+        assert wheels, f"no wheel produced in {out}"
+        wheel = wheels[0]
+        with zipfile.ZipFile(wheel) as zf:
+            names = set(zf.namelist())
+
+        for stem in ("code", "research", "analysis"):
+            expected = f"ouroboros/profiles/{stem}.yaml"
+            assert expected in names, (
+                f"{expected!r} missing from wheel; force-include in "
+                f"pyproject.toml probably regressed. Wheel contents (sample): "
+                f"{sorted(n for n in names if 'profile' in n)}"
+            )


### PR DESCRIPTION
## Summary

First PR in the [#830](https://github.com/Q00/ouroboros/issues/830) RFC v2 ("thin skill YAML + fat harness") stack. Wiring-only — no existing caller is modified.

- Adds `ExecutionProfile` / `EvidenceSchema` (pydantic, `extra="forbid"`, `frozen=True`) in `src/ouroboros/orchestrator/profile_loader.py`.
- Adds three bundled profiles in `src/ouroboros/profiles/` (`code`, `research`, `analysis`) seeded from @shaun0927's H4 sketch (axis, min_unit, evidence_schema, verifier_focus, suggested_tools).
- Adds `load_profile()` / `available_profiles()` with strict name validation, filename↔`profile` field consistency check, and an explicit `ProfileError` on missing / malformed / non-mapping inputs.
- Wheel `force-include` for `src/ouroboros/profiles` so the YAMLs ship with the installed package (loader resolves via `Path(__file__)`).

This is the thin-skill substrate the rest of the stack consumes — no behavior change yet.

## Follow-up stack

Subsequent PRs in the #830 stack:

| PR | Invariant | Purpose |
|----|-----------|---------|
| 2 | H2 | Typed evidence schema enforcement at the leaf boundary |
| 3 | H1 | External verifier loop + K=2 retry (biggest single quality jump) |
| 4 | H4 | Parameterized decomposer consuming `ExecutionProfile.axis` |
| 5 | H3 | PRE/POST wrappers around leaf prompts |
| 6 | H7 | Failure taxonomy + recovery routing |
| 7 | H5 | Adaptive model/tool routing |
| 8 | H6 | Per-dispatch context budget governance |
| 9 | — | Deprecate `agents/code-executor.md` in favor of `profiles/code.yaml` |

## Test plan

- [x] `uv run pytest tests/unit/orchestrator/test_profile_loader.py` — 15 passed
- [x] `uv run ruff check` clean on new files
- [x] `uv run ruff format --check` clean on new files
- [x] `uv run mypy src/ouroboros/orchestrator/profile_loader.py` — Success: no issues found
- [ ] Reviewer: verify wheel inclusion (`uv build && unzip -l dist/*.whl | grep profiles`)

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)