### PR TITLE
feat(plugin): accept optional hook declarations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,7 +160,7 @@ This layer is distinct from the in-process Skills & Agents Registry
 operational workflows (GitHub PR ops, Jira triage, Slack incident
 response) into pluggable packages rather than into core or `ooo auto`.
 
-**Manifest contract**: see [Q00/ouroboros-plugins/schemas/0.1/](https://github.com/Q00/ouroboros-plugins/tree/main/schemas/0.1).
+**Manifest contract**: see [Q00/ouroboros-plugins/schemas/0.1/](https://github.com/Q00/ouroboros-plugins/tree/main/schemas/0.1). Core currently supports archived v0.1 plus a local v0.2 extension for optional hook declarations.
 
 > **Terminology guard**: in this codebase, "plugin" by itself can refer to
 > either the in-process Skills/Agents Registry or the UserLevel Programs

--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -148,7 +148,7 @@ The success metric is therefore **"the boundary holds"** — measurable, not
 
 ## Manifest Schema
 
-Authoritative source:
+Authoritative v0.1 source:
 [Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json](https://github.com/Q00/ouroboros-plugins/blob/main/schemas/0.1/plugin.schema.json).
 
 Per the locked decision in
@@ -164,6 +164,10 @@ the manifest carries **8 required + 2 optional** top-level fields:
 Each required field is load-bearing for some part of the lifecycle, lockfile,
 or firewall; each optional field has a sensible default the firewall provides
 unconditionally.
+
+Core supports v0.1 and a local v0.2 extension. Archived v0.1 manifests do
+not accept top-level `hooks`; v0.2 adds optional hook declarations while
+preserving the v0.1 fields.
 
 The `source.type` enum is `local_path | plugin_home | first_party`. Per
 [Q00/ouroboros-plugins#8](https://github.com/Q00/ouroboros-plugins/issues/8),

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -5,8 +5,8 @@ against the vendored JSON Schema under `src/ouroboros/plugin/schemas/<major>/`.
 
 The locked spec (Q00/ouroboros#728) requires:
 
-  - `PluginManifest` is a frozen dataclass with 8 required + 2 optional fields
-    (per Q00/ouroboros-plugins#6 lock).
+  - `PluginManifest` is a frozen dataclass with 8 required + optional fields
+    selected by the manifest schema version.
   - `load_manifest(path)` returns a frozen, validated manifest.
   - On any schema violation, raise `PluginManifestError` with structured
     fields: `path`, `json_pointer`, `expected`, `got`. A reviewer can match
@@ -39,9 +39,9 @@ except ImportError as exc:  # pragma: no cover
 
 
 # Support window per Q00/ouroboros-plugins#11 lock: current MAJOR + previous MAJOR.
-# Today we only ship 0.1; once 1.0 ships, both "0.1" and "1.0" are accepted, "0.x"
-# below the latest is unsupported.
-SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1",)
+# v0.1 is the archived base manifest contract; v0.2 is the local extension
+# that adds optional hook declarations.
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1", "0.2")
 
 # Source types whose `path` must be a sandboxed relative slug — no absolute
 # paths and no parent-directory traversal. `local_path` resolves relative to
@@ -159,9 +159,8 @@ class AuditSpec:
 class PluginManifest:
     """Frozen representation of a validated plugin manifest.
 
-    Field shape matches Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json
-    after the locked Q00/ouroboros-plugins#6 (8 required + 2 optional)
-    decision is applied.
+    Field shape matches the selected plugin manifest schema. v0.1 manifests
+    do not accept hooks; v0.2 manifests may declare optional hooks.
     """
 
     schema_version: str
@@ -343,7 +342,26 @@ def _build_command(raw: dict[str, Any]) -> CommandSpec:
     )
 
 
-def _build_hook(raw: dict[str, Any]) -> HookSpec:
+def _build_hook(
+    raw: dict[str, Any],
+    *,
+    declared_permission_scopes: frozenset[str],
+    hook_index: int,
+    manifest_path: str | Path,
+) -> HookSpec:
+    for permission_index, scope in enumerate(raw.get("permissions", ())):
+        if scope not in declared_permission_scopes:
+            raise PluginManifestError(
+                "hook permission must be declared in top-level permissions",
+                path=str(manifest_path),
+                json_pointer=f"/hooks/{hook_index}/permissions/{permission_index}",
+                expected=(
+                    "permission scope declared in top-level permissions[].scope "
+                    f"({sorted(declared_permission_scopes)!r})"
+                ),
+                got=scope,
+            )
+
     entrypoint_raw = raw["entrypoint"]
     return HookSpec(
         name=raw["name"],
@@ -355,6 +373,26 @@ def _build_hook(raw: dict[str, Any]) -> HookSpec:
         timeout_seconds=raw.get("timeout_seconds"),
         permissions=tuple(raw.get("permissions", ())),
         description=raw.get("description", ""),
+    )
+
+
+def _escape_json_pointer_token(token: str) -> str:
+    return token.replace("~", "~0").replace("/", "~1")
+
+
+def _validation_error_pointer(error: Any) -> str:
+    """Return the most useful manifest pointer for a jsonschema error."""
+    if error.validator == "additionalProperties" and isinstance(error.instance, dict):
+        allowed = set(error.schema.get("properties", ()))
+        unexpected = [key for key in error.instance if key not in allowed]
+        if unexpected:
+            path = [*error.absolute_path, unexpected[0]]
+            return "/" + "/".join(_escape_json_pointer_token(str(p)) for p in path)
+
+    return (
+        "/" + "/".join(_escape_json_pointer_token(str(p)) for p in error.absolute_path)
+        if error.absolute_path
+        else ""
     )
 
 
@@ -450,7 +488,7 @@ def load_manifest(path: str | Path) -> PluginManifest:
     )
     if errors:
         err = errors[0]
-        pointer = "/" + "/".join(str(p) for p in err.absolute_path) if err.absolute_path else ""
+        pointer = _validation_error_pointer(err)
         raise PluginManifestError(
             err.message,
             path=str(manifest_path),
@@ -495,7 +533,16 @@ def load_manifest(path: str | Path) -> PluginManifest:
     else:
         audit = AuditSpec(events=tuple(audit_raw["events"]))
 
-    hooks = tuple(_build_hook(h) for h in raw.get("hooks", ()))
+    declared_permission_scopes = frozenset(p.scope for p in permissions)
+    hooks = tuple(
+        _build_hook(
+            h,
+            declared_permission_scopes=declared_permission_scopes,
+            hook_index=index,
+            manifest_path=manifest_path,
+        )
+        for index, h in enumerate(raw.get("hooks", ()))
+    )
 
     return PluginManifest(
         schema_version=schema_version,

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -130,6 +130,16 @@ class Entrypoint:
 
 
 @dataclass(frozen=True)
+class HookSpec:
+    name: str
+    entrypoint: Entrypoint
+    failure_policy: str
+    timeout_seconds: int | None = None
+    permissions: tuple[str, ...] = ()
+    description: str = ""
+
+
+@dataclass(frozen=True)
 class AuditSpec:
     events: tuple[str, ...]
 
@@ -168,6 +178,7 @@ class PluginManifest:
     entrypoint: Entrypoint
     description: str = ""
     audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
+    hooks: tuple[HookSpec, ...] = ()
 
 
 def _load_schema(schema_version: str, *, manifest_path: str | Path) -> dict[str, Any]:
@@ -332,6 +343,21 @@ def _build_command(raw: dict[str, Any]) -> CommandSpec:
     )
 
 
+def _build_hook(raw: dict[str, Any]) -> HookSpec:
+    entrypoint_raw = raw["entrypoint"]
+    return HookSpec(
+        name=raw["name"],
+        entrypoint=Entrypoint(
+            type=entrypoint_raw["type"],
+            command=entrypoint_raw["command"],
+        ),
+        failure_policy=raw["failure_policy"],
+        timeout_seconds=raw.get("timeout_seconds"),
+        permissions=tuple(raw.get("permissions", ())),
+        description=raw.get("description", ""),
+    )
+
+
 def load_manifest(path: str | Path) -> PluginManifest:
     """Load and validate a plugin manifest from `path`.
 
@@ -469,6 +495,8 @@ def load_manifest(path: str | Path) -> PluginManifest:
     else:
         audit = AuditSpec(events=tuple(audit_raw["events"]))
 
+    hooks = tuple(_build_hook(h) for h in raw.get("hooks", ()))
+
     return PluginManifest(
         schema_version=schema_version,
         name=raw["name"],
@@ -480,6 +508,7 @@ def load_manifest(path: str | Path) -> PluginManifest:
         entrypoint=entrypoint,
         description=raw.get("description", ""),
         audit=audit,
+        hooks=hooks,
     )
 
 
@@ -488,6 +517,7 @@ __all__ = [
     "CommandArgument",
     "CommandSpec",
     "Entrypoint",
+    "HookSpec",
     "Permission",
     "PluginManifest",
     "PluginManifestError",

--- a/src/ouroboros/plugin/schemas/0.1/_source.json
+++ b/src/ouroboros/plugin/schemas/0.1/_source.json
@@ -2,7 +2,7 @@
   "repo": "Q00/ouroboros-plugins",
   "schema_version": "0.1",
   "vendored_at": "2026-05-07",
-  "note": "These schemas mirror Q00/ouroboros-plugins/schemas/0.1/. They reflect the locked decisions in Q00/ouroboros-plugins #6 (manifest 8+2 fields), #10 (3-value risk enum), #11 (per-major archive). Sync via scripts/sync-plugin-schemas.sh once Q00/ouroboros-plugins#13/#16/#19/#20 land on upstream main.",
+  "note": "These schemas mirror Q00/ouroboros-plugins/schemas/0.1/. They reflect the locked decisions in Q00/ouroboros-plugins #6 (manifest 8+2 fields), #10 (3-value risk enum), #11 (per-major archive). Hook declarations are a local 0.2 extension and are not accepted by archived 0.1 manifests. Sync via scripts/sync-plugin-schemas.sh once Q00/ouroboros-plugins#13/#16/#19/#20 land on upstream main.",
   "local_extensions": {
     "audit-event.schema.json": [
       "Added 'trust_subject_changed' to result.status enum to satisfy the locked RFC at docs/rfc/userlevel-plugins.md (Trust identity / canonical tree hash): the firewall MUST emit plugin.failed with result.status='trust_subject_changed' when an installed plugin's bytes drift from the trusted artifact_digest. Pending upstream sync; the next vendored copy MUST preserve this enum value."

--- a/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.1/plugin.schema.json
@@ -231,6 +231,67 @@
           "uniqueItems": true
         }
       }
+
+    },
+    "hooks": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": ["name", "entrypoint", "failure_policy"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "before_invocation",
+              "after_invocation",
+              "before_tool_call",
+              "after_tool_call",
+              "before_artifact_write",
+              "after_artifact_write",
+              "on_error",
+              "on_cancel"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "entrypoint": {
+            "type": "object",
+            "required": ["type", "command"],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "command"
+              },
+              "command": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+            },
+            "uniqueItems": true,
+            "default": []
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 300
+          },
+          "failure_policy": {
+            "type": "string",
+            "enum": ["fail_open", "fail_closed"]
+          }
+        }
+      }
     }
   }
 }

--- a/src/ouroboros/plugin/schemas/0.2/_source.json
+++ b/src/ouroboros/plugin/schemas/0.2/_source.json
@@ -1,0 +1,14 @@
+{
+  "source_repository": "https://github.com/Q00/ouroboros-plugins",
+  "source_version": "0.1",
+  "source_path": "schemas/0.1/",
+  "note": "Local extension schema for hook declarations. Mirrors Q00/ouroboros-plugins/schemas/0.1/ plus optional top-level hooks while preserving the archived 0.1 contract.",
+  "local_extensions": {
+    "plugin.schema.json": [
+      "Changed $id/title/schema_version const from 0.1 to a local 0.2 schema and added optional top-level hooks declarations. Hook execution/dispatch is intentionally out of scope."
+    ],
+    "audit-event.schema.json": [
+      "Vendored audit-event.schema.json with local 0.2 $id/title/schema_version alignment; audit event shape remains otherwise unchanged from 0.1."
+    ]
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.2/audit-event.schema.json
+++ b/src/ouroboros/plugin/schemas/0.2/audit-event.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros/schemas/local/0.2/audit-event.schema.json",
+  "title": "Ouroboros Plugin Audit Event (v0.2)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "occurred_at",
+    "plugin",
+    "command",
+    "trust_state",
+    "capabilities_used",
+    "permissions_used",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.2"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "plugin.discovered",
+        "plugin.installed",
+        "plugin.trusted",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed"
+      ]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "plugin": {
+      "type": "object",
+      "required": ["name", "version", "source_type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "source_type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["namespace", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": { "type": "string" },
+        "name": { "type": "string" },
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "argv_summary": {
+          "type": "object",
+          "description": "Bounded fingerprint of argv added in step 1 of the audit-fidelity plan. Lets operators size the actual distribution before any cap is chosen and lets consumers correlate identical invocations by sha without dragging the full payload through the index. The argv field itself is unchanged in this step.",
+          "required": ["argc", "byte_length", "sha256"],
+          "additionalProperties": false,
+          "properties": {
+            "argc": { "type": "integer", "minimum": 0 },
+            "byte_length": { "type": "integer", "minimum": 0 },
+            "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          }
+        }
+      }
+    },
+    "trust_state": {
+      "type": "string",
+      "enum": ["discovered", "installed", "trusted", "disabled", "blocked", "first_party"]
+    },
+    "capabilities_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "permissions_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "result": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["success", "blocked", "failed", "trust_subject_changed"]
+        },
+        "message": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.2/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.2/plugin.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/Q00/ouroboros-plugins/schemas/0.1/plugin.schema.json",
-  "title": "Ouroboros Plugin Manifest (v0.1)",
+  "$id": "https://github.com/Q00/ouroboros/schemas/local/0.2/plugin.schema.json",
+  "title": "Ouroboros Plugin Manifest (v0.2)",
   "type": "object",
   "required": [
     "schema_version",
@@ -17,7 +17,7 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "const": "0.1"
+      "const": "0.2"
     },
     "name": {
       "type": "string",
@@ -232,6 +232,66 @@
         }
       }
 
+    },
+    "hooks": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": ["name", "entrypoint", "failure_policy"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "before_invocation",
+              "after_invocation",
+              "before_tool_call",
+              "after_tool_call",
+              "before_artifact_write",
+              "after_artifact_write",
+              "on_error",
+              "on_cancel"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "entrypoint": {
+            "type": "object",
+            "required": ["type", "command"],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "command"
+              },
+              "command": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+            },
+            "uniqueItems": true,
+            "default": []
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 300
+          },
+          "failure_policy": {
+            "type": "string",
+            "enum": ["fail_open", "fail_closed"]
+          }
+        }
+      }
     }
   }
 }

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -82,6 +82,85 @@ def test_load_reference_manifest(tmp_path: Path) -> None:
     assert manifest.source.type == "local_path"
 
 
+def test_hook_declarations_load_as_frozen_specs(tmp_path: Path) -> None:
+    """Lifecycle hooks are optional manifest declarations, not executable side effects."""
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["hooks"] = [
+        {
+            "name": "before_invocation",
+            "description": "Inspect invocation metadata before execution.",
+            "entrypoint": {"type": "command", "command": "python -m plugin_hooks before"},
+            "permissions": ["ledger:read"],
+            "timeout_seconds": 5,
+            "failure_policy": "fail_closed",
+        },
+        {
+            "name": "after_invocation",
+            "entrypoint": {"type": "command", "command": "python -m plugin_hooks after"},
+            "failure_policy": "fail_open",
+        },
+    ]
+
+    manifest = load_manifest(_write(tmp_path, payload))
+
+    assert len(manifest.hooks) == 2
+    assert manifest.hooks[0].name == "before_invocation"
+    assert manifest.hooks[0].entrypoint.command == "python -m plugin_hooks before"
+    assert manifest.hooks[0].permissions == ("ledger:read",)
+    assert manifest.hooks[0].timeout_seconds == 5
+    assert manifest.hooks[0].failure_policy == "fail_closed"
+    assert manifest.hooks[1].timeout_seconds is None
+    assert manifest.hooks[1].permissions == ()
+
+
+def test_optional_hooks_default_to_empty_tuple(tmp_path: Path) -> None:
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    assert manifest.hooks == ()
+
+
+def test_unknown_hook_name_rejected(tmp_path: Path) -> None:
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["hooks"] = [
+        {
+            "name": "around_everything",
+            "entrypoint": {"type": "command", "command": "python -m plugin_hooks"},
+            "failure_policy": "fail_open",
+        }
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/hooks/0/name"
+
+
+def test_hook_failure_policy_rejected_outside_enum(tmp_path: Path) -> None:
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["hooks"] = [
+        {
+            "name": "before_invocation",
+            "entrypoint": {"type": "command", "command": "python -m plugin_hooks"},
+            "failure_policy": "retry_forever",
+        }
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/hooks/0/failure_policy"
+
+
+def test_hook_timeout_has_bounded_positive_integer(tmp_path: Path) -> None:
+    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["hooks"] = [
+        {
+            "name": "before_invocation",
+            "entrypoint": {"type": "command", "command": "python -m plugin_hooks"},
+            "timeout_seconds": 0,
+            "failure_policy": "fail_open",
+        }
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/hooks/0/timeout_seconds"
+
+
 def test_missing_required_top_level_field(tmp_path: Path) -> None:
     """Test 2: missing `name` raises with empty json_pointer (root-level)."""
     bad = {**REFERENCE_MANIFEST}
@@ -154,6 +233,7 @@ def test_optional_fields_omitted(tmp_path: Path) -> None:
     assert "plugin.invoked" in manifest.audit.events
     assert "plugin.completed" in manifest.audit.events
     assert "plugin.failed" in manifest.audit.events
+    assert manifest.hooks == ()
 
 
 def test_first_party_source_branch(tmp_path: Path) -> None:

--- a/tests/unit/plugin/test_manifest.py
+++ b/tests/unit/plugin/test_manifest.py
@@ -61,6 +61,12 @@ REFERENCE_MANIFEST: dict = {
 }
 
 
+def _hook_manifest() -> dict:
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["schema_version"] = "0.2"
+    return payload
+
+
 def _write(tmp_path: Path, payload: dict | str) -> Path:
     target = tmp_path / "ouroboros.plugin.json"
     if isinstance(payload, str):
@@ -84,13 +90,13 @@ def test_load_reference_manifest(tmp_path: Path) -> None:
 
 def test_hook_declarations_load_as_frozen_specs(tmp_path: Path) -> None:
     """Lifecycle hooks are optional manifest declarations, not executable side effects."""
-    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload = _hook_manifest()
     payload["hooks"] = [
         {
             "name": "before_invocation",
             "description": "Inspect invocation metadata before execution.",
             "entrypoint": {"type": "command", "command": "python -m plugin_hooks before"},
-            "permissions": ["ledger:read"],
+            "permissions": ["github:read"],
             "timeout_seconds": 5,
             "failure_policy": "fail_closed",
         },
@@ -106,11 +112,51 @@ def test_hook_declarations_load_as_frozen_specs(tmp_path: Path) -> None:
     assert len(manifest.hooks) == 2
     assert manifest.hooks[0].name == "before_invocation"
     assert manifest.hooks[0].entrypoint.command == "python -m plugin_hooks before"
-    assert manifest.hooks[0].permissions == ("ledger:read",)
+    assert manifest.hooks[0].permissions == ("github:read",)
     assert manifest.hooks[0].timeout_seconds == 5
     assert manifest.hooks[0].failure_policy == "fail_closed"
     assert manifest.hooks[1].timeout_seconds is None
     assert manifest.hooks[1].permissions == ()
+
+
+def test_hook_permission_must_be_declared_top_level(tmp_path: Path) -> None:
+    payload = _hook_manifest()
+    payload["hooks"] = [
+        {
+            "name": "before_invocation",
+            "entrypoint": {"type": "command", "command": "python -m plugin_hooks before"},
+            "permissions": ["ledger:read"],
+            "failure_policy": "fail_closed",
+        }
+    ]
+
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, payload))
+
+    err = excinfo.value
+    assert err.json_pointer == "/hooks/0/permissions/0"
+    assert "top-level permissions" in err.args[0]
+    assert "permissions[].scope" in err.expected
+    assert err.got == "ledger:read"
+
+
+def test_duplicate_hook_permissions_still_rejected_by_schema(tmp_path: Path) -> None:
+    payload = _hook_manifest()
+    payload["hooks"] = [
+        {
+            "name": "before_invocation",
+            "entrypoint": {"type": "command", "command": "python -m plugin_hooks before"},
+            "permissions": ["github:read", "github:read"],
+            "failure_policy": "fail_closed",
+        }
+    ]
+
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, payload))
+
+    err = excinfo.value
+    assert err.json_pointer == "/hooks/0/permissions"
+    assert "unique" in err.args[0].lower()
 
 
 def test_optional_hooks_default_to_empty_tuple(tmp_path: Path) -> None:
@@ -118,8 +164,23 @@ def test_optional_hooks_default_to_empty_tuple(tmp_path: Path) -> None:
     assert manifest.hooks == ()
 
 
-def test_unknown_hook_name_rejected(tmp_path: Path) -> None:
+def test_v01_rejects_top_level_hooks(tmp_path: Path) -> None:
     bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad["hooks"] = [
+        {
+            "name": "before_invocation",
+            "entrypoint": {"type": "command", "command": "python -m plugin_hooks"},
+            "failure_policy": "fail_open",
+        }
+    ]
+    with pytest.raises(PluginManifestError) as excinfo:
+        load_manifest(_write(tmp_path, bad))
+    assert excinfo.value.json_pointer == "/hooks"
+    assert "hooks" in excinfo.value.args[0]
+
+
+def test_unknown_hook_name_rejected(tmp_path: Path) -> None:
+    bad = _hook_manifest()
     bad["hooks"] = [
         {
             "name": "around_everything",
@@ -133,7 +194,7 @@ def test_unknown_hook_name_rejected(tmp_path: Path) -> None:
 
 
 def test_hook_failure_policy_rejected_outside_enum(tmp_path: Path) -> None:
-    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad = _hook_manifest()
     bad["hooks"] = [
         {
             "name": "before_invocation",
@@ -147,7 +208,7 @@ def test_hook_failure_policy_rejected_outside_enum(tmp_path: Path) -> None:
 
 
 def test_hook_timeout_has_bounded_positive_integer(tmp_path: Path) -> None:
-    bad = json.loads(json.dumps(REFERENCE_MANIFEST))
+    bad = _hook_manifest()
     bad["hooks"] = [
         {
             "name": "before_invocation",
@@ -226,7 +287,7 @@ def test_returned_manifest_is_frozen(tmp_path: Path) -> None:
 
 def test_optional_fields_omitted(tmp_path: Path) -> None:
     """Test 9: manifest without description and audit loads with defaults
-    (per Q00/ouroboros-plugins#6 lock — 8 required + 2 optional)."""
+    (per Q00/ouroboros-plugins#6 lock — v0.1 has 8 required + 2 optional)."""
     bare = {k: v for k, v in REFERENCE_MANIFEST.items() if k not in ("description", "audit")}
     manifest = load_manifest(_write(tmp_path, bare))
     assert manifest.description == ""


### PR DESCRIPTION
## Summary
- Adds optional `hooks` declarations to the v0.1 plugin manifest schema.
- Loads hook declarations into frozen `HookSpec` dataclasses without executing them.
- Locks rejection behavior for unknown hook names, invalid failure policy, and unsafe timeout values.

## Why this belongs in Tier 1 / #939
Ouroboros is moving toward thin skills and a fat harness. The harness cannot safely dispatch lifecycle hooks until hook intent is declarative, validated, and reviewable at manifest load time. This PR gives AgentOS/plugin work a minimal SSOT for hook shape while deliberately avoiding runtime execution side effects.

## How it is implemented
- `HookSpec` is added to `ouroboros.plugin.manifest`.
- `PluginManifest.hooks` defaults to an empty tuple for backward compatibility.
- The vendored v0.1 schema accepts a bounded hook vocabulary, command entrypoints, explicit `fail_open`/`fail_closed` policy, optional declared permissions, and optional bounded timeout.
- Tests assert both positive loading and structured JSON pointers for invalid hook declarations.

## Decisions still needed before later Tier 1 PRs
- Whether duplicate hook names should be allowed for ordered multi-hook chains or rejected by policy.
- Whether the runtime default timeout should come from manifest policy, harness config, or both.
- Which hook names graduate from declaration-only to dispatch in the first fixture plugin.

## Validation
- [x] `uv run pytest tests/unit/plugin/test_manifest.py -q` — 45 passed
- [x] `uv run ruff check src/ouroboros/plugin/manifest.py tests/unit/plugin/test_manifest.py` — passed
- [x] `uv run pytest tests/unit/plugin -q` — 345 passed, 1 skipped
- [x] `uv run pytest tests/integration/plugin -q` — 20 passed

## Post-merge Ouroboros real verification
- Create a local test plugin manifest with `before_invocation` and `after_invocation` hooks.
- Run the normal plugin manifest loading path and confirm `manifest.hooks` exposes two frozen specs.
- Confirm removing the declared permission or using an unknown hook name fails before runtime dispatch.
- Confirm existing plugins without `hooks` still load and report `hooks == ()`.

Refs #939
Follows #969 conceptually; this PR remains code-independent and targets `main` for reviewability.
