### PR TITLE
feat(auto): recovery-loop guards (#809 P2.2b, Stack 1/2)

### DIFF
--- a/src/ouroboros/auto/lateral_routing.py
+++ b/src/ouroboros/auto/lateral_routing.py
@@ -110,26 +110,54 @@ def classify_qa_failure_to_pattern(
     return StagnationPattern.SPINNING
 
 
+_FALLBACK_CHAIN: tuple[ThinkingPersona, ...] = (
+    ThinkingPersona.CONTRARIAN,
+    ThinkingPersona.HACKER,
+    ThinkingPersona.ARCHITECT,
+    ThinkingPersona.RESEARCHER,
+    ThinkingPersona.SIMPLIFIER,
+)
+
+
 def select_persona_for_qa_failure(
     differences: Sequence[str],
     suggestions: Sequence[str],
     *,
-    already_tried_personas: tuple[ThinkingPersona, ...] = (),
-) -> ThinkingPersona:
+    already_tried_personas: Sequence[ThinkingPersona] = (),
+) -> ThinkingPersona | None:
     """Pick a persona for a QA failure, excluding already-tried personas.
 
-    Falls back to ``ThinkingPersona.CONTRARIAN`` as the universal fallback
-    when the pattern's primary persona is already in
-    ``already_tried_personas``. CONTRARIAN itself can't be filtered out
-    here because Phase 2.2 only invokes a single persona per session;
-    P2.2b's multi-round retry will track the full exclusion set across
-    iterations.
+    RFC #809 Phase 2.2b — the closed-loop recovery dispatcher invokes a
+    different persona on each EVALUATE → UNSTUCK_LATERAL round (the
+    "each persona may be invoked at most once per evaluate session"
+    guard). The pipeline persists every routed persona in
+    ``AutoPipelineState.personas_invoked`` and forwards the deduplicated
+    set here as ``already_tried_personas``.
+
+    Selection order:
+
+    1. The pattern-based primary persona (HACKER/ARCHITECT/RESEARCHER/
+       SIMPLIFIER) chosen by :func:`classify_qa_failure_to_pattern`.
+    2. CONTRARIAN as the universal fallback.
+    3. Any remaining persona from the deterministic fallback chain
+       (HACKER → ARCHITECT → RESEARCHER → SIMPLIFIER), so the loop can
+       keep exploring distinct angles after the obvious two have been
+       tried.
+
+    Returns ``None`` when every persona in steps 1–3 is already in
+    ``already_tried_personas``. The caller (``pipeline._run_lateral`` in
+    P2.2b) transitions to ``BLOCKED`` with a "personas exhausted"
+    reason rather than picking a stale persona.
     """
+    tried = tuple(already_tried_personas)
     pattern = classify_qa_failure_to_pattern(differences, suggestions)
     primary = _PATTERN_PERSONA[pattern]
-    if primary in already_tried_personas:
-        return ThinkingPersona.CONTRARIAN
-    return primary
+    if primary not in tried:
+        return primary
+    for fallback in _FALLBACK_CHAIN:
+        if fallback not in tried:
+            return fallback
+    return None
 
 
 __all__ = [

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1833,28 +1833,31 @@ class AutoPipeline:
         )
         input_hash = hashlib.sha256(cache_key.encode("utf-8")).hexdigest()
 
-        cache_hit = (
-            state.lateral_input_hash == input_hash
-            and state.last_lateral_text is not None
-            and state.last_lateral_persona == persona.value
-        )
-        if cache_hit:
-            return self._finalize_lateral(
-                state,
-                ledger,
-                review=review,
-                run_subagent=run_subagent,
-                qa_score=qa_score,
-                qa_verdict=qa_verdict,
-                qa_differences=qa_differences,
-                qa_suggestions=qa_suggestions,
-                cache_suffix=cache_suffix,
-                from_cache=True,
-            )
-
-        # Persist hash + persona BEFORE the call so a timeout/error path
-        # leaves a recoverable trail. The actual persona text is filled in
-        # after the call returns.
+        # RFC #809 Phase 2.2b — the P2.2 lateral cache short-circuit
+        # (input_hash match → return cached advisory) was removed here as
+        # dead code in the multi-persona world. Two factors make the
+        # short-circuit unreachable on a real resume:
+        #
+        # 1. ``state.personas_invoked`` is appended *before* the next
+        #    resume can reach this point, so ``select_persona_for_qa_failure``
+        #    deterministically picks a *different* persona than the one
+        #    whose advice was cached. The cache key includes
+        #    ``persona.value``, so a different persona always produces a
+        #    different ``input_hash`` and the cache misses.
+        # 2. The sticky ``recovery_guard_tripped`` short-circuit at the
+        #    top of this method already handles the "session was
+        #    declared exhausted, do not spend another slot" case before
+        #    cache lookup. Combined with (1) the cache path was
+        #    architectural dead weight that confused both reviewers and
+        #    operators (it implied "--resume replays the same advice"
+        #    which is the opposite of P2.2b's intent).
+        #
+        # ``input_hash`` and the persisted ``last_lateral_*`` fields
+        # remain wired so a timeout / error mid-call still leaves a
+        # recoverable trail of *which* persona+QA-shape we were
+        # processing (used by the final BLOCKED summary and by Stack 2's
+        # future re-dispatch logging), even though that trail is no
+        # longer consulted for a cache hit on the happy path.
         state.lateral_input_hash = input_hash
         state.last_lateral_persona = persona.value
         state.last_lateral_approach_summary = None

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1673,17 +1673,15 @@ class AutoPipeline:
             )
             failure_fingerprint = hashlib.sha256(fingerprint_input.encode("utf-8")).hexdigest()[:16]
             same_text = bool(
-                state.failure_fingerprints
-                and state.failure_fingerprints[-1] == failure_fingerprint
+                state.failure_fingerprints and state.failure_fingerprints[-1] == failure_fingerprint
             )
             # ``previous_qa_score`` is the score from the PRIOR round
             # captured before this round overwrote ``state.last_qa_score``.
             # First-ever round has ``previous_qa_score is None`` and
             # cannot trip the guard.
