### PR TITLE
feat(orchestrator): support typed blocked leaf evidence

### DIFF
--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -287,12 +287,12 @@ def validate_evidence(profile: ExecutionProfile, record: EvidenceRecord) -> Vali
     """
     schema = profile.evidence_schema
 
+    rejected = tuple(expr for expr in schema.rejected_if if _evaluate_rejection(expr, record.data))
     blocker = _parse_blocker(record.data)
     if blocker is not None:
         return ValidationResult(ok=False, blocker=blocker)
 
     missing = tuple(name for name in schema.required if name not in record.data)
-    rejected = tuple(expr for expr in schema.rejected_if if _evaluate_rejection(expr, record.data))
 
     return ValidationResult(
         ok=not missing and not rejected,

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -13,8 +13,9 @@ The evaluator for `rejected_if` is intentionally narrow. It supports only
 `<field> == <literal>` where literal is parsed first as JSON (so YAML/JSON
 authors can write `null`, `true`, `false`, numbers, strings, lists) and
 then as a Python literal as a fallback (so legacy `None`/`True`/`False`
-keep working). Any other expression shape raises EvidenceError so that
-profile authors get an immediate, loud failure instead of silent acceptance.
+keep working). Any other expression shape raises ProfileEvidenceConfigError
+so that profile authors get an immediate, loud failure instead of silent
+acceptance.
 
 Usage:
     from ouroboros.orchestrator.evidence_schema import (
@@ -49,7 +50,11 @@ _DECODER = json.JSONDecoder()
 
 
 class EvidenceError(ValueError):
-    """Raised when evidence cannot be parsed or a profile expression is invalid."""
+    """Raised when leaf evidence cannot be parsed or validated."""
+
+
+class ProfileEvidenceConfigError(EvidenceError):
+    """Raised when a profile-authored evidence expression is invalid."""
 
 
 class BlockerCode(StrEnum):
@@ -200,7 +205,7 @@ def _parse_literal(raw: str) -> Any:
         return ast.literal_eval(raw)
     except (ValueError, SyntaxError) as exc:
         msg = f"Unsupported literal in rejected_if right-hand side: {raw!r} ({exc})"
-        raise EvidenceError(msg) from exc
+        raise ProfileEvidenceConfigError(msg) from exc
 
 
 def _parse_blocker(data: dict[str, Any]) -> EvidenceBlocker | None:
@@ -252,8 +257,9 @@ def _parse_blocker(data: dict[str, Any]) -> EvidenceBlocker | None:
 def _evaluate_rejection(expr: str, data: dict[str, Any]) -> bool:
     """Evaluate a single rejected_if expression.
 
-    Grammar: `<field> == <literal>` only. Anything else raises EvidenceError
-    so profile authors notice immediately instead of silently passing.
+    Grammar: `<field> == <literal>` only. Anything else raises
+    ProfileEvidenceConfigError so profile authors notice immediately instead
+    of silently passing.
     """
     match = _EXPR_RE.match(expr)
     if not match:
@@ -261,7 +267,7 @@ def _evaluate_rejection(expr: str, data: dict[str, Any]) -> bool:
             f"Unsupported rejected_if expression: {expr!r}. "
             "Only '<field> == <literal>' is currently supported."
         )
-        raise EvidenceError(msg)
+        raise ProfileEvidenceConfigError(msg)
     field_name = match.group("field")
     literal = _parse_literal(match.group("lit"))
     # Missing fields evaluate as None for comparison purposes — that way
@@ -282,8 +288,9 @@ def validate_evidence(profile: ExecutionProfile, record: EvidenceRecord) -> Vali
         and no rejected_if expression matched.
 
     Raises:
-        EvidenceError: If any rejected_if expression has unsupported syntax.
-            (Profile bugs should be loud, not silent.)
+        EvidenceError: If leaf evidence is malformed.
+        ProfileEvidenceConfigError: If any rejected_if expression has unsupported
+            syntax. (Profile bugs should be loud, not silent.)
     """
     schema = profile.evidence_schema
 
