### PR TITLE
docs(plugin): define lifecycle hook contract

### DIFF
--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -291,6 +291,150 @@ Audit events conform to
 The compatibility surface between this schema and the existing core ledger
 writer is tracked in #737.
 
+## Lifecycle Hook Contract
+
+This section is the locked design target for #939 PR 1. It defines the
+vocabulary and safety policy for plugin lifecycle hooks, but it does **not**
+make hook execution part of the v0.1 manifest/runtime contract yet. Until a
+later PR updates the manifest schema and firewall implementation, conforming
+core releases MUST continue to treat plugin entrypoints exactly as described
+in the Invocation Contract above.
+
+The intent is to keep the plugin layer extensible without letting plugins
+reach around the harness. Hooks are harness callbacks, not a second runtime:
+they run only when the firewall/orchestrator invokes them, with bounded input,
+bounded output, explicit permissions, and audit events.
+
+### v1 hook vocabulary
+
+The first implementation should start with the smallest hook set that proves
+the contract and keeps review scope small.
+
+| Hook | Phase | Side-effect class | Default failure policy | Required permission class | v1 status |
+|---|---|---|---|---|---|
+| `before_invocation` | After trust/confirmation, before `plugin.invoked` or immediately before the command subprocess starts (final placement decided by the implementation PR) | Read-only inspection / policy | `fail_closed` for policy hooks, `fail_open` for observability-only hooks | `plugin.lifecycle.read` for read-only, stronger scope for policy decisions | **Included** |
+| `after_invocation` | After `plugin.completed` / `plugin.failed` is known, before the wrapper returns to the caller | Observability / summary emission | `fail_open` | `plugin.lifecycle.read` | **Included** |
+| `before_tool_call` | Before a plugin-mediated tool call is allowed to execute | Policy / possible mutation gate | `fail_closed` | tool-specific permission plus `plugin.tool.intercept` | Deferred |
+| `after_tool_call` | After a plugin-mediated tool call result is available | Observability or result annotation | `fail_open` unless it mutates returned evidence | `plugin.tool.observe` | Deferred |
+| `before_artifact_write` | Before artifact service writes plugin-provided output | Policy / mutation gate | `fail_closed` | artifact-specific write permission | Deferred |
+| `after_artifact_write` | After artifact write completes | Observability | `fail_open` | `plugin.artifact.observe` | Deferred |
+| `on_error` | When the wrapper sees a plugin/runtime error | Observability / recovery hint | `fail_open`; MUST NOT mask the original error | `plugin.lifecycle.read` | Deferred |
+| `on_cancel` | When a plugin invocation is cancelled | Observability / cleanup hint | `fail_open`; cleanup side effects require explicit permission | `plugin.lifecycle.read` or cleanup-specific scope | Deferred |
+
+The following candidate hooks are intentionally **not** in the v1 hook
+vocabulary:
+
+- `before_runtime_start` / `after_runtime_start`: runtime adapters and
+  capability policy are still Track C Tier 2 work; plugins MUST NOT receive a
+  runtime-start interception point before that substrate is stable.
+- `before_state_commit` / `after_state_commit`: state/replay projections are
+  owned by #946; adding state hooks first would create a second state mutation
+  path.
+- `on_event`: too broad for v1. It risks turning the audit/event stream into a
+  plugin message bus.
+- `on_rewind`: rewind semantics depend on replay/projection contracts that are
+  not yet stable.
+
+### Hook ordering
+
+For the included v1 hooks, the intended happy-path order is:
+
+```text
+trust check
+confirmation gate
+before_invocation hook(s)
+plugin.invoked
+plugin.permission_used*
+entrypoint subprocess
+plugin.completed | plugin.failed
+after_invocation hook(s)
+return InvocationResult
+```
+
+`plugin.permission_used*` keeps the current v0 behavior: one event for each
+declared `required: true` permission. Hook-specific permission emission is a
+future extension; v1 hook PRs MUST NOT silently change the coarse permission
+emission model.
+
+If the final implementation places `before_invocation` immediately after
+`plugin.invoked` instead, the implementation PR must document why and update
+the table above. The safety invariant is unchanged: the hook cannot run before
+the pre-invocation trust check succeeds.
+
+### Failure and timeout policy
+
+Every hook declaration must resolve to one of these failure policies:
+
+| Policy | Meaning | Allowed for |
+|---|---|---|
+| `fail_open` | Record hook failure and continue the original invocation. | Observability-only hooks whose output cannot authorize or mutate work. |
+| `fail_closed` | Stop the original invocation and emit a failed/blocked audit result. | Policy, security, mutating, or authority-bearing hooks. |
+
+Timeouts are failures for policy purposes. A hook that times out under
+`fail_open` produces an audit event and the original invocation continues. A
+hook that times out under `fail_closed` blocks the original invocation. The
+default timeout is intentionally short and implementation-defined in v1; the
+manifest/schema PR must document the exact default and any maximum override.
+
+Hooks MUST NOT retry indefinitely. Any retry policy must be bounded and must
+preserve the original invocation's idempotency and audit ordering.
+
+### Permission and mutation boundaries
+
+Hooks inherit the same trust model as commands: a required permission that is
+not trusted blocks before plugin-controlled code runs. Additional rules:
+
+1. Read-only lifecycle hooks require at least a read lifecycle scope such as
+   `plugin.lifecycle.read`.
+2. Hooks that can block, authorize, rewrite, or mutate work require an explicit
+   policy/mutation permission and default to `fail_closed`.
+3. Hooks MUST NOT directly edit `.omx`, EventStore rows, artifacts, or user
+   files. Mutations must go through the same harness service boundary that the
+   underlying command would use.
+4. Hook output is advisory unless the hook is declared as a policy hook and the
+   caller explicitly consumes the decision.
+5. Plugin permission approval is not implemented here. Required permission
+   denial remains fail-closed at the firewall; future HITL approval must route
+   through #960 rather than adding a hook-local prompt.
+
+### Hook audit events
+
+Hook execution must be observable without storing unbounded output. Future hook
+implementation PRs should use these event names unless the vendored
+`audit-event.schema.json` evolves first:
+
+- `plugin.hook.invoked`
+- `plugin.hook.completed`
+- `plugin.hook.failed`
+- `plugin.hook.blocked`
+
+Hook event payloads follow the same bounded-payload rules as command audit
+events:
+
+- include plugin identity, command name when applicable, hook name,
+  invocation/session correlation, failure policy, timeout, and status;
+- store stdout/stderr as hashes or bounded previews only;
+- apply the argv/secret redaction rules above;
+- do not add fields outside the vendored audit schema until the schema is
+  updated in `ouroboros-plugins` and re-vendored into core.
+
+### Review boundary for follow-up PRs
+
+The hook rollout should remain reviewable:
+
+1. **Contract/docs PR** (this section): vocabulary and policy only.
+2. **Manifest/schema PR**: optional hook declarations with backward
+   compatibility for existing v0.1 manifests.
+3. **Policy validator PR**: hook permission, timeout, and failure-policy
+   validation without executing hooks.
+4. **Minimal invocation PR**: `before_invocation` / `after_invocation` only,
+   with fixture tests.
+5. **Deferred hook PRs**: tool, artifact, state, or rewind hooks only after the
+   corresponding harness substrate is stable.
+
+This sequencing is intentional: it prevents hook support from becoming a
+second unreviewable plugin runtime.
+
 ### Audit-event compatibility (resolves #737)
 
 The audit-event schema is the canonical shape for plugin-emitted events. The

