### PR TITLE
fix(auto): mutual-agreement closure gate for interview driver

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -811,11 +811,18 @@ def _turn_from_result(
     if not session_id:
         raise HandlerError("ouroboros_interview did not return a session_id")
     text = result.content[0].text if result.content else ""
+    raw_ambiguity = meta.get("ambiguity_score")
+    ambiguity_score: float | None
+    if isinstance(raw_ambiguity, (int, float)):
+        ambiguity_score = float(raw_ambiguity)
+    else:
+        ambiguity_score = None
     return InterviewTurn(
         question=_extract_interview_question(text, session_id=session_id),
         session_id=session_id,
         seed_ready=bool(meta.get("seed_ready")),
         completed=bool(meta.get("completed")),
+        ambiguity_score=ambiguity_score,
     )
 
 

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -217,14 +217,44 @@ class AutoInterviewDriver:
             self._save(state)
 
             if backend_done and not ledger_done:
-                # Backend said done but ledger isn't — pick the first open gap
-                # and answer it. This drives the backend to reopen with
+                # Backend said done but ledger isn't — pick the first detected
+                # gap and answer it. This drives the backend to reopen with
                 # substantive new content; we never accept closure unilaterally.
-                first_gap = ledger.open_gaps()[0]
-                answer = self.answerer.answer_gap(first_gap, ledger, answer_context)
-                question_for_record = (
-                    f"[driver gap-reopen '{first_gap}': backend_completed=True ledger_done=False]"
-                )
+                # Mirror the safety guards that ``_answer_with_gap_steering``
+                # enforces so a backend-reported "done" against a CONFLICTING /
+                # BLOCKED / goal-missing ledger does NOT silently get a
+                # fabricated auto-answer appended — those terminal conditions
+                # must surface the unresolved conflict immediately.
+                detected_gaps = self.gap_detector.detect(ledger)
+                if not detected_gaps:
+                    # Defensive: ``ledger.is_seed_ready()`` was False yet the
+                    # structured detector finds no actionable gap. Treat as
+                    # the canonical "must keep asking" path so we at least
+                    # send something through the backend instead of crashing.
+                    answer = self._answer_with_gap_steering(turn.question, ledger, answer_context)
+                    question_for_record = turn.question
+                else:
+                    first_gap = detected_gaps[0]
+                    if first_gap.section == "goal" or first_gap.state in {
+                        LedgerStatus.CONFLICTING,
+                        LedgerStatus.BLOCKED,
+                    }:
+                        blocker_text = first_gap.message
+                        state.mark_blocked(blocker_text, tool_name="auto_answerer")
+                        record_authoring_backend(state)
+                        self._save(state)
+                        return AutoInterviewResult(
+                            "blocked",
+                            state.interview_session_id,
+                            ledger,
+                            state.current_round,
+                            blocker_text,
+                        )
+                    answer = self.answerer.answer_gap(first_gap.section, ledger, answer_context)
+                    question_for_record = (
+                        f"[driver gap-reopen '{first_gap.section}': "
+                        "backend_completed=True ledger_done=False]"
+                    )
             else:
                 answer = self._answer_with_gap_steering(turn.question, ledger, answer_context)
                 question_for_record = turn.question

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -20,18 +20,10 @@ from ouroboros.auto.answerer import (
     AutoBlocker,
 )
 from ouroboros.auto.blocker_attribution import record_authoring_backend
-from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.gap_detector import GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.repo_context import repo_auto_answer_context
-from ouroboros.auto.safe_defaults import (
-    AUTO_ANSWER_PREFIX,
-    SAFE_DEFAULT_SYNTHESIS_TAG,
-    SafeDefaultFinalization,
-    build_safe_default_synthesis,
-    finalize_safe_defaultable_gaps,
-)
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 
 log = structlog.get_logger(__name__)
@@ -45,6 +37,11 @@ class InterviewTurn:
     session_id: str
     seed_ready: bool = False
     completed: bool = False
+    # Optional diagnostic surface — backend's own ambiguity reading for the
+    # current turn. The driver never gates on this; it is only used to build
+    # informative blocker messages when the mutual-agreement closure gate
+    # exhausts its budget without both parties converging.
+    ambiguity_score: float | None = None
 
 
 class InterviewBackend(Protocol):
@@ -191,16 +188,49 @@ class AutoInterviewDriver:
                 "blocked", state.interview_session_id, ledger, state.current_round, blocker
             )
 
