### PR TITLE
fix(auto): bump interview/seed phase timeouts and exempt user_preferences from shell-metachar scan

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -33,6 +33,7 @@ from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
+    DEFAULT_TIMEOUT_SECONDS_BY_PHASE,
     MAX_EVALUATE_ROUNDS,
     AutoPhase,
     AutoPipelineState,
@@ -235,7 +236,9 @@ class AutoPipeline:
     attach_source: str | None = None
     reconcile_run: bool = False
     reconcile_source: str | None = None
-    seed_timeout_seconds: float = 120.0
+    seed_timeout_seconds: float = float(
+        DEFAULT_TIMEOUT_SECONDS_BY_PHASE[AutoPhase.SEED_GENERATION.value]
+    )
     run_start_timeout_seconds: float = 60.0
     progress_callback: AutoProgressCallback | None = None
     # Q00/ouroboros#773: chain RUN → RALPH_HANDOFF when ``complete_product``

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -6,10 +6,14 @@ from dataclasses import asdict, dataclass, field, fields
 from datetime import UTC, datetime
 from enum import StrEnum
 import json
+import logging
+import os
 from pathlib import Path
 import time
 from typing import Any
 from uuid import uuid4
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class AutoPhase(StrEnum):
@@ -76,14 +80,48 @@ class SeedOrigin(StrEnum):
 
 
 DEFAULT_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
-    AutoPhase.INTERVIEW.value: 120,
-    AutoPhase.SEED_GENERATION.value: 120,
+    AutoPhase.INTERVIEW.value: 600,
+    AutoPhase.SEED_GENERATION.value: 300,
     AutoPhase.REVIEW.value: 90,
     AutoPhase.REPAIR.value: 90,
     AutoPhase.RUN.value: 60,
     AutoPhase.EVALUATE.value: 90,
     AutoPhase.UNSTUCK_LATERAL.value: 60,
 }
+
+
+def _apply_phase_timeout_env_overrides(
+    defaults: dict[str, int],
+) -> dict[str, int]:
+    """Merge ``OUROBOROS_PHASE_TIMEOUT_<PHASE>_SECONDS`` overrides into ``defaults``.
+
+    Each phase listed in ``defaults`` may be overridden via an environment
+    variable named ``OUROBOROS_PHASE_TIMEOUT_<PHASE_UPPERCASE>_SECONDS`` (for
+    example ``OUROBOROS_PHASE_TIMEOUT_INTERVIEW_SECONDS=900``). Invalid values
+    (non-integer, non-positive) are ignored with a warning rather than raising
+    so a typo in the shell cannot crash module import.
+    """
+    overridden = dict(defaults)
+    for phase_value in defaults:
+        env_name = f"OUROBOROS_PHASE_TIMEOUT_{phase_value.upper()}_SECONDS"
+        raw = os.environ.get(env_name)
+        if raw is None:
+            continue
+        try:
+            parsed = int(raw)
+        except (TypeError, ValueError):
+            _LOGGER.warning("Ignoring %s=%r: must be a positive integer", env_name, raw)
+            continue
+        if parsed <= 0:
+            _LOGGER.warning("Ignoring %s=%r: must be a positive integer", env_name, raw)
+            continue
+        overridden[phase_value] = parsed
+    return overridden
+
+
+DEFAULT_TIMEOUT_SECONDS_BY_PHASE = _apply_phase_timeout_env_overrides(
+    DEFAULT_TIMEOUT_SECONDS_BY_PHASE
+)
 
 # RFC #809 Phase 2.2b — closed-loop recovery cap. Three EVALUATE rounds is
 # the SeedRepairer convention re-applied to the EVALUATE ⇄ UNSTUCK_LATERAL
@@ -115,9 +153,10 @@ _VALID_RECOVERY_GUARD_TAGS: frozenset[str] = frozenset(
 )
 
 # Top-level pipeline deadline (Q00/ouroboros#779). Default of 7200s (2h) covers
-# a typical product-bootstrap chain — interview ≤ 120s × 12 rounds + seed gen
-# 120s + review/repair ≤ 90s × 5 + run kick-off + ralph 10 generations × 5–15
-# min — with ~2× headroom and stays well under "user has gone home" scenarios.
+# a typical product-bootstrap chain — interview ≤ 600s (one LLM call per round
+# across up to 12 rounds, capped at the phase budget) + seed gen ≤ 300s +
+# review/repair ≤ 90s × 5 + run kick-off + ralph 10 generations × 5–15 min —
+# with headroom, and stays well under "user has gone home" scenarios.
 DEFAULT_PIPELINE_TIMEOUT_SECONDS: float = 7200.0
 MIN_PIPELINE_TIMEOUT_SECONDS: float = 60.0
 MAX_PIPELINE_TIMEOUT_SECONDS: float = 86400.0

