### PR TITLE
test: register integration pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 markers = [
+    "integration: integration tests that exercise cross-component behavior",
     "slow: integration tests that build artifacts or call subprocesses",
 ]
 


### PR DESCRIPTION
## Summary
- register the integration pytest marker used by integration suites
- remove PytestUnknownMarkWarning noise from e2e/integration runs

## Verification
- uv run pytest tests/e2e tests/integration
- uv run ruff check pyproject.toml