-        if turn.seed_ready or turn.completed:
-            return self._handle_completed_turn(state, ledger, turn, state.current_round)
-
+        # Closure gate: an interview closes only when the backend (semantic
+        # ambiguity model) AND the driver-side ledger (structural completeness)
+        # agree on the same turn. Disagreement in either direction is reframed
+        # as the next answer instead of being treated as a terminal block:
+        #
+        # * backend signals completion but the ledger has open gaps → answer
+        #   the first open gap so the backend re-scores against substantive
+        #   new content and either accepts or asks a follow-up.
+        # * backend keeps asking but the ledger is structurally full → keep
+        #   answering normally; let the backend drive the dialogue.
+        #
+        # ``max_rounds`` is the sole budget. If the loop exits without mutual
+        # agreement, the blocker reports both readiness states so callers can
+        # decide whether to raise ``max_rounds`` or sharpen the goal.
         for round_number in range(state.current_round + 1, self.max_rounds + 1):
+            backend_done = turn.seed_ready or turn.completed
+            ledger_done = ledger.is_seed_ready()
+            if backend_done and ledger_done:
+                state.pending_question = None
+                state.interview_completed = True
+                self._save(state)
+                return AutoInterviewResult(
+                    "seed_ready", state.interview_session_id, ledger, state.current_round
+                )
+
             state.mark_progress(f"interview round {round_number}/{self.max_rounds}")
             self._save(state)
 
-            answer = self._answer_with_gap_steering(turn.question, ledger, answer_context)
+            if backend_done and not ledger_done:
+                # Backend said done but ledger isn't — pick the first open gap
+                # and answer it. This drives the backend to reopen with
+                # substantive new content; we never accept closure unilaterally.
+                first_gap = ledger.open_gaps()[0]
+                answer = self.answerer.answer_gap(first_gap, ledger, answer_context)
+                question_for_record = (
+                    f"[driver gap-reopen '{first_gap}': backend_completed=True ledger_done=False]"
+                )
+            else:
+                answer = self._answer_with_gap_steering(turn.question, ledger, answer_context)
+                question_for_record = turn.question
+
             if answer.blocker is not None:
-                self.answerer.apply(answer, ledger, question=turn.question)
+                self.answerer.apply(answer, ledger, question=question_for_record)
                 state.ledger = ledger.to_dict()
                 blocker_text = answer.blocker.reason
                 state.mark_blocked(blocker_text, tool_name="auto_answerer")
@@ -214,14 +244,14 @@ class AutoInterviewDriver:
                     blocker_text,
                 )
             state.current_round = round_number
-            self.answerer.apply(answer, ledger, question=turn.question)
+            self.answerer.apply(answer, ledger, question=question_for_record)
             state.ledger = ledger.to_dict()
             state.pending_question = None
             _record_auto_answer(
                 state,
                 round_number=round_number,
                 source=answer.source.value,
-                question=turn.question,
+                question=question_for_record,
                 answer=answer.text,
             )
             state.mark_progress(
@@ -256,73 +286,31 @@ class AutoInterviewDriver:
                 )
 
             state.interview_session_id = turn.session_id
-            if turn.seed_ready or turn.completed:
-                return self._handle_completed_turn(state, ledger, turn, round_number)
             state.pending_question = turn.question
             self._save(state)
 
-        if not ledger.is_seed_ready():
-            if state.active_domain_profile_name:
-                _active_profile = DEFAULT_REGISTRY.get(state.active_domain_profile_name)
-                if _active_profile is None:
-                    finalization = SafeDefaultFinalization(
-                        (),
-                        tuple(
-                            f"{section}: active domain profile "
-                            f"{state.active_domain_profile_name!r} is not registered"
-                            for section in ledger.open_gaps()
-                        ),
-                    )
-                else:
-                    finalization = finalize_safe_defaultable_gaps(
-                        ledger,
-                        goal=state.goal,
-                        provenance=f"auto interview max rounds {self.max_rounds}",
-                        pending_question=state.pending_question,
-                        active_profile=_active_profile,
-                    )
-            else:
-                finalization = finalize_safe_defaultable_gaps(
-                    ledger,
-                    goal=state.goal,
-                    provenance=f"auto interview max rounds {self.max_rounds}",
-                    pending_question=state.pending_question,
-                    active_profile=None,
-                )
-            state.ledger = ledger.to_dict()
-            if finalization.completed and ledger.is_seed_ready():
-                synthesis_blocker = await self._record_safe_default_synthesis(
-                    state, ledger, finalization
-                )
-                if synthesis_blocker is None:
-                    state.pending_question = None
-                    state.interview_completed = True
-                    state.mark_progress(
-                        "auto interview finalized safe-defaultable gaps at max rounds",
-                        tool_name="interview_driver",
-                    )
-                    self._save(state)
-                    return AutoInterviewResult(
-                        "seed_ready", state.interview_session_id, ledger, self.max_rounds
-                    )
-                # Synthesis could not be persisted to the interview transcript —
-                # roll back the safe-default entries so ledger.open_gaps() and
-                # the blocker message reflect the genuinely unresolved state.
-                # Without this, downstream consumers of the convergence
-                # contract (interview stalled → name the unresolved sections)
-                # would see an apparently complete ledger paired with a block.
-                _revert_safe_default_entries(ledger, finalization.defaulted_sections)
-                state.ledger = ledger.to_dict()
-            gaps_list = finalization.unsafe_gaps or tuple(ledger.open_gaps())
-            gaps = ", ".join(gaps_list)
-            blocker = f"auto interview reached max rounds with unresolved gaps: {gaps}"
-            state.mark_blocked(blocker, tool_name="interview_driver")
-            record_authoring_backend(state)
+        # max_rounds exhausted — one final closure check, then diagnostic blocker.
+        backend_done = turn.seed_ready or turn.completed
+        ledger_done = ledger.is_seed_ready()
+        if backend_done and ledger_done:
+            state.pending_question = None
+            state.interview_completed = True
             self._save(state)
             return AutoInterviewResult(
-                "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
+                "seed_ready", state.interview_session_id, ledger, self.max_rounds
             )
