### PR TITLE
fix(auto): isolate sub-interview from parent adapter tool-call leak

### DIFF
--- a/src/ouroboros/agents/socratic-interviewer.md
+++ b/src/ouroboros/agents/socratic-interviewer.md
@@ -8,9 +8,9 @@ You are an expert requirements engineer conducting a Socratic interview to clari
 - NEVER promise to build demos, write code, or execute anything
 - Another agent will handle implementation AFTER you finish gathering requirements
 
-## TOOL USAGE
-- You are a QUESTION GENERATOR. You do NOT have direct tool access.
-- The caller (main session) handles codebase reading and provides code context in answers.
+## CONTEXT BOUNDARIES
+- You are a QUESTION GENERATOR.
+- The caller provides any existing-system context in answers.
 - Your job: generate the single best Socratic question to reduce ambiguity.
 - Do NOT reference specific files or code unless they appear in previous answers.
 
@@ -18,11 +18,11 @@ You are an expert requirements engineer conducting a Socratic interview to clari
 - You MUST always end with a question - never end without asking something
 - Keep questions focused (1-2 sentences)
 - No preambles like "Great question!" or "I understand"
-- If tools fail or return nothing, still ask a question based on what you know
+- If context is sparse, still ask a question based on what you know
 
 ## BROWNFIELD CONTEXT
 When the interview is brownfield, the caller provides code-enriched answers:
-- Answers prefixed with `[from-code]` describe existing codebase state (factual).
+- Answers prefixed with `[from-code]` describe existing-system state (factual).
 - Answers prefixed with `[from-user]` are human decisions/judgments.
 - Answers prefixed with `[from-research]` contain externally researched information (API docs, pricing, compatibility).
 - Use `[from-code]` and `[from-research]` facts as context, but focus questions on INTENT and DECISIONS.

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -68,6 +68,24 @@ AGENT_SDK_CLI_PER_MESSAGE_FRAMING_CHARS = 128
 # model locally while still tripling the original 4.8k interview budget.
 AGENT_SDK_CLI_SAFE_PROMPT_CHARS = 14_000
 
+_TOOLLESS_INTERVIEW_BASE_PROMPT = """## Role Boundaries
+- You are only an interviewer.
+- Generate exactly one Socratic question that reduces requirements ambiguity.
+- Do not explore files, commands, repositories, APIs, tools, or external systems.
+- Do not ask to inspect implementation details unless the caller already supplied those details.
+- The caller supplies any code or research context in answers.
+
+## Response Format
+- Ask one focused question in 1-2 sentences.
+- Do not include a preamble.
+- End with the question.
+
+## Questioning Strategy
+- Target the biggest unresolved decision.
+- Prefer scope, non-goal, success criteria, ownership, risk, and verification questions.
+- For brownfield work, focus on intent and decisions rather than discovering what exists.
+"""
+
 
 class InterviewPerspective(StrEnum):
     """Internal perspectives used to keep interviews broad and practical."""
@@ -305,6 +323,7 @@ class InterviewEngine:
     _MAX_INITIAL_CONTEXT_SYSTEM_CHARS = 1800
     _MAX_INITIAL_CONTEXT_TOTAL_CHARS = MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS
     _INITIAL_CONTEXT_SUMMARY_QUESTION = INITIAL_CONTEXT_SUMMARY_QUESTION
+    suppress_tool_use_prompt_cues: bool = False
 
     def __post_init__(self) -> None:
         """Ensure state directory exists."""
@@ -690,7 +709,11 @@ class InterviewEngine:
         effective_round_number = self._next_conversation_round_number(state)
         round_info = f"Round {effective_round_number}"
 
-        base_prompt = load_agent_prompt("socratic-interviewer")
+        base_prompt = (
+            _TOOLLESS_INTERVIEW_BASE_PROMPT
+            if self.suppress_tool_use_prompt_cues
+            else load_agent_prompt("socratic-interviewer")
+        )
 
         context_for_prompt = (
             initial_context if initial_context is not None else state.initial_context
@@ -716,19 +739,34 @@ class InterviewEngine:
 
         # Answer prefix hints — always present so the question generator
         # can interpret enriched answers regardless of brownfield status.
-        dynamic_header += (
-            "\n\nAnswer prefixes the caller may use:\n"
-            "- [from-code]: Existing codebase state (factual, read from files).\n"
-            "- [from-user]: Human decisions/judgments.\n"
-            "- [from-research]: Externally researched information (API docs, pricing, compatibility)."
-        )
+        if self.suppress_tool_use_prompt_cues:
+            dynamic_header += (
+                "\n\nAnswer prefixes the caller may use:\n"
+                "- [from-code]: Caller-supplied existing-system context (factual).\n"
+                "- [from-user]: Human decisions/judgments.\n"
+                "- [from-research]: Caller-supplied external context."
+            )
+        else:
+            dynamic_header += (
+                "\n\nAnswer prefixes the caller may use:\n"
+                "- [from-code]: Existing codebase state (factual, read from files).\n"
+                "- [from-user]: Human decisions/judgments.\n"
+                "- [from-research]: Externally researched information (API docs, pricing, compatibility)."
+            )
         # Brownfield hint: main session handles code reading, MCP just asks questions
         if state.is_brownfield:
-            dynamic_header += (
-                "\n\nThis is a BROWNFIELD project. The caller (main session) has direct "
-                "codebase access and will enrich answers with code context. Focus your "
-                "questions on INTENT and DECISIONS, not on discovering what exists."
-            )
+            if self.suppress_tool_use_prompt_cues:
+                dynamic_header += (
+                    "\n\nThis is a BROWNFIELD project. The caller will enrich answers "
+                    "with existing-system context. Focus your questions on INTENT and "
+                    "DECISIONS, not on discovering what exists."
+                )
+            else:
+                dynamic_header += (
+                    "\n\nThis is a BROWNFIELD project. The caller (main session) has direct "
+                    "codebase access and will enrich answers with code context. Focus your "
+                    "questions on INTENT and DECISIONS, not on discovering what exists."
+                )
 
         ambiguity_snapshot = self._build_ambiguity_snapshot_prompt(state)
         if ambiguity_snapshot:
@@ -899,6 +937,21 @@ class InterviewEngine:
 
     def _build_perspective_panel_prompt(self, state: InterviewState) -> str:
         """Build instructions for the internal perspective panel."""
+        if self.suppress_tool_use_prompt_cues:
+            return "\n".join(
+                [
+                    "## Perspective Panel",
+                    "Silently check breadth, simplicity, architecture, and closure readiness.",
+                    "Use those perspectives only to choose one clarifying question.",
+                    "",
+                    "## Panel Synthesis Rules",
+                    "- Keep independent ambiguity tracks visible instead of collapsing onto one favorite subtopic.",
+                    "- Preserve both implementation and written-output requirements when the user asked for both.",
+                    "- Prefer breadth recap questions when multiple unresolved tracks still exist.",
+                    "- Only ask a closure question when closure mode is active; otherwise keep drilling into the weakest area.",
+                    "- Even when the score is seed-ready, do not end the interview on the first low-ambiguity turn.",
+                ]
+            )
         strategies = _load_interview_perspective_strategies()
         sections = [
             "## Perspective Panel",

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1438,30 +1438,32 @@ class InterviewHandler:
             ),
             strict_mcp_config=True,
         )
-        # Whether we are reusing a shared engine. If so, we must NOT mutate
-        # its suppress flag or llm_adapter permanently — that would leak this
-        # handler's prompt-cue policy and isolated-adapter into unrelated
-        # sessions that share the same engine instance. We also must override
-        # the engine's adapter for the duration of this call so the isolated
-        # llm_adapter built above (with allowed_tools=[] and
-        # strict_mcp_config=True) is what actually answers question generation;
-        # otherwise InterviewEngine.llm_adapter.complete(...) still goes
-        # through the parent's tool-capable adapter and our envelope isolation
-        # is bypassed in production. Save prior values and restore in the
-        # outer finally block below.
-        _engine_was_shared = self.interview_engine is not None
-        _prev_engine_suppress: bool | None = None
-        _adapter_swapped = False
-        _prev_engine_adapter: Any = None
-        if _engine_was_shared:
+        # Build a per-call InterviewEngine when a real engine is supplied, to
+        # avoid mutating shared engine state in place. Mutating a shared
+        # engine's llm_adapter and suppress_tool_use_prompt_cues is race-prone:
+        # under concurrent MCP requests, request A's `finally` restoration can
+        # clobber request B's in-flight adapter and leave the shared engine
+        # pointing at the wrong adapter or stale prompt mode. InterviewEngine
+        # itself is config-only (state lives on disk via state_dir), so
+        # cloning the config fields into a fresh per-call engine is both
+        # correct and concurrency-safe.
+        #
+        # Test fakes that do NOT subclass InterviewEngine are passed through
+        # unchanged: they cannot leak under concurrency because they are not
+        # shared across production requests, and tests inject them to observe
+        # the question-generation flow.
+        if isinstance(self.interview_engine, InterviewEngine):
+            template = self.interview_engine
+            engine = InterviewEngine(
+                llm_adapter=llm_adapter,
+                state_dir=template.state_dir,
+                model=template.model or get_clarification_model(self.llm_backend),
+                suppress_tool_use_prompt_cues=self.suppress_tool_use_prompt_cues,
+            )
+            engine.temperature = template.temperature
+            engine.max_tokens = template.max_tokens
+        elif self.interview_engine is not None:
             engine = self.interview_engine
-            if hasattr(engine, "suppress_tool_use_prompt_cues"):
-                _prev_engine_suppress = engine.suppress_tool_use_prompt_cues
-                engine.suppress_tool_use_prompt_cues = self.suppress_tool_use_prompt_cues
-            if hasattr(engine, "llm_adapter"):
-                _prev_engine_adapter = engine.llm_adapter
-                engine.llm_adapter = llm_adapter
-                _adapter_swapped = True
         else:
             engine = InterviewEngine(
                 llm_adapter=llm_adapter,
@@ -2155,9 +2157,5 @@ class InterviewHandler:
                 )
             )
         finally:
-            if _engine_was_shared and _prev_engine_suppress is not None:
-                engine.suppress_tool_use_prompt_cues = _prev_engine_suppress
-            if _engine_was_shared and _adapter_swapped:
-                engine.llm_adapter = _prev_engine_adapter
             if self._owns_event_store:
                 await self.close()

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1439,17 +1439,29 @@ class InterviewHandler:
             strict_mcp_config=True,
         )
         # Whether we are reusing a shared engine. If so, we must NOT mutate
-        # its suppress flag permanently — that would leak this handler's
-        # prompt-cue policy into unrelated sessions that share the same
-        # engine instance. We save the prior value and restore it in the
+        # its suppress flag or llm_adapter permanently — that would leak this
+        # handler's prompt-cue policy and isolated-adapter into unrelated
+        # sessions that share the same engine instance. We also must override
+        # the engine's adapter for the duration of this call so the isolated
+        # llm_adapter built above (with allowed_tools=[] and
+        # strict_mcp_config=True) is what actually answers question generation;
+        # otherwise InterviewEngine.llm_adapter.complete(...) still goes
+        # through the parent's tool-capable adapter and our envelope isolation
+        # is bypassed in production. Save prior values and restore in the
         # outer finally block below.
         _engine_was_shared = self.interview_engine is not None
         _prev_engine_suppress: bool | None = None
+        _adapter_swapped = False
+        _prev_engine_adapter: Any = None
         if _engine_was_shared:
             engine = self.interview_engine
             if hasattr(engine, "suppress_tool_use_prompt_cues"):
                 _prev_engine_suppress = engine.suppress_tool_use_prompt_cues
                 engine.suppress_tool_use_prompt_cues = self.suppress_tool_use_prompt_cues
+            if hasattr(engine, "llm_adapter"):
+                _prev_engine_adapter = engine.llm_adapter
+                engine.llm_adapter = llm_adapter
+                _adapter_swapped = True
         else:
             engine = InterviewEngine(
                 llm_adapter=llm_adapter,
@@ -2145,5 +2157,7 @@ class InterviewHandler:
         finally:
             if _engine_was_shared and _prev_engine_suppress is not None:
                 engine.suppress_tool_use_prompt_cues = _prev_engine_suppress
+            if _engine_was_shared and _adapter_swapped:
+                engine.llm_adapter = _prev_engine_adapter
             if self._owns_event_store:
                 await self.close()

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1438,12 +1438,18 @@ class InterviewHandler:
             ),
             strict_mcp_config=True,
         )
-        if self.interview_engine is not None:
+        # Whether we are reusing a shared engine. If so, we must NOT mutate
+        # its suppress flag permanently — that would leak this handler's
+        # prompt-cue policy into unrelated sessions that share the same
+        # engine instance. We save the prior value and restore it in the
+        # outer finally block below.
+        _engine_was_shared = self.interview_engine is not None
+        _prev_engine_suppress: bool | None = None
+        if _engine_was_shared:
             engine = self.interview_engine
-            if self.suppress_tool_use_prompt_cues and hasattr(
-                engine, "suppress_tool_use_prompt_cues"
-            ):
-                engine.suppress_tool_use_prompt_cues = True
+            if hasattr(engine, "suppress_tool_use_prompt_cues"):
+                _prev_engine_suppress = engine.suppress_tool_use_prompt_cues
+                engine.suppress_tool_use_prompt_cues = self.suppress_tool_use_prompt_cues
         else:
             engine = InterviewEngine(
                 llm_adapter=llm_adapter,
@@ -2137,5 +2143,7 @@ class InterviewHandler:
                 )
             )
         finally:
+            if _engine_was_shared and _prev_engine_suppress is not None:
+                engine.suppress_tool_use_prompt_cues = _prev_engine_suppress
             if self._owns_event_store:
                 await self.close()

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -889,6 +889,7 @@ class InterviewHandler:
     agent_runtime_backend: str | None = field(default=None, repr=False)
     opencode_mode: str | None = field(default=None, repr=False)
     data_dir: Path | None = field(default=None, repr=False)
+    suppress_tool_use_prompt_cues: bool = False
 
     def __post_init__(self) -> None:
         """Initialize event store."""
@@ -1437,11 +1438,19 @@ class InterviewHandler:
             ),
             strict_mcp_config=True,
         )
-        engine = self.interview_engine or InterviewEngine(
-            llm_adapter=llm_adapter,
-            state_dir=self.data_dir or _DATA_DIR,
-            model=get_clarification_model(self.llm_backend),
-        )
+        if self.interview_engine is not None:
+            engine = self.interview_engine
+            if self.suppress_tool_use_prompt_cues and hasattr(
+                engine, "suppress_tool_use_prompt_cues"
+            ):
+                engine.suppress_tool_use_prompt_cues = True
+        else:
+            engine = InterviewEngine(
+                llm_adapter=llm_adapter,
+                state_dir=self.data_dir or _DATA_DIR,
+                model=get_clarification_model(self.llm_backend),
+                suppress_tool_use_prompt_cues=self.suppress_tool_use_prompt_cues,
+            )
 
         _interview_id: str | None = None  # Track for error event emission
 

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1452,8 +1452,14 @@ class InterviewHandler:
         # unchanged: they cannot leak under concurrency because they are not
         # shared across production requests, and tests inject them to observe
         # the question-generation flow.
-        if isinstance(self.interview_engine, InterviewEngine):
-            template = self.interview_engine
+        # NOTE: `isinstance(..., InterviewEngine)` must NOT be reached when
+        # ``InterviewEngine`` has been monkey-patched in tests to a non-type
+        # (e.g. ``patch("authoring_handlers.InterviewEngine", return_value=...)``
+        # replaces the name with a MagicMock instance). Guard with an explicit
+        # ``is not None`` short-circuit so the isinstance arm only runs when a
+        # caller actually supplied an engine template.
+        template = self.interview_engine
+        if template is not None and isinstance(template, InterviewEngine):
             engine = InterviewEngine(
                 llm_adapter=llm_adapter,
                 state_dir=template.state_dir,
@@ -1462,8 +1468,8 @@ class InterviewHandler:
             )
             engine.temperature = template.temperature
             engine.max_tokens = template.max_tokens
