### PR TITLE
feat(orchestrator): per-dispatch context budget (#830 PR 8/9)

### DIFF
--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -144,17 +144,21 @@ def compose_context(
     if budget is None:
         budget = _DEFAULT_BUDGET
 
-    ac_stripped = ac.strip()
+    # The AC text is contract-bound to flow through verbatim — leading
+    # indentation, trailing newlines, and whitespace-significant
+    # fenced/code-block content carry prompt semantics the dispatch
+    # path must not rewrite. The summary is the only place where we
+    # apply .strip() (it's free prose).
     parent_stripped = parent_summary.strip()
 
     # The AC section is non-negotiable. Charge the header against the
     # budget here so the rendered output (which always carries the
     # "## AC\n" prefix) stays under total_chars.
-    ac_section_cost = len(_AC_HEADER) + len(ac_stripped)
+    ac_section_cost = len(_AC_HEADER) + len(ac)
     if ac_section_cost > budget.total_chars:
         msg = (
             f"AC alone exceeds context budget "
-            f"(ac={len(ac_stripped)} chars + header={len(_AC_HEADER)} "
+            f"(ac={len(ac)} chars + header={len(_AC_HEADER)} "
             f"> total={budget.total_chars}); decompose further before "
             "dispatching."
         )
@@ -197,7 +201,7 @@ def compose_context(
     return ComposedContext(
         parent_summary=summary,
         sibling_lines=tuple(sibling_lines),
-        ac=ac_stripped,
+        ac=ac,
         truncated=truncated,
     )
 

--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -170,7 +170,13 @@ def compose_context(
     sibling_lines: list[str] = []
     sibling_overhead = len(_SIBLING_HEADER) + len(_SECTION_JOINER)
     sibling_inner = 0  # bytes inside the section (lines + newline joins).
-    sibling_ceiling = budget.total_chars - budget.parent_summary_reserve
+    # The parent-summary reserve is a floor only when there's a parent
+    # summary to place. With no parent, withholding the reserve from
+    # siblings would silently discard sibling status that fits in the
+    # total budget (bot finding on #890 r2).
+    sibling_ceiling = budget.total_chars
+    if parent_stripped:
+        sibling_ceiling -= budget.parent_summary_reserve
     for sib in siblings:
         line = sib.to_line()
         # `\n` joiner between sibling lines, only after the first.

--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -170,19 +170,21 @@ def compose_context(
     sibling_lines: list[str] = []
     sibling_overhead = len(_SIBLING_HEADER) + len(_SECTION_JOINER)
     sibling_inner = 0  # bytes inside the section (lines + newline joins).
-    # The parent-summary reserve is a floor only when there's a parent
-    # summary to place. With no parent, withholding the reserve from
-    # siblings would silently discard sibling status that fits in the
-    # total budget (bot finding on #890 r2). When a parent IS present,
-    # the reserve must also account for the parent section's own
-    # render overhead ("## Parent context\n" + "\n\n"); otherwise
-    # siblings can eat into bytes meant for the parent header, and
-    # the actual parent_summary content lands below the reserved size
-    # (bot finding on #890 r3).
     parent_overhead = len(_PARENT_HEADER) + len(_SECTION_JOINER)
+    # The parent_summary_reserve is a *floor* for the parent's content,
+    # not a hard pre-allocation. Subtract from the sibling ceiling only
+    # what the parent will actually occupy:
+    #   - no parent: subtract 0 (bot finding on r2)
+    #   - parent shorter than reserve: subtract len(parent) + overhead
+    #     so the unused reserve goes to siblings (bot finding on r3 round 2)
+    #   - parent at-or-above reserve: subtract reserve + overhead
+    #     so the floor is honored (bot finding on r2 round 2)
+    # The parent can still grow beyond its reserve later if siblings
+    # under-consume the remaining budget.
     sibling_ceiling = budget.total_chars
     if parent_stripped:
-        sibling_ceiling -= budget.parent_summary_reserve + parent_overhead
+        parent_floor = min(len(parent_stripped), budget.parent_summary_reserve)
+        sibling_ceiling -= parent_floor + parent_overhead
     for sib in siblings:
         line = sib.to_line()
         # `\n` joiner between sibling lines, only after the first.

--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -27,6 +27,14 @@ from dataclasses import dataclass
 DEFAULT_TOTAL_CHARS: int = 12_000
 DEFAULT_PARENT_SUMMARY_RESERVE: int = 1_500
 _TRUNCATED_SUFFIX: str = "\n…[truncated by context governor]"
+
+# Fixed overheads that ComposedContext.render() introduces. The budget
+# must charge against these so the rendered output stays under the
+# advertised hard limit.
+_AC_HEADER: str = "## AC\n"
+_PARENT_HEADER: str = "## Parent context\n"
+_SIBLING_HEADER: str = "## Sibling status\n"
+_SECTION_JOINER: str = "\n\n"
 # Module-level singleton so callers can pass-through "use defaults" without
 # constructing the frozen dataclass in argument defaults (ruff B008).
 _DEFAULT_BUDGET: ContextBudget
@@ -135,34 +143,61 @@ def compose_context(
     """
     if budget is None:
         budget = _DEFAULT_BUDGET
-    used = len(ac.strip())
-    if used > budget.total_chars:
-        # The caller violated the precondition. Don't try to salvage —
-        # the orchestrator must split the AC further first.
+
+    ac_stripped = ac.strip()
+    parent_stripped = parent_summary.strip()
+
+    # The AC section is non-negotiable. Charge the header against the
+    # budget here so the rendered output (which always carries the
+    # "## AC\n" prefix) stays under total_chars.
+    ac_section_cost = len(_AC_HEADER) + len(ac_stripped)
+    if ac_section_cost > budget.total_chars:
         msg = (
             f"AC alone exceeds context budget "
-            f"(ac={used} chars > total={budget.total_chars}); "
-            "decompose further before dispatching."
+            f"(ac={len(ac_stripped)} chars + header={len(_AC_HEADER)} "
+            f"> total={budget.total_chars}); decompose further before "
+            "dispatching."
         )
         raise ValueError(msg)
+    used = ac_section_cost
 
+    # Sibling section bookkeeping: include the header + section-joiner
+    # cost only if at least one sibling line lands in the output.
     sibling_lines: list[str] = []
+    sibling_overhead = len(_SIBLING_HEADER) + len(_SECTION_JOINER)
+    sibling_inner = 0  # bytes inside the section (lines + newline joins).
     sibling_ceiling = budget.total_chars - budget.parent_summary_reserve
     for sib in siblings:
         line = sib.to_line()
-        cost = len(line) + 1  # +1 for the newline join
-        if used + cost > sibling_ceiling:
+        # `\n` joiner between sibling lines, only after the first.
+        joiner_cost = 1 if sibling_lines else 0
+        prospective_section = sibling_overhead + sibling_inner + joiner_cost + len(line)
+        if used + prospective_section > sibling_ceiling:
             break
+        sibling_inner += joiner_cost + len(line)
         sibling_lines.append(line)
-        used += cost
+    if sibling_lines:
+        used += sibling_overhead + sibling_inner
 
-    remaining = budget.total_chars - used
-    summary, truncated = _truncate(parent_summary.strip(), max(0, remaining))
+    # Parent summary section: header + joiner only count if the summary
+    # actually lands. Without enough room for the header itself, the
+    # summary is dropped entirely and the flag is set so callers can
+    # log it.
+    parent_overhead = len(_PARENT_HEADER) + len(_SECTION_JOINER)
+    remaining_for_parent = budget.total_chars - used
+    if parent_stripped and remaining_for_parent > parent_overhead:
+        summary_budget = remaining_for_parent - parent_overhead
+        summary, truncated = _truncate(parent_stripped, summary_budget)
+    elif parent_stripped:
+        # Not enough headroom even for the parent header — drop it.
+        summary, truncated = "", True
+    else:
+        summary, truncated = "", False
 
     return ComposedContext(
         parent_summary=summary,
         sibling_lines=tuple(sibling_lines),
-        ac=ac.strip(),
+        ac=ac_stripped,
         truncated=truncated,
     )
 

--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -165,12 +165,41 @@ def compose_context(
         raise ValueError(msg)
     used = ac_section_cost
 
+    # Reserve honoring is a documented guarantee, not best-effort. If
+    # the AC alone leaves less than parent_overhead + the parent's
+    # actual content floor, the budget is structurally impossible —
+    # fail fast so the caller knows to either shrink the AC or raise
+    # the total. Silently returning an empty parent_summary with
+    # truncated=True would violate the API's "guaranteed minimum"
+    # contract (bot finding on #890 r4 round 2).
+    parent_overhead = len(_PARENT_HEADER) + len(_SECTION_JOINER)
+    parent_stripped_len = len(parent_stripped)
+    # Reserve honoring is a documented guarantee, not best-effort —
+    # only when the caller explicitly asked for one (reserve > 0). If
+    # the AC alone leaves less than parent_overhead + the parent's
+    # actual content floor, the budget is structurally impossible —
+    # fail fast so the caller knows to either shrink the AC or raise
+    # the total. With reserve=0 the parent is best-effort, so silent
+    # truncation is the right behavior (bot finding on #890 r4 round 2).
+    if parent_stripped and budget.parent_summary_reserve > 0:
+        parent_floor = min(parent_stripped_len, budget.parent_summary_reserve)
+        required_for_parent = parent_overhead + parent_floor
+        if ac_section_cost + required_for_parent > budget.total_chars:
+            msg = (
+                f"Budget cannot honor parent_summary_reserve="
+                f"{budget.parent_summary_reserve}: ac_section="
+                f"{ac_section_cost} + parent_overhead={parent_overhead} + "
+                f"parent_floor={parent_floor} > total="
+                f"{budget.total_chars}. Either shrink the AC or raise "
+                "total_chars / lower parent_summary_reserve."
+            )
+            raise ValueError(msg)
+
     # Sibling section bookkeeping: include the header + section-joiner
     # cost only if at least one sibling line lands in the output.
     sibling_lines: list[str] = []
     sibling_overhead = len(_SIBLING_HEADER) + len(_SECTION_JOINER)
     sibling_inner = 0  # bytes inside the section (lines + newline joins).
-    parent_overhead = len(_PARENT_HEADER) + len(_SECTION_JOINER)
     # The parent_summary_reserve is a *floor* for the parent's content,
     # not a hard pre-allocation. Subtract from the sibling ceiling only
     # what the parent will actually occupy:

--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -204,6 +204,11 @@ def compose_context(
     # not a hard pre-allocation. Subtract from the sibling ceiling only
     # what the parent will actually occupy:
     #   - no parent: subtract 0 (bot finding on r2)
+    #   - reserve == 0 with a parent: subtract 0. The parent is then
+    #     best-effort and consumes only leftover budget; siblings have
+    #     priority. Subtracting parent_overhead would let an optional
+    #     parent section drop sibling lines, violating the
+    #     "best-effort parent" contract (bot finding on r8).
     #   - parent shorter than reserve: subtract len(parent) + overhead
     #     so the unused reserve goes to siblings (bot finding on r3 round 2)
     #   - parent at-or-above reserve: subtract reserve + overhead
@@ -211,7 +216,7 @@ def compose_context(
     # The parent can still grow beyond its reserve later if siblings
     # under-consume the remaining budget.
     sibling_ceiling = budget.total_chars
-    if parent_stripped:
+    if parent_stripped and budget.parent_summary_reserve > 0:
         parent_floor = min(len(parent_stripped), budget.parent_summary_reserve)
         sibling_ceiling -= parent_floor + parent_overhead
     for sib in siblings:

--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -1,0 +1,180 @@
+"""Per-dispatch context budget governance (RFC v2 H6, #830).
+
+H6 keeps the harness in control of what flows into each leaf dispatch.
+Without governance, the layered PRE/POST wrappers (H3) plus profile
+metadata plus sibling status plus parent summary plus the AC text plus
+the body can balloon a single dispatch well past a healthy budget.
+
+This module gives the dispatch path a single, deterministic place to
+compose those segments, summarise sibling status to status lines
+(never bodies), and trim parent context when the budget is tight.
+
+The budget is measured in characters here rather than tokens. Char
+budgets are deterministic, profile-author-readable, and good enough
+for the structural guardrail H6 is about — tightening to tokenizer
+counts can come later when there's evidence the char approximation
+misses something load-bearing.
+
+This PR is wiring-only. parallel_executor still composes context
+ad-hoc until PR 9 routes context assembly through compose_context.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+DEFAULT_TOTAL_CHARS: int = 12_000
+DEFAULT_PARENT_SUMMARY_RESERVE: int = 1_500
+_TRUNCATED_SUFFIX: str = "\n…[truncated by context governor]"
+# Module-level singleton so callers can pass-through "use defaults" without
+# constructing the frozen dataclass in argument defaults (ruff B008).
+_DEFAULT_BUDGET: ContextBudget
+
+
+@dataclass(frozen=True)
+class ContextBudget:
+    """Per-dispatch budget knobs.
+
+    Attributes:
+        total_chars: Hard upper bound on the composed context size.
+        parent_summary_reserve: Minimum chars guaranteed for the
+            parent summary even when the total budget is tight.
+    """
+
+    total_chars: int = DEFAULT_TOTAL_CHARS
+    parent_summary_reserve: int = DEFAULT_PARENT_SUMMARY_RESERVE
+
+    def __post_init__(self) -> None:
+        if self.total_chars <= 0:
+            msg = f"total_chars must be positive, got {self.total_chars}"
+            raise ValueError(msg)
+        if self.parent_summary_reserve < 0:
+            msg = f"parent_summary_reserve must be >= 0, got {self.parent_summary_reserve}"
+            raise ValueError(msg)
+        if self.parent_summary_reserve > self.total_chars:
+            msg = (
+                f"parent_summary_reserve ({self.parent_summary_reserve}) "
+                f"cannot exceed total_chars ({self.total_chars})"
+            )
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class SiblingStatus:
+    """One-line status of a sibling AC.
+
+    Carries the minimum signal the leaf needs (id, accepted) without
+    pulling in the sibling's body or evidence record.
+    """
+
+    sibling_id: str
+    accepted: bool
+    headline: str = ""
+
+    def to_line(self) -> str:
+        marker = "✓" if self.accepted else "✗"
+        head = f": {self.headline.strip()}" if self.headline else ""
+        return f"{marker} {self.sibling_id}{head}"
+
+
+@dataclass(frozen=True)
+class ComposedContext:
+    """Output of compose_context — the dispatch path renders this."""
+
+    parent_summary: str
+    sibling_lines: tuple[str, ...]
+    ac: str
+    truncated: bool
+
+    def render(self) -> str:
+        parts: list[str] = []
+        if self.parent_summary:
+            parts.append(f"## Parent context\n{self.parent_summary}")
+        if self.sibling_lines:
+            parts.append(
+                "## Sibling status\n" + "\n".join(self.sibling_lines),
+            )
+        parts.append(f"## AC\n{self.ac}")
+        return "\n\n".join(parts)
+
+
+def _truncate(text: str, limit: int) -> tuple[str, bool]:
+    """Hard char-truncate `text` to `limit`, marking when it happened."""
+    if len(text) <= limit:
+        return text, False
+    if limit <= len(_TRUNCATED_SUFFIX):
+        return text[:limit], True
+    head = text[: limit - len(_TRUNCATED_SUFFIX)]
+    return head + _TRUNCATED_SUFFIX, True
+
+
+def compose_context(
+    *,
+    ac: str,
+    parent_summary: str = "",
+    siblings: Iterable[SiblingStatus] = (),
+    budget: ContextBudget | None = None,
+) -> ComposedContext:
+    """Assemble a single dispatch's context under the budget.
+
+    Order of operations:
+        1. AC text is non-negotiable; it goes in verbatim. If the AC
+           alone exceeds the budget, callers must have decomposed it
+           further before reaching this point — that is the
+           orchestrator's responsibility, not this module's.
+        2. Sibling lines are appended one at a time until they would
+           push the running total past (budget - parent_summary_reserve).
+           Status lines stay terse by construction (no bodies).
+        3. Parent summary is truncated to whatever space remains.
+
+    The result is a `ComposedContext` whose `.render()` produces the
+    final string. `truncated` is True when the parent summary was
+    char-truncated; siblings dropped silently due to budget pressure
+    do not set the flag (the dropped lines were never load-bearing).
+    """
+    if budget is None:
+        budget = _DEFAULT_BUDGET
+    used = len(ac.strip())
+    if used > budget.total_chars:
+        # The caller violated the precondition. Don't try to salvage —
+        # the orchestrator must split the AC further first.
+        msg = (
+            f"AC alone exceeds context budget "
+            f"(ac={used} chars > total={budget.total_chars}); "
+            "decompose further before dispatching."
+        )
+        raise ValueError(msg)
+
+    sibling_lines: list[str] = []
+    sibling_ceiling = budget.total_chars - budget.parent_summary_reserve
+    for sib in siblings:
+        line = sib.to_line()
+        cost = len(line) + 1  # +1 for the newline join
+        if used + cost > sibling_ceiling:
+            break
+        sibling_lines.append(line)
+        used += cost
+
+    remaining = budget.total_chars - used
+    summary, truncated = _truncate(parent_summary.strip(), max(0, remaining))
+
+    return ComposedContext(
+        parent_summary=summary,
+        sibling_lines=tuple(sibling_lines),
+        ac=ac.strip(),
+        truncated=truncated,
+    )
+
+
+_DEFAULT_BUDGET = ContextBudget()
+
+
+__all__ = [
+    "DEFAULT_PARENT_SUMMARY_RESERVE",
+    "DEFAULT_TOTAL_CHARS",
+    "ComposedContext",
+    "ContextBudget",
+    "SiblingStatus",
+    "compose_context",
+]

--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -173,10 +173,16 @@ def compose_context(
     # The parent-summary reserve is a floor only when there's a parent
     # summary to place. With no parent, withholding the reserve from
     # siblings would silently discard sibling status that fits in the
-    # total budget (bot finding on #890 r2).
+    # total budget (bot finding on #890 r2). When a parent IS present,
+    # the reserve must also account for the parent section's own
+    # render overhead ("## Parent context\n" + "\n\n"); otherwise
+    # siblings can eat into bytes meant for the parent header, and
+    # the actual parent_summary content lands below the reserved size
+    # (bot finding on #890 r3).
+    parent_overhead = len(_PARENT_HEADER) + len(_SECTION_JOINER)
     sibling_ceiling = budget.total_chars
     if parent_stripped:
-        sibling_ceiling -= budget.parent_summary_reserve
+        sibling_ceiling -= budget.parent_summary_reserve + parent_overhead
     for sib in siblings:
         line = sib.to_line()
         # `\n` joiner between sibling lines, only after the first.
@@ -192,8 +198,8 @@ def compose_context(
     # Parent summary section: header + joiner only count if the summary
     # actually lands. Without enough room for the header itself, the
     # summary is dropped entirely and the flag is set so callers can
-    # log it.
-    parent_overhead = len(_PARENT_HEADER) + len(_SECTION_JOINER)
+    # log it. (parent_overhead defined above when computing
+    # sibling_ceiling.)
     remaining_for_parent = budget.total_chars - used
     if parent_stripped and remaining_for_parent > parent_overhead:
         summary_budget = remaining_for_parent - parent_overhead

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -1,0 +1,139 @@
+"""Tests for ouroboros.orchestrator.context_governor (RFC v2 #830, PR 8)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.context_governor import (
+    DEFAULT_TOTAL_CHARS,
+    ComposedContext,
+    ContextBudget,
+    SiblingStatus,
+    compose_context,
+)
+
+
+class TestBudgetInvariants:
+    def test_non_positive_total_rejected(self) -> None:
+        with pytest.raises(ValueError, match="total_chars must be positive"):
+            ContextBudget(total_chars=0)
+
+    def test_negative_reserve_rejected(self) -> None:
+        with pytest.raises(ValueError, match="parent_summary_reserve must be >= 0"):
+            ContextBudget(total_chars=1000, parent_summary_reserve=-1)
+
+    def test_reserve_exceeds_total_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cannot exceed total_chars"):
+            ContextBudget(total_chars=100, parent_summary_reserve=200)
+
+    def test_defaults_are_safe(self) -> None:
+        budget = ContextBudget()
+        assert budget.total_chars == DEFAULT_TOTAL_CHARS
+        assert budget.parent_summary_reserve <= budget.total_chars
+
+
+class TestSiblingStatus:
+    def test_accepted_marker(self) -> None:
+        line = SiblingStatus("AC1", accepted=True, headline="added cache").to_line()
+        assert "✓" in line
+        assert "AC1" in line
+        assert "added cache" in line
+
+    def test_failed_marker(self) -> None:
+        line = SiblingStatus("AC2", accepted=False).to_line()
+        assert "✗" in line
+        assert "AC2" in line
+
+
+class TestComposedContext:
+    def test_render_sections(self) -> None:
+        ctx = ComposedContext(
+            parent_summary="parent",
+            sibling_lines=("✓ AC1: done", "✗ AC2"),
+            ac="this AC",
+            truncated=False,
+        )
+        rendered = ctx.render()
+        assert "## Parent context\nparent" in rendered
+        assert "## Sibling status" in rendered
+        assert "✓ AC1: done" in rendered
+        assert rendered.endswith("## AC\nthis AC")
+
+    def test_render_omits_empty_sections(self) -> None:
+        ctx = ComposedContext(parent_summary="", sibling_lines=(), ac="bare", truncated=False)
+        rendered = ctx.render()
+        assert "## Parent context" not in rendered
+        assert "## Sibling status" not in rendered
+        assert "## AC\nbare" in rendered
+
+
+class TestComposeContext:
+    def test_under_budget_keeps_everything(self) -> None:
+        result = compose_context(
+            ac="do the thing",
+            parent_summary="we are building X",
+            siblings=[SiblingStatus("AC1", accepted=True)],
+            budget=ContextBudget(total_chars=10_000, parent_summary_reserve=500),
+        )
+        assert result.parent_summary == "we are building X"
+        assert result.sibling_lines == ("✓ AC1",)
+        assert result.ac == "do the thing"
+        assert result.truncated is False
+
+    def test_parent_summary_truncated_when_tight(self) -> None:
+        big_summary = "x" * 5000
+        result = compose_context(
+            ac="ac",
+            parent_summary=big_summary,
+            budget=ContextBudget(total_chars=300, parent_summary_reserve=200),
+        )
+        assert result.truncated is True
+        assert len(result.parent_summary) <= 300
+        assert "truncated" in result.parent_summary
+
+    def test_sibling_lines_dropped_under_pressure(self) -> None:
+        siblings = [SiblingStatus(f"AC{i}", accepted=True, headline="x" * 80) for i in range(20)]
+        result = compose_context(
+            ac="ac",
+            parent_summary="",
+            siblings=siblings,
+            budget=ContextBudget(total_chars=500, parent_summary_reserve=200),
+        )
+        # Some siblings made it; the rest were dropped silently.
+        assert 0 < len(result.sibling_lines) < 20
+        # Dropping siblings does NOT set the truncation flag — those
+        # lines were status-only and not load-bearing.
+        assert result.truncated is False
+
+    def test_ac_over_budget_raises(self) -> None:
+        with pytest.raises(ValueError, match="AC alone exceeds context budget"):
+            compose_context(
+                ac="x" * 5000,
+                budget=ContextBudget(total_chars=1000, parent_summary_reserve=100),
+            )
+
+    def test_render_round_trip(self) -> None:
+        result = compose_context(
+            ac="ac body",
+            parent_summary="summary",
+            siblings=[SiblingStatus("AC1", accepted=True)],
+        )
+        rendered = result.render()
+        assert "ac body" in rendered
+        assert "summary" in rendered
+        assert "AC1" in rendered
+
+    def test_strips_whitespace_from_ac_and_summary(self) -> None:
+        result = compose_context(
+            ac="   ac body\n\n",
+            parent_summary="\n  summary\n",
+        )
+        assert result.ac == "ac body"
+        assert result.parent_summary == "summary"
+
+    def test_empty_inputs(self) -> None:
+        result = compose_context(ac="ac")
+        assert result.parent_summary == ""
+        assert result.sibling_lines == ()
+        assert result.ac == "ac"
+        assert result.truncated is False

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -186,6 +186,41 @@ class TestRenderedSizeContract:
         assert result.truncated is True
         assert len(result.render()) <= 30
 
+    def test_unused_parent_reserve_redistributes_to_siblings(self) -> None:
+        # Bot finding on #890 r2: with no parent summary present, the
+        # reserve must not gate siblings out of space they could
+        # otherwise occupy. Setup: total=120, parent_reserve=60, AC=2
+        # chars, no parent_summary. Previously only one sibling line
+        # fit because the ceiling subtracted the reserve unconditionally.
+        siblings = [SiblingStatus(f"AC{i}", accepted=True, headline="x" * 5) for i in range(5)]
+        result = compose_context(
+            ac="ac",
+            parent_summary="",
+            siblings=siblings,
+            budget=ContextBudget(total_chars=120, parent_summary_reserve=60),
+        )
+        # Without the fix this dropped to 1 line and rendered ~45 chars
+        # of 120 budget. With redistribution, multiple lines fit.
+        assert len(result.sibling_lines) >= 3, (
+            f"only {len(result.sibling_lines)} siblings placed; the "
+            f"reserve must not block them when parent_summary is empty"
+        )
+        assert len(result.render()) <= 120
+
+    def test_reserve_still_applies_when_parent_present(self) -> None:
+        # Symmetric guarantee: when a parent summary IS present, the
+        # reserve still acts as a floor — siblings cannot eat into it.
+        siblings = [SiblingStatus(f"AC{i}", accepted=True, headline="x" * 100) for i in range(20)]
+        result = compose_context(
+            ac="ac",
+            parent_summary="parent content here",
+            siblings=siblings,
+            budget=ContextBudget(total_chars=200, parent_summary_reserve=50),
+        )
+        # Parent summary got at least its reserve.
+        assert len(result.parent_summary) > 0
+        assert len(result.render()) <= 200
+
     def test_sibling_section_overhead_charged(self) -> None:
         # Budget large enough for AC + one sibling line but NOT enough
         # for the sibling header — the line must be dropped.

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -221,6 +221,31 @@ class TestRenderedSizeContract:
         assert len(result.parent_summary) > 0
         assert len(result.render()) <= 200
 
+    def test_short_parent_does_not_starve_siblings(self) -> None:
+        # Bot finding on #890 r4: when parent_summary is non-empty but
+        # SHORTER than parent_summary_reserve, the previous code still
+        # withheld the full reserve from the sibling ceiling, leaving
+        # usable budget idle and dropping siblings that would otherwise
+        # fit. Repro from the bot:
+        #   total=120, reserve=60, ac="ac", parent="p" (1 char), 7
+        #   siblings with 5-char headlines — previous code kept only 1
+        #   sibling line and rendered 59 chars (61 idle).
+        result = compose_context(
+            ac="ac",
+            parent_summary="p",
+            siblings=[SiblingStatus(str(i), accepted=True, headline="xxxxx") for i in range(7)],
+            budget=ContextBudget(total_chars=120, parent_summary_reserve=60),
+        )
+        # Parent's content is 1 char so the floor it actually needs is
+        # tiny; siblings should be able to consume the rest.
+        assert len(result.sibling_lines) >= 4, (
+            f"only {len(result.sibling_lines)} siblings placed; the "
+            f"reserve must collapse to the parent's actual size when "
+            f"the parent is shorter than the reserve"
+        )
+        assert result.parent_summary == "p"
+        assert len(result.render()) <= 120
+
     def test_parent_actual_content_meets_reserve_floor(self) -> None:
         # Bot finding on #890 r3: the reserve was applied to the
         # sibling ceiling without accounting for the parent section

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -123,12 +123,14 @@ class TestComposeContext:
         assert "summary" in rendered
         assert "AC1" in rendered
 
-    def test_strips_whitespace_from_ac_and_summary(self) -> None:
-        result = compose_context(
-            ac="   ac body\n\n",
-            parent_summary="\n  summary\n",
-        )
-        assert result.ac == "ac body"
+    def test_ac_preserved_verbatim(self) -> None:
+        # The AC text carries prompt semantics (leading indentation,
+        # trailing newlines, whitespace-significant fenced blocks).
+        # The governor must NOT rewrite it (bot finding on #890 round 2).
+        raw_ac = "   ac body\n\n"
+        result = compose_context(ac=raw_ac, parent_summary="\n  summary\n")
+        assert result.ac == raw_ac
+        # The parent summary IS free prose and may be stripped.
         assert result.parent_summary == "summary"
 
     def test_empty_inputs(self) -> None:

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -137,3 +137,65 @@ class TestComposeContext:
         assert result.sibling_lines == ()
         assert result.ac == "ac"
         assert result.truncated is False
+
+
+class TestRenderedSizeContract:
+    """`compose_context` must keep the *rendered* output under `total_chars`.
+
+    This is the contract the H6 governor advertises. Earlier versions
+    budgeted only the raw payloads and let section headers / joiners
+    push the rendered output over the limit (bot finding on PR #890).
+    """
+
+    @pytest.mark.parametrize("total", [64, 128, 256, 512, 1024, 4096])
+    def test_render_fits_budget(self, total: int) -> None:
+        result = compose_context(
+            ac="x" * (total // 4),
+            parent_summary="y" * total,  # over-large; will be truncated.
+            siblings=[
+                SiblingStatus(f"AC{i}", accepted=(i % 2 == 0), headline="z" * 20) for i in range(8)
+            ],
+            budget=ContextBudget(total_chars=total, parent_summary_reserve=total // 4),
+        )
+        assert len(result.render()) <= total, (
+            f"rendered size {len(result.render())} exceeds budget {total}; "
+            f"rendered=\n{result.render()!r}"
+        )
+
+    def test_ac_plus_header_over_budget_raises(self) -> None:
+        # The AC fits raw but pushes past once the "## AC\n" header is
+        # added; the governor must reject rather than silently overflow.
+        with pytest.raises(ValueError, match="AC alone exceeds"):
+            compose_context(
+                ac="x" * 100,
+                budget=ContextBudget(total_chars=100, parent_summary_reserve=0),
+            )
+
+    def test_parent_dropped_when_header_does_not_fit(self) -> None:
+        # 30-char budget: AC ("## AC\nshort" = 11 chars) leaves 19 chars
+        # remaining, which is less than the parent header (20). So the
+        # summary must be dropped and `truncated` set.
+        result = compose_context(
+            ac="short",
+            parent_summary="parent",
+            budget=ContextBudget(total_chars=30, parent_summary_reserve=0),
+        )
+        assert result.parent_summary == ""
+        assert result.truncated is True
+        assert len(result.render()) <= 30
+
+    def test_sibling_section_overhead_charged(self) -> None:
+        # Budget large enough for AC + one sibling line but NOT enough
+        # for the sibling header — the line must be dropped.
+        ac = "ac"
+        # "## AC\nac" = 8 chars. Sibling header alone = 18 chars.
+        # Budget = 28 leaves 20 chars after AC, which is more than the
+        # header (18) plus joiner (2) = 20 — but no room for any line.
+        result = compose_context(
+            ac=ac,
+            siblings=[SiblingStatus("AC1", accepted=True, headline="x" * 50)],
+            budget=ContextBudget(total_chars=30, parent_summary_reserve=0),
+        )
+        # Either the sibling line fit (with whatever room remains) or
+        # it was dropped — but the rendered output must stay <= budget.
+        assert len(result.render()) <= 30

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -221,6 +221,32 @@ class TestRenderedSizeContract:
         assert len(result.parent_summary) > 0
         assert len(result.render()) <= 200
 
+    def test_parent_actual_content_meets_reserve_floor(self) -> None:
+        # Bot finding on #890 r3: the reserve was applied to the
+        # sibling ceiling without accounting for the parent section
+        # header + joiner overhead. Siblings could therefore eat into
+        # the 20 chars of "## Parent context\n\n" overhead, and the
+        # actual parent_summary content would land below the
+        # advertised reserve.
+        #
+        # Bot's exact repro: total=100, reserve=50, ac='a', one sibling
+        # with 16-char headline, non-empty parent. The previous
+        # behavior returned a 100-char render with parent_summary only
+        # 30 chars long — 20 chars short of the reserved 50.
+        large_parent = "x" * 200
+        result = compose_context(
+            ac="a",
+            parent_summary=large_parent,
+            siblings=[SiblingStatus("AC1", accepted=True, headline="x" * 16)],
+            budget=ContextBudget(total_chars=100, parent_summary_reserve=50),
+        )
+        assert len(result.parent_summary) >= 50, (
+            f"parent_summary={len(result.parent_summary)} chars violates "
+            f"the reserve=50 floor; the sibling allocator must charge "
+            "parent_overhead too"
+        )
+        assert len(result.render()) <= 100
+
     def test_sibling_section_overhead_charged(self) -> None:
         # Budget large enough for AC + one sibling line but NOT enough
         # for the sibling header — the line must be dropped.

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -246,6 +246,32 @@ class TestRenderedSizeContract:
         assert result.parent_summary == "p"
         assert len(result.render()) <= 120
 
+    def test_impossible_reserve_raises(self) -> None:
+        # Bot finding on #890 r4 round 2: when the AC alone leaves less
+        # than parent_overhead + parent_summary_reserve, the function
+        # used to silently return parent_summary="" with truncated=True,
+        # violating the API's "guaranteed minimum" contract. Now it
+        # must fail fast so the caller can shrink the AC or raise the
+        # total.
+        with pytest.raises(ValueError, match="Budget cannot honor parent_summary_reserve"):
+            compose_context(
+                ac="x" * 35,
+                parent_summary="parent summary here",  # 19 chars
+                budget=ContextBudget(total_chars=50, parent_summary_reserve=30),
+            )
+
+    def test_impossible_reserve_with_zero_reserve_does_not_raise(self) -> None:
+        # When the caller explicitly opts out of the guarantee
+        # (reserve=0), the parent is best-effort; silent truncation is
+        # the right behavior, not fail-fast.
+        result = compose_context(
+            ac="x" * 35,
+            parent_summary="parent",
+            budget=ContextBudget(total_chars=50, parent_summary_reserve=0),
+        )
+        assert result.parent_summary == ""
+        assert result.truncated is True
+
     def test_parent_actual_content_meets_reserve_floor(self) -> None:
         # Bot finding on #890 r3: the reserve was applied to the
         # sibling ceiling without accounting for the parent section

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -221,6 +221,23 @@ class TestRenderedSizeContract:
         assert len(result.parent_summary) > 0
         assert len(result.render()) <= 200
 
+    def test_zero_reserve_does_not_steal_overhead_from_siblings(self) -> None:
+        # Bot finding on #890 r6: with parent_summary present but
+        # reserve=0, the previous code still subtracted parent_overhead
+        # (20 chars) from the sibling ceiling. That let an optional
+        # parent section drop sibling status, violating the
+        # "best-effort parent" contract for reserve=0.
+        siblings = [SiblingStatus(str(i), accepted=True, headline="xxxxx") for i in range(10)]
+        budget = ContextBudget(total_chars=200, parent_summary_reserve=0)
+        with_parent = compose_context(ac="ac", parent_summary="p", siblings=siblings, budget=budget)
+        without_parent = compose_context(
+            ac="ac", parent_summary="", siblings=siblings, budget=budget
+        )
+        # Siblings placed in the with_parent case must match (or exceed)
+        # the without_parent case — adding a best-effort parent must
+        # not push siblings out.
+        assert len(with_parent.sibling_lines) >= len(without_parent.sibling_lines)
+
     def test_short_parent_does_not_starve_siblings(self) -> None:
         # Bot finding on #890 r4: when parent_summary is non-empty but
         # SHORTER than parent_summary_reserve, the previous code still


### PR DESCRIPTION
## Summary

Eighth PR in the [#830](https://github.com/Q00/ouroboros/issues/830) RFC v2 stack. **Stacked on #889**.

Implements H6 (context budget governance). Gives the harness a single deterministic place to compose what flows into each leaf dispatch (parent summary, sibling status, AC text) under a char budget. Addresses Open Question #2 in #830 (per-dispatch token tax) structurally.

## What lands

- \`ContextBudget(total_chars, parent_summary_reserve)\` — rejects non-positive total and reserve > total.
- \`SiblingStatus(sibling_id, accepted, headline?)\` — \`to_line()\` returns a terse status marker. **No bodies, no evidence records.**
- \`ComposedContext(parent_summary, sibling_lines, ac, truncated)\` — \`.render()\` joins sections, omits empty ones.
- \`compose_context(...)\` enforces three rules:
  1. AC is non-negotiable; \`ValueError\` if it alone exceeds the total.
  2. Sibling lines added until they would cross \`(total - parent_summary_reserve)\`. Status-only by construction.
  3. Parent summary char-truncated to whatever space remains, marked with \`[truncated by context governor]\`.

## Why char-based

Char budgets are deterministic and profile-author-readable. Tokenizer-precise budgets can come later when there's evidence the approximation misses something load-bearing. The structural guardrail H6 is about is the bigger win than precision.

## Wiring scope

\`parallel_executor\` still composes context ad-hoc until PR 9 routes assembly through \`compose_context\`.

## Test plan

- [x] \`uv run pytest tests/unit/orchestrator/test_context_governor.py\` — 15 passed
- [x] \`uv run ruff check\` / \`ruff format --check\` — clean
- [x] \`uv run mypy src/ouroboros/orchestrator/context_governor.py\` — Success

Refs #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)