### PR TITLE
feat(runtime): classify malformed tool-use turns

### DIFF
--- a/src/ouroboros/providers/tool_use_diagnostics.py
+++ b/src/ouroboros/providers/tool_use_diagnostics.py
@@ -1,0 +1,87 @@
+"""Diagnostics for malformed provider tool-use turns.
+
+Some model/provider clients can report ``stop_reason='tool_use'`` while the
+message contains no actual tool-use block. That state should be treated as a
+runtime-boundary diagnostic instead of forcing a user to manually continue an
+ambiguous turn.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ToolUseTurnDiagnostic:
+    provider: str
+    stop_reason: str
+    tool_use_count: int
+    is_malformed: bool
+    retryable: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "stop_reason": self.stop_reason,
+            "tool_use_count": self.tool_use_count,
+            "is_malformed": self.is_malformed,
+            "retryable": self.retryable,
+            "reason": self.reason,
+        }
+
+
+def _get_field(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _iter_content_blocks(message: Any) -> tuple[Any, ...]:
+    content = _get_field(message, "content")
+    if content is None:
+        return ()
+    if isinstance(content, (str, bytes)):
+        return ()
+    try:
+        return tuple(content)
+    except TypeError:
+        return ()
+
+
+def _block_type(block: Any) -> str | None:
+    block_type = _get_field(block, "type")
+    if isinstance(block_type, str):
+        return block_type
+    return None
+
+
+def count_tool_use_blocks(message: Any) -> int:
+    """Return the number of explicit tool-use content blocks on a provider message."""
+    return sum(1 for block in _iter_content_blocks(message) if _block_type(block) == "tool_use")
+
+
+def diagnose_tool_use_turn(message: Any, *, provider: str) -> ToolUseTurnDiagnostic:
+    """Detect ``stop_reason=tool_use`` without matching tool-use content blocks.
+
+    The function is intentionally side-effect free so runtime adapters can call
+    it before deciding whether to retry, surface a blocker, or emit telemetry.
+    """
+    stop_reason = _get_field(message, "stop_reason")
+    normalized_stop = stop_reason if isinstance(stop_reason, str) else ""
+    tool_use_count = count_tool_use_blocks(message)
+    is_malformed = normalized_stop == "tool_use" and tool_use_count == 0
+    reason = (
+        "stop_reason=tool_use but no tool_use content blocks were present"
+        if is_malformed
+        else "tool-use turn is internally consistent"
+    )
+    return ToolUseTurnDiagnostic(
+        provider=provider,
+        stop_reason=normalized_stop,
+        tool_use_count=tool_use_count,
+        is_malformed=is_malformed,
+        retryable=is_malformed,
+        reason=reason,
+    )

--- a/src/ouroboros/providers/tool_use_diagnostics.py
+++ b/src/ouroboros/providers/tool_use_diagnostics.py
@@ -54,6 +54,8 @@ def _block_type(block: Any) -> str | None:
     block_type = _get_field(block, "type")
     if isinstance(block_type, str):
         return block_type
+    if type(block).__name__ == "ToolUseBlock":
+        return "tool_use"
     return None
 
 

--- a/tests/unit/providers/test_tool_use_diagnostics.py
+++ b/tests/unit/providers/test_tool_use_diagnostics.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.providers.tool_use_diagnostics import (
+    count_tool_use_blocks,
+    diagnose_tool_use_turn,
+)
+
+
+@dataclass
+class Block:
+    type: str
+    id: str = "tool-1"
+
+
+@dataclass
+class Message:
+    stop_reason: str
+    content: list[object]
+
+
+def test_detects_stop_reason_tool_use_without_tool_blocks() -> None:
+    diagnostic = diagnose_tool_use_turn(
+        {"stop_reason": "tool_use", "content": [{"type": "text", "text": "continue"}]},
+        provider="claude-code",
+    )
+
+    assert diagnostic.is_malformed is True
+    assert diagnostic.retryable is True
+    assert diagnostic.tool_use_count == 0
+    assert diagnostic.to_dict()["reason"].startswith("stop_reason=tool_use")
+
+
+def test_valid_tool_use_turn_is_not_malformed() -> None:
+    diagnostic = diagnose_tool_use_turn(
+        {"stop_reason": "tool_use", "content": [{"type": "tool_use", "id": "abc"}]},
+        provider="claude-code",
+    )
+
+    assert diagnostic.is_malformed is False
+    assert diagnostic.retryable is False
+    assert diagnostic.tool_use_count == 1
+
+
+def test_object_style_provider_messages_are_supported() -> None:
+    message = Message(stop_reason="tool_use", content=[Block(type="tool_use")])
+
+    assert count_tool_use_blocks(message) == 1
+    assert diagnose_tool_use_turn(message, provider="sdk-object").is_malformed is False
+
+
+def test_non_tool_use_stop_reason_is_consistent_even_without_content() -> None:
+    diagnostic = diagnose_tool_use_turn(
+        {"stop_reason": "end_turn", "content": []},
+        provider="claude-code",
+    )
+
+    assert diagnostic.is_malformed is False
+    assert diagnostic.retryable is False
+    assert diagnostic.stop_reason == "end_turn"

--- a/tests/unit/providers/test_tool_use_diagnostics.py
+++ b/tests/unit/providers/test_tool_use_diagnostics.py
@@ -20,6 +20,15 @@ class Message:
     content: list[object]
 
 
+class ToolUseBlock:
+    name = "Read"
+    input = {"file_path": "README.md"}
+
+
+class TextBlock:
+    text = "thinking text"
+
+
 def test_detects_stop_reason_tool_use_without_tool_blocks() -> None:
     diagnostic = diagnose_tool_use_turn(
         {"stop_reason": "tool_use", "content": [{"type": "text", "text": "continue"}]},
@@ -48,6 +57,27 @@ def test_object_style_provider_messages_are_supported() -> None:
 
     assert count_tool_use_blocks(message) == 1
     assert diagnose_tool_use_turn(message, provider="sdk-object").is_malformed is False
+
+
+def test_sdk_tool_use_block_class_without_type_is_supported() -> None:
+    message = Message(stop_reason="tool_use", content=[ToolUseBlock()])
+
+    diagnostic = diagnose_tool_use_turn(message, provider="claude-code-sdk")
+
+    assert count_tool_use_blocks(message) == 1
+    assert diagnostic.is_malformed is False
+    assert diagnostic.retryable is False
+    assert diagnostic.tool_use_count == 1
+
+
+def test_sdk_text_block_without_type_is_not_counted_as_tool_use() -> None:
+    message = Message(stop_reason="tool_use", content=[TextBlock()])
+
+    diagnostic = diagnose_tool_use_turn(message, provider="claude-code-sdk")
+
+    assert count_tool_use_blocks(message) == 0
+    assert diagnostic.is_malformed is True
+    assert diagnostic.retryable is True
 
 
 def test_non_tool_use_stop_reason_is_consistent_even_without_content() -> None:


### PR DESCRIPTION
## Summary
- Adds a side-effect-free diagnostic for provider turns where `stop_reason=tool_use` has zero `tool_use` content blocks.
- Supports both dict-style and SDK object-style response messages.
- Marks the malformed state as retryable for later adapter policy wiring.

## Why this belongs in Tier 1 / #925
The #831 hang class needs a precise runtime-boundary contract before Ouroboros can safely recover from it. This PR gives the harness a tested diagnostic primitive without changing provider behavior yet, keeping the change small and reviewable.

## How it is implemented
- New `ouroboros.providers.tool_use_diagnostics` module.
- `diagnose_tool_use_turn(...)` returns a frozen `ToolUseTurnDiagnostic` with provider, stop reason, tool-use count, malformed flag, retryable flag, and reason.
- Unit tests cover malformed, valid, object-style, and non-tool-use stop reasons.

## Decisions still needed before later Tier 1 PRs
- Which adapter should consume this first: Claude Code SDK, interview runtime, or the MCP bridge boundary.
- Whether retry should be automatic once, surfaced as `BLOCKED`, or converted into a structured runtime diagnostic event.
- What event name should record the malformed provider response if persisted.

## Validation
- [x] `uv run pytest tests/unit/providers/test_tool_use_diagnostics.py -q` — 4 passed
- [x] `uv run ruff check src/ouroboros/providers/tool_use_diagnostics.py tests/unit/providers/test_tool_use_diagnostics.py` — passed

## Post-merge Ouroboros real verification
- Feed a fixture provider message with `stop_reason=tool_use` and empty text-only content through the first adapter integration PR.
- Confirm the runtime does not require manual `continue` to classify the boundary state.
- Confirm the diagnostic includes provider, stop reason, `tool_use_count=0`, and `retryable=true`.
- Confirm a valid provider turn with a real `tool_use` block is not flagged.

Refs #925
