### PR TITLE
feat(orchestrator): let decomposition consume execution profiles

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -56,6 +56,11 @@ from ouroboros.orchestrator.control_plane import (
     serialize_control_plane_state,
 )
 from ouroboros.orchestrator.coordinator import CoordinatorReview, LevelCoordinator
+from ouroboros.orchestrator.decomposition_params import (
+    build_decomposition_system_prompt,
+    build_decomposition_user_prompt,
+    params_from_profile,
+)
 from ouroboros.orchestrator.events import (
     create_ac_stall_detected_event,
     create_heartbeat_event,
@@ -88,6 +93,7 @@ from ouroboros.orchestrator.policy import (
     PolicySessionRole,
     evaluate_capability_policy,
 )
+from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_message_projection import (
     project_runtime_message,
 )
@@ -481,6 +487,7 @@ class ParallelACExecutor:
         checkpoint_store: Any | None = None,
         inherited_runtime_handle: RuntimeHandle | None = None,
         task_cwd: str | None = None,
+        execution_profile: ExecutionProfile | None = None,
     ):
         """Initialize executor.
 
@@ -495,6 +502,8 @@ class ParallelACExecutor:
             inherited_runtime_handle: Optional parent Claude runtime handle for
                         delegated child executions.
             task_cwd: Explicit working directory override for task execution metadata.
+            execution_profile: Optional profile that makes decomposition split along
+                profile axis/min_unit instead of the legacy generic prompt.
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -503,6 +512,7 @@ class ParallelACExecutor:
         self._max_decomposition_depth = max(0, max_decomposition_depth)
         self._inherited_runtime_handle = inherited_runtime_handle
         self._task_cwd = task_cwd
+        self._execution_profile = execution_profile
         self._coordinator = LevelCoordinator(
             adapter,
             inherited_runtime_handle=inherited_runtime_handle,
@@ -2546,7 +2556,24 @@ class ParallelACExecutor:
             if node_identity is not None
             else f"AC #{ac_index + 1}"
         )
-        decompose_prompt = f"""Analyze this acceptance criterion and determine if it should be decomposed.
+        decomposition_system_prompt = (
+            "You are a task decomposition expert. Analyze tasks and break them down if needed."
+        )
+        if self._execution_profile is not None:
+            params = params_from_profile(
+                self._execution_profile,
+                min_branching=MIN_SUB_ACS,
+                max_branching=MAX_SUB_ACS,
+            )
+            decomposition_system_prompt = build_decomposition_system_prompt(params)
+            decompose_prompt = build_decomposition_user_prompt(
+                params,
+                ac_label=ac_label,
+                ac_content=ac_content,
+                seed_goal=seed_goal,
+            )
+        else:
+            decompose_prompt = f"""Analyze this acceptance criterion and determine if it should be decomposed.
 
 ## Goal Context
 {seed_goal}
@@ -2583,7 +2610,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 async for message in self._adapter.execute_task(
                     prompt=decompose_prompt,
                     tools=[],  # No tools for decomposition analysis
-                    system_prompt="You are a task decomposition expert. Analyze tasks and break them down if needed.",
+                    system_prompt=decomposition_system_prompt,
                     resume_handle=self._inherited_runtime_handle,
                 ):
                     if message.content:

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -87,6 +87,7 @@ from ouroboros.orchestrator.policy import (
     PolicySessionRole,
     evaluate_capability_policy,
 )
+from ouroboros.orchestrator.profile_loader import ExecutionProfile, ProfileError, load_profile
 from ouroboros.orchestrator.runtime_message_projection import (
     message_tool_input,
     message_tool_name,
@@ -252,6 +253,18 @@ async def get_pending_cancellations() -> frozenset[str]:
 # =============================================================================
 # Prompt Building
 # =============================================================================
+
+
+def _execution_profile_for_seed(seed: Seed) -> ExecutionProfile | None:
+    """Return the execution profile matching a seed task_type, if available."""
+    try:
+        return load_profile(seed.task_type)
+    except ProfileError:
+        log.warning(
+            "orchestrator.runner.execution_profile_unavailable",
+            task_type=seed.task_type,
+        )
+        return None
 
 
 def build_system_prompt(
@@ -2673,6 +2686,8 @@ class OrchestratorRunner:
                 f"  Stage {stage.stage_number}: ACs {[idx + 1 for idx in stage.ac_indices]}"
             )
 
+        execution_profile = _execution_profile_for_seed(seed)
+
         # Execute in parallel
         parallel_executor = ParallelACExecutor(
             adapter=self._adapter,
@@ -2684,6 +2699,7 @@ class OrchestratorRunner:
             inherited_runtime_handle=self._inherited_runtime_handle,
             task_cwd=self._effective_cwd(),
             checkpoint_store=self._checkpoint_store,
+            execution_profile=execution_profile,
         )
 
         # Check for cancellation before starting parallel execution

--- a/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
+++ b/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
@@ -100,3 +100,52 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
     executor._execute_atomic_ac.assert_awaited_once()
     assert len(execute_single_ac_spy.await_args_list) == 1
     assert execute_single_ac_spy.await_args.kwargs["depth"] == depth
+
+
+class _CapturingDecompositionRuntime:
+    def __init__(self) -> None:
+        self.prompt: str | None = None
+        self.system_prompt: str | None = None
+
+    async def execute_task(
+        self,
+        prompt: str,
+        tools: list[str] | None = None,
+        system_prompt: str | None = None,
+        resume_handle: object | None = None,
+        resume_session_id: str | None = None,
+    ):
+        del tools, resume_handle, resume_session_id
+        self.prompt = prompt
+        self.system_prompt = system_prompt
+        yield AgentMessage(type="result", content="ATOMIC")
+
+
+@pytest.mark.asyncio
+async def test_try_decompose_ac_uses_profile_axis_when_profile_is_configured() -> None:
+    """Profile-aware decomposition should use axis/min_unit from ExecutionProfile."""
+    from ouroboros.orchestrator.profile_loader import load_profile
+
+    runtime = _CapturingDecompositionRuntime()
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=True,
+        execution_profile=load_profile("research"),
+    )
+
+    result = await executor._try_decompose_ac(
+        ac_content="Compare three runtime designs with citations.",
+        ac_index=0,
+        seed_goal="Produce a sourced design memo",
+        tools=["Read"],
+        system_prompt="legacy system prompt",
+    )
+
+    assert result is None
+    assert runtime.prompt is not None
+    assert "Split along the axis: subtopic" in runtime.prompt
+    assert "single question answerable from independently cited sources" in runtime.prompt
+    assert runtime.system_prompt is not None
+    assert "'research' domain" in runtime.system_prompt

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2038,6 +2038,74 @@ class TestOrchestratorRunner:
         assert kwargs["session_id"] == tracker.session_id
 
     @pytest.mark.asyncio
+    async def test_execute_parallel_passes_execution_profile_to_executor(
+        self,
+        runner: OrchestratorRunner,
+        sample_seed: Seed,
+    ) -> None:
+        """Runner wiring should make profile-aware decomposition live in production."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        tracker = SessionTracker.create("exec_parallel", sample_seed.metadata.seed_id)
+        dependency_graph = DependencyGraph(
+            nodes=(ACNode(index=0, content=sample_seed.acceptance_criteria[0]),),
+            execution_levels=((0,),),
+        )
+        parallel_result = ParallelExecutionResult(
+            results=(
+                ACExecutionResult(
+                    ac_index=0,
+                    ac_content=sample_seed.acceptance_criteria[0],
+                    success=True,
+                    final_message="done",
+                ),
+            ),
+            success_count=1,
+            failure_count=0,
+            total_messages=1,
+        )
+        captured_init: dict[str, Any] = {}
+
+        class _FakeParallelExecutor:
+            def __init__(self, **kwargs: Any) -> None:
+                captured_init.update(kwargs)
+
+            async def execute_parallel(self, **kwargs: Any) -> ParallelExecutionResult:  # noqa: ARG002
+                return parallel_result
+
+        with (
+            patch(
+                "ouroboros.orchestrator.dependency_analyzer.DependencyAnalyzer.analyze",
+                AsyncMock(return_value=Result.ok(dependency_graph)),
+            ),
+            patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner._session_repo,
+                "mark_completed",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch(
+                "ouroboros.orchestrator.parallel_executor.ParallelACExecutor",
+                _FakeParallelExecutor,
+            ),
+        ):
+            result = await runner._execute_parallel(
+                seed=sample_seed,
+                exec_id="exec_parallel",
+                tracker=tracker,
+                merged_tools=["Read"],
+                tool_catalog=assemble_session_tool_catalog(["Read"]),
+                system_prompt="system",
+                start_time=tracker.start_time,
+            )
+
+        assert result.is_ok
+        profile = captured_init["execution_profile"]
+        assert profile is not None
+        assert profile.profile == sample_seed.task_type == "code"
+        assert profile.axis == "testable_unit"
+
+    @pytest.mark.asyncio
     async def test_execute_parallel_builds_dependency_analyzer_with_llm_adapter(
         self,
         runner: OrchestratorRunner,


### PR DESCRIPTION
## Summary

Adds the next #920 implementation slice: `ParallelACExecutor` can now run AC decomposition through an `ExecutionProfile` so split prompts use the profile axis/min_unit contract.

- adds an optional `execution_profile` constructor seam
- uses `params_from_profile()` and the profile-aware decomposition prompt builders when configured
- preserves legacy generic decomposition when no profile is supplied

## Agent OS direction

This starts wiring the #830 thin-profile/fat-harness substrate into the live executor path without flipping defaults. The next PR should select/pass the profile from the `ooo run` surface or execution strategy.

## Validation

- `uv run ruff check --fix tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py src/ouroboros/orchestrator/parallel_executor.py`
- `uv run pytest tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py tests/unit/orchestrator/test_decomposition_params.py`

Closes part of #920.