### PR TITLE
feat(orchestrator): PRE/POST phase wrappers (#830 PR 5/9)

### DIFF
--- a/src/ouroboros/orchestrator/phase_wrappers.py
+++ b/src/ouroboros/orchestrator/phase_wrappers.py
@@ -54,6 +54,19 @@ def _format_rejected(schema: EvidenceSchema) -> str:
     return "; ".join(schema.rejected_if)
 
 
+def _indent_ac(ac: str, indent: str = "  ") -> str:
+    """Apply a constant indent to every line of an AC.
+
+    Seed ACs are free-form text and may contain embedded newlines.
+    Indenting only the first line lets subsequent lines run flush-left
+    and visually escape the "Acceptance criterion to satisfy" section,
+    merging with the harness instructions that follow (bot finding on
+    #886 r2). Apply the indent to every non-empty line so the AC's
+    section boundary is preserved.
+    """
+    return "\n".join(indent + line if line else line for line in ac.splitlines())
+
+
 def build_pre_block(profile: ExecutionProfile, ac: str) -> str:
     """Compose the PRE wrapper for a single leaf dispatch.
 
@@ -65,7 +78,7 @@ def build_pre_block(profile: ExecutionProfile, ac: str) -> str:
     return (
         f"{_DEFAULT_PRE_HEADER}\n"
         f"Active profile: {profile.profile!r} (axis: {profile.axis}).\n"
-        f"Acceptance criterion to satisfy:\n  {ac.strip()}\n\n"
+        f"Acceptance criterion to satisfy:\n{_indent_ac(ac.strip())}\n\n"
         "Before touching any tool, restate this AC in one sentence and "
         "list every precondition you are assuming (paths, commands, "
         "external services). Do not begin execution if any precondition "
@@ -96,14 +109,15 @@ def build_post_block(profile: ExecutionProfile) -> str:
 def wrap_prompt(profile: ExecutionProfile, ac: str, body: str) -> WrappedPrompt:
     """Compose a profile-aware [PRE] + body + [POST] leaf prompt.
 
-    The `body` is the skill-/strategy-specific task instructions that
-    the existing dispatch path already supplies; this function does not
-    rewrite that content, it only frames it with the harness-owned
-    wrappers.
+    The `body` is the skill-/strategy-specific task instructions the
+    existing dispatch path supplies. It is passed through verbatim —
+    no stripping, no normalization — so formatting-sensitive content
+    (indented code blocks, JSON examples, deliberately blank-prefixed
+    markdown) survives intact (bot finding on #886 r2).
     """
     return WrappedPrompt(
         pre=build_pre_block(profile, ac),
-        body=body.strip(),
+        body=body,
         post=build_post_block(profile),
     )
 

--- a/src/ouroboros/orchestrator/phase_wrappers.py
+++ b/src/ouroboros/orchestrator/phase_wrappers.py
@@ -1,0 +1,116 @@
+"""PRE/POST phase wrappers for leaf prompts (RFC v2 H3, #830).
+
+H3 reframes "execution phases" from per-skill markdown (`phase-task-start`,
+`phase-task-end`) into harness-injected wrappers. The orchestrator
+prepends a [PRE] block (restate AC, list assumed preconditions, name the
+evidence schema) and appends a [POST] block (emit evidence record, do
+not declare DONE — harness adjudicates).
+
+This module is pure prompt-composition surface. parallel_executor and
+execution_strategy still pass through their existing system-prompt
+fragments; PR 9 wires `wrap_prompt` into the dispatch path.
+
+Why wrap at the harness layer instead of in skill markdown:
+  - The wrappers reference the active ExecutionProfile.evidence_schema
+    directly, so the format stays in lockstep with the H2 validator and
+    can never drift.
+  - Skills cannot opt out, so the "do not self-declare DONE" rule from
+    H1 is mechanical, not rhetorical.
+  - Per-domain skills shrink because they no longer carry phase prose.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile
+
+_DEFAULT_PRE_HEADER = "[PRE — harness-injected; restate before any action]"
+_DEFAULT_POST_HEADER = "[POST — harness-injected; emit and stop]"
+
+
+@dataclass(frozen=True)
+class WrappedPrompt:
+    """Composed leaf prompt with provenance of each segment."""
+
+    pre: str
+    body: str
+    post: str
+
+    def render(self) -> str:
+        """Join the three segments with double-newline separators."""
+        return f"{self.pre}\n\n{self.body}\n\n{self.post}"
+
+
+def _format_required(schema: EvidenceSchema) -> str:
+    if not schema.required:
+        return "(profile declares no required evidence fields)"
+    return ", ".join(schema.required)
+
+
+def _format_rejected(schema: EvidenceSchema) -> str:
+    if not schema.rejected_if:
+        return "(profile declares no automatic rejection rules)"
+    return "; ".join(schema.rejected_if)
+
+
+def build_pre_block(profile: ExecutionProfile, ac: str) -> str:
+    """Compose the PRE wrapper for a single leaf dispatch.
+
+    The leaf must restate the AC in its own words and surface its
+    assumed preconditions before touching any tool. This is the verifier
+    hook for SCOPE_CREEP — if the restatement drifts from the AC, the
+    verifier catches it on the first read.
+    """
+    return (
+        f"{_DEFAULT_PRE_HEADER}\n"
+        f"Active profile: {profile.profile!r} (axis: {profile.axis}).\n"
+        f"Acceptance criterion to satisfy:\n  {ac.strip()}\n\n"
+        "Before touching any tool, restate this AC in one sentence and "
+        "list every precondition you are assuming (paths, commands, "
+        "external services). Do not begin execution if any precondition "
+        "is unverified — surface the blocker instead."
+    )
+
+
+def build_post_block(profile: ExecutionProfile) -> str:
+    """Compose the POST wrapper for a single leaf dispatch.
+
+    Encodes the H1/H2 contract: emit a fenced JSON evidence record with
+    the schema's required keys, and never self-declare DONE — the
+    harness adjudicates via the verifier loop.
+    """
+    schema = profile.evidence_schema
+    return (
+        f"{_DEFAULT_POST_HEADER}\n"
+        "When you finish, emit a single fenced JSON block on its own "
+        "line, then stop. Required fields for this profile: "
+        f"{_format_required(schema)}.\n"
+        f"Automatic rejection rules: {_format_rejected(schema)}.\n\n"
+        "Do not declare the task DONE in prose — the harness adjudicates "
+        "via an external verifier pass. Your job ends when the evidence "
+        "block is emitted."
+    )
+
+
+def wrap_prompt(profile: ExecutionProfile, ac: str, body: str) -> WrappedPrompt:
+    """Compose a profile-aware [PRE] + body + [POST] leaf prompt.
+
+    The `body` is the skill-/strategy-specific task instructions that
+    the existing dispatch path already supplies; this function does not
+    rewrite that content, it only frames it with the harness-owned
+    wrappers.
+    """
+    return WrappedPrompt(
+        pre=build_pre_block(profile, ac),
+        body=body.strip(),
+        post=build_post_block(profile),
+    )
+
+
+__all__ = [
+    "WrappedPrompt",
+    "build_post_block",
+    "build_pre_block",
+    "wrap_prompt",
+]

--- a/src/ouroboros/orchestrator/phase_wrappers.py
+++ b/src/ouroboros/orchestrator/phase_wrappers.py
@@ -63,8 +63,14 @@ def _indent_ac(ac: str, indent: str = "  ") -> str:
     merging with the harness instructions that follow (bot finding on
     #886 r2). Apply the indent to every non-empty line so the AC's
     section boundary is preserved.
+
+    Uses ``str.split('\\n')`` (not ``splitlines()``) so terminal
+    newlines and trailing blank lines round-trip verbatim —
+    ``splitlines()`` drops the terminator, violating the
+    "passed through verbatim" contract for ACs that end with a
+    required newline or blank line (bot finding on #886 r4).
     """
-    return "\n".join(indent + line if line else line for line in ac.splitlines())
+    return "\n".join(indent + line if line else line for line in ac.split("\n"))
 
 
 def build_pre_block(profile: ExecutionProfile, ac: str) -> str:

--- a/src/ouroboros/orchestrator/phase_wrappers.py
+++ b/src/ouroboros/orchestrator/phase_wrappers.py
@@ -74,11 +74,17 @@ def build_pre_block(profile: ExecutionProfile, ac: str) -> str:
     assumed preconditions before touching any tool. This is the verifier
     hook for SCOPE_CREEP — if the restatement drifts from the AC, the
     verifier catches it on the first read.
+
+    The AC is passed through verbatim (no .strip()): seed ACs are free-
+    form text and may legitimately carry leading indentation (indented
+    code blocks, nested bullets, YAML snippets) or trailing whitespace.
+    Stripping would corrupt formatting-sensitive ACs before they reach
+    the leaf executor (bot finding on #886 r3).
     """
     return (
         f"{_DEFAULT_PRE_HEADER}\n"
         f"Active profile: {profile.profile!r} (axis: {profile.axis}).\n"
-        f"Acceptance criterion to satisfy:\n{_indent_ac(ac.strip())}\n\n"
+        f"Acceptance criterion to satisfy:\n{_indent_ac(ac)}\n\n"
         "Before touching any tool, restate this AC in one sentence and "
         "list every precondition you are assuming (paths, commands, "
         "external services). Do not begin execution if any precondition "

--- a/tests/unit/orchestrator/test_phase_wrappers.py
+++ b/tests/unit/orchestrator/test_phase_wrappers.py
@@ -46,6 +46,28 @@ class TestPreBlock:
         assert "   spaced AC" not in block
         assert "  spaced AC\n\nBefore" in block
 
+    def test_multiline_ac_every_line_indented(self, code_profile: ExecutionProfile) -> None:
+        # Bot finding on #886 r2: subsequent lines of a multiline AC
+        # used to run flush-left and visually escape the AC section,
+        # merging with the harness instructions below. Every non-empty
+        # line must carry the two-space indent.
+        multiline = "first line\nsecond line\nthird line"
+        block = build_pre_block(code_profile, multiline)
+        assert "  first line" in block
+        assert "  second line" in block
+        assert "  third line" in block
+        # Flush-left lines (which would escape the section) must not
+        # appear adjacent to the AC body.
+        assert "\nsecond line" not in block
+        assert "\nthird line" not in block
+
+    def test_blank_lines_in_ac_preserved(self, code_profile: ExecutionProfile) -> None:
+        # Blank lines stay blank (not "  ") so the AC's paragraph
+        # structure survives untouched.
+        ac = "paragraph one\n\nparagraph two"
+        block = build_pre_block(code_profile, ac)
+        assert "  paragraph one\n\n  paragraph two" in block
+
 
 class TestPostBlock:
     def test_lists_required_fields(self, code_profile: ExecutionProfile) -> None:
@@ -95,9 +117,13 @@ class TestWrapPrompt:
         # PRE / body / POST are double-newline separated.
         assert rendered.count("\n\n") >= 2
 
-    def test_body_is_trimmed(self, code_profile: ExecutionProfile) -> None:
-        wrapped = wrap_prompt(code_profile, "AC", "\n\n  body\n\n")
-        assert wrapped.body == "body"
+    def test_body_passes_through_verbatim(self, code_profile: ExecutionProfile) -> None:
+        # Bot finding on #886 r2: body must NOT be normalized. Indented
+        # code blocks, JSON examples, deliberately blank-prefixed
+        # markdown must survive the wrapper unchanged.
+        body = "\n\n  indented body\n  with blank-prefixed lines\n\n"
+        wrapped = wrap_prompt(code_profile, "AC", body)
+        assert wrapped.body == body
 
     def test_profile_distinction_reflected(self) -> None:
         c = wrap_prompt(load_profile("code"), "AC", "body").render()

--- a/tests/unit/orchestrator/test_phase_wrappers.py
+++ b/tests/unit/orchestrator/test_phase_wrappers.py
@@ -38,13 +38,24 @@ class TestPreBlock:
         block = build_pre_block(code_profile, "x")
         assert "blocker" in block.lower()
 
-    def test_strips_ac_whitespace(self, code_profile: ExecutionProfile) -> None:
-        block = build_pre_block(code_profile, "   spaced AC\n\n")
-        # Leading triple-space and trailing double-newline came from the
-        # caller; the wrapper must strip them so the AC text sits flush
-        # against the bullet indent.
-        assert "   spaced AC" not in block
-        assert "  spaced AC\n\nBefore" in block
+    def test_ac_passes_through_verbatim(self, code_profile: ExecutionProfile) -> None:
+        # Bot finding on #886 r3: ACs are free-form text and may
+        # carry intentional leading indentation (indented code blocks,
+        # nested bullets, YAML snippets). Stripping corrupts those
+        # before they reach the leaf executor.
+        ac = "   indented code:\n     pass\n"
+        block = build_pre_block(code_profile, ac)
+        # Every line is indented two more spaces; original indentation
+        # survives intact inside the AC body.
+        assert "     indented code:" in block  # 2 + 3 = 5 spaces
+        assert "       pass" in block  # 2 + 5 = 7 spaces
+
+    def test_trailing_whitespace_preserved(self, code_profile: ExecutionProfile) -> None:
+        # Trailing whitespace can be load-bearing (e.g. markdown line
+        # breaks via two trailing spaces). The wrapper must not eat it.
+        ac = "ac body  "  # two trailing spaces
+        block = build_pre_block(code_profile, ac)
+        assert "  ac body  \n" in block
 
     def test_multiline_ac_every_line_indented(self, code_profile: ExecutionProfile) -> None:
         # Bot finding on #886 r2: subsequent lines of a multiline AC

--- a/tests/unit/orchestrator/test_phase_wrappers.py
+++ b/tests/unit/orchestrator/test_phase_wrappers.py
@@ -1,0 +1,109 @@
+"""Tests for ouroboros.orchestrator.phase_wrappers (RFC v2 #830, PR 5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.phase_wrappers import (
+    WrappedPrompt,
+    build_post_block,
+    build_pre_block,
+    wrap_prompt,
+)
+from ouroboros.orchestrator.profile_loader import (
+    EvidenceSchema,
+    ExecutionProfile,
+    load_profile,
+)
+
+
+@pytest.fixture
+def code_profile() -> ExecutionProfile:
+    return load_profile("code")
+
+
+class TestPreBlock:
+    def test_includes_profile_and_axis(self, code_profile: ExecutionProfile) -> None:
+        block = build_pre_block(code_profile, "Add caching layer")
+        assert "'code'" in block
+        assert "axis: testable_unit" in block
+        assert "Add caching layer" in block
+
+    def test_demands_restatement(self, code_profile: ExecutionProfile) -> None:
+        block = build_pre_block(code_profile, "x")
+        assert "restate" in block.lower()
+        assert "precondition" in block.lower()
+
+    def test_blocker_path_named(self, code_profile: ExecutionProfile) -> None:
+        block = build_pre_block(code_profile, "x")
+        assert "blocker" in block.lower()
+
+    def test_strips_ac_whitespace(self, code_profile: ExecutionProfile) -> None:
+        block = build_pre_block(code_profile, "   spaced AC\n\n")
+        # Leading triple-space and trailing double-newline came from the
+        # caller; the wrapper must strip them so the AC text sits flush
+        # against the bullet indent.
+        assert "   spaced AC" not in block
+        assert "  spaced AC\n\nBefore" in block
+
+
+class TestPostBlock:
+    def test_lists_required_fields(self, code_profile: ExecutionProfile) -> None:
+        block = build_post_block(code_profile)
+        for required in code_profile.evidence_schema.required:
+            assert required in block
+
+    def test_lists_rejection_rules(self, code_profile: ExecutionProfile) -> None:
+        block = build_post_block(code_profile)
+        assert "tests_passed == []" in block
+
+    def test_forbids_self_declared_done(self, code_profile: ExecutionProfile) -> None:
+        block = build_post_block(code_profile)
+        assert "Do not declare" in block
+        assert "DONE" in block
+
+    def test_demands_fenced_json(self, code_profile: ExecutionProfile) -> None:
+        block = build_post_block(code_profile)
+        assert "fenced JSON" in block
+
+    def test_handles_empty_schema_gracefully(self) -> None:
+        bare = ExecutionProfile(
+            profile="bare",
+            axis="a",
+            min_unit="m",
+            verifier_focus="v",
+            evidence_schema=EvidenceSchema(),
+        )
+        block = build_post_block(bare)
+        assert "no required evidence fields" in block
+        assert "no automatic rejection rules" in block
+
+
+class TestWrapPrompt:
+    def test_returns_wrapped_prompt_with_three_parts(self, code_profile: ExecutionProfile) -> None:
+        wrapped = wrap_prompt(code_profile, "AC text", "Body content here")
+        assert isinstance(wrapped, WrappedPrompt)
+        assert wrapped.body == "Body content here"
+        assert "[PRE" in wrapped.pre
+        assert "[POST" in wrapped.post
+
+    def test_render_joins_with_blank_lines(self, code_profile: ExecutionProfile) -> None:
+        wrapped = wrap_prompt(code_profile, "AC", "Body")
+        rendered = wrapped.render()
+        assert rendered.startswith("[PRE")
+        assert rendered.endswith(wrapped.post)
+        # PRE / body / POST are double-newline separated.
+        assert rendered.count("\n\n") >= 2
+
+    def test_body_is_trimmed(self, code_profile: ExecutionProfile) -> None:
+        wrapped = wrap_prompt(code_profile, "AC", "\n\n  body\n\n")
+        assert wrapped.body == "body"
+
+    def test_profile_distinction_reflected(self) -> None:
+        c = wrap_prompt(load_profile("code"), "AC", "body").render()
+        r = wrap_prompt(load_profile("research"), "AC", "body").render()
+        a = wrap_prompt(load_profile("analysis"), "AC", "body").render()
+        assert "testable_unit" in c
+        assert "subtopic" in r
+        assert "perspective" in a
+        assert c != r != a

--- a/tests/unit/orchestrator/test_phase_wrappers.py
+++ b/tests/unit/orchestrator/test_phase_wrappers.py
@@ -57,6 +57,27 @@ class TestPreBlock:
         block = build_pre_block(code_profile, ac)
         assert "  ac body  \n" in block
 
+    def test_terminal_newline_preserved(self, code_profile: ExecutionProfile) -> None:
+        # Bot finding on #886 r4: splitlines() dropped terminal newlines
+        # and trailing blank lines, violating the verbatim contract for
+        # ACs whose grammar requires a closing newline.
+        ac = "line one\nline two\n"
+        block = build_pre_block(code_profile, ac)
+        # AC has two content lines + a trailing empty produced by the
+        # closing \n. Indented output must keep the empty so the
+        # section ends cleanly before the wrapper's joiner.
+        assert "  line one\n  line two\n\n\nBefore" in block
+
+    def test_trailing_blank_line_preserved(self, code_profile: ExecutionProfile) -> None:
+        # ACs that intentionally end with a blank line (e.g. to terminate
+        # a fenced code block) must round-trip verbatim.
+        ac = "content\n\n"
+        block = build_pre_block(code_profile, ac)
+        # "content\n\n".split("\n") = ["content", "", ""]; indent skips
+        # empty lines, so rejoined: "  content\n\n". The wrapper then
+        # adds its own "\n\n" before "Before".
+        assert "  content\n\n\n\nBefore" in block
+
     def test_multiline_ac_every_line_indented(self, code_profile: ExecutionProfile) -> None:
         # Bot finding on #886 r2: subsequent lines of a multiline AC
         # used to run flush-left and visually escape the AC section,


### PR DESCRIPTION
## Summary

Fifth PR in the [#830](https://github.com/Q00/ouroboros/issues/830) RFC v2 stack. **Stacked on #885**.

Implements H3 (phase scaffolding as harness-injected wrappers). Moves [PRE]/[POST] structure off skill markdown (\`phase-task-start\`, \`phase-task-end\`) and into composed prompt segments owned by the harness.

The wrappers reference \`ExecutionProfile.evidence_schema\` directly, so the contract stays in lockstep with the H2 validator and cannot drift. Skills cannot opt out — the "do not self-declare DONE" rule from H1 becomes mechanical.

## What lands

- \`WrappedPrompt\` — pre / body / post triplet, \`.render()\` joins with double-newlines.
- \`build_pre_block(profile, ac)\` — forces restatement + precondition listing before any tool call. The verbatim AC gives the verifier a SCOPE_CREEP signal on first read.
- \`build_post_block(profile)\` — instructs a single fenced JSON block per \`evidence_schema\`, names every \`required\` field and \`rejected_if\` rule, forbids prose DONE declarations.
- \`wrap_prompt(profile, ac, body)\` — drop-in composition the dispatch path will plug into in PR 9.

## Wiring scope

Pure prompt-composition module. \`parallel_executor\` and \`execution_strategy\` are unchanged. PR 9 wires \`wrap_prompt\` into dispatch.

## Test plan

- [x] \`uv run pytest tests/unit/orchestrator/test_phase_wrappers.py\` — 13 passed
- [x] \`uv run ruff check\` / \`ruff format --check\` — clean
- [x] \`uv run mypy src/ouroboros/orchestrator/phase_wrappers.py\` — Success

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)