-        blocker = "auto interview reached max rounds before backend marked the Seed ready"
+
+        if turn.ambiguity_score is not None:
+            ambiguity_part = f"ambiguity_score={turn.ambiguity_score:.2f}"
+        else:
+            ambiguity_part = "ambiguity_score=unknown"
+        open_gaps = ledger.open_gaps()
+        gaps_part = f"open_gaps={open_gaps}" if open_gaps else "open_gaps=[]"
+        blocker = (
+            f"auto interview reached max_rounds={self.max_rounds} without closure: "
+            f"backend_done={backend_done} ({ambiguity_part}), "
+            f"ledger_done={ledger_done} ({gaps_part})"
+        )
         state.mark_blocked(blocker, tool_name="interview_driver")
         record_authoring_backend(state)
         self._save(state)
@@ -431,113 +419,6 @@ class AutoInterviewDriver:
         return any(
             _normalize_answer_text(item.get("answer", "")) == proposed
             for item in ledger.question_history
-        )
-
-    def _handle_completed_turn(
-        self, state: AutoPipelineState, ledger: SeedDraftLedger, turn: InterviewTurn, rounds: int
-    ) -> AutoInterviewResult:
-        state.interview_session_id = turn.session_id
-        state.pending_question = None
-        if ledger.is_seed_ready():
-            state.interview_completed = True
-            self._save(state)
-            return AutoInterviewResult("seed_ready", turn.session_id, ledger, rounds)
-        gaps = ", ".join(ledger.open_gaps())
-        blocker = f"interview backend completed before auto ledger was ready: {gaps}"
-        state.mark_blocked(blocker, tool_name="interview_driver")
-        record_authoring_backend(state)
-        self._save(state)
-        return AutoInterviewResult("blocked", state.interview_session_id, ledger, rounds, blocker)
-
-    # Maximum number of completion-signal turns the driver will send when
-    # closing the interview after safe-default finalization. The production
-    # InterviewHandler requires a stability streak of
-    # ``AUTO_COMPLETE_STREAK_REQUIRED`` (=2) qualifying completion signals
-    # before it actually closes the transcript, so a single synthesis turn
-    # does not always suffice — we send the full synthesis once and then
-    # short follow-up confirmations until the backend confirms or we hit
-    # this cap.
-    _SYNTHESIS_COMPLETION_MAX_ATTEMPTS = 3
-
-    async def _record_safe_default_synthesis(
-        self,
-        state: AutoPipelineState,
-        ledger: SeedDraftLedger,
-        finalization: SafeDefaultFinalization,
-    ) -> str | None:
-        """Persist the safe-default synthesis through the interview backend.
-
-        The downstream seed generator reads from the interview transcript on
-        disk, not from the auto ledger, so a ledger that becomes Seed-ready
-        only via :func:`finalize_safe_defaultable_gaps` would otherwise leave
-        the transcript missing those assumptions (Q00/ouroboros#763 review on
-        ``c072ed94``). Push the synthesis answer through ``backend.answer``
-        so the transcript and ledger stay in sync, then send up to
-        :pyattr:`_SYNTHESIS_COMPLETION_MAX_ATTEMPTS - 1` short confirmation
-        turns until the backend signals ``seed_ready``/``completed``. The
-        production interview handler requires a streak of two qualifying
-        completion signals before it closes the transcript (review of
-        ``64875869``), so a single synthesis turn does not reliably end the
-        session. Returns ``None`` on success or when there is nothing to
-        synthesize, and a blocker string if the synthesis cannot be
-        persisted within the attempt budget.
-        """
-        synthesis = build_safe_default_synthesis(finalization)
-        if not synthesis or not state.interview_session_id:
-            return None
-        follow_up = (
-            f"{AUTO_ANSWER_PREFIX}{SAFE_DEFAULT_SYNTHESIS_TAG} "
-            "Mark the interview complete and hand off for seed generation. "
-            "No remaining ambiguity for safe-defaultable sections."
-        )
-        # Capture the question that was pending before synthesis started so
-        # the ledger can record the correct Q/A pairing for round 1.
-        prior_pending_question = state.pending_question or "auto safe-default finalization"
-        for attempt in range(self._SYNTHESIS_COMPLETION_MAX_ATTEMPTS):
-            text = synthesis if attempt == 0 else follow_up
-            try:
-                turn = _validate_turn(
-                    await self._with_timeout(
-                        self.backend.answer(state.interview_session_id, text),
-                        state,
-                        tool_name="interview.answer",
-                    )
-                )
-            except TimeoutError as exc:
-                # The backend may or may not have processed the call —
-                # invalidate our cached pending_question so a later
-                # ``--resume`` queries live state via ``backend.resume`` and
-                # cannot replay an already-answered prompt.
-                state.pending_question = None
-                self._save(state)
-                return (
-                    "safe-default synthesis could not be persisted to the "
-                    f"interview transcript: {exc}"
-                )
-            except Exception as exc:
-                state.pending_question = None
-                self._save(state)
-                return f"safe-default synthesis answer failed: {exc}"
-            state.interview_session_id = turn.session_id
-            # Sync pending_question with the backend's latest turn so that a
-            # later ``--resume`` after synthesis failure re-enters the
-            # interview at the correct prompt instead of replaying the
-            # pre-synthesis question (review of ``cc128420``).
-            state.pending_question = turn.question or None
-            if attempt == 0:
-                ledger.record_qa(prior_pending_question, synthesis)
-                state.ledger = ledger.to_dict()
-            self._save(state)
-            if turn.seed_ready or turn.completed:
-                return None
-        # The backend still has not honoured the completion signal. Caller
-        # rolls back the safe-default entries and emits the canonical
-        # "unresolved gaps" blocker; we just signal the failure here. The
-        # final ``state.pending_question`` reflects the live backend prompt.
-        return (
-            "interview backend did not honour the safe-default completion "
-            f"signal within {self._SYNTHESIS_COMPLETION_MAX_ATTEMPTS} attempts; "
-            "transcript would still contain an unanswered question."
         )
 
     async def _with_timeout(
@@ -754,5 +635,8 @@ def _validate_turn(value: object) -> InterviewTurn:
         raise TypeError(msg)
     if type(value.seed_ready) is not bool or type(value.completed) is not bool:
         msg = "interview backend returned non-boolean completion flags"
+        raise TypeError(msg)
+    if value.ambiguity_score is not None and not isinstance(value.ambiguity_score, (int, float)):
+        msg = "interview backend returned non-numeric ambiguity_score"
         raise TypeError(msg)
     return value

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -215,102 +215,6 @@ def test_seed_draft_ledger_uses_later_repeated_non_goal_as_correction() -> None:
     ]
 
 
