### PR TITLE
feat(orchestrator): typed evidence schema validator (#830 PR 2/9)

### DIFF
--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -37,17 +37,14 @@ from typing import Any
 
 from ouroboros.orchestrator.profile_loader import ExecutionProfile
 
-# Fence delimiters for ```json ... ``` evidence blocks. Leaf prompts in
-# later PRs instruct executors to emit evidence inside one of these.
-# We deliberately do NOT use a single regex to extract the JSON body:
-# a non-greedy `{.*?}` stops at the first `}` even inside a quoted
-# string, so any valid evidence payload that contains "}" in a string
-# value would be truncated and rejected (bot finding on PR #883).
-# Instead we slice between fences and let json.loads handle string
-# escaping correctly.
+# Fence openers signal where the JSON evidence body starts. Once we've
+# located the opener, parsing the body is delegated to JSON itself via
+# json.JSONDecoder.raw_decode — that's how we avoid every sentinel-
+# scanning class of bug (the closing ``` or any `}` may appear inside a
+# JSON string value, and only a real JSON parser knows string boundaries).
 _FENCE_OPENERS: tuple[str, ...] = ("```json", "```JSON", "```")
-_FENCE_CLOSER: str = "```"
 _EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
+_DECODER = json.JSONDecoder()
 
 
 class EvidenceError(ValueError):
@@ -94,12 +91,12 @@ class EvidenceRecord:
         return self.data.get(name, default)
 
 
-def _extract_fenced_payload(text: str) -> str | None:
-    """Return the body of the first ```json ... ``` (or bare ```) fence.
+def _find_body_start(text: str) -> int:
+    """Locate where the JSON body begins.
 
-    The slice respects fence markers — not braces inside JSON strings —
-    so a payload like `{"note": "hello } more"}` survives extraction.
-    Returns None when no fence is found.
+    Scans for the earliest fence opener (```json / ```JSON / ```). If
+    none is found we treat the whole input as a bare JSON body — the
+    JSON decoder will skip leading whitespace itself.
     """
     best_open = -1
     best_open_len = 0
@@ -111,32 +108,38 @@ def _extract_fenced_payload(text: str) -> str | None:
             best_open = idx
             best_open_len = len(opener)
     if best_open == -1:
-        return None
-
+        return 0
     body_start = best_open + best_open_len
-    close_idx = text.find(_FENCE_CLOSER, body_start)
-    if close_idx == -1:
-        return None
-    return text[body_start:close_idx].strip()
+    # JSONDecoder tolerates leading whitespace but `raw_decode` requires
+    # the *first* non-whitespace character to start the value, so skip
+    # whitespace explicitly to give clean offsets in error messages.
+    while body_start < len(text) and text[body_start] in " \t\r\n":
+        body_start += 1
+    return body_start
 
 
 def extract_evidence(text: str) -> EvidenceRecord:
     """Pull a JSON evidence record out of a leaf executor's raw output.
 
     Accepts either a bare JSON object or a single ```json``` fenced block.
-    Raises EvidenceError on missing / malformed payloads so the harness can
-    surface a clear failure instead of silently accepting empty results.
+    Body extraction is delegated to ``json.JSONDecoder.raw_decode`` so
+    the parser — not sentinel scanning — decides where the JSON value
+    ends. That keeps `}` and ``` inside string values from truncating
+    valid payloads.
+
+    Raises EvidenceError on missing / malformed payloads so the harness
+    can surface a clear failure instead of silently accepting empty
+    results.
     """
     if not text or not text.strip():
         msg = "Leaf output is empty; no evidence record to validate."
         raise EvidenceError(msg)
 
-    payload = _extract_fenced_payload(text)
-    if payload is None:
-        payload = text.strip()
+    start = _find_body_start(text)
+    body = text[start:]
 
     try:
-        parsed = json.loads(payload)
+        parsed, _ = _DECODER.raw_decode(body)
     except json.JSONDecodeError as exc:
         msg = f"Evidence is not valid JSON: {exc.msg} (line {exc.lineno}, col {exc.colno})"
         raise EvidenceError(msg) from exc

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -1,0 +1,181 @@
+"""Typed evidence record + validator (RFC v2 H2, #830).
+
+Turns the H2 invariant from "the markdown says emit evidence" into a parser-
+enforced contract: leaf executors emit a structured evidence record, the
+harness validates it against the active ExecutionProfile's evidence_schema
+before accepting the result.
+
+This module is pure validator surface — it does not yet wire into
+parallel_executor. The H1 verifier loop (next PR in the stack) consumes
+the ValidationResult to decide between accept / retry / escalate.
+
+The evaluator for `rejected_if` is intentionally narrow. It supports only
+`<field> == <literal>` where literal is parsed via ast.literal_eval. Any
+other expression shape raises EvidenceError so that profile authors get an
+immediate, loud failure instead of silent acceptance.
+
+Usage:
+    from ouroboros.orchestrator.evidence_schema import (
+        extract_evidence, validate_evidence,
+    )
+    record = extract_evidence(raw_leaf_text)
+    result = validate_evidence(profile, record)
+    if not result.ok:
+        # surface result.missing_fields / result.rejected_by to the harness
+        ...
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+import json
+import re
+from typing import Any
+
+from ouroboros.orchestrator.profile_loader import ExecutionProfile
+
+# Match the first ```json ... ``` fenced block. Leaf prompts in later PRs
+# will instruct executors to emit evidence inside one of these.
+_FENCED_JSON_RE = re.compile(
+    r"```(?:json)?\s*(?P<body>\{.*?\})\s*```",
+    re.DOTALL,
+)
+_EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
+
+
+class EvidenceError(ValueError):
+    """Raised when evidence cannot be parsed or a profile expression is invalid."""
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of validating an evidence record against a profile.
+
+    Attributes:
+        ok: True iff no required field is missing and no rejected_if matched.
+        missing_fields: Required fields the record did not provide.
+        rejected_by: rejected_if expressions that evaluated True against
+            the record (verbatim, in profile order).
+    """
+
+    ok: bool
+    missing_fields: tuple[str, ...] = ()
+    rejected_by: tuple[str, ...] = ()
+
+    def reasons(self) -> tuple[str, ...]:
+        """Human-readable, harness-friendly summary of all failure reasons."""
+        out: list[str] = []
+        if self.missing_fields:
+            out.append("missing required fields: " + ", ".join(self.missing_fields))
+        out.extend(f"rejected by {expr!r}" for expr in self.rejected_by)
+        return tuple(out)
+
+
+@dataclass(frozen=True)
+class EvidenceRecord:
+    """Container for the leaf-emitted evidence dict.
+
+    Kept deliberately permissive — schema enforcement is the validator's
+    job. We store the raw mapping plus a reference to the source text so
+    callers can show provenance on rejection.
+    """
+
+    data: dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+
+    def get(self, name: str, default: Any = None) -> Any:
+        return self.data.get(name, default)
+
+
+def extract_evidence(text: str) -> EvidenceRecord:
+    """Pull a JSON evidence record out of a leaf executor's raw output.
+
+    Accepts either a bare JSON object or a single ```json``` fenced block.
+    Raises EvidenceError on missing / malformed payloads so the harness can
+    surface a clear failure instead of silently accepting empty results.
+    """
+    if not text or not text.strip():
+        msg = "Leaf output is empty; no evidence record to validate."
+        raise EvidenceError(msg)
+
+    match = _FENCED_JSON_RE.search(text)
+    payload = match.group("body") if match else text.strip()
+
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        msg = f"Evidence is not valid JSON: {exc.msg} (line {exc.lineno}, col {exc.colno})"
+        raise EvidenceError(msg) from exc
+
+    if not isinstance(parsed, dict):
+        msg = f"Evidence must be a JSON object, got {type(parsed).__name__}"
+        raise EvidenceError(msg)
+
+    return EvidenceRecord(data=parsed, source=text)
+
+
+def _parse_literal(raw: str) -> Any:
+    """Safely parse the right-hand side of a `field == literal` expression."""
+    try:
+        return ast.literal_eval(raw)
+    except (ValueError, SyntaxError) as exc:
+        msg = f"Unsupported literal in rejected_if right-hand side: {raw!r} ({exc})"
+        raise EvidenceError(msg) from exc
+
+
+def _evaluate_rejection(expr: str, data: dict[str, Any]) -> bool:
+    """Evaluate a single rejected_if expression.
+
+    Grammar: `<field> == <literal>` only. Anything else raises EvidenceError
+    so profile authors notice immediately instead of silently passing.
+    """
+    match = _EXPR_RE.match(expr)
+    if not match:
+        msg = (
+            f"Unsupported rejected_if expression: {expr!r}. "
+            "Only '<field> == <literal>' is currently supported."
+        )
+        raise EvidenceError(msg)
+    field_name = match.group("field")
+    literal = _parse_literal(match.group("lit"))
+    # Missing fields evaluate as None for comparison purposes — that way
+    # `field == None` triggers on absent keys without needing a separate
+    # `is_missing` predicate.
+    return data.get(field_name) == literal
+
+
+def validate_evidence(profile: ExecutionProfile, record: EvidenceRecord) -> ValidationResult:
+    """Validate an evidence record against a profile's evidence_schema.
+
+    Args:
+        profile: Loaded ExecutionProfile (see profile_loader.load_profile).
+        record: Parsed evidence record (see extract_evidence).
+
+    Returns:
+        ValidationResult with ok=True iff all required fields are present
+        and no rejected_if expression matched.
+
+    Raises:
+        EvidenceError: If any rejected_if expression has unsupported syntax.
+            (Profile bugs should be loud, not silent.)
+    """
+    schema = profile.evidence_schema
+
+    missing = tuple(name for name in schema.required if name not in record.data)
+    rejected = tuple(expr for expr in schema.rejected_if if _evaluate_rejection(expr, record.data))
+
+    return ValidationResult(
+        ok=not missing and not rejected,
+        missing_fields=missing,
+        rejected_by=rejected,
+    )
+
+
+__all__ = [
+    "EvidenceError",
+    "EvidenceRecord",
+    "ValidationResult",
+    "extract_evidence",
+    "validate_evidence",
+]

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -10,9 +10,11 @@ parallel_executor. The H1 verifier loop (next PR in the stack) consumes
 the ValidationResult to decide between accept / retry / escalate.
 
 The evaluator for `rejected_if` is intentionally narrow. It supports only
-`<field> == <literal>` where literal is parsed via ast.literal_eval. Any
-other expression shape raises EvidenceError so that profile authors get an
-immediate, loud failure instead of silent acceptance.
+`<field> == <literal>` where literal is parsed first as JSON (so YAML/JSON
+authors can write `null`, `true`, `false`, numbers, strings, lists) and
+then as a Python literal as a fallback (so legacy `None`/`True`/`False`
+keep working). Any other expression shape raises EvidenceError so that
+profile authors get an immediate, loud failure instead of silent acceptance.
 
 Usage:
     from ouroboros.orchestrator.evidence_schema import (
@@ -35,12 +37,16 @@ from typing import Any
 
 from ouroboros.orchestrator.profile_loader import ExecutionProfile
 
-# Match the first ```json ... ``` fenced block. Leaf prompts in later PRs
-# will instruct executors to emit evidence inside one of these.
-_FENCED_JSON_RE = re.compile(
-    r"```(?:json)?\s*(?P<body>\{.*?\})\s*```",
-    re.DOTALL,
-)
+# Fence delimiters for ```json ... ``` evidence blocks. Leaf prompts in
+# later PRs instruct executors to emit evidence inside one of these.
+# We deliberately do NOT use a single regex to extract the JSON body:
+# a non-greedy `{.*?}` stops at the first `}` even inside a quoted
+# string, so any valid evidence payload that contains "}" in a string
+# value would be truncated and rejected (bot finding on PR #883).
+# Instead we slice between fences and let json.loads handle string
+# escaping correctly.
+_FENCE_OPENERS: tuple[str, ...] = ("```json", "```JSON", "```")
+_FENCE_CLOSER: str = "```"
 _EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
 
 
@@ -88,6 +94,32 @@ class EvidenceRecord:
         return self.data.get(name, default)
 
 
+def _extract_fenced_payload(text: str) -> str | None:
+    """Return the body of the first ```json ... ``` (or bare ```) fence.
+
+    The slice respects fence markers — not braces inside JSON strings —
+    so a payload like `{"note": "hello } more"}` survives extraction.
+    Returns None when no fence is found.
+    """
+    best_open = -1
+    best_open_len = 0
+    for opener in _FENCE_OPENERS:
+        idx = text.find(opener)
+        if idx == -1:
+            continue
+        if best_open == -1 or idx < best_open:
+            best_open = idx
+            best_open_len = len(opener)
+    if best_open == -1:
+        return None
+
+    body_start = best_open + best_open_len
+    close_idx = text.find(_FENCE_CLOSER, body_start)
+    if close_idx == -1:
+        return None
+    return text[body_start:close_idx].strip()
+
+
 def extract_evidence(text: str) -> EvidenceRecord:
     """Pull a JSON evidence record out of a leaf executor's raw output.
 
@@ -99,8 +131,9 @@ def extract_evidence(text: str) -> EvidenceRecord:
         msg = "Leaf output is empty; no evidence record to validate."
         raise EvidenceError(msg)
 
-    match = _FENCED_JSON_RE.search(text)
-    payload = match.group("body") if match else text.strip()
+    payload = _extract_fenced_payload(text)
+    if payload is None:
+        payload = text.strip()
 
     try:
         parsed = json.loads(payload)
@@ -116,7 +149,19 @@ def extract_evidence(text: str) -> EvidenceRecord:
 
 
 def _parse_literal(raw: str) -> Any:
-    """Safely parse the right-hand side of a `field == literal` expression."""
+    """Safely parse the right-hand side of a `field == literal` expression.
+
+    Profiles are YAML-authored and the evidence is JSON, so the natural
+    literal spellings authors will reach for are `null`, `true`, `false`,
+    plus numbers / strings / lists. We try JSON first so those work
+    out-of-the-box. We fall back to ast.literal_eval so legacy Python
+    spellings (`None`, `True`, `False`) keep working too.
+    """
+    raw = raw.strip()
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
     try:
         return ast.literal_eval(raw)
     except (ValueError, SyntaxError) as exc:

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -80,6 +80,24 @@ class TestExtractEvidence:
         record = extract_evidence('```JSON\n{"x": 1}\n```\n')
         assert record.data == {"x": 1}
 
+    def test_triple_backtick_inside_json_string_value(self) -> None:
+        # Regression: an earlier fence-scanner stopped at the first raw
+        # ``` after the opener, even when it sat inside a quoted JSON
+        # string value (bot finding on PR #883 round 2). The JSON-aware
+        # raw_decode must let `json.JSONDecoder` decide where the value
+        # ends.
+        text = '```json\n{"note": "embedded ``` triple-backtick survives", "ok": true}\n```\n'
+        record = extract_evidence(text)
+        assert record.data["ok"] is True
+        assert "triple-backtick" in record.data["note"]
+
+    def test_extra_text_after_object_is_ignored(self) -> None:
+        # raw_decode stops at the end of the first JSON value, so trailing
+        # narrative text inside the fence does not corrupt parsing.
+        text = '```json\n{"x": 1}\nsome trailing prose\n```\n'
+        record = extract_evidence(text)
+        assert record.data == {"x": 1}
+
 
 class TestValidateCodeProfile:
     def test_accepts_complete_record(self, code_profile) -> None:

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -58,6 +58,28 @@ class TestExtractEvidence:
         with pytest.raises(EvidenceError, match="must be a JSON object"):
             extract_evidence("[1, 2, 3]")
 
+    def test_quoted_brace_inside_string_value(self) -> None:
+        # Regression: old regex stopped at the first `}` even inside a
+        # JSON string value, truncating the payload (bot finding #1 on
+        # PR #883). The fence-aware extractor must keep the entire body
+        # and let json.loads handle string escaping.
+        payload = '{"note": "hello } still inside string", "ok": true}'
+        record = extract_evidence(payload)
+        assert record.data == {
+            "note": "hello } still inside string",
+            "ok": True,
+        }
+
+    def test_quoted_backticks_inside_string_value(self) -> None:
+        text = '```json\n{"note": "embedded `single backtick` survives", "ok": true}\n```\n'
+        record = extract_evidence(text)
+        assert record.data["ok"] is True
+        assert "single backtick" in record.data["note"]
+
+    def test_uppercase_json_fence_tag(self) -> None:
+        record = extract_evidence('```JSON\n{"x": 1}\n```\n')
+        assert record.data == {"x": 1}
+
 
 class TestValidateCodeProfile:
     def test_accepts_complete_record(self, code_profile) -> None:
@@ -200,3 +222,64 @@ class TestRejectionGrammar:
         result = validate_evidence(profile, record)
         assert result.ok is False
         assert result.rejected_by == ("never_emitted == None",)
+
+
+class TestJsonYamlLiteralSpellings:
+    """rejected_if must accept literals YAML / JSON authors write.
+
+    Profiles are YAML-authored and evidence is JSON, so authors reach
+    for `null`, `true`, `false` — not Python's `None`/`True`/`False`.
+    Both spellings must work (bot finding #2 on PR #883).
+    """
+
+    def _profile_with_rule(self, rule: str):
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        return load_profile("code").model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=(rule,),
+                )
+            }
+        )
+
+    def test_json_null_literal(self) -> None:
+        profile = self._profile_with_rule("flag == null")
+        record = EvidenceRecord(data={"flag": None})
+        result = validate_evidence(profile, record)
+        assert result.ok is False
+        assert result.rejected_by == ("flag == null",)
+
+    def test_json_true_literal(self) -> None:
+        profile = self._profile_with_rule("flag == true")
+        record = EvidenceRecord(data={"flag": True})
+        assert validate_evidence(profile, record).ok is False
+
+    def test_json_false_literal(self) -> None:
+        profile = self._profile_with_rule("flag == false")
+        record = EvidenceRecord(data={"flag": False})
+        assert validate_evidence(profile, record).ok is False
+
+    def test_python_spellings_still_work(self) -> None:
+        # Backwards-compat with the legacy Python literal spellings.
+        for rule, value in (
+            ("flag == None", None),
+            ("flag == True", True),
+            ("flag == False", False),
+        ):
+            profile = self._profile_with_rule(rule)
+            record = EvidenceRecord(data={"flag": value})
+            assert validate_evidence(profile, record).ok is False, (
+                f"{rule!r} did not trigger for {value!r}"
+            )
+
+    def test_json_number_literal(self) -> None:
+        profile = self._profile_with_rule("count == 0")
+        record = EvidenceRecord(data={"count": 0})
+        assert validate_evidence(profile, record).ok is False
+
+    def test_json_string_literal(self) -> None:
+        profile = self._profile_with_rule('status == "blocked"')
+        record = EvidenceRecord(data={"status": "blocked"})
+        assert validate_evidence(profile, record).ok is False

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -1,0 +1,202 @@
+"""Tests for ouroboros.orchestrator.evidence_schema (RFC v2 #830, PR 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.evidence_schema import (
+    EvidenceError,
+    EvidenceRecord,
+    extract_evidence,
+    validate_evidence,
+)
+from ouroboros.orchestrator.profile_loader import load_profile
+
+
+@pytest.fixture
+def code_profile():
+    return load_profile("code")
+
+
+@pytest.fixture
+def research_profile():
+    return load_profile("research")
+
+
+@pytest.fixture
+def analysis_profile():
+    return load_profile("analysis")
+
+
+class TestExtractEvidence:
+    def test_bare_json_object(self) -> None:
+        record = extract_evidence('{"files_touched": ["a.py"]}')
+        assert record.data == {"files_touched": ["a.py"]}
+
+    def test_fenced_json_block(self) -> None:
+        text = 'summary line\n```json\n{"x": 1}\n```\ntrailing\n'
+        record = extract_evidence(text)
+        assert record.data == {"x": 1}
+
+    def test_fenced_block_without_lang_tag(self) -> None:
+        record = extract_evidence('prelude\n```\n{"y": 2}\n```\n')
+        assert record.data == {"y": 2}
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(EvidenceError, match="empty"):
+            extract_evidence("")
+
+    def test_whitespace_only_rejected(self) -> None:
+        with pytest.raises(EvidenceError, match="empty"):
+            extract_evidence("   \n\t  ")
+
+    def test_malformed_json(self) -> None:
+        with pytest.raises(EvidenceError, match="not valid JSON"):
+            extract_evidence("{not: json}")
+
+    def test_non_object_payload(self) -> None:
+        with pytest.raises(EvidenceError, match="must be a JSON object"):
+            extract_evidence("[1, 2, 3]")
+
+
+class TestValidateCodeProfile:
+    def test_accepts_complete_record(self, code_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "files_touched": ["src/a.py"],
+                "commands_run": ["pytest"],
+                "tests_passed": ["test_a"],
+            }
+        )
+        result = validate_evidence(code_profile, record)
+        assert result.ok is True
+        assert result.missing_fields == ()
+        assert result.rejected_by == ()
+
+    def test_rejects_empty_tests_passed(self, code_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "files_touched": ["src/a.py"],
+                "commands_run": ["pytest"],
+                "tests_passed": [],
+            }
+        )
+        result = validate_evidence(code_profile, record)
+        assert result.ok is False
+        assert result.rejected_by == ("tests_passed == []",)
+        assert result.missing_fields == ()
+
+    def test_reports_missing_fields(self, code_profile) -> None:
+        record = EvidenceRecord(data={"files_touched": ["a.py"]})
+        result = validate_evidence(code_profile, record)
+        assert result.ok is False
+        assert "commands_run" in result.missing_fields
+        assert "tests_passed" in result.missing_fields
+
+    def test_reasons_summarize_failures(self, code_profile) -> None:
+        record = EvidenceRecord(data={"tests_passed": []})
+        result = validate_evidence(code_profile, record)
+        reasons = result.reasons()
+        assert any("missing required fields" in r for r in reasons)
+        assert any("tests_passed == []" in r for r in reasons)
+
+
+class TestValidateResearchProfile:
+    def test_accepts_triangulated(self, research_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "external_sources": ["https://example.com/a"],
+                "claims": [{"text": "x", "source": 0}],
+                "triangulated_sources": ["https://example.com/a", "https://example.com/b"],
+            }
+        )
+        result = validate_evidence(research_profile, record)
+        assert result.ok is True
+
+    def test_rejects_no_external_sources(self, research_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "external_sources": [],
+                "claims": [],
+                "triangulated_sources": [],
+            }
+        )
+        result = validate_evidence(research_profile, record)
+        assert result.ok is False
+        assert "external_sources == []" in result.rejected_by
+        assert "triangulated_sources == []" in result.rejected_by
+
+
+class TestValidateAnalysisProfile:
+    def test_accepts_perspectives(self, analysis_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "claims": [{"text": "x"}],
+                "perspectives_compared": ["pro", "con"],
+            }
+        )
+        result = validate_evidence(analysis_profile, record)
+        assert result.ok is True
+
+    def test_rejects_one_sided(self, analysis_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "claims": [{"text": "x"}],
+                "perspectives_compared": [],
+            }
+        )
+        result = validate_evidence(analysis_profile, record)
+        assert result.ok is False
+        assert result.rejected_by == ("perspectives_compared == []",)
+
+
+class TestRejectionGrammar:
+    """rejected_if grammar is intentionally narrow; bad expressions must surface."""
+
+    def test_unsupported_expression_raises(
+        self, code_profile, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        broken = code_profile.model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=("len(tests_passed) < 1",),
+                )
+            }
+        )
+        record = EvidenceRecord(data={"tests_passed": [1]})
+        with pytest.raises(EvidenceError, match="Unsupported rejected_if"):
+            validate_evidence(broken, record)
+
+    def test_unsupported_literal_raises(self, code_profile) -> None:
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        broken = code_profile.model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=("tests_passed == os.system",),
+                )
+            }
+        )
+        record = EvidenceRecord(data={"tests_passed": []})
+        with pytest.raises(EvidenceError, match="Unsupported literal"):
+            validate_evidence(broken, record)
+
+    def test_missing_field_compared_to_none_triggers(self) -> None:
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        profile = load_profile("code").model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=("never_emitted == None",),
+                )
+            }
+        )
+        record = EvidenceRecord(data={})
+        result = validate_evidence(profile, record)
+        assert result.ok is False
+        assert result.rejected_by == ("never_emitted == None",)


### PR DESCRIPTION
## Summary

Second PR in the [#830](https://github.com/Q00/ouroboros/issues/830) RFC v2 stack. **Stacked on #881** — base branch is `feat/orchestrator-profile-loader`, not `main`. Rebase onto `main` after #881 merges.

Implements H2 (typed evidence record) as a pure validator surface. Leaf executor's free prose becomes a parser-enforced JSON contract before the harness accepts the result.

- `extract_evidence(text)` — pulls a JSON object out of either a bare body or a single ```json``` fenced block; raises `EvidenceError` on empty / malformed / non-object payloads.
- `validate_evidence(profile, record)` — returns a `ValidationResult` exposing `missing_fields` and `rejected_by`, never silently accepting.
- `ValidationResult.reasons()` — harness-friendly failure strings the upcoming H1 verifier loop will surface to retry / escalate.
- Narrow `rejected_if` grammar: `<field> == <literal>` only (literal via `ast.literal_eval`). Any other shape raises `EvidenceError` so profile authors notice during authoring, not in production.

## Wiring scope

**Pure validator module — no caller is modified.** `parallel_executor` still accepts whatever the leaf returns; the wire-up happens with the H1 verifier in PR 3/9 of the stack. This keeps the diff focused on the contract itself.

## Test plan

- [x] `uv run pytest tests/unit/orchestrator/test_evidence_schema.py` — 18 passed
- [x] `uv run pytest tests/unit/orchestrator/` (both files) — 33 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy src/ouroboros/orchestrator/evidence_schema.py` — Success: no issues found
- [ ] Reviewer: confirm rejected_if grammar narrowness is the right tradeoff vs supporting `len(x) == 0`, `x in [...]`, etc. now.

## Stack

| # | PR | Status |
|---|----|--------|
| 1 | #881 — profile YAML schema + loader | open |
| 2 | this PR — H2 typed evidence validator | open |
| 3 | H1 external verifier loop (K=2 retry) | next |
| 4 | H4 parameterized decomposer | queued |
| 5 | H3 PRE/POST wrappers | queued |
| 6 | H7 failure taxonomy | queued |
| 7 | H5 adaptive routing | queued |
| 8 | H6 context budget | queued |
| 9 | Deprecate code-executor.md | queued |

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)