@@ -305,6 +312,7 @@ __all__ = [
     "BlockerCode",
     "EvidenceBlocker",
     "EvidenceError",
+    "ProfileEvidenceConfigError",
     "EvidenceRecord",
     "ValidationResult",
     "extract_evidence",

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass, field
+from enum import StrEnum
 import json
 import re
 from typing import Any
@@ -51,6 +52,31 @@ class EvidenceError(ValueError):
     """Raised when evidence cannot be parsed or a profile expression is invalid."""
 
 
+class BlockerCode(StrEnum):
+    """Machine-readable terminal blocker classes surfaced by leaf evidence."""
+
+    MISSING_AUTHORITY = "MISSING_AUTHORITY"
+    MISSING_ACCESS = "MISSING_ACCESS"
+    MISSING_TOOL = "MISSING_TOOL"
+    MISSING_CONFIGURATION = "MISSING_CONFIGURATION"
+    UNSAFE_SCOPE_CHANGE = "UNSAFE_SCOPE_CHANGE"
+    EXTERNAL_DEPENDENCY = "EXTERNAL_DEPENDENCY"
+
+
+@dataclass(frozen=True)
+class EvidenceBlocker:
+    """Typed precondition that prevents the leaf from completing an AC."""
+
+    code: BlockerCode
+    reason: str
+    required_by: str = ""
+
+    def summary(self) -> str:
+        detail = f": {self.reason}" if self.reason else ""
+        suffix = f" (required_by: {self.required_by})" if self.required_by else ""
+        return f"blocked[{self.code.value}]{detail}{suffix}"
+
+
 @dataclass(frozen=True)
 class ValidationResult:
     """Outcome of validating an evidence record against a profile.
@@ -60,15 +86,20 @@ class ValidationResult:
         missing_fields: Required fields the record did not provide.
         rejected_by: rejected_if expressions that evaluated True against
             the record (verbatim, in profile order).
+        blocker: typed terminal blocker if the leaf could not satisfy a
+            legitimate precondition. Blockers are not missing evidence.
     """
 
     ok: bool
     missing_fields: tuple[str, ...] = ()
     rejected_by: tuple[str, ...] = ()
+    blocker: EvidenceBlocker | None = None
 
     def reasons(self) -> tuple[str, ...]:
         """Human-readable, harness-friendly summary of all failure reasons."""
         out: list[str] = []
+        if self.blocker is not None:
+            out.append(self.blocker.summary())
         if self.missing_fields:
             out.append("missing required fields: " + ", ".join(self.missing_fields))
         out.extend(f"rejected by {expr!r}" for expr in self.rejected_by)
@@ -172,6 +203,52 @@ def _parse_literal(raw: str) -> Any:
         raise EvidenceError(msg) from exc
 
 
+def _parse_blocker(data: dict[str, Any]) -> EvidenceBlocker | None:
+    """Return a typed blocker from a blocked evidence record, if present."""
+    status = data.get("status")
+    if status not in {"blocked", "BLOCKED"}:
+        return None
+
+    raw_blocker = data.get("blocker")
+    if raw_blocker is None:
+        # Preserve compatibility with ordinary evidence schemas that use
+        # status == "blocked" as a domain field or rejected_if literal.
+        # A terminal blocker is typed only when the blocker object is present.
+        return None
+    if not isinstance(raw_blocker, dict):
+        msg = "Blocked evidence blocker must be an object."
+        raise EvidenceError(msg)
+
+    raw_code = raw_blocker.get("code")
+    if not isinstance(raw_code, str):
+        msg = "Blocked evidence blocker.code must be a string."
+        raise EvidenceError(msg)
+    try:
+        code = BlockerCode(raw_code)
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in BlockerCode)
+        msg = f"Unknown blocker.code {raw_code!r}; expected one of: {valid}"
+        raise EvidenceError(msg) from exc
+
+    raw_reason = raw_blocker.get("reason")
+    if not isinstance(raw_reason, str) or not raw_reason.strip():
+        msg = "Blocked evidence blocker.reason must be a non-empty string."
+        raise EvidenceError(msg)
+
+    raw_required_by = raw_blocker.get("required_by", "")
+    if raw_required_by is None:
+        raw_required_by = ""
+    if not isinstance(raw_required_by, str):
+        msg = "Blocked evidence blocker.required_by must be a string when present."
+        raise EvidenceError(msg)
+
+    return EvidenceBlocker(
+        code=code,
+        reason=raw_reason.strip(),
+        required_by=raw_required_by.strip(),
+    )
+
+
 def _evaluate_rejection(expr: str, data: dict[str, Any]) -> bool:
     """Evaluate a single rejected_if expression.
 
@@ -210,6 +287,10 @@ def validate_evidence(profile: ExecutionProfile, record: EvidenceRecord) -> Vali
     """
     schema = profile.evidence_schema
 