--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -366,6 +366,14 @@ hook audit event(s) and the blocked invocation result; it MUST NOT emit
 `plugin.failed` for the command entrypoint because the plugin command never
 started.
 
+`after_invocation` is scoped to started command entrypoint invocations only:
+it runs only after that entrypoint reaches `plugin.completed` or
+`plugin.failed`. It MUST NOT run for pre-start terminal outcomes such as trust
+denial, confirmation rejection, or a `fail_closed` `before_invocation` block.
+Those outcomes are represented by `plugin.failed` for trust/confirmation
+denials or by `plugin.hook.blocked` / `plugin.hook.failed` for hook failures,
+as applicable.
+
 ### Failure and timeout policy
 
 Every hook declaration must resolve to one of these failure policies:
@@ -424,6 +432,9 @@ events:
 - do not add fields outside the vendored audit schema until the schema is
   updated in `ouroboros-plugins` and re-vendored into core.
 
+Core MUST NOT emit `plugin.hook.*` events until the upstream audit-event
+schema and vendored core copy both include those event names.
+
 ### Review boundary for follow-up PRs
 
 The hook rollout should remain reviewable:
@@ -433,9 +444,11 @@ The hook rollout should remain reviewable:
    compatibility for existing v0.1 manifests.
 3. **Policy validator PR**: hook permission, timeout, and failure-policy
    validation without executing hooks.
-4. **Minimal invocation PR**: `before_invocation` / `after_invocation` only,
+4. **Audit-event schema/vendoring PR**: add `plugin.hook.*` event support
+   upstream and re-vendor it into core before any runtime emits hook events.
+5. **Minimal invocation PR**: `before_invocation` / `after_invocation` only,
    with fixture tests.
-5. **Deferred hook PRs**: tool, artifact, state, or rewind hooks only after the
+6. **Deferred hook PRs**: tool, artifact, state, or rewind hooks only after the
    corresponding harness substrate is stable.
 
 This sequencing is intentional: it prevents hook support from becoming a

