### PR TITLE
feat(auto): persist typed recovery plans after QA failure

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -30,6 +30,10 @@ from ouroboros.auto.lateral_routing import select_persona_for_qa_failure
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.listeners import RALPH_CANCEL_BLOCKER_REASON, mirror_ralph_job_events
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
+from ouroboros.auto.recovery_plan import (
+    build_lateral_recovery_plan,
+    build_manual_recovery_plan,
+)
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
@@ -1566,6 +1570,7 @@ class AutoPipeline:
             state.last_lateral_approach_summary = None
             state.last_lateral_text = None
             state.lateral_input_hash = None
+            state.last_recovery_plan = None
         state.evaluate_artifact = artifact
         state.evaluate_artifact_hash = artifact_hash
 
@@ -1774,6 +1779,12 @@ class AutoPipeline:
                 run_subagent=run_subagent,
             )
 
+        state.last_recovery_plan = build_manual_recovery_plan(
+            qa_score=score,
+            qa_verdict=verdict,
+            differences=tuple(differences),
+            suggestions=tuple(suggestions),
+        ).to_dict()
         diff_preview = "; ".join(differences[:3]) if differences else ""
         sug_preview = "; ".join(suggestions[:3]) if suggestions else ""
         summary_parts = [f"evaluator did not pass: {verdict} (score {score:.2f}){cache_suffix}"]
@@ -2030,6 +2041,15 @@ class AutoPipeline:
         lateral_suffix = " [lateral cached]" if from_cache else ""
         persona_name = state.last_lateral_persona or "unknown"
         approach = state.last_lateral_approach_summary or ""