+    blocker = _parse_blocker(record.data)
+    if blocker is not None:
+        return ValidationResult(ok=False, blocker=blocker)
+
     missing = tuple(name for name in schema.required if name not in record.data)
     rejected = tuple(expr for expr in schema.rejected_if if _evaluate_rejection(expr, record.data))
 
@@ -221,6 +302,8 @@ def validate_evidence(profile: ExecutionProfile, record: EvidenceRecord) -> Vali
 
 
 __all__ = [
+    "BlockerCode",
+    "EvidenceBlocker",
     "EvidenceError",
     "EvidenceRecord",
     "ValidationResult",

--- a/src/ouroboros/orchestrator/failure_taxonomy.py
+++ b/src/ouroboros/orchestrator/failure_taxonomy.py
@@ -142,6 +142,9 @@ def classify(attempt: Attempt) -> FailureClass | None:
     if attempt.evidence_error is not None:
         return FailureClass.EVIDENCE_MISSING
 
+    if attempt.validation is not None and attempt.validation.blocker is not None:
+        return FailureClass.BLOCKED
+
     if attempt.validation is not None and not attempt.validation.ok:
         return FailureClass.EVIDENCE_MISSING
 

--- a/src/ouroboros/orchestrator/failure_taxonomy.py
+++ b/src/ouroboros/orchestrator/failure_taxonomy.py
@@ -139,7 +139,7 @@ def classify(attempt: Attempt) -> FailureClass | None:
             # rather than crashing the orchestrator.
             return FailureClass.STALL
 
-    if attempt.evidence_error is not None:
+    if attempt.evidence_error is not None or attempt.validation_error is not None:
         return FailureClass.EVIDENCE_MISSING
 
     if attempt.validation is not None and attempt.validation.blocker is not None:

--- a/src/ouroboros/orchestrator/phase_wrappers.py
+++ b/src/ouroboros/orchestrator/phase_wrappers.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ouroboros.orchestrator.evidence_schema import BlockerCode
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile
 
 _DEFAULT_PRE_HEADER = "[PRE — harness-injected; restate before any action]"
@@ -52,6 +53,10 @@ def _format_rejected(schema: EvidenceSchema) -> str:
     if not schema.rejected_if:
         return "(profile declares no automatic rejection rules)"
     return "; ".join(schema.rejected_if)
+
+
+def _format_blocker_codes() -> str:
+    return ", ".join(code.value for code in BlockerCode)
 
 
 def _indent_ac(ac: str, indent: str = "  ") -> str:
@@ -94,7 +99,8 @@ def build_pre_block(profile: ExecutionProfile, ac: str) -> str:
         "Before touching any tool, restate this AC in one sentence and "
         "list every precondition you are assuming (paths, commands, "
         "external services). Do not begin execution if any precondition "
-        "is unverified — surface the blocker instead."
+        "is unverified — surface the blocker using the typed blocked JSON "
+        "contract in the POST block instead."
     )
 
 
@@ -112,6 +118,11 @@ def build_post_block(profile: ExecutionProfile) -> str:
         "line, then stop. Required fields for this profile: "
         f"{_format_required(schema)}.\n"
         f"Automatic rejection rules: {_format_rejected(schema)}.\n\n"
+        "If a required precondition is unavailable, emit this typed "
+        "terminal blocker shape instead of prose or partial evidence: "
+        '{"status":"blocked","blocker":{"code":"<one of: '
+        f'{_format_blocker_codes()}>","reason":"<non-empty reason>",'
+        '"required_by":"<AC/precondition/tool that requires it>"}}.\n\n'
         "Do not declare the task DONE in prose — the harness adjudicates "
         "via an external verifier pass. Your job ends when the evidence "
         "block is emitted."

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -17,9 +17,10 @@ Loop semantics:
     2. The harness parses evidence (H2). If evidence cannot be extracted,
        that counts as a FAIL with a parser reason — verifier is NOT called.
     3. The harness validates the record against profile.evidence_schema.