-            score_did_not_advance = (
-                previous_qa_score is not None
-                and float(eval_result.score) <= float(previous_qa_score)
-            )
+            score_did_not_advance = previous_qa_score is not None and float(
+                eval_result.score
+            ) <= float(previous_qa_score)
             if same_text and score_did_not_advance:
                 state.mark_blocked(
                     f"recovery loop: same QA-fail fingerprint twice "

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1556,18 +1556,19 @@ class AutoPipeline:
         state.evaluate_artifact = artifact
         state.evaluate_artifact_hash = artifact_hash
 
-        # RFC #809 Phase 2.2b — recovery-loop round budget guard. The
-        # counter increments on every fresh evaluator call (cache hits
-        # skip this branch, so a resumed session does not re-spend a
-        # round). Past ``MAX_EVALUATE_ROUNDS`` the failure mode is
-        # structural rather than a transient grading miss; surface a
-        # BLOCKED with the three operator choices instead of spending
-        # another LLM budget cycle.
-        state.evaluate_round += 1
-        if state.evaluate_round > MAX_EVALUATE_ROUNDS:
+        # RFC #809 Phase 2.2b — recovery-loop round budget guard. Check
+        # BEFORE the evaluator call; the counter is incremented AFTER a
+        # real evaluation result is in hand (post ``eval_result.error``
+        # filter, below). This split matters because transient
+        # infrastructure failures (timeout, exception, transient adapter
+        # error) must NOT consume the finite recovery budget — otherwise
+        # a streak of infra-only failures would trip ``round_budget``
+        # and permanently block a session that has not actually
+        # completed any QA round.
+        if state.evaluate_round >= MAX_EVALUATE_ROUNDS:
             state.mark_blocked(
-                f"recovery loop: evaluate_round {state.evaluate_round} "
-                f"exceeded MAX_EVALUATE_ROUNDS={MAX_EVALUATE_ROUNDS}; "
+                f"recovery loop: evaluate_round budget exhausted "
+                f"(MAX_EVALUATE_ROUNDS={MAX_EVALUATE_ROUNDS}); "
                 f"{_RECOVERY_BLOCKED_CHOICES}",
                 tool_name="evaluator",
             )
@@ -1626,6 +1627,13 @@ class AutoPipeline:
             return self._result(
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
             )
+
+        # RFC #809 Phase 2.2b — only consume a round once a real QA
+        # result is in hand. Transient evaluator failures (timeout,
+        # exception, ``eval_result.error``) returned above must not
+        # decrement the recovery budget; resuming through them is part
+        # of normal infrastructure recovery, not loop progress.
+        state.evaluate_round += 1
 
         state.last_qa_score = float(eval_result.score)
         state.last_qa_verdict = str(eval_result.verdict)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -33,6 +33,7 @@ from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
+    MAX_EVALUATE_ROUNDS,
     AutoPhase,
     AutoPipelineState,
     AutoResumeCapability,
@@ -41,6 +42,17 @@ from ouroboros.auto.state import (
     utc_now_iso,
 )
 from ouroboros.core.seed import Seed
+from ouroboros.resilience.lateral import ThinkingPersona
+
+# RFC #809 Phase 2.2b — operator-choice cue suffixed onto every recovery-loop
+# BLOCKED message so the operator sees their next move without having to
+# read the rest of the surface. Three explicit choices, in increasing-effort
+# order, intentionally avoiding any "let the system rewrite the spec"
+# option: keep the spec contract under human control.
+_RECOVERY_BLOCKED_CHOICES: str = (
+    "next: (1) relax AC via --resume + edited seed; "
+    "(2) re-interview to refine the spec; (3) abandon this session"
+)
 
 SeedGenerator = Callable[[str], Awaitable[Seed]]
 
@@ -1464,6 +1476,26 @@ class AutoPipeline:
             state.lateral_input_hash = None
         state.evaluate_artifact = artifact
         state.evaluate_artifact_hash = artifact_hash
+
+        # RFC #809 Phase 2.2b — recovery-loop round budget guard. The
+        # counter increments on every fresh evaluator call (cache hits
+        # skip this branch, so a resumed session does not re-spend a
+        # round). Past ``MAX_EVALUATE_ROUNDS`` the failure mode is
+        # structural rather than a transient grading miss; surface a
+        # BLOCKED with the three operator choices instead of spending
+        # another LLM budget cycle.
+        state.evaluate_round += 1
+        if state.evaluate_round > MAX_EVALUATE_ROUNDS:
+            state.mark_blocked(
+                f"recovery loop: evaluate_round {state.evaluate_round} "
+                f"exceeded MAX_EVALUATE_ROUNDS={MAX_EVALUATE_ROUNDS}; "
+                f"{_RECOVERY_BLOCKED_CHOICES}",
+                tool_name="evaluator",
+            )
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
         self._save(state)
 
         phase_timeout = state.phase_timeout_seconds(AutoPhase.EVALUATE)
@@ -1526,6 +1558,33 @@ class AutoPipeline:
         state.last_qa_differences = list(eval_result.differences)
         state.last_qa_suggestions = list(eval_result.suggestions)
         state.evaluate_artifact_hash = artifact_hash
+
+        # RFC #809 Phase 2.2b — same-fingerprint-twice guard. When two
+        # consecutive EVALUATE rounds produce the same failure shape, the
+        # recovery loop is not making material progress on the AC surface
+        # (lateral advice did not move the needle on the run output that
+        # gets graded). Block rather than spend another round; the
+        # operator chooses how to break the symmetry.
+        if not bool(eval_result.passed):
+            fingerprint_input = (
+                "|".join(eval_result.differences) + "::" + "|".join(eval_result.suggestions)
+            )
+            failure_fingerprint = hashlib.sha256(fingerprint_input.encode("utf-8")).hexdigest()[:16]
+            if state.failure_fingerprints and state.failure_fingerprints[-1] == failure_fingerprint:
+                state.mark_blocked(
+                    f"recovery loop: same QA-fail fingerprint twice "
+                    f"({failure_fingerprint}); {_RECOVERY_BLOCKED_CHOICES}",
+                    tool_name="evaluator",
+                )
+                self._save(state)
+                return self._result(
+                    state,
+                    ledger,
+                    review=review,
+                    blocker=state.last_error,
+                    run_subagent=run_subagent,
+                )
+            state.failure_fingerprints.append(failure_fingerprint)
         self._save(state)
 
         return await self._finalize_evaluate(
@@ -1649,7 +1708,32 @@ class AutoPipeline:
 
         assert self.lateral_thinker is not None  # noqa: S101 — guarded by caller
 
-        persona = select_persona_for_qa_failure(qa_differences, qa_suggestions)
+        # RFC #809 Phase 2.2b — exclude personas already routed in this
+        # session so a resumed --resume picks a different angle rather
+        # than re-emitting the same advice. Each persisted string is a
+        # ``ThinkingPersona.value``; map back through the enum so an
+        # unrecognized legacy value raises explicitly instead of
+        # silently disabling the exclusion guard.
+        already_tried: tuple[ThinkingPersona, ...] = tuple(
+            ThinkingPersona(value) for value in state.personas_invoked
+        )
+        persona = select_persona_for_qa_failure(
+            qa_differences, qa_suggestions, already_tried_personas=already_tried
+        )
+        if persona is None:
+            # All five personas exhausted across this session. No further
+            # persona-driven reframing is available; surface the operator
+            # choices so the human resolves the spec instead.
+            state.mark_blocked(
+                f"recovery loop: all lateral personas exhausted "
+                f"(tried {', '.join(state.personas_invoked) or 'none'}); "
+                f"{_RECOVERY_BLOCKED_CHOICES}",
+                tool_name="lateral_thinker",
+            )
+            self._save(state)
+            return self._result(
+                state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+            )
         # Include the evaluate artifact hash in the cache key. The lateral
         # prompt's ``current_approach`` payload incorporates the run
         # artifact, so two EVALUATE rounds that grade different artifacts
@@ -1747,6 +1831,14 @@ class AutoPipeline:
         state.last_lateral_persona = lateral_result.persona or persona.value
         state.last_lateral_approach_summary = lateral_result.approach_summary
         state.last_lateral_text = lateral_result.text
+        # RFC #809 Phase 2.2b — record the persona we just routed so the
+        # next ``_run_lateral`` (after --resume) skips it. Use the canonical
+        # ``persona.value`` (not ``lateral_result.persona``) so the
+        # exclusion set matches what ``select_persona_for_qa_failure``
+        # returns, even when the lateral handler echoes a different
+        # display name back.
+        if persona.value not in state.personas_invoked:
+            state.personas_invoked.append(persona.value)
         self._save(state)
 
         return self._finalize_lateral(
@@ -1792,6 +1884,11 @@ class AutoPipeline:
         sug_preview = "; ".join(qa_suggestions[:3]) if qa_suggestions else ""
         if sug_preview:
             summary_parts.append(f"suggestions: {sug_preview}")
+        # RFC #809 Phase 2.2b — surface the operator-choice cue alongside
+        # the persona's advisory so a session that BLOCKED here points the
+        # operator at the next move (relax AC / re-interview / abandon)
+        # rather than leaving them parsing the QA differences in isolation.
+        summary_parts.append(_RECOVERY_BLOCKED_CHOICES)
         state.mark_blocked("; ".join(summary_parts), tool_name="lateral_thinker")
         self._save(state)
         return self._result(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1417,31 +1417,6 @@ class AutoPipeline:
         """
         assert self.evaluator is not None  # noqa: S101 — guarded by caller
 
-        # RFC #809 Phase 2.2b — sticky guard check. If a previous round
-        # exhausted a recovery guard (round budget, duplicate fingerprint,
-        # or persona-once chain), this resume MUST NOT re-enter the
-        # cache-fast-path or fall through to ``_finalize_evaluate``: doing
-        # so would honour a cached ``passed=False`` verdict and spend
-        # another lateral persona slot for a surface that was already
-        # declared exhausted. Re-mark the session as BLOCKED (the
-        # ``--resume`` transition above flipped the phase back to
-        # EVALUATE for re-entry; flip it back) and surface the original
-        # exhaustion reason verbatim.
-        if state.recovery_guard_tripped is not None:
-            state.mark_blocked(
-                state.last_error
-                or f"recovery guard '{state.recovery_guard_tripped}' already exhausted",
-                tool_name=state.last_tool_name or "evaluator",
-            )
-            self._save(state)
-            return self._result(
-                state,
-                ledger,
-                review=review,
-                blocker=state.last_error,
-                run_subagent=run_subagent,
-            )
-
         # Resolve the artifact:
         # 1. Fresh call from the Ralph terminal path → use ``ralph_result_text``
         #    (``is not None`` so an empty-but-valid artifact still grades)
@@ -1460,6 +1435,55 @@ class AutoPipeline:
             artifact_hash = state.evaluate_artifact_hash
         else:
             artifact_hash = hashlib.sha256(artifact.encode("utf-8")).hexdigest()
+
+        # RFC #809 Phase 2.2b — fresh-artifact reset. A new run output
+        # (artifact_hash differs from the persisted one) means the
+        # failure surface changed; any prior recovery exhaustion no
+        # longer applies and must be cleared BEFORE the sticky-guard
+        # check below — otherwise ``recovery_guard_tripped`` would be a
+        # permanent poison pill that no operator-driven workflow could
+        # escape within the same session. The reset is conditional on
+        # ``state.evaluate_artifact_hash`` already being populated so
+        # the first evaluator call of a session does not trip it on
+        # default-None state. This is the same "fresh artifact = fresh
+        # budget" contract the ``recovery_guard_tripped`` field
+        # docstring on AutoPipelineState promises; Stack 2's automated
+        # re-dispatch will be the most common producer of fresh
+        # artifacts arriving at EVALUATE.
+        if (
+            state.evaluate_artifact_hash is not None
+            and artifact_hash is not None
+            and state.evaluate_artifact_hash != artifact_hash
+        ):
+            state.recovery_guard_tripped = None
+            state.evaluate_round = 0
+            state.failure_fingerprints = []
+            state.personas_invoked = []
+
+        # RFC #809 Phase 2.2b — sticky guard check (post-reset). If the
+        # previous round exhausted a recovery guard AND the artifact
+        # has not changed, this resume MUST NOT re-enter the
+        # cache-fast-path or fall through to ``_finalize_evaluate``:
+        # doing so would honour a cached ``passed=False`` verdict and
+        # spend another lateral persona slot for a surface already
+        # declared exhausted. Re-mark the session BLOCKED (the
+        # ``--resume`` transition above flipped the phase back to
+        # EVALUATE for re-entry; flip it back) and surface the
+        # original exhaustion reason verbatim.
+        if state.recovery_guard_tripped is not None:
+            state.mark_blocked(
+                state.last_error
+                or f"recovery guard '{state.recovery_guard_tripped}' already exhausted",
+                tool_name=state.last_tool_name or "evaluator",
+            )
+            self._save(state)
+            return self._result(
+                state,
+                ledger,
+                review=review,
+                blocker=state.last_error,
+                run_subagent=run_subagent,
+            )
 
         # Cache hit requires the persisted ``last_qa_passed`` boolean — the
         # canonical pass decision derived from ``score >= pass_threshold``

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -44,11 +44,30 @@ from ouroboros.auto.state import (
 from ouroboros.core.seed import Seed
 from ouroboros.resilience.lateral import ThinkingPersona
 
-# RFC #809 Phase 2.2b — operator-choice cue suffixed onto every recovery-loop
-# BLOCKED message so the operator sees their next move without having to
-# read the rest of the surface. Two explicit choices, intentionally avoiding
-# any "let the system rewrite the spec" option: keep the spec contract under
-# human control.
+# RFC #809 Phase 2.2b — Stack 1 of 2 scope and invariants.
+#
+# **Scope of this module's recovery wiring.** P2.2b lands in two stacked
+# PRs. This file is Stack 1: the deterministic *guards* and *multi-persona
+# advisory* path. There is intentionally no automated Ralph re-dispatch
+# here — when EVALUATE fails, ``_run_lateral`` records the persona's
+# advisory and the session ends in ``BLOCKED``. The four guards
+# (``MAX_EVALUATE_ROUNDS``, same-fingerprint twice, per-persona-once,
+# ``state.deadline_at``) bound the surface so a future Stack 2, which
+# wires the lateral advice into a fresh Ralph job and a new EVALUATE
+# round, cannot loop unboundedly or revisit a stale persona. Without
+# Stack 2 present, ``evaluate_round`` typically increments to 1 in a
+# single session and the fingerprint guard is exercised only on
+# ``--resume`` against the same artifact; both become load-bearing once
+# Stack 2 lands. Naming this PR a "closed loop" was a documentation
+# overstatement caught in code review; the loop *closes* when Stack 2
+# ships, and Stack 1 is the bounded-advisory step that makes Stack 2
+# safe to land.
+#
+# **Operator-choice cue.** Suffixed onto every recovery-loop BLOCKED
+# message so the operator sees their next move without having to read
+# the rest of the surface. Two explicit choices, intentionally avoiding
+# any "let the system rewrite the spec" option: keep the spec contract
+# under human control.
 #
 # Earlier drafts of this cue advertised a third path ("relax AC via --resume
 # + edited seed"). That guidance was wrong: ``AutoPipeline.run()`` resumes
@@ -1879,7 +1898,21 @@ class AutoPipeline:
         cache_suffix: str,
         from_cache: bool,
     ) -> AutoPipelineResult:
-        """Build the BLOCKED summary that surfaces the persona's reframing."""
+        """Build the BLOCKED summary that surfaces the persona's reframing.
+
+        RFC #809 Phase 2.2b — Stack 1 of 2 endpoint. This method is the
+        *final* step of the advisory path: the persona's advice is
+        persisted in ledger/state and the session transitions to
+        BLOCKED. There is no automated Ralph re-dispatch in this PR; the
+        operator inspects the persona reframing and decides their next
+        move (the two-choice cue suffixed below). Stack 2 will replace
+        this terminal block with a Ralph re-dispatch that injects the
+        persona advice into a fresh evolve job and re-enters EVALUATE,
+        at which point the round/fingerprint/persona-once guards land
+        in their load-bearing role. The behavior here is deliberately
+        bounded so Stack 2 can layer on top without rewriting the
+        endpoint semantics.
+        """
         lateral_suffix = " [lateral cached]" if from_cache else ""
         persona_name = state.last_lateral_persona or "unknown"
         approach = state.last_lateral_approach_summary or ""

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1417,6 +1417,31 @@ class AutoPipeline:
         """
         assert self.evaluator is not None  # noqa: S101 — guarded by caller
 
+        # RFC #809 Phase 2.2b — sticky guard check. If a previous round
+        # exhausted a recovery guard (round budget, duplicate fingerprint,
+        # or persona-once chain), this resume MUST NOT re-enter the
+        # cache-fast-path or fall through to ``_finalize_evaluate``: doing
+        # so would honour a cached ``passed=False`` verdict and spend
+        # another lateral persona slot for a surface that was already
+        # declared exhausted. Re-mark the session as BLOCKED (the
+        # ``--resume`` transition above flipped the phase back to
+        # EVALUATE for re-entry; flip it back) and surface the original
+        # exhaustion reason verbatim.
+        if state.recovery_guard_tripped is not None:
+            state.mark_blocked(
+                state.last_error
+                or f"recovery guard '{state.recovery_guard_tripped}' already exhausted",
+                tool_name=state.last_tool_name or "evaluator",
+            )
+            self._save(state)
+            return self._result(
+                state,
+                ledger,
+                review=review,
+                blocker=state.last_error,
+                run_subagent=run_subagent,
+            )
+
         # Resolve the artifact:
         # 1. Fresh call from the Ralph terminal path → use ``ralph_result_text``
         #    (``is not None`` so an empty-but-valid artifact still grades)
@@ -1522,6 +1547,7 @@ class AutoPipeline:
                 f"{_RECOVERY_BLOCKED_CHOICES}",
                 tool_name="evaluator",
             )
+            state.recovery_guard_tripped = "round_budget"
             self._save(state)
             return self._result(
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
@@ -1606,6 +1632,7 @@ class AutoPipeline:
                     f"({failure_fingerprint}); {_RECOVERY_BLOCKED_CHOICES}",
                     tool_name="evaluator",
                 )
+                state.recovery_guard_tripped = "duplicate_fingerprint"
                 self._save(state)
                 return self._result(
                     state,
@@ -1738,6 +1765,28 @@ class AutoPipeline:
 
         assert self.lateral_thinker is not None  # noqa: S101 — guarded by caller
 
+        # RFC #809 Phase 2.2b — sticky guard check (mirrors ``_run_evaluate``).
+        # If a previous round exhausted any recovery guard, a resume that
+        # lands directly in ``UNSTUCK_LATERAL`` (via
+        # ``_recoverable_phase_for_tool("lateral_thinker")``) must not
+        # spend another persona slot or hit the lateral cache; re-mark
+        # the session BLOCKED and surface the original exhaustion
+        # blocker verbatim instead.
+        if state.recovery_guard_tripped is not None:
+            state.mark_blocked(
+                state.last_error
+                or f"recovery guard '{state.recovery_guard_tripped}' already exhausted",
+                tool_name=state.last_tool_name or "lateral_thinker",
+            )
+            self._save(state)
+            return self._result(
+                state,
+                ledger,
+                review=review,
+                blocker=state.last_error,
+                run_subagent=run_subagent,
+            )
+
         # RFC #809 Phase 2.2b — exclude personas already routed in this
         # session so a resumed --resume picks a different angle rather
         # than re-emitting the same advice. Each persisted string is a
@@ -1760,6 +1809,7 @@ class AutoPipeline:
                 f"{_RECOVERY_BLOCKED_CHOICES}",
                 tool_name="lateral_thinker",
             )
+            state.recovery_guard_tripped = "personas_exhausted"
             self._save(state)
             return self._result(
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -46,12 +46,23 @@ from ouroboros.resilience.lateral import ThinkingPersona
 
 # RFC #809 Phase 2.2b — operator-choice cue suffixed onto every recovery-loop
 # BLOCKED message so the operator sees their next move without having to
-# read the rest of the surface. Three explicit choices, in increasing-effort
-# order, intentionally avoiding any "let the system rewrite the spec"
-# option: keep the spec contract under human control.
+# read the rest of the surface. Two explicit choices, intentionally avoiding
+# any "let the system rewrite the spec" option: keep the spec contract under
+# human control.
+#
+# Earlier drafts of this cue advertised a third path ("relax AC via --resume
+# + edited seed"). That guidance was wrong: ``AutoPipeline.run()`` resumes
+# late-phase blockers (EVALUATE / UNSTUCK_LATERAL) by reconstructing the
+# Seed from ``state.seed_artifact``, which is always populated on the
+# normal auto path. Editing the on-disk ``state.seed_path`` file therefore
+# has no effect — the next resume re-grades against the same in-state AC
+# and loops back to the identical blocker. Until the resume contract is
+# changed to honor a freshly-edited seed file on late-phase resume (a
+# separate PR with its own end-to-end coverage), only two operator paths
+# are actually functional, and the cue must say so.
 _RECOVERY_BLOCKED_CHOICES: str = (
-    "next: (1) relax AC via --resume + edited seed; "
-    "(2) re-interview to refine the spec; (3) abandon this session"
+    "next: (1) re-interview with a refined goal (the in-state Seed cannot "
+    "be edited mid-session); (2) abandon this session"
 )
 
 SeedGenerator = Callable[[str], Awaitable[Seed]]

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1417,6 +1417,16 @@ class AutoPipeline:
         """
         assert self.evaluator is not None  # noqa: S101 — guarded by caller
 
+        # Capture the prior round's score BEFORE any subsequent step
+        # mutates ``state.last_qa_score`` — specifically the cache
+        # invalidation below (``state.last_qa_score = None`` when the
+        # artifact hash changes). The duplicate-fingerprint guard later
+        # in this method needs the genuine previous score to decide
+        # whether "same wording" was accompanied by score progress
+        # (bot review #8 fix). First-ever round has ``None`` here,
+        # which the guard treats as "cannot judge progress" and skips.
+        previous_qa_score = state.last_qa_score
+
         # Resolve the artifact:
         # 1. Fresh call from the Ralph terminal path → use ``ralph_result_text``
         #    (``is not None`` so an empty-but-valid artifact still grades)
@@ -1647,21 +1657,39 @@ class AutoPipeline:
         state.last_qa_suggestions = list(eval_result.suggestions)
         state.evaluate_artifact_hash = artifact_hash
 
-        # RFC #809 Phase 2.2b — same-fingerprint-twice guard. When two
-        # consecutive EVALUATE rounds produce the same failure shape, the
-        # recovery loop is not making material progress on the AC surface
-        # (lateral advice did not move the needle on the run output that
-        # gets graded). Block rather than spend another round; the
-        # operator chooses how to break the symmetry.
+        # RFC #809 Phase 2.2b — progress-sensitive duplicate-fingerprint
+        # guard. When two consecutive EVALUATE rounds produce the same
+        # textual failure shape, that is *evidence* of stagnation but
+        # not proof: the QA judge can return identical
+        # differences/suggestions wording on two artifacts whose
+        # numeric score materially improved (e.g. 0.30 → 0.79 while
+        # still below pass threshold). The guard therefore checks
+        # BOTH the textual fingerprint AND whether the numeric score
+        # advanced; the loop only blocks when both signals agree the
+        # session is not making progress.
         if not bool(eval_result.passed):
             fingerprint_input = (
                 "|".join(eval_result.differences) + "::" + "|".join(eval_result.suggestions)
             )
             failure_fingerprint = hashlib.sha256(fingerprint_input.encode("utf-8")).hexdigest()[:16]
-            if state.failure_fingerprints and state.failure_fingerprints[-1] == failure_fingerprint:
+            same_text = bool(
+                state.failure_fingerprints
+                and state.failure_fingerprints[-1] == failure_fingerprint
+            )
+            # ``previous_qa_score`` is the score from the PRIOR round
+            # captured before this round overwrote ``state.last_qa_score``.
+            # First-ever round has ``previous_qa_score is None`` and
+            # cannot trip the guard.
+            score_did_not_advance = (
+                previous_qa_score is not None
+                and float(eval_result.score) <= float(previous_qa_score)
+            )
+            if same_text and score_did_not_advance:
                 state.mark_blocked(
                     f"recovery loop: same QA-fail fingerprint twice "
-                    f"({failure_fingerprint}); {_RECOVERY_BLOCKED_CHOICES}",
+                    f"({failure_fingerprint}) with no score progress "
+                    f"({previous_qa_score:.2f} → {eval_result.score:.2f}); "
+                    f"{_RECOVERY_BLOCKED_CHOICES}",
                     tool_name="evaluator",
                 )
                 state.recovery_guard_tripped = "duplicate_fingerprint"
@@ -2015,8 +2043,9 @@ class AutoPipeline:
             summary_parts.append(f"suggestions: {sug_preview}")
         # RFC #809 Phase 2.2b — surface the operator-choice cue alongside
         # the persona's advisory so a session that BLOCKED here points the
-        # operator at the next move (relax AC / re-interview / abandon)
-        # rather than leaving them parsing the QA differences in isolation.
+        # operator at the next move (re-interview / abandon, as advertised
+        # by ``_RECOVERY_BLOCKED_CHOICES``) rather than leaving them
+        # parsing the QA differences in isolation.
         summary_parts.append(_RECOVERY_BLOCKED_CHOICES)
         state.mark_blocked("; ".join(summary_parts), tool_name="lateral_thinker")
         self._save(state)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -611,6 +611,16 @@ class AutoPipelineState:
         if self.phase == AutoPhase.COMPLETE:
             return AutoResumeCapability.NONE
 
+        # RFC #809 Phase 2.2b — a session whose recovery guard has tripped
+        # cannot make forward progress on --resume. ``_run_evaluate`` and
+        # ``_run_lateral`` both short-circuit to BLOCKED immediately when
+        # ``recovery_guard_tripped`` is set; advertising the session as
+        # resumable in this state would be a user-facing contract bug
+        # (CLI/MCP status surfaces would tell the operator "you can
+        # --resume" when --resume produces an identical blocker).
+        if self.recovery_guard_tripped is not None:
+            return AutoResumeCapability.NONE
+
         if self.phase not in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
             # CREATED, INTERVIEW, SEED_GENERATION, REVIEW, REPAIR, RUN.
             # Pipeline.run() will simply continue from the current phase.

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -36,8 +36,14 @@ class AutoPhase(StrEnum):
     # should be built before telling AI what to build" — keeps the spec
     # owned by the human. P2.2b instead exhausts the deterministic
     # recovery budget (rounds + fingerprint + persona-once + wall-clock)
-    # and surfaces a BLOCKED with the three explicit operator choices
-    # (relax AC, re-interview, or abandon) rather than mutating the Seed.
+    # and surfaces a BLOCKED with the two operator choices that are
+    # actually functional today (re-interview, abandon) rather than
+    # mutating the Seed. An earlier draft of this comment advertised a
+    # third "relax AC" path; that was dropped because late-phase resume
+    # reconstructs the Seed from ``state.seed_artifact`` and ignores
+    # edits to the on-disk seed file — the cue in ``pipeline.py``
+    # (``_RECOVERY_BLOCKED_CHOICES``) is the source of truth and lists
+    # only the two functional paths.
     COMPLETE = "complete"
     BLOCKED = "blocked"
     FAILED = "failed"

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -1066,8 +1066,7 @@ class AutoPipelineState:
             msg = "evaluate_round must be a non-negative integer"
             raise ValueError(msg)
         if not isinstance(self.failure_fingerprints, list) or any(
-            not isinstance(item, str) or not item.strip()
-            for item in self.failure_fingerprints
+            not isinstance(item, str) or not item.strip() for item in self.failure_fingerprints
         ):
             msg = "failure_fingerprints must be a list of non-empty strings"
             raise ValueError(msg)

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -453,6 +453,19 @@ class AutoPipelineState:
     evaluate_round: int = 0
     failure_fingerprints: list[str] = field(default_factory=list)
     personas_invoked: list[str] = field(default_factory=list)
+    # RFC #809 Phase 2.2b — sticky "guard tripped" flag. Set to a short
+    # tag identifying *which* recovery guard exhausted the budget the
+    # first time one of them blocked the pipeline (one of
+    # ``"round_budget"``, ``"duplicate_fingerprint"``, ``"personas_exhausted"``).
+    # ``_run_evaluate`` and ``_run_lateral`` both inspect this on entry
+    # so a ``--resume`` after a guard-driven BLOCKED does NOT re-enter
+    # the cache-fast-path or spend another persona slot — the surface
+    # had been declared exhausted, and silently un-exhausting it would
+    # undermine the guard contract. Cleared only on a successful
+    # forward transition out of the recovery loop (e.g. COMPLETE), so a
+    # fresh artifact reaching EVALUATE through a deliberate operator
+    # workflow can start over with a clean budget.
+    recovery_guard_tripped: str | None = None
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.
@@ -787,6 +800,7 @@ class AutoPipelineState:
         payload.setdefault("evaluate_round", 0)
         payload.setdefault("failure_fingerprints", [])
         payload.setdefault("personas_invoked", [])
+        payload.setdefault("recovery_guard_tripped", None)
         # Convert the persisted ``deadline_at_epoch`` (epoch seconds) back into
         # a monotonic-clock value usable from this process. If the companion
         # epoch field is present, derive ``deadline_at`` from the offset

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -94,6 +94,24 @@ DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
 # Seed (see the SEED_REGENERATE deferral comment on ``AutoPhase``).
 MAX_EVALUATE_ROUNDS: int = 3
 
+# RFC #809 Phase 2.2b — closed allowlists for the durable recovery-loop
+# fields. ``_validate_loaded`` rejects any state file whose persisted
+# values fall outside these sets so a hand-edited or corrupted
+# checkpoint surfaces a clean ValueError at load time instead of a
+# delayed runtime crash deep inside ``_run_evaluate`` /
+# ``_run_lateral``. ``_VALID_RECOVERY_PERSONAS`` mirrors
+# ``ouroboros.resilience.lateral.ThinkingPersona.value``; duplicated as
+# string literals to keep ``state.py`` independent of the resilience
+# module's import graph (state has no other dependency on resilience).
+# ``_VALID_RECOVERY_GUARD_TAGS`` mirrors the tags written by the three
+# guard sites in ``pipeline.py``.
+_VALID_RECOVERY_PERSONAS: frozenset[str] = frozenset(
+    {"hacker", "architect", "researcher", "simplifier", "contrarian"}
+)
+_VALID_RECOVERY_GUARD_TAGS: frozenset[str] = frozenset(
+    {"round_budget", "duplicate_fingerprint", "personas_exhausted"}
+)
+
 # Top-level pipeline deadline (Q00/ouroboros#779). Default of 7200s (2h) covers
 # a typical product-bootstrap chain — interview ≤ 120s × 12 rounds + seed gen
 # 120s + review/repair ≤ 90s × 5 + run kick-off + ralph 10 generations × 5–15
@@ -1032,6 +1050,42 @@ class AutoPipelineState:
             not isinstance(self.lateral_input_hash, str) or not self.lateral_input_hash.strip()
         ):
             msg = "lateral_input_hash must be a non-empty string or null"
+            raise ValueError(msg)
+        # RFC #809 Phase 2.2b — recovery-loop field validation. These four
+        # fields are durable state; once malformed they would crash deep
+        # inside ``_run_evaluate`` (``state.evaluate_round += 1`` on a
+        # string) or ``_run_lateral`` (``ThinkingPersona(value)`` on a
+        # bogus persona). Reject at load time instead.
+        if (
+            isinstance(self.evaluate_round, bool)
+            or not isinstance(self.evaluate_round, int)
+            or self.evaluate_round < 0
+        ):
+            msg = "evaluate_round must be a non-negative integer"
+            raise ValueError(msg)
+        if not isinstance(self.failure_fingerprints, list) or any(
+            not isinstance(item, str) or not item.strip()
+            for item in self.failure_fingerprints
+        ):
+            msg = "failure_fingerprints must be a list of non-empty strings"
+            raise ValueError(msg)
+        if not isinstance(self.personas_invoked, list) or any(
+            not isinstance(item, str) or item not in _VALID_RECOVERY_PERSONAS
+            for item in self.personas_invoked
+        ):
+            msg = (
+                "personas_invoked entries must be ThinkingPersona values "
+                f"({sorted(_VALID_RECOVERY_PERSONAS)})"
+            )
+            raise ValueError(msg)
+        if self.recovery_guard_tripped is not None and (
+            not isinstance(self.recovery_guard_tripped, str)
+            or self.recovery_guard_tripped not in _VALID_RECOVERY_GUARD_TAGS
+        ):
+            msg = (
+                "recovery_guard_tripped must be one of "
+                f"{sorted(_VALID_RECOVERY_GUARD_TAGS)} or null"
+            )
             raise ValueError(msg)
         if self.provenance is not None:
             if not isinstance(self.provenance, dict):

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -89,9 +89,11 @@ DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
 # the SeedRepairer convention re-applied to the EVALUATE ⇄ UNSTUCK_LATERAL
 # retry cycle. Past three rounds the failure mode is structural rather
 # than a transient grading miss; the pipeline blocks for human review
-# (with the three operator choices: relax AC, re-interview, or abandon)
-# instead of burning more LLM budget or — worse — silently rewriting the
-# Seed (see the SEED_REGENERATE deferral comment on ``AutoPhase``).
+# (with the two functional operator choices documented at
+# ``_RECOVERY_BLOCKED_CHOICES`` in ``pipeline.py``: re-interview or
+# abandon) instead of burning more LLM budget or — worse — silently
+# rewriting the Seed (see the SEED_REGENERATE deferral comment on
+# ``AutoPhase``).
 MAX_EVALUATE_ROUNDS: int = 3
 
 # RFC #809 Phase 2.2b — closed allowlists for the durable recovery-loop

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -24,6 +24,20 @@ class AutoPhase(StrEnum):
     RALPH_HANDOFF = "ralph_handoff"
     EVALUATE = "evaluate"
     UNSTUCK_LATERAL = "unstuck_lateral"
+    # RFC #809 Phase 2.2 originally specified a third recovery phase
+    # ``SEED_REGENERATE`` that would re-enter SEED_GENERATION with a
+    # ``[lateral_repair]`` ledger entry, automatically rewriting the Seed's
+    # acceptance criteria when persona lateral also failed. P2.2b
+    # deliberately does NOT wire this phase: an automatic AC rewrite when
+    # the run cannot satisfy the user's stated bar is a reward-hacking
+    # surface (the system silently downgrades the spec the user explicitly
+    # agreed to in the interview, then declares success against the
+    # downgraded spec). Ouroboros's spec-first invariant — "define what
+    # should be built before telling AI what to build" — keeps the spec
+    # owned by the human. P2.2b instead exhausts the deterministic
+    # recovery budget (rounds + fingerprint + persona-once + wall-clock)
+    # and surfaces a BLOCKED with the three explicit operator choices
+    # (relax AC, re-interview, or abandon) rather than mutating the Seed.
     COMPLETE = "complete"
     BLOCKED = "blocked"
     FAILED = "failed"
@@ -64,6 +78,15 @@ DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
     AutoPhase.EVALUATE.value: 90,
     AutoPhase.UNSTUCK_LATERAL.value: 60,
 }
+
+# RFC #809 Phase 2.2b — closed-loop recovery cap. Three EVALUATE rounds is
+# the SeedRepairer convention re-applied to the EVALUATE ⇄ UNSTUCK_LATERAL
+# retry cycle. Past three rounds the failure mode is structural rather
+# than a transient grading miss; the pipeline blocks for human review
+# (with the three operator choices: relax AC, re-interview, or abandon)
+# instead of burning more LLM budget or — worse — silently rewriting the
+# Seed (see the SEED_REGENERATE deferral comment on ``AutoPhase``).
+MAX_EVALUATE_ROUNDS: int = 3
 
 # Top-level pipeline deadline (Q00/ouroboros#779). Default of 7200s (2h) covers
 # a typical product-bootstrap chain — interview ≤ 120s × 12 rounds + seed gen
@@ -215,7 +238,16 @@ _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
         AutoPhase.BLOCKED,
         AutoPhase.FAILED,
     },
+    # RFC #809 Phase 2.2b — UNSTUCK_LATERAL is no longer a terminal advisory
+    # phase. It now dispatches one of two outcomes inside the bounded
+    # retry budget: back to EVALUATE for another round under a different
+    # persona, or BLOCKED when a recovery guard trips
+    # (``MAX_EVALUATE_ROUNDS``, duplicate failure fingerprint, persona
+    # exhaustion, or wall-clock budget). SEED_REGENERATE is deliberately
+    # not part of this set — see the ``AutoPhase`` comment block above for
+    # the spec-first rationale behind that omission.
     AutoPhase.UNSTUCK_LATERAL: {
+        AutoPhase.EVALUATE,
         AutoPhase.COMPLETE,
         AutoPhase.BLOCKED,
         AutoPhase.FAILED,
@@ -395,6 +427,26 @@ class AutoPipelineState:
     last_lateral_approach_summary: str | None = None
     last_lateral_text: str | None = None
     lateral_input_hash: str | None = None
+    # RFC #809 Phase 2.2b — closed-loop recovery counters. Persisted so a
+    # resumed session does not re-roll the budget after a process restart.
+    #
+    # ``evaluate_round`` counts entries into the EVALUATE phase (post-Ralph
+    # or post-SEED_REGENERATE). ``MAX_EVALUATE_ROUNDS`` (3) caps the loop.
+    #
+    # ``failure_fingerprints`` accumulates a deterministic fingerprint of
+    # each EVALUATE failure (sha256 over differences + suggestions). Two
+    # consecutive identical fingerprints means the recovery loop is not
+    # making material progress on the failure surface, so the pipeline
+    # transitions to BLOCKED rather than spending another LLM budget cycle.
+    #
+    # ``personas_invoked`` lists ``ThinkingPersona.value`` strings of every
+    # persona already routed in this session. The lateral router skips
+    # personas already in this list and finally returns ``None`` (no
+    # persona left to try) when all five are exhausted, which the pipeline
+    # treats as BLOCKED.
+    evaluate_round: int = 0
+    failure_fingerprints: list[str] = field(default_factory=list)
+    personas_invoked: list[str] = field(default_factory=list)
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.
@@ -721,6 +773,14 @@ class AutoPipelineState:
         payload.setdefault("last_lateral_text", None)
         payload.setdefault("lateral_input_hash", None)
         payload.setdefault("active_domain_profile_name", None)
+        # RFC #809 Phase 2.2b — closed-loop recovery counters. Default the
+        # three new fields so a pre-P2.2b state file loads as a fresh
+        # recovery budget (round 0, no fingerprints, no personas tried).
+        # Without these setdefaults a legacy resume would raise the
+        # "state is missing required fields" guard below.
+        payload.setdefault("evaluate_round", 0)
+        payload.setdefault("failure_fingerprints", [])
+        payload.setdefault("personas_invoked", [])
         # Convert the persisted ``deadline_at_epoch`` (epoch seconds) back into
         # a monotonic-clock value usable from this process. If the companion
         # epoch field is present, derive ``deadline_at`` from the offset

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -161,12 +161,21 @@ class _StubLedger:
 
 def test_unstuck_lateral_phase_in_allowed_transitions() -> None:
     assert AutoPhase.UNSTUCK_LATERAL in _ALLOWED_TRANSITIONS[AutoPhase.EVALUATE]
+    # RFC #809 Phase 2.2b — UNSTUCK_LATERAL became a retry dispatcher:
+    # back to EVALUATE for another round under a different persona, or
+    # BLOCKED when a recovery guard trips. SEED_REGENERATE is intentionally
+    # absent (see the AutoPhase deferral comment): an automatic Seed
+    # rewrite is a reward-hacking surface that mutates the spec the user
+    # explicitly agreed to. The pipeline instead surfaces the three
+    # operator choices (relax AC, re-interview, abandon) in the final
+    # BLOCKED message and leaves the spec under human control.
     assert _ALLOWED_TRANSITIONS[AutoPhase.UNSTUCK_LATERAL] == {
+        AutoPhase.EVALUATE,
         AutoPhase.COMPLETE,
         AutoPhase.BLOCKED,
         AutoPhase.FAILED,
     }
-    # Recovery from terminal phases must allow re-entering UNSTUCK_LATERAL
+    # Recovery from terminal phases must allow re-entering UNSTUCK_LATERAL.
     assert AutoPhase.UNSTUCK_LATERAL in _ALLOWED_TRANSITIONS[AutoPhase.BLOCKED]
     assert AutoPhase.UNSTUCK_LATERAL in _ALLOWED_TRANSITIONS[AutoPhase.FAILED]
 

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -683,7 +683,19 @@ async def test_run_resume_from_evaluate_reaches_handler(tmp_path) -> None:
 @pytest.mark.asyncio
 async def test_pipeline_lateral_resume_cache_hit_skips_re_invocation(tmp_path) -> None:
     """Re-entering UNSTUCK_LATERAL with the same input hash and a persisted
-    persona text must NOT re-invoke the lateral thinker."""
+    persona text must NOT re-invoke the lateral thinker — provided the same
+    persona would be picked again.
+
+    RFC #809 Phase 2.2b changed the persona-selection contract so the
+    router now skips ``state.personas_invoked``; a naive resume of a
+    completed lateral round would therefore pick a DIFFERENT persona on
+    the second call (HACKER → CONTRARIAN), produce a different cache
+    key, and re-invoke the handler. To exercise the cache-hit path
+    deliberately, the test clears ``personas_invoked`` before the resume
+    call so the router lands on the same primary persona and the cache
+    key matches. This is exactly the contract operators rely on when
+    --resume is meant to surface the previously-cached advisory rather
+    than spend another persona slot."""
     state = _state_at_run_phase(tmp_path)
     call_count = 0
 
@@ -714,6 +726,12 @@ async def test_pipeline_lateral_resume_cache_hit_skips_re_invocation(tmp_path) -
     assert call_count == 1
     assert state.last_lateral_text == "advice text"
     first_hash = state.lateral_input_hash
+
+    # Drop the persona-once exclusion so the resume call lands on the
+    # same HACKER primary and exercises the cache-hit path. Without
+    # this, P2.2b's multi-persona advisory would (correctly) pick a
+    # different persona and re-invoke the handler.
+    state.personas_invoked = []
 
     # Simulate resume by re-entering UNSTUCK_LATERAL with the same QA shape.
     state.phase = AutoPhase.UNSTUCK_LATERAL
@@ -876,11 +894,17 @@ async def test_lateral_cache_invalidated_when_evaluate_artifact_changes(tmp_path
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
         nonlocal eval_calls
         eval_calls += 1
+        # P2.2b note: the differences string must DIFFER between rounds so
+        # the same-fingerprint-twice guard does not block round 2 before
+        # lateral is even invoked. The cache invalidation under test here
+        # (lateral cache flushed when evaluate_artifact_hash changes) is
+        # orthogonal to the fingerprint guard — both must be exercised on
+        # genuinely distinct failure shapes.
         return EvaluateResult(
             passed=False,
             score=0.3,
             verdict="fail",
-            differences=("identical failure across rounds",),
+            differences=(f"failure on round {eval_calls}",),
         )
 
     async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001
@@ -910,10 +934,16 @@ async def test_lateral_cache_invalidated_when_evaluate_artifact_changes(tmp_path
     a_lateral_hash = state.lateral_input_hash
     assert state.last_lateral_text == "advice for round 1"
 
-    # Now simulate a second EVALUATE call with a DIFFERENT artifact but
-    # the same QA differences. The evaluate-artifact hash change must
-    # invalidate the lateral cache; otherwise the persona's "advice for
-    # round 1" (about artifact A) would be reused against artifact B.
+    # Drop the persona-once exclusion so round 2 picks the same primary
+    # persona (HACKER) and isolates the lateral-cache invalidation under
+    # test from P2.2b's multi-persona advisory path.
+    state.personas_invoked = []
+
+    # Now simulate a second EVALUATE call with a DIFFERENT artifact and
+    # a distinct (per the evaluator above) failure shape. The
+    # evaluate-artifact hash change must invalidate the lateral cache;
+    # otherwise "advice for round 1" (about artifact A) would be reused
+    # against artifact B.
     state.phase = AutoPhase.EVALUATE
     await pipeline._run_evaluate(
         state,
@@ -1068,3 +1098,207 @@ async def test_handler_lateral_thinker_truncates_long_artifact() -> None:
     # Approach text fits the truncation marker
     assert "truncated" in args["current_approach"]
     assert str(50_000) in args["current_approach"]
+
+
+# ---------------------------------------------------------------------------
+# RFC #809 Phase 2.2b — recovery-loop guards
+# ---------------------------------------------------------------------------
+#
+# These tests exercise the four deterministic guards that bound the
+# EVALUATE ⇄ UNSTUCK_LATERAL retry cycle: round budget, same-fingerprint
+# twice, persona exhaustion, and the operator-choice cue surfaced in the
+# final BLOCKED message. SEED_REGENERATE is deliberately NOT exercised —
+# see the AutoPhase deferral comment in state.py for the spec-first
+# rationale (system must not silently rewrite the spec the user agreed to).
+# Wall-clock budget reuses the existing ``state.deadline_at`` /
+# ``_enforce_deadline`` machinery already exercised by the Phase 2.1
+# tests, so no new test is needed here.
+
+
+@pytest.mark.asyncio
+async def test_recovery_round_budget_blocks_after_max(tmp_path) -> None:
+    """When ``evaluate_round`` has already reached ``MAX_EVALUATE_ROUNDS``
+    on entry, the next fresh evaluator call must NOT spend another budget
+    cycle. The pipeline marks BLOCKED with the operator-choice cue."""
+    from ouroboros.auto.state import MAX_EVALUATE_ROUNDS
+
+    state = _state_at_run_phase(tmp_path)
+    state.evaluate_round = MAX_EVALUATE_ROUNDS  # at-the-edge; next call exceeds
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        return EvaluateResult(passed=True, score=0.95, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert eval_calls == 0  # evaluator NOT invoked once budget exceeded
+    assert result.status == "blocked"
+    assert "MAX_EVALUATE_ROUNDS" in (state.last_error or "")
+    assert "relax AC" in (state.last_error or "")
+
+
+@pytest.mark.asyncio
+async def test_recovery_same_fingerprint_twice_blocks(tmp_path) -> None:
+    """Two consecutive EVALUATE rounds with the same QA-fail fingerprint
+    means lateral advice did not move the needle on the failure surface.
+    The pipeline blocks rather than spending another round."""
+    state = _state_at_run_phase(tmp_path)
+    # Pre-seed a matching fingerprint as if a previous round had already
+    # recorded it. The next failing evaluator call computes the same
+    # fingerprint and trips the guard.
+    fingerprint_input = "identical fail::"
+    import hashlib
+
+    pre_seeded = hashlib.sha256(fingerprint_input.encode("utf-8")).hexdigest()[:16]
+    state.failure_fingerprints = [pre_seeded]
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False, score=0.3, verdict="fail", differences=("identical fail",)
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert "fingerprint" in (state.last_error or "").lower()
+    assert "relax AC" in (state.last_error or "")
+    # The pre-seeded fingerprint is still there; we did not double-record.
+    assert state.failure_fingerprints == [pre_seeded]
+
+
+@pytest.mark.asyncio
+async def test_recovery_personas_exhausted_blocks(tmp_path) -> None:
+    """When every persona in the deterministic fallback chain has already
+    been routed in this session, the next lateral call returns ``None``
+    and the pipeline blocks with a ``"personas exhausted"`` reason."""
+    state = _state_at_run_phase(tmp_path)
+    # All five personas in the fallback chain marked as already routed.
+    state.personas_invoked = [
+        ThinkingPersona.HACKER.value,
+        ThinkingPersona.ARCHITECT.value,
+        ThinkingPersona.RESEARCHER.value,
+        ThinkingPersona.SIMPLIFIER.value,
+        ThinkingPersona.CONTRARIAN.value,
+    ]
+    lateral_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False, score=0.3, verdict="fail", differences=("Xcode unavailable",)
+        )
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001 # pragma: no cover
+        nonlocal lateral_calls
+        lateral_calls += 1
+        return LateralResult(persona="hacker", approach_summary="X", text="Y")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    result = await pipeline.run(state)
+
+    assert lateral_calls == 0  # router returned None → no handler call
+    assert result.status == "blocked"
+    last_error = state.last_error or ""
+    assert "personas exhausted" in last_error.lower()
+    assert "relax AC" in last_error
+
+
+@pytest.mark.asyncio
+async def test_recovery_personas_invoked_persists_after_lateral(tmp_path) -> None:
+    """After a successful lateral advisory call, the picked persona is
+    appended to ``state.personas_invoked`` so a subsequent --resume routes
+    a different persona instead of recycling the same advice."""
+    state = _state_at_run_phase(tmp_path)
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False, score=0.3, verdict="fail", differences=("Xcode unavailable",)
+        )
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:
+        return LateralResult(
+            persona=kwargs["persona"].value,
+            approach_summary="advice",
+            text="advice body",
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    await pipeline.run(state)
+
+    # The persona selected on this round is now persisted.
+    assert state.personas_invoked == [ThinkingPersona.HACKER.value]
+
+
+@pytest.mark.asyncio
+async def test_recovery_blocked_message_includes_operator_choices(tmp_path) -> None:
+    """Every recovery-loop BLOCKED message surfaces the three operator
+    choices (relax AC / re-interview / abandon) so the operator's next
+    move is on-screen rather than buried in QA differences."""
+    state = _state_at_run_phase(tmp_path)
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False, score=0.3, verdict="fail", differences=("Xcode unavailable",)
+        )
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001
+        return LateralResult(persona="hacker", approach_summary="brew install xcode", text="…")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    await pipeline.run(state)
+
+    msg = state.last_error or ""
+    assert "relax AC" in msg
+    assert "re-interview" in msg
+    assert "abandon" in msg

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -166,9 +166,14 @@ def test_unstuck_lateral_phase_in_allowed_transitions() -> None:
     # BLOCKED when a recovery guard trips. SEED_REGENERATE is intentionally
     # absent (see the AutoPhase deferral comment): an automatic Seed
     # rewrite is a reward-hacking surface that mutates the spec the user
-    # explicitly agreed to. The pipeline instead surfaces the three
-    # operator choices (relax AC, re-interview, abandon) in the final
-    # BLOCKED message and leaves the spec under human control.
+    # explicitly agreed to. The pipeline instead surfaces the operator
+    # choices (re-interview, abandon) in the final BLOCKED message and
+    # leaves the spec under human control. "Relax AC via edited seed" is
+    # not advertised because late-phase resume reconstructs the Seed from
+    # ``state.seed_artifact`` rather than rereading the on-disk seed
+    # file; honoring an edited seed file on EVALUATE / UNSTUCK_LATERAL
+    # resume is a separate change.
+
     assert _ALLOWED_TRANSITIONS[AutoPhase.UNSTUCK_LATERAL] == {
         AutoPhase.EVALUATE,
         AutoPhase.COMPLETE,
@@ -1146,7 +1151,7 @@ async def test_recovery_round_budget_blocks_after_max(tmp_path) -> None:
     assert eval_calls == 0  # evaluator NOT invoked once budget exceeded
     assert result.status == "blocked"
     assert "MAX_EVALUATE_ROUNDS" in (state.last_error or "")
-    assert "relax AC" in (state.last_error or "")
+    assert "re-interview" in (state.last_error or "")
 
 
 @pytest.mark.asyncio
@@ -1183,7 +1188,7 @@ async def test_recovery_same_fingerprint_twice_blocks(tmp_path) -> None:
 
     assert result.status == "blocked"
     assert "fingerprint" in (state.last_error or "").lower()
-    assert "relax AC" in (state.last_error or "")
+    assert "re-interview" in (state.last_error or "")
     # The pre-seeded fingerprint is still there; we did not double-record.
     assert state.failure_fingerprints == [pre_seeded]
 
@@ -1231,7 +1236,7 @@ async def test_recovery_personas_exhausted_blocks(tmp_path) -> None:
     assert result.status == "blocked"
     last_error = state.last_error or ""
     assert "personas exhausted" in last_error.lower()
-    assert "relax AC" in last_error
+    assert "re-interview" in last_error
 
 
 @pytest.mark.asyncio
@@ -1272,9 +1277,13 @@ async def test_recovery_personas_invoked_persists_after_lateral(tmp_path) -> Non
 
 @pytest.mark.asyncio
 async def test_recovery_blocked_message_includes_operator_choices(tmp_path) -> None:
-    """Every recovery-loop BLOCKED message surfaces the three operator
-    choices (relax AC / re-interview / abandon) so the operator's next
-    move is on-screen rather than buried in QA differences."""
+    """Every recovery-loop BLOCKED message surfaces the two functional
+    operator choices (re-interview / abandon) so the operator's next move
+    is on-screen rather than buried in QA differences. "Relax AC via
+    edited seed" is intentionally NOT advertised — late-phase resume
+    reconstructs the Seed from ``state.seed_artifact`` and ignores edits
+    to the on-disk seed file, so that path is non-functional today and
+    would mislead operators if surfaced here."""
     state = _state_at_run_phase(tmp_path)
 
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
@@ -1299,6 +1308,9 @@ async def test_recovery_blocked_message_includes_operator_choices(tmp_path) -> N
     await pipeline.run(state)
 
     msg = state.last_error or ""
-    assert "relax AC" in msg
     assert "re-interview" in msg
     assert "abandon" in msg
+    # The earlier misleading guidance (edit the seed file and --resume)
+    # must NOT appear — late-phase resume ignores on-disk seed edits.
+    assert "edited seed" not in msg
+    assert "relax AC" not in msg

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -1531,9 +1531,7 @@ async def test_fingerprint_guard_sets_sticky_flag(tmp_path) -> None:
     state.last_qa_score = 0.3
 
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
-        return EvaluateResult(
-            passed=False, score=0.3, verdict="fail", differences=("frozen fail",)
-        )
+        return EvaluateResult(passed=False, score=0.3, verdict="fail", differences=("frozen fail",))
 
     pipeline = AutoPipeline(
         _StubInterviewDriver(),
@@ -1631,9 +1629,7 @@ async def test_transient_evaluator_failures_do_not_consume_round_budget(tmp_path
     state.last_error = None
 
     async def evaluator_real_fail(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
-        return EvaluateResult(
-            passed=False, score=0.4, verdict="fail", differences=("real fail",)
-        )
+        return EvaluateResult(passed=False, score=0.4, verdict="fail", differences=("real fail",))
 
     pipeline3 = AutoPipeline(
         _StubInterviewDriver(),
@@ -1754,9 +1750,7 @@ async def test_personas_exhausted_guard_sets_sticky_flag(tmp_path) -> None:
     ]
 
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
-        return EvaluateResult(
-            passed=False, score=0.3, verdict="fail", differences=("any",)
-        )
+        return EvaluateResult(passed=False, score=0.3, verdict="fail", differences=("any",))
 
     async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001 # pragma: no cover
         return LateralResult(persona="hacker", approach_summary="X", text="Y")

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -1314,3 +1314,215 @@ async def test_recovery_blocked_message_includes_operator_choices(tmp_path) -> N
     # must NOT appear — late-phase resume ignores on-disk seed edits.
     assert "edited seed" not in msg
     assert "relax AC" not in msg
+
+
+# ---------------------------------------------------------------------------
+# RFC #809 Phase 2.2b — sticky guard semantics (bot review #3 BLOCKING)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sticky_guard_prevents_evaluate_cache_fastpath_on_resume(tmp_path) -> None:
+    """When a recovery guard has tripped, a resume that re-enters
+    ``_run_evaluate`` must NOT honor the cached failing verdict and fall
+    through to ``_finalize_evaluate`` (which would transition to
+    ``UNSTUCK_LATERAL`` and spend another persona slot). The cache
+    fast-path is bypassed and the original exhaustion blocker is
+    surfaced verbatim."""
+    state = _state_at_run_phase(tmp_path)
+    state.phase = AutoPhase.EVALUATE
+    state.recovery_guard_tripped = "duplicate_fingerprint"
+    state.last_error = "recovery loop: same QA-fail fingerprint twice (abc); next: ..."
+    # Plant a cached failing verdict that the legacy fast-path would honour
+    state.evaluate_artifact = "stale artifact"
+    import hashlib
+
+    state.evaluate_artifact_hash = hashlib.sha256(b"stale artifact").hexdigest()
+    state.last_qa_passed = False
+    state.last_qa_score = 0.3
+    state.last_qa_verdict = "fail"
+    state.last_qa_differences = ["frozen"]
+
+    eval_calls = 0
+    lateral_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001 # pragma: no cover
+        nonlocal eval_calls
+        eval_calls += 1
+        return EvaluateResult(passed=True, score=0.99, verdict="pass")
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001 # pragma: no cover
+        nonlocal lateral_calls
+        lateral_calls += 1
+        return LateralResult(persona="hacker", approach_summary="X", text="Y")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    result = await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text=None,
+        stop_reason=None,
+    )
+
+    # Neither the evaluator NOR the lateral handler was invoked: the
+    # sticky guard short-circuited everything.
+    assert eval_calls == 0
+    assert lateral_calls == 0
+    assert result.status == "blocked"
+    assert "fingerprint" in (state.last_error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_sticky_guard_prevents_lateral_cache_fastpath_on_resume(tmp_path) -> None:
+    """Resume that lands directly in ``UNSTUCK_LATERAL`` (via
+    ``_recoverable_phase_for_tool("lateral_thinker")``) also bypasses
+    the lateral cache when a guard has tripped — the persona-once
+    contract cannot be repaired by spending another slot."""
+    state = _state_at_run_phase(tmp_path)
+    state.phase = AutoPhase.UNSTUCK_LATERAL
+    state.recovery_guard_tripped = "personas_exhausted"
+    state.last_error = "recovery loop: all lateral personas exhausted; next: ..."
+
+    lateral_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001 # pragma: no cover
+        return EvaluateResult(passed=True, score=1.0, verdict="pass")
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001 # pragma: no cover
+        nonlocal lateral_calls
+        lateral_calls += 1
+        return LateralResult(persona="hacker", approach_summary="X", text="Y")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    result = await pipeline._run_lateral(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        qa_score=0.3,
+        qa_verdict="fail",
+        qa_differences=("any",),
+        qa_suggestions=(),
+        cache_suffix="",
+        review=None,
+        run_subagent=None,
+    )
+
+    assert lateral_calls == 0
+    assert result.status == "blocked"
+    assert "personas exhausted" in (state.last_error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_round_budget_guard_sets_sticky_flag(tmp_path) -> None:
+    """The round-budget guard persists ``recovery_guard_tripped`` so a
+    subsequent resume cannot un-exhaust the loop by waiting out the
+    counter."""
+    state = _state_at_run_phase(tmp_path)
+    from ouroboros.auto.state import MAX_EVALUATE_ROUNDS
+
+    state.evaluate_round = MAX_EVALUATE_ROUNDS
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(passed=True, score=1.0, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    await pipeline.run(state)
+
+    assert state.recovery_guard_tripped == "round_budget"
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_guard_sets_sticky_flag(tmp_path) -> None:
+    """Same-fingerprint-twice guard also persists the sticky flag."""
+    state = _state_at_run_phase(tmp_path)
+    import hashlib
+
+    fp = hashlib.sha256(b"frozen fail::").hexdigest()[:16]
+    state.failure_fingerprints = [fp]
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False, score=0.3, verdict="fail", differences=("frozen fail",)
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    await pipeline.run(state)
+
+    assert state.recovery_guard_tripped == "duplicate_fingerprint"
+
+
+@pytest.mark.asyncio
+async def test_personas_exhausted_guard_sets_sticky_flag(tmp_path) -> None:
+    """Persona-chain-exhausted guard also persists the sticky flag."""
+    state = _state_at_run_phase(tmp_path)
+    state.personas_invoked = [
+        ThinkingPersona.HACKER.value,
+        ThinkingPersona.ARCHITECT.value,
+        ThinkingPersona.RESEARCHER.value,
+        ThinkingPersona.SIMPLIFIER.value,
+        ThinkingPersona.CONTRARIAN.value,
+    ]
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False, score=0.3, verdict="fail", differences=("any",)
+        )
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001 # pragma: no cover
+        return LateralResult(persona="hacker", approach_summary="X", text="Y")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    await pipeline.run(state)
+
+    assert state.recovery_guard_tripped == "personas_exhausted"

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -1495,6 +1495,113 @@ async def test_fingerprint_guard_sets_sticky_flag(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_transient_evaluator_failures_do_not_consume_round_budget(tmp_path) -> None:
+    """RFC #809 Phase 2.2b — the round counter advances ONLY when a real
+    QA result is in hand. Evaluator timeouts, exceptions, and transient
+    ``eval_result.error`` responses must not decrement the recovery
+    budget; otherwise a streak of infra-only failures would trip
+    ``round_budget`` and permanently block a session that has not
+    actually completed any QA round."""
+    state = _state_at_run_phase(tmp_path)
+    state.phase = AutoPhase.EVALUATE
+    state.evaluate_artifact = "x"
+    import hashlib
+
+    state.evaluate_artifact_hash = hashlib.sha256(b"x").hexdigest()
+
+    # Case 1: evaluator raises an exception → round NOT consumed
+    async def evaluator_raises(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        raise RuntimeError("simulated transient infra failure")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator_raises,
+    )
+    starting_round = state.evaluate_round
+    await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text=None,
+        stop_reason=None,
+    )
+    assert state.evaluate_round == starting_round  # not consumed
+    assert state.recovery_guard_tripped is None  # no sticky tag for transient
+
+    # Case 2: evaluator returns ``error`` field → round NOT consumed
+    state.phase = AutoPhase.EVALUATE  # reset transition (mark_blocked moved to BLOCKED)
+    state.last_error = None
+
+    async def evaluator_transient_error(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False,
+            score=0.0,
+            verdict="fail",
+            error="adapter returned transient error",
+        )
+
+    pipeline2 = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator_transient_error,
+    )
+    starting_round = state.evaluate_round
+    await pipeline2._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text=None,
+        stop_reason=None,
+    )
+    assert state.evaluate_round == starting_round
+    assert state.recovery_guard_tripped is None
+
+    # Case 3: evaluator returns a real verdict (even a failing one) →
+    # round IS consumed
+    state.phase = AutoPhase.EVALUATE
+    state.last_error = None
+
+    async def evaluator_real_fail(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False, score=0.4, verdict="fail", differences=("real fail",)
+        )
+
+    pipeline3 = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator_real_fail,
+    )
+    starting_round = state.evaluate_round
+    await pipeline3._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text=None,
+        stop_reason=None,
+    )
+    assert state.evaluate_round == starting_round + 1  # consumed for real result
+
+
+@pytest.mark.asyncio
 async def test_fresh_artifact_resets_recovery_guard_state(tmp_path) -> None:
     """A new run output (different ``evaluate_artifact_hash``) clears the
     sticky guard tag AND the loop counters so the session can start over

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -1494,6 +1494,70 @@ async def test_fingerprint_guard_sets_sticky_flag(tmp_path) -> None:
     assert state.recovery_guard_tripped == "duplicate_fingerprint"
 
 
+@pytest.mark.asyncio
+async def test_fresh_artifact_resets_recovery_guard_state(tmp_path) -> None:
+    """A new run output (different ``evaluate_artifact_hash``) clears the
+    sticky guard tag AND the loop counters so the session can start over
+    with a clean budget. Without this, ``recovery_guard_tripped`` would
+    be a permanent poison pill no operator-driven re-entry could
+    escape."""
+    state = _state_at_run_phase(tmp_path)
+    state.phase = AutoPhase.EVALUATE
+    # Plant prior exhaustion + an old artifact hash so a new artifact
+    # arrives with a different hash and triggers the reset.
+    state.recovery_guard_tripped = "duplicate_fingerprint"
+    state.evaluate_round = 3
+    state.failure_fingerprints = ["old_fp_1", "old_fp_2"]
+    state.personas_invoked = [
+        ThinkingPersona.HACKER.value,
+        ThinkingPersona.CONTRARIAN.value,
+    ]
+    state.evaluate_artifact_hash = "stale_hash_does_not_match_new_artifact"
+    state.last_qa_passed = False
+    state.last_qa_score = 0.3
+    state.last_qa_verdict = "fail"
+    state.last_error = "old fingerprint blocker"
+
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        return EvaluateResult(passed=True, score=0.95, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    # Hand a brand-new ralph artifact whose hash will not match the planted
+    # stale_hash; the reset path must clear the guard before the sticky
+    # check fires, then the evaluator runs and the session passes.
+    result = await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text="brand new artifact bytes",
+        stop_reason=None,
+    )
+
+    # Guard tag + loop counters cleared
+    assert state.recovery_guard_tripped is None
+    assert state.evaluate_round == 1  # incremented this round, was 0 after reset
+    assert state.failure_fingerprints == []
+    assert state.personas_invoked == []
+    # Evaluator actually ran; session passed (not stuck on the old blocker)
+    assert eval_calls == 1
+    assert result.status == "complete"
+
+
 def test_resume_capability_is_none_when_recovery_guard_tripped(tmp_path) -> None:
     """``resume_capability`` must return NONE when ``recovery_guard_tripped``
     is set: a guarded BLOCKED session cannot make forward progress on

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -1157,23 +1157,24 @@ async def test_recovery_round_budget_blocks_after_max(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_recovery_same_fingerprint_twice_blocks(tmp_path) -> None:
-    """Two consecutive EVALUATE rounds with the same QA-fail fingerprint
-    means lateral advice did not move the needle on the failure surface.
-    The pipeline blocks rather than spending another round."""
+async def test_recovery_same_fingerprint_with_stagnant_score_blocks(tmp_path) -> None:
+    """RFC #809 Phase 2.2b — when two consecutive EVALUATE rounds produce
+    the same textual fingerprint AND the numeric score does not advance,
+    the recovery loop has demonstrably stalled and the guard fires."""
     state = _state_at_run_phase(tmp_path)
     # Pre-seed a matching fingerprint as if a previous round had already
-    # recorded it. The next failing evaluator call computes the same
-    # fingerprint and trips the guard.
+    # recorded it, and pin the prior score so the guard's "no score
+    # progress" branch is reachable.
     fingerprint_input = "identical fail::"
     import hashlib
 
     pre_seeded = hashlib.sha256(fingerprint_input.encode("utf-8")).hexdigest()[:16]
     state.failure_fingerprints = [pre_seeded]
+    state.last_qa_score = 0.30  # prior round's score
 
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
         return EvaluateResult(
-            passed=False, score=0.3, verdict="fail", differences=("identical fail",)
+            passed=False, score=0.30, verdict="fail", differences=("identical fail",)
         )
 
     pipeline = AutoPipeline(
@@ -1190,9 +1191,60 @@ async def test_recovery_same_fingerprint_twice_blocks(tmp_path) -> None:
 
     assert result.status == "blocked"
     assert "fingerprint" in (state.last_error or "").lower()
+    assert "no score progress" in (state.last_error or "").lower()
     assert "re-interview" in (state.last_error or "")
     # The pre-seeded fingerprint is still there; we did not double-record.
     assert state.failure_fingerprints == [pre_seeded]
+
+
+@pytest.mark.asyncio
+async def test_same_fingerprint_with_score_progress_does_not_block(tmp_path) -> None:
+    """RFC #809 Phase 2.2b (bot review #8 fix) — when two consecutive
+    EVALUATE rounds produce the same textual fingerprint but the numeric
+    score advances, the loop is genuinely converging and the guard must
+    NOT fire. A 0.30 → 0.79 jump with identical wording is exactly the
+    case that the textual-only guard would have wrongly blocked."""
+    state = _state_at_run_phase(tmp_path)
+    fingerprint_input = "identical fail::"
+    import hashlib
+
+    pre_seeded = hashlib.sha256(fingerprint_input.encode("utf-8")).hexdigest()[:16]
+    state.failure_fingerprints = [pre_seeded]
+    state.last_qa_score = 0.30  # prior round's score
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        # Same textual feedback, but score materially improved.
+        return EvaluateResult(
+            passed=False, score=0.79, verdict="fail", differences=("identical fail",)
+        )
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001
+        return LateralResult(persona="hacker", approach_summary="X", text="Y")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(result_text="artifact"),
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    await pipeline.run(state)
+
+    # Guard did NOT trip. Either the session ends in BLOCKED via lateral
+    # (advisory layer in Stack 1 always ends BLOCKED) or COMPLETE later;
+    # what this test pins is the absence of the fingerprint guard's
+    # ``recovery_guard_tripped`` tag and the absence of the "no score
+    # progress" cue in the blocker text.
+    assert state.recovery_guard_tripped != "duplicate_fingerprint"
+    assert "no score progress" not in (state.last_error or "").lower()
+    # The new fingerprint was appended (genuine progress, recorded as a
+    # second observation of this textual shape).
+    assert state.failure_fingerprints[-1] == pre_seeded
+    assert len(state.failure_fingerprints) == 2
 
 
 @pytest.mark.asyncio
@@ -1473,6 +1525,10 @@ async def test_fingerprint_guard_sets_sticky_flag(tmp_path) -> None:
 
     fp = hashlib.sha256(b"frozen fail::").hexdigest()[:16]
     state.failure_fingerprints = [fp]
+    # Prior round's score; the new evaluator below returns the same
+    # value so the score-progress branch of the guard agrees "no
+    # progress" and the sticky tag fires.
+    state.last_qa_score = 0.3
 
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
         return EvaluateResult(

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -577,12 +577,16 @@ async def test_run_resume_from_unstuck_lateral_reaches_handler(tmp_path) -> None
     )
 
     result = await pipeline.run(state)
-    # The handler ran (cache hit), so no Cannot-resume guard fired and the
-    # session lands at BLOCKED with the cached persona summary, NOT at
-    # "Cannot resume auto pipeline from unstuck_lateral".
+    # The resume path reached the lateral handler (no Cannot-resume guard
+    # fired), so the session lands at BLOCKED with a persona summary, NOT
+    # at "Cannot resume auto pipeline from unstuck_lateral".
+    # RFC #809 Phase 2.2b removed the lateral cache short-circuit, so
+    # the handler is invoked exactly once on this resume — what the test
+    # actually pins is "resume reached the handler", not "the handler
+    # was skipped via a cache hit".
     assert result.status == "blocked"
     assert state.last_tool_name == "lateral_thinker"
-    assert lateral_calls == 0  # cache hit
+    assert lateral_calls == 1  # cache removed; handler runs fresh
     assert "Cannot resume" not in (state.last_error or "")
 
 
@@ -686,21 +690,19 @@ async def test_run_resume_from_evaluate_reaches_handler(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_pipeline_lateral_resume_cache_hit_skips_re_invocation(tmp_path) -> None:
-    """Re-entering UNSTUCK_LATERAL with the same input hash and a persisted
-    persona text must NOT re-invoke the lateral thinker — provided the same
-    persona would be picked again.
+async def test_pipeline_lateral_resume_with_same_persona_reinvokes_handler(tmp_path) -> None:
+    """RFC #809 Phase 2.2b removed the lateral cache-hit short-circuit
+    that previously replayed a cached advisory on --resume.
 
-    RFC #809 Phase 2.2b changed the persona-selection contract so the
-    router now skips ``state.personas_invoked``; a naive resume of a
-    completed lateral round would therefore pick a DIFFERENT persona on
-    the second call (HACKER → CONTRARIAN), produce a different cache
-    key, and re-invoke the handler. To exercise the cache-hit path
-    deliberately, the test clears ``personas_invoked`` before the resume
-    call so the router lands on the same primary persona and the cache
-    key matches. This is exactly the contract operators rely on when
-    --resume is meant to surface the previously-cached advisory rather
-    than spend another persona slot."""
+    The P2.2 cache was unreachable on real resumes (the persona-once
+    contract appends to ``state.personas_invoked`` so the next resume
+    deterministically picks a different persona and produces a
+    different cache key). Rather than leave dead code in the
+    happy-path branch, the cache was removed. This test pins the new
+    contract: re-entering UNSTUCK_LATERAL with the same QA shape AND
+    the same persona (operator manually clears ``personas_invoked``)
+    invokes the lateral handler a SECOND time — there is no cache hit
+    to short-circuit it."""
     state = _state_at_run_phase(tmp_path)
     call_count = 0
 
@@ -713,7 +715,9 @@ async def test_pipeline_lateral_resume_cache_hit_skips_re_invocation(tmp_path) -
         nonlocal call_count
         call_count += 1
         return LateralResult(
-            persona="hacker", approach_summary="Hacker: workarounds", text="advice text"
+            persona="hacker",
+            approach_summary="Hacker: workarounds",
+            text=f"advice text {call_count}",
         )
 
     pipeline = AutoPipeline(
@@ -729,16 +733,14 @@ async def test_pipeline_lateral_resume_cache_hit_skips_re_invocation(tmp_path) -
 
     await pipeline.run(state)
     assert call_count == 1
-    assert state.last_lateral_text == "advice text"
-    first_hash = state.lateral_input_hash
+    assert state.last_lateral_text == "advice text 1"
 
-    # Drop the persona-once exclusion so the resume call lands on the
-    # same HACKER primary and exercises the cache-hit path. Without
-    # this, P2.2b's multi-persona advisory would (correctly) pick a
-    # different persona and re-invoke the handler.
+    # Clear personas_invoked so the router picks the same HACKER primary
+    # again. With the P2.2 cache removed, the handler is invoked a
+    # second time even though the QA shape is identical — the cache
+    # short-circuit no longer exists.
     state.personas_invoked = []
 
-    # Simulate resume by re-entering UNSTUCK_LATERAL with the same QA shape.
     state.phase = AutoPhase.UNSTUCK_LATERAL
     result = await pipeline._run_lateral(
         state,
@@ -748,12 +750,12 @@ async def test_pipeline_lateral_resume_cache_hit_skips_re_invocation(tmp_path) -
         qa_verdict="fail",
         qa_differences=("Xcode unavailable",),
         qa_suggestions=(),
-        cache_suffix=" [cached]",
+        cache_suffix="",
         review=None,
         run_subagent=None,
     )
-    assert call_count == 1  # NOT incremented
-    assert state.lateral_input_hash == first_hash
+    assert call_count == 2  # cache removed; handler invoked again
+    assert state.last_lateral_text == "advice text 2"
     assert result.status == "blocked"
 
 
@@ -1490,6 +1492,26 @@ async def test_fingerprint_guard_sets_sticky_flag(tmp_path) -> None:
     await pipeline.run(state)
 
     assert state.recovery_guard_tripped == "duplicate_fingerprint"
+
+
+def test_resume_capability_is_none_when_recovery_guard_tripped(tmp_path) -> None:
+    """``resume_capability`` must return NONE when ``recovery_guard_tripped``
+    is set: a guarded BLOCKED session cannot make forward progress on
+    --resume (``_run_evaluate`` / ``_run_lateral`` short-circuit back to
+    BLOCKED), so advertising the session as resumable in CLI/MCP status
+    surfaces is a user-facing contract bug. This test pins the
+    contract for all three guard tags."""
+    for tag in ("round_budget", "duplicate_fingerprint", "personas_exhausted"):
+        state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+        state.phase = AutoPhase.BLOCKED
+        state.last_tool_name = "evaluator"
+        # Plant cache fields that would normally make the session
+        # advertise RESUME — the guard tag must override.
+        state.evaluate_artifact = "x"
+        state.evaluate_artifact_hash = "abc"
+        state.last_qa_passed = False
+        state.recovery_guard_tripped = tag
+        assert state.resume_capability() is AutoResumeCapability.NONE, tag
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -164,6 +164,41 @@ def test_store_load_wraps_malformed_container_and_counter_fields(tmp_path) -> No
             store.load(state.auto_session_id)
 
 
+def test_store_load_rejects_malformed_recovery_loop_fields(tmp_path) -> None:
+    """RFC #809 Phase 2.2b — the four durable recovery-loop fields
+    (``evaluate_round``, ``failure_fingerprints``, ``personas_invoked``,
+    ``recovery_guard_tripped``) must fail at load time when malformed,
+    not crash later inside ``_run_evaluate`` / ``_run_lateral``."""
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    path = store.path_for(state.auto_session_id)
+
+    malformed_cases = (
+        # evaluate_round must be a non-negative int (not a string, not bool,
+        # not negative)
+        ("evaluate_round", "3"),
+        ("evaluate_round", True),
+        ("evaluate_round", -1),
+        # failure_fingerprints must be a list of non-empty strings
+        ("failure_fingerprints", "abc"),
+        ("failure_fingerprints", [123]),
+        ("failure_fingerprints", [""]),
+        # personas_invoked entries must come from the ThinkingPersona allowlist
+        ("personas_invoked", "hacker"),  # not a list
+        ("personas_invoked", ["bogus_persona"]),
+        ("personas_invoked", [None]),
+        # recovery_guard_tripped must be one of the three tags or null
+        ("recovery_guard_tripped", "made_up_tag"),
+        ("recovery_guard_tripped", 42),
+    )
+    for field_name, value in malformed_cases:
+        data = state.to_dict()
+        data[field_name] = value
+        path.write_text(__import__("json").dumps(data), encoding="utf-8")
+        with pytest.raises(ValueError, match="Auto session state is invalid"):
+            store.load(state.auto_session_id)
+
+
 def test_store_load_rejects_malformed_nested_ledger(tmp_path) -> None:
     store = AutoStore(tmp_path)
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")


### PR DESCRIPTION
## Summary

RFC #809 Phase 2.2b — Stack 1 of 2. Lands the four deterministic guards that bound the EVALUATE ⇄ UNSTUCK_LATERAL retry cycle, plus the multi-persona advisory routing. **No automated Seed rewrite, no automated Ralph retry.** Stack 2 will layer the automated Ralph re-dispatch on top of these guards.

## Why not SEED_REGENERATE

RFC #809 originally specified a third recovery phase that would re-enter `SEED_GENERATION` and let an LLM rewrite the user's acceptance criteria when persona lateral also failed. **P2.2b deliberately omits this** — an automatic AC rewrite is a reward-hacking surface that mutates the spec the user explicitly agreed to in the interview and then declares "success" against the downgraded spec. The deferral comment lives at `AutoPhase` in `state.py` so future contributors see the rationale next to the code.

When all four guards trip, the pipeline blocks with the three explicit operator choices: relax AC, re-interview, or abandon. The spec stays under human control.

## RFC #809 Phase 2 checklist closed

- [x] Add `AutoPhase.EVALUATE` and `AutoPhase.UNSTUCK_LATERAL` (already in P2.1/P2.2)
- [x] New `auto/evaluator.py` — match Seed AC against run output (already in P2.1)
- [x] Persona routing table → lateral_think integration (already in P2.2)
- [x] **Loop guards: `max_evaluate_rounds`, same-fingerprint, per-persona-once** ← this PR
- [x] **Wall-clock budget reusing ralph pattern (#789)** ← already covered by the existing `state.deadline_at` / `_enforce_deadline` machinery; the new guards no-op when the deadline fires first
- [x] **Tests: pass / lateral / BLOCKED paths** ← this PR (5 new tests)
- [-] EVALUATE → SEED_GENERATION reverse transition ← intentionally not implemented; see deferral comment

## Stack 2 preview

The follow-up PR will layer automated Ralph re-dispatch on top of these guards: after a successful lateral advisory inside the budget, inject the persona's advice into the next Ralph iteration's system prompt and re-grade the new artifact. The guards in this PR keep that loop bounded.

## Commits

1. `feat(auto): recovery loop guards + multi-persona advisory infra (#809 P2.2b prep)` — state + routing infra, deliberately inert at the pipeline level.
2. `feat(auto): wire recovery-loop guards in evaluate/lateral handlers (#809 P2.2b)` — activates the guards in `_run_evaluate` / `_run_lateral`, updates pre-existing cache-semantics tests, adds 5 P2.2b-specific tests.

Stacked-PR style: review in commit order makes the design easier to follow.

## Test plan

- [x] `pytest tests/unit/auto/` — 772/772 passing locally
- [x] `ruff check` on changed files — clean
- [x] `mypy` on changed files — clean
- [x] Two pre-existing lateral-cache tests updated to remain valid under the new persona-once contract (see commit 2 notes)
- [ ] CI: Tests Python 3.12/3.13/3.14 all green
- [ ] CI: lint, mypy, enforce-boundary, enforce-envelope