### PR TITLE
feat(profiles): introduce profile YAML schema + loader

### DIFF
--- a/src/ouroboros/orchestrator/decomposition_params.py
+++ b/src/ouroboros/orchestrator/decomposition_params.py
@@ -61,7 +61,7 @@ def params_from_profile(
     profile: ExecutionProfile,
     *,
     min_branching: int = DEFAULT_MIN_BRANCHING,
-    max_branching: int = DEFAULT_MAX_BRANCHING,
+    max_branching: int | None = None,
 ) -> DecompositionParams:
     """Project an ExecutionProfile into the decomposer's parameter shape."""
     return DecompositionParams(
@@ -70,7 +70,7 @@ def params_from_profile(
         min_unit=profile.min_unit,
         cut_signal=profile.cut_signal,
         min_branching=min_branching,
-        max_branching=max_branching,
+        max_branching=profile.max_branching if max_branching is None else max_branching,
     )
 
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2559,12 +2559,15 @@ class ParallelACExecutor:
         decomposition_system_prompt = (
             "You are a task decomposition expert. Analyze tasks and break them down if needed."
         )
+        min_sub_acs = MIN_SUB_ACS
+        max_sub_acs = MAX_SUB_ACS
         if self._execution_profile is not None:
             params = params_from_profile(
                 self._execution_profile,
                 min_branching=MIN_SUB_ACS,
-                max_branching=MAX_SUB_ACS,
             )
+            min_sub_acs = params.min_branching
+            max_sub_acs = params.max_branching
             decomposition_system_prompt = build_decomposition_system_prompt(params)
             decompose_prompt = build_decomposition_user_prompt(
                 params,
@@ -2631,7 +2634,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             if json_match:
                 sub_acs = json.loads(json_match.group())
                 if isinstance(sub_acs, list) and all(isinstance(s, str) for s in sub_acs):
-                    if MIN_SUB_ACS <= len(sub_acs) <= MAX_SUB_ACS:
+                    if min_sub_acs <= len(sub_acs) <= max_sub_acs:
                         log.info(
                             "parallel_executor.decomposition.success",
                             ac_index=ac_index,

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 
 from enum import StrEnum
 from pathlib import Path
-from typing import Final
+from typing import Final, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 import yaml
 
 _PROFILES_DIR: Final[Path] = Path(__file__).resolve().parent.parent / "profiles"
@@ -33,6 +33,14 @@ class VerifierCapability(StrEnum):
 
     READ_ONLY_DISCOVERY = "read_only_discovery"
     SUBPROCESS_TEST_RUNNER = "subprocess_test_runner"
+
+
+class SuggestedModelTier(StrEnum):
+    """Profile-declared model cost/quality hint consumed by routing H5."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
 
 
 class EvidenceSchema(BaseModel):
@@ -72,6 +80,10 @@ class ExecutionProfile(BaseModel):
         min_length=1,
         description="Profile identifier (e.g. 'code'). Must match filename stem.",
     )
+    schema_version: Literal[1] = Field(
+        default=1,
+        description="Profile schema version. v1 is the RFC #830 YAML profile shape.",
+    )
     axis: str = Field(
         ...,
         min_length=1,
@@ -85,6 +97,15 @@ class ExecutionProfile(BaseModel):
     cut_signal: str = Field(
         default="",
         description="Heuristic signal that a sub-AC is small enough to stop splitting.",
+    )
+    max_branching: int = Field(
+        default=5,
+        ge=2,
+        description="Maximum number of sub-ACs the H4 decomposer should emit.",
+    )
+    must_produce: tuple[str, ...] = Field(
+        default=(),
+        description="Evidence fields the leaf executor should explicitly produce.",
     )
     evidence_schema: EvidenceSchema = Field(default_factory=EvidenceSchema)
     verifier_focus: str = Field(
@@ -105,6 +126,21 @@ class ExecutionProfile(BaseModel):
         default=(),
         description="Tool names the leaf executor may use; harness still gates.",
     )
+    suggested_model_tier: SuggestedModelTier = Field(
+        default=SuggestedModelTier.MEDIUM,
+        description="Profile-declared cost/quality hint for H5 adaptive routing.",
+    )
+
+    @model_validator(mode="after")
+    def _must_produce_subset_of_required_evidence(self) -> ExecutionProfile:
+        unknown = sorted(set(self.must_produce) - set(self.evidence_schema.required))
+        if unknown:
+            msg = (
+                "must_produce entries must also appear in "
+                f"evidence_schema.required: {', '.join(unknown)}"
+            )
+            raise ValueError(msg)
+        return self
 
 
 class ProfileError(ValueError):
@@ -184,6 +220,7 @@ __all__ = [
     "EvidenceSchema",
     "ExecutionProfile",
     "ProfileError",
+    "SuggestedModelTier",
     "VerifierCapability",
     "available_profiles",
     "load_profile",

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -26,14 +26,6 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 import yaml
 
 _PROFILES_DIR: Final[Path] = Path(__file__).resolve().parent.parent / "profiles"
-_REQUIRED_YAML_PROFILE_KNOBS: Final[frozenset[str]] = frozenset(
-    {
-        "schema_version",
-        "max_branching",
-        "must_produce",
-        "suggested_model_tier",
-    }
-)
 
 
 class VerifierCapability(StrEnum):
@@ -203,14 +195,14 @@ def load_profile(name: str, *, profiles_dir: Path | None = None) -> ExecutionPro
         msg = f"Profile {name!r} must be a YAML mapping at the top level, got {type(raw).__name__}"
         raise ProfileError(msg)
 
-    missing_knobs = sorted(_REQUIRED_YAML_PROFILE_KNOBS - raw.keys())
-    if missing_knobs:
-        msg = (
-            f"Profile {name!r} is missing required structured profile knob(s): "
-            f"{', '.join(missing_knobs)}"
-        )
-        raise ProfileError(msg)
-
+    # RFC v2 structured knobs (schema_version, max_branching, must_produce,
+    # suggested_model_tier) intentionally fall through to schema defaults when
+    # a YAML profile omits them. Hard-failing on absence would break existing
+    # out-of-tree custom profiles for no runtime safety gain at this layer —
+    # the Literal[1] schema_version still rejects unsupported versions, and
+    # `max_branching` keeps its ge=2 floor via Pydantic. Built-in profiles
+    # declare every knob explicitly so the RFC v2 example shape stays
+    # representable in-tree.
     try:
         profile = ExecutionProfile.model_validate(raw)
     except ValidationError as exc:

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -26,6 +26,14 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 import yaml
 
 _PROFILES_DIR: Final[Path] = Path(__file__).resolve().parent.parent / "profiles"
+_REQUIRED_YAML_PROFILE_KNOBS: Final[frozenset[str]] = frozenset(
+    {
+        "schema_version",
+        "max_branching",
+        "must_produce",
+        "suggested_model_tier",
+    }
+)
 
 
 class VerifierCapability(StrEnum):
@@ -193,6 +201,14 @@ def load_profile(name: str, *, profiles_dir: Path | None = None) -> ExecutionPro
 
     if not isinstance(raw, dict):
         msg = f"Profile {name!r} must be a YAML mapping at the top level, got {type(raw).__name__}"
+        raise ProfileError(msg)
+
+    missing_knobs = sorted(_REQUIRED_YAML_PROFILE_KNOBS - raw.keys())
+    if missing_knobs:
+        msg = (
+            f"Profile {name!r} is missing required structured profile knob(s): "
+            f"{', '.join(missing_knobs)}"
+        )
         raise ProfileError(msg)
 
     try:

--- a/src/ouroboros/profiles/analysis.yaml
+++ b/src/ouroboros/profiles/analysis.yaml
@@ -1,7 +1,12 @@
 profile: analysis
+schema_version: 1
 axis: perspective
 min_unit: "single perspective compared against at least one contrasting view"
 cut_signal: "sub-AC produces a standalone comparison with explicit tradeoffs"
+max_branching: 5
+must_produce:
+  - claims
+  - perspectives_compared
 evidence_schema:
   required:
     - claims
@@ -19,3 +24,4 @@ suggested_tools:
   - Bash
   - Glob
   - Grep
+suggested_model_tier: medium

--- a/src/ouroboros/profiles/code.yaml
+++ b/src/ouroboros/profiles/code.yaml
@@ -1,7 +1,12 @@
 profile: code
+schema_version: 1
 axis: testable_unit
 min_unit: "single function or module with at least one runnable test"
 cut_signal: "sub-AC produces an independently runnable test"
+max_branching: 5
+must_produce:
+  - tests_passed
+  - files_touched
 evidence_schema:
   required:
     - files_touched
@@ -20,3 +25,4 @@ suggested_tools:
   - Bash
   - Glob
   - Grep
+suggested_model_tier: medium

--- a/src/ouroboros/profiles/research.yaml
+++ b/src/ouroboros/profiles/research.yaml
@@ -1,7 +1,12 @@
 profile: research
+schema_version: 1
 axis: subtopic
 min_unit: "single question answerable from independently cited sources"
 cut_signal: "sub-AC produces a standalone markdown section with citations"
+max_branching: 5
+must_produce:
+  - triangulated_sources
+  - claims
 evidence_schema:
   required:
     - external_sources
@@ -21,3 +26,4 @@ suggested_tools:
   - Bash
   - Glob
   - Grep
+suggested_model_tier: medium

--- a/tests/unit/orchestrator/test_decomposition_params.py
+++ b/tests/unit/orchestrator/test_decomposition_params.py
@@ -33,6 +33,28 @@ class TestParamsFromProfile:
         assert params.min_branching == 3
         assert params.max_branching == 4
 
+    def test_profile_max_branching_drives_decomposer(self, tmp_path) -> None:
+        (tmp_path / "custom.yaml").write_text(
+            """
+profile: custom
+schema_version: 1
+axis: source
+min_unit: "single sourced claim"
+cut_signal: "claim has citations"
+max_branching: 3
+must_produce: [claims]
+evidence_schema:
+  required: [claims]
+verifier_capability: read_only_discovery
+verifier_focus: "Check claim support."
+suggested_tools: [Read, Grep]
+suggested_model_tier: medium
+""",
+            encoding="utf-8",
+        )
+        params = params_from_profile(load_profile("custom", profiles_dir=tmp_path))
+        assert params.max_branching == 3
+
 
 class TestInvariants:
     def test_min_branching_must_be_positive(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
+++ b/tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py
@@ -103,7 +103,8 @@ async def test_atomic_judgment_stops_single_ac_recursion_at_any_analyzed_depth(
 
 
 class _CapturingDecompositionRuntime:
-    def __init__(self) -> None:
+    def __init__(self, content: str = "ATOMIC") -> None:
+        self.content = content
         self.prompt: str | None = None
         self.system_prompt: str | None = None
 
@@ -118,7 +119,7 @@ class _CapturingDecompositionRuntime:
         del tools, resume_handle, resume_session_id
         self.prompt = prompt
         self.system_prompt = system_prompt
-        yield AgentMessage(type="result", content="ATOMIC")
+        yield AgentMessage(type="result", content=self.content)
 
 
 @pytest.mark.asyncio
@@ -149,3 +150,51 @@ async def test_try_decompose_ac_uses_profile_axis_when_profile_is_configured() -
     assert "single question answerable from independently cited sources" in runtime.prompt
     assert runtime.system_prompt is not None
     assert "'research' domain" in runtime.system_prompt
+
+
+@pytest.mark.asyncio
+async def test_try_decompose_ac_uses_profile_max_branching_from_loaded_yaml(tmp_path) -> None:
+    """Loaded profile max_branching should drive the live decomposer prompt and bounds."""
+    from ouroboros.orchestrator.profile_loader import load_profile
+
+    (tmp_path / "custom.yaml").write_text(
+        """
+profile: custom
+schema_version: 1
+axis: source
+min_unit: "single sourced claim"
+cut_signal: "claim has citations"
+max_branching: 3
+must_produce: [claims]
+evidence_schema:
+  required: [claims]
+verifier_capability: read_only_discovery
+verifier_focus: "Check claim support."
+suggested_tools: [Read, Grep]
+suggested_model_tier: medium
+""",
+        encoding="utf-8",
+    )
+    runtime = _CapturingDecompositionRuntime(
+        content='["Sub-AC 1: a", "Sub-AC 2: b", "Sub-AC 3: c"]'
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=True,
+        execution_profile=load_profile("custom", profiles_dir=tmp_path),
+    )
+
+    result = await executor._try_decompose_ac(
+        ac_content="Split a research task into sourced claims.",
+        ac_index=0,
+        seed_goal="Produce a sourced memo",
+        tools=["Read"],
+        system_prompt="legacy system prompt",
+    )
+
+    assert result == ["Sub-AC 1: a", "Sub-AC 2: b", "Sub-AC 3: c"]
+    assert runtime.prompt is not None
+    assert "2-3 sub-ACs" in runtime.prompt
+    assert "2-5 sub-ACs" not in runtime.prompt

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -76,20 +76,55 @@ class TestSchemaValidation:
         path.write_text(body, encoding="utf-8")
         return path
 
+    def _valid_body(self, name: str, *, extra: str = "") -> str:
+        return f"""
+profile: {name}
+schema_version: 1
+axis: source
+min_unit: claim
+max_branching: 3
+must_produce: [claims]
+evidence_schema:
+  required: [claims]
+verifier_capability: read_only_discovery
+verifier_focus: "Check claims."
+suggested_model_tier: medium
+{extra}
+"""
+
     def test_missing_required_field(self, tmp_path: Path) -> None:
         self._write(
             tmp_path,
             "broken",
-            "profile: broken\naxis: x\nmin_unit: y\n",  # no verifier_focus
+            self._valid_body("broken").replace('verifier_focus: "Check claims."\n', ""),
         )
         with pytest.raises(ProfileError, match="schema validation"):
             load_profile("broken", profiles_dir=tmp_path)
+
+    @pytest.mark.parametrize(
+        "knob",
+        ("schema_version", "max_branching", "must_produce", "suggested_model_tier"),
+    )
+    def test_structured_profile_knobs_are_required_for_yaml_loading(
+        self, tmp_path: Path, knob: str
+    ) -> None:
+        lines = [
+            line
+            for line in self._valid_body("missing_knob").splitlines()
+            if not line.startswith(f"{knob}:")
+        ]
+        self._write(tmp_path, "missing_knob", "\n".join(lines))
+
+        with pytest.raises(ProfileError, match=rf"required structured profile knob.*{knob}"):
+            load_profile("missing_knob", profiles_dir=tmp_path)
 
     def test_verifier_capability_is_required(self, tmp_path: Path) -> None:
         self._write(
             tmp_path,
             "missing_capability",
-            "profile: missing_capability\naxis: x\nmin_unit: y\nverifier_focus: z\n",
+            self._valid_body("missing_capability").replace(
+                "verifier_capability: read_only_discovery\n", ""
+            ),
         )
         with pytest.raises(ProfileError, match="verifier_capability"):
             load_profile("missing_capability", profiles_dir=tmp_path)
@@ -98,9 +133,7 @@ class TestSchemaValidation:
         self._write(
             tmp_path,
             "extra",
-            (
-                "profile: extra\naxis: x\nmin_unit: y\nverifier_capability: read_only_discovery\nverifier_focus: z\nunknown_field: oops\n"
-            ),
+            self._valid_body("extra", extra="unknown_field: oops\n"),
         )
         with pytest.raises(ProfileError, match="schema validation"):
             load_profile("extra", profiles_dir=tmp_path)
@@ -204,7 +237,7 @@ suggested_model_tier: medium
         self._write(
             tmp_path,
             "alpha",
-            "profile: beta\naxis: x\nmin_unit: y\nverifier_capability: read_only_discovery\nverifier_focus: z\n",
+            self._valid_body("beta"),
         )
         with pytest.raises(ProfileError, match="name mismatch"):
             load_profile("alpha", profiles_dir=tmp_path)

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -102,21 +102,34 @@ suggested_model_tier: medium
             load_profile("broken", profiles_dir=tmp_path)
 
     @pytest.mark.parametrize(
-        "knob",
-        ("schema_version", "max_branching", "must_produce", "suggested_model_tier"),
+        ("knob", "expected_default"),
+        (
+            ("schema_version", 1),
+            ("max_branching", 5),
+            ("must_produce", ()),
+            ("suggested_model_tier", "medium"),
+        ),
     )
-    def test_structured_profile_knobs_are_required_for_yaml_loading(
-        self, tmp_path: Path, knob: str
+    def test_structured_profile_knobs_fall_back_to_schema_defaults(
+        self, tmp_path: Path, knob: str, expected_default: object
     ) -> None:
-        lines = [
-            line
-            for line in self._valid_body("missing_knob").splitlines()
-            if not line.startswith(f"{knob}:")
-        ]
+        """Legacy/out-of-tree YAML cards that omit RFC v2 knobs still load.
+
+        Hard-failing on a missing optional knob would be a backwards-incompatible
+        loader regression — the schema already supplies sensible defaults, and
+        the Literal[1] schema_version still rejects unsupported versions. Built-in
+        cards declare every knob explicitly (covered by
+        ``test_builtin_profiles_declare_rfc_v2_structured_knobs``).
+        """
+        # must_produce defaults to (), so when removed we must also drop the
+        # paired evidence_schema row that exists only to satisfy the subset
+        # invariant; otherwise the profile is unchanged.
+        body = self._valid_body("missing_knob")
+        lines = [line for line in body.splitlines() if not line.startswith(f"{knob}:")]
         self._write(tmp_path, "missing_knob", "\n".join(lines))
 
-        with pytest.raises(ProfileError, match=rf"required structured profile knob.*{knob}"):
-            load_profile("missing_knob", profiles_dir=tmp_path)
+        profile = load_profile("missing_knob", profiles_dir=tmp_path)
+        assert getattr(profile, knob) == expected_default
 
     def test_verifier_capability_is_required(self, tmp_path: Path) -> None:
         self._write(

--- a/tests/unit/orchestrator/test_profile_loader.py
+++ b/tests/unit/orchestrator/test_profile_loader.py
@@ -41,6 +41,22 @@ class TestBuiltinProfiles:
         assert "Read" in profile.suggested_tools
         assert profile.verifier_capability is VerifierCapability.SUBPROCESS_TEST_RUNNER
 
+    @pytest.mark.parametrize("name", BUILTIN_PROFILES)
+    def test_builtin_profiles_declare_rfc_v2_structured_knobs(self, name: str) -> None:
+        """The thin YAML card must carry every knob the harness consumes.
+
+        Issue #830's accepted v2 contract names these as structured profile
+        fields, not prose. Keeping them on the schema makes the RFC example
+        representable even while downstream PRs wire individual consumers.
+        """
+        profile = load_profile(name)
+
+        assert profile.schema_version == 1
+        assert profile.max_branching >= 2
+        assert profile.must_produce
+        assert set(profile.must_produce).issubset(profile.evidence_schema.required)
+        assert profile.suggested_model_tier == "medium"
+
     def test_research_profile_requires_triangulation(self) -> None:
         profile = load_profile("research")
         assert "triangulated_sources" in profile.evidence_schema.required
@@ -88,6 +104,101 @@ class TestSchemaValidation:
         )
         with pytest.raises(ProfileError, match="schema validation"):
             load_profile("extra", profiles_dir=tmp_path)
+
+    def test_rfc_v2_example_profile_shape_loads(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "code",
+            """
+profile: code
+schema_version: 1
+axis: testable_unit
+min_unit: "single function with at least one test"
+cut_signal: "sub-AC produces an independently runnable test"
+max_branching: 4
+must_produce:
+  - tests_passed
+  - files_touched
+evidence_schema:
+  required: [files_touched, commands_run, tests_passed]
+  rejected_if:
+    - "tests_passed == []"
+verifier_capability: subprocess_test_runner
+verifier_focus: "Run the project's test command."
+suggested_tools: [Read, Edit, Write, Bash, Glob, Grep]
+suggested_model_tier: medium
+""",
+        )
+
+        profile = load_profile("code", profiles_dir=tmp_path)
+
+        assert profile.schema_version == 1
+        assert profile.max_branching == 4
+        assert profile.must_produce == ("tests_passed", "files_touched")
+        assert profile.suggested_model_tier == "medium"
+
+    def test_unsupported_schema_version_rejected(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "future",
+            """
+profile: future
+schema_version: 2
+axis: source
+min_unit: claim
+max_branching: 3
+must_produce: [claims]
+evidence_schema:
+  required: [claims]
+verifier_capability: read_only_discovery
+verifier_focus: "Check claims."
+suggested_model_tier: medium
+""",
+        )
+        with pytest.raises(ProfileError, match="schema_version"):
+            load_profile("future", profiles_dir=tmp_path)
+
+    def test_max_branching_must_leave_room_to_split(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "too_narrow",
+            """
+profile: too_narrow
+schema_version: 1
+axis: source
+min_unit: claim
+max_branching: 1
+must_produce: [claims]
+evidence_schema:
+  required: [claims]
+verifier_capability: read_only_discovery
+verifier_focus: "Check claims."
+suggested_model_tier: medium
+""",
+        )
+        with pytest.raises(ProfileError, match="max_branching"):
+            load_profile("too_narrow", profiles_dir=tmp_path)
+
+    def test_must_produce_must_be_required_evidence(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "mismatch",
+            """
+profile: mismatch
+schema_version: 1
+axis: source
+min_unit: claim
+max_branching: 3
+must_produce: [citations]
+evidence_schema:
+  required: [claims]
+verifier_capability: read_only_discovery
+verifier_focus: "Check claims."
+suggested_model_tier: medium
+""",
+        )
+        with pytest.raises(ProfileError, match="must_produce"):
+            load_profile("mismatch", profiles_dir=tmp_path)
 
     def test_filename_must_match_profile_field(self, tmp_path: Path) -> None:
         self._write(


### PR DESCRIPTION
## Summary
- Extend `ExecutionProfile` with structured RFC v2 profile knobs: `schema_version`, `max_branching`, `must_produce`, and `suggested_model_tier`.
- Add loader-side validation for supported schema version, usable branching limits, and `must_produce` being backed by required evidence.
- Update bundled profile YAMLs and let `params_from_profile()` use the profile-declared `max_branching` unless explicitly overridden.

## Test Plan
- RED: targeted tests first failed because the loader lacked the new fields, rejected the RFC v2 YAML shape as extra inputs, and ignored profile `max_branching`.
- `uv run --python 3.12 pytest tests/unit/orchestrator -q` — 1258 passed, 1 skipped.
- `uv run --python 3.12 ruff check src/ouroboros/orchestrator/profile_loader.py src/ouroboros/orchestrator/decomposition_params.py tests/unit/orchestrator/test_profile_loader.py tests/unit/orchestrator/test_decomposition_params.py`
- `uv run --python 3.12 ruff format --check src/ouroboros/orchestrator/profile_loader.py src/ouroboros/orchestrator/decomposition_params.py tests/unit/orchestrator/test_profile_loader.py tests/unit/orchestrator/test_decomposition_params.py`
- `uv run --python 3.12 mypy src/ouroboros/orchestrator/profile_loader.py src/ouroboros/orchestrator/decomposition_params.py`
- `git diff --check`
- Static added-line security scan: no matches for hardcoded secrets, shell injection, `eval`/`exec`, pickle, or SQL string-format patterns.
- Independent pre-commit review: passed with no security concerns or blocking logic errors.

Refs #830
