### PR TITLE
feat(orchestrator): external verifier loop (#830 PR 3/9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ exclude = [
 # so they must reach the installed wheel as package data, not just the
 # source tree.
 "src/ouroboros/plugin/schemas" = "ouroboros/plugin/schemas"
+# Execution profile YAMLs (RFC v2 #830). The loader resolves them via
+# Path(__file__).parent.parent / "profiles", so they must ship with the wheel.
+"src/ouroboros/profiles" = "ouroboros/profiles"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ packages = ["src/ouroboros"]
 exclude = [
     "src/ouroboros/opencode/plugin/**",
     "src/ouroboros/plugin/schemas/**",
+    "src/ouroboros/profiles/**",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+markers = [
+    "slow: integration tests that build artifacts or call subprocesses",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -37,17 +37,14 @@ from typing import Any
 
 from ouroboros.orchestrator.profile_loader import ExecutionProfile
 
-# Fence delimiters for ```json ... ``` evidence blocks. Leaf prompts in
-# later PRs instruct executors to emit evidence inside one of these.
-# We deliberately do NOT use a single regex to extract the JSON body:
-# a non-greedy `{.*?}` stops at the first `}` even inside a quoted
-# string, so any valid evidence payload that contains "}" in a string
-# value would be truncated and rejected (bot finding on PR #883).
-# Instead we slice between fences and let json.loads handle string
-# escaping correctly.
+# Fence openers signal where the JSON evidence body starts. Once we've
+# located the opener, parsing the body is delegated to JSON itself via
+# json.JSONDecoder.raw_decode — that's how we avoid every sentinel-
+# scanning class of bug (the closing ``` or any `}` may appear inside a
+# JSON string value, and only a real JSON parser knows string boundaries).
 _FENCE_OPENERS: tuple[str, ...] = ("```json", "```JSON", "```")
-_FENCE_CLOSER: str = "```"
 _EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
+_DECODER = json.JSONDecoder()
 
 
 class EvidenceError(ValueError):
@@ -94,12 +91,12 @@ class EvidenceRecord:
         return self.data.get(name, default)
 
 
-def _extract_fenced_payload(text: str) -> str | None:
-    """Return the body of the first ```json ... ``` (or bare ```) fence.
+def _find_body_start(text: str) -> int:
+    """Locate where the JSON body begins.
 
-    The slice respects fence markers — not braces inside JSON strings —
-    so a payload like `{"note": "hello } more"}` survives extraction.
-    Returns None when no fence is found.
+    Scans for the earliest fence opener (```json / ```JSON / ```). If
+    none is found we treat the whole input as a bare JSON body — the
+    JSON decoder will skip leading whitespace itself.
     """
     best_open = -1
     best_open_len = 0
@@ -111,32 +108,38 @@ def _extract_fenced_payload(text: str) -> str | None:
             best_open = idx
             best_open_len = len(opener)
     if best_open == -1:
-        return None
-
+        return 0
     body_start = best_open + best_open_len
-    close_idx = text.find(_FENCE_CLOSER, body_start)
-    if close_idx == -1:
-        return None
-    return text[body_start:close_idx].strip()
+    # JSONDecoder tolerates leading whitespace but `raw_decode` requires
+    # the *first* non-whitespace character to start the value, so skip
+    # whitespace explicitly to give clean offsets in error messages.
+    while body_start < len(text) and text[body_start] in " \t\r\n":
+        body_start += 1
+    return body_start
 
 
 def extract_evidence(text: str) -> EvidenceRecord:
     """Pull a JSON evidence record out of a leaf executor's raw output.
 
     Accepts either a bare JSON object or a single ```json``` fenced block.
-    Raises EvidenceError on missing / malformed payloads so the harness can
-    surface a clear failure instead of silently accepting empty results.
+    Body extraction is delegated to ``json.JSONDecoder.raw_decode`` so
+    the parser — not sentinel scanning — decides where the JSON value
+    ends. That keeps `}` and ``` inside string values from truncating
+    valid payloads.
+
+    Raises EvidenceError on missing / malformed payloads so the harness
+    can surface a clear failure instead of silently accepting empty
+    results.
     """
     if not text or not text.strip():
         msg = "Leaf output is empty; no evidence record to validate."
         raise EvidenceError(msg)
 
-    payload = _extract_fenced_payload(text)
-    if payload is None:
-        payload = text.strip()
+    start = _find_body_start(text)
+    body = text[start:]
 
     try:
-        parsed = json.loads(payload)
+        parsed, _ = _DECODER.raw_decode(body)
     except json.JSONDecodeError as exc:
         msg = f"Evidence is not valid JSON: {exc.msg} (line {exc.lineno}, col {exc.colno})"
         raise EvidenceError(msg) from exc

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -1,0 +1,181 @@
+"""Typed evidence record + validator (RFC v2 H2, #830).
+
+Turns the H2 invariant from "the markdown says emit evidence" into a parser-
+enforced contract: leaf executors emit a structured evidence record, the
+harness validates it against the active ExecutionProfile's evidence_schema
+before accepting the result.
+
+This module is pure validator surface — it does not yet wire into
+parallel_executor. The H1 verifier loop (next PR in the stack) consumes
+the ValidationResult to decide between accept / retry / escalate.
+
+The evaluator for `rejected_if` is intentionally narrow. It supports only
+`<field> == <literal>` where literal is parsed via ast.literal_eval. Any
+other expression shape raises EvidenceError so that profile authors get an
+immediate, loud failure instead of silent acceptance.
+
+Usage:
+    from ouroboros.orchestrator.evidence_schema import (
+        extract_evidence, validate_evidence,
+    )
+    record = extract_evidence(raw_leaf_text)
+    result = validate_evidence(profile, record)
+    if not result.ok:
+        # surface result.missing_fields / result.rejected_by to the harness
+        ...
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+import json
+import re
+from typing import Any
+
+from ouroboros.orchestrator.profile_loader import ExecutionProfile
+
+# Match the first ```json ... ``` fenced block. Leaf prompts in later PRs
+# will instruct executors to emit evidence inside one of these.
+_FENCED_JSON_RE = re.compile(
+    r"```(?:json)?\s*(?P<body>\{.*?\})\s*```",
+    re.DOTALL,
+)
+_EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
+
+
+class EvidenceError(ValueError):
+    """Raised when evidence cannot be parsed or a profile expression is invalid."""
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of validating an evidence record against a profile.
+
+    Attributes:
+        ok: True iff no required field is missing and no rejected_if matched.
+        missing_fields: Required fields the record did not provide.
+        rejected_by: rejected_if expressions that evaluated True against
+            the record (verbatim, in profile order).
+    """
+
+    ok: bool
+    missing_fields: tuple[str, ...] = ()
+    rejected_by: tuple[str, ...] = ()
+
+    def reasons(self) -> tuple[str, ...]:
+        """Human-readable, harness-friendly summary of all failure reasons."""
+        out: list[str] = []
+        if self.missing_fields:
+            out.append("missing required fields: " + ", ".join(self.missing_fields))
+        out.extend(f"rejected by {expr!r}" for expr in self.rejected_by)
+        return tuple(out)
+
+
+@dataclass(frozen=True)
+class EvidenceRecord:
+    """Container for the leaf-emitted evidence dict.
+
+    Kept deliberately permissive — schema enforcement is the validator's
+    job. We store the raw mapping plus a reference to the source text so
+    callers can show provenance on rejection.
+    """
+
+    data: dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+
+    def get(self, name: str, default: Any = None) -> Any:
+        return self.data.get(name, default)
+
+
+def extract_evidence(text: str) -> EvidenceRecord:
+    """Pull a JSON evidence record out of a leaf executor's raw output.
+
+    Accepts either a bare JSON object or a single ```json``` fenced block.
+    Raises EvidenceError on missing / malformed payloads so the harness can
+    surface a clear failure instead of silently accepting empty results.
+    """
+    if not text or not text.strip():
+        msg = "Leaf output is empty; no evidence record to validate."
+        raise EvidenceError(msg)
+
+    match = _FENCED_JSON_RE.search(text)
+    payload = match.group("body") if match else text.strip()
+
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        msg = f"Evidence is not valid JSON: {exc.msg} (line {exc.lineno}, col {exc.colno})"
+        raise EvidenceError(msg) from exc
+
+    if not isinstance(parsed, dict):
+        msg = f"Evidence must be a JSON object, got {type(parsed).__name__}"
+        raise EvidenceError(msg)
+
+    return EvidenceRecord(data=parsed, source=text)
+
+
+def _parse_literal(raw: str) -> Any:
+    """Safely parse the right-hand side of a `field == literal` expression."""
+    try:
+        return ast.literal_eval(raw)
+    except (ValueError, SyntaxError) as exc:
+        msg = f"Unsupported literal in rejected_if right-hand side: {raw!r} ({exc})"
+        raise EvidenceError(msg) from exc
+
+
+def _evaluate_rejection(expr: str, data: dict[str, Any]) -> bool:
+    """Evaluate a single rejected_if expression.
+
+    Grammar: `<field> == <literal>` only. Anything else raises EvidenceError
+    so profile authors notice immediately instead of silently passing.
+    """
+    match = _EXPR_RE.match(expr)
+    if not match:
+        msg = (
+            f"Unsupported rejected_if expression: {expr!r}. "
+            "Only '<field> == <literal>' is currently supported."
+        )
+        raise EvidenceError(msg)
+    field_name = match.group("field")
+    literal = _parse_literal(match.group("lit"))
+    # Missing fields evaluate as None for comparison purposes — that way
+    # `field == None` triggers on absent keys without needing a separate
+    # `is_missing` predicate.
+    return data.get(field_name) == literal
+
+
+def validate_evidence(profile: ExecutionProfile, record: EvidenceRecord) -> ValidationResult:
+    """Validate an evidence record against a profile's evidence_schema.
+
+    Args:
+        profile: Loaded ExecutionProfile (see profile_loader.load_profile).
+        record: Parsed evidence record (see extract_evidence).
+
+    Returns:
+        ValidationResult with ok=True iff all required fields are present
+        and no rejected_if expression matched.
+
+    Raises:
+        EvidenceError: If any rejected_if expression has unsupported syntax.
+            (Profile bugs should be loud, not silent.)
+    """
+    schema = profile.evidence_schema
+
+    missing = tuple(name for name in schema.required if name not in record.data)
+    rejected = tuple(expr for expr in schema.rejected_if if _evaluate_rejection(expr, record.data))
+
+    return ValidationResult(
+        ok=not missing and not rejected,
+        missing_fields=missing,
+        rejected_by=rejected,
+    )
+
+
+__all__ = [
+    "EvidenceError",
+    "EvidenceRecord",
+    "ValidationResult",
+    "extract_evidence",
+    "validate_evidence",
+]

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -10,9 +10,11 @@ parallel_executor. The H1 verifier loop (next PR in the stack) consumes
 the ValidationResult to decide between accept / retry / escalate.
 
 The evaluator for `rejected_if` is intentionally narrow. It supports only
-`<field> == <literal>` where literal is parsed via ast.literal_eval. Any
-other expression shape raises EvidenceError so that profile authors get an
-immediate, loud failure instead of silent acceptance.
+`<field> == <literal>` where literal is parsed first as JSON (so YAML/JSON
+authors can write `null`, `true`, `false`, numbers, strings, lists) and
+then as a Python literal as a fallback (so legacy `None`/`True`/`False`
+keep working). Any other expression shape raises EvidenceError so that
+profile authors get an immediate, loud failure instead of silent acceptance.
 
 Usage:
     from ouroboros.orchestrator.evidence_schema import (
@@ -35,12 +37,16 @@ from typing import Any
 
 from ouroboros.orchestrator.profile_loader import ExecutionProfile
 
-# Match the first ```json ... ``` fenced block. Leaf prompts in later PRs
-# will instruct executors to emit evidence inside one of these.
-_FENCED_JSON_RE = re.compile(
-    r"```(?:json)?\s*(?P<body>\{.*?\})\s*```",
-    re.DOTALL,
-)
+# Fence delimiters for ```json ... ``` evidence blocks. Leaf prompts in
+# later PRs instruct executors to emit evidence inside one of these.
+# We deliberately do NOT use a single regex to extract the JSON body:
+# a non-greedy `{.*?}` stops at the first `}` even inside a quoted
+# string, so any valid evidence payload that contains "}" in a string
+# value would be truncated and rejected (bot finding on PR #883).
+# Instead we slice between fences and let json.loads handle string
+# escaping correctly.
+_FENCE_OPENERS: tuple[str, ...] = ("```json", "```JSON", "```")
+_FENCE_CLOSER: str = "```"
 _EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
 
 
@@ -88,6 +94,32 @@ class EvidenceRecord:
         return self.data.get(name, default)
 
 
+def _extract_fenced_payload(text: str) -> str | None:
+    """Return the body of the first ```json ... ``` (or bare ```) fence.
+
+    The slice respects fence markers — not braces inside JSON strings —
+    so a payload like `{"note": "hello } more"}` survives extraction.
+    Returns None when no fence is found.
+    """
+    best_open = -1
+    best_open_len = 0
+    for opener in _FENCE_OPENERS:
+        idx = text.find(opener)
+        if idx == -1:
+            continue
+        if best_open == -1 or idx < best_open:
+            best_open = idx
+            best_open_len = len(opener)
+    if best_open == -1:
+        return None
+
+    body_start = best_open + best_open_len
+    close_idx = text.find(_FENCE_CLOSER, body_start)
+    if close_idx == -1:
+        return None
+    return text[body_start:close_idx].strip()
+
+
 def extract_evidence(text: str) -> EvidenceRecord:
     """Pull a JSON evidence record out of a leaf executor's raw output.
 
@@ -99,8 +131,9 @@ def extract_evidence(text: str) -> EvidenceRecord:
         msg = "Leaf output is empty; no evidence record to validate."
         raise EvidenceError(msg)
 
-    match = _FENCED_JSON_RE.search(text)
-    payload = match.group("body") if match else text.strip()
+    payload = _extract_fenced_payload(text)
+    if payload is None:
+        payload = text.strip()
 
     try:
         parsed = json.loads(payload)
@@ -116,7 +149,19 @@ def extract_evidence(text: str) -> EvidenceRecord:
 
 
 def _parse_literal(raw: str) -> Any:
-    """Safely parse the right-hand side of a `field == literal` expression."""
+    """Safely parse the right-hand side of a `field == literal` expression.
+
+    Profiles are YAML-authored and the evidence is JSON, so the natural
+    literal spellings authors will reach for are `null`, `true`, `false`,
+    plus numbers / strings / lists. We try JSON first so those work
+    out-of-the-box. We fall back to ast.literal_eval so legacy Python
+    spellings (`None`, `True`, `False`) keep working too.
+    """
+    raw = raw.strip()
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
     try:
         return ast.literal_eval(raw)
     except (ValueError, SyntaxError) as exc:

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -1,0 +1,160 @@
+"""Execution profile YAML loader (RFC v2 H4).
+
+Loads structured per-domain profiles consumed by harness invariants
+(verifier focus, decomposition axis, evidence schema, suggested tools).
+
+This module is wiring-only: it defines the schema and loads YAML files.
+No existing caller is modified by this module — downstream PRs wire the
+loaded profile into `execution_strategy`, `parallel_executor`, and the
+forthcoming verifier loop.
+
+Usage:
+    from ouroboros.orchestrator.profile_loader import load_profile
+
+    profile = load_profile("code")
+    profile.axis        # "testable_unit"
+    profile.suggested_tools  # ["Read", "Edit", ...]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+import yaml
+
+_PROFILES_DIR: Final[Path] = Path(__file__).resolve().parent.parent / "profiles"
+
+
+class EvidenceSchema(BaseModel):
+    """Schema describing required evidence fields and rejection rules.
+
+    Consumed by H2 (typed evidence record) in a follow-up PR.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    required: tuple[str, ...] = Field(
+        default=(),
+        description="Evidence field names that every leaf result must include.",
+    )
+    rejected_if: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Reject expressions evaluated against the evidence record "
+            "(e.g. 'tests_passed == []'). Free-form for now; the verifier "
+            "PR will define an evaluator."
+        ),
+    )
+
+
+class ExecutionProfile(BaseModel):
+    """Per-domain execution profile (RFC v2 thin skill).
+
+    See https://github.com/Q00/ouroboros/issues/830 for the v2 spec.
+    Field shape matches shaun0927's H4 sketch (axis, min_unit, evidence_schema,
+    verifier_focus, suggested_tools).
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    profile: str = Field(
+        ...,
+        min_length=1,
+        description="Profile identifier (e.g. 'code'). Must match filename stem.",
+    )
+    axis: str = Field(
+        ...,
+        min_length=1,
+        description="Decomposition axis (e.g. 'testable_unit', 'subtopic').",
+    )
+    min_unit: str = Field(
+        ...,
+        min_length=1,
+        description="Smallest dispatchable unit description for the decomposer.",
+    )
+    cut_signal: str = Field(
+        default="",
+        description="Heuristic signal that a sub-AC is small enough to stop splitting.",
+    )
+    evidence_schema: EvidenceSchema = Field(default_factory=EvidenceSchema)
+    verifier_focus: str = Field(
+        ...,
+        min_length=1,
+        description="Instruction passed to the external verifier subagent (H1).",
+    )
+    suggested_tools: tuple[str, ...] = Field(
+        default=(),
+        description="Tool names the leaf executor may use; harness still gates.",
+    )
+
+
+class ProfileError(ValueError):
+    """Raised when a profile cannot be located or parsed."""
+
+
+def _candidate_path(name: str, profiles_dir: Path) -> Path:
+    if not name or "/" in name or "\\" in name or name.startswith("."):
+        msg = f"Invalid profile name: {name!r}"
+        raise ProfileError(msg)
+    return profiles_dir / f"{name}.yaml"
+
+
+def load_profile(name: str, *, profiles_dir: Path | None = None) -> ExecutionProfile:
+    """Load and validate an execution profile by name.
+
+    Args:
+        name: Profile identifier (filename stem, e.g. 'code').
+        profiles_dir: Override the default profiles directory (tests use this).
+
+    Returns:
+        Validated ExecutionProfile instance.
+
+    Raises:
+        ProfileError: If the file is missing, malformed, or violates the schema.
+    """
+    base = profiles_dir if profiles_dir is not None else _PROFILES_DIR
+    path = _candidate_path(name, base)
+    if not path.is_file():
+        msg = f"Profile not found: {name!r} (looked in {base})"
+        raise ProfileError(msg)
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        msg = f"Profile {name!r} is not valid YAML: {exc}"
+        raise ProfileError(msg) from exc
+
+    if not isinstance(raw, dict):
+        msg = f"Profile {name!r} must be a YAML mapping at the top level, got {type(raw).__name__}"
+        raise ProfileError(msg)
+
+    try:
+        profile = ExecutionProfile.model_validate(raw)
+    except ValidationError as exc:
+        msg = f"Profile {name!r} failed schema validation: {exc}"
+        raise ProfileError(msg) from exc
+
+    if profile.profile != name:
+        msg = f"Profile name mismatch: file {name!r} declares profile={profile.profile!r}"
+        raise ProfileError(msg)
+
+    return profile
+
+
+def available_profiles(profiles_dir: Path | None = None) -> tuple[str, ...]:
+    """Return sorted list of profile names discoverable in the profiles dir."""
+    base = profiles_dir if profiles_dir is not None else _PROFILES_DIR
+    if not base.is_dir():
+        return ()
+    return tuple(sorted(p.stem for p in base.glob("*.yaml")))
+
+
+__all__ = [
+    "EvidenceSchema",
+    "ExecutionProfile",
+    "ProfileError",
+    "available_profiles",
+    "load_profile",
+]

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -120,8 +120,20 @@ def load_profile(name: str, *, profiles_dir: Path | None = None) -> ExecutionPro
         msg = f"Profile not found: {name!r} (looked in {base})"
         raise ProfileError(msg)
 
+    # Normalize filesystem + decoding errors into ProfileError so the
+    # documented contract holds — callers should never see a raw OSError
+    # or UnicodeDecodeError leak from the production loader.
     try:
-        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = f"Profile {name!r} could not be read from {path}: {exc}"
+        raise ProfileError(msg) from exc
+    except UnicodeDecodeError as exc:
+        msg = f"Profile {name!r} at {path} is not valid UTF-8: {exc.reason} (byte {exc.start})"
+        raise ProfileError(msg) from exc
+
+    try:
+        raw = yaml.safe_load(text)
     except yaml.YAMLError as exc:
         msg = f"Profile {name!r} is not valid YAML: {exc}"
         raise ProfileError(msg) from exc

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -44,6 +44,21 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 
 DEFAULT_MAX_RETRIES: int = 2
 
+# Canonical failure classes the H7 router knows how to route. Verifier
+# implementations may set VerifierVerdict.failure_class to any of these
+# (or leave it None); any other string is rejected up front so a typo
+# in a verifier impl surfaces at construction time, not when the
+# downstream classifier silently degrades to STALL.
+_VALID_FAILURE_CLASSES: frozenset[str] = frozenset(
+    {
+        "EVIDENCE_MISSING",
+        "FABRICATION_SUSPECTED",
+        "SCOPE_CREEP",
+        "STALL",
+        "BLOCKED",
+    }
+)
+
 
 @dataclass(frozen=True)
 class VerifierVerdict:
@@ -81,6 +96,17 @@ class VerifierVerdict:
                 "VerifierVerdict(passed=False) must include at least one "
                 "reason; the retry loop feeds reasons back to the "
                 "executor and surfaces them on exhaustion."
+            )
+            raise ValueError(msg)
+        if self.failure_class is not None and self.failure_class not in _VALID_FAILURE_CLASSES:
+            # Verifier impls that emit an unknown failure_class would
+            # silently degrade to STALL in the H7 classifier — a typo
+            # would mask a real fabrication or scope-creep signal.
+            # Reject up front so the H1↔H7 contract stays explicit.
+            valid = ", ".join(sorted(_VALID_FAILURE_CLASSES))
+            msg = (
+                f"VerifierVerdict.failure_class={self.failure_class!r} is "
+                f"not a recognized taxonomy value. Valid: {valid}, or None."
             )
             raise ValueError(msg)
 
@@ -203,12 +229,25 @@ def run_with_verifier(
         if record is not None:
             validation = validate_evidence(profile, record)
             if validation.ok:
-                verdict = verifier(
-                    profile=profile,
-                    ac=ac,
-                    leaf_output=leaf_output,
-                    record=record,
-                )
+                try:
+                    verdict = verifier(
+                        profile=profile,
+                        ac=ac,
+                        leaf_output=leaf_output,
+                        record=record,
+                    )
+                except Exception as exc:
+                    # Verifier impls run tests / query LLMs, so transient
+                    # operational failures (timeout, network, crashed
+                    # subprocess) are part of normal production. Treat
+                    # them as a FAIL with a surfaceable reason rather
+                    # than letting them abort the AC — the retry budget
+                    # exists precisely for this.
+                    verdict = VerifierVerdict(
+                        passed=False,
+                        reasons=(f"verifier raised {type(exc).__name__}: {exc}",),
+                        failure_class="STALL",
+                    )
 
         attempt = Attempt(
             leaf_output=leaf_output,

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -242,7 +242,7 @@ def run_with_verifier(
             validation = validate_evidence(profile, record)
             if validation.ok:
                 try:
-                    verdict = verifier(
+                    raw_verdict = verifier(
                         profile=profile,
                         ac=ac,
                         leaf_output=leaf_output,
@@ -267,6 +267,21 @@ def run_with_verifier(
                         reasons=(f"verifier raised {type(exc).__name__}: {exc}",),
                         failure_class="STALL",
                     )
+                else:
+                    # Verifier is only a static Protocol — Python won't
+                    # enforce the return type at runtime. A buggy impl
+                    # that returns None (or any non-VerifierVerdict) would
+                    # otherwise sit as `attempt.verdict`, produce empty
+                    # _failure_reasons(), and silently burn the entire
+                    # retry budget. Surface the contract violation here.
+                    if not isinstance(raw_verdict, VerifierVerdict):
+                        msg = (
+                            f"Verifier returned {type(raw_verdict).__name__}, "
+                            "expected VerifierVerdict. This is a verifier "
+                            "implementation bug, not a transient failure."
+                        )
+                        raise VerifierContractError(msg)
+                    verdict = raw_verdict
 
         attempt = Attempt(
             leaf_output=leaf_output,

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -44,6 +44,18 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 
 DEFAULT_MAX_RETRIES: int = 2
 
+
+class VerifierContractError(ValueError):
+    """Raised when a VerifierVerdict is constructed in an invalid shape.
+
+    Subclasses ValueError for backward compatibility with callers that
+    check `ValueError`, but acts as a distinct exception type so the
+    bounded-retry loop can distinguish a verifier *implementation bug*
+    (this class — must propagate) from an *operational failure* (any
+    other Exception — converted to a STALL verdict and retried).
+    """
+
+
 # Canonical failure classes the H7 router knows how to route. Verifier
 # implementations may set VerifierVerdict.failure_class to any of these
 # (or leave it None); any other string is rejected up front so a typo
@@ -83,10 +95,10 @@ class VerifierVerdict:
     def __post_init__(self) -> None:
         if self.passed and self.reasons:
             msg = "VerifierVerdict(passed=True) must not carry reasons"
-            raise ValueError(msg)
+            raise VerifierContractError(msg)
         if self.passed and self.failure_class is not None:
             msg = "VerifierVerdict(passed=True) must not carry a failure_class"
-            raise ValueError(msg)
+            raise VerifierContractError(msg)
         if not self.passed and not self.reasons:
             # A bare FAIL with no reasons produces no feedback for the
             # retry executor and no surfaceable explanation on budget
@@ -97,7 +109,7 @@ class VerifierVerdict:
                 "reason; the retry loop feeds reasons back to the "
                 "executor and surfaces them on exhaustion."
             )
-            raise ValueError(msg)
+            raise VerifierContractError(msg)
         if self.failure_class is not None and self.failure_class not in _VALID_FAILURE_CLASSES:
             # Verifier impls that emit an unknown failure_class would
             # silently degrade to STALL in the H7 classifier — a typo
@@ -108,7 +120,7 @@ class VerifierVerdict:
                 f"VerifierVerdict.failure_class={self.failure_class!r} is "
                 f"not a recognized taxonomy value. Valid: {valid}, or None."
             )
-            raise ValueError(msg)
+            raise VerifierContractError(msg)
 
 
 class Verifier(Protocol):
@@ -236,6 +248,13 @@ def run_with_verifier(
                         leaf_output=leaf_output,
                         record=record,
                     )
+                except VerifierContractError:
+                    # A verifier impl that constructs an invalid verdict
+                    # is a deterministic programming bug, not a transient
+                    # operational failure. Surface it — masking it as
+                    # STALL would burn the retry budget and ship a
+                    # broken verifier to production.
+                    raise
                 except Exception as exc:
                     # Verifier impls run tests / query LLMs, so transient
                     # operational failures (timeout, network, crashed
@@ -272,6 +291,7 @@ __all__ = [
     "LeafExecutor",
     "LoopResult",
     "Verifier",
+    "VerifierContractError",
     "VerifierVerdict",
     "run_with_verifier",
 ]

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -44,6 +44,20 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 
 DEFAULT_MAX_RETRIES: int = 2
 
+# Exception types treated as *operational* failures (transient: network
+# blip, LLM timeout, subprocess crash). Anything outside this tuple is
+# treated as a deterministic programming bug and re-raised so production
+# diagnosis is not blocked by silent STALL retries. (Bot finding on
+# PR #884 r5: AttributeError / KeyError / AssertionError must not be
+# swallowed as transient failures.)
+_OPERATIONAL_VERIFIER_ERRORS: tuple[type[BaseException], ...] = (
+    TimeoutError,
+    ConnectionError,  # parent of BrokenPipe/ConnectionRefused/etc.
+    # OSError catches transient FS/subprocess/sockets. ConnectionError
+    # subclasses OSError, but we list it explicitly above for clarity.
+    OSError,
+)
+
 
 class VerifierContractError(ValueError):
     """Raised when a VerifierVerdict is constructed in an invalid shape.
@@ -255,13 +269,17 @@ def run_with_verifier(
                     # STALL would burn the retry budget and ship a
                     # broken verifier to production.
                     raise
-                except Exception as exc:
-                    # Verifier impls run tests / query LLMs, so transient
-                    # operational failures (timeout, network, crashed
-                    # subprocess) are part of normal production. Treat
-                    # them as a FAIL with a surfaceable reason rather
-                    # than letting them abort the AC — the retry budget
-                    # exists precisely for this.
+                except _OPERATIONAL_VERIFIER_ERRORS as exc:
+                    # Operational failures (timeout, network blip,
+                    # subprocess crash) are part of normal production
+                    # for verifier impls that run tests or query LLMs.
+                    # Treat them as a FAIL with a surfaceable reason so
+                    # the retry budget can absorb the blip.
+                    #
+                    # Programming bugs (AttributeError, KeyError, etc.)
+                    # are NOT in the catch list — they propagate so the
+                    # operator can fix the broken verifier instead of
+                    # watching it silently exhaust retries.
                     verdict = VerifierVerdict(
                         passed=False,
                         reasons=(f"verifier raised {type(exc).__name__}: {exc}",),

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -52,7 +52,10 @@ class VerifierVerdict:
     Attributes:
         passed: True iff the verifier accepted the leaf result.
         reasons: Human-readable, harness-surfaceable failure reasons.
-            Must be empty when `passed` is True.
+            Must be empty when `passed` is True; must be non-empty
+            when `passed` is False (the retry loop feeds these back
+            to the executor — a bare FAIL with no reasons is opaque
+            and indistinguishable from the first attempt).
         failure_class: Optional hint for H7 (failure taxonomy). One of
             "EVIDENCE_MISSING", "FABRICATION_SUSPECTED", "SCOPE_CREEP",
             "STALL", "BLOCKED", or None for an unclassified failure.
@@ -68,6 +71,17 @@ class VerifierVerdict:
             raise ValueError(msg)
         if self.passed and self.failure_class is not None:
             msg = "VerifierVerdict(passed=True) must not carry a failure_class"
+            raise ValueError(msg)
+        if not self.passed and not self.reasons:
+            # A bare FAIL with no reasons produces no feedback for the
+            # retry executor and no surfaceable explanation on budget
+            # exhaustion. The harness cannot recover from an opaque
+            # FAIL, so reject it at construction time.
+            msg = (
+                "VerifierVerdict(passed=False) must include at least one "
+                "reason; the retry loop feeds reasons back to the "
+                "executor and surfaces them on exhaustion."
+            )
             raise ValueError(msg)
 
 

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -1,0 +1,224 @@
+"""External verifier loop (RFC v2 H1, #830).
+
+Wraps a leaf executor with a separate read-only verifier pass plus a
+bounded retry. The verifier is intentionally model-agnostic at this
+layer: it is any callable that, given the active profile, the leaf's
+parsed evidence record, the AC text, and the raw leaf output, returns a
+VerifierVerdict.
+
+This module is wiring-only at the orchestrator seam — `parallel_executor`
+is not yet routed through `run_with_verifier`. The integration PR follows
+once the failure taxonomy (H7) and routing (H5) hooks are in place. For
+now this gives downstream PRs a stable, fully-tested loop they can plug
+the real LLM-backed verifier into.
+
+Loop semantics:
+    1. Executor produces a leaf output.
+    2. The harness parses evidence (H2). If evidence cannot be extracted,
+       that counts as a FAIL with a parser reason — verifier is NOT called.
+    3. The harness validates the record against profile.evidence_schema.
+       If the record fails validation, the verifier is short-circuited
+       and the loop retries (the leaf would never satisfy the contract
+       even if the verifier said PASS).
+    4. Otherwise the verifier is invoked. PASS → return. FAIL → retry,
+       feeding the verdict reasons back to the executor.
+    5. After `max_retries` exhausted FAILs, return the last attempt with
+       accepted=False so the outer orchestrator can escalate.
+
+The retry budget defaults to K=2 per shaun0927's H1 sketch in #830.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from ouroboros.orchestrator.evidence_schema import (
+    EvidenceError,
+    EvidenceRecord,
+    ValidationResult,
+    extract_evidence,
+    validate_evidence,
+)
+from ouroboros.orchestrator.profile_loader import ExecutionProfile
+
+DEFAULT_MAX_RETRIES: int = 2
+
+
+@dataclass(frozen=True)
+class VerifierVerdict:
+    """Outcome of a single verifier pass.
+
+    Attributes:
+        passed: True iff the verifier accepted the leaf result.
+        reasons: Human-readable, harness-surfaceable failure reasons.
+            Must be empty when `passed` is True.
+        failure_class: Optional hint for H7 (failure taxonomy). One of
+            "EVIDENCE_MISSING", "FABRICATION_SUSPECTED", "SCOPE_CREEP",
+            "STALL", "BLOCKED", or None for an unclassified failure.
+    """
+
+    passed: bool
+    reasons: tuple[str, ...] = ()
+    failure_class: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.passed and self.reasons:
+            msg = "VerifierVerdict(passed=True) must not carry reasons"
+            raise ValueError(msg)
+        if self.passed and self.failure_class is not None:
+            msg = "VerifierVerdict(passed=True) must not carry a failure_class"
+            raise ValueError(msg)
+
+
+class Verifier(Protocol):
+    """Callable that adjudicates a leaf result against the active profile.
+
+    Implementations are expected to be **read-only** with respect to the
+    workspace — they may inspect files, run test commands, or query an
+    LLM, but must not mutate state the executor produced.
+    """
+
+    def __call__(
+        self,
+        *,
+        profile: ExecutionProfile,
+        ac: str,
+        leaf_output: str,
+        record: EvidenceRecord,
+    ) -> VerifierVerdict: ...
+
+
+class LeafExecutor(Protocol):
+    """Callable that runs the leaf executor for a given AC.
+
+    The `feedback` argument carries verifier reasons from the previous
+    attempt; it is empty on the first call and non-empty on retries so
+    the executor can address the verifier's complaints directly.
+    """
+
+    def __call__(self, *, ac: str, feedback: tuple[str, ...]) -> str: ...
+
+
+@dataclass(frozen=True)
+class Attempt:
+    """One executor + verifier pass within a single AC."""
+
+    leaf_output: str
+    record: EvidenceRecord | None
+    evidence_error: str | None
+    validation: ValidationResult | None
+    verdict: VerifierVerdict | None
+
+    @property
+    def accepted(self) -> bool:
+        return self.verdict is not None and self.verdict.passed
+
+
+@dataclass(frozen=True)
+class LoopResult:
+    """Aggregate outcome of run_with_verifier."""
+
+    accepted: bool
+    attempts: tuple[Attempt, ...] = field(default_factory=tuple)
+
+    @property
+    def final(self) -> Attempt:
+        if not self.attempts:
+            msg = "LoopResult has no attempts (executor was never called)"
+            raise RuntimeError(msg)
+        return self.attempts[-1]
+
+
+def _failure_reasons(attempt: Attempt) -> tuple[str, ...]:
+    """Collect surfaceable reasons from an attempt's failure mode."""
+    if attempt.evidence_error is not None:
+        return (f"evidence parse failed: {attempt.evidence_error}",)
+    out: list[str] = []
+    if attempt.validation is not None and not attempt.validation.ok:
+        out.extend(attempt.validation.reasons())
+    if attempt.verdict is not None and not attempt.verdict.passed:
+        out.extend(attempt.verdict.reasons)
+    return tuple(out)
+
+
+def run_with_verifier(
+    *,
+    executor: LeafExecutor,
+    verifier: Verifier,
+    profile: ExecutionProfile,
+    ac: str,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> LoopResult:
+    """Run the leaf executor with verifier-backed bounded retry.
+
+    Args:
+        executor: Leaf executor callable (see LeafExecutor).
+        verifier: Verifier callable (see Verifier). Only invoked when the
+            evidence record is structurally valid.
+        profile: Active ExecutionProfile.
+        ac: AC text passed unchanged to the executor each attempt.
+        max_retries: Number of retries *after* the first attempt. K=2
+            means up to 3 total executor calls.
+
+    Returns:
+        LoopResult with `accepted=True` iff some attempt passed the
+        verifier, plus the full attempt transcript for upstream logging
+        and failure-taxonomy classification (H7).
+    """
+    if max_retries < 0:
+        msg = f"max_retries must be >= 0, got {max_retries}"
+        raise ValueError(msg)
+
+    attempts: list[Attempt] = []
+    feedback: tuple[str, ...] = ()
+
+    for _ in range(max_retries + 1):
+        leaf_output = executor(ac=ac, feedback=feedback)
+
+        try:
+            record: EvidenceRecord | None = extract_evidence(leaf_output)
+            evidence_error: str | None = None
+        except EvidenceError as exc:
+            record = None
+            evidence_error = str(exc)
+
+        validation: ValidationResult | None = None
+        verdict: VerifierVerdict | None = None
+
+        if record is not None:
+            validation = validate_evidence(profile, record)
+            if validation.ok:
+                verdict = verifier(
+                    profile=profile,
+                    ac=ac,
+                    leaf_output=leaf_output,
+                    record=record,
+                )
+
+        attempt = Attempt(
+            leaf_output=leaf_output,
+            record=record,
+            evidence_error=evidence_error,
+            validation=validation,
+            verdict=verdict,
+        )
+        attempts.append(attempt)
+
+        if attempt.accepted:
+            return LoopResult(accepted=True, attempts=tuple(attempts))
+
+        feedback = _failure_reasons(attempt)
+
+    return LoopResult(accepted=False, attempts=tuple(attempts))
+
+
+__all__ = [
+    "DEFAULT_MAX_RETRIES",
+    "Attempt",
+    "LeafExecutor",
+    "LoopResult",
+    "Verifier",
+    "VerifierVerdict",
+    "run_with_verifier",
+]

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -31,6 +31,7 @@ The retry budget defaults to K=2 per shaun0927's H1 sketch in #830.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import subprocess
 from typing import Protocol
 
 from ouroboros.orchestrator.evidence_schema import (
@@ -45,17 +46,21 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 DEFAULT_MAX_RETRIES: int = 2
 
 # Exception types treated as *operational* failures (transient: network
-# blip, LLM timeout, subprocess crash). Anything outside this tuple is
-# treated as a deterministic programming bug and re-raised so production
-# diagnosis is not blocked by silent STALL retries. (Bot finding on
-# PR #884 r5: AttributeError / KeyError / AssertionError must not be
-# swallowed as transient failures.)
+# blip, LLM timeout, subprocess crash, non-zero test return code).
+# Anything outside this tuple is treated as a deterministic programming
+# bug and re-raised so production diagnosis is not blocked by silent
+# STALL retries. (Bot findings on PR #884: r5 — programming bugs must
+# propagate; r6 — subprocess.TimeoutExpired / subprocess.CalledProcessError
+# from test-running verifiers must be absorbed as STALL.)
 _OPERATIONAL_VERIFIER_ERRORS: tuple[type[BaseException], ...] = (
     TimeoutError,
     ConnectionError,  # parent of BrokenPipe/ConnectionRefused/etc.
     # OSError catches transient FS/subprocess/sockets. ConnectionError
     # subclasses OSError, but we list it explicitly above for clarity.
     OSError,
+    # Verifier impls following the module's documented model run tests
+    # via subprocess. Both timeout and non-zero exit must be retryable.
+    subprocess.SubprocessError,
 )
 
 

--- a/src/ouroboros/profiles/analysis.yaml
+++ b/src/ouroboros/profiles/analysis.yaml
@@ -1,0 +1,20 @@
+profile: analysis
+axis: perspective
+min_unit: "single perspective compared against at least one contrasting view"
+cut_signal: "sub-AC produces a standalone comparison with explicit tradeoffs"
+evidence_schema:
+  required:
+    - claims
+    - perspectives_compared
+  rejected_if:
+    - "perspectives_compared == []"
+verifier_focus: >
+  Confirm every conclusion is supported by an explicit comparison of
+  perspectives. Reject one-sided analyses that omit contrasting views or
+  fail to make tradeoffs explicit.
+suggested_tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep

--- a/src/ouroboros/profiles/code.yaml
+++ b/src/ouroboros/profiles/code.yaml
@@ -1,0 +1,21 @@
+profile: code
+axis: testable_unit
+min_unit: "single function or module with at least one runnable test"
+cut_signal: "sub-AC produces an independently runnable test"
+evidence_schema:
+  required:
+    - files_touched
+    - commands_run
+    - tests_passed
+  rejected_if:
+    - "tests_passed == []"
+verifier_focus: >
+  Run the project's test command. Confirm tests_passed list matches reality.
+  Reject claims about files or symbols that do not exist on disk.
+suggested_tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+  - Glob
+  - Grep

--- a/src/ouroboros/profiles/research.yaml
+++ b/src/ouroboros/profiles/research.yaml
@@ -1,0 +1,22 @@
+profile: research
+axis: subtopic
+min_unit: "single question answerable from independently cited sources"
+cut_signal: "sub-AC produces a standalone markdown section with citations"
+evidence_schema:
+  required:
+    - external_sources
+    - claims
+    - triangulated_sources
+  rejected_if:
+    - "external_sources == []"
+    - "triangulated_sources == []"
+verifier_focus: >
+  Confirm each claim is anchored to at least one external source URL or
+  document. Reject claims that cite no source or that rely on a single
+  unsupported reference.
+suggested_tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -80,6 +80,24 @@ class TestExtractEvidence:
         record = extract_evidence('```JSON\n{"x": 1}\n```\n')
         assert record.data == {"x": 1}
 
+    def test_triple_backtick_inside_json_string_value(self) -> None:
+        # Regression: an earlier fence-scanner stopped at the first raw
+        # ``` after the opener, even when it sat inside a quoted JSON
+        # string value (bot finding on PR #883 round 2). The JSON-aware
+        # raw_decode must let `json.JSONDecoder` decide where the value
+        # ends.
+        text = '```json\n{"note": "embedded ``` triple-backtick survives", "ok": true}\n```\n'
+        record = extract_evidence(text)
+        assert record.data["ok"] is True
+        assert "triple-backtick" in record.data["note"]
+
+    def test_extra_text_after_object_is_ignored(self) -> None:
+        # raw_decode stops at the end of the first JSON value, so trailing
+        # narrative text inside the fence does not corrupt parsing.
+        text = '```json\n{"x": 1}\nsome trailing prose\n```\n'
+        record = extract_evidence(text)
+        assert record.data == {"x": 1}
+
 
 class TestValidateCodeProfile:
     def test_accepts_complete_record(self, code_profile) -> None:

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -58,6 +58,28 @@ class TestExtractEvidence:
         with pytest.raises(EvidenceError, match="must be a JSON object"):
             extract_evidence("[1, 2, 3]")
 
+    def test_quoted_brace_inside_string_value(self) -> None:
+        # Regression: old regex stopped at the first `}` even inside a
+        # JSON string value, truncating the payload (bot finding #1 on
+        # PR #883). The fence-aware extractor must keep the entire body
+        # and let json.loads handle string escaping.
+        payload = '{"note": "hello } still inside string", "ok": true}'
+        record = extract_evidence(payload)
+        assert record.data == {
+            "note": "hello } still inside string",
+            "ok": True,
+        }
+
+    def test_quoted_backticks_inside_string_value(self) -> None:
+        text = '```json\n{"note": "embedded `single backtick` survives", "ok": true}\n```\n'
+        record = extract_evidence(text)
+        assert record.data["ok"] is True
+        assert "single backtick" in record.data["note"]
+
+    def test_uppercase_json_fence_tag(self) -> None:
+        record = extract_evidence('```JSON\n{"x": 1}\n```\n')
+        assert record.data == {"x": 1}
+
 
 class TestValidateCodeProfile:
     def test_accepts_complete_record(self, code_profile) -> None:
@@ -200,3 +222,64 @@ class TestRejectionGrammar:
         result = validate_evidence(profile, record)
         assert result.ok is False
         assert result.rejected_by == ("never_emitted == None",)
+
+
+class TestJsonYamlLiteralSpellings:
+    """rejected_if must accept literals YAML / JSON authors write.
+
+    Profiles are YAML-authored and evidence is JSON, so authors reach
+    for `null`, `true`, `false` — not Python's `None`/`True`/`False`.
+    Both spellings must work (bot finding #2 on PR #883).
+    """
+
+    def _profile_with_rule(self, rule: str):
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        return load_profile("code").model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=(rule,),
+                )
+            }
+        )
+
+    def test_json_null_literal(self) -> None:
+        profile = self._profile_with_rule("flag == null")
+        record = EvidenceRecord(data={"flag": None})
+        result = validate_evidence(profile, record)
+        assert result.ok is False
+        assert result.rejected_by == ("flag == null",)
+
+    def test_json_true_literal(self) -> None:
+        profile = self._profile_with_rule("flag == true")
+        record = EvidenceRecord(data={"flag": True})
+        assert validate_evidence(profile, record).ok is False
+
+    def test_json_false_literal(self) -> None:
+        profile = self._profile_with_rule("flag == false")
+        record = EvidenceRecord(data={"flag": False})
+        assert validate_evidence(profile, record).ok is False
+
+    def test_python_spellings_still_work(self) -> None:
+        # Backwards-compat with the legacy Python literal spellings.
+        for rule, value in (
+            ("flag == None", None),
+            ("flag == True", True),
+            ("flag == False", False),
+        ):
+            profile = self._profile_with_rule(rule)
+            record = EvidenceRecord(data={"flag": value})
+            assert validate_evidence(profile, record).ok is False, (
+                f"{rule!r} did not trigger for {value!r}"
+            )
+
+    def test_json_number_literal(self) -> None:
+        profile = self._profile_with_rule("count == 0")
+        record = EvidenceRecord(data={"count": 0})
+        assert validate_evidence(profile, record).ok is False
+
+    def test_json_string_literal(self) -> None:
+        profile = self._profile_with_rule('status == "blocked"')
+        record = EvidenceRecord(data={"status": "blocked"})
+        assert validate_evidence(profile, record).ok is False

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -1,0 +1,202 @@
+"""Tests for ouroboros.orchestrator.evidence_schema (RFC v2 #830, PR 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.evidence_schema import (
+    EvidenceError,
+    EvidenceRecord,
+    extract_evidence,
+    validate_evidence,
+)
+from ouroboros.orchestrator.profile_loader import load_profile
+
+
+@pytest.fixture
+def code_profile():
+    return load_profile("code")
+
+
+@pytest.fixture
+def research_profile():
+    return load_profile("research")
+
+
+@pytest.fixture
+def analysis_profile():
+    return load_profile("analysis")
+
+
+class TestExtractEvidence:
+    def test_bare_json_object(self) -> None:
+        record = extract_evidence('{"files_touched": ["a.py"]}')
+        assert record.data == {"files_touched": ["a.py"]}
+
+    def test_fenced_json_block(self) -> None:
+        text = 'summary line\n```json\n{"x": 1}\n```\ntrailing\n'
+        record = extract_evidence(text)
+        assert record.data == {"x": 1}
+
+    def test_fenced_block_without_lang_tag(self) -> None:
+        record = extract_evidence('prelude\n```\n{"y": 2}\n```\n')
+        assert record.data == {"y": 2}
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(EvidenceError, match="empty"):
+            extract_evidence("")
+
+    def test_whitespace_only_rejected(self) -> None:
+        with pytest.raises(EvidenceError, match="empty"):
+            extract_evidence("   \n\t  ")
+
+    def test_malformed_json(self) -> None:
+        with pytest.raises(EvidenceError, match="not valid JSON"):
+            extract_evidence("{not: json}")
+
+    def test_non_object_payload(self) -> None:
+        with pytest.raises(EvidenceError, match="must be a JSON object"):
+            extract_evidence("[1, 2, 3]")
+
+
+class TestValidateCodeProfile:
+    def test_accepts_complete_record(self, code_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "files_touched": ["src/a.py"],
+                "commands_run": ["pytest"],
+                "tests_passed": ["test_a"],
+            }
+        )
+        result = validate_evidence(code_profile, record)
+        assert result.ok is True
+        assert result.missing_fields == ()
+        assert result.rejected_by == ()
+
+    def test_rejects_empty_tests_passed(self, code_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "files_touched": ["src/a.py"],
+                "commands_run": ["pytest"],
+                "tests_passed": [],
+            }
+        )
+        result = validate_evidence(code_profile, record)
+        assert result.ok is False
+        assert result.rejected_by == ("tests_passed == []",)
+        assert result.missing_fields == ()
+
+    def test_reports_missing_fields(self, code_profile) -> None:
+        record = EvidenceRecord(data={"files_touched": ["a.py"]})
+        result = validate_evidence(code_profile, record)
+        assert result.ok is False
+        assert "commands_run" in result.missing_fields
+        assert "tests_passed" in result.missing_fields
+
+    def test_reasons_summarize_failures(self, code_profile) -> None:
+        record = EvidenceRecord(data={"tests_passed": []})
+        result = validate_evidence(code_profile, record)
+        reasons = result.reasons()
+        assert any("missing required fields" in r for r in reasons)
+        assert any("tests_passed == []" in r for r in reasons)
+
+
+class TestValidateResearchProfile:
+    def test_accepts_triangulated(self, research_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "external_sources": ["https://example.com/a"],
+                "claims": [{"text": "x", "source": 0}],
+                "triangulated_sources": ["https://example.com/a", "https://example.com/b"],
+            }
+        )
+        result = validate_evidence(research_profile, record)
+        assert result.ok is True
+
+    def test_rejects_no_external_sources(self, research_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "external_sources": [],
+                "claims": [],
+                "triangulated_sources": [],
+            }
+        )
+        result = validate_evidence(research_profile, record)
+        assert result.ok is False
+        assert "external_sources == []" in result.rejected_by
+        assert "triangulated_sources == []" in result.rejected_by
+
+
+class TestValidateAnalysisProfile:
+    def test_accepts_perspectives(self, analysis_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "claims": [{"text": "x"}],
+                "perspectives_compared": ["pro", "con"],
+            }
+        )
+        result = validate_evidence(analysis_profile, record)
+        assert result.ok is True
+
+    def test_rejects_one_sided(self, analysis_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "claims": [{"text": "x"}],
+                "perspectives_compared": [],
+            }
+        )
+        result = validate_evidence(analysis_profile, record)
+        assert result.ok is False
+        assert result.rejected_by == ("perspectives_compared == []",)
+
+
+class TestRejectionGrammar:
+    """rejected_if grammar is intentionally narrow; bad expressions must surface."""
+
+    def test_unsupported_expression_raises(
+        self, code_profile, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        broken = code_profile.model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=("len(tests_passed) < 1",),
+                )
+            }
+        )
+        record = EvidenceRecord(data={"tests_passed": [1]})
+        with pytest.raises(EvidenceError, match="Unsupported rejected_if"):
+            validate_evidence(broken, record)
+
+    def test_unsupported_literal_raises(self, code_profile) -> None:
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        broken = code_profile.model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=("tests_passed == os.system",),
+                )
+            }
+        )
+        record = EvidenceRecord(data={"tests_passed": []})
+        with pytest.raises(EvidenceError, match="Unsupported literal"):
+            validate_evidence(broken, record)
+
+    def test_missing_field_compared_to_none_triggers(self) -> None:
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        profile = load_profile("code").model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=("never_emitted == None",),
+                )
+            }
+        )
+        record = EvidenceRecord(data={})
+        result = validate_evidence(profile, record)
+        assert result.ok is False
+        assert result.rejected_by == ("never_emitted == None",)

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -1,0 +1,107 @@
+"""Tests for ouroboros.orchestrator.profile_loader (RFC v2 #830, PR 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ouroboros.orchestrator.profile_loader import (
+    ExecutionProfile,
+    ProfileError,
+    available_profiles,
+    load_profile,
+)
+
+BUILTIN_PROFILES = ("analysis", "code", "research")
+
+
+class TestBuiltinProfiles:
+    """Bundled profiles must load and expose the H4 surface."""
+
+    @pytest.mark.parametrize("name", BUILTIN_PROFILES)
+    def test_loads(self, name: str) -> None:
+        profile = load_profile(name)
+        assert isinstance(profile, ExecutionProfile)
+        assert profile.profile == name
+        assert profile.axis
+        assert profile.min_unit
+        assert profile.verifier_focus
+
+    def test_available_lists_all_builtins(self) -> None:
+        discovered = available_profiles()
+        for name in BUILTIN_PROFILES:
+            assert name in discovered
+
+    def test_code_profile_has_test_evidence(self) -> None:
+        profile = load_profile("code")
+        assert "tests_passed" in profile.evidence_schema.required
+        assert "Read" in profile.suggested_tools
+
+    def test_research_profile_requires_triangulation(self) -> None:
+        profile = load_profile("research")
+        assert "triangulated_sources" in profile.evidence_schema.required
+
+    def test_analysis_profile_requires_perspectives(self) -> None:
+        profile = load_profile("analysis")
+        assert "perspectives_compared" in profile.evidence_schema.required
+
+
+class TestSchemaValidation:
+    """Loader rejects ill-formed profile files."""
+
+    def _write(self, dir_: Path, name: str, body: str) -> Path:
+        path = dir_ / f"{name}.yaml"
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def test_missing_required_field(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "broken",
+            "profile: broken\naxis: x\nmin_unit: y\n",  # no verifier_focus
+        )
+        with pytest.raises(ProfileError, match="schema validation"):
+            load_profile("broken", profiles_dir=tmp_path)
+
+    def test_extra_field_rejected(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "extra",
+            ("profile: extra\naxis: x\nmin_unit: y\nverifier_focus: z\nunknown_field: oops\n"),
+        )
+        with pytest.raises(ProfileError, match="schema validation"):
+            load_profile("extra", profiles_dir=tmp_path)
+
+    def test_filename_must_match_profile_field(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "alpha",
+            "profile: beta\naxis: x\nmin_unit: y\nverifier_focus: z\n",
+        )
+        with pytest.raises(ProfileError, match="name mismatch"):
+            load_profile("alpha", profiles_dir=tmp_path)
+
+    def test_non_mapping_top_level(self, tmp_path: Path) -> None:
+        self._write(tmp_path, "list", "- a\n- b\n")
+        with pytest.raises(ProfileError, match="mapping"):
+            load_profile("list", profiles_dir=tmp_path)
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        self._write(tmp_path, "bad", "profile: [unterminated\n")
+        with pytest.raises(ProfileError, match="not valid YAML"):
+            load_profile("bad", profiles_dir=tmp_path)
+
+    def test_unknown_profile(self, tmp_path: Path) -> None:
+        with pytest.raises(ProfileError, match="not found"):
+            load_profile("ghost", profiles_dir=tmp_path)
+
+    def test_invalid_name_rejected(self, tmp_path: Path) -> None:
+        for bad in ("../etc/passwd", "a/b", ".hidden", ""):
+            with pytest.raises(ProfileError, match="Invalid profile name"):
+                load_profile(bad, profiles_dir=tmp_path)
+
+    def test_profile_is_frozen(self) -> None:
+        profile = load_profile("code")
+        with pytest.raises(ValueError, match="frozen"):
+            profile.axis = "mutated"  # type: ignore[misc]

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -177,19 +177,30 @@ class TestWheelPackaging:
             timeout=120,
             check=False,
         )
-        if result.returncode != 0:
-            pytest.skip(f"uv build did not produce a wheel: {result.stderr}")
+        # The whole point of this test is to catch packaging regressions —
+        # a non-zero build status is the regression signal, not a skip.
+        assert result.returncode == 0, (
+            f"uv build failed (rc={result.returncode}):\n"
+            f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+        )
 
         wheels = list(out.glob("*.whl"))
         assert wheels, f"no wheel produced in {out}"
         wheel = wheels[0]
         with zipfile.ZipFile(wheel) as zf:
-            names = set(zf.namelist())
+            # Keep the list — not a set — so duplicate ZIP entries (which
+            # PyPI rejects) are caught here. The exclude/force-include
+            # pairing in pyproject.toml is fragile; this is the guard.
+            names = zf.namelist()
 
         for stem in ("code", "research", "analysis"):
             expected = f"ouroboros/profiles/{stem}.yaml"
-            assert expected in names, (
-                f"{expected!r} missing from wheel; force-include in "
-                f"pyproject.toml probably regressed. Wheel contents (sample): "
+            occurrences = sum(1 for n in names if n == expected)
+            assert occurrences == 1, (
+                f"{expected!r} appears {occurrences} times in wheel "
+                f"(should be exactly 1). Duplicate entries usually mean "
+                f"the wheel `exclude` for src/ouroboros/profiles is "
+                f"missing alongside the `force-include`. Wheel contents "
+                f"(profiles sample): "
                 f"{sorted(n for n in names if 'profile' in n)}"
             )

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -105,3 +105,91 @@ class TestSchemaValidation:
         profile = load_profile("code")
         with pytest.raises(ValueError, match="frozen"):
             profile.axis = "mutated"  # type: ignore[misc]
+
+
+class TestIoErrorNormalization:
+    """Filesystem + decoding errors must surface as ProfileError.
+
+    The loader documents that callers see ProfileError on every failure
+    mode, but the read-text call could leak OSError / UnicodeDecodeError
+    (bot finding on PR #881). Normalize both to ProfileError so the
+    contract holds in production.
+    """
+
+    def test_invalid_utf8_raises_profile_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "garbled.yaml"
+        # 0xff is not a valid first byte in any UTF-8 sequence.
+        path.write_bytes(b"\xff\xfe garbage\n")
+        with pytest.raises(ProfileError, match="not valid UTF-8"):
+            load_profile("garbled", profiles_dir=tmp_path)
+
+    def test_unreadable_file_raises_profile_error(self, tmp_path: Path) -> None:
+        import os
+        import stat
+
+        path = tmp_path / "locked.yaml"
+        path.write_text(
+            "profile: locked\naxis: x\nmin_unit: y\nverifier_focus: z\n",
+            encoding="utf-8",
+        )
+        path.chmod(0)
+        try:
+            # Root can bypass the permission denial — skip if so.
+            if os.geteuid() == 0:
+                pytest.skip("root bypasses permission denial")
+            with pytest.raises(ProfileError, match="could not be read"):
+                load_profile("locked", profiles_dir=tmp_path)
+        finally:
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+class TestWheelPackaging:
+    """The bundled profile YAMLs must reach the installed wheel.
+
+    The loader resolves YAMLs via ``Path(__file__).parent.parent /
+    "profiles"``. If the ``pyproject.toml`` ``force-include`` entry for
+    ``src/ouroboros/profiles`` is dropped, the source tree still works
+    but ``pip install`` of the wheel ships a loader that cannot find
+    any profile.
+
+    This regression test builds the wheel in a tmpdir and asserts every
+    bundled profile is present at the expected path inside the .whl.
+    Skipped if ``uv`` is not available on PATH (CI sandboxes that
+    cannot spawn external builds).
+    """
+
+    @pytest.mark.slow
+    def test_wheel_contains_profile_yamls(self, tmp_path: Path) -> None:
+        import shutil
+        import subprocess
+        import zipfile
+
+        if shutil.which("uv") is None:
+            pytest.skip("uv is not on PATH; cannot build the wheel here")
+
+        repo_root = Path(__file__).resolve().parents[3]
+        out = tmp_path / "dist"
+        result = subprocess.run(
+            ["uv", "build", "--wheel", "--out-dir", str(out)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"uv build did not produce a wheel: {result.stderr}")
+
+        wheels = list(out.glob("*.whl"))
+        assert wheels, f"no wheel produced in {out}"
+        wheel = wheels[0]
+        with zipfile.ZipFile(wheel) as zf:
+            names = set(zf.namelist())
+
+        for stem in ("code", "research", "analysis"):
+            expected = f"ouroboros/profiles/{stem}.yaml"
+            assert expected in names, (
+                f"{expected!r} missing from wheel; force-include in "
+                f"pyproject.toml probably regressed. Wheel contents (sample): "
+                f"{sorted(n for n in names if 'profile' in n)}"
+            )

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -198,6 +198,40 @@ class TestVerifierExceptionWrapping:
         with pytest.raises(ValueError):
             VerifierVerdict(passed=False)
 
+    def test_verifier_returning_none_raises_contract_error(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        # Bot finding on #884 r4: Verifier is a static Protocol, so a
+        # buggy impl can return None (or any non-VerifierVerdict) at
+        # runtime. Without an explicit check, None would silently burn
+        # the retry budget with no reasons surfaced.
+        def returns_none(*, profile, ac, leaf_output, record):  # type: ignore[no-untyped-def]
+            return None
+
+        executor = ScriptedExecutor(outputs=[_code_evidence()])
+        with pytest.raises(VerifierContractError, match="expected VerifierVerdict"):
+            run_with_verifier(
+                executor=executor,
+                verifier=returns_none,  # type: ignore[arg-type]
+                profile=code_profile,
+                ac="x",
+            )
+
+    def test_verifier_returning_wrong_type_raises_contract_error(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        def returns_bool(*, profile, ac, leaf_output, record):  # type: ignore[no-untyped-def]
+            return True
+
+        executor = ScriptedExecutor(outputs=[_code_evidence()])
+        with pytest.raises(VerifierContractError, match="bool"):
+            run_with_verifier(
+                executor=executor,
+                verifier=returns_bool,  # type: ignore[arg-type]
+                profile=code_profile,
+                ac="x",
+            )
+
     def test_verifier_exhausts_budget_when_always_raises(
         self, code_profile: ExecutionProfile
     ) -> None:

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -98,6 +98,98 @@ class TestVerifierVerdict:
         with pytest.raises(ValueError, match="must include at least one reason"):
             VerifierVerdict(passed=False, failure_class="STALL")
 
+    def test_unknown_failure_class_rejected(self) -> None:
+        # The H7 classifier would silently degrade an unknown class to
+        # STALL, masking real fabrication / scope-creep signals from a
+        # verifier impl that typo'd the tag. Reject at construction.
+        with pytest.raises(ValueError, match="not a recognized taxonomy"):
+            VerifierVerdict(passed=False, reasons=("bad",), failure_class="MYSTERY")
+
+    @pytest.mark.parametrize(
+        "klass",
+        [
+            "EVIDENCE_MISSING",
+            "FABRICATION_SUSPECTED",
+            "SCOPE_CREEP",
+            "STALL",
+            "BLOCKED",
+        ],
+    )
+    def test_known_failure_classes_accepted(self, klass: str) -> None:
+        verdict = VerifierVerdict(passed=False, reasons=("r",), failure_class=klass)
+        assert verdict.failure_class == klass
+
+
+class TestVerifierExceptionWrapping:
+    """Verifier impls run tests / LLMs — transient failures become FAIL.
+
+    Per bot review on #884, letting a verifier exception escape would
+    skip the bounded-retry path and produce no LoopResult transcript
+    for upstream escalation. The loop must trap and convert to a FAIL
+    verdict with surfaceable reasons.
+    """
+
+    def test_verifier_runtime_error_becomes_fail_verdict(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        call_count = 0
+
+        def flaky_verifier(
+            *,
+            profile: ExecutionProfile,
+            ac: str,
+            leaf_output: str,
+            record: EvidenceRecord,
+        ) -> VerifierVerdict:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise TimeoutError("LLM call timed out")
+            return VerifierVerdict(passed=True)
+
+        executor = ScriptedExecutor(outputs=[_code_evidence(), _code_evidence()])
+        result = run_with_verifier(
+            executor=executor,
+            verifier=flaky_verifier,
+            profile=code_profile,
+            ac="x",
+        )
+        assert result.accepted is True
+        assert len(result.attempts) == 2
+        first = result.attempts[0]
+        assert first.verdict is not None
+        assert first.verdict.passed is False
+        assert first.verdict.failure_class == "STALL"
+        assert any("TimeoutError" in r for r in first.verdict.reasons)
+        # Retry executor must have seen the wrapped reason as feedback.
+        assert any("TimeoutError" in line for line in executor.feedbacks[1])
+
+    def test_verifier_exhausts_budget_when_always_raises(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        def always_boom(
+            *,
+            profile: ExecutionProfile,
+            ac: str,
+            leaf_output: str,
+            record: EvidenceRecord,
+        ) -> VerifierVerdict:
+            raise RuntimeError("verifier crashed")
+
+        executor = ScriptedExecutor(outputs=[_code_evidence()] * 3)
+        result = run_with_verifier(
+            executor=executor,
+            verifier=always_boom,
+            profile=code_profile,
+            ac="x",
+            max_retries=2,
+        )
+        assert result.accepted is False
+        assert len(result.attempts) == 3
+        for a in result.attempts:
+            assert a.verdict is not None
+            assert a.verdict.failure_class == "STALL"
+
 
 class TestHappyPath:
     def test_passes_on_first_attempt(self, code_profile: ExecutionProfile) -> None:

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -12,6 +12,7 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.verifier import (
     DEFAULT_MAX_RETRIES,
     LoopResult,
+    VerifierContractError,
     VerifierVerdict,
     run_with_verifier,
 )
@@ -163,6 +164,39 @@ class TestVerifierExceptionWrapping:
         assert any("TimeoutError" in r for r in first.verdict.reasons)
         # Retry executor must have seen the wrapped reason as feedback.
         assert any("TimeoutError" in line for line in executor.feedbacks[1])
+
+    def test_contract_error_propagates_not_masked_as_stall(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        # A verifier impl that constructs an invalid verdict is a
+        # deterministic programming bug — masking it as STALL would
+        # burn retry budget and ship a broken verifier. The loop must
+        # let VerifierContractError propagate (bot finding on #884 r3).
+        def buggy_verifier(
+            *,
+            profile: ExecutionProfile,
+            ac: str,
+            leaf_output: str,
+            record: EvidenceRecord,
+        ) -> VerifierVerdict:
+            # passed=True with reasons → __post_init__ raises
+            # VerifierContractError.
+            return VerifierVerdict(passed=True, reasons=("oops",))
+
+        executor = ScriptedExecutor(outputs=[_code_evidence()])
+        with pytest.raises(VerifierContractError):
+            run_with_verifier(
+                executor=executor,
+                verifier=buggy_verifier,
+                profile=code_profile,
+                ac="x",
+            )
+
+    def test_contract_error_is_value_error_subclass(self) -> None:
+        # Subclassing ValueError preserves backward compatibility for
+        # callers that already check `except ValueError`.
+        with pytest.raises(ValueError):
+            VerifierVerdict(passed=False)
 
     def test_verifier_exhausts_budget_when_always_raises(
         self, code_profile: ExecutionProfile

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -232,22 +232,24 @@ class TestVerifierExceptionWrapping:
                 ac="x",
             )
 
-    def test_verifier_exhausts_budget_when_always_raises(
+    def test_verifier_exhausts_budget_on_persistent_timeouts(
         self, code_profile: ExecutionProfile
     ) -> None:
-        def always_boom(
+        # TimeoutError is an operational failure — the retry loop must
+        # absorb it as STALL across the full budget.
+        def always_times_out(
             *,
             profile: ExecutionProfile,
             ac: str,
             leaf_output: str,
             record: EvidenceRecord,
         ) -> VerifierVerdict:
-            raise RuntimeError("verifier crashed")
+            raise TimeoutError("verifier timed out")
 
         executor = ScriptedExecutor(outputs=[_code_evidence()] * 3)
         result = run_with_verifier(
             executor=executor,
-            verifier=always_boom,
+            verifier=always_times_out,
             profile=code_profile,
             ac="x",
             max_retries=2,
@@ -257,6 +259,41 @@ class TestVerifierExceptionWrapping:
         for a in result.attempts:
             assert a.verdict is not None
             assert a.verdict.failure_class == "STALL"
+
+    @pytest.mark.parametrize(
+        "exc_factory",
+        [
+            lambda: AttributeError("verifier impl bug"),
+            lambda: KeyError("missing_field"),
+            lambda: AssertionError("invariant failed"),
+            lambda: RuntimeError("uncaught path"),
+            lambda: TypeError("wrong arg shape"),
+        ],
+    )
+    def test_programming_bug_exceptions_propagate(
+        self, code_profile: ExecutionProfile, exc_factory
+    ) -> None:
+        # Bot finding on #884 r5: programming bugs (AttributeError,
+        # KeyError, etc.) must NOT be silently retried as STALL — the
+        # operator needs the surfaced exception to fix the broken
+        # verifier instead of watching it exhaust retries.
+        def buggy(
+            *,
+            profile: ExecutionProfile,
+            ac: str,
+            leaf_output: str,
+            record: EvidenceRecord,
+        ) -> VerifierVerdict:
+            raise exc_factory()
+
+        executor = ScriptedExecutor(outputs=[_code_evidence()])
+        with pytest.raises(type(exc_factory())):
+            run_with_verifier(
+                executor=executor,
+                verifier=buggy,
+                profile=code_profile,
+                ac="x",
+            )
 
 
 class TestHappyPath:

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -81,6 +81,23 @@ class TestVerifierVerdict:
         )
         assert verdict.passed is False
 
+    def test_fail_without_reasons_rejected(self) -> None:
+        # A bare FAIL produces no feedback for the retry executor and no
+        # explanation on budget exhaustion — rejected at construction
+        # time per #884 review.
+        with pytest.raises(ValueError, match="must include at least one reason"):
+            VerifierVerdict(passed=False)
+
+    def test_fail_empty_reasons_tuple_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must include at least one reason"):
+            VerifierVerdict(passed=False, reasons=())
+
+    def test_fail_with_class_still_needs_reasons(self) -> None:
+        # failure_class alone is not enough — the executor needs prose
+        # to act on. Both are required when passed=False.
+        with pytest.raises(ValueError, match="must include at least one reason"):
+            VerifierVerdict(passed=False, failure_class="STALL")
+
 
 class TestHappyPath:
     def test_passes_on_first_attempt(self, code_profile: ExecutionProfile) -> None:

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -232,6 +232,49 @@ class TestVerifierExceptionWrapping:
                 ac="x",
             )
 
+    @pytest.mark.parametrize(
+        "operational_exc",
+        [
+            TimeoutError("LLM timed out"),
+            ConnectionError("network blip"),
+            OSError("transient FS error"),
+            __import__("subprocess").TimeoutExpired("pytest", 30),
+            __import__("subprocess").CalledProcessError(1, "pytest"),
+        ],
+    )
+    def test_operational_errors_become_stall_verdict(
+        self, code_profile: ExecutionProfile, operational_exc: BaseException
+    ) -> None:
+        # Bot finding on #884 r6: verifiers documented to run tests via
+        # subprocess hit TimeoutExpired / CalledProcessError; both must
+        # be absorbed as retryable STALL, not propagated as programming
+        # bugs.
+        captured_exc = operational_exc
+
+        def transient_then_pass(
+            *,
+            profile: ExecutionProfile,
+            ac: str,
+            leaf_output: str,
+            record: EvidenceRecord,
+        ) -> VerifierVerdict:
+            if not getattr(transient_then_pass, "fired", False):
+                transient_then_pass.fired = True  # type: ignore[attr-defined]
+                raise captured_exc
+            return VerifierVerdict(passed=True)
+
+        executor = ScriptedExecutor(outputs=[_code_evidence(), _code_evidence()])
+        result = run_with_verifier(
+            executor=executor,
+            verifier=transient_then_pass,
+            profile=code_profile,
+            ac="x",
+        )
+        assert result.accepted is True
+        assert result.attempts[0].verdict is not None
+        assert result.attempts[0].verdict.failure_class == "STALL"
+        assert any(type(captured_exc).__name__ in r for r in result.attempts[0].verdict.reasons)
+
     def test_verifier_exhausts_budget_on_persistent_timeouts(
         self, code_profile: ExecutionProfile
     ) -> None:

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -1,0 +1,266 @@
+"""Tests for ouroboros.orchestrator.verifier (RFC v2 #830, PR 3)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+
+import pytest
+
+from ouroboros.orchestrator.evidence_schema import EvidenceRecord
+from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
+from ouroboros.orchestrator.verifier import (
+    DEFAULT_MAX_RETRIES,
+    LoopResult,
+    VerifierVerdict,
+    run_with_verifier,
+)
+
+
+def _code_evidence(tests_passed: list[str] | None = None) -> str:
+    return json.dumps(
+        {
+            "files_touched": ["src/a.py"],
+            "commands_run": ["pytest"],
+            "tests_passed": tests_passed if tests_passed is not None else ["test_a"],
+        }
+    )
+
+
+@dataclass
+class ScriptedExecutor:
+    """Executor that returns canned outputs in order, recording feedback it saw."""
+
+    outputs: list[str]
+    feedbacks: list[tuple[str, ...]] = field(default_factory=list)
+
+    def __call__(self, *, ac: str, feedback: tuple[str, ...]) -> str:
+        self.feedbacks.append(feedback)
+        if not self.outputs:
+            msg = "ScriptedExecutor ran out of outputs"
+            raise AssertionError(msg)
+        return self.outputs.pop(0)
+
+
+@dataclass
+class ScriptedVerifier:
+    """Verifier that returns canned verdicts in order, recording invocations."""
+
+    verdicts: list[VerifierVerdict]
+    calls: int = 0
+
+    def __call__(
+        self,
+        *,
+        profile: ExecutionProfile,
+        ac: str,
+        leaf_output: str,
+        record: EvidenceRecord,
+    ) -> VerifierVerdict:
+        self.calls += 1
+        return self.verdicts.pop(0)
+
+
+@pytest.fixture
+def code_profile() -> ExecutionProfile:
+    return load_profile("code")
+
+
+class TestVerifierVerdict:
+    def test_pass_with_reasons_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must not carry reasons"):
+            VerifierVerdict(passed=True, reasons=("noise",))
+
+    def test_pass_with_failure_class_rejected(self) -> None:
+        with pytest.raises(ValueError, match="failure_class"):
+            VerifierVerdict(passed=True, failure_class="STALL")
+
+    def test_fail_can_carry_class_and_reasons(self) -> None:
+        verdict = VerifierVerdict(
+            passed=False, reasons=("missing test",), failure_class="EVIDENCE_MISSING"
+        )
+        assert verdict.passed is False
+
+
+class TestHappyPath:
+    def test_passes_on_first_attempt(self, code_profile: ExecutionProfile) -> None:
+        executor = ScriptedExecutor(outputs=[_code_evidence()])
+        verifier = ScriptedVerifier(verdicts=[VerifierVerdict(passed=True)])
+
+        result = run_with_verifier(
+            executor=executor, verifier=verifier, profile=code_profile, ac="do thing"
+        )
+
+        assert result.accepted is True
+        assert len(result.attempts) == 1
+        assert result.final.accepted is True
+        assert verifier.calls == 1
+        # First call must see empty feedback.
+        assert executor.feedbacks == [()]
+
+
+class TestRetryWithFeedback:
+    def test_fail_then_pass_within_budget(self, code_profile: ExecutionProfile) -> None:
+        executor = ScriptedExecutor(outputs=[_code_evidence(), _code_evidence()])
+        verifier = ScriptedVerifier(
+            verdicts=[
+                VerifierVerdict(passed=False, reasons=("tests look fake",)),
+                VerifierVerdict(passed=True),
+            ]
+        )
+
+        result = run_with_verifier(
+            executor=executor, verifier=verifier, profile=code_profile, ac="do thing"
+        )
+
+        assert result.accepted is True
+        assert len(result.attempts) == 2
+        # Second executor invocation must see the verifier's reason as feedback.
+        assert executor.feedbacks[0] == ()
+        assert executor.feedbacks[1] == ("tests look fake",)
+
+    def test_exhaust_retries_returns_unaccepted(self, code_profile: ExecutionProfile) -> None:
+        outputs = [_code_evidence() for _ in range(3)]
+        verdicts = [
+            VerifierVerdict(passed=False, reasons=("bad",), failure_class="STALL") for _ in range(3)
+        ]
+        executor = ScriptedExecutor(outputs=outputs)
+        verifier = ScriptedVerifier(verdicts=verdicts)
+
+        result = run_with_verifier(
+            executor=executor,
+            verifier=verifier,
+            profile=code_profile,
+            ac="x",
+            max_retries=2,
+        )
+
+        assert result.accepted is False
+        assert len(result.attempts) == 3
+        assert verifier.calls == 3
+        # Final attempt is not accepted but verdict is recorded.
+        assert result.final.verdict is not None
+        assert result.final.verdict.failure_class == "STALL"
+
+    def test_default_max_retries_is_two(self) -> None:
+        assert DEFAULT_MAX_RETRIES == 2
+
+
+class TestEvidenceShortCircuit:
+    def test_evidence_parse_error_skips_verifier(self, code_profile: ExecutionProfile) -> None:
+        executor = ScriptedExecutor(outputs=["not json at all", _code_evidence()])
+        verifier = ScriptedVerifier(verdicts=[VerifierVerdict(passed=True)])
+
+        result = run_with_verifier(
+            executor=executor, verifier=verifier, profile=code_profile, ac="x"
+        )
+
+        assert result.accepted is True
+        # Verifier called exactly once — on the second (well-formed) attempt.
+        assert verifier.calls == 1
+        first = result.attempts[0]
+        assert first.evidence_error is not None
+        assert first.record is None
+        assert first.verdict is None
+        # Feedback to the retry should mention the parse failure.
+        assert any("evidence parse failed" in line for line in executor.feedbacks[1])
+
+    def test_evidence_validation_fail_skips_verifier(self, code_profile: ExecutionProfile) -> None:
+        empty_tests = _code_evidence(tests_passed=[])
+        executor = ScriptedExecutor(outputs=[empty_tests, _code_evidence()])
+        verifier = ScriptedVerifier(verdicts=[VerifierVerdict(passed=True)])
+
+        result = run_with_verifier(
+            executor=executor, verifier=verifier, profile=code_profile, ac="x"
+        )
+
+        assert result.accepted is True
+        # First attempt failed H2 validation; verifier must not have been called yet.
+        assert verifier.calls == 1
+        first = result.attempts[0]
+        assert first.validation is not None and not first.validation.ok
+        assert first.verdict is None
+        assert any("tests_passed == []" in line for line in executor.feedbacks[1])
+
+    def test_evidence_fail_exhausts_budget_without_verifier(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        executor = ScriptedExecutor(outputs=["garbage"] * 3)
+        verifier = ScriptedVerifier(verdicts=[])  # would raise if invoked
+
+        result = run_with_verifier(
+            executor=executor,
+            verifier=verifier,
+            profile=code_profile,
+            ac="x",
+            max_retries=2,
+        )
+
+        assert result.accepted is False
+        assert verifier.calls == 0
+        assert all(a.evidence_error is not None for a in result.attempts)
+
+
+class TestErrorBubbling:
+    def test_executor_exception_bubbles(self, code_profile: ExecutionProfile) -> None:
+        def boom(*, ac: str, feedback: tuple[str, ...]) -> str:
+            raise RuntimeError("network died")
+
+        verifier = ScriptedVerifier(verdicts=[])
+
+        with pytest.raises(RuntimeError, match="network died"):
+            run_with_verifier(executor=boom, verifier=verifier, profile=code_profile, ac="x")
+
+    def test_negative_max_retries_rejected(self, code_profile: ExecutionProfile) -> None:
+        executor = ScriptedExecutor(outputs=[])
+        verifier = ScriptedVerifier(verdicts=[])
+        with pytest.raises(ValueError, match="max_retries must be >= 0"):
+            run_with_verifier(
+                executor=executor,
+                verifier=verifier,
+                profile=code_profile,
+                ac="x",
+                max_retries=-1,
+            )
+
+    def test_loop_result_final_without_attempts_raises(self) -> None:
+        empty = LoopResult(accepted=False, attempts=())
+        with pytest.raises(RuntimeError, match="no attempts"):
+            _ = empty.final
+
+
+class TestZeroRetryBudget:
+    def test_max_retries_zero_runs_exactly_once(self, code_profile: ExecutionProfile) -> None:
+        executor = ScriptedExecutor(outputs=[_code_evidence()])
+        verifier = ScriptedVerifier(verdicts=[VerifierVerdict(passed=False, reasons=("nope",))])
+
+        result = run_with_verifier(
+            executor=executor,
+            verifier=verifier,
+            profile=code_profile,
+            ac="x",
+            max_retries=0,
+        )
+
+        assert result.accepted is False
+        assert len(result.attempts) == 1
+        assert verifier.calls == 1
+
+
+def test_callable_verifier_via_function(code_profile: ExecutionProfile) -> None:
+    """Verifier Protocol must accept a plain function, not only dataclasses."""
+
+    def verifier(
+        *,
+        profile: ExecutionProfile,
+        ac: str,
+        leaf_output: str,
+        record: EvidenceRecord,
+    ) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    def executor(*, ac: str, feedback: tuple[str, ...]) -> str:
+        return _code_evidence()
+
+    result = run_with_verifier(executor=executor, verifier=verifier, profile=code_profile, ac="x")
+    assert result.accepted is True


### PR DESCRIPTION
## Summary

Third PR in the [#830](https://github.com/Q00/ouroboros/issues/830) RFC v2 stack. **Stacked on #883** (which is stacked on #881). Rebase onto `main` after the lower PRs merge.

Implements H1 (external verifier + bounded retry). The leaf executor no longer self-approves: it produces an output, the harness parses evidence (H2 from #883), and on a structurally-valid record invokes a separate verifier pass. FAIL feeds verdict reasons back to the next attempt; PASS terminates.

## Loop semantics

1. Executor produces output. Harness parses evidence (H2).
2. **Short-circuit**: if evidence cannot be parsed or fails H2 validation, the verifier is skipped — the leaf could not satisfy the contract even on PASS, so retry immediately with parser reasons as feedback.
3. Otherwise verifier is invoked. PASS terminates; FAIL retries with verdict reasons as feedback so the executor addresses the specific complaint.
4. After `max_retries` (default K=2) exhausted FAILs, return the full attempt transcript with `accepted=False` for the upstream taxonomy classifier (H7, follow-up PR).

## Surface

- `Verifier` Protocol: `(*, profile, ac, leaf_output, record) -> VerifierVerdict`
- `LeafExecutor` Protocol: `(*, ac, feedback) -> str`
- `VerifierVerdict(passed, reasons, failure_class)` — invariants enforced in `__post_init__` (PASS verdict must not carry reasons or a class).
- `run_with_verifier(*, executor, verifier, profile, ac, max_retries=2) -> LoopResult` — returns the full `Attempt` transcript.
- `DEFAULT_MAX_RETRIES = 2` per @shaun0927's H1 sketch.

## Wiring scope

**Loop scaffolding only.** `parallel_executor` is not yet routed through `run_with_verifier`. The integration PR depends on:
- H7 failure taxonomy (needs `failure_class` plumbing on the upstream side)
- H5 routing (decides which model tier the verifier subagent runs at)

Both land later in the stack. This PR gives those downstream PRs a stable, fully-tested loop they can plug their pieces into.

## Test plan

- [x] `uv run pytest tests/unit/orchestrator/test_verifier.py` — 15 passed
- [x] Combined orchestrator unit suite (loader + validator + verifier) — 48 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy src/ouroboros/orchestrator/verifier.py` — Success: no issues found
- [ ] Reviewer: confirm `max_retries=2` (= 3 total executor calls) is the right default. shaun0927's sketch said K=2 retries.

## Stack

| # | PR | Status |
|---|----|--------|
| 1 | #881 — profile YAML schema + loader | open |
| 2 | #883 — H2 typed evidence validator | open |
| 3 | this PR — H1 external verifier loop | open |
| 4 | H4 parameterized decomposer | next |
| 5 | H3 PRE/POST wrappers | queued |
| 6 | H7 failure taxonomy | queued |
| 7 | H5 adaptive routing | queued |
| 8 | H6 context budget | queued |
| 9 | Deprecate code-executor.md | queued |

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)