### PR TITLE
feat(orchestrator): failure taxonomy + recovery policy (#830 PR 6/9)

### DIFF
--- a/src/ouroboros/orchestrator/failure_taxonomy.py
+++ b/src/ouroboros/orchestrator/failure_taxonomy.py
@@ -1,0 +1,157 @@
+"""Failure classifier + recovery policy (RFC v2 H7, #830).
+
+H7 replaces the count-based retry in `parallel_executor` with a
+classifier: every failed leaf attempt is mapped to a FailureClass, and
+each class maps to a RecoveryPolicy that the orchestrator can act on.
+
+Currently `retry_attempt` in parallel_executor is a stall counter — it
+re-dispatches the same prompt with no notion of *why* the previous
+attempt failed. After PR 9 wires this module in, the harness will
+inspect the verifier's Attempt transcript, classify it, and route to
+the right recovery (retry / escalate model / redispatch / human).
+
+This module ships the classifier + policy table only. parallel_executor
+stays count-based until the integration PR.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ouroboros.orchestrator.verifier import Attempt
+
+
+class FailureClass(StrEnum):
+    """Domain-agnostic failure taxonomy from shaun0927's H7 sketch (#830).
+
+    Members:
+        EVIDENCE_MISSING: Leaf could not emit a parseable / validated
+            evidence record (covers both parse errors and H2 rejections).
+        FABRICATION_SUSPECTED: Verifier flagged claims about files,
+            symbols, or sources that do not exist. Verifier sets this
+            via VerifierVerdict.failure_class.
+        SCOPE_CREEP: Leaf's restatement / output drifted away from the
+            AC. Verifier-classified.
+        STALL: Verifier failed for an unclassified reason and the next
+            retry is unlikely to help (e.g. the leaf keeps repeating
+            itself). Verifier-classified or fallback for unrecognised
+            tags.
+        BLOCKED: Leaf surfaced a hard precondition it could not satisfy
+            (missing tool, missing access, env variable). Verifier-
+            classified.
+    """
+
+    EVIDENCE_MISSING = "EVIDENCE_MISSING"
+    FABRICATION_SUSPECTED = "FABRICATION_SUSPECTED"
+    SCOPE_CREEP = "SCOPE_CREEP"
+    STALL = "STALL"
+    BLOCKED = "BLOCKED"
+
+
+class RecoveryAction(StrEnum):
+    """What the orchestrator should do next after a classified failure."""
+
+    RETRY = "RETRY"  # same dispatch, with the verifier's feedback.
+    ESCALATE_MODEL = "ESCALATE_MODEL"  # rerun on a higher model tier.
+    REDISPATCH = "REDISPATCH"  # discard and split the AC again.
+    ESCALATE_HUMAN = "ESCALATE_HUMAN"  # surface to the operator.
+
+
+@dataclass(frozen=True)
+class RecoveryPolicy:
+    """Recovery action plus a one-line rationale for logging."""
+
+    action: RecoveryAction
+    rationale: str
+
+
+_POLICY_TABLE: dict[FailureClass, RecoveryPolicy] = {
+    FailureClass.EVIDENCE_MISSING: RecoveryPolicy(
+        action=RecoveryAction.RETRY,
+        rationale=(
+            "Leaf failed to emit a parseable evidence record; the "
+            "verifier feedback already names the missing/rejected fields."
+        ),
+    ),
+    FailureClass.FABRICATION_SUSPECTED: RecoveryPolicy(
+        action=RecoveryAction.ESCALATE_MODEL,
+        rationale=(
+            "Lower-tier leaf invented references; escalate to a tier "
+            "whose self-grounding is stronger before retrying."
+        ),
+    ),
+    FailureClass.SCOPE_CREEP: RecoveryPolicy(
+        action=RecoveryAction.REDISPATCH,
+        rationale=(
+            "Leaf's interpretation drifted; the AC needs to be split "
+            "further so each sub-AC names a single concrete deliverable."
+        ),
+    ),
+    FailureClass.STALL: RecoveryPolicy(
+        action=RecoveryAction.REDISPATCH,
+        rationale=(
+            "Repeat retries on the same prompt are unlikely to help; "
+            "redispatch with a sharper sub-AC."
+        ),
+    ),
+    FailureClass.BLOCKED: RecoveryPolicy(
+        action=RecoveryAction.ESCALATE_HUMAN,
+        rationale=(
+            "Leaf reported a hard precondition the harness cannot "
+            "satisfy automatically (missing tool / access / config)."
+        ),
+    ),
+}
+
+
+def policy_for(failure: FailureClass) -> RecoveryPolicy:
+    """Return the canonical recovery policy for a failure class."""
+    try:
+        return _POLICY_TABLE[failure]
+    except KeyError as exc:  # defensive — StrEnum makes this nearly unreachable.
+        msg = f"No recovery policy registered for {failure!r}"
+        raise ValueError(msg) from exc
+
+
+def classify(attempt: Attempt) -> FailureClass | None:
+    """Classify a single Attempt from the verifier loop.
+
+    Returns:
+        None when the attempt was accepted; otherwise a FailureClass.
+
+    Precedence (most specific first):
+        1. Verifier-supplied verdict.failure_class wins — the verifier
+           has the richest view of the leaf output.
+        2. Evidence parse failure or H2 validation failure both map to
+           EVIDENCE_MISSING.
+        3. Unattributed verifier FAILs fall through to STALL.
+    """
+    if attempt.accepted:
+        return None
+
+    if attempt.verdict is not None and attempt.verdict.failure_class:
+        raw = attempt.verdict.failure_class
+        try:
+            return FailureClass(raw)
+        except ValueError:
+            # Unknown tags from upstream verifiers degrade to STALL
+            # rather than crashing the orchestrator.
+            return FailureClass.STALL
+
+    if attempt.evidence_error is not None:
+        return FailureClass.EVIDENCE_MISSING
+
+    if attempt.validation is not None and not attempt.validation.ok:
+        return FailureClass.EVIDENCE_MISSING
+
+    return FailureClass.STALL
+
+
+__all__ = [
+    "FailureClass",
+    "RecoveryAction",
+    "RecoveryPolicy",
+    "classify",
+    "policy_for",
+]

--- a/tests/unit/orchestrator/test_failure_taxonomy.py
+++ b/tests/unit/orchestrator/test_failure_taxonomy.py
@@ -1,0 +1,116 @@
+"""Tests for ouroboros.orchestrator.failure_taxonomy (RFC v2 #830, PR 6)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
+from ouroboros.orchestrator.failure_taxonomy import (
+    FailureClass,
+    RecoveryAction,
+    classify,
+    policy_for,
+)
+from ouroboros.orchestrator.verifier import Attempt, VerifierVerdict
+
+
+def _accepted_attempt() -> Attempt:
+    return Attempt(
+        leaf_output="{}",
+        record=EvidenceRecord(data={}),
+        evidence_error=None,
+        validation=ValidationResult(ok=True),
+        verdict=VerifierVerdict(passed=True),
+    )
+
+
+def _attempt(
+    *,
+    evidence_error: str | None = None,
+    validation: ValidationResult | None = None,
+    verdict: VerifierVerdict | None = None,
+) -> Attempt:
+    return Attempt(
+        leaf_output="raw",
+        record=None if evidence_error else EvidenceRecord(data={}),
+        evidence_error=evidence_error,
+        validation=validation,
+        verdict=verdict,
+    )
+
+
+class TestClassify:
+    def test_accepted_returns_none(self) -> None:
+        assert classify(_accepted_attempt()) is None
+
+    def test_verifier_class_wins(self) -> None:
+        attempt = _attempt(
+            validation=ValidationResult(ok=True),
+            verdict=VerifierVerdict(
+                passed=False,
+                reasons=("bad",),
+                failure_class="FABRICATION_SUSPECTED",
+            ),
+        )
+        assert classify(attempt) == FailureClass.FABRICATION_SUSPECTED
+
+    def test_unknown_verifier_class_degrades_to_stall(self) -> None:
+        attempt = _attempt(
+            validation=ValidationResult(ok=True),
+            verdict=VerifierVerdict(passed=False, reasons=("?",), failure_class="UNREGISTERED"),
+        )
+        assert classify(attempt) == FailureClass.STALL
+
+    def test_evidence_parse_error_maps_to_evidence_missing(self) -> None:
+        attempt = _attempt(evidence_error="not json")
+        assert classify(attempt) == FailureClass.EVIDENCE_MISSING
+
+    def test_validation_failure_maps_to_evidence_missing(self) -> None:
+        attempt = _attempt(
+            validation=ValidationResult(ok=False, missing_fields=("tests_passed",), rejected_by=()),
+        )
+        assert classify(attempt) == FailureClass.EVIDENCE_MISSING
+
+    def test_unattributed_failure_maps_to_stall(self) -> None:
+        attempt = _attempt(
+            validation=ValidationResult(ok=True),
+            verdict=VerifierVerdict(passed=False, reasons=("vibes",)),
+        )
+        assert classify(attempt) == FailureClass.STALL
+
+    def test_verifier_class_overrides_validation_failure(self) -> None:
+        # If both are present, trust the verifier — it has the richer view.
+        attempt = _attempt(
+            validation=ValidationResult(ok=False, missing_fields=("x",), rejected_by=()),
+            verdict=VerifierVerdict(
+                passed=False,
+                reasons=("scope drift",),
+                failure_class="SCOPE_CREEP",
+            ),
+        )
+        assert classify(attempt) == FailureClass.SCOPE_CREEP
+
+
+class TestPolicyTable:
+    @pytest.mark.parametrize("cls", list(FailureClass))
+    def test_every_class_has_a_policy(self, cls: FailureClass) -> None:
+        policy = policy_for(cls)
+        assert policy.action in RecoveryAction
+        assert policy.rationale
+
+    def test_evidence_missing_retries(self) -> None:
+        assert policy_for(FailureClass.EVIDENCE_MISSING).action == RecoveryAction.RETRY
+
+    def test_fabrication_escalates_model(self) -> None:
+        assert (
+            policy_for(FailureClass.FABRICATION_SUSPECTED).action == RecoveryAction.ESCALATE_MODEL
+        )
+
+    def test_scope_creep_redispatches(self) -> None:
+        assert policy_for(FailureClass.SCOPE_CREEP).action == RecoveryAction.REDISPATCH
+
+    def test_stall_redispatches(self) -> None:
+        assert policy_for(FailureClass.STALL).action == RecoveryAction.REDISPATCH
+
+    def test_blocked_escalates_to_human(self) -> None:
+        assert policy_for(FailureClass.BLOCKED).action == RecoveryAction.ESCALATE_HUMAN

--- a/tests/unit/orchestrator/test_failure_taxonomy.py
+++ b/tests/unit/orchestrator/test_failure_taxonomy.py
@@ -55,9 +55,19 @@ class TestClassify:
         assert classify(attempt) == FailureClass.FABRICATION_SUSPECTED
 
     def test_unknown_verifier_class_degrades_to_stall(self) -> None:
+        # PR3 round 2 (#884) now rejects unknown failure_class at
+        # VerifierVerdict construction time, so the public API can no
+        # longer reach this path. We still keep `classify` defensive
+        # against bypassed construction (e.g. deserialization or future
+        # impls that hand-build the Attempt) — bypass __post_init__ via
+        # object.__setattr__ on the frozen dataclass to prove the
+        # defensive degradation still works.
+        verdict = VerifierVerdict(passed=False, reasons=("?",), failure_class="STALL")
+        # Bypass the frozen guard to inject an out-of-taxonomy tag.
+        object.__setattr__(verdict, "failure_class", "UNREGISTERED")
         attempt = _attempt(
             validation=ValidationResult(ok=True),
-            verdict=VerifierVerdict(passed=False, reasons=("?",), failure_class="UNREGISTERED"),
+            verdict=verdict,
         )
         assert classify(attempt) == FailureClass.STALL
 


### PR DESCRIPTION
## Summary

Sixth PR in the [#830](https://github.com/Q00/ouroboros/issues/830) RFC v2 stack. **Stacked on #886**.

Implements H7 (failure taxonomy + auto-recovery). Replaces \`parallel_executor\`'s count-based retry with a classifier that maps each failed verifier \`Attempt\` to a \`FailureClass\` and each class to a \`RecoveryPolicy\`.

## What lands

| Class | Action | Why |
|-------|--------|-----|
| \`EVIDENCE_MISSING\` | \`RETRY\` | Feedback already names the missing/rejected fields |
| \`FABRICATION_SUSPECTED\` | \`ESCALATE_MODEL\` | Lower tier invented references; need stronger self-grounding |
| \`SCOPE_CREEP\` | \`REDISPATCH\` | Sub-AC boundary needs sharpening |
| \`STALL\` | \`REDISPATCH\` | Same prompt unlikely to help on another retry |
| \`BLOCKED\` | \`ESCALATE_HUMAN\` | Hard precondition the harness cannot satisfy |

## Classification precedence

1. \`verdict.failure_class\` wins (verifier has the richest view).
2. Evidence parse / H2 validation failures → \`EVIDENCE_MISSING\`.
3. Unattributed verifier FAILs → \`STALL\` (also the fallback for unknown verifier tags so the orchestrator never crashes on a fresh class).

## Wiring scope

Pure classifier + policy table. \`parallel_executor\` stays count-based until PR 9 wires this into the retry loop.

## Test plan

- [x] \`uv run pytest tests/unit/orchestrator/test_failure_taxonomy.py\` — 17 passed
- [x] \`uv run ruff check\` / \`ruff format --check\` — clean
- [x] \`uv run mypy src/ouroboros/orchestrator/failure_taxonomy.py\` — Success

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)