-@pytest.mark.asyncio
-async def test_interview_driver_finalizes_safe_defaults_after_max_rounds(tmp_path) -> None:
-    answer_calls: list[tuple[str, str]] = []
-
-    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn("What should we verify?", "interview_1")
-
-    async def answer(session_id: str, text: str) -> InterviewTurn:
-        answer_calls.append((session_id, text))
-        # Mirror the production interview handler: a synthesis answer that
-        # carries the "mark the interview complete" completion signal
-        # closes the transcript on the same turn.
-        if "mark the interview complete" in text.lower():
-            return InterviewTurn("", session_id, seed_ready=True, completed=True)
-        return InterviewTurn("What else?", session_id, seed_ready=False)
-
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
-    ledger = SeedDraftLedger.from_goal(state.goal)
-    driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer),
-        store=AutoStore(tmp_path),
-        max_rounds=1,
-        timeout_seconds=1,
-    )
-
-    result = await driver.run(state, ledger)
-
-    assert result.status == "seed_ready"
-    assert state.phase == AutoPhase.INTERVIEW
-    assert state.interview_completed is True
-    assert ledger.is_seed_ready()
-    assert ledger.summary()["open_gaps"] == []
-    final_actor = ledger.sections["actors"].entries[-1]
-    assert final_actor.status == LedgerStatus.DEFAULTED
-    assert final_actor.source == LedgerSource.ASSUMPTION
-    assert any("safe-default policy" in item for item in final_actor.evidence)
-    # Synthesis must be persisted to the interview transcript so the seed
-    # generator (which reads the transcript) sees the same assumptions the
-    # ledger now records — guards against the ledger/transcript split-brain.
-    synthesis_text = next(
-        text for _sid, text in answer_calls if "safe-default synthesis" in text.lower()
-    )
-    assert "mark the interview complete" in synthesis_text.lower()
-    assert "actors" in synthesis_text
-    assert any("safe-default" in item.get("answer", "").lower() for item in ledger.question_history)
-
-
-@pytest.mark.asyncio
-async def test_interview_driver_blocks_when_safe_default_synthesis_rejected(tmp_path) -> None:
-    call_count = 0
-
-    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn("What should we verify?", "interview_1")
-
-    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return InterviewTurn("What else?", session_id, seed_ready=False)
-        msg = "interview backend refuses post-bound synthesis"
-        raise RuntimeError(msg)
-
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
-    ledger = SeedDraftLedger.from_goal(state.goal)
-    driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer),
-        store=AutoStore(tmp_path),
-        max_rounds=1,
-        timeout_seconds=1,
-    )
-
-    result = await driver.run(state, ledger)
-
-    assert result.status == "blocked"
-    assert state.phase == AutoPhase.BLOCKED
-    # Synthesis failure rolls back the safe-default entries so the canonical
-    # "unresolved gaps" blocker is reported and the ledger reflects the
-    # genuinely unresolved sections — preserving the convergence contract.
-    assert "unresolved gaps" in (result.blocker or "")
-    assert state.interview_completed is False
-    assert ledger.open_gaps(), (
-        "rolled-back ledger must expose at least one unresolved gap so the "
-        "convergence contract still names actionable sections"
-    )
-    assert not any(
-        entry.key.endswith(".safe_default_finalization")
-        for section in ledger.sections.values()
-        for entry in section.entries
-    ), "safe-default policy entries must be reverted on synthesis failure"
-    # Backend.answer raised after the first synthesis turn — the driver
-    # cannot trust the cached pending_question because the backend may have
-    # processed (or partially processed) the call. Force ``--resume`` to
-    # query live state via ``backend.resume()`` instead of replaying.
-    assert state.pending_question is None
-
-
 def test_revert_safe_default_entries_preserves_user_keys_with_matching_suffix() -> None:
     """Regression: rollback must NOT remove a non-policy entry whose key
     coincidentally ends with ``.safe_default_finalization``.
@@ -378,98 +282,6 @@ def test_revert_safe_default_entries_preserves_user_keys_with_matching_suffix() 
         "a user-authored entry whose key shares the suffix MUST survive rollback"
     )
     assert "constraints.other" in remaining_keys
-
-
-@pytest.mark.asyncio
-async def test_interview_driver_finalizes_when_backend_requires_two_completion_signals(
-    tmp_path,
-) -> None:
-    # The production interview handler closes the transcript only after a
-    # streak of two qualifying completion signals. The driver must follow up
-    # with additional confirmation turns until the backend confirms.
-    completion_streak = 0
-    answer_calls: list[tuple[str, str]] = []
-
-    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn("What should we verify?", "interview_1")
-
-    async def answer(session_id: str, text: str) -> InterviewTurn:
-        nonlocal completion_streak
-        answer_calls.append((session_id, text))
-        if "mark the interview complete" in text.lower():
-            completion_streak += 1
-            if completion_streak >= 2:
-                return InterviewTurn("", session_id, seed_ready=True, completed=True)
-            # Streak shortfall — backend asks the user to confirm again.
-            return InterviewTurn("Type done once more", session_id, seed_ready=False)
-        return InterviewTurn("What else?", session_id, seed_ready=False)
-
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
-    ledger = SeedDraftLedger.from_goal(state.goal)
-    driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer),
-        store=AutoStore(tmp_path),
-        max_rounds=1,
-        timeout_seconds=1,
-    )
-
-    result = await driver.run(state, ledger)
-
-    assert result.status == "seed_ready"
-    assert state.interview_completed is True
-    assert ledger.is_seed_ready()
-    # Round-1 user answer + synthesis (turn 1) + confirmation (turn 2) = 3.
-    completion_signal_calls = [
-        text for _sid, text in answer_calls if "mark the interview complete" in text.lower()
-    ]
-    assert len(completion_signal_calls) >= 2, (
-        "expected the driver to send at least two completion signals to satisfy "
-        f"the streak contract; got {completion_signal_calls!r}"
-    )
-
-
-@pytest.mark.asyncio
-async def test_interview_driver_blocks_when_backend_ignores_synthesis_completion_signal(
-    tmp_path,
-) -> None:
-    # The synthesis text carries a "mark the interview complete" signal; if
-    # a backend ignores it and keeps asking questions, the persisted
-    # transcript would diverge from auto state. The driver must block
-    # rather than declaring seed_ready against a still-open transcript.
-    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn("What should we verify?", "interview_1")
-
-    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
-        # Always return another question with seed_ready=False, regardless
-        # of the answer text — simulating a backend that does not honour
-        # the completion signal.
-        return InterviewTurn("Anything else?", session_id, seed_ready=False)
-
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
-    ledger = SeedDraftLedger.from_goal(state.goal)
-    driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer),
-        store=AutoStore(tmp_path),
-        max_rounds=1,
-        timeout_seconds=1,
-    )
-
-    result = await driver.run(state, ledger)
-
-    assert result.status == "blocked"
-    assert state.phase == AutoPhase.BLOCKED
-    # Backend ignored the completion signal → synthesis failed → ledger is
-    # rolled back and the canonical "unresolved gaps" blocker is emitted.
-    assert "unresolved gaps" in (result.blocker or "")
-    assert state.interview_completed is False
-    assert ledger.open_gaps()
-    # After synthesis failure the driver must leave pending_question pointing
-    # at the backend's latest live prompt (or cleared) — never the stale
-    # pre-synthesis question. A later ``--resume`` would otherwise replay an
-    # already-answered prompt against an advanced session. The fake backend
-    # always returns "Anything else?" after the synthesis turns, so that's
-    # what the auto state should now hold.
-    assert state.pending_question == "Anything else?"
 
 
 def test_safe_default_blocks_when_interview_answer_introduces_unsafe_context() -> None:
@@ -916,8 +728,15 @@ async def test_interview_driver_keeps_unsafe_gaps_blocking_after_max_rounds(tmp_
 
     assert result.status == "blocked"
     assert state.phase == AutoPhase.BLOCKED
-    assert "unresolved gaps" in (result.blocker or "")
-    assert "unsafe default context" in (result.blocker or "")
+    blocker = result.blocker or ""
+    # New mutual-agreement closure gate emits a structured diagnostic naming
+    # both readiness states and the unresolved sections. The auto path no
+    # longer attempts safe-default finalization, so the goal's unsafe-context
+    # words ("production"/"credentials") cannot sneak a closure through —
+    # the diagnostic blocker is the only terminal outcome here.
+    assert "without closure" in blocker
+    assert "ledger_done=False" in blocker
+    assert "open_gaps=" in blocker
     assert not ledger.is_seed_ready()
 
 
@@ -1503,7 +1322,13 @@ async def test_interview_driver_blocks_when_backend_never_marks_ready(tmp_path) 
     result = await driver.run(state, ledger)
 
     assert result.status == "blocked"
-    assert "before backend marked" in (result.blocker or "")
+    blocker = result.blocker or ""
+    # Ledger is pre-filled (`_fill_ready`) so ledger_done is True, but the
+    # mock backend never sends a completion flag — the mutual-agreement gate
+    # refuses closure and emits the structured diagnostic naming both states.
+    assert "without closure" in blocker
+    assert "backend_done=False" in blocker
+    assert "ledger_done=True" in blocker
 
 
 @pytest.mark.asyncio
@@ -1748,11 +1573,20 @@ async def test_pipeline_resumes_repair_phase_through_review(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_interview_driver_blocks_when_backend_completes_before_ledger_ready(tmp_path) -> None:
+async def test_interview_driver_emits_diagnostic_when_readiness_models_disagree(tmp_path) -> None:
+    """Backend insists 'done' but ledger stays incomplete (and vice versa): under
+    the mutual-agreement closure gate the driver never accepts unilateral
+    closure — it keeps answering open gaps until both parties agree or
+    max_rounds exhausts. When the budget runs out, the blocker must surface
+    both readiness states so callers can decide how to recover.
+    """
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What should we verify?", "interview_1")
 
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        # Backend permanently claims completion regardless of content — driver
+        # must NOT accept this while ledger still has open gaps.
         return InterviewTurn("done", session_id, seed_ready=True, completed=True)
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
@@ -1764,7 +1598,11 @@ async def test_interview_driver_blocks_when_backend_completes_before_ledger_read
     result = await driver.run(state, ledger)
 
     assert result.status == "blocked"
-    assert "completed before auto ledger was ready" in (result.blocker or "")
+    blocker = result.blocker or ""
+    assert "without closure" in blocker
+    assert "backend_done=True" in blocker
+    assert "ledger_done=False" in blocker
+    assert "open_gaps=" in blocker
     assert state.phase == AutoPhase.BLOCKED
 
 
@@ -3724,9 +3562,12 @@ async def test_convergence_contract_stalled_generic_followups_report_actionable_
     blocker = result.blocker or ""
     assert result.status == "blocked"
     assert state.phase == AutoPhase.BLOCKED
-    assert "unresolved gaps" in blocker
+    # New diagnostic format names both readiness states and lists the open
+    # gap sections so callers can decide whether to raise max_rounds or
+    # sharpen the goal — preserving the convergence contract that stalls
+    # must surface actionable section names, not just "reached max_rounds".
+    assert "without closure" in blocker
+    assert "open_gaps=" in blocker
     open_gaps = ledger.open_gaps()
     assert open_gaps, "stalled generic loop must leave at least one open required gap"
-    # The blocker must name at least one specific unresolved section, not just
-    # report that max_rounds was reached.
     assert any(section in blocker for section in open_gaps)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1607,6 +1607,72 @@ async def test_interview_driver_emits_diagnostic_when_readiness_models_disagree(
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_blocks_on_conflict_when_backend_signals_premature_closure(
+    tmp_path,
+) -> None:
+    """A CONFLICTING/BLOCKED gap must surface as a blocker — never get a
+    fabricated auto-answer appended — even when the backend declares closure.
+
+    Regression test for ouroboros-agent[bot] review finding (PR #962): the
+    backend-done branch must not bypass ``_answer_with_gap_steering``'s
+    safety guards against unresolved conflicts.
+    """
+    answer_calls: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answer_calls.append(text)
+        # Backend insists on closure regardless of content — the driver MUST
+        # still refuse to fabricate gap-fills when the next gap is CONFLICTING.
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    # Seed a CONFLICTING actors entry — the rest stays open. The gap detector
+    # surfaces CONFLICTING gaps before plain MISSING ones, so this is the
+    # first gap the disagreement branch will see.
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.conflict",
+            value="Conflicting actor declaration",
+            source=LedgerSource.USER_GOAL,
+            confidence=0.85,
+            status=LedgerStatus.CONFLICTING,
+        ),
+    )
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=3,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.phase == AutoPhase.BLOCKED
+    # Exactly ONE backend.answer call: the first answer to the start turn
+    # goes through the normal path; backend then returns completed=True and
+    # the very next loop iteration enters the disagreement branch where the
+    # CONFLICTING actors gap MUST short-circuit into a blocker — without
+    # firing a second backend.answer for a fabricated gap-fill.
+    assert len(answer_calls) == 1, (
+        "driver must terminate on CONFLICTING gap immediately after the "
+        f"backend reports closure, not push another answer: {answer_calls!r}"
+    )
+    # The blocker reason must surface the conflict, not be swallowed into
+    # the generic "max_rounds without closure" diagnostic.
+    blocker = result.blocker or ""
+    assert "max_rounds" not in blocker, (
+        f"expected the CONFLICTING gap to surface immediately, "
+        f"not be swallowed into the max_rounds diagnostic: {blocker!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_steers_generic_questions_to_open_gaps(tmp_path) -> None:
     answers: list[str] = []
 

--- a/tests/unit/auto/test_safe_defaults_domain_profile.py
+++ b/tests/unit/auto/test_safe_defaults_domain_profile.py
@@ -10,21 +10,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import pytest
-
-from ouroboros.auto.domain_profile import DEFAULT_REGISTRY, DomainProfile
-from ouroboros.auto.interview_driver import (
-    AutoInterviewDriver,
-    FunctionInterviewBackend,
-    InterviewTurn,
-)
+from ouroboros.auto.domain_profile import DomainProfile
 from ouroboros.auto.ledger import LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.safe_defaults import (
     _DefaultSpec,
     build_safe_default_synthesis,
     finalize_safe_defaultable_gaps,
 )
-from ouroboros.auto.state import AutoPipelineState, AutoStore
+from ouroboros.auto.state import AutoPipelineState
 
 # ---------------------------------------------------------------------------
 # Minimal stubs
@@ -268,87 +261,3 @@ def test_active_profile_legacy_state_defaults_to_none() -> None:
     restored = AutoPipelineState.from_dict(payload)
 
     assert restored.active_domain_profile_name is None
-
-
-@pytest.mark.asyncio
-async def test_interview_driver_persists_profile_resolved_synthesis(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Driver transcript persistence should use the profile-resolved spec."""
-    profile = _make_profile(
-        name="story-profile",
-        safe_defaults={
-            "actors": _DefaultSpec(
-                value="Assume the protagonist and narrator are the only story actors.",
-                rationale="Narrative domain actor policy",
-            )
-        },
-    )
-    monkeypatch.setattr(DEFAULT_REGISTRY, "_profiles", [profile])
-    answer_calls: list[str] = []
-
-    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn("What should we verify?", "interview_1")
-
-    async def answer(session_id: str, text: str) -> InterviewTurn:
-        answer_calls.append(text)
-        if "mark the interview complete" in text.lower():
-            return InterviewTurn("", session_id, seed_ready=True, completed=True)
-        return InterviewTurn("What else?", session_id, seed_ready=False)
-
-    state = AutoPipelineState(goal="Draft a local short story outline", cwd=str(tmp_path))
-    state.active_domain_profile_name = "story-profile"
-    ledger = SeedDraftLedger.from_goal(state.goal)
-    driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer),
-        store=AutoStore(tmp_path),
-        max_rounds=1,
-        timeout_seconds=1,
-    )
-
-    result = await driver.run(state, ledger)
-
-    assert result.status == "seed_ready"
-    synthesis = next(text for text in answer_calls if "safe-default synthesis" in text.lower())
-    assert "Assume the protagonist and narrator are the only story actors." in synthesis
-    assert "Assume the primary actor is the user or automation agent" not in synthesis
-    assert any(
-        "protagonist and narrator" in item.get("answer", "") for item in ledger.question_history
-    )
-
-
-@pytest.mark.asyncio
-async def test_interview_driver_missing_requested_profile_blocks_safe_defaulting(
-    tmp_path: Path,
-) -> None:
-    """A requested but unregistered profile must not fall back to coding defaults."""
-    answer_calls: list[str] = []
-
-    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn("What should we verify?", "interview_1")
-
-    async def answer(session_id: str, text: str) -> InterviewTurn:
-        answer_calls.append(text)
-        return InterviewTurn("What else?", session_id, seed_ready=False)
-
-    state = AutoPipelineState(goal="Draft a local short story outline", cwd=str(tmp_path))
-    state.active_domain_profile_name = "missing-story-profile"
-    ledger = SeedDraftLedger.from_goal(state.goal)
-    driver = AutoInterviewDriver(
-        FunctionInterviewBackend(start, answer),
-        store=AutoStore(tmp_path),
-        max_rounds=1,
-        timeout_seconds=1,
-    )
-
-    result = await driver.run(state, ledger)
-
-    assert result.status == "blocked"
-    assert "missing-story-profile" in (result.blocker or "")
-    assert ledger.open_gaps()
-    assert not any(
-        entry.key.endswith(".safe_default_finalization")
-        for section in ledger.sections.values()
-        for entry in section.entries
-    )
-    assert not any("safe-default synthesis" in text.lower() for text in answer_calls)


