### PR TITLE
feat(orchestrator): adaptive model/tool routing (#830 PR 7/9)

### DIFF
--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -46,6 +46,15 @@ class ModelTier(StrEnum):
 
 _TIER_ORDER: tuple[ModelTier, ...] = (ModelTier.HAIKU, ModelTier.SONNET, ModelTier.OPUS)
 
+# Tools the verifier route MUST drop from the executor's profile tool
+# set. The H1 contract says the verifier is read-only with respect to
+# source files, so Edit/Write/NotebookEdit are filtered. Bash is *not*
+# in this set — code profile's verifier_focus says "Run the project's
+# test command", which requires Bash to be available. Whether a Bash
+# invocation is read-only is the verifier prompt's responsibility, not
+# the router's. (Bot finding on PR #889.)
+_VERIFIER_DENIED_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "NotebookEdit", "MultiEdit"})
+
 
 @dataclass(frozen=True)
 class RouteDecision:
@@ -133,14 +142,22 @@ def decide_route(
     if role is DispatchRole.VERIFIER:
         executor_tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
         verifier_tier = _bump_tier(executor_tier)
+        # Derive verifier tools from the profile so domain-specific
+        # verifications work — e.g. the code profile's verifier_focus
+        # says "Run the project's test command", which needs Bash.
+        # Strip only the file-mutation tools; Bash and any read-only
+        # discovery tools (Read / Glob / Grep) pass through.
+        verifier_tools = tuple(
+            t for t in profile.suggested_tools if t not in _VERIFIER_DENIED_TOOLS
+        )
         return RouteDecision(
             tier=verifier_tier,
-            # Read-only: verifier must not mutate state. Tools intentionally
-            # exclude Write/Edit/Bash; PR 9 plumbs these through the adapter.
-            tools=("Read", "Glob", "Grep"),
+            tools=verifier_tools,
             rationale=(
-                "Verifier runs one tier above the executor; read-only "
-                "toolset keeps the pass non-destructive."
+                f"Verifier runs one tier above the executor on "
+                f"{profile.profile!r} profile; profile tools minus "
+                f"{sorted(_VERIFIER_DENIED_TOOLS)} stay read-only with "
+                "respect to source files."
             ),
         )
 

--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -69,6 +69,36 @@ _TIER_ORDER: tuple[ModelTier, ...] = (ModelTier.HAIKU, ModelTier.SONNET, ModelTi
 # route through a dedicated read-only test runner — see module docstring.
 _VERIFIER_TOOLS: tuple[str, ...] = ("Read", "Glob", "Grep")
 
+# Phrases in profile.verifier_focus that signal the verifier needs to
+# execute subprocesses (typically test commands). When detected, the
+# router raises NotImplementedError so the caller knows to plumb a
+# dedicated read-only test runner instead of silently routing a
+# profile whose verifier contract this seam cannot satisfy
+# (bot finding on #889 r4).
+_VERIFIER_SUBPROCESS_MARKERS: tuple[str, ...] = (
+    "test command",
+    "subprocess",
+    "shell command",
+    "pytest",
+)
+
+
+def _check_verifier_supported(profile: ExecutionProfile) -> None:
+    """Raise NotImplementedError if the profile needs subprocess verifier."""
+    focus_lower = profile.verifier_focus.lower()
+    for marker in _VERIFIER_SUBPROCESS_MARKERS:
+        if marker in focus_lower:
+            msg = (
+                f"Profile {profile.profile!r} declares verifier_focus that "
+                f"requires {marker!r} (subprocess execution). The current "
+                f"verifier route is hard-fixed to {list(_VERIFIER_TOOLS)} "
+                "to enforce H1 read-only-ness structurally, so it cannot "
+                "complete this profile's verifier contract. Wire a "
+                "dedicated read-only test runner before routing "
+                "DispatchRole.VERIFIER for this profile."
+            )
+            raise NotImplementedError(msg)
+
 
 @dataclass(frozen=True)
 class RouteDecision:
@@ -109,8 +139,12 @@ def decide_route(
         profile: Active ExecutionProfile (suggested_tools is the source
             of truth for the executor's tool set).
         fabrication_retry: True when retrying after H7 classified the
-            previous attempt as FABRICATION_SUSPECTED. Bumps the
-            executor and the verifier one tier up.
+            previous attempt as FABRICATION_SUSPECTED. Escalates the
+            executor one tier up (SONNET → OPUS). The verifier always
+            runs one tier above the executor and is capped at OPUS, so
+            in practice the verifier tier is unchanged on retry once
+            the executor reaches OPUS — the cap, not the bump, defines
+            the verifier on retry.
 
     Returns:
         RouteDecision with the chosen tier, the resolved tool tuple,
@@ -121,6 +155,14 @@ def decide_route(
             routing seam fails fast on unknown inputs (e.g. a raw
             string from config/JSON) rather than silently falling
             through to the verifier branch with the wrong tools.
+        NotImplementedError: For DispatchRole.VERIFIER when the
+            profile's verifier_focus requires subprocess invocation
+            (e.g. code profile's "Run the project's test command").
+            The current verifier-tool envelope is hard-fixed read-only
+            (Read/Glob/Grep) for H1 contract enforcement and cannot
+            satisfy such profiles — the caller must wire a dedicated
+            read-only test runner before using VERIFIER routing for
+            them.
     """
     if not isinstance(role, DispatchRole):
         msg = (
@@ -154,6 +196,12 @@ def decide_route(
         )
 
     if role is DispatchRole.VERIFIER:
+        # Profiles whose verifier_focus needs subprocess execution
+        # cannot be satisfied by the read-only (Read/Glob/Grep) envelope
+        # this router enforces. Surface that explicitly instead of
+        # silently returning a route the verifier cannot complete (bot
+        # finding on #889 r4).
+        _check_verifier_supported(profile)
         executor_tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
         verifier_tier = _bump_tier(executor_tier)
         return RouteDecision(

--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -10,28 +10,36 @@ IDs — the integration PR (PR 9) maps `ModelTier.HAIKU / SONNET / OPUS`
 onto the adapter's current model knobs. Decoupling lets profile
 authors think in cost/quality bands rather than vendor SKU drift.
 
-Routing rules at this PR:
-    decomposer  → HAIKU, no tools
-    executor    → SONNET (default) or OPUS for FABRICATION_SUSPECTED
-                  retries (the H7 ESCALATE_MODEL hook).
-                  Tools come from profile.suggested_tools.
-    verifier    → one tier above the executor.
-                  Tools are hard-fixed to Read / Glob / Grep — these are
-                  the only operations the H1 read-only contract can
-                  guarantee at the routing layer. The router CANNOT
-                  authorize Bash on the verifier seam: Bash can mutate
-                  the workspace and the router can't inspect command
-                  text. Code-style profiles whose verifier_focus needs
-                  to execute the project's test command must route
-                  that through a dedicated read-only test runner (a
-                  separate follow-up PR), not via this generic
-                  verifier-tool envelope.
+Implementation status at this PR:
 
-This module is wiring-only. parallel_executor still uses its current
-hardcoded adapter call until PR 9. The docstring previously claimed
-AC-aware routing — that is intentionally deferred; `decide_route()`
-takes role + profile + retry hint, no AC, until a profile actually
-demands per-AC routing logic (bot non-blocking suggestion on r2).
+  DECOMPOSER (implemented)
+    Tier HAIKU. Tools = (). Decomposition is structured-output
+    planning; HAIKU keeps the per-AC fixed cost low and tools are
+    intentionally empty.
+
+  EXECUTOR (implemented)
+    Tier SONNET by default. Escalates to OPUS when
+    `fabrication_retry=True` per the H7 ESCALATE_MODEL hook.
+    Tools come from `profile.suggested_tools` verbatim.
+
+  VERIFIER (intentionally NOT implemented — raises NotImplementedError)
+    Routing verifier dispatches requires a structured capability flag
+    on ExecutionProfile (read-only-discovery vs subprocess-test-runner)
+    that does not yet exist on the #881 schema. Earlier rounds of #889
+    review tried two approximations and both were rejected:
+      - hard-fixing the verifier tools to (Read, Glob, Grep) silently
+        breaks the code profile, whose verifier_focus needs subprocess
+        execution.
+      - substring-matching `verifier_focus` prose for subprocess markers
+        is fragile (innocuous wording changes flip runtime behavior).
+    The seam therefore refuses to guess and raises NotImplementedError
+    with a clear pointer: add `verifier_capability` to ExecutionProfile
+    (a #881 follow-up) or plumb a custom verifier dispatcher before
+    using `DispatchRole.VERIFIER`.
+
+This module is wiring-only. `parallel_executor` still uses its current
+hardcoded adapter call. `decide_route()` takes role + profile + retry
+hint — no AC text — until a profile demands per-AC routing.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -92,7 +92,21 @@ def decide_route(
     Returns:
         RouteDecision with the chosen tier, the resolved tool tuple,
         and a one-line rationale for logs.
+
+    Raises:
+        TypeError: If `role` is not a `DispatchRole` member. The public
+            routing seam fails fast on unknown inputs (e.g. a raw
+            string from config/JSON) rather than silently falling
+            through to the verifier branch with the wrong tools.
     """
+    if not isinstance(role, DispatchRole):
+        msg = (
+            f"decide_route(role=...) requires a DispatchRole member, "
+            f"got {role!r} of type {type(role).__name__}. "
+            f"Valid roles: {[r.name for r in DispatchRole]}."
+        )
+        raise TypeError(msg)
+
     if role is DispatchRole.DECOMPOSER:
         return RouteDecision(
             tier=ModelTier.HAIKU,
@@ -116,19 +130,24 @@ def decide_route(
             ),
         )
 
-    # role == VERIFIER
-    executor_tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
-    verifier_tier = _bump_tier(executor_tier)
-    return RouteDecision(
-        tier=verifier_tier,
-        # Read-only: verifier must not mutate state. Tools intentionally
-        # exclude Write/Edit/Bash; PR 9 plumbs these through the adapter.
-        tools=("Read", "Glob", "Grep"),
-        rationale=(
-            "Verifier runs one tier above the executor; read-only "
-            "toolset keeps the pass non-destructive."
-        ),
-    )
+    if role is DispatchRole.VERIFIER:
+        executor_tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
+        verifier_tier = _bump_tier(executor_tier)
+        return RouteDecision(
+            tier=verifier_tier,
+            # Read-only: verifier must not mutate state. Tools intentionally
+            # exclude Write/Edit/Bash; PR 9 plumbs these through the adapter.
+            tools=("Read", "Glob", "Grep"),
+            rationale=(
+                "Verifier runs one tier above the executor; read-only "
+                "toolset keeps the pass non-destructive."
+            ),
+        )
+
+    # Exhaustive — every DispatchRole member handled above. Reached only
+    # if a new role is added without updating decide_route.
+    msg = f"Unhandled DispatchRole: {role!r}"
+    raise NotImplementedError(msg)
 
 
 __all__ = [

--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -1,0 +1,139 @@
+"""Adaptive model/tool routing (RFC v2 H5, #830).
+
+H5 moves model and tool selection out of skills and into the harness.
+The skill never picks a model. Each dispatch has a role (decomposer /
+executor / verifier), and the harness chooses an appropriate tier and
+tool set per role + profile + AC text.
+
+Tiers are intentionally abstract strings rather than concrete model
+IDs — the integration PR (PR 9) maps `ModelTier.HAIKU / SONNET / OPUS`
+onto the adapter's current model knobs. Decoupling lets profile
+authors think in cost/quality bands rather than vendor SKU drift.
+
+Routing rules at this PR:
+    decomposer  → HAIKU
+    executor    → SONNET (default) or OPUS for FABRICATION_SUSPECTED
+                  retries (the H7 ESCALATE_MODEL hook)
+    verifier    → one tier above the executor (read-only, can afford it)
+
+This module is wiring-only. parallel_executor still uses its current
+hardcoded adapter call until PR 9.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ouroboros.orchestrator.profile_loader import ExecutionProfile
+
+
+class DispatchRole(StrEnum):
+    """Which leg of the verifier loop this dispatch serves."""
+
+    DECOMPOSER = "DECOMPOSER"
+    EXECUTOR = "EXECUTOR"
+    VERIFIER = "VERIFIER"
+
+
+class ModelTier(StrEnum):
+    """Abstract cost/quality tier — the adapter layer maps to concrete IDs."""
+
+    HAIKU = "HAIKU"
+    SONNET = "SONNET"
+    OPUS = "OPUS"
+
+
+_TIER_ORDER: tuple[ModelTier, ...] = (ModelTier.HAIKU, ModelTier.SONNET, ModelTier.OPUS)
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    """Resolved (tier, tools) for a single dispatch."""
+
+    tier: ModelTier
+    tools: tuple[str, ...]
+    rationale: str
+
+
+def _bump_tier(tier: ModelTier, *, steps: int = 1) -> ModelTier:
+    """Return the tier `steps` levels above `tier`, capped at OPUS."""
+    idx = _TIER_ORDER.index(tier)
+    return _TIER_ORDER[min(idx + steps, len(_TIER_ORDER) - 1)]
+
+
+def _executor_tier(
+    profile: ExecutionProfile,  # noqa: ARG001 — reserved for per-profile overrides
+    *,
+    fabrication_retry: bool,
+) -> ModelTier:
+    base = ModelTier.SONNET
+    if fabrication_retry:
+        return _bump_tier(base)
+    return base
+
+
+def decide_route(
+    *,
+    role: DispatchRole,
+    profile: ExecutionProfile,
+    fabrication_retry: bool = False,
+) -> RouteDecision:
+    """Choose a tier and tool set for a single dispatch.
+
+    Args:
+        role: Which loop leg this dispatch is for.
+        profile: Active ExecutionProfile (suggested_tools is the source
+            of truth for the executor's tool set).
+        fabrication_retry: True when retrying after H7 classified the
+            previous attempt as FABRICATION_SUSPECTED. Bumps the
+            executor and the verifier one tier up.
+
+    Returns:
+        RouteDecision with the chosen tier, the resolved tool tuple,
+        and a one-line rationale for logs.
+    """
+    if role is DispatchRole.DECOMPOSER:
+        return RouteDecision(
+            tier=ModelTier.HAIKU,
+            tools=(),
+            rationale=(
+                "Decomposition is structured-output planning; "
+                "HAIKU keeps the per-AC fixed cost low."
+            ),
+        )
+
+    if role is DispatchRole.EXECUTOR:
+        tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
+        return RouteDecision(
+            tier=tier,
+            tools=profile.suggested_tools,
+            rationale=(
+                "Executor: SONNET by default; escalate to OPUS on "
+                "FABRICATION_SUSPECTED retry per H7."
+                if not fabrication_retry
+                else "Executor: escalated one tier after FABRICATION_SUSPECTED."
+            ),
+        )
+
+    # role == VERIFIER
+    executor_tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
+    verifier_tier = _bump_tier(executor_tier)
+    return RouteDecision(
+        tier=verifier_tier,
+        # Read-only: verifier must not mutate state. Tools intentionally
+        # exclude Write/Edit/Bash; PR 9 plumbs these through the adapter.
+        tools=("Read", "Glob", "Grep"),
+        rationale=(
+            "Verifier runs one tier above the executor; read-only "
+            "toolset keeps the pass non-destructive."
+        ),
+    )
+
+
+__all__ = [
+    "DispatchRole",
+    "ModelTier",
+    "RouteDecision",
+    "decide_route",
+]

--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -3,7 +3,7 @@
 H5 moves model and tool selection out of skills and into the harness.
 The skill never picks a model. Each dispatch has a role (decomposer /
 executor / verifier), and the harness chooses an appropriate tier and
-tool set per role + profile + AC text.
+tool set per role + profile.
 
 Tiers are intentionally abstract strings rather than concrete model
 IDs — the integration PR (PR 9) maps `ModelTier.HAIKU / SONNET / OPUS`
@@ -11,13 +11,27 @@ onto the adapter's current model knobs. Decoupling lets profile
 authors think in cost/quality bands rather than vendor SKU drift.
 
 Routing rules at this PR:
-    decomposer  → HAIKU
+    decomposer  → HAIKU, no tools
     executor    → SONNET (default) or OPUS for FABRICATION_SUSPECTED
-                  retries (the H7 ESCALATE_MODEL hook)
-    verifier    → one tier above the executor (read-only, can afford it)
+                  retries (the H7 ESCALATE_MODEL hook).
+                  Tools come from profile.suggested_tools.
+    verifier    → one tier above the executor.
+                  Tools are hard-fixed to Read / Glob / Grep — these are
+                  the only operations the H1 read-only contract can
+                  guarantee at the routing layer. The router CANNOT
+                  authorize Bash on the verifier seam: Bash can mutate
+                  the workspace and the router can't inspect command
+                  text. Code-style profiles whose verifier_focus needs
+                  to execute the project's test command must route
+                  that through a dedicated read-only test runner (a
+                  separate follow-up PR), not via this generic
+                  verifier-tool envelope.
 
 This module is wiring-only. parallel_executor still uses its current
-hardcoded adapter call until PR 9.
+hardcoded adapter call until PR 9. The docstring previously claimed
+AC-aware routing — that is intentionally deferred; `decide_route()`
+takes role + profile + retry hint, no AC, until a profile actually
+demands per-AC routing logic (bot non-blocking suggestion on r2).
 """
 
 from __future__ import annotations
@@ -46,14 +60,14 @@ class ModelTier(StrEnum):
 
 _TIER_ORDER: tuple[ModelTier, ...] = (ModelTier.HAIKU, ModelTier.SONNET, ModelTier.OPUS)
 
-# Tools the verifier route MUST drop from the executor's profile tool
-# set. The H1 contract says the verifier is read-only with respect to
-# source files, so Edit/Write/NotebookEdit are filtered. Bash is *not*
-# in this set — code profile's verifier_focus says "Run the project's
-# test command", which requires Bash to be available. Whether a Bash
-# invocation is read-only is the verifier prompt's responsibility, not
-# the router's. (Bot finding on PR #889.)
-_VERIFIER_DENIED_TOOLS: frozenset[str] = frozenset({"Edit", "Write", "NotebookEdit", "MultiEdit"})
+# Tools available to a verifier at the routing layer. Strictly read-only
+# discovery tools — the H1 contract is that a verifier cannot mutate the
+# workspace, and the router cannot inspect Bash command text to enforce
+# that, so Bash is excluded structurally rather than delegated to prompt
+# obedience (bot finding on PR #889 r3 reversed r2's keep-Bash position).
+# Profiles whose verifier_focus needs subprocess test execution must
+# route through a dedicated read-only test runner — see module docstring.
+_VERIFIER_TOOLS: tuple[str, ...] = ("Read", "Glob", "Grep")
 
 
 @dataclass(frozen=True)
@@ -142,22 +156,20 @@ def decide_route(
     if role is DispatchRole.VERIFIER:
         executor_tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
         verifier_tier = _bump_tier(executor_tier)
-        # Derive verifier tools from the profile so domain-specific
-        # verifications work — e.g. the code profile's verifier_focus
-        # says "Run the project's test command", which needs Bash.
-        # Strip only the file-mutation tools; Bash and any read-only
-        # discovery tools (Read / Glob / Grep) pass through.
-        verifier_tools = tuple(
-            t for t in profile.suggested_tools if t not in _VERIFIER_DENIED_TOOLS
-        )
         return RouteDecision(
             tier=verifier_tier,
-            tools=verifier_tools,
+            # Hard-fixed read-only set. NOT derived from profile.
+            # Granting Bash here would let a verifier mutate the
+            # workspace via shell commands — the router cannot enforce
+            # read-only-ness on Bash invocations, so it must not
+            # authorize Bash at this seam. Subprocess-based verifier
+            # workflows route through a separate read-only test runner.
+            tools=_VERIFIER_TOOLS,
             rationale=(
                 f"Verifier runs one tier above the executor on "
-                f"{profile.profile!r} profile; profile tools minus "
-                f"{sorted(_VERIFIER_DENIED_TOOLS)} stay read-only with "
-                "respect to source files."
+                f"{profile.profile!r} profile; toolset hard-fixed to "
+                f"{list(_VERIFIER_TOOLS)} so the H1 read-only contract "
+                "is enforced structurally, not by prompt obedience."
             ),
         )
 

--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -69,36 +69,6 @@ _TIER_ORDER: tuple[ModelTier, ...] = (ModelTier.HAIKU, ModelTier.SONNET, ModelTi
 # route through a dedicated read-only test runner — see module docstring.
 _VERIFIER_TOOLS: tuple[str, ...] = ("Read", "Glob", "Grep")
 
-# Phrases in profile.verifier_focus that signal the verifier needs to
-# execute subprocesses (typically test commands). When detected, the
-# router raises NotImplementedError so the caller knows to plumb a
-# dedicated read-only test runner instead of silently routing a
-# profile whose verifier contract this seam cannot satisfy
-# (bot finding on #889 r4).
-_VERIFIER_SUBPROCESS_MARKERS: tuple[str, ...] = (
-    "test command",
-    "subprocess",
-    "shell command",
-    "pytest",
-)
-
-
-def _check_verifier_supported(profile: ExecutionProfile) -> None:
-    """Raise NotImplementedError if the profile needs subprocess verifier."""
-    focus_lower = profile.verifier_focus.lower()
-    for marker in _VERIFIER_SUBPROCESS_MARKERS:
-        if marker in focus_lower:
-            msg = (
-                f"Profile {profile.profile!r} declares verifier_focus that "
-                f"requires {marker!r} (subprocess execution). The current "
-                f"verifier route is hard-fixed to {list(_VERIFIER_TOOLS)} "
-                "to enforce H1 read-only-ness structurally, so it cannot "
-                "complete this profile's verifier contract. Wire a "
-                "dedicated read-only test runner before routing "
-                "DispatchRole.VERIFIER for this profile."
-            )
-            raise NotImplementedError(msg)
-
 
 @dataclass(frozen=True)
 class RouteDecision:
@@ -155,14 +125,15 @@ def decide_route(
             routing seam fails fast on unknown inputs (e.g. a raw
             string from config/JSON) rather than silently falling
             through to the verifier branch with the wrong tools.
-        NotImplementedError: For DispatchRole.VERIFIER when the
-            profile's verifier_focus requires subprocess invocation
-            (e.g. code profile's "Run the project's test command").
-            The current verifier-tool envelope is hard-fixed read-only
-            (Read/Glob/Grep) for H1 contract enforcement and cannot
-            satisfy such profiles — the caller must wire a dedicated
-            read-only test runner before using VERIFIER routing for
-            them.
+        NotImplementedError: For DispatchRole.VERIFIER. Routing
+            verifier dispatches requires a structured capability flag
+            on ExecutionProfile (read-only-discovery vs subprocess-
+            test-runner) that does not yet exist. Earlier rounds tried
+            substring-matching `verifier_focus` text — that was
+            rejected as fragile. The seam intentionally refuses to
+            guess; add a `verifier_capability` field to
+            ExecutionProfile (#881 follow-up) or plumb a custom
+            verifier dispatcher before using VERIFIER routing.
     """
     if not isinstance(role, DispatchRole):
         msg = (
@@ -196,30 +167,32 @@ def decide_route(
         )
 
     if role is DispatchRole.VERIFIER:
-        # Profiles whose verifier_focus needs subprocess execution
-        # cannot be satisfied by the read-only (Read/Glob/Grep) envelope
-        # this router enforces. Surface that explicitly instead of
-        # silently returning a route the verifier cannot complete (bot
-        # finding on #889 r4).
-        _check_verifier_supported(profile)
-        executor_tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
-        verifier_tier = _bump_tier(executor_tier)
-        return RouteDecision(
-            tier=verifier_tier,
-            # Hard-fixed read-only set. NOT derived from profile.
-            # Granting Bash here would let a verifier mutate the
-            # workspace via shell commands — the router cannot enforce
-            # read-only-ness on Bash invocations, so it must not
-            # authorize Bash at this seam. Subprocess-based verifier
-            # workflows route through a separate read-only test runner.
-            tools=_VERIFIER_TOOLS,
-            rationale=(
-                f"Verifier runs one tier above the executor on "
-                f"{profile.profile!r} profile; toolset hard-fixed to "
-                f"{list(_VERIFIER_TOOLS)} so the H1 read-only contract "
-                "is enforced structurally, not by prompt obedience."
-            ),
+        # ExecutionProfile does not yet expose a structured capability
+        # flag describing what verifier envelope each profile actually
+        # needs (read-only discovery vs subprocess test runner). The
+        # earlier rounds tried two approximations:
+        #   r3 — silently return (Read, Glob, Grep) for every profile.
+        #        Wrong for code profile whose verifier_focus needs
+        #        `pytest`.
+        #   r4 — substring-match `verifier_focus` for subprocess markers.
+        #        Fragile: prose changes break runtime behavior.
+        # Until ExecutionProfile carries a structured `verifier_capability`
+        # field, the honest answer at this seam is "I don't know what
+        # this profile needs". Fail fast so the caller (#891 wiring
+        # follow-ups) cannot accidentally route a verifier through an
+        # envelope that may not match the profile's contract
+        # (bot finding on #889 r5).
+        msg = (
+            f"DispatchRole.VERIFIER routing for profile "
+            f"{profile.profile!r} is not implemented: ExecutionProfile "
+            "does not yet expose a structured capability flag "
+            "(read-only-discovery vs subprocess-test-runner), and the "
+            "router will not infer it from free-form verifier_focus "
+            "text. Add a `verifier_capability` field to ExecutionProfile "
+            "(follow-up to #881) before wiring the verifier seam, or "
+            "plumb a custom verifier dispatcher for this profile."
         )
+        raise NotImplementedError(msg)
 
     # Exhaustive — every DispatchRole member handled above. Reached only
     # if a new role is added without updating decide_route.

--- a/tests/unit/orchestrator/test_routing.py
+++ b/tests/unit/orchestrator/test_routing.py
@@ -80,13 +80,35 @@ class TestVerifierRoute:
         )
         assert route.tier == ModelTier.OPUS
 
-    def test_read_only_tool_set(self, code_profile: ExecutionProfile) -> None:
+    def test_excludes_file_mutation_tools(self, code_profile: ExecutionProfile) -> None:
+        # H1 read-only contract is about source files. Edit/Write must
+        # be filtered out of the verifier tool set.
         route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
-        assert set(route.tools) == {"Read", "Glob", "Grep"}
-        # Mutating tools must not appear.
         assert "Edit" not in route.tools
         assert "Write" not in route.tools
+
+    def test_keeps_bash_for_code_profile(self, code_profile: ExecutionProfile) -> None:
+        # code profile's verifier_focus says "Run the project's test
+        # command". The verifier MUST be able to invoke Bash or the
+        # routing layer chooses a tool set that cannot satisfy its own
+        # verifier contract (bot finding on #889).
+        route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
+        assert "Bash" in route.tools
+
+    def test_verifier_tools_derived_from_profile(self) -> None:
+        # Research profile has no Bash; verifier tools should reflect
+        # that even though Bash is generally permitted for verifiers.
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        custom = load_profile("research").model_copy(
+            update={
+                "suggested_tools": ("Read", "Glob", "Grep"),
+                "evidence_schema": EvidenceSchema(),
+            }
+        )
+        route = decide_route(role=DispatchRole.VERIFIER, profile=custom)
         assert "Bash" not in route.tools
+        assert set(route.tools) == {"Read", "Glob", "Grep"}
 
 
 class TestRationaleStrings:

--- a/tests/unit/orchestrator/test_routing.py
+++ b/tests/unit/orchestrator/test_routing.py
@@ -66,39 +66,49 @@ class TestExecutorRoute:
 
 
 class TestVerifierRoute:
-    def test_default_one_tier_above_executor(self, code_profile: ExecutionProfile) -> None:
-        route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
+    def test_default_one_tier_above_executor(self, research_profile: ExecutionProfile) -> None:
+        # Use research (no subprocess verifier_focus marker) so the
+        # route is supported and we can assert the tier choice.
         # Default executor = SONNET → verifier = OPUS.
+        route = decide_route(role=DispatchRole.VERIFIER, profile=research_profile)
         assert route.tier == ModelTier.OPUS
 
-    def test_fabrication_caps_at_opus(self, code_profile: ExecutionProfile) -> None:
+    def test_fabrication_caps_at_opus(self, research_profile: ExecutionProfile) -> None:
         # Executor escalates to OPUS; verifier "one above" should cap there.
         route = decide_route(
             role=DispatchRole.VERIFIER,
-            profile=code_profile,
+            profile=research_profile,
             fabrication_retry=True,
         )
         assert route.tier == ModelTier.OPUS
 
-    def test_read_only_tool_set_enforced_structurally(self, code_profile: ExecutionProfile) -> None:
-        # Bot finding on #889 r3: H1 read-only contract is enforced at
-        # the routing layer, not delegated to prompt obedience. The
-        # verifier tool set is HARD-FIXED to read-only discovery tools
-        # regardless of what the profile lists. Bash is excluded
-        # structurally because the router cannot inspect Bash command
-        # text to verify a command is read-only.
-        route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
+    def test_read_only_tool_set_enforced_structurally(
+        self, research_profile: ExecutionProfile
+    ) -> None:
+        # H1 read-only contract is enforced at the routing layer, not
+        # delegated to prompt obedience. The verifier tool set is
+        # HARD-FIXED to read-only discovery tools regardless of what
+        # the profile lists. Bash is excluded structurally because the
+        # router cannot inspect Bash command text to verify a command
+        # is read-only.
+        route = decide_route(role=DispatchRole.VERIFIER, profile=research_profile)
         assert set(route.tools) == {"Read", "Glob", "Grep"}
         assert "Bash" not in route.tools
         assert "Edit" not in route.tools
         assert "Write" not in route.tools
 
+    def test_subprocess_verifier_focus_raises(self, code_profile: ExecutionProfile) -> None:
+        # Bot finding on #889 r4: code profile's verifier_focus says
+        # "Run the project's test command", which cannot be satisfied
+        # by the read-only verifier envelope. The router must surface
+        # that gap explicitly, not silently return an impossible route.
+        with pytest.raises(NotImplementedError, match="test command"):
+            decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
+
     def test_verifier_tools_ignore_profile_extensions(self) -> None:
-        # Even if a profile lists extra tools, the verifier seam does
-        # not grant them. Subprocess-based verifier needs (e.g. code
-        # profile's "Run the project's test command") route through a
-        # separate read-only test runner (follow-up PR), not via the
-        # verifier-tool envelope.
+        # Even if a profile lists extra tools (Bash/Edit), the verifier
+        # seam does not grant them. Use a profile whose verifier_focus
+        # does NOT mention subprocess so the route is supported.
         from ouroboros.orchestrator.profile_loader import EvidenceSchema
 
         custom = load_profile("research").model_copy(
@@ -112,9 +122,11 @@ class TestVerifierRoute:
 
 
 class TestRationaleStrings:
-    def test_each_route_has_rationale(self, code_profile: ExecutionProfile) -> None:
+    def test_each_route_has_rationale(self, research_profile: ExecutionProfile) -> None:
+        # Use research profile so VERIFIER route is supported (no
+        # subprocess marker in verifier_focus).
         for role in DispatchRole:
-            route = decide_route(role=role, profile=code_profile)
+            route = decide_route(role=role, profile=research_profile)
             assert route.rationale, f"{role} returned empty rationale"
 
 

--- a/tests/unit/orchestrator/test_routing.py
+++ b/tests/unit/orchestrator/test_routing.py
@@ -66,67 +66,27 @@ class TestExecutorRoute:
 
 
 class TestVerifierRoute:
-    def test_default_one_tier_above_executor(self, research_profile: ExecutionProfile) -> None:
-        # Use research (no subprocess verifier_focus marker) so the
-        # route is supported and we can assert the tier choice.
-        # Default executor = SONNET → verifier = OPUS.
-        route = decide_route(role=DispatchRole.VERIFIER, profile=research_profile)
-        assert route.tier == ModelTier.OPUS
-
-    def test_fabrication_caps_at_opus(self, research_profile: ExecutionProfile) -> None:
-        # Executor escalates to OPUS; verifier "one above" should cap there.
-        route = decide_route(
-            role=DispatchRole.VERIFIER,
-            profile=research_profile,
-            fabrication_retry=True,
-        )
-        assert route.tier == ModelTier.OPUS
-
-    def test_read_only_tool_set_enforced_structurally(
-        self, research_profile: ExecutionProfile
-    ) -> None:
-        # H1 read-only contract is enforced at the routing layer, not
-        # delegated to prompt obedience. The verifier tool set is
-        # HARD-FIXED to read-only discovery tools regardless of what
-        # the profile lists. Bash is excluded structurally because the
-        # router cannot inspect Bash command text to verify a command
-        # is read-only.
-        route = decide_route(role=DispatchRole.VERIFIER, profile=research_profile)
-        assert set(route.tools) == {"Read", "Glob", "Grep"}
-        assert "Bash" not in route.tools
-        assert "Edit" not in route.tools
-        assert "Write" not in route.tools
-
-    def test_subprocess_verifier_focus_raises(self, code_profile: ExecutionProfile) -> None:
-        # Bot finding on #889 r4: code profile's verifier_focus says
-        # "Run the project's test command", which cannot be satisfied
-        # by the read-only verifier envelope. The router must surface
-        # that gap explicitly, not silently return an impossible route.
-        with pytest.raises(NotImplementedError, match="test command"):
-            decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
-
-    def test_verifier_tools_ignore_profile_extensions(self) -> None:
-        # Even if a profile lists extra tools (Bash/Edit), the verifier
-        # seam does not grant them. Use a profile whose verifier_focus
-        # does NOT mention subprocess so the route is supported.
-        from ouroboros.orchestrator.profile_loader import EvidenceSchema
-
-        custom = load_profile("research").model_copy(
-            update={
-                "suggested_tools": ("Read", "Glob", "Grep", "Bash", "Edit"),
-                "evidence_schema": EvidenceSchema(),
-            }
-        )
-        route = decide_route(role=DispatchRole.VERIFIER, profile=custom)
-        assert set(route.tools) == {"Read", "Glob", "Grep"}
+    @pytest.mark.parametrize("profile_name", ["code", "research", "analysis"])
+    def test_verifier_routing_unimplemented(self, profile_name: str) -> None:
+        # Bot finding on #889 r5: without a structured
+        # verifier_capability field on ExecutionProfile, the router
+        # cannot honestly say what envelope each profile needs.
+        # Earlier rounds tried hard-fixed tools (wrong for code) and
+        # substring detection on verifier_focus prose (fragile). The
+        # honest answer is "not implemented" — fail fast so callers
+        # know to add the capability flag or plumb a custom verifier
+        # dispatcher before routing.
+        profile = load_profile(profile_name)
+        with pytest.raises(NotImplementedError, match="verifier_capability"):
+            decide_route(role=DispatchRole.VERIFIER, profile=profile)
 
 
 class TestRationaleStrings:
-    def test_each_route_has_rationale(self, research_profile: ExecutionProfile) -> None:
-        # Use research profile so VERIFIER route is supported (no
-        # subprocess marker in verifier_focus).
-        for role in DispatchRole:
-            route = decide_route(role=role, profile=research_profile)
+    def test_decomposer_and_executor_have_rationale(self, code_profile: ExecutionProfile) -> None:
+        # VERIFIER is intentionally unimplemented (see above), so only
+        # the two routes that return a RouteDecision are exercised.
+        for role in (DispatchRole.DECOMPOSER, DispatchRole.EXECUTOR):
+            route = decide_route(role=role, profile=code_profile)
             assert route.rationale, f"{role} returned empty rationale"
 
 

--- a/tests/unit/orchestrator/test_routing.py
+++ b/tests/unit/orchestrator/test_routing.py
@@ -1,0 +1,96 @@
+"""Tests for ouroboros.orchestrator.routing (RFC v2 #830, PR 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
+from ouroboros.orchestrator.routing import (
+    DispatchRole,
+    ModelTier,
+    decide_route,
+)
+
+
+@pytest.fixture
+def code_profile() -> ExecutionProfile:
+    return load_profile("code")
+
+
+@pytest.fixture
+def research_profile() -> ExecutionProfile:
+    return load_profile("research")
+
+
+class TestDecomposerRoute:
+    def test_uses_haiku(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(role=DispatchRole.DECOMPOSER, profile=code_profile)
+        assert route.tier == ModelTier.HAIKU
+
+    def test_empty_tool_set(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(role=DispatchRole.DECOMPOSER, profile=code_profile)
+        assert route.tools == ()
+
+    def test_decomposer_ignores_fabrication_flag(self, code_profile: ExecutionProfile) -> None:
+        plain = decide_route(role=DispatchRole.DECOMPOSER, profile=code_profile)
+        retry = decide_route(
+            role=DispatchRole.DECOMPOSER,
+            profile=code_profile,
+            fabrication_retry=True,
+        )
+        assert plain.tier == retry.tier == ModelTier.HAIKU
+
+
+class TestExecutorRoute:
+    def test_default_is_sonnet(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(role=DispatchRole.EXECUTOR, profile=code_profile)
+        assert route.tier == ModelTier.SONNET
+
+    def test_tools_come_from_profile(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(role=DispatchRole.EXECUTOR, profile=code_profile)
+        assert route.tools == code_profile.suggested_tools
+        assert "Read" in route.tools and "Edit" in route.tools
+
+    def test_research_profile_tools_distinct(self, research_profile: ExecutionProfile) -> None:
+        route = decide_route(role=DispatchRole.EXECUTOR, profile=research_profile)
+        # Research profile in #881 does not declare Edit.
+        assert "Edit" not in route.tools
+
+    def test_fabrication_retry_escalates_to_opus(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(
+            role=DispatchRole.EXECUTOR,
+            profile=code_profile,
+            fabrication_retry=True,
+        )
+        assert route.tier == ModelTier.OPUS
+
+
+class TestVerifierRoute:
+    def test_default_one_tier_above_executor(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
+        # Default executor = SONNET → verifier = OPUS.
+        assert route.tier == ModelTier.OPUS
+
+    def test_fabrication_caps_at_opus(self, code_profile: ExecutionProfile) -> None:
+        # Executor escalates to OPUS; verifier "one above" should cap there.
+        route = decide_route(
+            role=DispatchRole.VERIFIER,
+            profile=code_profile,
+            fabrication_retry=True,
+        )
+        assert route.tier == ModelTier.OPUS
+
+    def test_read_only_tool_set(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
+        assert set(route.tools) == {"Read", "Glob", "Grep"}
+        # Mutating tools must not appear.
+        assert "Edit" not in route.tools
+        assert "Write" not in route.tools
+        assert "Bash" not in route.tools
+
+
+class TestRationaleStrings:
+    def test_each_route_has_rationale(self, code_profile: ExecutionProfile) -> None:
+        for role in DispatchRole:
+            route = decide_route(role=role, profile=code_profile)
+            assert route.rationale, f"{role} returned empty rationale"

--- a/tests/unit/orchestrator/test_routing.py
+++ b/tests/unit/orchestrator/test_routing.py
@@ -80,34 +80,34 @@ class TestVerifierRoute:
         )
         assert route.tier == ModelTier.OPUS
 
-    def test_excludes_file_mutation_tools(self, code_profile: ExecutionProfile) -> None:
-        # H1 read-only contract is about source files. Edit/Write must
-        # be filtered out of the verifier tool set.
+    def test_read_only_tool_set_enforced_structurally(self, code_profile: ExecutionProfile) -> None:
+        # Bot finding on #889 r3: H1 read-only contract is enforced at
+        # the routing layer, not delegated to prompt obedience. The
+        # verifier tool set is HARD-FIXED to read-only discovery tools
+        # regardless of what the profile lists. Bash is excluded
+        # structurally because the router cannot inspect Bash command
+        # text to verify a command is read-only.
         route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
+        assert set(route.tools) == {"Read", "Glob", "Grep"}
+        assert "Bash" not in route.tools
         assert "Edit" not in route.tools
         assert "Write" not in route.tools
 
-    def test_keeps_bash_for_code_profile(self, code_profile: ExecutionProfile) -> None:
-        # code profile's verifier_focus says "Run the project's test
-        # command". The verifier MUST be able to invoke Bash or the
-        # routing layer chooses a tool set that cannot satisfy its own
-        # verifier contract (bot finding on #889).
-        route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
-        assert "Bash" in route.tools
-
-    def test_verifier_tools_derived_from_profile(self) -> None:
-        # Research profile has no Bash; verifier tools should reflect
-        # that even though Bash is generally permitted for verifiers.
+    def test_verifier_tools_ignore_profile_extensions(self) -> None:
+        # Even if a profile lists extra tools, the verifier seam does
+        # not grant them. Subprocess-based verifier needs (e.g. code
+        # profile's "Run the project's test command") route through a
+        # separate read-only test runner (follow-up PR), not via the
+        # verifier-tool envelope.
         from ouroboros.orchestrator.profile_loader import EvidenceSchema
 
         custom = load_profile("research").model_copy(
             update={
-                "suggested_tools": ("Read", "Glob", "Grep"),
+                "suggested_tools": ("Read", "Glob", "Grep", "Bash", "Edit"),
                 "evidence_schema": EvidenceSchema(),
             }
         )
         route = decide_route(role=DispatchRole.VERIFIER, profile=custom)
-        assert "Bash" not in route.tools
         assert set(route.tools) == {"Read", "Glob", "Grep"}
 
 

--- a/tests/unit/orchestrator/test_routing.py
+++ b/tests/unit/orchestrator/test_routing.py
@@ -94,3 +94,32 @@ class TestRationaleStrings:
         for role in DispatchRole:
             route = decide_route(role=role, profile=code_profile)
             assert route.rationale, f"{role} returned empty rationale"
+
+
+class TestRoleValidation:
+    """Unknown role types must fail fast, not silently route to VERIFIER.
+
+    Without this guard a raw string from config/JSON (e.g. "EXECUTOR")
+    would compare with `is` to the enum member, fall through every
+    `is` check, and silently end up on the verifier branch — wrong
+    model tier, wrong tools, no error.
+    """
+
+    def test_raw_string_rejected(self, code_profile: ExecutionProfile) -> None:
+        with pytest.raises(TypeError, match="DispatchRole"):
+            decide_route(role="EXECUTOR", profile=code_profile)  # type: ignore[arg-type]
+
+    def test_none_rejected(self, code_profile: ExecutionProfile) -> None:
+        with pytest.raises(TypeError, match="DispatchRole"):
+            decide_route(role=None, profile=code_profile)  # type: ignore[arg-type]
+
+    def test_int_rejected(self, code_profile: ExecutionProfile) -> None:
+        with pytest.raises(TypeError, match="DispatchRole"):
+            decide_route(role=0, profile=code_profile)  # type: ignore[arg-type]
+
+    def test_error_message_lists_valid_roles(self, code_profile: ExecutionProfile) -> None:
+        with pytest.raises(TypeError) as exc:
+            decide_route(role="VERIFIER", profile=code_profile)  # type: ignore[arg-type]
+        msg = str(exc.value)
+        for role in DispatchRole:
+            assert role.name in msg


### PR DESCRIPTION
## Summary

Seventh PR in the [#830](https://github.com/Q00/ouroboros/issues/830) RFC v2 stack. **Stacked on #887**.

Implements H5 (adaptive model/tool routing). Skills never pick a model; the harness chooses a tier per role + profile + H7 retry context.

## Routing rules

| Role | Tier | Tools | Notes |
|------|------|-------|-------|
| \`DECOMPOSER\` | \`HAIKU\` | none | Planning only; HAIKU keeps the per-AC fixed cost low |
| \`EXECUTOR\` | \`SONNET\` | \`profile.suggested_tools\` | Bumps to \`OPUS\` on \`fabrication_retry\` per H7's \`ESCALATE_MODEL\` |
| \`VERIFIER\` | One tier above executor (capped at \`OPUS\`) | \`Read\` / \`Glob\` / \`Grep\` only | Read-only so verifier cannot mutate state the executor produced |

## Why abstract tiers

\`ModelTier\` is an abstract band (\`HAIKU\` / \`SONNET\` / \`OPUS\`), not a concrete model ID. The adapter layer maps to vendor SKUs in PR 9. Profile authors think in cost/quality bands rather than SKU drift.

## Wiring scope

\`parallel_executor\` still uses its hardcoded adapter call until PR 9 plumbs \`decide_route\` through dispatch.

## Test plan

- [x] \`uv run pytest tests/unit/orchestrator/test_routing.py\` — 11 passed
- [x] \`uv run ruff check\` / \`ruff format --check\` — clean
- [x] \`uv run mypy src/ouroboros/orchestrator/routing.py\` — Success

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)