### PR TITLE
feat(orchestrator): add fat-harness baseline metrics report

### DIFF
--- a/src/ouroboros/orchestrator/baseline_metrics.py
+++ b/src/ouroboros/orchestrator/baseline_metrics.py
@@ -1,0 +1,283 @@
+"""Fixture-only fat-harness baseline metrics report (#961 / #830).
+
+The AgentOS SSOT (#961) requires five baseline metrics before the
+`ooo run` fat-harness path can be treated as stronger by default:
+1-shot AC pass rate, K=2 recovery rate, fabrication incidents, char
+budget per AC, and new-domain cost. This module defines the deterministic
+report shape and gate evaluation only; it does not invoke LLMs, run live
+executions, or wire into `parallel_executor` yet.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from statistics import median
+from typing import Any
+
+DEFAULT_MAX_RETRIES: int = 2
+RECOVERY_RATE_TARGET: float = 0.70
+NEW_DOMAIN_LOC_TARGET: int = 50
+NEW_DOMAIN_YAML_TARGET: int = 1
+
+
+class FatHarnessGateStatus(StrEnum):
+    """Evaluation state for a baseline metric gate."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    CAPTURED = "captured"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True)
+class FatHarnessMetricSample:
+    """One acceptance-criterion sample used to build a baseline report.
+
+    The sample is intentionally small and fixture-friendly so tests or
+    later capture adapters can construct it without depending on live LLM
+    calls. `attempt_count=1` means the AC passed or failed on the first
+    leaf attempt; `attempt_count=3` with K=2 means the retry budget was
+    exhausted.
+    """
+
+    ac_id: str
+    accepted: bool
+    attempt_count: int
+    fabrication_incidents: int = 0
+    prompt_chars: int = 0
+    completion_chars: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.ac_id:
+            msg = "ac_id must not be empty"
+            raise ValueError(msg)
+        if self.attempt_count < 1:
+            msg = "attempt_count must be >= 1"
+            raise ValueError(msg)
+        for field_name in ("fabrication_incidents", "prompt_chars", "completion_chars"):
+            if getattr(self, field_name) < 0:
+                msg = f"{field_name} must be non-negative"
+                raise ValueError(msg)
+
+    @property
+    def total_chars(self) -> int:
+        """Prompt + completion chars for the AC dispatch."""
+        return self.prompt_chars + self.completion_chars
+
+    @property
+    def accepted_first_try(self) -> bool:
+        """Whether the verifier accepted the AC on the first leaf attempt."""
+        return self.accepted and self.attempt_count == 1
+
+    def recovered_within(self, max_retries: int) -> bool:
+        """Whether an initially failed AC recovered inside the retry budget."""
+        return self.accepted and 1 < self.attempt_count <= max_retries + 1
+
+
+@dataclass(frozen=True)
+class FatHarnessGateResult:
+    """One metric's gate status plus enough context for PR/report output."""
+
+    name: str
+    status: FatHarnessGateStatus
+    value: float | int | None
+    target: str
+    rationale: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return {
+            "status": self.status.value,
+            "value": self.value,
+            "target": self.target,
+            "rationale": self.rationale,
+        }
+
+
+@dataclass(frozen=True)
+class FatHarnessMetricsReport:
+    """Aggregate baseline metrics for the fat-harness acceptance gates."""
+
+    profile: str
+    max_retries: int
+    total_acs: int
+    one_shot_pass_rate: float
+    k_recovery_rate: float | None
+    fabrication_incidents_per_100_acs: float
+    median_chars_per_ac: float
+    new_domain_loc_delta: int
+    new_domain_yaml_delta: int
+    gates: tuple[FatHarnessGateResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-serializable report shape."""
+        return {
+            "profile": self.profile,
+            "max_retries": self.max_retries,
+            "total_acs": self.total_acs,
+            "metrics": {
+                "one_shot_pass_rate": self.one_shot_pass_rate,
+                "k_recovery_rate": self.k_recovery_rate,
+                "fabrication_incidents_per_100_acs": self.fabrication_incidents_per_100_acs,
+                "median_chars_per_ac": self.median_chars_per_ac,
+                "new_domain_loc_delta": self.new_domain_loc_delta,
+                "new_domain_yaml_delta": self.new_domain_yaml_delta,
+            },
+            "gates": {gate.name: gate.to_dict() for gate in self.gates},
+        }
+
+
+def _require_non_negative(name: str, value: int | float) -> None:
+    if value < 0:
+        msg = f"{name} must be non-negative"
+        raise ValueError(msg)
+
+
+def _status_for_threshold(value: float, target: float) -> FatHarnessGateStatus:
+    return FatHarnessGateStatus.PASS if value >= target else FatHarnessGateStatus.FAIL
+
+
+def build_fat_harness_metrics_report(
+    profile: str,
+    samples: Iterable[FatHarnessMetricSample],
+    new_domain_loc_delta: int,
+    new_domain_yaml_delta: int = 0,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    baseline_median_chars_per_ac: float | None = None,
+) -> FatHarnessMetricsReport:
+    """Build a deterministic report for the five #961 fat-harness gates.
+
+    Args:
+        profile: Execution profile name the samples came from.
+        samples: AC-level fixture/capture samples.
+        new_domain_loc_delta: Extra Python LOC needed to add one new domain.
+        new_domain_yaml_delta: Extra YAML files needed to add one new domain.
+        max_retries: Retry budget K. K=2 is the #830 default.
+        baseline_median_chars_per_ac: Existing median char budget to compare
+            against. When omitted, the char-budget metric is captured but not
+            pass/fail evaluated because this report itself is the baseline.
+    """
+    if not profile:
+        msg = "profile must not be empty"
+        raise ValueError(msg)
+    _require_non_negative("new_domain_loc_delta", new_domain_loc_delta)
+    _require_non_negative("new_domain_yaml_delta", new_domain_yaml_delta)
+    _require_non_negative("max_retries", max_retries)
+    if baseline_median_chars_per_ac is not None:
+        _require_non_negative("baseline_median_chars_per_ac", baseline_median_chars_per_ac)
+
+    sample_tuple = tuple(samples)
+    if not sample_tuple:
+        msg = "samples must not be empty"
+        raise ValueError(msg)
+
+    total_acs = len(sample_tuple)
+    one_shot_count = sum(sample.accepted_first_try for sample in sample_tuple)
+    one_shot_pass_rate = one_shot_count / total_acs
+
+    initial_failures = [sample for sample in sample_tuple if not sample.accepted_first_try]
+    recovered = [sample for sample in initial_failures if sample.recovered_within(max_retries)]
+    k_recovery_rate = None if not initial_failures else len(recovered) / len(initial_failures)
+
+    fabrication_incidents = sum(sample.fabrication_incidents for sample in sample_tuple)
+    fabrication_incidents_per_100_acs = fabrication_incidents * 100 / total_acs
+    median_chars_per_ac = float(median(sample.total_chars for sample in sample_tuple))
+
+    recovery_status = (
+        FatHarnessGateStatus.NOT_APPLICABLE
+        if k_recovery_rate is None
+        else _status_for_threshold(k_recovery_rate, RECOVERY_RATE_TARGET)
+    )
+    char_status = (
+        FatHarnessGateStatus.CAPTURED
+        if baseline_median_chars_per_ac is None
+        else (
+            FatHarnessGateStatus.PASS
+            if median_chars_per_ac <= baseline_median_chars_per_ac
+            else FatHarnessGateStatus.FAIL
+        )
+    )
+    domain_status = (
+        FatHarnessGateStatus.PASS
+        if new_domain_loc_delta <= NEW_DOMAIN_LOC_TARGET
+        and new_domain_yaml_delta <= NEW_DOMAIN_YAML_TARGET
+        else FatHarnessGateStatus.FAIL
+    )
+
+    gates = (
+        FatHarnessGateResult(
+            name="one_shot_pass_rate",
+            status=FatHarnessGateStatus.CAPTURED,
+            value=one_shot_pass_rate,
+            target="baseline + post-change measurement; target >= +10pp improvement",
+            rationale="Baseline capture is enough for this fixture-only report.",
+        ),
+        FatHarnessGateResult(
+            name="k_recovery_rate",
+            status=recovery_status,
+            value=k_recovery_rate,
+            target=f">= {RECOVERY_RATE_TARGET:.0%} of initially failed ACs recover within K={max_retries}",
+            rationale=(
+                "No initially failed ACs were present."
+                if k_recovery_rate is None
+                else "Recovered ACs are accepted attempts after the first try inside the retry budget."
+            ),
+        ),
+        FatHarnessGateResult(
+            name="fabrication_incidents_per_100_acs",
+            status=(
+                FatHarnessGateStatus.PASS
+                if fabrication_incidents_per_100_acs == 0
+                else FatHarnessGateStatus.FAIL
+            ),
+            value=fabrication_incidents_per_100_acs,
+            target="0 verifier-detected fabrication incidents per 100 ACs",
+            rationale="Counts verifier-detected non-existent paths/symbols/sources.",
+        ),
+        FatHarnessGateResult(
+            name="median_chars_per_ac",
+            status=char_status,
+            value=median_chars_per_ac,
+            target=(
+                "capture baseline median chars per AC"
+                if baseline_median_chars_per_ac is None
+                else f"<= baseline median chars per AC ({baseline_median_chars_per_ac:g})"
+            ),
+            rationale="Uses prompt + completion chars as the deterministic token-budget proxy.",
+        ),
+        FatHarnessGateResult(
+            name="new_domain_cost",
+            status=domain_status,
+            value=new_domain_loc_delta,
+            target=(
+                f"<= {NEW_DOMAIN_LOC_TARGET} LOC and <= {NEW_DOMAIN_YAML_TARGET} YAML "
+                "for one new profile/domain"
+            ),
+            rationale=f"Observed {new_domain_loc_delta} LOC and {new_domain_yaml_delta} YAML files.",
+        ),
+    )
+
+    return FatHarnessMetricsReport(
+        profile=profile,
+        max_retries=max_retries,
+        total_acs=total_acs,
+        one_shot_pass_rate=one_shot_pass_rate,
+        k_recovery_rate=k_recovery_rate,
+        fabrication_incidents_per_100_acs=fabrication_incidents_per_100_acs,
+        median_chars_per_ac=median_chars_per_ac,
+        new_domain_loc_delta=new_domain_loc_delta,
+        new_domain_yaml_delta=new_domain_yaml_delta,
+        gates=gates,
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_RETRIES",
+    "FatHarnessGateResult",
+    "FatHarnessGateStatus",
+    "FatHarnessMetricSample",
+    "FatHarnessMetricsReport",
+    "build_fat_harness_metrics_report",
+]

--- a/tests/unit/orchestrator/test_baseline_metrics.py
+++ b/tests/unit/orchestrator/test_baseline_metrics.py
@@ -1,0 +1,232 @@
+"""Tests for fat-harness baseline metrics reports (#961 / #830)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ouroboros.orchestrator.baseline_metrics import (
+    FatHarnessGateStatus,
+    FatHarnessMetricSample,
+    build_fat_harness_metrics_report,
+)
+
+
+def test_report_captures_five_baseline_gates() -> None:
+    report = build_fat_harness_metrics_report(
+        profile="code",
+        samples=(
+            FatHarnessMetricSample(
+                ac_id="AC-1",
+                accepted=True,
+                attempt_count=1,
+                prompt_chars=900,
+                completion_chars=100,
+            ),
+            FatHarnessMetricSample(
+                ac_id="AC-2",
+                accepted=True,
+                attempt_count=2,
+                prompt_chars=1100,
+                completion_chars=300,
+            ),
+            FatHarnessMetricSample(
+                ac_id="AC-3",
+                accepted=False,
+                attempt_count=3,
+                fabrication_incidents=1,
+                prompt_chars=1300,
+                completion_chars=500,
+            ),
+        ),
+        new_domain_loc_delta=42,
+        new_domain_yaml_delta=1,
+    )
+
+    assert report.total_acs == 3
+    assert report.one_shot_pass_rate == pytest.approx(1 / 3)
+    assert report.k_recovery_rate == pytest.approx(1 / 2)
+    assert report.fabrication_incidents_per_100_acs == pytest.approx(100 / 3)
+    assert report.median_chars_per_ac == 1400
+    assert report.new_domain_loc_delta == 42
+    assert report.new_domain_yaml_delta == 1
+
+    gates = {gate.name: gate for gate in report.gates}
+    assert set(gates) == {
+        "one_shot_pass_rate",
+        "k_recovery_rate",
+        "fabrication_incidents_per_100_acs",
+        "median_chars_per_ac",
+        "new_domain_cost",
+    }
+    assert gates["one_shot_pass_rate"].status == FatHarnessGateStatus.CAPTURED
+    assert gates["k_recovery_rate"].status == FatHarnessGateStatus.FAIL
+    assert gates["fabrication_incidents_per_100_acs"].status == FatHarnessGateStatus.FAIL
+    assert gates["median_chars_per_ac"].status == FatHarnessGateStatus.CAPTURED
+    assert gates["new_domain_cost"].status == FatHarnessGateStatus.PASS
+
+
+def test_report_accepts_public_positional_arguments_and_passes_thresholds() -> None:
+    report = build_fat_harness_metrics_report(
+        "code",
+        (
+            FatHarnessMetricSample("AC-1", accepted=True, attempt_count=1),
+            FatHarnessMetricSample("AC-2", accepted=True, attempt_count=2),
+            FatHarnessMetricSample("AC-3", accepted=True, attempt_count=3),
+        ),
+        50,
+        1,
+        baseline_median_chars_per_ac=0,
+    )
+
+    gates = {gate.name: gate for gate in report.gates}
+    assert report.one_shot_pass_rate == pytest.approx(1 / 3)
+    assert report.k_recovery_rate == 1.0
+    assert gates["k_recovery_rate"].status == FatHarnessGateStatus.PASS
+    assert gates["fabrication_incidents_per_100_acs"].status == FatHarnessGateStatus.PASS
+    assert gates["median_chars_per_ac"].status == FatHarnessGateStatus.PASS
+    assert gates["new_domain_cost"].status == FatHarnessGateStatus.PASS
+
+
+def test_report_marks_char_budget_and_new_domain_cost_failures() -> None:
+    report = build_fat_harness_metrics_report(
+        profile="code",
+        samples=(
+            FatHarnessMetricSample(
+                ac_id="AC-1",
+                accepted=True,
+                attempt_count=1,
+                prompt_chars=40,
+                completion_chars=60,
+            ),
+        ),
+        new_domain_loc_delta=51,
+        new_domain_yaml_delta=2,
+        baseline_median_chars_per_ac=99,
+    )
+
+    gates = {gate.name: gate for gate in report.gates}
+    assert report.median_chars_per_ac == 100
+    assert gates["median_chars_per_ac"].status == FatHarnessGateStatus.FAIL
+    assert gates["new_domain_cost"].status == FatHarnessGateStatus.FAIL
+
+
+def test_report_is_json_serializable() -> None:
+    report = build_fat_harness_metrics_report(
+        profile="research",
+        samples=(
+            FatHarnessMetricSample(
+                ac_id="AC-1",
+                accepted=True,
+                attempt_count=1,
+                prompt_chars=500,
+                completion_chars=250,
+            ),
+        ),
+        new_domain_loc_delta=0,
+        new_domain_yaml_delta=1,
+        baseline_median_chars_per_ac=800,
+    )
+
+    payload = report.to_dict()
+
+    assert payload["profile"] == "research"
+    assert payload["metrics"]["median_chars_per_ac"] == 750
+    assert payload["gates"]["median_chars_per_ac"]["status"] == "pass"
+    json.dumps(payload)
+
+
+def test_recovery_rate_is_not_applicable_without_initial_failures() -> None:
+    report = build_fat_harness_metrics_report(
+        profile="analysis",
+        samples=(
+            FatHarnessMetricSample(
+                ac_id="AC-1",
+                accepted=True,
+                attempt_count=1,
+                prompt_chars=100,
+                completion_chars=50,
+            ),
+        ),
+        new_domain_loc_delta=0,
+        new_domain_yaml_delta=1,
+    )
+
+    assert report.k_recovery_rate is None
+    gates = {gate.name: gate for gate in report.gates}
+    assert gates["k_recovery_rate"].status == FatHarnessGateStatus.NOT_APPLICABLE
+
+
+def test_empty_sample_set_is_rejected() -> None:
+    with pytest.raises(ValueError, match="samples must not be empty"):
+        build_fat_harness_metrics_report(profile="code", samples=(), new_domain_loc_delta=0)
+
+
+def test_invalid_report_inputs_are_rejected() -> None:
+    sample = FatHarnessMetricSample(ac_id="AC-1", accepted=True, attempt_count=1)
+
+    with pytest.raises(ValueError, match="profile must not be empty"):
+        build_fat_harness_metrics_report(profile="", samples=(sample,), new_domain_loc_delta=0)
+
+    with pytest.raises(ValueError, match="new_domain_loc_delta must be non-negative"):
+        build_fat_harness_metrics_report(profile="code", samples=(sample,), new_domain_loc_delta=-1)
+
+    with pytest.raises(ValueError, match="new_domain_yaml_delta must be non-negative"):
+        build_fat_harness_metrics_report(
+            profile="code",
+            samples=(sample,),
+            new_domain_loc_delta=0,
+            new_domain_yaml_delta=-1,
+        )
+
+    with pytest.raises(ValueError, match="max_retries must be non-negative"):
+        build_fat_harness_metrics_report(
+            profile="code",
+            samples=(sample,),
+            new_domain_loc_delta=0,
+            max_retries=-1,
+        )
+
+    with pytest.raises(ValueError, match="baseline_median_chars_per_ac must be non-negative"):
+        build_fat_harness_metrics_report(
+            profile="code",
+            samples=(sample,),
+            new_domain_loc_delta=0,
+            baseline_median_chars_per_ac=-1,
+        )
+
+
+def test_invalid_sample_values_are_rejected() -> None:
+    with pytest.raises(ValueError, match="ac_id must not be empty"):
+        FatHarnessMetricSample(ac_id="", accepted=True, attempt_count=1)
+
+    with pytest.raises(ValueError, match="attempt_count must be >= 1"):
+        FatHarnessMetricSample(ac_id="AC-1", accepted=True, attempt_count=0)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        FatHarnessMetricSample(
+            ac_id="AC-1",
+            accepted=True,
+            attempt_count=1,
+            fabrication_incidents=-1,
+        )
+
+
+def test_sample_helpers_describe_first_try_and_recovery() -> None:
+    first_try = FatHarnessMetricSample(
+        ac_id="AC-1",
+        accepted=True,
+        attempt_count=1,
+        prompt_chars=12,
+        completion_chars=8,
+    )
+    recovered = FatHarnessMetricSample(ac_id="AC-2", accepted=True, attempt_count=3)
+    exhausted = FatHarnessMetricSample(ac_id="AC-3", accepted=True, attempt_count=4)
+
+    assert first_try.total_chars == 20
+    assert first_try.accepted_first_try is True
+    assert first_try.recovered_within(max_retries=2) is False
+    assert recovered.accepted_first_try is False
+    assert recovered.recovered_within(max_retries=2) is True
+    assert exhausted.recovered_within(max_retries=2) is False


### PR DESCRIPTION
## Summary
- Adds a fixture-only `ouroboros.orchestrator.baseline_metrics` report module for #961 / #830 fat-harness baseline capture.
- Defines frozen sample/result/report dataclasses plus deterministic gate statuses for 1-shot pass rate, K recovery, fabrication incidents, median chars per AC, and new-domain cost.
- Keeps this intentionally offline: no LLM calls, no live execution, and no `parallel_executor` wiring.

## Test Plan
- RED (implementation absent): `uv run --python 3.12 pytest tests/unit/orchestrator/test_baseline_metrics.py -q` -> `ModuleNotFoundError: No module named 'ouroboros.orchestrator.baseline_metrics'`; `RED_EXIT=2`.
- RED (public positional API before fix): `uv run --python 3.12 pytest tests/unit/orchestrator/test_baseline_metrics.py -q` -> `1 failed, 8 passed in 0.53s` (`TypeError: build_fat_harness_metrics_report() takes 0 positional arguments but 4 positional arguments ... were given`).
- GREEN focused: `uv run --python 3.12 pytest tests/unit/orchestrator/test_baseline_metrics.py -q` -> `9 passed in 0.31s`.
- Regression slice: `uv run --python 3.12 pytest tests/unit/orchestrator/test_baseline_metrics.py tests/unit/orchestrator/test_failure_taxonomy.py tests/unit/orchestrator/test_verifier.py -q` -> `66 passed in 0.45s`.
- Lint: `uv run ruff check src/ouroboros/orchestrator/baseline_metrics.py tests/unit/orchestrator/test_baseline_metrics.py` -> `All checks passed!`.
- Format: `uv run ruff format --check src/ouroboros/orchestrator/baseline_metrics.py tests/unit/orchestrator/test_baseline_metrics.py` -> `2 files already formatted`.
- Types: `uv run mypy src/ouroboros/orchestrator/baseline_metrics.py tests/unit/orchestrator/test_baseline_metrics.py` -> `Success: no issues found in 2 source files`.

Refs #961
Refs #830
