### PR TITLE
feat(orchestrator): route verifiers by profile capability

### DIFF
--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -93,11 +93,12 @@ class ExecutionProfile(BaseModel):
         description="Instruction passed to the external verifier subagent (H1).",
     )
     verifier_capability: VerifierCapability = Field(
-        VerifierCapability.READ_ONLY_DISCOVERY,
+        ...,
         description=(
             "Structured verifier execution envelope. READ_ONLY_DISCOVERY "
-            "may inspect files only; SUBPROCESS_TEST_RUNNER may also run "
-            "bounded test/check commands without mutating the workspace."
+            "may inspect files only; SUBPROCESS_TEST_RUNNER requires a "
+            "harness-owned read-only test runner and must not be modeled as "
+            "unrestricted shell access."
         ),
     )
     suggested_tools: tuple[str, ...] = Field(

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -18,6 +18,7 @@ Usage:
 
 from __future__ import annotations
 
+from enum import StrEnum
 from pathlib import Path
 from typing import Final
 
@@ -25,6 +26,13 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 import yaml
 
 _PROFILES_DIR: Final[Path] = Path(__file__).resolve().parent.parent / "profiles"
+
+
+class VerifierCapability(StrEnum):
+    """Structured verifier envelope required by an execution profile."""
+
+    READ_ONLY_DISCOVERY = "read_only_discovery"
+    SUBPROCESS_TEST_RUNNER = "subprocess_test_runner"
 
 
 class EvidenceSchema(BaseModel):
@@ -83,6 +91,14 @@ class ExecutionProfile(BaseModel):
         ...,
         min_length=1,
         description="Instruction passed to the external verifier subagent (H1).",
+    )
+    verifier_capability: VerifierCapability = Field(
+        VerifierCapability.READ_ONLY_DISCOVERY,
+        description=(
+            "Structured verifier execution envelope. READ_ONLY_DISCOVERY "
+            "may inspect files only; SUBPROCESS_TEST_RUNNER may also run "
+            "bounded test/check commands without mutating the workspace."
+        ),
     )
     suggested_tools: tuple[str, ...] = Field(
         default=(),
@@ -167,6 +183,7 @@ __all__ = [
     "EvidenceSchema",
     "ExecutionProfile",
     "ProfileError",
+    "VerifierCapability",
     "available_profiles",
     "load_profile",
 ]

--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -25,8 +25,10 @@ Implementation status at this PR:
   VERIFIER (implemented)
     Routing verifier dispatches is based on the structured
     `ExecutionProfile.verifier_capability` field. Read-only discovery
-    verifiers receive file-discovery tools only; subprocess-test-runner
-    verifiers additionally receive Bash so they can run bounded tests.
+    verifiers receive file-discovery tools only. Subprocess-test-runner
+    verifiers still receive read-only discovery tools at the agent-tool
+    layer and set `requires_external_test_runner=True`, so callers know
+    to provide a harness-owned bounded runner instead of raw Bash.
 
 This module is wiring-only. `parallel_executor` still uses its current
 hardcoded adapter call. `decide_route()` takes role + profile + retry
@@ -61,7 +63,7 @@ _TIER_ORDER: tuple[ModelTier, ...] = (ModelTier.HAIKU, ModelTier.SONNET, ModelTi
 
 # Tools available to verifier envelopes at the routing layer.
 _VERIFIER_READ_ONLY_TOOLS: tuple[str, ...] = ("Read", "Glob", "Grep")
-_VERIFIER_TEST_RUNNER_TOOLS: tuple[str, ...] = ("Read", "Glob", "Grep", "Bash")
+_VERIFIER_TEST_RUNNER_TOOLS: tuple[str, ...] = _VERIFIER_READ_ONLY_TOOLS
 
 
 @dataclass(frozen=True)
@@ -71,6 +73,7 @@ class RouteDecision:
     tier: ModelTier
     tools: tuple[str, ...]
     rationale: str
+    requires_external_test_runner: bool = False
 
 
 def _bump_tier(tier: ModelTier, *, steps: int = 1) -> ModelTier:
@@ -168,9 +171,11 @@ def decide_route(
                 tier=tier,
                 tools=_VERIFIER_TEST_RUNNER_TOOLS,
                 rationale=(
-                    "Verifier: one tier above executor with subprocess test "
-                    "runner capability from verifier_capability."
+                    "Verifier: one tier above executor; profile requires a "
+                    "harness-owned read-only subprocess test runner, so raw "
+                    "Bash is not granted as an agent tool."
                 ),
+                requires_external_test_runner=True,
             )
         msg = f"Unhandled verifier_capability: {profile.verifier_capability!r}"
         raise NotImplementedError(msg)

--- a/src/ouroboros/orchestrator/routing.py
+++ b/src/ouroboros/orchestrator/routing.py
@@ -22,20 +22,11 @@ Implementation status at this PR:
     `fabrication_retry=True` per the H7 ESCALATE_MODEL hook.
     Tools come from `profile.suggested_tools` verbatim.
 
-  VERIFIER (intentionally NOT implemented — raises NotImplementedError)
-    Routing verifier dispatches requires a structured capability flag
-    on ExecutionProfile (read-only-discovery vs subprocess-test-runner)
-    that does not yet exist on the #881 schema. Earlier rounds of #889
-    review tried two approximations and both were rejected:
-      - hard-fixing the verifier tools to (Read, Glob, Grep) silently
-        breaks the code profile, whose verifier_focus needs subprocess
-        execution.
-      - substring-matching `verifier_focus` prose for subprocess markers
-        is fragile (innocuous wording changes flip runtime behavior).
-    The seam therefore refuses to guess and raises NotImplementedError
-    with a clear pointer: add `verifier_capability` to ExecutionProfile
-    (a #881 follow-up) or plumb a custom verifier dispatcher before
-    using `DispatchRole.VERIFIER`.
+  VERIFIER (implemented)
+    Routing verifier dispatches is based on the structured
+    `ExecutionProfile.verifier_capability` field. Read-only discovery
+    verifiers receive file-discovery tools only; subprocess-test-runner
+    verifiers additionally receive Bash so they can run bounded tests.
 
 This module is wiring-only. `parallel_executor` still uses its current
 hardcoded adapter call. `decide_route()` takes role + profile + retry
@@ -47,7 +38,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from ouroboros.orchestrator.profile_loader import ExecutionProfile
+from ouroboros.orchestrator.profile_loader import ExecutionProfile, VerifierCapability
 
 
 class DispatchRole(StrEnum):
@@ -68,14 +59,9 @@ class ModelTier(StrEnum):
 
 _TIER_ORDER: tuple[ModelTier, ...] = (ModelTier.HAIKU, ModelTier.SONNET, ModelTier.OPUS)
 
-# Tools available to a verifier at the routing layer. Strictly read-only
-# discovery tools — the H1 contract is that a verifier cannot mutate the
-# workspace, and the router cannot inspect Bash command text to enforce
-# that, so Bash is excluded structurally rather than delegated to prompt
-# obedience (bot finding on PR #889 r3 reversed r2's keep-Bash position).
-# Profiles whose verifier_focus needs subprocess test execution must
-# route through a dedicated read-only test runner — see module docstring.
-_VERIFIER_TOOLS: tuple[str, ...] = ("Read", "Glob", "Grep")
+# Tools available to verifier envelopes at the routing layer.
+_VERIFIER_READ_ONLY_TOOLS: tuple[str, ...] = ("Read", "Glob", "Grep")
+_VERIFIER_TEST_RUNNER_TOOLS: tuple[str, ...] = ("Read", "Glob", "Grep", "Bash")
 
 
 @dataclass(frozen=True)
@@ -133,15 +119,6 @@ def decide_route(
             routing seam fails fast on unknown inputs (e.g. a raw
             string from config/JSON) rather than silently falling
             through to the verifier branch with the wrong tools.
-        NotImplementedError: For DispatchRole.VERIFIER. Routing
-            verifier dispatches requires a structured capability flag
-            on ExecutionProfile (read-only-discovery vs subprocess-
-            test-runner) that does not yet exist. Earlier rounds tried
-            substring-matching `verifier_focus` text — that was
-            rejected as fragile. The seam intentionally refuses to
-            guess; add a `verifier_capability` field to
-            ExecutionProfile (#881 follow-up) or plumb a custom
-            verifier dispatcher before using VERIFIER routing.
     """
     if not isinstance(role, DispatchRole):
         msg = (
@@ -175,31 +152,27 @@ def decide_route(
         )
 
     if role is DispatchRole.VERIFIER:
-        # ExecutionProfile does not yet expose a structured capability
-        # flag describing what verifier envelope each profile actually
-        # needs (read-only discovery vs subprocess test runner). The
-        # earlier rounds tried two approximations:
-        #   r3 — silently return (Read, Glob, Grep) for every profile.
-        #        Wrong for code profile whose verifier_focus needs
-        #        `pytest`.
-        #   r4 — substring-match `verifier_focus` for subprocess markers.
-        #        Fragile: prose changes break runtime behavior.
-        # Until ExecutionProfile carries a structured `verifier_capability`
-        # field, the honest answer at this seam is "I don't know what
-        # this profile needs". Fail fast so the caller (#891 wiring
-        # follow-ups) cannot accidentally route a verifier through an
-        # envelope that may not match the profile's contract
-        # (bot finding on #889 r5).
-        msg = (
-            f"DispatchRole.VERIFIER routing for profile "
-            f"{profile.profile!r} is not implemented: ExecutionProfile "
-            "does not yet expose a structured capability flag "
-            "(read-only-discovery vs subprocess-test-runner), and the "
-            "router will not infer it from free-form verifier_focus "
-            "text. Add a `verifier_capability` field to ExecutionProfile "
-            "(follow-up to #881) before wiring the verifier seam, or "
-            "plumb a custom verifier dispatcher for this profile."
-        )
+        executor_tier = _executor_tier(profile, fabrication_retry=fabrication_retry)
+        tier = _bump_tier(executor_tier)
+        if profile.verifier_capability is VerifierCapability.READ_ONLY_DISCOVERY:
+            return RouteDecision(
+                tier=tier,
+                tools=_VERIFIER_READ_ONLY_TOOLS,
+                rationale=(
+                    "Verifier: one tier above executor with read-only "
+                    "discovery tools from verifier_capability."
+                ),
+            )
+        if profile.verifier_capability is VerifierCapability.SUBPROCESS_TEST_RUNNER:
+            return RouteDecision(
+                tier=tier,
+                tools=_VERIFIER_TEST_RUNNER_TOOLS,
+                rationale=(
+                    "Verifier: one tier above executor with subprocess test "
+                    "runner capability from verifier_capability."
+                ),
+            )
+        msg = f"Unhandled verifier_capability: {profile.verifier_capability!r}"
         raise NotImplementedError(msg)
 
     # Exhaustive — every DispatchRole member handled above. Reached only

--- a/src/ouroboros/profiles/analysis.yaml
+++ b/src/ouroboros/profiles/analysis.yaml
@@ -8,6 +8,7 @@ evidence_schema:
     - perspectives_compared
   rejected_if:
     - "perspectives_compared == []"
+verifier_capability: read_only_discovery
 verifier_focus: >
   Confirm every conclusion is supported by an explicit comparison of
   perspectives. Reject one-sided analyses that omit contrasting views or

--- a/src/ouroboros/profiles/code.yaml
+++ b/src/ouroboros/profiles/code.yaml
@@ -9,6 +9,7 @@ evidence_schema:
     - tests_passed
   rejected_if:
     - "tests_passed == []"
+verifier_capability: subprocess_test_runner
 verifier_focus: >
   Run the project's test command. Confirm tests_passed list matches reality.
   Reject claims about files or symbols that do not exist on disk.

--- a/src/ouroboros/profiles/research.yaml
+++ b/src/ouroboros/profiles/research.yaml
@@ -10,6 +10,7 @@ evidence_schema:
   rejected_if:
     - "external_sources == []"
     - "triangulated_sources == []"
+verifier_capability: read_only_discovery
 verifier_focus: >
   Confirm each claim is anchored to at least one external source URL or
   document. Reject claims that cite no source or that rely on a single

--- a/tests/unit/orchestrator/test_phase_wrappers.py
+++ b/tests/unit/orchestrator/test_phase_wrappers.py
@@ -13,6 +13,7 @@ from ouroboros.orchestrator.phase_wrappers import (
 from ouroboros.orchestrator.profile_loader import (
     EvidenceSchema,
     ExecutionProfile,
+    VerifierCapability,
     load_profile,
 )
 
@@ -126,6 +127,7 @@ class TestPostBlock:
             axis="a",
             min_unit="m",
             verifier_focus="v",
+            verifier_capability=VerifierCapability.READ_ONLY_DISCOVERY,
             evidence_schema=EvidenceSchema(),
         )
         block = build_post_block(bare)

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -9,6 +9,7 @@ import pytest
 from ouroboros.orchestrator.profile_loader import (
     ExecutionProfile,
     ProfileError,
+    VerifierCapability,
     available_profiles,
     load_profile,
 )
@@ -27,6 +28,7 @@ class TestBuiltinProfiles:
         assert profile.axis
         assert profile.min_unit
         assert profile.verifier_focus
+        assert isinstance(profile.verifier_capability, VerifierCapability)
 
     def test_available_lists_all_builtins(self) -> None:
         discovered = available_profiles()
@@ -37,14 +39,17 @@ class TestBuiltinProfiles:
         profile = load_profile("code")
         assert "tests_passed" in profile.evidence_schema.required
         assert "Read" in profile.suggested_tools
+        assert profile.verifier_capability is VerifierCapability.SUBPROCESS_TEST_RUNNER
 
     def test_research_profile_requires_triangulation(self) -> None:
         profile = load_profile("research")
         assert "triangulated_sources" in profile.evidence_schema.required
+        assert profile.verifier_capability is VerifierCapability.READ_ONLY_DISCOVERY
 
     def test_analysis_profile_requires_perspectives(self) -> None:
         profile = load_profile("analysis")
         assert "perspectives_compared" in profile.evidence_schema.required
+        assert profile.verifier_capability is VerifierCapability.READ_ONLY_DISCOVERY
 
 
 class TestSchemaValidation:

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -69,11 +69,22 @@ class TestSchemaValidation:
         with pytest.raises(ProfileError, match="schema validation"):
             load_profile("broken", profiles_dir=tmp_path)
 
+    def test_verifier_capability_is_required(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "missing_capability",
+            "profile: missing_capability\naxis: x\nmin_unit: y\nverifier_focus: z\n",
+        )
+        with pytest.raises(ProfileError, match="verifier_capability"):
+            load_profile("missing_capability", profiles_dir=tmp_path)
+
     def test_extra_field_rejected(self, tmp_path: Path) -> None:
         self._write(
             tmp_path,
             "extra",
-            ("profile: extra\naxis: x\nmin_unit: y\nverifier_focus: z\nunknown_field: oops\n"),
+            (
+                "profile: extra\naxis: x\nmin_unit: y\nverifier_capability: read_only_discovery\nverifier_focus: z\nunknown_field: oops\n"
+            ),
         )
         with pytest.raises(ProfileError, match="schema validation"):
             load_profile("extra", profiles_dir=tmp_path)
@@ -82,7 +93,7 @@ class TestSchemaValidation:
         self._write(
             tmp_path,
             "alpha",
-            "profile: beta\naxis: x\nmin_unit: y\nverifier_focus: z\n",
+            "profile: beta\naxis: x\nmin_unit: y\nverifier_capability: read_only_discovery\nverifier_focus: z\n",
         )
         with pytest.raises(ProfileError, match="name mismatch"):
             load_profile("alpha", profiles_dir=tmp_path)
@@ -134,7 +145,7 @@ class TestIoErrorNormalization:
 
         path = tmp_path / "locked.yaml"
         path.write_text(
-            "profile: locked\naxis: x\nmin_unit: y\nverifier_focus: z\n",
+            "profile: locked\naxis: x\nmin_unit: y\nverifier_capability: read_only_discovery\nverifier_focus: z\n",
             encoding="utf-8",
         )
         path.chmod(0)

--- a/tests/unit/orchestrator/test_routing.py
+++ b/tests/unit/orchestrator/test_routing.py
@@ -66,26 +66,32 @@ class TestExecutorRoute:
 
 
 class TestVerifierRoute:
-    @pytest.mark.parametrize("profile_name", ["code", "research", "analysis"])
-    def test_verifier_routing_unimplemented(self, profile_name: str) -> None:
-        # Bot finding on #889 r5: without a structured
-        # verifier_capability field on ExecutionProfile, the router
-        # cannot honestly say what envelope each profile needs.
-        # Earlier rounds tried hard-fixed tools (wrong for code) and
-        # substring detection on verifier_focus prose (fragile). The
-        # honest answer is "not implemented" — fail fast so callers
-        # know to add the capability flag or plumb a custom verifier
-        # dispatcher before routing.
+    def test_code_profile_gets_test_runner_tools(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
+        assert route.tier == ModelTier.OPUS
+        assert route.tools == ("Read", "Glob", "Grep", "Bash")
+        assert "subprocess test runner" in route.rationale
+
+    @pytest.mark.parametrize("profile_name", ["research", "analysis"])
+    def test_read_only_profiles_exclude_bash(self, profile_name: str) -> None:
         profile = load_profile(profile_name)
-        with pytest.raises(NotImplementedError, match="verifier_capability"):
-            decide_route(role=DispatchRole.VERIFIER, profile=profile)
+        route = decide_route(role=DispatchRole.VERIFIER, profile=profile)
+        assert route.tier == ModelTier.OPUS
+        assert route.tools == ("Read", "Glob", "Grep")
+        assert "read-only" in route.rationale
+
+    def test_fabrication_retry_caps_verifier_at_opus(self, code_profile: ExecutionProfile) -> None:
+        route = decide_route(
+            role=DispatchRole.VERIFIER,
+            profile=code_profile,
+            fabrication_retry=True,
+        )
+        assert route.tier == ModelTier.OPUS
 
 
 class TestRationaleStrings:
     def test_decomposer_and_executor_have_rationale(self, code_profile: ExecutionProfile) -> None:
-        # VERIFIER is intentionally unimplemented (see above), so only
-        # the two routes that return a RouteDecision are exercised.
-        for role in (DispatchRole.DECOMPOSER, DispatchRole.EXECUTOR):
+        for role in DispatchRole:
             route = decide_route(role=role, profile=code_profile)
             assert route.rationale, f"{role} returned empty rationale"
 

--- a/tests/unit/orchestrator/test_routing.py
+++ b/tests/unit/orchestrator/test_routing.py
@@ -69,8 +69,9 @@ class TestVerifierRoute:
     def test_code_profile_gets_test_runner_tools(self, code_profile: ExecutionProfile) -> None:
         route = decide_route(role=DispatchRole.VERIFIER, profile=code_profile)
         assert route.tier == ModelTier.OPUS
-        assert route.tools == ("Read", "Glob", "Grep", "Bash")
-        assert "subprocess test runner" in route.rationale
+        assert route.tools == ("Read", "Glob", "Grep")
+        assert route.requires_external_test_runner is True
+        assert "raw Bash is not granted" in route.rationale
 
     @pytest.mark.parametrize("profile_name", ["research", "analysis"])
     def test_read_only_profiles_exclude_bash(self, profile_name: str) -> None:
@@ -78,6 +79,7 @@ class TestVerifierRoute:
         route = decide_route(role=DispatchRole.VERIFIER, profile=profile)
         assert route.tier == ModelTier.OPUS
         assert route.tools == ("Read", "Glob", "Grep")
+        assert route.requires_external_test_runner is False
         assert "read-only" in route.rationale
 
     def test_fabrication_retry_caps_verifier_at_opus(self, code_profile: ExecutionProfile) -> None:


### PR DESCRIPTION
## Summary

Adds the first #920 implementation PR for the Agent OS fat-harness roadmap: verifier routing now uses structured profile metadata instead of free-form `verifier_focus` prose.

- adds `ExecutionProfile.verifier_capability` with `read_only_discovery` and `subprocess_test_runner` envelopes
- marks code as subprocess-test-runner and research/analysis as read-only discovery
- wires `DispatchRole.VERIFIER` through the capability instead of raising `NotImplementedError`

## Agent OS direction

This keeps authority in the harness contract: profiles declare what verifier envelope they need, while routing decides tools structurally. That is aligned with #920 and avoids the rejected alternatives of either fixed read-only verifier tools or substring inference from prose.

## Validation

- `uv run ruff check src/ouroboros/orchestrator/profile_loader.py src/ouroboros/orchestrator/routing.py tests/unit/orchestrator/test_profile_loader.py tests/unit/orchestrator/test_routing.py`
- `uv run pytest tests/unit/orchestrator/test_profile_loader.py tests/unit/orchestrator/test_routing.py`

Closes part of #920.