+        state.last_recovery_plan = build_lateral_recovery_plan(
+            qa_score=qa_score,
+            qa_verdict=qa_verdict,
+            differences=tuple(qa_differences),
+            suggestions=tuple(qa_suggestions),
+            persona=persona_name,
+            approach_summary=approach,
+            lateral_text=state.last_lateral_text or "",
+        ).to_dict()
         summary_parts = [
             f"evaluator did not pass: {qa_verdict} (score {qa_score:.2f}){cache_suffix}",
             f"lateral persona {persona_name}{lateral_suffix}: {approach}"

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1752,6 +1752,7 @@ class AutoPipeline:
         """
         cache_suffix = " [cached]" if from_cache else ""
         if passed:
+            state.last_recovery_plan = None
             state.transition(
                 AutoPhase.COMPLETE,
                 f"evaluator passed: {verdict} (score {score:.2f}){cache_suffix}"

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1837,6 +1837,7 @@ class AutoPipeline:
         import hashlib
 
         assert self.lateral_thinker is not None  # noqa: S101 — guarded by caller
+        state.last_recovery_plan = None
 
         # RFC #809 Phase 2.2b — sticky guard check (mirrors ``_run_evaluate``).
         # If a previous round exhausted any recovery guard, a resume that

--- a/src/ouroboros/auto/recovery_plan.py
+++ b/src/ouroboros/auto/recovery_plan.py
@@ -164,6 +164,18 @@ def build_lateral_recovery_plan(
     if lateral_text:
         instruction_parts.append(lateral_text)
     instruction = "\n\n".join(instruction_parts).strip()
+    if not instruction:
+        return AutoRecoveryPlan(
+            action=RecoveryPlanAction.MANUAL_INTERVENTION,
+            safe_to_redispatch=False,
+            reason="QA failed but lateral recovery advice was empty.",
+            qa_score=qa_score,
+            qa_verdict=qa_verdict,
+            differences=tuple(differences),
+            suggestions=tuple(suggestions),
+            persona=persona,
+            instruction="Inspect QA differences manually before redispatch.",
+        )
     return AutoRecoveryPlan(
         action=RecoveryPlanAction.RALPH_REDISPATCH,
         safe_to_redispatch=True,

--- a/src/ouroboros/auto/recovery_plan.py
+++ b/src/ouroboros/auto/recovery_plan.py
@@ -35,6 +35,9 @@ class AutoRecoveryPlan:
     instruction: str = ""
 
     def __post_init__(self) -> None:
+        if not isinstance(self.action, RecoveryPlanAction):
+            msg = "action must be a RecoveryPlanAction"
+            raise ValueError(msg)
         if not isinstance(self.safe_to_redispatch, bool):
             msg = "safe_to_redispatch must be a boolean"
             raise ValueError(msg)

--- a/src/ouroboros/auto/recovery_plan.py
+++ b/src/ouroboros/auto/recovery_plan.py
@@ -99,17 +99,31 @@ class AutoRecoveryPlan:
                 f"recovery plan action must be one of {[item.value for item in RecoveryPlanAction]}"
             )
             raise ValueError(msg) from exc
+        differences = _string_tuple_field(data, "differences")
+        suggestions = _string_tuple_field(data, "suggestions")
         return cls(
             action=action,
             safe_to_redispatch=data.get("safe_to_redispatch"),
             reason=data.get("reason"),
             qa_score=data.get("qa_score"),
             qa_verdict=data.get("qa_verdict"),
-            differences=tuple(data.get("differences", ())),
-            suggestions=tuple(data.get("suggestions", ())),
+            differences=differences,
+            suggestions=suggestions,
             persona=data.get("persona"),
             instruction=data.get("instruction", ""),
         )
+
+
+def _string_tuple_field(data: dict[str, Any], field_name: str) -> tuple[str, ...]:
+    """Return a strict tuple-of-strings field from persisted JSON."""
+    raw = data.get(field_name, ())
+    if not isinstance(raw, list | tuple):
+        msg = f"recovery plan {field_name} must be a list of strings"
+        raise ValueError(msg)
+    if any(not isinstance(item, str) for item in raw):
+        msg = f"recovery plan {field_name} must be a list of strings"
+        raise ValueError(msg)
+    return tuple(raw)
 
 
 def build_manual_recovery_plan(

--- a/src/ouroboros/auto/recovery_plan.py
+++ b/src/ouroboros/auto/recovery_plan.py
@@ -1,0 +1,169 @@
+"""Typed auto-mode recovery plan artifacts.
+
+The complete-product recovery loop needs a machine-readable handoff between
+QA/lateral analysis and a future Ralph redispatch. This module defines that
+artifact without executing it: the pipeline can persist a plan today, while a
+follow-up PR can consume the same shape to safely redispatch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class RecoveryPlanAction(StrEnum):
+    """Next action proposed by a recovery plan."""
+
+    RALPH_REDISPATCH = "ralph_redispatch"
+    MANUAL_INTERVENTION = "manual_intervention"
+
+
+@dataclass(frozen=True)
+class AutoRecoveryPlan:
+    """Durable recovery artifact produced after a QA failure."""
+
+    action: RecoveryPlanAction
+    safe_to_redispatch: bool
+    reason: str
+    qa_score: float
+    qa_verdict: str
+    differences: tuple[str, ...] = field(default_factory=tuple)
+    suggestions: tuple[str, ...] = field(default_factory=tuple)
+    persona: str | None = None
+    instruction: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.safe_to_redispatch, bool):
+            msg = "safe_to_redispatch must be a boolean"
+            raise ValueError(msg)
+        if isinstance(self.qa_score, bool) or not isinstance(self.qa_score, int | float):
+            msg = "qa_score must be a number"
+            raise ValueError(msg)
+        if not isinstance(self.qa_verdict, str) or not self.qa_verdict.strip():
+            msg = "qa_verdict must be a non-empty string"
+            raise ValueError(msg)
+        if not isinstance(self.reason, str) or not self.reason.strip():
+            msg = "reason must be a non-empty string"
+            raise ValueError(msg)
+        if self.persona is not None and (
+            not isinstance(self.persona, str) or not self.persona.strip()
+        ):
+            msg = "persona must be a non-empty string or null"
+            raise ValueError(msg)
+        if not isinstance(self.instruction, str):
+            msg = "instruction must be a string"
+            raise ValueError(msg)
+        for field_name, values in (
+            ("differences", self.differences),
+            ("suggestions", self.suggestions),
+        ):
+            if not isinstance(values, tuple) or any(not isinstance(item, str) for item in values):
+                msg = f"{field_name} must be a tuple of strings"
+                raise ValueError(msg)
+        if self.action is RecoveryPlanAction.RALPH_REDISPATCH and not self.safe_to_redispatch:
+            msg = "ralph_redispatch plans must set safe_to_redispatch=true"
+            raise ValueError(msg)
+        if self.action is RecoveryPlanAction.MANUAL_INTERVENTION and self.safe_to_redispatch:
+            msg = "manual_intervention plans must set safe_to_redispatch=false"
+            raise ValueError(msg)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "action": self.action.value,
+            "safe_to_redispatch": self.safe_to_redispatch,
+            "reason": self.reason,
+            "qa_score": float(self.qa_score),
+            "qa_verdict": self.qa_verdict,
+            "differences": list(self.differences),
+            "suggestions": list(self.suggestions),
+            "persona": self.persona,
+            "instruction": self.instruction,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AutoRecoveryPlan:
+        """Deserialize and validate a persisted recovery plan."""
+        if not isinstance(data, dict):
+            msg = "recovery plan must be an object"
+            raise ValueError(msg)
+        try:
+            action = RecoveryPlanAction(data["action"])
+        except KeyError as exc:
+            msg = "recovery plan is missing action"
+            raise ValueError(msg) from exc
+        except ValueError as exc:
+            msg = f"recovery plan action must be one of {[item.value for item in RecoveryPlanAction]}"
+            raise ValueError(msg) from exc
+        return cls(
+            action=action,
+            safe_to_redispatch=data.get("safe_to_redispatch"),
+            reason=data.get("reason"),
+            qa_score=data.get("qa_score"),
+            qa_verdict=data.get("qa_verdict"),
+            differences=tuple(data.get("differences", ())),
+            suggestions=tuple(data.get("suggestions", ())),
+            persona=data.get("persona"),
+            instruction=data.get("instruction", ""),
+        )
+
+
+def build_manual_recovery_plan(
+    *,
+    qa_score: float,
+    qa_verdict: str,
+    differences: tuple[str, ...],
+    suggestions: tuple[str, ...],
+) -> AutoRecoveryPlan:
+    """Build a non-dispatchable plan when no automated recovery advisor ran."""
+    instruction = "; ".join(suggestions[:3]) if suggestions else "Inspect QA differences manually."
+    return AutoRecoveryPlan(
+        action=RecoveryPlanAction.MANUAL_INTERVENTION,
+        safe_to_redispatch=False,
+        reason="QA failed without an automated recovery advisor.",
+        qa_score=qa_score,
+        qa_verdict=qa_verdict,
+        differences=tuple(differences),
+        suggestions=tuple(suggestions),
+        instruction=instruction,
+    )
+
+
+def build_lateral_recovery_plan(
+    *,
+    qa_score: float,
+    qa_verdict: str,
+    differences: tuple[str, ...],
+    suggestions: tuple[str, ...],
+    persona: str,
+    approach_summary: str,
+    lateral_text: str,
+) -> AutoRecoveryPlan:
+    """Build the future Ralph-redispatch artifact from lateral advice."""
+    instruction_parts = []
+    if approach_summary:
+        instruction_parts.append(approach_summary)
+    if lateral_text:
+        instruction_parts.append(lateral_text)
+    instruction = "\n\n".join(instruction_parts).strip()
+    return AutoRecoveryPlan(
+        action=RecoveryPlanAction.RALPH_REDISPATCH,
+        safe_to_redispatch=True,
+        reason="QA failed and lateral recovery advice is available for Ralph redispatch.",
+        qa_score=qa_score,
+        qa_verdict=qa_verdict,
+        differences=tuple(differences),
+        suggestions=tuple(suggestions),
+        persona=persona,
+        instruction=instruction,
+    )
+
+
+__all__ = [
+    "AutoRecoveryPlan",
+    "RecoveryPlanAction",
+    "build_lateral_recovery_plan",
+    "build_manual_recovery_plan",
+]