--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -312,7 +312,7 @@ the contract and keeps review scope small.
 
 | Hook | Phase | Side-effect class | Default failure policy | Required permission class | v1 status |
 |---|---|---|---|---|---|
-| `before_invocation` | After trust/confirmation, before `plugin.invoked` or immediately before the command subprocess starts (final placement decided by the implementation PR) | Read-only inspection / policy | `fail_closed` for policy hooks, `fail_open` for observability-only hooks | `plugin.lifecycle.read` for read-only, stronger scope for policy decisions | **Included** |
+| `before_invocation` | After trust/confirmation, before `plugin.invoked` | Read-only inspection / policy | `fail_closed` for policy hooks, `fail_open` for observability-only hooks | `plugin.lifecycle.read` for read-only, stronger scope for policy decisions | **Included** |
 | `after_invocation` | After `plugin.completed` / `plugin.failed` is known, before the wrapper returns to the caller | Observability / summary emission | `fail_open` | `plugin.lifecycle.read` | **Included** |
 | `before_tool_call` | Before a plugin-mediated tool call is allowed to execute | Policy / possible mutation gate | `fail_closed` | tool-specific permission plus `plugin.tool.intercept` | Deferred |
 | `after_tool_call` | After a plugin-mediated tool call result is available | Observability or result annotation | `fail_open` unless it mutates returned evidence | `plugin.tool.observe` | Deferred |
@@ -356,10 +356,15 @@ declared `required: true` permission. Hook-specific permission emission is a
 future extension; v1 hook PRs MUST NOT silently change the coarse permission
 emission model.
 
-If the final implementation places `before_invocation` immediately after
-`plugin.invoked` instead, the implementation PR must document why and update
-the table above. The safety invariant is unchanged: the hook cannot run before
-the pre-invocation trust check succeeds.
+The placement of `before_invocation` is deterministic: it runs only after the
+pre-invocation trust check and any command confirmation have succeeded, and it
+runs before `plugin.invoked` is emitted. If a required permission is not trusted
+or the confirmation gate is rejected, `before_invocation` MUST NOT run. If a
+`fail_closed` `before_invocation` hook blocks the call, the wrapper emits the
+hook audit event(s) and the blocked invocation result; it MUST NOT emit
+`plugin.invoked`, `plugin.permission_used`, `plugin.completed`, or
+`plugin.failed` for the command entrypoint because the plugin command never
+started.
 
 ### Failure and timeout policy
 
@@ -413,7 +418,8 @@ events:
 
 - include plugin identity, command name when applicable, hook name,
   invocation/session correlation, failure policy, timeout, and status;
-- store stdout/stderr as hashes or bounded previews only;
+- store stdout/stderr only as sha256 hashes; raw stdout/stderr and bounded
+  previews MUST NOT be copied into the ledger;
 - apply the argv/secret redaction rules above;
 - do not add fields outside the vendored audit schema until the schema is
   updated in `ouroboros-plugins` and re-vendored into core.


### PR DESCRIPTION
## Summary

Implements the first reviewable Tier 1 slice for #939 by documenting the UserLevel plugin lifecycle hook contract before any schema or runtime wiring.

This PR intentionally keeps the change docs-only so reviewers can lock the contract before later PRs add manifest declarations, validators, hook execution, and fixtures.

## What changed

- Added `Lifecycle Hook Contract` to `docs/rfc/userlevel-plugins.md`.
- Defines the initial v1 hook vocabulary:
  - included first: `before_invocation`, `after_invocation`
  - deferred: tool/artifact/error/cancel hooks
  - excluded for now: runtime/state/event/rewind hooks
- Documents hook ordering, failure/timeout policy, permission and mutation boundaries, audit event names, and follow-up PR sequencing.
- Preserves current v0.1 behavior: no manifest schema change and no hook execution in this PR.

## Why

#939 needs plugin extensibility without letting `ouroboros-plugins` bypass core harness boundaries. This locks the hook vocabulary and safety policy first, keeping thin skills / fat harness intact and making the next implementation PRs reviewable.

## Validation

```bash
uv run pytest tests/unit/plugin -q
# 340 passed, 1 skipped

uv run pytest tests/integration/plugin -q
# 20 passed

uv run ruff check src tests/unit/plugin tests/integration/plugin
# All checks passed
```

Not run: full `uv run ruff check src tests` because the working tree contains unrelated untracked `tests/benchmark` lint issues outside this PR scope.

## Follow-ups

1. Add optional hook declarations to the plugin manifest schema.
2. Add hook permission/timeout/failure-policy validator without execution.
3. Add minimal `before_invocation` / `after_invocation` hook execution with fixture tests.
4. Defer tool/artifact/state/rewind hooks until their harness substrates are stable.

Closes no issue by itself; contributes to #939.