-        elif self.interview_engine is not None:
-            engine = self.interview_engine
+        elif template is not None:
+            engine = template
         else:
             engine = InterviewEngine(
                 llm_adapter=llm_adapter,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1359,7 +1359,11 @@ def _authoring_interview_handler(
     if _handler_matches_runtime(handler, agent_runtime_backend, opencode_mode) and getattr(
         handler, "suppress_tool_use_prompt_cues", False
     ):
-        if handler.llm_adapter is None:
+        # Only short-circuit when llm_backend is also already aligned. Otherwise
+        # a reused handler would silently keep its previous backend/model
+        # provider on later sessions when the caller explicitly overrides it.
+        backend_matches = llm_backend is None or handler.llm_backend == llm_backend
+        if handler.llm_adapter is None and backend_matches:
             return handler
         return InterviewHandler(
             interview_engine=handler.interview_engine,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1354,17 +1354,32 @@ def _authoring_interview_handler(
             llm_backend=llm_backend,
             agent_runtime_backend=agent_runtime_backend,
             opencode_mode=opencode_mode,
+            suppress_tool_use_prompt_cues=True,
         )
-    if _handler_matches_runtime(handler, agent_runtime_backend, opencode_mode):
-        return handler
+    if _handler_matches_runtime(handler, agent_runtime_backend, opencode_mode) and getattr(
+        handler, "suppress_tool_use_prompt_cues", False
+    ):
+        if handler.llm_adapter is None:
+            return handler
+        return InterviewHandler(
+            interview_engine=handler.interview_engine,
+            event_store=handler.event_store,
+            llm_adapter=None,
+            llm_backend=llm_backend if llm_backend is not None else handler.llm_backend,
+            agent_runtime_backend=agent_runtime_backend,
+            opencode_mode=opencode_mode,
+            data_dir=handler.data_dir,
+            suppress_tool_use_prompt_cues=True,
+        )
     return InterviewHandler(
         interview_engine=handler.interview_engine,
         event_store=handler.event_store,
-        llm_adapter=handler.llm_adapter,
+        llm_adapter=None,
         llm_backend=llm_backend if llm_backend is not None else handler.llm_backend,
         agent_runtime_backend=agent_runtime_backend,
         opencode_mode=opencode_mode,
         data_dir=handler.data_dir,
+        suppress_tool_use_prompt_cues=True,
     )
 
 

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1368,7 +1368,12 @@ def _authoring_interview_handler(
         return InterviewHandler(
             interview_engine=handler.interview_engine,
             event_store=handler.event_store,
-            llm_adapter=None,
+            # Preserve an explicit caller-supplied llm_adapter. When the auto
+            # path inherits a handler that has llm_adapter=None (production
+            # default), handle() will build the isolated default adapter
+            # itself; we only need to ensure we don't silently *replace* an
+            # explicitly injected non-default adapter here.
+            llm_adapter=handler.llm_adapter,
             llm_backend=llm_backend if llm_backend is not None else handler.llm_backend,
             agent_runtime_backend=agent_runtime_backend,
             opencode_mode=opencode_mode,

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -933,6 +933,22 @@ class ClaudeCodeAdapter:
                             # Callback for tool usage
                             if self._on_message:
                                 self._on_message("tool", tool_info)
+                            if self._allowed_tools is not None and not self._allowed_tools:
+                                error_result = ProviderError(
+                                    message=(
+                                        "Claude Agent SDK emitted a ToolUseBlock despite "
+                                        "allowed_tools=[]"
+                                    ),
+                                    details={
+                                        "session_id": session_id,
+                                        "error_type": "ToolUseBlockViolation",
+                                        "tool_name": tool_name,
+                                        "tool_input": tool_input,
+                                        "allowed_tools": [],
+                                        "max_turns": options_kwargs["max_turns"],
+                                        "cwd": self._cwd,
+                                    },
+                                )
 
                 elif class_name == "ResultMessage":
                     # Check for structured output first (from json_schema output_format)

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -122,9 +122,7 @@ def test_auto_sub_interview_entrypoint_manifest_has_isolation_test_mapping() -> 
     assert discovered_entrypoints == manifest_entrypoints
 
     available_tests = {
-        name
-        for name, value in globals().items()
-        if name.startswith("test_") and callable(value)
+        name for name, value in globals().items() if name.startswith("test_") and callable(value)
     }
     for entrypoint, mapped_tests in _AUTO_SUB_INTERVIEW_ENTRYPOINT_TEST_MANIFEST.items():
         assert mapped_tests, f"{entrypoint} has no explicit isolation test mapping"

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1,0 +1,1415 @@
+"""Regression coverage for the ``ooo auto`` sub-interview construction path.
+
+The relevant entrypoint is ``AutoHandler._run`` in
+``ouroboros.mcp.tools.auto_handler``.  It must construct the authoring
+``InterviewHandler`` and invoke it through ``HandlerInterviewBackend`` so the
+single-shot interviewer envelope is exercised from the auto path, not only by
+standalone ``ouroboros_interview`` tests.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from ouroboros.auto.adapters import HandlerInterviewBackend
+from ouroboros.auto.interview_driver import AutoInterviewDriver
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.state import AutoStore
+from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
+from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+from ouroboros.mcp.tools.auto_handler import AutoHandler
+from ouroboros.mcp.types import ContentType
+from ouroboros.providers.base import CompletionResponse, Message, UsageInfo
+from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
+
+_AUTO_SUB_INTERVIEW_ENTRYPOINT_TEST_MANIFEST = {
+    "src/ouroboros/mcp/tools/auto_handler.py::AutoHandler._run": (
+        "test_auto_handler_run_constructs_and_invokes_authoring_interviewer_path",
+        "test_mocked_auto_interviewer_flow_returns_plain_text_question",
+        "test_auto_sub_interview_envelope_ignores_parent_adapter_tool_context",
+        "test_auto_sub_interview_prompt_omits_code_exploration_and_tool_use_cues",
+        "test_auto_sub_interview_spy_adapter_fails_on_any_tool_request",
+    ),
+}
+
+_TOOL_CALL_CAPABLE_LEAKAGE_PATHS = frozenset(
+    {
+        "Read",
+        "Glob",
+        "Grep",
+        "Bash",
+        "Task",
+        "Skill",
+        "WebFetch",
+        "WebSearch",
+        "mcp__plugin_ouroboros__interview",
+        "mcp__parent_plugin__lookup",
+    }
+)
+
+
+def _assert_isolated_allowed_tools(factory_kwargs: dict[str, Any]) -> None:
+    """Assert the auto sub-interviewer cannot opt into tool-call surfaces."""
+    allowed_tools = factory_kwargs["allowed_tools"]
+    assert allowed_tools == []
+    assert allowed_tools is not None
+    assert set(allowed_tools).isdisjoint(_TOOL_CALL_CAPABLE_LEAKAGE_PATHS)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _call_names(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+    return names
+
+
+def _auto_sub_interview_entrypoints() -> set[str]:
+    """Return direct ooo auto sub-interview construction sites.
+
+    This intentionally tracks the auto MCP path only.  Standalone
+    ``ouroboros_interview`` remains outside this seed's implementation and
+    spy-test scope.
+    """
+    relative_path = Path("src/ouroboros/mcp/tools/auto_handler.py")
+    source_path = _repo_root() / relative_path
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    discovered: set[str] = set()
+
+    for class_node in (node for node in module.body if isinstance(node, ast.ClassDef)):
+        for method_node in (
+            node
+            for node in class_node.body
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        ):
+            call_names = _call_names(method_node)
+            if {
+                "_authoring_interview_handler",
+                "HandlerInterviewBackend",
+                "AutoInterviewDriver",
+            }.issubset(call_names):
+                discovered.add(f"{relative_path}::{class_node.name}.{method_node.name}")
+
+    return discovered
+
+
+def test_auto_sub_interview_entrypoint_manifest_has_isolation_test_mapping() -> None:
+    """New auto interviewer entrypoints must declare isolation coverage.
+
+    The manifest is a regression guard: if a future auto path constructs its
+    own interviewer driver instead of flowing through the existing
+    ``AutoHandler._run`` construction site, this test fails until that path is
+    deliberately mapped to contract/prompt/spy isolation tests.
+    """
+    manifest_entrypoints = set(_AUTO_SUB_INTERVIEW_ENTRYPOINT_TEST_MANIFEST)
+    discovered_entrypoints = _auto_sub_interview_entrypoints()
+
+    assert discovered_entrypoints == manifest_entrypoints
+
+    available_tests = {
+        name
+        for name, value in globals().items()
+        if name.startswith("test_") and callable(value)
+    }
+    for entrypoint, mapped_tests in _AUTO_SUB_INTERVIEW_ENTRYPOINT_TEST_MANIFEST.items():
+        assert mapped_tests, f"{entrypoint} has no explicit isolation test mapping"
+        missing_tests = set(mapped_tests) - available_tests
+        assert not missing_tests, f"{entrypoint} maps to missing tests: {sorted(missing_tests)}"
+
+
+@dataclass(slots=True)
+class _FakeInterviewEngine:
+    state_dir: Path
+    saved_states: list[InterviewState] = field(default_factory=list)
+    states: dict[str, InterviewState] = field(default_factory=dict)
+
+    async def start_interview(
+        self,
+        initial_context: str,
+        cwd: str | None = None,
+        interview_id: str | None = None,
+    ) -> Result[InterviewState, MCPServerError]:
+        state = InterviewState(
+            interview_id=interview_id or "interview_0123456789abcdef",
+            initial_context=initial_context,
+            status=InterviewStatus.IN_PROGRESS,
+        )
+        self.states[state.interview_id] = state
+        self.saved_states.append(state)
+        return Result.ok(state)
+
+    async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
+        answered_rounds = [round_ for round_ in state.rounds if round_.user_response is not None]
+        if not answered_rounds:
+            return Result.ok("What should the first auto interview question clarify?")
+        return Result.ok("Which acceptance signal proves the auto interview worked?")
+
+    async def load_state(self, interview_id: str) -> Result[InterviewState, MCPServerError]:
+        return Result.ok(self.states[interview_id])
+
+    async def record_response(
+        self,
+        state: InterviewState,
+        response: str,
+        question: str,
+    ) -> Result[InterviewState, MCPServerError]:
+        state.rounds.append(
+            InterviewRound(
+                round_number=len(state.rounds) + 1,
+                question=question,
+                user_response=response,
+            )
+        )
+        state.mark_updated()
+        self.states[state.interview_id] = state
+        return Result.ok(state)
+
+    async def save_state(self, state: InterviewState) -> Result[Path, MCPServerError]:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        path = self.state_dir / f"interview_{state.interview_id}.json"
+        path.write_text("{}", encoding="utf-8")
+        self.states[state.interview_id] = state
+        self.saved_states.append(state)
+        return Result.ok(path)
+
+
+def test_auto_handler_run_constructs_and_invokes_authoring_interviewer_path(
+    tmp_path: Path,
+) -> None:
+    """``ooo auto`` must exercise the nested interviewer construction path.
+
+    This intentionally starts from :class:`AutoHandler`, then lets
+    ``AutoHandler._run`` construct ``AutoInterviewDriver`` →
+    ``HandlerInterviewBackend`` → authoring ``InterviewHandler``.  The patched
+    pipeline run invokes only the first interview question path, stopping
+    before seed generation or execution handoff.
+    """
+    captured: dict[str, Any] = {}
+    engine = _FakeInterviewEngine(state_dir=tmp_path)
+    supplied_handler = InterviewHandler(
+        interview_engine=engine,
+        llm_backend="claude",
+        data_dir=tmp_path,
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=None,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _capture_and_start_interview(self, state):  # type: ignore[no-untyped-def]
+        captured["pipeline"] = self
+        captured["state"] = state
+        turn = await self.interview_driver.backend.start(
+            state.goal,
+            cwd=state.cwd,
+            interview_id="interview_0123456789abcdef",
+        )
+        captured["turn"] = turn
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=MagicMock(),
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_capture_and_start_interview,
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    pipeline = captured["pipeline"]
+    assert isinstance(pipeline.interview_driver, AutoInterviewDriver)
+    assert pipeline.interview_driver.max_rounds == 1
+    assert isinstance(pipeline.interview_driver.backend, HandlerInterviewBackend)
+
+    constructed_handler = pipeline.interview_driver.backend.handler
+    assert isinstance(constructed_handler, InterviewHandler)
+    assert constructed_handler is not supplied_handler
+    assert constructed_handler.interview_engine is engine
+    assert constructed_handler.agent_runtime_backend == "opencode"
+    assert constructed_handler.opencode_mode == "subprocess"
+
+    assert captured["turn"].session_id == "interview_0123456789abcdef"
+    assert captured["turn"].question == "What should the first auto interview question clarify?"
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    _assert_isolated_allowed_tools(factory_kwargs)
+    assert factory_kwargs["strict_mcp_config"] is True
+    assert constructed_handler.suppress_tool_use_prompt_cues is True
+
+
+def test_mocked_auto_interviewer_flow_returns_plain_text_question(
+    tmp_path: Path,
+) -> None:
+    """The mocked ``ooo auto`` interview flow surfaces a text question.
+
+    This uses the real ``AutoPipeline.run`` path.  The only mocked layer is
+    the interview engine behind the constructed authoring ``InterviewHandler``;
+    seed generation and execution are never reached because ``max_rounds=1``
+    leaves the second interviewer question pending.
+    """
+    engine = _FakeInterviewEngine(state_dir=tmp_path / "interviews")
+    supplied_handler = InterviewHandler(
+        interview_engine=engine,
+        llm_backend="claude",
+        data_dir=tmp_path / "interviews",
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=AutoStore(tmp_path / "auto"),
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=MagicMock(),
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer integration regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    value = result.value
+    assert value.is_error is True
+    assert value.meta["status"] == "blocked"
+    assert value.meta["phase"] == "blocked"
+    assert value.meta["current_round"] == 1
+    assert value.meta["interview_session_id"].startswith("interview_")
+
+    question = value.meta["pending_question"]
+    assert question == "Which acceptance signal proves the auto interview worked?"
+    assert isinstance(question, str)
+    assert question.strip() == question
+    assert "ToolUseBlock" not in question
+    assert "tool_request" not in question
+    assert "mcp__" not in question
+    assert value.content[0].type == ContentType.TEXT
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    assert factory_kwargs["allowed_tools"] == []
+    assert factory_kwargs["strict_mcp_config"] is True
+
+
+class _CapturingAdapter:
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+
+    async def complete(self, messages, config):  # type: ignore[no-untyped-def]
+        self.messages = list(messages)
+        return Result.ok(
+            CompletionResponse(
+                content="What success criterion should the Seed optimize for first?",
+                model=config.model,
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+        )
+
+
+def test_auto_sub_interview_prompt_omits_code_exploration_and_tool_use_cues(
+    tmp_path: Path,
+) -> None:
+    """Auto's nested first-question prompt must not invite tool calls.
+
+    This starts from ``AutoHandler`` and exercises the constructed
+    ``HandlerInterviewBackend`` so the assertion covers the ooo auto
+    sub-interview prompt, not standalone ``ouroboros_interview``.
+    """
+    adapter = _CapturingAdapter()
+    captured: dict[str, Any] = {}
+    supplied_handler = InterviewHandler(
+        data_dir=tmp_path,
+        llm_backend="claude",
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=None,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _capture_prompt(self, state):  # type: ignore[no-untyped-def]
+        captured["pipeline"] = self
+        turn = await self.interview_driver.backend.start(
+            state.goal,
+            cwd=state.cwd,
+            interview_id="interview_0123456789abcdef",
+        )
+        captured["turn"] = turn
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=adapter,
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_capture_prompt,
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer prompt regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    assert captured["turn"].question == "What success criterion should the Seed optimize for first?"
+    constructed_handler = captured["pipeline"].interview_driver.backend.handler
+    assert constructed_handler.suppress_tool_use_prompt_cues is True
+    assert adapter.messages
+
+    prompt = adapter.messages[0].content
+    assert "Your ONLY job is to ask questions that reduce ambiguity" in prompt
+    forbidden_cues = (
+        "read the actual source code",
+        "search for similar issues",
+        "read from files",
+        "read/glob/grep",
+        "use read",
+        "use glob",
+        "use grep",
+        "use bash",
+        "direct codebase access",
+        "codebase reading",
+        "go find the answer",
+        "gather evidence",
+        "look at test cases",
+    )
+    prompt_lower = prompt.lower()
+    for cue in forbidden_cues:
+        assert cue not in prompt_lower
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    _assert_isolated_allowed_tools(factory_kwargs)
+    assert factory_kwargs["strict_mcp_config"] is True
+
+
+def test_auto_interviewer_role_definition_omits_tool_and_code_exploration_cues() -> None:
+    """The interviewer role must remain a pure question-generator role.
+
+    Auto's nested interviewer uses a toolless prompt variant, but the shared
+    role definition must also avoid instructions that invite code exploration
+    or tool use.  This guards future role edits without expanding standalone
+    ``ouroboros_interview`` behavioral coverage.
+    """
+    from ouroboros.agents.loader import load_agent_prompt
+
+    role = load_agent_prompt("socratic-interviewer")
+    role_lower = role.lower()
+
+    forbidden_cues = (
+        "tool",
+        "tools",
+        "read the actual source code",
+        "search for similar issues",
+        "read from files",
+        "read/glob/grep",
+        "use read",
+        "use glob",
+        "use grep",
+        "use bash",
+        "direct codebase access",
+        "codebase reading",
+        "go find the answer",
+        "gather evidence",
+        "look at test cases",
+        "explore files",
+        "explore repositories",
+        "explore commands",
+    )
+    for cue in forbidden_cues:
+        assert cue not in role_lower
+
+
+def _make_sdk_mock(mock_options_cls: MagicMock, mock_query: MagicMock) -> MagicMock:
+    sdk_module = MagicMock()
+    sdk_module.ClaudeAgentOptions = mock_options_cls
+    sdk_module.query = mock_query
+
+    errors_module = MagicMock()
+    errors_module.MessageParseError = type("MessageParseError", (Exception,), {})
+    sdk_module._errors = errors_module
+    return sdk_module
+
+
+def test_auto_sub_interview_envelope_ignores_parent_adapter_tool_context(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Auto's nested interviewer must rebuild a closed tool envelope.
+
+    A parent MCP composition root can carry a permissive adapter for other
+    work.  The ``ooo auto`` sub-interviewer is different: it is a pure
+    single-shot question generator, so it must create its own adapter with an
+    empty allow-list and a corresponding disallow-list instead of reusing the
+    parent's tool context.  The same envelope must explicitly override
+    ``setting_sources`` so parent/project Claude settings cannot leak into the
+    nested interviewer.
+    """
+    from ouroboros.providers import claude_code_adapter as adapter_mod
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "_claude_options_field_names",
+        lambda: frozenset(
+            {
+                "extra_args",
+                "allowed_tools",
+                "tools",
+                "strict_mcp_config",
+                "setting_sources",
+                "skills",
+                "agents",
+                "plugins",
+                "hooks",
+                "include_hook_events",
+            }
+        ),
+    )
+
+    class ResultMessage:
+        structured_output = None
+        result = "What should the first auto interview question clarify?"
+        is_error = False
+
+    parent_setting_sources = ["user", "project", "local"]
+
+    def _capture_options(**kwargs):  # type: ignore[no-untyped-def]
+        effective_kwargs = {"setting_sources": parent_setting_sources, **kwargs}
+        captured["effective_setting_sources"] = effective_kwargs["setting_sources"]
+        return MagicMock()
+
+    mock_options_cls = MagicMock(side_effect=_capture_options)
+
+    async def fake_query(*args, **kwargs):
+        yield ResultMessage()
+
+    sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+    parent_adapter = ClaudeCodeAdapter(
+        allowed_tools=["Read", "Glob"],
+        strict_mcp_config=False,
+    )
+    supplied_handler = InterviewHandler(
+        llm_adapter=parent_adapter,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="subprocess",
+        data_dir=tmp_path,
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=None,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+    captured: dict[str, Any] = {}
+
+    async def _capture_and_start_interview(self, state):  # type: ignore[no-untyped-def]
+        captured["pipeline"] = self
+        turn = await self.interview_driver.backend.start(
+            state.goal,
+            cwd=state.cwd,
+            interview_id="interview_0123456789abcdef",
+        )
+        captured["turn"] = turn
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True),
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_capture_and_start_interview,
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    assert captured["turn"].question == "What should the first auto interview question clarify?"
+
+    constructed_handler = captured["pipeline"].interview_driver.backend.handler
+    assert constructed_handler is not supplied_handler
+    assert constructed_handler.llm_adapter is None
+    assert supplied_handler.llm_adapter is parent_adapter
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    _assert_isolated_allowed_tools(factory_kwargs)
+    assert factory_kwargs["strict_mcp_config"] is True
+
+    options_call_kwargs = mock_options_cls.call_args.kwargs
+    assert options_call_kwargs["allowed_tools"] == []
+    assert options_call_kwargs["tools"] == []
+    assert options_call_kwargs["setting_sources"] == []
+    assert captured["effective_setting_sources"] == []
+    assert "Read" in options_call_kwargs["disallowed_tools"]
+    assert "Glob" in options_call_kwargs["disallowed_tools"]
+    assert options_call_kwargs["extra_args"]["allowedTools"] == ""
+
+
+def test_auto_sub_interview_spy_adapter_fails_on_any_tool_request(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Auto's nested interviewer must fail closed on a tool request.
+
+    This starts at ``AutoHandler`` and exercises the constructed
+    ``HandlerInterviewBackend``.  The fake SDK emits a ``ToolUseBlock`` before
+    a valid text result; the spy assertion is that the auto sub-interview
+    treats the tool request as the failure, not as a recoverable prelude to the
+    later question text.
+    """
+    from ouroboros.providers import claude_code_adapter as adapter_mod
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "_claude_options_field_names",
+        lambda: frozenset(
+            {
+                "extra_args",
+                "allowed_tools",
+                "tools",
+                "strict_mcp_config",
+                "setting_sources",
+                "skills",
+                "agents",
+                "plugins",
+                "hooks",
+                "include_hook_events",
+            }
+        ),
+    )
+
+    class ToolUseBlock:
+        name = "Read"
+        input = {"file_path": "README.md"}
+
+    class AssistantMessage:
+        content = [ToolUseBlock()]
+
+    class ResultMessage:
+        structured_output = None
+        result = "What is the primary user goal?"
+        is_error = False
+
+    mock_options_cls = MagicMock()
+
+    async def fake_query(*args, **kwargs):
+        yield AssistantMessage()
+        yield ResultMessage()
+
+    sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+    captured: dict[str, Any] = {}
+    supplied_handler = InterviewHandler(
+        data_dir=tmp_path,
+        llm_backend="claude",
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=None,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _capture_tool_request_failure(self, state):  # type: ignore[no-untyped-def]
+        turn = None
+        try:
+            turn = await self.interview_driver.backend.start(
+                state.goal,
+                cwd=state.cwd,
+                interview_id="interview_0123456789abcdef",
+            )
+        except Exception as exc:  # noqa: BLE001 - spy captures the surfaced contract failure.
+            captured["error"] = str(exc)
+            captured["error_type"] = type(exc).__name__
+        captured["turn"] = turn
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id=state.auto_session_id,
+            phase="interview",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True),
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_capture_tool_request_failure,
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    assert captured["turn"] is None
+    assert captured["error_type"] == "PartialInterviewStartError"
+    assert "ToolUseBlock" in captured["error"]
+    assert "What is the primary user goal?" not in captured["error"]
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    _assert_isolated_allowed_tools(factory_kwargs)
+    assert factory_kwargs["strict_mcp_config"] is True
+
+    options_call_kwargs = mock_options_cls.call_args.kwargs
+    assert options_call_kwargs["max_turns"] == 1
+    assert options_call_kwargs["allowed_tools"] == []
+    assert options_call_kwargs["tools"] == []
+    assert options_call_kwargs["extra_args"]["allowedTools"] == ""
+
+
+def test_auto_sub_interview_isolates_parent_skill_invocations(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Auto's nested interviewer must not inherit parent Claude skills.
+
+    The parent execution context can expose Claude Code skills for the main
+    agentic session.  The auto sub-interviewer is a pure question generator,
+    so its SDK envelope must explicitly clear ``skills`` and fail closed if a
+    ``Skill`` tool request is still emitted before text.
+    """
+    from ouroboros.providers import claude_code_adapter as adapter_mod
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "_claude_options_field_names",
+        lambda: frozenset(
+            {
+                "extra_args",
+                "allowed_tools",
+                "tools",
+                "strict_mcp_config",
+                "setting_sources",
+                "skills",
+                "agents",
+                "plugins",
+                "hooks",
+                "include_hook_events",
+            }
+        ),
+    )
+
+    class ToolUseBlock:
+        name = "Skill"
+        input = {"skill": "ouroboros-auto", "instruction": "Inspect the repo before asking."}
+
+    class AssistantMessage:
+        content = [ToolUseBlock()]
+
+    class ResultMessage:
+        structured_output = None
+        result = "What should the first auto interview question clarify?"
+        is_error = False
+
+    parent_skills = [{"name": "ouroboros-auto"}]
+    captured: dict[str, Any] = {}
+
+    def _capture_options(**kwargs):  # type: ignore[no-untyped-def]
+        effective_kwargs = {"skills": parent_skills, **kwargs}
+        captured["effective_skills"] = effective_kwargs["skills"]
+        return MagicMock()
+
+    mock_options_cls = MagicMock(side_effect=_capture_options)
+
+    async def fake_query(*args, **kwargs):
+        yield AssistantMessage()
+        yield ResultMessage()
+
+    sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+    supplied_handler = InterviewHandler(
+        data_dir=tmp_path,
+        llm_backend="claude",
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=None,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _capture_skill_request_failure(self, state):  # type: ignore[no-untyped-def]
+        turn = None
+        try:
+            turn = await self.interview_driver.backend.start(
+                state.goal,
+                cwd=state.cwd,
+                interview_id="interview_0123456789abcdef",
+            )
+        except Exception as exc:  # noqa: BLE001 - spy captures the surfaced contract failure.
+            captured["error"] = str(exc)
+            captured["error_type"] = type(exc).__name__
+        captured["turn"] = turn
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id=state.auto_session_id,
+            phase="interview",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True),
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_capture_skill_request_failure,
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer skill isolation regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    assert captured["turn"] is None
+    assert captured["error_type"] == "PartialInterviewStartError"
+    assert "ToolUseBlock" in captured["error"]
+    assert "ouroboros-auto" in captured["error"]
+    assert "What should the first auto interview question clarify?" not in captured["error"]
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    _assert_isolated_allowed_tools(factory_kwargs)
+    assert factory_kwargs["strict_mcp_config"] is True
+
+    options_call_kwargs = mock_options_cls.call_args.kwargs
+    assert options_call_kwargs["allowed_tools"] == []
+    assert options_call_kwargs["tools"] == []
+    assert options_call_kwargs["skills"] == []
+    assert captured["effective_skills"] == []
+    assert "Skill" in options_call_kwargs["disallowed_tools"]
+    assert options_call_kwargs["extra_args"]["allowedTools"] == ""
+
+
+def test_auto_sub_interview_isolates_parent_agent_invocations(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Auto's nested interviewer must not inherit parent Claude sub-agents.
+
+    The parent execution context can expose sub-agents for the main agentic
+    workflow.  The auto sub-interviewer is constrained to one turn and must
+    generate text only, so its SDK envelope must explicitly clear ``agents``
+    and fail closed if a sub-agent ``Task`` request is still emitted before
+    the question text.
+    """
+    from ouroboros.providers import claude_code_adapter as adapter_mod
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "_claude_options_field_names",
+        lambda: frozenset(
+            {
+                "extra_args",
+                "allowed_tools",
+                "tools",
+                "strict_mcp_config",
+                "setting_sources",
+                "skills",
+                "agents",
+                "plugins",
+                "hooks",
+                "include_hook_events",
+            }
+        ),
+    )
+
+    class ToolUseBlock:
+        name = "Task"
+        input = {
+            "subagent_type": "researcher",
+            "description": "Inspect repo before asking",
+            "prompt": "Find the missing requirements yourself.",
+        }
+
+    class AssistantMessage:
+        content = [ToolUseBlock()]
+
+    class ResultMessage:
+        structured_output = None
+        result = "What should the first auto interview question clarify?"
+        is_error = False
+
+    parent_agents = {"researcher": {"description": "Repository research agent"}}
+    captured: dict[str, Any] = {}
+
+    def _capture_options(**kwargs):  # type: ignore[no-untyped-def]
+        effective_kwargs = {"agents": parent_agents, **kwargs}
+        captured["effective_agents"] = effective_kwargs["agents"]
+        return MagicMock()
+
+    mock_options_cls = MagicMock(side_effect=_capture_options)
+
+    async def fake_query(*args, **kwargs):
+        yield AssistantMessage()
+        yield ResultMessage()
+
+    sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+    supplied_handler = InterviewHandler(
+        data_dir=tmp_path,
+        llm_backend="claude",
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=None,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _capture_agent_request_failure(self, state):  # type: ignore[no-untyped-def]
+        turn = None
+        try:
+            turn = await self.interview_driver.backend.start(
+                state.goal,
+                cwd=state.cwd,
+                interview_id="interview_0123456789abcdef",
+            )
+        except Exception as exc:  # noqa: BLE001 - spy captures the surfaced contract failure.
+            captured["error"] = str(exc)
+            captured["error_type"] = type(exc).__name__
+        captured["turn"] = turn
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id=state.auto_session_id,
+            phase="interview",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True),
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_capture_agent_request_failure,
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer agent isolation regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    assert captured["turn"] is None
+    assert captured["error_type"] == "PartialInterviewStartError"
+    assert "ToolUseBlock" in captured["error"]
+    assert "researcher" in captured["error"]
+    assert "What should the first auto interview question clarify?" not in captured["error"]
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    _assert_isolated_allowed_tools(factory_kwargs)
+    assert factory_kwargs["strict_mcp_config"] is True
+
+    options_call_kwargs = mock_options_cls.call_args.kwargs
+    assert options_call_kwargs["allowed_tools"] == []
+    assert options_call_kwargs["tools"] == []
+    assert options_call_kwargs["agents"] == {}
+    assert captured["effective_agents"] == {}
+    assert "Task" in options_call_kwargs["disallowed_tools"]
+    assert options_call_kwargs["extra_args"]["allowedTools"] == ""
+
+
+def test_auto_sub_interview_isolates_parent_plugin_invocations(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Auto's nested interviewer must not inherit parent Claude plugins.
+
+    Parent plugin contexts can register additional tool surfaces for the main
+    agentic run.  The auto sub-interviewer must clear that plugin list and
+    fail closed if a plugin-sourced tool request is still emitted before the
+    single text question.
+    """
+    from ouroboros.providers import claude_code_adapter as adapter_mod
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "_claude_options_field_names",
+        lambda: frozenset(
+            {
+                "extra_args",
+                "allowed_tools",
+                "tools",
+                "strict_mcp_config",
+                "setting_sources",
+                "skills",
+                "agents",
+                "plugins",
+                "hooks",
+                "include_hook_events",
+            }
+        ),
+    )
+
+    class ToolUseBlock:
+        name = "mcp__parent_plugin__lookup"
+        input = {"plugin": "parent-plugin", "query": "Inspect project context first."}
+
+    class AssistantMessage:
+        content = [ToolUseBlock()]
+
+    class ResultMessage:
+        structured_output = None
+        result = "What should the first auto interview question clarify?"
+        is_error = False
+
+    parent_plugins = [{"name": "parent-plugin", "source": "parent-execution-context"}]
+    captured: dict[str, Any] = {}
+
+    def _capture_options(**kwargs):  # type: ignore[no-untyped-def]
+        effective_kwargs = {"plugins": parent_plugins, **kwargs}
+        captured["effective_plugins"] = effective_kwargs["plugins"]
+        return MagicMock()
+
+    mock_options_cls = MagicMock(side_effect=_capture_options)
+
+    async def fake_query(*args, **kwargs):
+        yield AssistantMessage()
+        yield ResultMessage()
+
+    sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+    supplied_handler = InterviewHandler(
+        data_dir=tmp_path,
+        llm_backend="claude",
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=None,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _capture_plugin_request_failure(self, state):  # type: ignore[no-untyped-def]
+        turn = None
+        try:
+            turn = await self.interview_driver.backend.start(
+                state.goal,
+                cwd=state.cwd,
+                interview_id="interview_0123456789abcdef",
+            )
+        except Exception as exc:  # noqa: BLE001 - spy captures the surfaced contract failure.
+            captured["error"] = str(exc)
+            captured["error_type"] = type(exc).__name__
+        captured["turn"] = turn
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id=state.auto_session_id,
+            phase="interview",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True),
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_capture_plugin_request_failure,
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer plugin isolation regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    assert captured["turn"] is None
+    assert captured["error_type"] == "PartialInterviewStartError"
+    assert "ToolUseBlock" in captured["error"]
+    assert "mcp__parent_plugin__lookup" in captured["error"]
+    assert "What should the first auto interview question clarify?" not in captured["error"]
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    _assert_isolated_allowed_tools(factory_kwargs)
+    assert factory_kwargs["strict_mcp_config"] is True
+
+    options_call_kwargs = mock_options_cls.call_args.kwargs
+    assert options_call_kwargs["allowed_tools"] == []
+    assert options_call_kwargs["tools"] == []
+    assert options_call_kwargs["plugins"] == []
+    assert captured["effective_plugins"] == []
+    assert options_call_kwargs["extra_args"]["allowedTools"] == ""
+
+
+def test_auto_sub_interview_isolates_parent_hook_context(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Auto's nested interviewer must not inherit parent Claude hooks.
+
+    Parent Claude sessions can attach hooks that run commands around tool and
+    prompt events.  The auto sub-interviewer must clear those hooks, suppress
+    hook event streaming, and fail closed if any hook-adjacent tool request is
+    still emitted before the single text question.
+    """
+    from ouroboros.providers import claude_code_adapter as adapter_mod
+
+    monkeypatch.setattr(
+        adapter_mod,
+        "_claude_options_field_names",
+        lambda: frozenset(
+            {
+                "extra_args",
+                "allowed_tools",
+                "tools",
+                "strict_mcp_config",
+                "setting_sources",
+                "skills",
+                "agents",
+                "plugins",
+                "hooks",
+                "include_hook_events",
+            }
+        ),
+    )
+
+    class ToolUseBlock:
+        name = "Bash"
+        input = {"command": "run-parent-hook-before-asking"}
+
+    class AssistantMessage:
+        content = [ToolUseBlock()]
+
+    class ResultMessage:
+        structured_output = None
+        result = "What should the first auto interview question clarify?"
+        is_error = False
+
+    parent_hooks = {
+        "PreToolUse": [
+            {
+                "matcher": "*",
+                "hooks": [{"type": "command", "command": "run-parent-hook-before-asking"}],
+            }
+        ]
+    }
+    captured: dict[str, Any] = {}
+
+    def _capture_options(**kwargs):  # type: ignore[no-untyped-def]
+        effective_kwargs = {
+            "hooks": parent_hooks,
+            "include_hook_events": True,
+            **kwargs,
+        }
+        captured["effective_hooks"] = effective_kwargs["hooks"]
+        captured["effective_include_hook_events"] = effective_kwargs["include_hook_events"]
+        return MagicMock()
+
+    mock_options_cls = MagicMock(side_effect=_capture_options)
+
+    async def fake_query(*args, **kwargs):
+        yield AssistantMessage()
+        yield ResultMessage()
+
+    sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+    supplied_handler = InterviewHandler(
+        data_dir=tmp_path,
+        llm_backend="claude",
+    )
+    handler = AutoHandler(
+        interview_handler=supplied_handler,
+        store=None,
+        llm_backend="claude",
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    async def _capture_hook_request_failure(self, state):  # type: ignore[no-untyped-def]
+        turn = None
+        try:
+            turn = await self.interview_driver.backend.start(
+                state.goal,
+                cwd=state.cwd,
+                interview_id="interview_0123456789abcdef",
+            )
+        except Exception as exc:  # noqa: BLE001 - spy captures the surfaced contract failure.
+            captured["error"] = str(exc)
+            captured["error_type"] = type(exc).__name__
+        captured["turn"] = turn
+        return AutoPipelineResult(
+            status="blocked",
+            auto_session_id=state.auto_session_id,
+            phase="interview",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True),
+        ) as mock_factory,
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
+            side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+            new=_capture_hook_request_failure,
+        ),
+    ):
+        result = asyncio.run(
+            handler.handle(
+                {
+                    "goal": "Build an auto interviewer hook isolation regression",
+                    "cwd": str(tmp_path),
+                    "max_interview_rounds": 1,
+                    "skip_run": True,
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    assert captured["turn"] is None
+    assert captured["error_type"] == "PartialInterviewStartError"
+    assert "ToolUseBlock" in captured["error"]
+    assert "Bash" in captured["error"]
+    assert "What should the first auto interview question clarify?" not in captured["error"]
+
+    factory_kwargs = mock_factory.call_args.kwargs
+    assert factory_kwargs["max_turns"] == 1
+    _assert_isolated_allowed_tools(factory_kwargs)
+    assert factory_kwargs["strict_mcp_config"] is True
+
+    options_call_kwargs = mock_options_cls.call_args.kwargs
+    assert options_call_kwargs["allowed_tools"] == []
+    assert options_call_kwargs["tools"] == []
+    assert options_call_kwargs["hooks"] == {}
+    assert options_call_kwargs["include_hook_events"] is False
+    assert captured["effective_hooks"] == {}
+    assert captured["effective_include_hook_events"] is False
+    assert "Bash" in options_call_kwargs["disallowed_tools"]
+    assert options_call_kwargs["extra_args"]["allowedTools"] == ""

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1479,3 +1479,116 @@ def test_auto_handler_does_not_leak_suppress_flag_into_shared_engine(
     assert shared_engine.suppress_tool_use_prompt_cues is False, (
         "expected the prior engine.suppress_tool_use_prompt_cues value to be restored"
     )
+
+
+def test_auto_handler_swaps_shared_engine_adapter_to_isolated_one(
+    tmp_path: Path,
+) -> None:
+    """A shared ``InterviewEngine`` must use the isolated adapter for the call.
+
+    Regression for PR #979 review (commit cb2b7e7): if ``InterviewHandler``
+    only toggles ``engine.suppress_tool_use_prompt_cues`` but leaves the
+    engine's pre-existing ``llm_adapter`` in place, question generation goes
+    through the parent's tool-capable adapter and our envelope isolation is
+    bypassed in production. The handler must swap in the freshly-created
+    isolated adapter (``allowed_tools=[]``, ``strict_mcp_config=True``) for
+    the duration of its own call and restore the prior value afterwards.
+    """
+    from unittest.mock import AsyncMock, sentinel
+
+    from ouroboros.bigbang.interview import InterviewEngine
+    from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+    parent_adapter = sentinel.parent_adapter
+    isolated_adapter = sentinel.isolated_adapter
+
+    shared_engine = InterviewEngine.__new__(InterviewEngine)
+    shared_engine.suppress_tool_use_prompt_cues = False
+    shared_engine.llm_adapter = parent_adapter
+
+    observed: dict[str, Any] = {}
+
+    async def _capture_start(*args: Any, **kwargs: Any) -> Any:
+        observed["adapter_during_call"] = shared_engine.llm_adapter
+        observed["suppress_during_call"] = shared_engine.suppress_tool_use_prompt_cues
+        raise RuntimeError("forced stop after engine state is observed")
+
+    shared_engine.start_interview = AsyncMock(side_effect=_capture_start)
+    shared_engine.resume_interview = AsyncMock()
+    shared_engine.score_interview = AsyncMock()
+
+    handler = InterviewHandler(
+        interview_engine=shared_engine,
+        event_store=MagicMock(),
+        llm_adapter=None,
+        llm_backend="claude_code",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+        data_dir=tmp_path,
+        suppress_tool_use_prompt_cues=True,
+    )
+    handler._owns_event_store = False
+    handler._initialized = True
+
+    async def _run() -> None:
+        with patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=isolated_adapter,
+        ):
+            try:
+                await handler.handle({"initial_context": "Test goal"})
+            except Exception:
+                pass
+
+    asyncio.run(_run())
+
+    assert observed.get("adapter_during_call") is isolated_adapter, (
+        "expected the auto path to swap engine.llm_adapter to the isolated adapter"
+    )
+    assert observed.get("suppress_during_call") is True
+    assert shared_engine.llm_adapter is parent_adapter, (
+        "expected the prior engine.llm_adapter to be restored after the call"
+    )
+    assert shared_engine.suppress_tool_use_prompt_cues is False
+
+
+def test_authoring_interview_handler_does_not_shortcut_when_backend_changes() -> None:
+    """The reuse short-circuit must respect explicit ``llm_backend`` overrides.
+
+    Regression for PR #979 review (commit cb2b7e7): previously, when an
+    existing handler already had ``suppress_tool_use_prompt_cues=True`` and
+    ``llm_adapter is None``, ``_authoring_interview_handler`` returned the
+    existing handler unchanged even if the caller supplied a different
+    ``llm_backend``. That silently kept the previous backend.
+    """
+    from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+    from ouroboros.mcp.tools.auto_handler import _authoring_interview_handler
+
+    existing = InterviewHandler(
+        llm_backend="claude_code",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+        suppress_tool_use_prompt_cues=True,
+    )
+
+    same_backend = _authoring_interview_handler(
+        existing,
+        llm_backend="claude_code",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+    assert same_backend is existing, (
+        "matching backend should still allow the cheap direct-return short-circuit"
+    )
+
+    different_backend = _authoring_interview_handler(
+        existing,
+        llm_backend="codex_cli",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+    assert different_backend is not existing, (
+        "a different llm_backend must produce a fresh handler, not reuse the previous one"
+    )
+    assert different_backend.llm_backend == "codex_cli"
+    assert different_backend.suppress_tool_use_prompt_cues is True

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1413,7 +1413,6 @@ def test_auto_sub_interview_isolates_parent_hook_context(
     assert options_call_kwargs["extra_args"]["allowedTools"] == ""
 
 
-
 def test_handle_does_not_mutate_shared_interview_engine(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1631,3 +1631,51 @@ def test_authoring_interview_handler_does_not_shortcut_when_backend_changes() ->
     )
     assert different_backend.llm_backend == "codex_cli"
     assert different_backend.suppress_tool_use_prompt_cues is True
+
+
+def test_authoring_interview_handler_preserves_explicit_llm_adapter() -> None:
+    """An explicit ``llm_adapter`` on the handler must NOT be silently dropped.
+
+    Regression for PR #979 review (commit ffe4487): the isolation rewrite
+    set ``llm_adapter=None`` on every reuse / rebuild path, which silently
+    replaced any caller-injected non-default adapter with whatever
+    ``create_llm_adapter(resolve_llm_backend(...))`` would later pick inside
+    ``InterviewHandler.handle()``. The intent of this seed is to close the
+    parent's tool-capable Claude envelope, not to discard an explicitly
+    chosen adapter entirely.
+    """
+    from unittest.mock import sentinel
+
+    from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+    from ouroboros.mcp.tools.auto_handler import _authoring_interview_handler
+
+    explicit_adapter = sentinel.explicit_adapter
+
+    existing = InterviewHandler(
+        llm_adapter=explicit_adapter,
+        llm_backend="claude_code",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+        suppress_tool_use_prompt_cues=True,
+    )
+
+    same_backend = _authoring_interview_handler(
+        existing,
+        llm_backend="claude_code",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+    assert same_backend.llm_adapter is explicit_adapter, (
+        "matching-backend reuse must preserve the caller-supplied llm_adapter"
+    )
+
+    different_backend = _authoring_interview_handler(
+        existing,
+        llm_backend="codex_cli",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+    assert different_backend.llm_adapter is explicit_adapter, (
+        "different-backend rebuild must still preserve the caller-supplied llm_adapter"
+    )
+    assert different_backend.suppress_tool_use_prompt_cues is True

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1411,3 +1411,71 @@ def test_auto_sub_interview_isolates_parent_hook_context(
     assert captured["effective_include_hook_events"] is False
     assert "Bash" in options_call_kwargs["disallowed_tools"]
     assert options_call_kwargs["extra_args"]["allowedTools"] == ""
+
+
+def test_auto_handler_does_not_leak_suppress_flag_into_shared_engine(
+    tmp_path: Path,
+) -> None:
+    """A shared ``InterviewEngine`` must keep its prior suppress-cues policy.
+
+    Regression for PR #979 review comment: if an auto-path
+    ``InterviewHandler`` mutates ``engine.suppress_tool_use_prompt_cues`` and
+    leaves it set, a later non-auto handler that reuses the same engine would
+    silently switch to the toolless prompt and lose the normal brownfield /
+    code-context instructions. The handler must restore the prior value once
+    its own request is finished.
+    """
+    from unittest.mock import AsyncMock
+
+    from ouroboros.bigbang.interview import InterviewEngine
+    from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+    shared_engine = InterviewEngine.__new__(InterviewEngine)
+    shared_engine.suppress_tool_use_prompt_cues = False
+    shared_engine.start_interview = AsyncMock(
+        side_effect=RuntimeError("forced stop after engine flag is observed")
+    )
+    shared_engine.resume_interview = AsyncMock()
+    shared_engine.score_interview = AsyncMock()
+
+    observed: dict[str, bool] = {}
+
+    original_start = shared_engine.start_interview
+
+    async def _capture_start(*args: Any, **kwargs: Any) -> Any:
+        observed["during_call"] = shared_engine.suppress_tool_use_prompt_cues
+        return await original_start(*args, **kwargs)
+
+    shared_engine.start_interview.side_effect = _capture_start  # type: ignore[assignment]
+
+    handler = InterviewHandler(
+        interview_engine=shared_engine,
+        event_store=MagicMock(),
+        llm_adapter=MagicMock(),
+        llm_backend="claude_code",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+        data_dir=tmp_path,
+        suppress_tool_use_prompt_cues=True,
+    )
+    handler._owns_event_store = False
+    handler._initialized = True
+
+    async def _run() -> None:
+        with patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=MagicMock(),
+        ):
+            try:
+                await handler.handle({"initial_context": "Test goal"})
+            except Exception:
+                pass
+
+    asyncio.run(_run())
+
+    assert observed.get("during_call") is True, (
+        "expected the auto path to set suppress_tool_use_prompt_cues=True for the call"
+    )
+    assert shared_engine.suppress_tool_use_prompt_cues is False, (
+        "expected the prior engine.suppress_tool_use_prompt_cues value to be restored"
+    )

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1413,86 +1413,17 @@ def test_auto_sub_interview_isolates_parent_hook_context(
     assert options_call_kwargs["extra_args"]["allowedTools"] == ""
 
 
-def test_auto_handler_does_not_leak_suppress_flag_into_shared_engine(
+
+def test_handle_does_not_mutate_shared_interview_engine(
     tmp_path: Path,
 ) -> None:
-    """A shared ``InterviewEngine`` must keep its prior suppress-cues policy.
+    """A shared ``InterviewEngine`` must not be mutated by ``handle()``.
 
-    Regression for PR #979 review comment: if an auto-path
-    ``InterviewHandler`` mutates ``engine.suppress_tool_use_prompt_cues`` and
-    leaves it set, a later non-auto handler that reuses the same engine would
-    silently switch to the toolless prompt and lose the normal brownfield /
-    code-context instructions. The handler must restore the prior value once
-    its own request is finished.
-    """
-    from unittest.mock import AsyncMock
-
-    from ouroboros.bigbang.interview import InterviewEngine
-    from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
-
-    shared_engine = InterviewEngine.__new__(InterviewEngine)
-    shared_engine.suppress_tool_use_prompt_cues = False
-    shared_engine.start_interview = AsyncMock(
-        side_effect=RuntimeError("forced stop after engine flag is observed")
-    )
-    shared_engine.resume_interview = AsyncMock()
-    shared_engine.score_interview = AsyncMock()
-
-    observed: dict[str, bool] = {}
-
-    original_start = shared_engine.start_interview
-
-    async def _capture_start(*args: Any, **kwargs: Any) -> Any:
-        observed["during_call"] = shared_engine.suppress_tool_use_prompt_cues
-        return await original_start(*args, **kwargs)
-
-    shared_engine.start_interview.side_effect = _capture_start  # type: ignore[assignment]
-
-    handler = InterviewHandler(
-        interview_engine=shared_engine,
-        event_store=MagicMock(),
-        llm_adapter=MagicMock(),
-        llm_backend="claude_code",
-        agent_runtime_backend="claude_code",
-        opencode_mode=None,
-        data_dir=tmp_path,
-        suppress_tool_use_prompt_cues=True,
-    )
-    handler._owns_event_store = False
-    handler._initialized = True
-
-    async def _run() -> None:
-        with patch(
-            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
-            return_value=MagicMock(),
-        ):
-            try:
-                await handler.handle({"initial_context": "Test goal"})
-            except Exception:
-                pass
-
-    asyncio.run(_run())
-
-    assert observed.get("during_call") is True, (
-        "expected the auto path to set suppress_tool_use_prompt_cues=True for the call"
-    )
-    assert shared_engine.suppress_tool_use_prompt_cues is False, (
-        "expected the prior engine.suppress_tool_use_prompt_cues value to be restored"
-    )
-
-
-def test_auto_handler_swaps_shared_engine_adapter_to_isolated_one(
-    tmp_path: Path,
-) -> None:
-    """A shared ``InterviewEngine`` must use the isolated adapter for the call.
-
-    Regression for PR #979 review (commit cb2b7e7): if ``InterviewHandler``
-    only toggles ``engine.suppress_tool_use_prompt_cues`` but leaves the
-    engine's pre-existing ``llm_adapter`` in place, question generation goes
-    through the parent's tool-capable adapter and our envelope isolation is
-    bypassed in production. The handler must swap in the freshly-created
-    isolated adapter (``allowed_tools=[]``, ``strict_mcp_config=True``) for
-    the duration of its own call and restore the prior value afterwards.
+    Regression for PR #979 review (commit 0399211): the previous fix saved
+    and restored ``engine.llm_adapter`` and ``engine.suppress_tool_use_prompt_cues``
+    in-place, which is race-prone under concurrent MCP requests. The correct
+    behavior is to never touch the shared engine: build a per-call replica
+    that carries the isolated adapter and suppress flag.
     """
     from unittest.mock import AsyncMock, sentinel
 
@@ -1505,17 +1436,28 @@ def test_auto_handler_swaps_shared_engine_adapter_to_isolated_one(
     shared_engine = InterviewEngine.__new__(InterviewEngine)
     shared_engine.suppress_tool_use_prompt_cues = False
     shared_engine.llm_adapter = parent_adapter
+    shared_engine.state_dir = tmp_path
+    shared_engine.model = "shared-model"
 
-    observed: dict[str, Any] = {}
+    # The shared engine's start_interview must NEVER be called — the handler
+    # should build its own per-call engine instead.
+    shared_engine.start_interview = AsyncMock(
+        side_effect=AssertionError("shared engine.start_interview must not be called")
+    )
 
-    async def _capture_start(*args: Any, **kwargs: Any) -> Any:
-        observed["adapter_during_call"] = shared_engine.llm_adapter
-        observed["suppress_during_call"] = shared_engine.suppress_tool_use_prompt_cues
-        raise RuntimeError("forced stop after engine state is observed")
+    captured: dict[str, Any] = {}
 
-    shared_engine.start_interview = AsyncMock(side_effect=_capture_start)
-    shared_engine.resume_interview = AsyncMock()
-    shared_engine.score_interview = AsyncMock()
+    real_engine_init = InterviewEngine.__init__
+
+    def _capture_init(self, *args: Any, **kwargs: Any) -> None:
+        real_engine_init(self, *args, **kwargs)
+        captured["new_engine_adapter"] = self.llm_adapter
+        captured["new_engine_suppress"] = self.suppress_tool_use_prompt_cues
+
+        async def _stop(*a: Any, **kw: Any) -> Any:
+            raise RuntimeError("forced stop after engine construction is observed")
+
+        self.start_interview = _stop  # type: ignore[assignment]
 
     handler = InterviewHandler(
         interview_engine=shared_engine,
@@ -1531,25 +1473,123 @@ def test_auto_handler_swaps_shared_engine_adapter_to_isolated_one(
     handler._initialized = True
 
     async def _run() -> None:
-        with patch(
+        try:
+            await handler.handle({"initial_context": "Test goal"})
+        except Exception:
+            pass
+
+    with (
+        patch(
             "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
             return_value=isolated_adapter,
-        ):
-            try:
-                await handler.handle({"initial_context": "Test goal"})
-            except Exception:
-                pass
+        ),
+        patch.object(InterviewEngine, "__init__", _capture_init),
+    ):
+        asyncio.run(_run())
 
-    asyncio.run(_run())
-
-    assert observed.get("adapter_during_call") is isolated_adapter, (
-        "expected the auto path to swap engine.llm_adapter to the isolated adapter"
+    assert captured.get("new_engine_adapter") is isolated_adapter, (
+        "expected the per-call engine to be constructed with the isolated adapter"
     )
-    assert observed.get("suppress_during_call") is True
+    assert captured.get("new_engine_suppress") is True
     assert shared_engine.llm_adapter is parent_adapter, (
-        "expected the prior engine.llm_adapter to be restored after the call"
+        "shared engine.llm_adapter must not be mutated"
     )
-    assert shared_engine.suppress_tool_use_prompt_cues is False
+    assert shared_engine.suppress_tool_use_prompt_cues is False, (
+        "shared engine.suppress_tool_use_prompt_cues must not be mutated"
+    )
+
+
+def test_concurrent_handle_calls_do_not_corrupt_shared_engine(
+    tmp_path: Path,
+) -> None:
+    """Two concurrent ``handle()`` calls must not race on the shared engine.
+
+    Regression for PR #979 review (commit 0399211): under save/restore
+    mutation, two concurrent requests could clobber each other's adapter or
+    leave the shared engine permanently pointed at an isolated adapter. With
+    per-call cloning, the shared engine is never mutated, so the race
+    disappears by construction. This test asserts that even when many
+    concurrent handlers run, the shared engine's fields are pristine and each
+    handler saw its own isolated adapter.
+    """
+    from unittest.mock import AsyncMock, sentinel
+
+    from ouroboros.bigbang.interview import InterviewEngine
+    from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+    parent_adapter = sentinel.parent_adapter
+
+    shared_engine = InterviewEngine.__new__(InterviewEngine)
+    shared_engine.suppress_tool_use_prompt_cues = False
+    shared_engine.llm_adapter = parent_adapter
+    shared_engine.state_dir = tmp_path
+    shared_engine.model = "shared-model"
+    shared_engine.start_interview = AsyncMock(
+        side_effect=AssertionError("shared engine.start_interview must not be called")
+    )
+
+    seen_adapters: list[Any] = []
+    real_engine_init = InterviewEngine.__init__
+
+    def _capture_init(self, *args: Any, **kwargs: Any) -> None:
+        real_engine_init(self, *args, **kwargs)
+        seen_adapters.append(self.llm_adapter)
+
+        async def _stop(*a: Any, **kw: Any) -> Any:
+            await asyncio.sleep(0)
+            raise RuntimeError("forced stop after engine construction is observed")
+
+        self.start_interview = _stop  # type: ignore[assignment]
+
+    def _make_handler() -> InterviewHandler:
+        handler = InterviewHandler(
+            interview_engine=shared_engine,
+            event_store=MagicMock(),
+            llm_adapter=None,
+            llm_backend="claude_code",
+            agent_runtime_backend="claude_code",
+            opencode_mode=None,
+            data_dir=tmp_path,
+            suppress_tool_use_prompt_cues=True,
+        )
+        handler._owns_event_store = False
+        handler._initialized = True
+        return handler
+
+    async def _run_one(idx: int) -> None:
+        try:
+            await _make_handler().handle({"initial_context": f"goal-{idx}"})
+        except Exception:
+            pass
+
+    async def _run_all() -> None:
+        await asyncio.gather(*(_run_one(i) for i in range(8)))
+
+    isolated_adapters = [MagicMock(name=f"isolated-{i}") for i in range(8)]
+    adapter_iter = iter(isolated_adapters)
+    # Patch once outside the gather so concurrent tasks share a single patch
+    # lifetime — overlapping `with patch.object(InterviewEngine, "__init__")`
+    # contexts from inside each task would leak between gather members and
+    # into other tests.
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            side_effect=lambda *_a, **_kw: next(adapter_iter),
+        ),
+        patch.object(InterviewEngine, "__init__", _capture_init),
+    ):
+        asyncio.run(_run_all())
+
+    assert len(seen_adapters) == 8
+    assert all(a is not parent_adapter for a in seen_adapters), (
+        "every per-call engine must use its own isolated adapter, never the parent"
+    )
+    assert shared_engine.llm_adapter is parent_adapter, (
+        "shared engine.llm_adapter must remain untouched after concurrent calls"
+    )
+    assert shared_engine.suppress_tool_use_prompt_cues is False, (
+        "shared engine.suppress_tool_use_prompt_cues must remain untouched"
+    )
 
 
 def test_authoring_interview_handler_does_not_shortcut_when_backend_changes() -> None:

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -695,6 +695,63 @@ class TestJsonSchemaHandling:
         assert "Read" in options_call_kwargs["disallowed_tools"]
 
     @pytest.mark.asyncio
+    async def test_empty_allowed_tools_spy_fails_on_tool_use_block(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Spy regression: a no-tools request must fail on any ToolUseBlock.
+
+        The ``ooo auto`` sub-interview path runs with ``max_turns=1`` and
+        ``allowed_tools=[]``.  If Claude emits a tool block anyway, accepting a
+        later text result would hide the turn-stealing leak this path is meant
+        to prevent.
+        """
+        from ouroboros.providers import claude_code_adapter as adapter_mod
+
+        monkeypatch.setattr(
+            adapter_mod,
+            "_claude_options_field_names",
+            lambda: frozenset({"extra_args", "allowed_tools", "tools"}),
+        )
+
+        adapter = ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True)
+        config = CompletionConfig(model="claude-sonnet-4-6", max_turns=1)
+
+        class ToolUseBlock:
+            name = "Read"
+            input = {"file_path": "README.md"}
+
+        class AssistantMessage:
+            content = [ToolUseBlock()]
+
+        class ResultMessage:
+            structured_output = None
+            result = "What is the primary user goal?"
+            is_error = False
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            yield AssistantMessage()
+            yield ResultMessage()
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_err
+        assert result.error.details["error_type"] == "ToolUseBlockViolation"
+        assert result.error.details["tool_name"] == "Read"
+        assert result.error.details["allowed_tools"] == []
+        assert result.error.details["max_turns"] == 1
+
+    @pytest.mark.asyncio
     async def test_explicit_allowed_tools_sets_visible_sdk_tools(self) -> None:
         """Explicit tool envelopes restrict both permissions and exposed SDK tools."""
         allowed_tools = ["Read", "Grep", "mcp__ouroboros__qa"]


### PR DESCRIPTION
## Summary

`ooo auto` sub-interview still crashed with `Reached maximum number of turns (1)` after #869 / #974 because two new leak surfaces remained:

- `AutoHandler._authoring_interview_handler` reused the **parent's tool-capable `llm_adapter`** when constructing the nested `InterviewHandler` — the envelope patches from #869/#974 never reached this code path.
- The `socratic-interviewer` agent role and the `_build_perspective_panel_prompt` strategies contained **code-exploration / file-reading cues** that induced a `ToolUseBlock` under `max_turns=1`, consuming the only allowed turn before any text could be emitted.

## Root cause closure

Four surfaces closed with one isolation contract:

1. **Adapter inheritance** — `auto_handler._authoring_interview_handler` now forces `llm_adapter=None` and propagates `suppress_tool_use_prompt_cues=True` on every reuse path so the nested interview never inherits a tool-armed adapter from the auto driver.
2. **Authoring handler plumbing** — `InterviewHandler` accepts and forwards the suppress flag into `InterviewEngine`.
3. **Prompt cues** — `bigbang/interview.py` introduces `_TOOLLESS_INTERVIEW_BASE_PROMPT` and rewrites the answer-prefix, brownfield, and perspective-panel sections to drop file-reading / tool-use language when suppressed.
4. **Contract enforcement** — `claude_code_adapter` returns a `ToolUseBlockViolation` `ProviderError` when the SDK still emits a `ToolUseBlock` under `allowed_tools=[]`, so spy-style regression tests fail closed.

Out of scope (tracked separately): the `_ISOLATION_OVERRIDES (\"agents\", [])` SDK type mismatch, replacing the CLI completion path, and extending the same spy coverage to the standalone `ouroboros_interview` path.

## Test plan

- [x] `uv run pytest -q tests/unit/mcp/tools/test_auto_interview_construction.py` — **11 passed** (new, 1416 lines; entrypoint manifest, envelope isolation per surface — `allowed_tools/disallowed_tools/setting_sources/skills/agents/plugins/hooks`, prompt-content assertions, mocked auto flow returning plain-text question, spy adapter failing on any tool request)
- [x] `uv run pytest -q tests/unit/providers/test_claude_code_adapter.py` — **51 passed**
- [x] `uv run pytest -q tests/unit/bigbang/test_interview.py` — **66 passed** (standalone interview behavior unchanged)
- [x] `uv run pytest -q tests/unit/mcp/tools/ -k interview` — **104 passed**
- [x] `uv run mypy` on changed files — clean
- [x] **Live end-to-end**: `ooo auto` with `skip_run=true`, `max_interview_rounds=3` → 3 rounds completed, real Socratic question returned (\"Should acceptance be verified specifically as `ouroboros greet` exiting with code 0 …\"), `ambiguity_score=0.29`, **no `max_turns=1` exception, no empty responses**.

## Related

- #869 — original `ooo_interview` max_turns=1 exception
- #974 — closed the `allowed_tools=[]` SDK falsy-short-circuit leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)