### PR DESCRIPTION
## Summary
- Replace two independent readiness gates (backend ambiguity score vs. driver 10-section ledger) with a single closure principle: an interview closes only when both agree on the same turn; disagreement is reframed as the next answer.
- Delete the auto-path safe-default finalization that short-circuited backend follow-ups — when the backend signals premature closure the driver now answers the first open gap so the backend re-scores instead of unilaterally winning.
- Emit a structured diagnostic blocker on max_rounds exhaustion: `backend_done=… (ambiguity_score=…), ledger_done=… (open_gaps=[…])` so callers can decide whether to raise the bound or sharpen the goal.

## Background
Both v0.38.0 \`ooo auto\` blocker paths were symmetric races:
- \`reached max rounds before backend marked the Seed ready\` — ledger full, backend's 2-streak ambiguity gate stuck (e.g. fuzzy success criteria).
- \`completed before auto ledger was ready: <gaps>\` — backend declared closure while 7 of 10 required sections (actors / inputs / outputs / constraints / non_goals / failure_modes / runtime_context) were still empty.

The two modules had drifted apart: the backend evolved a scalar ambiguity model and the driver a structural ledger model, with no synchronisation layer left. This PR collapses them into one gate (\`Closure = backend_done ∧ ledger_done\`).

## Test plan
- [x] \`uv run ruff check src tests\`
- [x] \`uv run ruff format --check src tests\`
- [x] \`uv run mypy src/ouroboros/auto/interview_driver.py src/ouroboros/auto/adapters.py\`
- [x] \`uv run pytest tests/unit/auto tests/unit/cli/test_auto_command.py tests/integration/auto\` — 844 passed
- [x] \`uv run pytest tests/unit/mcp tests/unit/auto/test_surface.py\` — 999 passed
- [ ] Manual: re-run \`ooo auto\` against the original failing goal (the one that produced \`auto_82859c9fd9c1\` / \`auto_5af92c62c3bd\`) and confirm the driver converges or emits the new diagnostic blocker instead of deadlocking on the contract gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)