-       If the record fails validation, the verifier is short-circuited
-       and the loop retries (the leaf would never satisfy the contract
-       even if the verifier said PASS).
+       If the record carries a typed blocker, the loop terminates as
+       BLOCKED without verifier invocation. Other validation failures
+       short-circuit the verifier and retry (the leaf would never satisfy
+       the contract even if the verifier said PASS).
     4. Otherwise the verifier is invoked. PASS → return. FAIL → retry,
        feeding the verdict reasons back to the executor.
     5. After `max_retries` exhausted FAILs, return the last attempt with

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -185,6 +185,10 @@ class Attempt:
     def accepted(self) -> bool:
         return self.verdict is not None and self.verdict.passed
 
+    @property
+    def blocked(self) -> bool:
+        return self.validation is not None and self.validation.blocker is not None
+
 
 @dataclass(frozen=True)
 class LoopResult:
@@ -317,6 +321,8 @@ def run_with_verifier(
 
         if attempt.accepted:
             return LoopResult(accepted=True, attempts=tuple(attempts))
+        if attempt.blocked:
+            return LoopResult(accepted=False, attempts=tuple(attempts))
 
         feedback = _failure_reasons(attempt)
 

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -38,6 +38,7 @@ from typing import Protocol
 from ouroboros.orchestrator.evidence_schema import (
     EvidenceError,
     EvidenceRecord,
+    ProfileEvidenceConfigError,
     ValidationResult,
     extract_evidence,
     validate_evidence,
@@ -269,6 +270,12 @@ def run_with_verifier(
         if record is not None:
             try:
                 validation = validate_evidence(profile, record)
+            except ProfileEvidenceConfigError:
+                # Profile-authored rejected_if expressions are deterministic
+                # configuration bugs. Retrying the same leaf cannot repair the
+                # profile, so surface the error immediately instead of
+                # converting it into an evidence validation retry.
+                raise
             except EvidenceError as exc:
                 validation_error = str(exc)
                 validation = None

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -180,6 +180,7 @@ class Attempt:
     evidence_error: str | None
     validation: ValidationResult | None
     verdict: VerifierVerdict | None
+    validation_error: str | None = None
 
     @property
     def accepted(self) -> bool:
@@ -209,6 +210,8 @@ def _failure_reasons(attempt: Attempt) -> tuple[str, ...]:
     """Collect surfaceable reasons from an attempt's failure mode."""
     if attempt.evidence_error is not None:
         return (f"evidence parse failed: {attempt.evidence_error}",)
+    if attempt.validation_error is not None:
+        return (f"evidence validation failed: {attempt.validation_error}",)
     out: list[str] = []
     if attempt.validation is not None and not attempt.validation.ok:
         out.extend(attempt.validation.reasons())
@@ -259,11 +262,16 @@ def run_with_verifier(
             evidence_error = str(exc)
 
         validation: ValidationResult | None = None
+        validation_error: str | None = None
         verdict: VerifierVerdict | None = None
 
         if record is not None:
-            validation = validate_evidence(profile, record)
-            if validation.ok:
+            try:
+                validation = validate_evidence(profile, record)
+            except EvidenceError as exc:
+                validation_error = str(exc)
+                validation = None
+            if validation is not None and validation.ok:
                 try:
                     raw_verdict = verifier(
                         profile=profile,
@@ -314,6 +322,7 @@ def run_with_verifier(
             leaf_output=leaf_output,
             record=record,
             evidence_error=evidence_error,
+            validation_error=validation_error,
             validation=validation,
             verdict=verdict,
         )

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -346,3 +346,27 @@ class TestBlockedEvidence:
     ) -> None:
         with pytest.raises(EvidenceError, match=message):
             validate_evidence(code_profile, EvidenceRecord(data=payload))
+
+    def test_blocked_record_still_surfaces_malformed_profile_rule(self, code_profile) -> None:
+        from ouroboros.orchestrator.profile_loader import EvidenceSchema
+
+        broken = code_profile.model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=("len(tests_passed) < 1",),
+                )
+            }
+        )
+        record = EvidenceRecord(
+            data={
+                "status": "blocked",
+                "blocker": {
+                    "code": "MISSING_TOOL",
+                    "reason": "pytest is not installed",
+                },
+            }
+        )
+
+        with pytest.raises(EvidenceError, match="Unsupported rejected_if"):
+            validate_evidence(broken, record)

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -301,3 +301,48 @@ class TestJsonYamlLiteralSpellings:
         profile = self._profile_with_rule('status == "blocked"')
         record = EvidenceRecord(data={"status": "blocked"})
         assert validate_evidence(profile, record).ok is False
+
+
+class TestBlockedEvidence:
+    def test_blocked_record_is_typed_not_missing_evidence(self, code_profile) -> None:
+        record = EvidenceRecord(
+            data={
+                "status": "blocked",
+                "blocker": {
+                    "code": "MISSING_TOOL",
+                    "reason": "pytest is not installed in the execution image",
+                    "required_by": "AC-1 test verification",
+                },
+            }
+        )
+        result = validate_evidence(code_profile, record)
+        assert result.ok is False
+        assert result.missing_fields == ()
+        assert result.rejected_by == ()
+        assert result.blocker is not None
+        assert result.blocker.code.value == "MISSING_TOOL"
+        assert result.reasons() == (
+            "blocked[MISSING_TOOL]: pytest is not installed in the execution image "
+            "(required_by: AC-1 test verification)",
+        )
+
+    @pytest.mark.parametrize(
+        ("payload", "message"),
+        [
+            ({"status": "blocked", "blocker": "nope"}, "blocker must be an object"),
+            ({"status": "blocked", "blocker": {"reason": "x"}}, "blocker.code"),
+            (
+                {"status": "blocked", "blocker": {"code": "MYSTERY", "reason": "x"}},
+                "Unknown blocker.code",
+            ),
+            (
+                {"status": "blocked", "blocker": {"code": "MISSING_TOOL", "reason": ""}},
+                "blocker.reason",
+            ),
+        ],
+    )
+    def test_malformed_blocked_record_is_schema_error(
+        self, code_profile, payload, message: str
+    ) -> None:
+        with pytest.raises(EvidenceError, match=message):
+            validate_evidence(code_profile, EvidenceRecord(data=payload))

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -7,6 +7,7 @@ import pytest
 from ouroboros.orchestrator.evidence_schema import (
     EvidenceError,
     EvidenceRecord,
+    ProfileEvidenceConfigError,
     extract_evidence,
     validate_evidence,
 )
@@ -207,7 +208,7 @@ class TestRejectionGrammar:
             }
         )
         record = EvidenceRecord(data={"tests_passed": [1]})
