### PR TITLE
feat(hitl): add typed WAIT/RESUME contract

### DIFF
--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -73,10 +73,15 @@ def _normalize_string_tuple(name: str, value: Any) -> tuple[str, ...]:
     if isinstance(value, str) or not isinstance(value, tuple | list):
         raise TypeError(f"HumanInput {name} must be a tuple or list of strings")
     normalized: list[str] = []
+    seen: set[str] = set()
     for item in value:
         if not isinstance(item, str):
             raise TypeError(f"HumanInput {name} entries must be strings")
-        normalized.append(_require_non_empty(name, item))
+        normalized_item = _require_non_empty(name, item)
+        if normalized_item in seen:
+            raise ValueError(f"HumanInput {name} entries must be unique after trimming")
+        seen.add(normalized_item)
+        normalized.append(normalized_item)
     return tuple(normalized)
 
 

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -1,0 +1,249 @@
+"""Typed human-in-the-loop contracts for WAIT/RESUME flows.
+
+The HITL contract is the stable payload shape behind ``hitl.*`` events.
+It intentionally models request/response correlation and persistence-safe
+payloads without choosing a renderer (CLI, MCP, TUI, or structured question).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, ClassVar
+
+HITL_CONTRACT_SCHEMA_VERSION = 1
+MAX_HITL_PAYLOAD_BYTES = 8192
+_SECRET_MARKERS = ("password", "passwd", "secret", "token", "api_key", "apikey", "credential")
+
+
+class HumanInputKind(StrEnum):
+    FREE_TEXT = "free_text"
+    SINGLE_SELECT = "single_select"
+    MULTI_SELECT = "multi_select"
+    APPROVAL = "approval"
+    DESTRUCTIVE_CONFIRMATION = "destructive_confirmation"
+
+
+class HumanInputSource(StrEnum):
+    INTERVIEW = "interview"
+    PLUGIN_FIREWALL = "plugin_firewall"
+    CONTROL_PLANE = "control_plane"
+    PLAN_APPROVAL = "plan_approval"
+    RUNTIME_POLICY = "runtime_policy"
+
+
+class HumanInputRiskClass(StrEnum):
+    LOW = "low"
+    MATERIAL_BRANCH = "material_branch"
+    CREDENTIAL_GATED = "credential_gated"
+    EXTERNAL_PRODUCTION = "external_production"
+    DESTRUCTIVE = "destructive"
+
+
+class HumanInputTimeoutAction(StrEnum):
+    STAY_WAITING = "stay_waiting"
+    CANCEL = "cancel"
+    EXPIRE_BLOCKED = "expire_blocked"
+
+
+class HumanInputResponseKind(StrEnum):
+    TEXT = "text"
+    SELECTION = "selection"
+    APPROVAL = "approval"
+    CANCEL = "cancel"
+    TIMEOUT = "timeout"
+
+
+def _require_non_empty(name: str, value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"HumanInput {name} must be non-empty")
+    return normalized
+
+
+def _ensure_json_safe_payload(name: str, value: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError(f"HumanInput {name} must be a dict")
+    text = repr(value)
+    if len(text.encode("utf-8")) > MAX_HITL_PAYLOAD_BYTES:
+        raise ValueError(f"HumanInput {name} exceeds {MAX_HITL_PAYLOAD_BYTES} bytes")
+    lowered = text.lower()
+    if any(marker in lowered for marker in _SECRET_MARKERS):
+        raise ValueError(f"HumanInput {name} must not persist secret-like content")
+    return dict(value)
+
+
+@dataclass(frozen=True, slots=True)
+class HumanInputRequest:
+    request_id: str
+    session_id: str
+    created_by: str
+    kind: HumanInputKind
+    source: HumanInputSource
+    risk_class: HumanInputRiskClass
+    question: str
+    resume_target: str
+    schema_version: int = HITL_CONTRACT_SCHEMA_VERSION
+    run_id: str | None = None
+    invocation_id: str | None = None
+    title: str | None = None
+    body: str | None = None
+    options: tuple[str, ...] = ()
+    required_permission: str | None = None
+    timeout_seconds: int | None = None
+    timeout_action: HumanInputTimeoutAction = HumanInputTimeoutAction.STAY_WAITING
+    surface: str | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    REQUESTED_EVENT_TYPE: ClassVar[str] = "hitl.requested"
+    TIMED_OUT_EVENT_TYPE: ClassVar[str] = "hitl.timed_out"
+    CANCELLED_EVENT_TYPE: ClassVar[str] = "hitl.cancelled"
+
+    def __post_init__(self) -> None:
+        if self.schema_version < 1:
+            raise ValueError("HumanInputRequest schema_version must be >= 1")
+        if not isinstance(self.kind, HumanInputKind):
+            raise TypeError("HumanInputRequest kind must be a HumanInputKind")
+        if not isinstance(self.source, HumanInputSource):
+            raise TypeError("HumanInputRequest source must be a HumanInputSource")
+        if not isinstance(self.risk_class, HumanInputRiskClass):
+            raise TypeError("HumanInputRequest risk_class must be a HumanInputRiskClass")
+        if not isinstance(self.timeout_action, HumanInputTimeoutAction):
+            raise TypeError("HumanInputRequest timeout_action must be a HumanInputTimeoutAction")
+
+        for field_name in ("request_id", "session_id", "created_by", "question", "resume_target"):
+            object.__setattr__(
+                self, field_name, _require_non_empty(field_name, getattr(self, field_name))
+            )
+        for field_name in (
+            "run_id",
+            "invocation_id",
+            "title",
+            "body",
+            "required_permission",
+            "surface",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                object.__setattr__(self, field_name, _require_non_empty(field_name, value))
+        if self.timeout_seconds is not None and self.timeout_seconds < 1:
+            raise ValueError("HumanInputRequest timeout_seconds must be >= 1 when provided")
+        if (
+            self.kind in {HumanInputKind.SINGLE_SELECT, HumanInputKind.MULTI_SELECT}
+            and not self.options
+        ):
+            raise ValueError("select HumanInputRequest requires at least one option")
+        if any(not option.strip() for option in self.options):
+            raise ValueError("HumanInputRequest options must be non-empty")
+        object.__setattr__(self, "options", tuple(self.options))
+        object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
+
+    @property
+    def aggregate_id(self) -> str:
+        return self.run_id or self.invocation_id or self.session_id
+
+    def to_event_data(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "request_id": self.request_id,
+            "session_id": self.session_id,
+            "kind": self.kind.value,
+            "source": self.source.value,
+            "risk_class": self.risk_class.value,
+            "question": self.question,
+            "resume_target": self.resume_target,
+            "created_by": self.created_by,
+            "timeout_action": self.timeout_action.value,
+            "created_at": self.created_at.isoformat(),
+        }
+        if self.run_id is not None:
+            data["run_id"] = self.run_id
+        if self.invocation_id is not None:
+            data["invocation_id"] = self.invocation_id
+        if self.title is not None:
+            data["title"] = self.title
+        if self.body is not None:
+            data["body"] = self.body
+        if self.options:
+            data["options"] = list(self.options)
+        if self.required_permission is not None:
+            data["required_permission"] = self.required_permission
+        if self.timeout_seconds is not None:
+            data["timeout_seconds"] = self.timeout_seconds
+        if self.surface is not None:
+            data["surface"] = self.surface
+        if self.payload:
+            data["payload"] = dict(self.payload)
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class HumanInputResponse:
+    request_id: str
+    actor: str
+    response_kind: HumanInputResponseKind
+    schema_version: int = HITL_CONTRACT_SCHEMA_VERSION
+    session_id: str | None = None
+    run_id: str | None = None
+    invocation_id: str | None = None
+    selected_values: tuple[str, ...] = ()
+    text: str | None = None
+    approval_decision: bool | None = None
+    surface: str | None = None
+    payload: dict[str, Any] = field(default_factory=dict)
+    received_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    ANSWERED_EVENT_TYPE: ClassVar[str] = "hitl.answered"
+
+    def __post_init__(self) -> None:
+        if self.schema_version < 1:
+            raise ValueError("HumanInputResponse schema_version must be >= 1")
+        if not isinstance(self.response_kind, HumanInputResponseKind):
+            raise TypeError("HumanInputResponse response_kind must be a HumanInputResponseKind")
+        object.__setattr__(self, "request_id", _require_non_empty("request_id", self.request_id))
+        object.__setattr__(self, "actor", _require_non_empty("actor", self.actor))
+        for field_name in ("session_id", "run_id", "invocation_id", "text", "surface"):
+            value = getattr(self, field_name)
+            if value is not None:
+                object.__setattr__(self, field_name, _require_non_empty(field_name, value))
+        if any(not value.strip() for value in self.selected_values):
+            raise ValueError("HumanInputResponse selected_values must be non-empty")
+        if (
+            self.approval_decision is not None
+            and self.response_kind is not HumanInputResponseKind.APPROVAL
+        ):
+            raise ValueError("approval_decision is only valid for approval responses")
+        object.__setattr__(self, "selected_values", tuple(self.selected_values))
+        object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
+
+    @property
+    def aggregate_id(self) -> str:
+        return self.run_id or self.invocation_id or self.session_id or self.request_id
+
+    def to_event_data(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "request_id": self.request_id,
+            "actor": self.actor,
+            "response_kind": self.response_kind.value,
+            "received_at": self.received_at.isoformat(),
+        }
+        if self.session_id is not None:
+            data["session_id"] = self.session_id
+        if self.run_id is not None:
+            data["run_id"] = self.run_id
+        if self.invocation_id is not None:
+            data["invocation_id"] = self.invocation_id
+        if self.selected_values:
+            data["selected_values"] = list(self.selected_values)
+        if self.text is not None:
+            data["text"] = self.text
+        if self.approval_decision is not None:
+            data["approval_decision"] = self.approval_decision
+        if self.surface is not None:
+            data["surface"] = self.surface
+        if self.payload:
+            data["payload"] = dict(self.payload)
+        return data

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -69,6 +69,17 @@ def _require_non_empty(name: str, value: str) -> str:
     return normalized
 
 
+def _normalize_string_tuple(name: str, value: Any) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, tuple | list):
+        raise TypeError(f"HumanInput {name} must be a tuple or list of strings")
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise TypeError(f"HumanInput {name} entries must be strings")
+        normalized.append(_require_non_empty(name, item))
+    return tuple(normalized)
+
+
 def _contains_secret_marker(value: str) -> bool:
     lowered = value.lower()
     return any(marker in lowered for marker in _SECRET_MARKERS)
@@ -180,16 +191,17 @@ class HumanInputRequest:
             value = getattr(self, field_name)
             if value is not None:
                 object.__setattr__(self, field_name, _require_non_empty(field_name, value))
-        if self.timeout_seconds is not None and self.timeout_seconds < 1:
-            raise ValueError("HumanInputRequest timeout_seconds must be >= 1 when provided")
+        if self.timeout_seconds is not None:
+            if type(self.timeout_seconds) is not int:
+                raise TypeError("HumanInputRequest timeout_seconds must be an int")
+            if self.timeout_seconds < 1:
+                raise ValueError("HumanInputRequest timeout_seconds must be >= 1 when provided")
         if (
             self.kind in {HumanInputKind.SINGLE_SELECT, HumanInputKind.MULTI_SELECT}
             and not self.options
         ):
             raise ValueError("select HumanInputRequest requires at least one option")
-        if any(not option.strip() for option in self.options):
-            raise ValueError("HumanInputRequest options must be non-empty")
-        object.__setattr__(self, "options", tuple(self.options))
+        object.__setattr__(self, "options", _normalize_string_tuple("options", self.options))
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
 
     @property
@@ -260,13 +272,15 @@ class HumanInputResponse:
             value = getattr(self, field_name)
             if value is not None:
                 object.__setattr__(self, field_name, _require_non_empty(field_name, value))
-        if any(not value.strip() for value in self.selected_values):
-            raise ValueError("HumanInputResponse selected_values must be non-empty")
+        object.__setattr__(
+            self,
+            "selected_values",
+            _normalize_string_tuple("selected_values", self.selected_values),
+        )
         if self.run_id is None and self.invocation_id is None and self.session_id is None:
             raise ValueError(
                 "HumanInputResponse requires session_id, run_id, or invocation_id for request correlation"
             )
-        object.__setattr__(self, "selected_values", tuple(self.selected_values))
         self._validate_response_content()
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
 

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -80,6 +80,14 @@ def _normalize_string_tuple(name: str, value: Any) -> tuple[str, ...]:
     return tuple(normalized)
 
 
+def _normalize_utc_datetime(name: str, value: datetime) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError(f"HumanInput {name} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"HumanInput {name} must be timezone-aware")
+    return value.astimezone(UTC)
+
+
 def _contains_secret_marker(value: str) -> bool:
     lowered = value.lower()
     return any(marker in lowered for marker in _SECRET_MARKERS)
@@ -123,9 +131,9 @@ def _thaw_json_value(value: FrozenJsonValue) -> JsonValue:
     return value
 
 
-def _ensure_json_safe_payload(name: str, value: dict[str, Any]) -> Mapping[str, FrozenJsonValue]:
-    if not isinstance(value, dict):
-        raise TypeError(f"HumanInput {name} must be a dict")
+def _ensure_json_safe_payload(name: str, value: Mapping[str, Any]) -> Mapping[str, FrozenJsonValue]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"HumanInput {name} must be a mapping")
     normalized = _normalize_json_value(name, value, name)
     encoded = json.dumps(normalized, allow_nan=False, separators=(",", ":")).encode("utf-8")
     if len(encoded) > MAX_HITL_PAYLOAD_BYTES:
@@ -203,6 +211,9 @@ class HumanInputRequest:
             raise ValueError("select HumanInputRequest requires at least one option")
         object.__setattr__(self, "options", _normalize_string_tuple("options", self.options))
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
+        object.__setattr__(
+            self, "created_at", _normalize_utc_datetime("created_at", self.created_at)
+        )
 
     @property
     def aggregate_id(self) -> str:
@@ -283,6 +294,9 @@ class HumanInputResponse:
             )
         self._validate_response_content()
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
+        object.__setattr__(
+            self, "received_at", _normalize_utc_datetime("received_at", self.received_at)
+        )
 
     def _validate_response_content(self) -> None:
         has_text = self.text is not None

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -217,7 +217,7 @@ class HumanInputRequest:
 
     @property
     def aggregate_id(self) -> str:
-        return self.run_id or self.invocation_id or self.session_id
+        return self.request_id
 
     def to_event_data(self) -> dict[str, Any]:
         data: dict[str, Any] = {
@@ -288,10 +288,6 @@ class HumanInputResponse:
             "selected_values",
             _normalize_string_tuple("selected_values", self.selected_values),
         )
-        if self.run_id is None and self.invocation_id is None and self.session_id is None:
-            raise ValueError(
-                "HumanInputResponse requires session_id, run_id, or invocation_id for request correlation"
-            )
         self._validate_response_content()
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
         object.__setattr__(
@@ -332,7 +328,7 @@ class HumanInputResponse:
 
     @property
     def aggregate_id(self) -> str:
-        return self.run_id or self.invocation_id or self.session_id or self.request_id
+        return self.request_id
 
     def to_event_data(self) -> dict[str, Any]:
         data: dict[str, Any] = {

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -205,8 +205,8 @@ class HumanInputRequest:
     CANCELLED_EVENT_TYPE: ClassVar[str] = "hitl.cancelled"
 
     def __post_init__(self) -> None:
-        if self.schema_version < 1:
-            raise ValueError("HumanInputRequest schema_version must be >= 1")
+        if type(self.schema_version) is not int or self.schema_version < 1:
+            raise ValueError("HumanInputRequest schema_version must be a positive integer")
         if not isinstance(self.kind, HumanInputKind):
             raise TypeError("HumanInputRequest kind must be a HumanInputKind")
         if not isinstance(self.source, HumanInputSource):
@@ -305,8 +305,8 @@ class HumanInputResponse:
     ANSWERED_EVENT_TYPE: ClassVar[str] = "hitl.answered"
 
     def __post_init__(self) -> None:
-        if self.schema_version < 1:
-            raise ValueError("HumanInputResponse schema_version must be >= 1")
+        if type(self.schema_version) is not int or self.schema_version < 1:
+            raise ValueError("HumanInputResponse schema_version must be a positive integer")
         if not isinstance(self.response_kind, HumanInputResponseKind):
             raise TypeError("HumanInputResponse response_kind must be a HumanInputResponseKind")
         object.__setattr__(self, "request_id", _require_non_empty("request_id", self.request_id))

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -244,6 +244,11 @@ class HumanInputRequest:
                 raise TypeError("HumanInputRequest timeout_seconds must be an int")
             if self.timeout_seconds < 1:
                 raise ValueError("HumanInputRequest timeout_seconds must be >= 1 when provided")
+        elif self.timeout_action is not HumanInputTimeoutAction.STAY_WAITING:
+            raise ValueError(
+                "HumanInputRequest timeout_action requires a timeout_seconds value "
+                "(only STAY_WAITING is valid when timeout_seconds is None)"
+            )
         if (
             self.kind in {HumanInputKind.SINGLE_SELECT, HumanInputKind.MULTI_SELECT}
             and not self.options

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -17,7 +17,34 @@ from typing import Any, ClassVar, cast
 
 HITL_CONTRACT_SCHEMA_VERSION = 1
 MAX_HITL_PAYLOAD_BYTES = 8192
-_SECRET_MARKERS = ("password", "passwd", "secret", "token", "api_key", "apikey", "credential")
+_SECRET_KEY_NAMES = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "auth_token",
+        "bearer_token",
+        "client_secret",
+        "credential",
+        "credentials",
+        "id_token",
+        "passwd",
+        "password",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "token",
+    }
+)
+_SECRET_KEY_SUFFIXES = (
+    "_api_key",
+    "_credential",
+    "_credentials",
+    "_passwd",
+    "_password",
+    "_secret",
+    "_token",
+)
 
 type JsonScalar = str | int | float | bool | None
 type JsonValue = JsonScalar | dict[str, JsonValue] | list[JsonValue]
@@ -93,9 +120,9 @@ def _normalize_utc_datetime(name: str, value: datetime) -> datetime:
     return value.astimezone(UTC)
 
 
-def _contains_secret_marker(value: str) -> bool:
-    lowered = value.lower()
-    return any(marker in lowered for marker in _SECRET_MARKERS)
+def _is_secret_like_key(value: str) -> bool:
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized in _SECRET_KEY_NAMES or normalized.endswith(_SECRET_KEY_SUFFIXES)
 
 
 def _normalize_json_value(name: str, value: Any, path: str) -> JsonValue:
@@ -108,7 +135,7 @@ def _normalize_json_value(name: str, value: Any, path: str) -> JsonValue:
         for key, item in value.items():
             if not isinstance(key, str):
                 raise TypeError(f"HumanInput {name} key at {path} must be a string")
-            if _contains_secret_marker(key):
+            if _is_secret_like_key(key):
                 raise ValueError(f"HumanInput {name} must not persist secret-like content")
             normalized[key] = _normalize_json_value(name, item, f"{path}.{key}")
         return normalized

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -96,6 +96,14 @@ def _require_non_empty(name: str, value: str) -> str:
     return normalized
 
 
+def _require_non_blank_text(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"HumanInput {name} must be a string")
+    if not value.strip():
+        raise ValueError(f"HumanInput {name} must be non-empty")
+    return value
+
+
 def _normalize_string_tuple(name: str, value: Any) -> tuple[str, ...]:
     if isinstance(value, str) or not isinstance(value, tuple | list):
         raise TypeError(f"HumanInput {name} must be a tuple or list of strings")
@@ -311,10 +319,12 @@ class HumanInputResponse:
             raise TypeError("HumanInputResponse response_kind must be a HumanInputResponseKind")
         object.__setattr__(self, "request_id", _require_non_empty("request_id", self.request_id))
         object.__setattr__(self, "actor", _require_non_empty("actor", self.actor))
-        for field_name in ("session_id", "run_id", "invocation_id", "text", "surface"):
+        for field_name in ("session_id", "run_id", "invocation_id", "surface"):
             value = getattr(self, field_name)
             if value is not None:
                 object.__setattr__(self, field_name, _require_non_empty(field_name, value))
+        if self.text is not None:
+            object.__setattr__(self, "text", _require_non_blank_text("text", self.text))
         object.__setattr__(
             self,
             "selected_values",

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -76,8 +76,6 @@ def _contains_secret_marker(value: str) -> bool:
 
 def _normalize_json_value(name: str, value: Any, path: str) -> JsonValue:
     if value is None or isinstance(value, str | int | bool):
-        if isinstance(value, str) and _contains_secret_marker(value):
-            raise ValueError(f"HumanInput {name} must not persist secret-like content")
         return value
     if isinstance(value, float):
         return value
@@ -264,6 +262,10 @@ class HumanInputResponse:
                 object.__setattr__(self, field_name, _require_non_empty(field_name, value))
         if any(not value.strip() for value in self.selected_values):
             raise ValueError("HumanInputResponse selected_values must be non-empty")
+        if self.run_id is None and self.invocation_id is None and self.session_id is None:
+            raise ValueError(
+                "HumanInputResponse requires session_id, run_id, or invocation_id for request correlation"
+            )
         object.__setattr__(self, "selected_values", tuple(self.selected_values))
         self._validate_response_content()
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -7,14 +7,21 @@ payloads without choosing a renderer (CLI, MCP, TUI, or structured question).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any, ClassVar
+import json
+from types import MappingProxyType
+from typing import Any, ClassVar, cast
 
 HITL_CONTRACT_SCHEMA_VERSION = 1
 MAX_HITL_PAYLOAD_BYTES = 8192
 _SECRET_MARKERS = ("password", "passwd", "secret", "token", "api_key", "apikey", "credential")
+
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | dict[str, JsonValue] | list[JsonValue]
+type FrozenJsonValue = JsonScalar | Mapping[str, FrozenJsonValue] | tuple[FrozenJsonValue, ...]
 
 
 class HumanInputKind(StrEnum):
@@ -62,16 +69,63 @@ def _require_non_empty(name: str, value: str) -> str:
     return normalized
 
 
-def _ensure_json_safe_payload(name: str, value: dict[str, Any]) -> dict[str, Any]:
+def _contains_secret_marker(value: str) -> bool:
+    lowered = value.lower()
+    return any(marker in lowered for marker in _SECRET_MARKERS)
+
+
+def _normalize_json_value(name: str, value: Any, path: str) -> JsonValue:
+    if value is None or isinstance(value, str | int | bool):
+        if isinstance(value, str) and _contains_secret_marker(value):
+            raise ValueError(f"HumanInput {name} must not persist secret-like content")
+        return value
+    if isinstance(value, float):
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"HumanInput {name} key at {path} must be a string")
+            if _contains_secret_marker(key):
+                raise ValueError(f"HumanInput {name} must not persist secret-like content")
+            normalized[key] = _normalize_json_value(name, item, f"{path}.{key}")
+        return normalized
+    if isinstance(value, list | tuple):
+        return [
+            _normalize_json_value(name, item, f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    raise TypeError(f"HumanInput {name} value at {path} must be JSON serializable")
+
+
+def _freeze_json_value(value: JsonValue) -> FrozenJsonValue:
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_json_value(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json_value(item) for item in value)
+    return value
+
+
+def _thaw_json_value(value: FrozenJsonValue) -> JsonValue:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json_value(item) for item in value]
+    return value
+
+
+def _ensure_json_safe_payload(name: str, value: dict[str, Any]) -> Mapping[str, FrozenJsonValue]:
     if not isinstance(value, dict):
         raise TypeError(f"HumanInput {name} must be a dict")
-    text = repr(value)
-    if len(text.encode("utf-8")) > MAX_HITL_PAYLOAD_BYTES:
+    normalized = _normalize_json_value(name, value, name)
+    encoded = json.dumps(normalized, allow_nan=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_HITL_PAYLOAD_BYTES:
         raise ValueError(f"HumanInput {name} exceeds {MAX_HITL_PAYLOAD_BYTES} bytes")
-    lowered = text.lower()
-    if any(marker in lowered for marker in _SECRET_MARKERS):
-        raise ValueError(f"HumanInput {name} must not persist secret-like content")
-    return dict(value)
+    return cast(Mapping[str, FrozenJsonValue], _freeze_json_value(normalized))
+
+
+def _payload_to_event_data(value: Mapping[str, FrozenJsonValue]) -> dict[str, JsonValue]:
+    return cast(dict[str, JsonValue], _thaw_json_value(value))
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,7 +148,7 @@ class HumanInputRequest:
     timeout_seconds: int | None = None
     timeout_action: HumanInputTimeoutAction = HumanInputTimeoutAction.STAY_WAITING
     surface: str | None = None
-    payload: dict[str, Any] = field(default_factory=dict)
+    payload: Mapping[str, FrozenJsonValue] = field(default_factory=dict)
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     REQUESTED_EVENT_TYPE: ClassVar[str] = "hitl.requested"
@@ -175,7 +229,7 @@ class HumanInputRequest:
         if self.surface is not None:
             data["surface"] = self.surface
         if self.payload:
-            data["payload"] = dict(self.payload)
+            data["payload"] = _payload_to_event_data(self.payload)
         return data
 
 
@@ -192,7 +246,7 @@ class HumanInputResponse:
     text: str | None = None
     approval_decision: bool | None = None
     surface: str | None = None
-    payload: dict[str, Any] = field(default_factory=dict)
+    payload: Mapping[str, FrozenJsonValue] = field(default_factory=dict)
     received_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     ANSWERED_EVENT_TYPE: ClassVar[str] = "hitl.answered"
@@ -210,13 +264,41 @@ class HumanInputResponse:
                 object.__setattr__(self, field_name, _require_non_empty(field_name, value))
         if any(not value.strip() for value in self.selected_values):
             raise ValueError("HumanInputResponse selected_values must be non-empty")
-        if (
-            self.approval_decision is not None
-            and self.response_kind is not HumanInputResponseKind.APPROVAL
-        ):
-            raise ValueError("approval_decision is only valid for approval responses")
         object.__setattr__(self, "selected_values", tuple(self.selected_values))
+        self._validate_response_content()
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
+
+    def _validate_response_content(self) -> None:
+        has_text = self.text is not None
+        has_selection = bool(self.selected_values)
+        has_approval = self.approval_decision is not None
+
+        if has_approval and self.response_kind is not HumanInputResponseKind.APPROVAL:
+            raise ValueError("approval_decision is only valid for approval responses")
+
+        if self.response_kind is HumanInputResponseKind.TEXT:
+            if not has_text:
+                raise ValueError("text responses require text")
+            if has_selection:
+                raise ValueError("text responses must not include selection content")
+            return
+
+        if self.response_kind is HumanInputResponseKind.SELECTION:
+            if not has_selection:
+                raise ValueError("selection responses require selected_values")
+            if has_text or has_approval:
+                raise ValueError("selection responses must not include text or approval content")
+            return
+
+        if self.response_kind is HumanInputResponseKind.APPROVAL:
+            if not has_approval:
+                raise ValueError("approval responses require approval_decision")
+            if has_text or has_selection:
+                raise ValueError("approval responses must not include text or selection content")
+            return
+
+        if has_text or has_selection or has_approval:
+            raise ValueError("cancel and timeout responses must not include answer content")
 
     @property
     def aggregate_id(self) -> str:
@@ -245,5 +327,5 @@ class HumanInputResponse:
         if self.surface is not None:
             data["surface"] = self.surface
         if self.payload:
-            data["payload"] = dict(self.payload)
+            data["payload"] = _payload_to_event_data(self.payload)
         return data

--- a/src/ouroboros/events/hitl.py
+++ b/src/ouroboros/events/hitl.py
@@ -6,6 +6,13 @@ from ouroboros.core.hitl_contract import HumanInputRequest, HumanInputResponse
 from ouroboros.events.base import BaseEvent
 
 
+def _require_non_empty_event_field(name: str, value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"HITL event {name} must be non-empty")
+    return normalized
+
+
 def create_hitl_requested_event(request: HumanInputRequest) -> BaseEvent:
     return BaseEvent(
         type=HumanInputRequest.REQUESTED_EVENT_TYPE,
@@ -26,7 +33,7 @@ def create_hitl_answered_event(response: HumanInputResponse) -> BaseEvent:
 
 def create_hitl_timed_out_event(request: HumanInputRequest, *, reason: str) -> BaseEvent:
     data = request.to_event_data()
-    data["reason"] = reason
+    data["reason"] = _require_non_empty_event_field("reason", reason)
     return BaseEvent(
         type=HumanInputRequest.TIMED_OUT_EVENT_TYPE,
         aggregate_type="hitl",
@@ -39,9 +46,9 @@ def create_hitl_cancelled_event(
     request: HumanInputRequest, *, reason: str, actor: str | None = None
 ) -> BaseEvent:
     data = request.to_event_data()
-    data["reason"] = reason
+    data["reason"] = _require_non_empty_event_field("reason", reason)
     if actor is not None:
-        data["actor"] = actor
+        data["actor"] = _require_non_empty_event_field("actor", actor)
     return BaseEvent(
         type=HumanInputRequest.CANCELLED_EVENT_TYPE,
         aggregate_type="hitl",

--- a/src/ouroboros/events/hitl.py
+++ b/src/ouroboros/events/hitl.py
@@ -1,0 +1,50 @@
+"""Event factories for human-in-the-loop WAIT/RESUME contracts."""
+
+from __future__ import annotations
+
+from ouroboros.core.hitl_contract import HumanInputRequest, HumanInputResponse
+from ouroboros.events.base import BaseEvent
+
+
+def create_hitl_requested_event(request: HumanInputRequest) -> BaseEvent:
+    return BaseEvent(
+        type=HumanInputRequest.REQUESTED_EVENT_TYPE,
+        aggregate_type="hitl",
+        aggregate_id=request.aggregate_id,
+        data=request.to_event_data(),
+    )
+
+
+def create_hitl_answered_event(response: HumanInputResponse) -> BaseEvent:
+    return BaseEvent(
+        type=HumanInputResponse.ANSWERED_EVENT_TYPE,
+        aggregate_type="hitl",
+        aggregate_id=response.aggregate_id,
+        data=response.to_event_data(),
+    )
+
+
+def create_hitl_timed_out_event(request: HumanInputRequest, *, reason: str) -> BaseEvent:
+    data = request.to_event_data()
+    data["reason"] = reason
+    return BaseEvent(
+        type=HumanInputRequest.TIMED_OUT_EVENT_TYPE,
+        aggregate_type="hitl",
+        aggregate_id=request.aggregate_id,
+        data=data,
+    )
+
+
+def create_hitl_cancelled_event(
+    request: HumanInputRequest, *, reason: str, actor: str | None = None
+) -> BaseEvent:
+    data = request.to_event_data()
+    data["reason"] = reason
+    if actor is not None:
+        data["actor"] = actor
+    return BaseEvent(
+        type=HumanInputRequest.CANCELLED_EVENT_TYPE,
+        aggregate_type="hitl",
+        aggregate_id=request.aggregate_id,
+        data=data,
+    )

--- a/src/ouroboros/events/hitl.py
+++ b/src/ouroboros/events/hitl.py
@@ -33,6 +33,16 @@ def _validate_response_matches_request(
     if response.request_id != request.request_id:
         raise ValueError("HITL response request_id must match the originating request")
 
+    for field_name in ("session_id", "run_id", "invocation_id"):
+        response_value = getattr(response, field_name)
+        if response_value is None:
+            continue
+        request_value = getattr(request, field_name)
+        if request_value is not None and response_value != request_value:
+            raise ValueError(
+                f"HITL response {field_name} must match the originating request when provided"
+            )
+
     if response.response_kind is HumanInputResponseKind.CANCEL:
         return
 

--- a/src/ouroboros/events/hitl.py
+++ b/src/ouroboros/events/hitl.py
@@ -33,6 +33,14 @@ def _validate_response_matches_request(
     if response.request_id != request.request_id:
         raise ValueError("HITL response request_id must match the originating request")
 
+    if response.response_kind is HumanInputResponseKind.CANCEL:
+        return
+
+    if response.response_kind is HumanInputResponseKind.TIMEOUT:
+        if request.timeout_seconds is None:
+            raise ValueError("timeout HITL responses require a request timeout_seconds value")
+        return
+
     if request.kind in (
         HumanInputKind.APPROVAL,
         HumanInputKind.DESTRUCTIVE_CONFIRMATION,

--- a/src/ouroboros/events/hitl.py
+++ b/src/ouroboros/events/hitl.py
@@ -33,7 +33,10 @@ def _validate_response_matches_request(
     if response.request_id != request.request_id:
         raise ValueError("HITL response request_id must match the originating request")
 
-    if request.kind is HumanInputKind.APPROVAL:
+    if request.kind in (
+        HumanInputKind.APPROVAL,
+        HumanInputKind.DESTRUCTIVE_CONFIRMATION,
+    ):
         if response.response_kind is not HumanInputResponseKind.APPROVAL:
             raise ValueError("approval HITL requests require an approval response")
         return

--- a/src/ouroboros/events/hitl.py
+++ b/src/ouroboros/events/hitl.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from ouroboros.core.hitl_contract import HumanInputRequest, HumanInputResponse
+from ouroboros.core.hitl_contract import (
+    HumanInputKind,
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputResponseKind,
+)
 from ouroboros.events.base import BaseEvent
 
 
@@ -22,7 +27,41 @@ def create_hitl_requested_event(request: HumanInputRequest) -> BaseEvent:
     )
 
 
-def create_hitl_answered_event(response: HumanInputResponse) -> BaseEvent:
+def _validate_response_matches_request(
+    request: HumanInputRequest, response: HumanInputResponse
+) -> None:
+    if response.request_id != request.request_id:
+        raise ValueError("HITL response request_id must match the originating request")
+
+    if request.kind is HumanInputKind.APPROVAL:
+        if response.response_kind is not HumanInputResponseKind.APPROVAL:
+            raise ValueError("approval HITL requests require an approval response")
+        return
+
+    if request.kind is HumanInputKind.FREE_TEXT:
+        if response.response_kind is not HumanInputResponseKind.TEXT:
+            raise ValueError("free-text HITL requests require a text response")
+        return
+
+    if request.kind in (HumanInputKind.SINGLE_SELECT, HumanInputKind.MULTI_SELECT):
+        if response.response_kind is not HumanInputResponseKind.SELECTION:
+            raise ValueError("select HITL requests require a selection response")
+        options = set(request.options or ())
+        selected_values = response.selected_values or ()
+        invalid_values = [value for value in selected_values if value not in options]
+        if invalid_values:
+            raise ValueError("HITL response selected_values must be present in request options")
+        if request.kind is HumanInputKind.SINGLE_SELECT and len(selected_values) != 1:
+            raise ValueError("single-select HITL requests require exactly one selected value")
+        return
+
+    raise ValueError(f"unsupported HITL request kind: {request.kind}")
+
+
+def create_hitl_answered_event(
+    request: HumanInputRequest, response: HumanInputResponse
+) -> BaseEvent:
+    _validate_response_matches_request(request, response)
     return BaseEvent(
         type=HumanInputResponse.ANSWERED_EVENT_TYPE,
         aggregate_type="hitl",
@@ -32,6 +71,8 @@ def create_hitl_answered_event(response: HumanInputResponse) -> BaseEvent:
 
 
 def create_hitl_timed_out_event(request: HumanInputRequest, *, reason: str) -> BaseEvent:
+    if request.timeout_seconds is None:
+        raise ValueError("HITL timed_out events require a request timeout_seconds value")
     data = request.to_event_data()
     data["reason"] = _require_non_empty_event_field("reason", reason)
     return BaseEvent(

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -140,6 +140,42 @@ def test_request_rejects_non_integer_timeout_seconds() -> None:
             )
 
 
+@pytest.mark.parametrize(
+    "timeout_action",
+    (HumanInputTimeoutAction.CANCEL, HumanInputTimeoutAction.EXPIRE_BLOCKED),
+)
+def test_request_rejects_timeout_action_without_timeout_seconds(
+    timeout_action: HumanInputTimeoutAction,
+) -> None:
+    with pytest.raises(ValueError, match="timeout_action"):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plan",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLAN_APPROVAL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Approve?",
+            resume_target="plan:approval",
+            timeout_action=timeout_action,
+        )
+
+
+def test_request_allows_default_timeout_action_without_timeout_seconds() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve?",
+        resume_target="plan:approval",
+    )
+    assert request.timeout_seconds is None
+    assert request.timeout_action is HumanInputTimeoutAction.STAY_WAITING
+
+
 def test_request_rejects_secret_like_persisted_payload() -> None:
     with pytest.raises(ValueError, match="secret-like"):
         HumanInputRequest(

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -173,6 +173,22 @@ def test_request_allows_secret_marker_words_in_plain_values() -> None:
     }
 
 
+def test_request_allows_benign_token_metadata_keys() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        created_by="plugin-firewall",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLUGIN_FIREWALL,
+        risk_class=HumanInputRiskClass.LOW,
+        question="Approve?",
+        resume_target="plugin:permission",
+        payload={"token_count": 1024, "token_limit": 4096},
+    )
+
+    assert request.to_event_data()["payload"] == {"token_count": 1024, "token_limit": 4096}
+
+
 def test_request_accepts_mapping_payloads_and_freezes_normalized_copy() -> None:
     source: dict[str, object] = {"items": ["alpha", {"count": 1}]}
     request = HumanInputRequest(

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -370,6 +370,29 @@ def test_response_allows_request_id_only_correlation() -> None:
     assert "invocation_id" not in response.to_event_data()
 
 
+def test_text_response_preserves_verbatim_text() -> None:
+    text = "  def example():\n      return 'ok'\n"
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.TEXT,
+        text=text,
+    )
+
+    assert response.text == text
+    assert response.to_event_data()["text"] == text
+
+
+def test_text_response_rejects_all_whitespace_text() -> None:
+    with pytest.raises(ValueError, match="text"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.TEXT,
+            text="  \n\t",
+        )
+
+
 def test_response_rejects_approval_decision_on_non_approval() -> None:
     with pytest.raises(ValueError, match="approval_decision"):
         HumanInputResponse(

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -109,6 +109,21 @@ def test_select_request_rejects_string_options_iterable() -> None:
         )
 
 
+def test_select_request_rejects_duplicate_options_after_trimming() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plan",
+            kind=HumanInputKind.SINGLE_SELECT,
+            source=HumanInputSource.PLAN_APPROVAL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Pick one",
+            resume_target="plan:approval",
+            options=("Approve", "Approve "),
+        )
+
+
 def test_request_rejects_non_integer_timeout_seconds() -> None:
     for timeout_seconds in (1.5, True):
         with pytest.raises(TypeError, match="timeout_seconds"):
@@ -355,6 +370,16 @@ def test_selection_response_rejects_string_selected_values_iterable() -> None:
             session_id="session-1",
             response_kind=HumanInputResponseKind.SELECTION,
             selected_values="approve",  # type: ignore[arg-type]
+        )
+
+
+def test_selection_response_rejects_duplicate_selected_values_after_trimming() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.SELECTION,
+            selected_values=("approve", "approve "),
         )
 
 

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -41,7 +41,7 @@ def test_human_input_request_serializes_wait_contract() -> None:
 
     data = request.to_event_data()
 
-    assert request.aggregate_id == "run-1"
+    assert request.aggregate_id == "hitl-1"
     assert data["kind"] == "single_select"
     assert data["source"] == "interview"
     assert data["risk_class"] == "material_branch"
@@ -263,7 +263,7 @@ def test_human_input_response_serializes_matching_answer() -> None:
 
     data = response.to_event_data()
 
-    assert response.aggregate_id == "run-1"
+    assert response.aggregate_id == "hitl-1"
     assert data["request_id"] == "hitl-1"
     assert data["actor"] == "local-user"
     assert data["response_kind"] == "approval"
@@ -282,14 +282,19 @@ def test_response_is_frozen() -> None:
         response.actor = "other"  # type: ignore[misc]
 
 
-def test_response_requires_request_correlation_aggregate() -> None:
-    with pytest.raises(ValueError, match="request correlation"):
-        HumanInputResponse(
-            request_id="hitl-1",
-            actor="local-user",
-            response_kind=HumanInputResponseKind.TEXT,
-            text="continue",
-        )
+def test_response_allows_request_id_only_correlation() -> None:
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.TEXT,
+        text="continue",
+    )
+
+    assert response.aggregate_id == "hitl-1"
+    assert response.to_event_data()["request_id"] == "hitl-1"
+    assert "session_id" not in response.to_event_data()
+    assert "run_id" not in response.to_event_data()
+    assert "invocation_id" not in response.to_event_data()
 
 
 def test_response_rejects_approval_decision_on_non_approval() -> None:

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import dataclasses
+from datetime import UTC, datetime
+import json
 
 import pytest
 
 from ouroboros.core.hitl_contract import (
+    MAX_HITL_PAYLOAD_BYTES,
     HumanInputKind,
     HumanInputRequest,
     HumanInputResponse,
@@ -75,6 +78,77 @@ def test_request_rejects_secret_like_persisted_payload() -> None:
         )
 
 
+def test_request_rejects_non_json_payload_values() -> None:
+    with pytest.raises(TypeError, match="JSON serializable"):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plugin-firewall",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.CREDENTIAL_GATED,
+            question="Approve?",
+            resume_target="plugin:permission",
+            payload={"created_at": datetime.now(UTC)},
+        )
+
+
+def test_request_payload_is_json_serializable_and_deeply_unaliased() -> None:
+    nested = {"items": [{"name": "alpha"}]}
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve?",
+        resume_target="plan:approval",
+        payload=nested,
+    )
+
+    nested["items"][0]["name"] = "mutated"
+    data = request.to_event_data()
+
+    assert data["payload"] == {"items": [{"name": "alpha"}]}
+    json.dumps(data)
+
+
+def test_request_payload_event_data_is_deep_copy() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve?",
+        resume_target="plan:approval",
+        payload={"items": [{"name": "alpha"}]},
+    )
+
+    first = request.to_event_data()
+    first["payload"]["items"][0]["name"] = "mutated"
+    second = request.to_event_data()
+
+    assert second["payload"] == {"items": [{"name": "alpha"}]}
+
+
+def test_request_rejects_payload_over_json_encoded_byte_limit() -> None:
+    with pytest.raises(ValueError, match=str(MAX_HITL_PAYLOAD_BYTES)):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plan",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLAN_APPROVAL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Approve?",
+            resume_target="plan:approval",
+            payload={"value": "x" * MAX_HITL_PAYLOAD_BYTES},
+        )
+
+
 def test_human_input_response_serializes_matching_answer() -> None:
     response = HumanInputResponse(
         request_id="hitl-1",
@@ -114,4 +188,72 @@ def test_response_rejects_approval_decision_on_non_approval() -> None:
             response_kind=HumanInputResponseKind.TEXT,
             text="yes",
             approval_decision=True,
+        )
+
+
+def test_text_response_requires_text_and_forbids_other_answer_content() -> None:
+    with pytest.raises(ValueError, match="require text"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.TEXT,
+        )
+    with pytest.raises(ValueError, match="must not include selection"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.TEXT,
+            text="yes",
+            selected_values=("yes",),
+        )
+
+
+def test_selection_response_requires_selected_values_and_forbids_other_answer_content() -> None:
+    with pytest.raises(ValueError, match="require selected_values"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.SELECTION,
+        )
+    with pytest.raises(ValueError, match="must not include text"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.SELECTION,
+            selected_values=("yes",),
+            text="yes",
+        )
+
+
+def test_approval_response_requires_decision_and_forbids_other_answer_content() -> None:
+    with pytest.raises(ValueError, match="require approval_decision"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.APPROVAL,
+        )
+    with pytest.raises(ValueError, match="must not include text"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.APPROVAL,
+            approval_decision=True,
+            text="yes",
+        )
+
+
+def test_cancel_and_timeout_responses_forbid_answer_content() -> None:
+    with pytest.raises(ValueError, match="must not include answer content"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.CANCEL,
+            text="never mind",
+        )
+    with pytest.raises(ValueError, match="must not include answer content"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.TIMEOUT,
+            selected_values=("late",),
         )

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -281,6 +281,21 @@ def test_request_rejects_payload_over_json_encoded_byte_limit() -> None:
         )
 
 
+def test_request_rejects_bool_schema_version() -> None:
+    with pytest.raises(ValueError, match="schema_version"):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plan",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLAN_APPROVAL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Approve?",
+            resume_target="plan:approval",
+            schema_version=True,
+        )
+
+
 def test_human_input_response_serializes_matching_answer() -> None:
     response = HumanInputResponse(
         request_id="hitl-1",
@@ -299,6 +314,33 @@ def test_human_input_response_serializes_matching_answer() -> None:
     assert data["actor"] == "local-user"
     assert data["response_kind"] == "approval"
     assert data["approval_decision"] is True
+
+
+def test_human_input_response_serializes_cancel_and_timeout_answers() -> None:
+    cancel = HumanInputResponse(
+        request_id="hitl-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.CANCEL,
+    )
+    timeout = HumanInputResponse(
+        request_id="hitl-2",
+        actor="runtime",
+        response_kind=HumanInputResponseKind.TIMEOUT,
+    )
+
+    assert cancel.to_event_data()["response_kind"] == "cancel"
+    assert timeout.to_event_data()["response_kind"] == "timeout"
+
+
+def test_response_rejects_bool_schema_version() -> None:
+    with pytest.raises(ValueError, match="schema_version"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.TEXT,
+            text="continue",
+            schema_version=True,
+        )
 
 
 def test_response_is_frozen() -> None:

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from ouroboros.core.hitl_contract import (
+    HumanInputKind,
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputResponseKind,
+    HumanInputRiskClass,
+    HumanInputSource,
+    HumanInputTimeoutAction,
+)
+
+
+def test_human_input_request_serializes_wait_contract() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        invocation_id="invoke-1",
+        created_by="deep-interview",
+        kind=HumanInputKind.SINGLE_SELECT,
+        source=HumanInputSource.INTERVIEW,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Which track should run first?",
+        options=("plugin", "runtime"),
+        required_permission="plugin:execute",
+        timeout_seconds=60,
+        timeout_action=HumanInputTimeoutAction.EXPIRE_BLOCKED,
+        resume_target="deep-interview:round-2",
+        surface="structured_question",
+        payload={"redacted": True},
+    )
+
+    data = request.to_event_data()
+
+    assert request.aggregate_id == "run-1"
+    assert data["kind"] == "single_select"
+    assert data["source"] == "interview"
+    assert data["risk_class"] == "material_branch"
+    assert data["timeout_action"] == "expire_blocked"
+    assert data["required_permission"] == "plugin:execute"
+    assert data["options"] == ["plugin", "runtime"]
+
+
+def test_select_request_requires_options() -> None:
+    with pytest.raises(ValueError, match="requires at least one option"):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plan",
+            kind=HumanInputKind.SINGLE_SELECT,
+            source=HumanInputSource.PLAN_APPROVAL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Pick one",
+            resume_target="plan:approval",
+        )
+
+
+def test_request_rejects_secret_like_persisted_payload() -> None:
+    with pytest.raises(ValueError, match="secret-like"):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plugin-firewall",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.CREDENTIAL_GATED,
+            question="Approve?",
+            resume_target="plugin:permission",
+            payload={"api_key": "should-not-persist"},
+        )
+
+
+def test_human_input_response_serializes_matching_answer() -> None:
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.APPROVAL,
+        approval_decision=True,
+        surface="cli",
+    )
+
+    data = response.to_event_data()
+
+    assert response.aggregate_id == "run-1"
+    assert data["request_id"] == "hitl-1"
+    assert data["actor"] == "local-user"
+    assert data["response_kind"] == "approval"
+    assert data["approval_decision"] is True
+
+
+def test_response_is_frozen() -> None:
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.TEXT,
+        text="continue",
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        response.actor = "other"  # type: ignore[misc]
+
+
+def test_response_rejects_approval_decision_on_non_approval() -> None:
+    with pytest.raises(ValueError, match="approval_decision"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.TEXT,
+            text="yes",
+            approval_decision=True,
+        )

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import dataclasses
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 import json
+from types import MappingProxyType
 
 import pytest
 
@@ -47,6 +48,36 @@ def test_human_input_request_serializes_wait_contract() -> None:
     assert data["timeout_action"] == "expire_blocked"
     assert data["required_permission"] == "plugin:execute"
     assert data["options"] == ["plugin", "runtime"]
+    assert data["created_at"].endswith("+00:00")
+
+
+def test_request_normalizes_aware_datetimes_to_utc_and_rejects_naive_datetimes() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve?",
+        resume_target="plan:approval",
+        created_at=datetime(2026, 1, 1, 12, 0, tzinfo=timezone(timedelta(hours=9))),
+    )
+
+    assert request.to_event_data()["created_at"] == "2026-01-01T03:00:00+00:00"
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plan",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLAN_APPROVAL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Approve?",
+            resume_target="plan:approval",
+            created_at=datetime(2026, 1, 1, 12, 0),
+        )
 
 
 def test_select_request_requires_options() -> None:
@@ -125,6 +156,27 @@ def test_request_allows_secret_marker_words_in_plain_values() -> None:
     assert request.to_event_data()["payload"] == {
         "reason": "token budget exceeded; credential check required"
     }
+
+
+def test_request_accepts_mapping_payloads_and_freezes_normalized_copy() -> None:
+    source: dict[str, object] = {"items": ["alpha", {"count": 1}]}
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        created_by="plugin-firewall",
+        kind=HumanInputKind.FREE_TEXT,
+        source=HumanInputSource.PLUGIN_FIREWALL,
+        risk_class=HumanInputRiskClass.LOW,
+        question="Explain remediation?",
+        resume_target="runtime:resume",
+        payload=MappingProxyType(source),
+    )
+
+    items = source["items"]
+    assert isinstance(items, list)
+    items.append("mutated")
+
+    assert request.to_event_data()["payload"] == {"items": ["alpha", {"count": 1}]}
 
 
 def test_request_rejects_non_json_payload_values() -> None:

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -63,6 +63,37 @@ def test_select_request_requires_options() -> None:
         )
 
 
+def test_select_request_rejects_string_options_iterable() -> None:
+    with pytest.raises(TypeError, match="options"):
+        HumanInputRequest(
+            request_id="hitl-1",
+            session_id="session-1",
+            created_by="plan",
+            kind=HumanInputKind.SINGLE_SELECT,
+            source=HumanInputSource.PLAN_APPROVAL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Pick one",
+            resume_target="plan:approval",
+            options="yes",  # type: ignore[arg-type]
+        )
+
+
+def test_request_rejects_non_integer_timeout_seconds() -> None:
+    for timeout_seconds in (1.5, True):
+        with pytest.raises(TypeError, match="timeout_seconds"):
+            HumanInputRequest(
+                request_id="hitl-1",
+                session_id="session-1",
+                created_by="plan",
+                kind=HumanInputKind.APPROVAL,
+                source=HumanInputSource.PLAN_APPROVAL,
+                risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+                question="Approve?",
+                resume_target="plan:approval",
+                timeout_seconds=timeout_seconds,  # type: ignore[arg-type]
+            )
+
+
 def test_request_rejects_secret_like_persisted_payload() -> None:
     with pytest.raises(ValueError, match="secret-like"):
         HumanInputRequest(
@@ -256,6 +287,17 @@ def test_selection_response_requires_selected_values_and_forbids_other_answer_co
             response_kind=HumanInputResponseKind.SELECTION,
             selected_values=("yes",),
             text="yes",
+        )
+
+
+def test_selection_response_rejects_string_selected_values_iterable() -> None:
+    with pytest.raises(TypeError, match="selected_values"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            session_id="session-1",
+            response_kind=HumanInputResponseKind.SELECTION,
+            selected_values="approve",  # type: ignore[arg-type]
         )
 
 

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -78,6 +78,24 @@ def test_request_rejects_secret_like_persisted_payload() -> None:
         )
 
 
+def test_request_allows_secret_marker_words_in_plain_values() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        created_by="plugin-firewall",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLUGIN_FIREWALL,
+        risk_class=HumanInputRiskClass.CREDENTIAL_GATED,
+        question="Approve?",
+        resume_target="plugin:permission",
+        payload={"reason": "token budget exceeded; credential check required"},
+    )
+
+    assert request.to_event_data()["payload"] == {
+        "reason": "token budget exceeded; credential check required"
+    }
+
+
 def test_request_rejects_non_json_payload_values() -> None:
     with pytest.raises(TypeError, match="JSON serializable"):
         HumanInputRequest(
@@ -173,6 +191,7 @@ def test_response_is_frozen() -> None:
     response = HumanInputResponse(
         request_id="hitl-1",
         actor="local-user",
+        session_id="session-1",
         response_kind=HumanInputResponseKind.TEXT,
         text="continue",
     )
@@ -180,11 +199,22 @@ def test_response_is_frozen() -> None:
         response.actor = "other"  # type: ignore[misc]
 
 
+def test_response_requires_request_correlation_aggregate() -> None:
+    with pytest.raises(ValueError, match="request correlation"):
+        HumanInputResponse(
+            request_id="hitl-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.TEXT,
+            text="continue",
+        )
+
+
 def test_response_rejects_approval_decision_on_non_approval() -> None:
     with pytest.raises(ValueError, match="approval_decision"):
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.TEXT,
             text="yes",
             approval_decision=True,
@@ -196,12 +226,14 @@ def test_text_response_requires_text_and_forbids_other_answer_content() -> None:
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.TEXT,
         )
     with pytest.raises(ValueError, match="must not include selection"):
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.TEXT,
             text="yes",
             selected_values=("yes",),
@@ -213,12 +245,14 @@ def test_selection_response_requires_selected_values_and_forbids_other_answer_co
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.SELECTION,
         )
     with pytest.raises(ValueError, match="must not include text"):
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.SELECTION,
             selected_values=("yes",),
             text="yes",
@@ -230,12 +264,14 @@ def test_approval_response_requires_decision_and_forbids_other_answer_content() 
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.APPROVAL,
         )
     with pytest.raises(ValueError, match="must not include text"):
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.APPROVAL,
             approval_decision=True,
             text="yes",
@@ -247,6 +283,7 @@ def test_cancel_and_timeout_responses_forbid_answer_content() -> None:
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.CANCEL,
             text="never mind",
         )
@@ -254,6 +291,7 @@ def test_cancel_and_timeout_responses_forbid_answer_content() -> None:
         HumanInputResponse(
             request_id="hitl-1",
             actor="local-user",
+            session_id="session-1",
             response_kind=HumanInputResponseKind.TIMEOUT,
             selected_values=("late",),
         )

--- a/tests/unit/events/test_hitl_events.py
+++ b/tests/unit/events/test_hitl_events.py
@@ -31,6 +31,7 @@ def _request() -> HumanInputRequest:
         risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
         question="Approve the plan?",
         resume_target="ralplan:approval",
+        timeout_seconds=60,
     )
 
 
@@ -74,7 +75,7 @@ def test_answered_event_preserves_request_correlation() -> None:
         approval_decision=True,
     )
 
-    event = create_hitl_answered_event(response)
+    event = create_hitl_answered_event(_request(), response)
 
     assert event.type == "hitl.answered"
     assert event.aggregate_id == "hitl-1"
@@ -119,6 +120,95 @@ def test_timeout_and_cancel_events_reuse_request_payload() -> None:
 def test_timeout_event_rejects_empty_reason() -> None:
     with pytest.raises(ValueError, match="reason"):
         create_hitl_timed_out_event(_request(), reason="   ")
+
+
+def test_timeout_event_rejects_request_without_timeout() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve the plan?",
+        resume_target="ralplan:approval",
+    )
+
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        create_hitl_timed_out_event(request, reason="deadline elapsed")
+
+
+def test_answered_event_rejects_mismatched_request_id() -> None:
+    response = HumanInputResponse(
+        request_id="other-hitl",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.APPROVAL,
+        approval_decision=True,
+    )
+
+    with pytest.raises(ValueError, match="request_id"):
+        create_hitl_answered_event(_request(), response)
+
+
+def test_answered_event_rejects_kind_mismatch() -> None:
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.TEXT,
+        text="approved",
+    )
+
+    with pytest.raises(ValueError, match="approval"):
+        create_hitl_answered_event(_request(), response)
+
+
+def test_answered_event_rejects_selection_outside_request_options() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.SINGLE_SELECT,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Pick one",
+        resume_target="ralplan:approval",
+        options=("Approve", "Reject"),
+    )
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.SELECTION,
+        selected_values=("Escalate",),
+    )
+
+    with pytest.raises(ValueError, match="selected_values"):
+        create_hitl_answered_event(request, response)
+
+
+def test_answered_event_rejects_multiple_single_select_values() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.SINGLE_SELECT,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Pick one",
+        resume_target="ralplan:approval",
+        options=("Approve", "Reject"),
+    )
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.SELECTION,
+        selected_values=("Approve", "Reject"),
+    )
+
+    with pytest.raises(ValueError, match="single-select"):
+        create_hitl_answered_event(request, response)
 
 
 def test_cancel_event_rejects_empty_reason() -> None:

--- a/tests/unit/events/test_hitl_events.py
+++ b/tests/unit/events/test_hitl_events.py
@@ -163,6 +163,59 @@ def test_answered_event_rejects_kind_mismatch() -> None:
         create_hitl_answered_event(_request(), response)
 
 
+def test_answered_event_accepts_cancel_and_timeout_responses() -> None:
+    cancel = HumanInputResponse(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.CANCEL,
+        payload={"reason_code": "user_abort"},
+    )
+    timeout = HumanInputResponse(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        actor="runtime",
+        response_kind=HumanInputResponseKind.TIMEOUT,
+        payload={"deadline_ms": 60000},
+    )
+
+    cancel_event = create_hitl_answered_event(_request(), cancel)
+    timeout_event = create_hitl_answered_event(_request(), timeout)
+
+    assert cancel_event.type == "hitl.answered"
+    assert cancel_event.data["response_kind"] == "cancel"
+    assert cancel_event.data["payload"] == {"reason_code": "user_abort"}
+    assert cancel_event.data["actor"] == "local-user"
+    assert timeout_event.type == "hitl.answered"
+    assert timeout_event.data["response_kind"] == "timeout"
+    assert timeout_event.data["payload"] == {"deadline_ms": 60000}
+    assert timeout_event.data["actor"] == "runtime"
+
+
+def test_answered_event_rejects_timeout_response_without_request_timeout() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve the plan?",
+        resume_target="ralplan:approval",
+    )
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        actor="runtime",
+        response_kind=HumanInputResponseKind.TIMEOUT,
+    )
+
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        create_hitl_answered_event(request, response)
+
+
 def test_destructive_confirmation_answered_event_accepts_approval_response() -> None:
     request = HumanInputRequest(
         request_id="hitl-1",

--- a/tests/unit/events/test_hitl_events.py
+++ b/tests/unit/events/test_hitl_events.py
@@ -298,3 +298,45 @@ def test_cancel_event_rejects_empty_reason() -> None:
 def test_cancel_event_rejects_empty_actor() -> None:
     with pytest.raises(ValueError, match="actor"):
         create_hitl_cancelled_event(_request(), reason="user aborted", actor="   ")
+
+
+@pytest.mark.parametrize(
+    ("field_name", "request_value", "response_value"),
+    (
+        ("session_id", "session-1", "session-2"),
+        ("run_id", "run-1", "run-2"),
+        ("invocation_id", "inv-1", "inv-2"),
+    ),
+)
+def test_answered_event_rejects_correlation_mismatch(
+    field_name: str, request_value: str, response_value: str
+) -> None:
+    request_kwargs: dict[str, object] = {
+        "request_id": "hitl-1",
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "invocation_id": "inv-1",
+        "created_by": "plan",
+        "kind": HumanInputKind.APPROVAL,
+        "source": HumanInputSource.PLAN_APPROVAL,
+        "risk_class": HumanInputRiskClass.MATERIAL_BRANCH,
+        "question": "Approve the plan?",
+        "resume_target": "ralplan:approval",
+        "timeout_seconds": 60,
+    }
+    request = HumanInputRequest(**request_kwargs)  # type: ignore[arg-type]
+
+    response_kwargs: dict[str, object] = {
+        "request_id": "hitl-1",
+        "actor": "local-user",
+        "response_kind": HumanInputResponseKind.APPROVAL,
+        "approval_decision": True,
+        "session_id": request.session_id,
+        "run_id": request.run_id,
+        "invocation_id": request.invocation_id,
+    }
+    response_kwargs[field_name] = response_value
+    response = HumanInputResponse(**response_kwargs)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match=field_name):
+        create_hitl_answered_event(request, response)

--- a/tests/unit/events/test_hitl_events.py
+++ b/tests/unit/events/test_hitl_events.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from ouroboros.core.hitl_contract import (
     HumanInputKind,
     HumanInputRequest,
@@ -38,6 +40,26 @@ def test_requested_event_uses_hitl_event_type_and_run_aggregate() -> None:
     assert event.aggregate_id == "run-1"
     assert event.data["request_id"] == "hitl-1"
     assert event.data["resume_target"] == "ralplan:approval"
+
+
+def test_requested_event_data_is_plain_json() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve the plan?",
+        resume_target="ralplan:approval",
+        payload={"items": ("alpha", {"count": 1})},
+    )
+
+    event = create_hitl_requested_event(request)
+
+    assert event.data["payload"] == {"items": ["alpha", {"count": 1}]}
+    json.dumps(event.data)
 
 
 def test_answered_event_preserves_request_correlation() -> None:

--- a/tests/unit/events/test_hitl_events.py
+++ b/tests/unit/events/test_hitl_events.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from ouroboros.core.hitl_contract import (
+    HumanInputKind,
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputResponseKind,
+    HumanInputRiskClass,
+    HumanInputSource,
+)
+from ouroboros.events.hitl import (
+    create_hitl_answered_event,
+    create_hitl_cancelled_event,
+    create_hitl_requested_event,
+    create_hitl_timed_out_event,
+)
+
+
+def _request() -> HumanInputRequest:
+    return HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve the plan?",
+        resume_target="ralplan:approval",
+    )
+
+
+def test_requested_event_uses_hitl_event_type_and_run_aggregate() -> None:
+    event = create_hitl_requested_event(_request())
+
+    assert event.type == "hitl.requested"
+    assert event.aggregate_type == "hitl"
+    assert event.aggregate_id == "run-1"
+    assert event.data["request_id"] == "hitl-1"
+    assert event.data["resume_target"] == "ralplan:approval"
+
+
+def test_answered_event_preserves_request_correlation() -> None:
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.APPROVAL,
+        approval_decision=True,
+    )
+
+    event = create_hitl_answered_event(response)
+
+    assert event.type == "hitl.answered"
+    assert event.aggregate_id == "run-1"
+    assert event.data["request_id"] == "hitl-1"
+    assert event.data["approval_decision"] is True
+
+
+def test_timeout_and_cancel_events_reuse_request_payload() -> None:
+    request = _request()
+
+    timed_out = create_hitl_timed_out_event(request, reason="deadline elapsed")
+    cancelled = create_hitl_cancelled_event(request, reason="user aborted", actor="local-user")
+
+    assert timed_out.type == "hitl.timed_out"
+    assert timed_out.data["reason"] == "deadline elapsed"
+    assert cancelled.type == "hitl.cancelled"
+    assert cancelled.data["actor"] == "local-user"

--- a/tests/unit/events/test_hitl_events.py
+++ b/tests/unit/events/test_hitl_events.py
@@ -34,12 +34,12 @@ def _request() -> HumanInputRequest:
     )
 
 
-def test_requested_event_uses_hitl_event_type_and_run_aggregate() -> None:
+def test_requested_event_uses_hitl_event_type_and_request_aggregate() -> None:
     event = create_hitl_requested_event(_request())
 
     assert event.type == "hitl.requested"
     assert event.aggregate_type == "hitl"
-    assert event.aggregate_id == "run-1"
+    assert event.aggregate_id == "hitl-1"
     assert event.data["request_id"] == "hitl-1"
     assert event.data["resume_target"] == "ralplan:approval"
 
@@ -77,9 +77,31 @@ def test_answered_event_preserves_request_correlation() -> None:
     event = create_hitl_answered_event(response)
 
     assert event.type == "hitl.answered"
-    assert event.aggregate_id == "run-1"
+    assert event.aggregate_id == "hitl-1"
     assert event.data["request_id"] == "hitl-1"
     assert event.data["approval_decision"] is True
+
+
+def test_same_run_hitl_requests_use_distinct_request_aggregates() -> None:
+    first = _request()
+    second = HumanInputRequest(
+        request_id="hitl-2",
+        session_id=first.session_id,
+        run_id=first.run_id,
+        created_by=first.created_by,
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve the alternate plan?",
+        resume_target="ralplan:approval-2",
+    )
+
+    first_event = create_hitl_requested_event(first)
+    second_event = create_hitl_requested_event(second)
+
+    assert first_event.data["run_id"] == second_event.data["run_id"] == "run-1"
+    assert first_event.aggregate_id == "hitl-1"
+    assert second_event.aggregate_id == "hitl-2"
 
 
 def test_timeout_and_cancel_events_reuse_request_payload() -> None:

--- a/tests/unit/events/test_hitl_events.py
+++ b/tests/unit/events/test_hitl_events.py
@@ -163,6 +163,32 @@ def test_answered_event_rejects_kind_mismatch() -> None:
         create_hitl_answered_event(_request(), response)
 
 
+def test_destructive_confirmation_answered_event_accepts_approval_response() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.DESTRUCTIVE_CONFIRMATION,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.DESTRUCTIVE,
+        question="Delete the index?",
+        resume_target="ralplan:approval",
+    )
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.APPROVAL,
+        approval_decision=True,
+    )
+
+    event = create_hitl_answered_event(request, response)
+
+    assert event.type == "hitl.answered"
+    assert event.aggregate_id == "hitl-1"
+    assert event.data["approval_decision"] is True
+
+
 def test_answered_event_rejects_selection_outside_request_options() -> None:
     request = HumanInputRequest(
         request_id="hitl-1",

--- a/tests/unit/events/test_hitl_events.py
+++ b/tests/unit/events/test_hitl_events.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from ouroboros.core.hitl_contract import (
     HumanInputKind,
     HumanInputRequest,
@@ -90,3 +92,18 @@ def test_timeout_and_cancel_events_reuse_request_payload() -> None:
     assert timed_out.data["reason"] == "deadline elapsed"
     assert cancelled.type == "hitl.cancelled"
     assert cancelled.data["actor"] == "local-user"
+
+
+def test_timeout_event_rejects_empty_reason() -> None:
+    with pytest.raises(ValueError, match="reason"):
+        create_hitl_timed_out_event(_request(), reason="   ")
+
+
+def test_cancel_event_rejects_empty_reason() -> None:
+    with pytest.raises(ValueError, match="reason"):
+        create_hitl_cancelled_event(_request(), reason="   ")
+
+
+def test_cancel_event_rejects_empty_actor() -> None:
+    with pytest.raises(ValueError, match="actor"):
+        create_hitl_cancelled_event(_request(), reason="user aborted", actor="   ")


### PR DESCRIPTION
## Summary
- Adds typed `HumanInputRequest` / `HumanInputResponse` contracts for HITL WAIT/RESUME flows.
- Adds `hitl.requested`, `hitl.answered`, `hitl.timed_out`, and `hitl.cancelled` event factories.
- Locks request/response correlation, bounded persisted payloads, source/risk/surface metadata, and secret-like payload rejection.

## Why this belongs in Tier 1 / #960
HITL needs to be a harness primitive, not ad hoc prompt text inside skills. A durable typed contract is the smallest safe first step toward making deep-interview, plan approval, destructive confirmation, and plugin permission requests share one WAIT/RESUME boundary.

## How it is implemented
- New `ouroboros.core.hitl_contract` holds renderer-neutral request/response dataclasses and enums.
- New `ouroboros.events.hitl` serializes those contracts into replayable event-store records.
- Tests prove schema invariants, immutability, request/answer correlation, timeout/cancel event shape, and payload redaction guardrails.

## Decisions still needed before later Tier 1 PRs
- Which existing flow is first adapter: deep-interview vs ralplan approval.
- Whether timeout resumes as `CANCEL`, `WAIT_EXPIRED`/blocked, or stays waiting by default per source.
- How local actor identity should be normalized across CLI, MCP, TUI, and plugin surfaces.

## Validation
- [x] `uv run pytest tests/unit/core/test_hitl_contract.py tests/unit/events/test_hitl_events.py -q` — 9 passed
- [x] `uv run ruff check src/ouroboros/core/hitl_contract.py src/ouroboros/events/hitl.py tests/unit/core/test_hitl_contract.py tests/unit/events/test_hitl_events.py` — passed

## Post-merge Ouroboros real verification
- Trigger one existing question/approval flow after the adapter PR lands.
- Confirm `hitl.requested` is persisted before answer collection.
- Confirm the matching `hitl.answered` event uses the same `request_id` and run/session correlation.
- Confirm a secret-like answer/payload is not persisted unredacted.
- Confirm no work continues while the associated control directive is `WAIT`.

Refs #960
