### PR TITLE
feat(orchestrator): profile-aware decomposition params (#830 PR 4/9)

### DIFF
--- a/src/ouroboros/orchestrator/decomposition_params.py
+++ b/src/ouroboros/orchestrator/decomposition_params.py
@@ -1,0 +1,143 @@
+"""Profile-aware decomposition parameters + prompt builder (RFC v2 H4, #830).
+
+H4 reframes decomposition from "free prose system prompt" to "structured
+parameters consumed by a uniform decomposer". Adding a new domain becomes
+a YAML edit, not a prompt-engineering pass.
+
+The current `parallel_executor._try_decompose_ac` runs with a hardcoded
+`system_prompt="You are a task decomposition expert..."` — the splitter
+has no notion of which profile it is splitting for. After PR 9 wires
+this module in, the decomposer will receive a `DecompositionParams`
+built from the active `ExecutionProfile` and use the axis/min_unit/
+cut_signal verbatim.
+
+This PR ships the parameter shape and the prompt builder only.
+parallel_executor is unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.orchestrator.profile_loader import ExecutionProfile
+
+DEFAULT_MIN_BRANCHING: int = 2
+DEFAULT_MAX_BRANCHING: int = 5
+
+
+@dataclass(frozen=True)
+class DecompositionParams:
+    """Structured inputs the uniform decomposer consumes.
+
+    Attributes:
+        profile_name: Profile identifier (e.g. 'code'); preserved for logs.
+        axis: Decomposition axis (e.g. 'testable_unit', 'subtopic').
+        min_unit: Smallest dispatchable unit description.
+        cut_signal: Heuristic that a sub-AC is small enough to stop.
+        min_branching: Minimum sub-AC count when splitting (>= 1).
+        max_branching: Maximum sub-AC count when splitting.
+    """
+
+    profile_name: str
+    axis: str
+    min_unit: str
+    cut_signal: str
+    min_branching: int = DEFAULT_MIN_BRANCHING
+    max_branching: int = DEFAULT_MAX_BRANCHING
+
+    def __post_init__(self) -> None:
+        if self.min_branching < 1:
+            msg = f"min_branching must be >= 1, got {self.min_branching}"
+            raise ValueError(msg)
+        if self.max_branching < self.min_branching:
+            msg = (
+                f"max_branching ({self.max_branching}) must be >= "
+                f"min_branching ({self.min_branching})"
+            )
+            raise ValueError(msg)
+
+
+def params_from_profile(
+    profile: ExecutionProfile,
+    *,
+    min_branching: int = DEFAULT_MIN_BRANCHING,
+    max_branching: int = DEFAULT_MAX_BRANCHING,
+) -> DecompositionParams:
+    """Project an ExecutionProfile into the decomposer's parameter shape."""
+    return DecompositionParams(
+        profile_name=profile.profile,
+        axis=profile.axis,
+        min_unit=profile.min_unit,
+        cut_signal=profile.cut_signal,
+        min_branching=min_branching,
+        max_branching=max_branching,
+    )
+
+
+def build_decomposition_system_prompt(params: DecompositionParams) -> str:
+    """Build the profile-aware system prompt for the decomposer.
+
+    Replaces the current
+    `"You are a task decomposition expert. Analyze tasks and break them
+    down if needed."` system prompt with one that names the axis and
+    min_unit explicitly, so the splitter's output respects the profile.
+    """
+    return (
+        "You are a task decomposition expert for the "
+        f"{params.profile_name!r} domain.\n"
+        f"Split along the axis: {params.axis}.\n"
+        f"Smallest acceptable unit: {params.min_unit}.\n"
+        "Each sub-AC must be independently executable along this axis "
+        "and never overlap a sibling."
+    )
+
+
+def build_decomposition_user_prompt(
+    params: DecompositionParams,
+    *,
+    ac_label: str,
+    ac_content: str,
+    seed_goal: str,
+) -> str:
+    """Build the user-side decomposer prompt.
+
+    Mirrors the body shape currently used in
+    `parallel_executor._try_decompose_ac` so PR 9's wiring is a drop-in
+    replacement: the LLM still answers with ATOMIC or a JSON array.
+    """
+    cut_signal_line = (
+        f"A sub-AC is small enough when: {params.cut_signal}.\n" if params.cut_signal else ""
+    )
+    return (
+        "Analyze this acceptance criterion and determine if it should be "
+        "decomposed.\n\n"
+        "## Goal Context\n"
+        f"{seed_goal}\n\n"
+        f"## Acceptance Criterion ({ac_label})\n"
+        f"{ac_content}\n\n"
+        "## Instructions\n"
+        f"Split along the axis: {params.axis}.\n"
+        f"Smallest acceptable unit: {params.min_unit}.\n"
+        f"{cut_signal_line}"
+        f"If this AC is complex along the {params.axis} axis, decompose "
+        f"it into {params.min_branching}-{params.max_branching} sub-ACs.\n"
+        "If the AC is already at or below the minimum unit, respond with: "
+        "ATOMIC\n\n"
+        "If decomposing, respond with ONLY a JSON array of sub-AC "
+        'descriptions: ["Sub-AC 1: ...", "Sub-AC 2: ...", ...]\n\n'
+        "Each sub-AC must be:\n"
+        f"- Independently executable along the {params.axis} axis\n"
+        f"- Not smaller than: {params.min_unit}\n"
+        "- Non-overlapping with siblings\n\n"
+        'Respond with either "ATOMIC" or the JSON array only, nothing else.'
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_BRANCHING",
+    "DEFAULT_MIN_BRANCHING",
+    "DecompositionParams",
+    "build_decomposition_system_prompt",
+    "build_decomposition_user_prompt",
+    "params_from_profile",
+]

--- a/tests/unit/orchestrator/test_decomposition_params.py
+++ b/tests/unit/orchestrator/test_decomposition_params.py
@@ -1,0 +1,116 @@
+"""Tests for ouroboros.orchestrator.decomposition_params (RFC v2 #830, PR 4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.decomposition_params import (
+    DEFAULT_MAX_BRANCHING,
+    DEFAULT_MIN_BRANCHING,
+    DecompositionParams,
+    build_decomposition_system_prompt,
+    build_decomposition_user_prompt,
+    params_from_profile,
+)
+from ouroboros.orchestrator.profile_loader import load_profile
+
+
+class TestParamsFromProfile:
+    def test_projects_code_profile(self) -> None:
+        params = params_from_profile(load_profile("code"))
+        assert params.profile_name == "code"
+        assert params.axis == "testable_unit"
+        assert "function" in params.min_unit
+        assert params.cut_signal  # non-empty
+
+    def test_defaults_branching(self) -> None:
+        params = params_from_profile(load_profile("research"))
+        assert params.min_branching == DEFAULT_MIN_BRANCHING == 2
+        assert params.max_branching == DEFAULT_MAX_BRANCHING == 5
+
+    def test_override_branching(self) -> None:
+        params = params_from_profile(load_profile("analysis"), min_branching=3, max_branching=4)
+        assert params.min_branching == 3
+        assert params.max_branching == 4
+
+
+class TestInvariants:
+    def test_min_branching_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="min_branching must be >= 1"):
+            DecompositionParams(
+                profile_name="x",
+                axis="a",
+                min_unit="m",
+                cut_signal="",
+                min_branching=0,
+                max_branching=5,
+            )
+
+    def test_max_below_min_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max_branching"):
+            DecompositionParams(
+                profile_name="x",
+                axis="a",
+                min_unit="m",
+                cut_signal="",
+                min_branching=3,
+                max_branching=2,
+            )
+
+
+class TestSystemPrompt:
+    def test_mentions_axis_and_min_unit(self) -> None:
+        params = params_from_profile(load_profile("code"))
+        prompt = build_decomposition_system_prompt(params)
+        assert "'code'" in prompt
+        assert "testable_unit" in prompt
+        assert params.min_unit in prompt
+
+    def test_distinguishes_profiles(self) -> None:
+        a = build_decomposition_system_prompt(params_from_profile(load_profile("code")))
+        b = build_decomposition_system_prompt(params_from_profile(load_profile("research")))
+        c = build_decomposition_system_prompt(params_from_profile(load_profile("analysis")))
+        assert a != b != c
+        assert "testable_unit" in a
+        assert "subtopic" in b
+        assert "perspective" in c
+
+
+class TestUserPrompt:
+    def test_carries_ac_and_goal(self) -> None:
+        params = params_from_profile(load_profile("code"))
+        prompt = build_decomposition_user_prompt(
+            params, ac_label="AC #2.1", ac_content="Add caching layer", seed_goal="Speed up API"
+        )
+        assert "AC #2.1" in prompt
+        assert "Add caching layer" in prompt
+        assert "Speed up API" in prompt
+        assert "testable_unit" in prompt
+        assert params.cut_signal in prompt
+
+    def test_branching_bounds_in_prompt(self) -> None:
+        params = params_from_profile(load_profile("code"), min_branching=2, max_branching=4)
+        prompt = build_decomposition_user_prompt(
+            params, ac_label="x", ac_content="y", seed_goal="z"
+        )
+        assert "2-4 sub-ACs" in prompt
+
+    def test_atomic_instruction_present(self) -> None:
+        params = params_from_profile(load_profile("code"))
+        prompt = build_decomposition_user_prompt(
+            params, ac_label="x", ac_content="y", seed_goal="z"
+        )
+        assert "ATOMIC" in prompt
+        assert "JSON array" in prompt
+
+    def test_omits_cut_signal_line_when_empty(self) -> None:
+        params = DecompositionParams(
+            profile_name="bare",
+            axis="a",
+            min_unit="m",
+            cut_signal="",
+        )
+        prompt = build_decomposition_user_prompt(
+            params, ac_label="x", ac_content="y", seed_goal="z"
+        )
+        assert "A sub-AC is small enough when:" not in prompt


### PR DESCRIPTION
## Summary

Fourth PR in the [#830](https://github.com/Q00/ouroboros/issues/830) RFC v2 stack. **Stacked on #884** (which is stacked on #883, which is stacked on #881).

Implements H4 (decomposition parameters, not prompt text). The current `parallel_executor._try_decompose_ac` runs with a hardcoded `system_prompt="You are a task decomposition expert..."` — the splitter has no notion of which profile it is splitting for. This module gives the splitter axis-aware structured params built from the active `ExecutionProfile`.

## What lands

- `DecompositionParams` dataclass: `axis`, `min_unit`, `cut_signal`, `min/max_branching`. `__post_init__` enforces `min >= 1` and `max >= min`.
- `params_from_profile(profile, *, min_branching=2, max_branching=5)` projects an `ExecutionProfile` into the params.
- `build_decomposition_system_prompt(params)` — profile-aware replacement for the existing decomposer system prompt.
- `build_decomposition_user_prompt(params, *, ac_label, ac_content, seed_goal)` — drop-in body shape that mirrors the current `_try_decompose_ac` user prompt.

## Wiring scope

**Pure prompt-builder module — `parallel_executor` is unchanged.** The integration into `_try_decompose_ac` lands in PR 9 alongside the phase-wrappers and routing pieces.

## Test plan

- [x] `uv run pytest tests/unit/orchestrator/test_decomposition_params.py` — 11 passed
- [x] Combined stack (PR1+2+3+4) — 59 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy src/ouroboros/orchestrator/decomposition_params.py` — Success

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)