-        with pytest.raises(EvidenceError, match="Unsupported rejected_if"):
+        with pytest.raises(ProfileEvidenceConfigError, match="Unsupported rejected_if"):
             validate_evidence(broken, record)
 
     def test_unsupported_literal_raises(self, code_profile) -> None:
@@ -222,7 +223,7 @@ class TestRejectionGrammar:
             }
         )
         record = EvidenceRecord(data={"tests_passed": []})
-        with pytest.raises(EvidenceError, match="Unsupported literal"):
+        with pytest.raises(ProfileEvidenceConfigError, match="Unsupported literal"):
             validate_evidence(broken, record)
 
     def test_missing_field_compared_to_none_triggers(self) -> None:
@@ -368,5 +369,5 @@ class TestBlockedEvidence:
             }
         )
 
-        with pytest.raises(EvidenceError, match="Unsupported rejected_if"):
+        with pytest.raises(ProfileEvidenceConfigError, match="Unsupported rejected_if"):
             validate_evidence(broken, record)

--- a/tests/unit/orchestrator/test_failure_taxonomy.py
+++ b/tests/unit/orchestrator/test_failure_taxonomy.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
+from ouroboros.orchestrator.evidence_schema import (
+    BlockerCode,
+    EvidenceBlocker,
+    EvidenceRecord,
+    ValidationResult,
+)
 from ouroboros.orchestrator.failure_taxonomy import (
     FailureClass,
     RecoveryAction,
@@ -80,6 +85,18 @@ class TestClassify:
             validation=ValidationResult(ok=False, missing_fields=("tests_passed",), rejected_by=()),
         )
         assert classify(attempt) == FailureClass.EVIDENCE_MISSING