--- a/src/ouroboros/mcp/server/security.py
+++ b/src/ouroboros/mcp/server/security.py
@@ -441,7 +441,9 @@ class InputValidator:
 
     # Fields that carry freetext content (code, prompts, descriptions).
     # These are exempt from shell-metacharacter checks because no
-    # Ouroboros tool ever passes them to a shell.
+    # Ouroboros tool ever passes them to a shell. ``user_preferences``
+    # carries operator-supplied freetext per ledger section (see
+    # ``answerer.py``) and likewise never reaches a shell.
     FREETEXT_FIELDS: set[str] = {
         "artifact",
         "quality_bar",
@@ -460,6 +462,7 @@ class InputValidator:
         "desc",
         "entry",
         "reason",
+        "user_preferences",
     }
 
     def __init__(self) -> None:

--- a/tests/unit/auto/test_pipeline_deadline.py
+++ b/tests/unit/auto/test_pipeline_deadline.py
@@ -23,6 +23,7 @@ from ouroboros.auto.pipeline import (
 )
 from ouroboros.auto.state import (
     DEFAULT_PIPELINE_TIMEOUT_SECONDS,
+    DEFAULT_TIMEOUT_SECONDS_BY_PHASE,
     AutoPhase,
     AutoPipelineState,
     AutoStore,
@@ -68,6 +69,16 @@ class _NeverInterviewDriver:
 
 async def _unused_seed_generator(_session_id: str):  # pragma: no cover
     raise AssertionError("seed generator should not be invoked when deadline trips")
+
+
+def test_seed_generation_timeout_uses_state_default_policy() -> None:
+    """AutoPipeline's live seed-generation timeout must track state policy."""
+    pipeline = AutoPipeline(_NeverInterviewDriver(), _unused_seed_generator)
+
+    assert pipeline.seed_timeout_seconds == float(
+        DEFAULT_TIMEOUT_SECONDS_BY_PHASE[AutoPhase.SEED_GENERATION.value]
+    )
+    assert pipeline.seed_timeout_seconds == 300.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -20,7 +20,7 @@ def test_state_transition_and_stale_detection() -> None:
     assert state.phase == AutoPhase.INTERVIEW
     assert state.last_progress_message == "starting interview"
 
-    future = datetime.fromisoformat(state.last_progress_at) + timedelta(seconds=121)
+    future = datetime.fromisoformat(state.last_progress_at) + timedelta(seconds=601)
     assert state.is_stale(future)
 
 
@@ -71,7 +71,7 @@ def test_phase_timeout_seconds_falls_back_to_canonical_default() -> None:
     state.timeout_seconds_by_phase.pop(AutoPhase.INTERVIEW.value)
 
     expected = float(DEFAULT_TIMEOUT_SECONDS_BY_PHASE[AutoPhase.INTERVIEW.value])
-    assert expected == 120.0
+    assert expected == 600.0
     assert state.phase_timeout_seconds(AutoPhase.INTERVIEW) == expected
 
 
@@ -726,3 +726,24 @@ def test_resume_capability_failed_mirrors_blocked() -> None:
     assert state.phase is AutoPhase.FAILED
     assert state.interview_session_id is None
     assert state.resume_capability() is AutoResumeCapability.RETRY
+
+
+def test_phase_timeout_env_override_applied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OUROBOROS_PHASE_TIMEOUT_<PHASE>_SECONDS overrides the default at import."""
+    from ouroboros.auto import state as state_module
+
+    monkeypatch.setenv("OUROBOROS_PHASE_TIMEOUT_INTERVIEW_SECONDS", "900")
+    monkeypatch.setenv("OUROBOROS_PHASE_TIMEOUT_RUN_SECONDS", "0")  # invalid -> ignored
+    monkeypatch.setenv("OUROBOROS_PHASE_TIMEOUT_REVIEW_SECONDS", "garbage")  # invalid
+
+    merged = state_module._apply_phase_timeout_env_overrides(
+        {
+            AutoPhase.INTERVIEW.value: 600,
+            AutoPhase.RUN.value: 60,
+            AutoPhase.REVIEW.value: 90,
+        }
+    )
+
+    assert merged[AutoPhase.INTERVIEW.value] == 900
+    assert merged[AutoPhase.RUN.value] == 60  # invalid override silently ignored
+    assert merged[AutoPhase.REVIEW.value] == 90  # invalid override silently ignored

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1371,7 +1371,7 @@ async def test_auto_handler_passes_state_interview_timeout_to_driver(monkeypatch
     result = await AutoHandler().handle({"goal": "Build a CLI", "cwd": str(tmp_path)})
 
     assert result.is_ok
-    assert captured["driver_timeout_seconds"] == 120.0
+    assert captured["driver_timeout_seconds"] == 600.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -210,7 +210,7 @@ def test_run_auto_passes_state_interview_timeout_to_driver(tmp_path) -> None:
 
 
 def test_run_auto_uses_default_state_interview_timeout_for_new_sessions() -> None:
-    """New sessions must inherit the 120s default from AutoPipelineState."""
+    """New sessions must inherit the 600s default from AutoPipelineState."""
     import asyncio
 
     from ouroboros.cli.commands.auto import _run_auto
@@ -239,7 +239,7 @@ def test_run_auto_uses_default_state_interview_timeout_for_new_sessions() -> Non
         )
 
     assert result.status == "complete"
-    assert captured["driver_timeout_seconds"] == 120.0
+    assert captured["driver_timeout_seconds"] == 600.0
 
 
 def test_resume_rejects_lower_bound_override(tmp_path) -> None:

--- a/tests/unit/mcp/server/test_security.py
+++ b/tests/unit/mcp/server/test_security.py
@@ -244,7 +244,7 @@ class TestInputValidator:
                 "goal": "g",
                 "user_preferences": {
                     "constraints": "no shell here; just a semicolon",
-                    "non_goals": ["item one", "item; two"],
+                    "non_goals": "item one; item two",
                 },
             },
         )

--- a/tests/unit/mcp/server/test_security.py
+++ b/tests/unit/mcp/server/test_security.py
@@ -235,6 +235,22 @@ class TestInputValidator:
         assert result.is_err
         assert "Shell metacharacter" in str(result.error)
 
+    def test_validate_allows_user_preferences_punctuation_as_freetext(self) -> None:
+        """Operator-supplied user_preferences carry freetext, never shell input."""
+        validator = InputValidator()
+        result = validator.validate(
+            "ouroboros_auto",
+            {
+                "goal": "g",
+                "user_preferences": {
+                    "constraints": "no shell here; just a semicolon",
+                    "non_goals": ["item one", "item; two"],
+                },
+            },
+        )
+
+        assert result.is_ok
+
 
 class TestRateLimiter:
     """Test RateLimiter class."""


### PR DESCRIPTION
## Summary

Two narrowly-scoped fixes for blockers observed during real `ooo auto` invocations.

- `DEFAULT_TIMEOUT_SECONDS_BY_PHASE[INTERVIEW]` 120 → **600s**, `[SEED_GENERATION]` 120 → **300s**.
  The phase timeout wraps the entire multi-round Socratic interview ([pipeline.py:480-486](https://github.com/Q00/ouroboros/blob/main/src/ouroboros/auto/pipeline.py#L480)), not a single round. 120s could not accommodate even one slow LLM round.
  Empirical blocker observed locally: `interview phase exceeded 120s` on a `complete_product=true` invocation.
- Per-phase env override `OUROBOROS_PHASE_TIMEOUT_<PHASE>_SECONDS` for operator control without a rebuild. Invalid values logged and ignored.
- `InputValidator.FREETEXT_FIELDS` gains `user_preferences`. The shell-metachar scan (`;|&&||`) was rejecting legitimate operator prefs like `"split fixes by domain; no large PR"`. The payload never reaches a shell — it feeds `answerer.py` as plain text via `raw_value.strip()`.

## Background — offending commits

The 120s INTERVIEW timeout was introduced in the per-phase budget table when `DEFAULT_TIMEOUT_SECONDS_BY_PHASE` was added (`src/ouroboros/auto/state.py`). The shell-metachar scan was added with `FREETEXT_FIELDS` (`src/ouroboros/mcp/server/security.py`). Both predate the empirical observation that the interview phase exceeds 120s on first use and that `user_preferences` carries semicolons in natural-language guidance.

## Test plan
- [x] `uv run pytest tests/unit/auto/test_state.py` — 55 passed (new env-override test included)
- [x] `uv run pytest tests/unit/mcp/server/test_security.py` — 22 passed (new user_preferences freetext test)
- [x] `uv run pytest tests/unit/auto tests/unit/mcp/tools tests/unit/mcp/server` (combined with PR B) — 1467 passed
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] In-process e2e repro: `;` in user_preferences now accepted; INTERVIEW default == 600s

🤖 Generated with [Claude Code](https://claude.com/claude-code)