--- a/src/ouroboros/auto/recovery_plan.py
+++ b/src/ouroboros/auto/recovery_plan.py
@@ -95,7 +95,9 @@ class AutoRecoveryPlan:
             msg = "recovery plan is missing action"
             raise ValueError(msg) from exc
         except ValueError as exc:
-            msg = f"recovery plan action must be one of {[item.value for item in RecoveryPlanAction]}"
+            msg = (
+                f"recovery plan action must be one of {[item.value for item in RecoveryPlanAction]}"
+            )
             raise ValueError(msg) from exc
         return cls(
             action=action,

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -13,6 +13,8 @@ import time
 from typing import Any
 from uuid import uuid4
 
+from ouroboros.auto.recovery_plan import AutoRecoveryPlan
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -525,6 +527,9 @@ class AutoPipelineState:
     # fresh artifact reaching EVALUATE through a deliberate operator
     # workflow can start over with a clean budget.
     recovery_guard_tripped: str | None = None
+    # Typed artifact for the next automated recovery step. Current PRs persist
+    # this plan after QA/lateral failure; a follow-up redispatch PR consumes it.
+    last_recovery_plan: dict[str, Any] | None = None
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.
@@ -870,6 +875,7 @@ class AutoPipelineState:
         payload.setdefault("failure_fingerprints", [])
         payload.setdefault("personas_invoked", [])
         payload.setdefault("recovery_guard_tripped", None)
+        payload.setdefault("last_recovery_plan", None)
         # Convert the persisted ``deadline_at_epoch`` (epoch seconds) back into
         # a monotonic-clock value usable from this process. If the companion
         # epoch field is present, derive ``deadline_at`` from the offset
@@ -1118,6 +1124,12 @@ class AutoPipelineState:
                 f"({sorted(_VALID_RECOVERY_PERSONAS)})"
             )
             raise ValueError(msg)