+
+    def test_typed_blocked_validation_maps_to_blocked(self) -> None:
+        attempt = _attempt(
+            validation=ValidationResult(
+                ok=False,
+                blocker=EvidenceBlocker(
+                    code=BlockerCode.MISSING_ACCESS,
+                    reason="repository token is missing",
+                ),
+            ),
+        )
+        assert classify(attempt) == FailureClass.BLOCKED
 
     def test_unattributed_failure_maps_to_stall(self) -> None:
         attempt = _attempt(

--- a/tests/unit/orchestrator/test_failure_taxonomy.py
+++ b/tests/unit/orchestrator/test_failure_taxonomy.py
@@ -80,6 +80,11 @@ class TestClassify:
         attempt = _attempt(evidence_error="not json")
         assert classify(attempt) == FailureClass.EVIDENCE_MISSING
 
+    def test_evidence_validation_error_maps_to_evidence_missing(self) -> None:
+        attempt = _attempt()
+        object.__setattr__(attempt, "validation_error", "blocker.reason missing")
+        assert classify(attempt) == FailureClass.EVIDENCE_MISSING
+
     def test_validation_failure_maps_to_evidence_missing(self) -> None:
         attempt = _attempt(
             validation=ValidationResult(ok=False, missing_fields=("tests_passed",), rejected_by=()),

--- a/tests/unit/orchestrator/test_phase_wrappers.py
+++ b/tests/unit/orchestrator/test_phase_wrappers.py
@@ -37,6 +37,7 @@ class TestPreBlock:
     def test_blocker_path_named(self, code_profile: ExecutionProfile) -> None:
         block = build_pre_block(code_profile, "x")
         assert "blocker" in block.lower()
+        assert "typed blocked JSON" in block
 
     def test_ac_passes_through_verbatim(self, code_profile: ExecutionProfile) -> None:
         # Bot finding on #886 r3: ACs are free-form text and may
@@ -119,6 +120,15 @@ class TestPostBlock:
     def test_demands_fenced_json(self, code_profile: ExecutionProfile) -> None:
         block = build_post_block(code_profile)
         assert "fenced JSON" in block
+
+    def test_documents_typed_blocker_payload(self, code_profile: ExecutionProfile) -> None:
+        block = build_post_block(code_profile)
+        assert '"status":"blocked"' in block
+        assert '"blocker"' in block
+        assert '"code"' in block
+        assert "MISSING_TOOL" in block
+        assert '"reason"' in block
+        assert '"required_by"' in block
 
     def test_handles_empty_schema_gracefully(self) -> None:
         bare = ExecutionProfile(

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -422,6 +422,34 @@ class TestEvidenceShortCircuit:
         # Feedback to the retry should mention the parse failure.
         assert any("evidence parse failed" in line for line in executor.feedbacks[1])
 
+    def test_blocked_evidence_stops_without_retry_or_verifier(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        blocked = json.dumps({
+            "status": "blocked",
+            "blocker": {
+                "code": "MISSING_CONFIGURATION",
+                "reason": "DATABASE_URL is required to verify this AC",
+            },
+        })
+        executor = ScriptedExecutor(outputs=[blocked, _code_evidence()])
+        verifier = ScriptedVerifier(verdicts=[VerifierVerdict(passed=True)])
+
+        result = run_with_verifier(
+            executor=executor,
+            verifier=verifier,
+            profile=code_profile,
+            ac="x",
+        )
+
+        assert result.accepted is False
+        assert len(result.attempts) == 1
+        assert result.final.blocked is True
+        assert result.final.validation is not None
+        assert result.final.validation.blocker is not None
+        assert verifier.calls == 0
+        assert len(executor.feedbacks) == 1
+
     def test_evidence_validation_fail_skips_verifier(self, code_profile: ExecutionProfile) -> None:
         empty_tests = _code_evidence(tests_passed=[])
         executor = ScriptedExecutor(outputs=[empty_tests, _code_evidence()])

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -425,13 +425,15 @@ class TestEvidenceShortCircuit:
     def test_blocked_evidence_stops_without_retry_or_verifier(
         self, code_profile: ExecutionProfile
     ) -> None:
-        blocked = json.dumps({
-            "status": "blocked",
-            "blocker": {
-                "code": "MISSING_CONFIGURATION",
-                "reason": "DATABASE_URL is required to verify this AC",
-            },
-        })
+        blocked = json.dumps(
+            {
+                "status": "blocked",
+                "blocker": {
+                    "code": "MISSING_CONFIGURATION",
+                    "reason": "DATABASE_URL is required to verify this AC",
+                },
+            }
+        )
         executor = ScriptedExecutor(outputs=[blocked, _code_evidence()])
         verifier = ScriptedVerifier(verdicts=[VerifierVerdict(passed=True)])
 

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -469,6 +469,30 @@ class TestEvidenceShortCircuit:
         assert first.verdict is None
         assert any("tests_passed == []" in line for line in executor.feedbacks[1])
 
+    def test_malformed_blocker_validation_retries_without_crashing(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        malformed_blocker = json.dumps({"status": "blocked", "blocker": {"code": "MISSING_TOOL"}})
+        executor = ScriptedExecutor(outputs=[malformed_blocker, _code_evidence()])
+        verifier = ScriptedVerifier(verdicts=[VerifierVerdict(passed=True)])
+
+        result = run_with_verifier(
+            executor=executor,
+            verifier=verifier,
+            profile=code_profile,
+            ac="x",
+        )
+
+        assert result.accepted is True
+        assert verifier.calls == 1
+        first = result.attempts[0]
+        assert first.record is not None
+        assert first.validation_error is not None
+        assert "blocker.reason" in first.validation_error
+        assert first.validation is None
+        assert first.verdict is None
+        assert any("evidence validation failed" in line for line in executor.feedbacks[1])
+
     def test_evidence_fail_exhausts_budget_without_verifier(
         self, code_profile: ExecutionProfile
     ) -> None:

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -7,8 +7,8 @@ import json
 
 import pytest
 
-from ouroboros.orchestrator.evidence_schema import EvidenceRecord
-from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
+from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ProfileEvidenceConfigError
+from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile, load_profile
 from ouroboros.orchestrator.verifier import (
     DEFAULT_MAX_RETRIES,
     LoopResult,
@@ -492,6 +492,32 @@ class TestEvidenceShortCircuit:
         assert first.validation is None
         assert first.verdict is None
         assert any("evidence validation failed" in line for line in executor.feedbacks[1])
+
+    def test_malformed_profile_rejected_if_propagates_without_retry(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        broken_profile = code_profile.model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=(),
+                    rejected_if=("len(tests_passed) < 1",),
+                )
+            }
+        )
+        executor = ScriptedExecutor(outputs=[_code_evidence(), _code_evidence()])
+        verifier = ScriptedVerifier(verdicts=[VerifierVerdict(passed=True)])
+
+        with pytest.raises(ProfileEvidenceConfigError, match="Unsupported rejected_if"):
+            run_with_verifier(
+                executor=executor,
+                verifier=verifier,
+                profile=broken_profile,
+                ac="x",
+            )
+
+        # A malformed profile cannot be fixed by asking the leaf to retry.
+        assert len(executor.feedbacks) == 1
+        assert verifier.calls == 0
 
     def test_evidence_fail_exhausts_budget_without_verifier(
         self, code_profile: ExecutionProfile


### PR DESCRIPTION
## Summary

Adds the next #920 fat-harness implementation slice: leaf evidence can now represent a legitimate terminal blocker without being treated as missing evidence.

- adds typed blocker codes and `EvidenceBlocker`
- validates `status: blocked` + `blocker` evidence as a terminal blocked state
- stops the verifier loop without retrying or invoking the verifier for typed blockers
- maps typed blocked validation results to the H7 `BLOCKED` failure class

## Agent OS direction

This gives the harness a machine-readable terminal state for missing authority, access, tools, configuration, unsafe scope changes, and external dependencies. That is required before `ooo run` can distinguish “retry the leaf” from “surface a deterministic blocker.”

## Validation

- `uv run ruff check --fix src/ouroboros/orchestrator/evidence_schema.py tests/unit/orchestrator/test_evidence_schema.py`
- `uv run pytest tests/unit/orchestrator/test_evidence_schema.py tests/unit/orchestrator/test_verifier.py tests/unit/orchestrator/test_failure_taxonomy.py`

Closes part of #920.