+        if self.last_recovery_plan is not None:
+            try:
+                AutoRecoveryPlan.from_dict(self.last_recovery_plan)
+            except Exception as exc:
+                msg = "last_recovery_plan must be a valid AutoRecoveryPlan object or null"
+                raise ValueError(msg) from exc
         if self.recovery_guard_tripped is not None and (
             not isinstance(self.recovery_guard_tripped, str)
             or self.recovery_guard_tripped not in _VALID_RECOVERY_GUARD_TAGS

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -104,6 +104,20 @@ def _state_at_run_phase(tmp_path) -> AutoPipelineState:
     return state
 
 
+def _stale_recovery_plan() -> dict[str, Any]:
+    return {
+        "action": "ralph_redispatch",
+        "safe_to_redispatch": True,
+        "reason": "stale successful lateral advice from an earlier round",
+        "qa_score": 0.2,
+        "qa_verdict": "fail",
+        "differences": ["old failure"],
+        "suggestions": ["old suggestion"],
+        "persona": "hacker",
+        "instruction": "old redispatch instruction",
+    }
+
+
 async def _run_starter_ok(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
     return {
         "job_id": "job_run_001",
@@ -371,6 +385,42 @@ async def test_pipeline_qa_fail_enters_unstuck_lateral_and_blocks_with_persona(t
 
 
 @pytest.mark.asyncio
+async def test_pipeline_empty_lateral_advice_is_not_dispatchable(tmp_path) -> None:
+    state = _state_at_run_phase(tmp_path)
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False,
+            score=0.30,
+            verdict="fail",
+            differences=("Xcode is not available in the sandbox",),
+            suggestions=("try CLI build via swift test",),
+        )
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001
+        return LateralResult(persona="hacker", approach_summary="", text="")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_recovery_plan is not None
+    assert state.last_recovery_plan["action"] == "manual_intervention"
+    assert state.last_recovery_plan["safe_to_redispatch"] is False
+    assert state.last_recovery_plan["instruction"]
+
+
+@pytest.mark.asyncio
 async def test_pipeline_qa_fail_without_lateral_thinker_falls_back_to_phase_2_1(tmp_path) -> None:
     """When lateral_thinker is None, QA fail must land in BLOCKED with the
     Phase 2.1 message (no persona consultation)."""
@@ -437,6 +487,7 @@ async def test_pipeline_lateral_skipped_when_complete_product_false(tmp_path) ->
 async def test_pipeline_lateral_timeout_blocks_with_recoverable_tool_name(tmp_path) -> None:
     state = _state_at_run_phase(tmp_path)
     state.timeout_seconds_by_phase[AutoPhase.UNSTUCK_LATERAL.value] = 1
+    state.last_recovery_plan = _stale_recovery_plan()
 
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
         return EvaluateResult(passed=False, score=0.1, verdict="fail", differences=("xx",))
@@ -460,11 +511,13 @@ async def test_pipeline_lateral_timeout_blocks_with_recoverable_tool_name(tmp_pa
     assert result.status == "blocked"
     assert state.last_tool_name == "lateral_thinker"
     assert "timed out" in (state.last_error or "")
+    assert state.last_recovery_plan is None
 
 
 @pytest.mark.asyncio
 async def test_pipeline_lateral_handler_error_blocks(tmp_path) -> None:
     state = _state_at_run_phase(tmp_path)
+    state.last_recovery_plan = _stale_recovery_plan()
 
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
         return EvaluateResult(passed=False, score=0.1, verdict="fail", differences=("xx",))
@@ -492,6 +545,7 @@ async def test_pipeline_lateral_handler_error_blocks(tmp_path) -> None:
     assert result.status == "blocked"
     assert state.last_tool_name == "lateral_thinker"
     assert "lateral_think tool unreachable" in (state.last_error or "")
+    assert state.last_recovery_plan is None
 
 
 @pytest.mark.asyncio
@@ -1288,6 +1342,7 @@ async def test_recovery_personas_exhausted_blocks(tmp_path) -> None:
     been routed in this session, the next lateral call returns ``None``
     and the pipeline blocks with a ``"personas exhausted"`` reason."""
     state = _state_at_run_phase(tmp_path)
+    state.last_recovery_plan = _stale_recovery_plan()
     # All five personas in the fallback chain marked as already routed.
     state.personas_invoked = [
         ThinkingPersona.HACKER.value,
@@ -1326,6 +1381,7 @@ async def test_recovery_personas_exhausted_blocks(tmp_path) -> None:
     last_error = state.last_error or ""
     assert "personas exhausted" in last_error.lower()
     assert "re-interview" in last_error
+    assert state.last_recovery_plan is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -351,6 +351,11 @@ async def test_pipeline_qa_fail_enters_unstuck_lateral_and_blocks_with_persona(t
     # MCP-facing result fields populated
     assert result.last_lateral_persona == "hacker"
     assert result.last_lateral_text is not None
+    assert state.last_recovery_plan is not None
+    assert state.last_recovery_plan["action"] == "ralph_redispatch"
+    assert state.last_recovery_plan["safe_to_redispatch"] is True
+    assert state.last_recovery_plan["persona"] == "hacker"
+    assert "Reframe the verification path" in state.last_recovery_plan["instruction"]
 
 
 @pytest.mark.asyncio
@@ -378,6 +383,9 @@ async def test_pipeline_qa_fail_without_lateral_thinker_falls_back_to_phase_2_1(
     result = await pipeline.run(state)
     assert result.status == "blocked"
     assert state.last_tool_name == "evaluator"  # NOT lateral_thinker
+    assert state.last_recovery_plan is not None
+    assert state.last_recovery_plan["action"] == "manual_intervention"
+    assert state.last_recovery_plan["safe_to_redispatch"] is False
     assert state.last_lateral_persona is None
 
 
@@ -819,6 +827,17 @@ def test_state_round_trips_lateral_fields(tmp_path) -> None:
     state.last_lateral_approach_summary = "Hacker: works around"
     state.last_lateral_text = "lateral prompt body"
     state.lateral_input_hash = "abc123"
+    state.last_recovery_plan = {
+        "action": "ralph_redispatch",
+        "safe_to_redispatch": True,
+        "reason": "QA failed and lateral advice is available",
+        "qa_score": 0.3,
+        "qa_verdict": "fail",
+        "differences": ["missing stdout"],
+        "suggestions": ["run cli"],
+        "persona": "hacker",
+        "instruction": "Run the CLI directly",
+    }
     store = AutoStore(tmp_path)
     store.save(state)
     reloaded = store.load(state.auto_session_id)
@@ -826,6 +845,8 @@ def test_state_round_trips_lateral_fields(tmp_path) -> None:
     assert reloaded.last_lateral_approach_summary == "Hacker: works around"
     assert reloaded.last_lateral_text == "lateral prompt body"
     assert reloaded.lateral_input_hash == "abc123"
+    assert reloaded.last_recovery_plan is not None
+    assert reloaded.last_recovery_plan["action"] == "ralph_redispatch"
 
 
 def test_state_loads_legacy_dump_without_lateral_fields(tmp_path) -> None:
@@ -837,6 +858,7 @@ def test_state_loads_legacy_dump_without_lateral_fields(tmp_path) -> None:
         "last_lateral_approach_summary",
         "last_lateral_text",
         "lateral_input_hash",
+        "last_recovery_plan",
     ):
         raw.pop(key, None)
     reloaded = AutoPipelineState.from_dict(raw)
@@ -844,6 +866,7 @@ def test_state_loads_legacy_dump_without_lateral_fields(tmp_path) -> None:
     assert reloaded.last_lateral_approach_summary is None
     assert reloaded.last_lateral_text is None
     assert reloaded.lateral_input_hash is None
+    assert reloaded.last_recovery_plan is None
 
 
 def test_resume_capability_lateral_with_cached_text_is_resumable(tmp_path) -> None:

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -274,6 +274,17 @@ async def test_pipeline_qa_pass_does_not_enter_unstuck_lateral(tmp_path) -> None
     """QA pass path must skip UNSTUCK_LATERAL entirely (Phase 2.1 behaviour
     preserved)."""
     state = _state_at_run_phase(tmp_path)
+    state.last_recovery_plan = {
+        "action": "manual_intervention",
+        "safe_to_redispatch": False,
+        "reason": "stale QA failure from an earlier round",
+        "qa_score": 0.2,
+        "qa_verdict": "fail",
+        "differences": ["old failure"],
+        "suggestions": ["old suggestion"],
+        "persona": None,
+        "instruction": "old recovery instruction",
+    }
     lateral_calls = 0
 
     async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
@@ -299,6 +310,7 @@ async def test_pipeline_qa_pass_does_not_enter_unstuck_lateral(tmp_path) -> None
     assert result.status == "complete"
     assert lateral_calls == 0
     assert state.last_lateral_persona is None
+    assert state.last_recovery_plan is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_recovery_plan.py
+++ b/tests/unit/auto/test_recovery_plan.py
@@ -29,6 +29,23 @@ def test_lateral_recovery_plan_round_trips() -> None:
     assert AutoRecoveryPlan.from_dict(plan.to_dict()) == plan
 
 
+def test_empty_lateral_advice_is_manual_intervention() -> None:
+    plan = build_lateral_recovery_plan(
+        qa_score=0.42,
+        qa_verdict="fail",
+        differences=("missing CLI output",),
+        suggestions=("inspect stdout",),
+        persona="hacker",
+        approach_summary="",
+        lateral_text="",
+    )
+
+    assert plan.action is RecoveryPlanAction.MANUAL_INTERVENTION
+    assert plan.safe_to_redispatch is False
+    assert plan.persona == "hacker"
+    assert plan.instruction
+
+
 def test_manual_plan_is_not_auto_dispatchable() -> None:
     plan = build_manual_recovery_plan(
         qa_score=0.25,

--- a/tests/unit/auto/test_recovery_plan.py
+++ b/tests/unit/auto/test_recovery_plan.py
@@ -1,0 +1,55 @@
+"""Tests for typed auto recovery plan artifacts."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.recovery_plan import (
+    AutoRecoveryPlan,
+    RecoveryPlanAction,
+    build_lateral_recovery_plan,
+    build_manual_recovery_plan,
+)
+
+
+def test_lateral_recovery_plan_round_trips() -> None:
+    plan = build_lateral_recovery_plan(
+        qa_score=0.42,
+        qa_verdict="fail",
+        differences=("missing CLI output",),
+        suggestions=("add a smoke test",),
+        persona="hacker",
+        approach_summary="Use a smaller verification path",
+        lateral_text="Run the CLI directly and capture stdout.",
+    )
+
+    assert plan.action is RecoveryPlanAction.RALPH_REDISPATCH
+    assert plan.safe_to_redispatch is True
+    assert "Run the CLI" in plan.instruction
+    assert AutoRecoveryPlan.from_dict(plan.to_dict()) == plan
+
+
+def test_manual_plan_is_not_auto_dispatchable() -> None:
+    plan = build_manual_recovery_plan(
+        qa_score=0.25,
+        qa_verdict="fail",
+        differences=("missing auth decision",),
+        suggestions=("ask the user",),
+    )
+
+    assert plan.action is RecoveryPlanAction.MANUAL_INTERVENTION
+    assert plan.safe_to_redispatch is False
+    assert plan.instruction == "ask the user"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"action": "ralph_redispatch", "safe_to_redispatch": False, "reason": "x", "qa_score": 0.1, "qa_verdict": "fail"},
+        {"action": "manual_intervention", "safe_to_redispatch": True, "reason": "x", "qa_score": 0.1, "qa_verdict": "fail"},
+        {"action": "mystery", "safe_to_redispatch": False, "reason": "x", "qa_score": 0.1, "qa_verdict": "fail"},
+    ],
+)
+def test_invalid_plan_payloads_raise(payload) -> None:
+    with pytest.raises(ValueError):
+        AutoRecoveryPlan.from_dict(payload)

--- a/tests/unit/auto/test_recovery_plan.py
+++ b/tests/unit/auto/test_recovery_plan.py
@@ -66,6 +66,22 @@ def test_manual_plan_is_not_auto_dispatchable() -> None:
             "qa_score": 0.1,
             "qa_verdict": "fail",
         },
+        {
+            "action": "manual_intervention",
+            "safe_to_redispatch": False,
+            "reason": "x",
+            "qa_score": 0.1,
+            "qa_verdict": "fail",
+            "differences": "oops",
+        },
+        {
+            "action": "manual_intervention",
+            "safe_to_redispatch": False,
+            "reason": "x",
+            "qa_score": 0.1,
+            "qa_verdict": "fail",
+            "suggestions": ["ok", 123],
+        },
     ],
 )
 def test_invalid_plan_payloads_raise(payload) -> None:

--- a/tests/unit/auto/test_recovery_plan.py
+++ b/tests/unit/auto/test_recovery_plan.py
@@ -46,6 +46,17 @@ def test_empty_lateral_advice_is_manual_intervention() -> None:
     assert plan.instruction
 
 
+def test_direct_construction_rejects_string_action() -> None:
+    with pytest.raises(ValueError, match="action"):
+        AutoRecoveryPlan(
+            action="ralph_redispatch",  # type: ignore[arg-type]
+            safe_to_redispatch=True,
+            reason="x",
+            qa_score=0.1,
+            qa_verdict="fail",
+        )
+
+
 def test_manual_plan_is_not_auto_dispatchable() -> None:
     plan = build_manual_recovery_plan(
         qa_score=0.25,

--- a/tests/unit/auto/test_recovery_plan.py
+++ b/tests/unit/auto/test_recovery_plan.py
@@ -45,9 +45,27 @@ def test_manual_plan_is_not_auto_dispatchable() -> None:
 @pytest.mark.parametrize(
     "payload",
     [
-        {"action": "ralph_redispatch", "safe_to_redispatch": False, "reason": "x", "qa_score": 0.1, "qa_verdict": "fail"},
-        {"action": "manual_intervention", "safe_to_redispatch": True, "reason": "x", "qa_score": 0.1, "qa_verdict": "fail"},
-        {"action": "mystery", "safe_to_redispatch": False, "reason": "x", "qa_score": 0.1, "qa_verdict": "fail"},
+        {
+            "action": "ralph_redispatch",
+            "safe_to_redispatch": False,
+            "reason": "x",
+            "qa_score": 0.1,
+            "qa_verdict": "fail",
+        },
+        {
+            "action": "manual_intervention",
+            "safe_to_redispatch": True,
+            "reason": "x",
+            "qa_score": 0.1,
+            "qa_verdict": "fail",
+        },
+        {
+            "action": "mystery",
+            "safe_to_redispatch": False,
+            "reason": "x",
+            "qa_score": 0.1,
+            "qa_verdict": "fail",
+        },
     ],
 )
 def test_invalid_plan_payloads_raise(payload) -> None:

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -747,3 +747,11 @@ def test_phase_timeout_env_override_applied(monkeypatch: pytest.MonkeyPatch) -> 
     assert merged[AutoPhase.INTERVIEW.value] == 900
     assert merged[AutoPhase.RUN.value] == 60  # invalid override silently ignored
     assert merged[AutoPhase.REVIEW.value] == 90  # invalid override silently ignored
+
+
+def test_state_rejects_malformed_recovery_plan() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp")
+    data = state.to_dict()
+    data["last_recovery_plan"] = {"action": "ralph_redispatch", "safe_to_redispatch": False}
+    with pytest.raises(ValueError, match="last_recovery_plan"):
+        AutoPipelineState.from_dict(data)


### PR DESCRIPTION
## Summary

Adds the first #921 implementation PR for the self-healing `ooo auto` loop: QA failures now leave a typed recovery plan artifact instead of only prose blocker text.

- adds `AutoRecoveryPlan` with `ralph_redispatch` and `manual_intervention` actions
- persists `state.last_recovery_plan` for lateral-advised QA failures and no-lateral fallback failures
- validates persisted recovery plans on state load
- keeps current behavior terminal/BLOCKED; this PR creates the consumable artifact for a later redispatch PR

## Agent OS direction

This keeps the recovery contract machine-readable. The future redispatch step should consume `last_recovery_plan` directly rather than scraping `last_error` or lateral prose.

## Validation

- `uv run ruff check --fix src/ouroboros/auto/recovery_plan.py src/ouroboros/auto/state.py src/ouroboros/auto/pipeline.py tests/unit/auto/test_recovery_plan.py tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_state.py`
- `uv run pytest tests/unit/auto/test_recovery_plan.py tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_state.py`

Closes part of #921.