### PR TITLE
feat(harness): add Run/Step/Artifact/Verdict projection records (#946 PR-1a)

### DIFF
--- a/src/ouroboros/harness/__init__.py
+++ b/src/ouroboros/harness/__init__.py
@@ -1,0 +1,30 @@
+"""Harness projection vocabulary for Ouroboros.
+
+This module hosts the public Run / Stage / Step / Artifact / Verdict
+projection vocabulary derived from the canonical event store. The records
+are read-models, not a replacement for the underlying ``EventStore``.
+
+See ``ouroboros.harness.projection`` for the schema.
+"""
+
+from ouroboros.harness.projection import (
+    ArtifactRecord,
+    RunRecord,
+    StageKind,
+    StageRecord,
+    StepKind,
+    StepRecord,
+    VerdictOutcome,
+    VerdictRecord,
+)
+
+__all__ = [
+    "ArtifactRecord",
+    "RunRecord",
+    "StageKind",
+    "StageRecord",
+    "StepKind",
+    "StepRecord",
+    "VerdictOutcome",
+    "VerdictRecord",
+]

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -51,27 +51,43 @@ from pydantic import (
 PROJECTION_SCHEMA_VERSION = 1
 """Initial schema version for the projection vocabulary."""
 
+ProjectionSchemaVersion = Literal[1]
+"""Supported projection schema version for v1 records."""
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers — immutable metadata + identifier hygiene
 # ---------------------------------------------------------------------------
 
 
-def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
-    """Normalize the incoming value into an immutable ``MappingProxyType``.
+def _freeze_value(value: Any) -> Any:
+    """Recursively copy common JSON-like containers into immutable views."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_freeze_value(item) for item in value)
+    return value
 
-    Accepts ``None``, plain mappings, and existing ``MappingProxyType``
-    views. Anything else is rejected so callers cannot smuggle mutable
-    state in through unexpected types. ``ValueError`` is raised on
-    non-mapping inputs so Pydantic surfaces it as a regular
-    ``ValidationError``.
-    """
+
+def _thaw_value(value: Any) -> Any:
+    """Convert immutable container views back to plain serializable containers."""
+    if isinstance(value, Mapping):
+        return {key: _thaw_value(item) for key, item in value.items()}
+    if isinstance(value, tuple | frozenset):
+        return [_thaw_value(item) for item in value]
+    return value
+
+
+def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
+    """Normalize incoming mapping-shaped input into a recursively frozen copy."""
     if value is None:
         return MappingProxyType({})
-    if isinstance(value, MappingProxyType):
-        return value
     if isinstance(value, Mapping):
-        return MappingProxyType(dict(value))
+        frozen = _freeze_value(value)
+        if isinstance(frozen, MappingProxyType):
+            return frozen
     msg = f"metadata must be a mapping, got {type(value).__name__}"
     raise ValueError(msg)
 
@@ -88,17 +104,11 @@ def _empty_frozen_metadata() -> Mapping[str, Any]:
 
 
 def _ensure_frozen_after(value: Any) -> Mapping[str, Any]:
-    """Final-stage wrapper that guarantees a ``MappingProxyType`` view.
-
-    Pydantic's built-in mapping handling may unwrap a ``MappingProxyType``
-    back into a plain dict between the ``BeforeValidator`` and the final
-    field value. This AfterValidator runs last so the stored attribute
-    is always a read-only view regardless of upstream coercion choices.
-    """
-    if isinstance(value, MappingProxyType):
-        return value
+    """Final-stage wrapper guaranteeing recursively immutable values."""
     if isinstance(value, Mapping):
-        return MappingProxyType(dict(value))
+        frozen = _freeze_value(value)
+        if isinstance(frozen, MappingProxyType):
+            return frozen
     msg = f"metadata must be a mapping, got {type(value).__name__}"
     raise ValueError(msg)
 
@@ -107,7 +117,7 @@ FrozenMetadata = Annotated[
     Mapping[str, Any],
     BeforeValidator(_coerce_to_mapping),
     AfterValidator(_ensure_frozen_after),
-    PlainSerializer(lambda value: dict(value), return_type=dict, when_used="always"),
+    PlainSerializer(lambda value: _thaw_value(value), return_type=dict, when_used="always"),
 ]
 """Metadata field type that blocks top-level dict mutation.
 
@@ -245,7 +255,7 @@ class ArtifactRecord(BaseModel, frozen=True):
             and additive; top-level mutation is blocked at runtime.
     """
 
-    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    schema_version: ProjectionSchemaVersion = PROJECTION_SCHEMA_VERSION
     artifact_id: Identifier = Field(default_factory=lambda: _new_id("artifact"))
     step_id: Identifier
     kind: str = Field(..., min_length=1)
@@ -300,7 +310,7 @@ class StepRecord(BaseModel, frozen=True):
             ``MappingProxyType`` view.
     """
 
-    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    schema_version: ProjectionSchemaVersion = PROJECTION_SCHEMA_VERSION
     step_id: Identifier = Field(default_factory=lambda: _new_id("step"))
     run_id: Identifier
     stage_id: Identifier
@@ -363,7 +373,7 @@ class StageRecord(BaseModel, frozen=True):
             ``MappingProxyType`` view.
     """
 
-    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    schema_version: ProjectionSchemaVersion = PROJECTION_SCHEMA_VERSION
     stage_id: Identifier = Field(default_factory=lambda: _new_id("stage"))
     run_id: Identifier
     kind: StageKind
@@ -406,7 +416,7 @@ class VerdictRecord(BaseModel, frozen=True):
             ``MappingProxyType`` view.
     """
 
-    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    schema_version: ProjectionSchemaVersion = PROJECTION_SCHEMA_VERSION
     verdict_id: Identifier = Field(default_factory=lambda: _new_id("verdict"))
     run_id: Identifier
     scope: Literal["run", "ac"]
@@ -461,7 +471,7 @@ class RunRecord(BaseModel, frozen=True):
             ``MappingProxyType`` view.
     """
 
-    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    schema_version: ProjectionSchemaVersion = PROJECTION_SCHEMA_VERSION
     run_id: Identifier = Field(default_factory=lambda: _new_id("run"))
     seed_id: Identifier
     goal: str = Field(default="")
@@ -495,6 +505,7 @@ __all__ = [
     "ArtifactRecord",
     "FrozenMetadata",
     "Identifier",
+    "ProjectionSchemaVersion",
     "IdentifierTuple",
     "RunRecord",
     "StageKind",

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -42,6 +42,7 @@ from pydantic import (
     AfterValidator,
     BaseModel,
     BeforeValidator,
+    ConfigDict,
     Field,
     PlainSerializer,
     field_validator,
@@ -222,12 +223,23 @@ class VerdictOutcome(StrEnum):
 # ---------------------------------------------------------------------------
 
 
+def _require_aware_datetime(field_name: str, value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None or value.utcoffset() is None:
+        msg = f"{field_name} must be timezone-aware"
+        raise ValueError(msg)
+    return value
+
+
 def _new_id(prefix: str) -> str:
     """Return a stable, prefixed identifier suitable for projection records."""
     return f"{prefix}_{uuid4().hex[:12]}"
 
 
 class ArtifactRecord(BaseModel, frozen=True):
+    model_config = ConfigDict(extra="forbid")
+
     """A produced artifact attached to a single step.
 
     Artifacts are owner-agnostic — plugins and core harness modules use the
@@ -277,6 +289,8 @@ class ArtifactRecord(BaseModel, frozen=True):
 
 
 class StepRecord(BaseModel, frozen=True):
+    model_config = ConfigDict(extra="forbid")
+
     """One bounded unit of work observed by the harness.
 
     A step is the projection equivalent of a single model call, tool call,
@@ -325,6 +339,11 @@ class StepRecord(BaseModel, frozen=True):
     artifact_ids: IdentifierTuple = Field(default_factory=tuple)
     metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
 
+    @field_validator("started_at", "ended_at")
+    @classmethod
+    def _timestamps_must_be_aware(cls, value: datetime | None, info: Any) -> datetime | None:
+        return _require_aware_datetime(info.field_name, value)
+
     @field_validator("ac_id")
     @classmethod
     def _ac_id_not_blank(cls, value: str | None) -> str | None:
@@ -354,6 +373,8 @@ class StepRecord(BaseModel, frozen=True):
 
 
 class StageRecord(BaseModel, frozen=True):
+    model_config = ConfigDict(extra="forbid")
+
     """A named harness phase that groups related step records.
 
     Stages mirror the user-visible workflow phases (``interview``,
@@ -382,6 +403,11 @@ class StageRecord(BaseModel, frozen=True):
     step_ids: IdentifierTuple = Field(default_factory=tuple)
     metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
 
+    @field_validator("started_at", "ended_at")
+    @classmethod
+    def _timestamps_must_be_aware(cls, value: datetime | None, info: Any) -> datetime | None:
+        return _require_aware_datetime(info.field_name, value)
+
     @model_validator(mode="after")
     def _validate_timestamps(self) -> StageRecord:
         if self.ended_at is not None and self.ended_at < self.started_at:
@@ -391,6 +417,8 @@ class StageRecord(BaseModel, frozen=True):
 
 
 class VerdictRecord(BaseModel, frozen=True):
+    model_config = ConfigDict(extra="forbid")
+
     """Run- or AC-level verdict with explicit evidence links.
 
     Verdicts are the harness-owned terminal judgment over either an entire
@@ -428,6 +456,13 @@ class VerdictRecord(BaseModel, frozen=True):
     recorded_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
 
+    @field_validator("recorded_at")
+    @classmethod
+    def _recorded_at_must_be_aware(cls, value: datetime | None, info: Any) -> datetime | None:
+        checked = _require_aware_datetime(info.field_name, value)
+        assert checked is not None
+        return checked
+
     @field_validator("ac_id")
     @classmethod
     def _ac_id_not_blank(cls, value: str | None) -> str | None:
@@ -451,6 +486,8 @@ class VerdictRecord(BaseModel, frozen=True):
 
 
 class RunRecord(BaseModel, frozen=True):
+    model_config = ConfigDict(extra="forbid")
+
     """A single user-goal / Seed execution envelope.
 
     A run is the top-level projection unit. It carries the goal, the seed
@@ -480,6 +517,11 @@ class RunRecord(BaseModel, frozen=True):
     stage_ids: IdentifierTuple = Field(default_factory=tuple)
     verdict_id: Identifier | None = Field(default=None)
     metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
+
+    @field_validator("started_at", "ended_at")
+    @classmethod
+    def _timestamps_must_be_aware(cls, value: datetime | None, info: Any) -> datetime | None:
+        return _require_aware_datetime(info.field_name, value)
 
     @field_validator("verdict_id")
     @classmethod

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -1,0 +1,334 @@
+"""Run / Stage / Step / Artifact / Verdict projection records.
+
+These records are the public, schema-versioned read-model that the Ouroboros
+harness presents over the underlying ``EventStore``. They give plugins,
+maintainers, evaluation pipelines, and CLI consumers a stable vocabulary
+for describing the work a run performed without each consumer reinventing
+its own status format.
+
+Design constraints (per the acceptance criteria attached to issue #946):
+
+* Records are immutable Pydantic models (``frozen=True``) so they can be
+  treated as values in projections, comparisons, and persistence layers.
+* Every ``StepRecord`` either links to one or more source event IDs via
+  :attr:`StepRecord.source_event_ids`, or explicitly marks itself as legacy
+  or inferred via :attr:`StepRecord.legacy_inferred`. Projections that
+  cannot honor this invariant should refuse to construct the record.
+* ``ArtifactRecord`` exposes a small, owner-agnostic shape so plugins can
+  attach output to steps without inventing plugin-local schemas.
+* Each record carries a ``schema_version``; v1 is the initial release and
+  future additive fields bump the version.
+
+This module intentionally contains *only* the record schema and a small
+set of factory helpers. The projection builder that walks ``EventStore``
+events into these records is delivered in a follow-up PR so this surface
+can be reviewed independently of any wiring.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+PROJECTION_SCHEMA_VERSION = 1
+"""Initial schema version for the projection vocabulary."""
+
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class StageKind(StrEnum):
+    """Named harness phases that group ``StepRecord`` entries.
+
+    Values match the public surface names users see in CLI output and
+    documentation. Additional kinds are added as additive entries; old
+    values are retained for replay compatibility.
+    """
+
+    INTERVIEW = "interview"
+    SEED = "seed"
+    EXECUTE = "execute"
+    EVALUATE = "evaluate"
+    EVOLVE = "evolve"
+    PLUGIN = "plugin"
+    HITL = "hitl"
+
+
+class StepKind(StrEnum):
+    """Bounded unit-of-work classifications for ``StepRecord``."""
+
+    MODEL_CALL = "model_call"
+    TOOL_CALL = "tool_call"
+    SHELL_COMMAND = "shell_command"
+    SUBAGENT_DISPATCH = "subagent_dispatch"
+    PLUGIN_COMMAND = "plugin_command"
+    EVALUATION_CHECK = "evaluation_check"
+    EVIDENCE_SUBMISSION = "evidence_submission"
+    HARNESS_INTERNAL = "harness_internal"
+
+
+class VerdictOutcome(StrEnum):
+    """Terminal status of a verdict record."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    ESCALATE_HUMAN = "escalate_human"
+    CANCELLED = "cancelled"
+    UNKNOWN = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Record models
+# ---------------------------------------------------------------------------
+
+
+def _new_id(prefix: str) -> str:
+    """Return a stable, prefixed identifier suitable for projection records."""
+    return f"{prefix}_{uuid4().hex[:12]}"
+
+
+class ArtifactRecord(BaseModel, frozen=True):
+    """A produced artifact attached to a single step.
+
+    Artifacts are owner-agnostic — plugins and core harness modules use the
+    same shape. The ``kind`` discriminator allows downstream consumers to
+    filter without inspecting opaque payloads.
+
+    Attributes:
+        artifact_id: Stable identifier for cross-record references.
+        step_id: Identifier of the producing :class:`StepRecord`.
+        kind: Short discriminator such as ``"file"``, ``"patch"``,
+            ``"verdict"``, ``"evidence"``, ``"log_excerpt"``, ``"capsule"``.
+            The set is intentionally open so plugins can register new kinds
+            in a later PR; the harness only enforces that the value is a
+            non-empty string.
+        path: Optional filesystem path or URI when the artifact lives on
+            disk or in remote storage.
+        media_type: Optional IANA media type (for example
+            ``"application/json"`` or ``"text/markdown"``).
+        size_bytes: Optional payload size for storage-aware consumers.
+        digest: Optional content digest (``algorithm:hex``) so artifacts
+            can be addressed without holding their payload in memory.
+        summary: Short, human-readable description suitable for CLI output.
+        metadata: Free-form metadata bag; consumers must treat it as
+            opaque and additive.
+    """
+
+    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    artifact_id: str = Field(default_factory=lambda: _new_id("artifact"), min_length=1)
+    step_id: str = Field(..., min_length=1)
+    kind: str = Field(..., min_length=1)
+    path: str | None = Field(default=None)
+    media_type: str | None = Field(default=None)
+    size_bytes: int | None = Field(default=None, ge=0)
+    digest: str | None = Field(default=None)
+    summary: str = Field(default="")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("kind")
+    @classmethod
+    def _kind_must_be_non_blank(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            msg = "ArtifactRecord.kind must be a non-empty string"
+            raise ValueError(msg)
+        return normalized
+
+
+class StepRecord(BaseModel, frozen=True):
+    """One bounded unit of work observed by the harness.
+
+    A step is the projection equivalent of a single model call, tool call,
+    shell command, plugin dispatch, or harness-internal action. It is the
+    smallest publicly addressable unit of work in a run.
+
+    Attributes:
+        step_id: Stable identifier for cross-record references.
+        run_id: Identifier of the owning :class:`RunRecord`.
+        stage_id: Identifier of the owning :class:`StageRecord`.
+        kind: Discriminator from :class:`StepKind`.
+        name: Short human-readable label such as the tool name, command
+            name, or plugin command.
+        ac_id: Optional acceptance-criterion identifier when the step is
+            executed inside an AC context.
+        started_at: When the unit of work began.
+        ended_at: When the unit of work finished (``None`` while running).
+        ok: Optional success indicator. ``True`` indicates success,
+            ``False`` indicates failure, ``None`` means undetermined.
+        source_event_ids: Identifiers of the source events that produced
+            this projection. Empty only when ``legacy_inferred`` is True.
+        legacy_inferred: Marks the record as projected from legacy data
+            that did not preserve enough metadata to link source events.
+            Consumers may filter on this flag when computing audit views.
+        artifact_ids: Identifiers of artifacts produced by the step. Each
+            value must match a :attr:`ArtifactRecord.artifact_id`.
+        metadata: Free-form metadata bag for additive consumer data.
+    """
+
+    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    step_id: str = Field(default_factory=lambda: _new_id("step"), min_length=1)
+    run_id: str = Field(..., min_length=1)
+    stage_id: str = Field(..., min_length=1)
+    kind: StepKind
+    name: str = Field(default="", description="Short human-readable label")
+    ac_id: str | None = Field(default=None)
+    started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    ended_at: datetime | None = Field(default=None)
+    ok: bool | None = Field(default=None)
+    source_event_ids: tuple[str, ...] = Field(default_factory=tuple)
+    legacy_inferred: bool = Field(default=False)
+    artifact_ids: tuple[str, ...] = Field(default_factory=tuple)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _enforce_source_event_invariant(self) -> StepRecord:
+        if not self.source_event_ids and not self.legacy_inferred:
+            msg = (
+                "StepRecord must link source_event_ids or set legacy_inferred=True; "
+                "see #946 acceptance criterion #3."
+            )
+            raise ValueError(msg)
+        if self.ended_at is not None and self.ended_at < self.started_at:
+            msg = "StepRecord.ended_at cannot precede started_at"
+            raise ValueError(msg)
+        return self
+
+
+class StageRecord(BaseModel, frozen=True):
+    """A named harness phase that groups related step records.
+
+    Stages mirror the user-visible workflow phases (``interview``,
+    ``seed``, ``execute``, ``evaluate``, ``evolve``, ``plugin``,
+    ``hitl``). They allow CLI and inspection tooling to summarize work at
+    a level coarser than individual steps but finer than an entire run.
+
+    Attributes:
+        stage_id: Stable identifier for cross-record references.
+        run_id: Identifier of the owning :class:`RunRecord`.
+        kind: Phase discriminator from :class:`StageKind`.
+        started_at: When the stage entered.
+        ended_at: When the stage exited (``None`` while active).
+        step_ids: Step identifiers contained in this stage, in execution
+            order.
+        metadata: Free-form metadata bag for additive consumer data.
+    """
+
+    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    stage_id: str = Field(default_factory=lambda: _new_id("stage"), min_length=1)
+    run_id: str = Field(..., min_length=1)
+    kind: StageKind
+    started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    ended_at: datetime | None = Field(default=None)
+    step_ids: tuple[str, ...] = Field(default_factory=tuple)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_timestamps(self) -> StageRecord:
+        if self.ended_at is not None and self.ended_at < self.started_at:
+            msg = "StageRecord.ended_at cannot precede started_at"
+            raise ValueError(msg)
+        return self
+
+
+class VerdictRecord(BaseModel, frozen=True):
+    """Run- or AC-level verdict with explicit evidence links.
+
+    Verdicts are the harness-owned terminal judgment over either an entire
+    run or an individual acceptance criterion. They reference the source
+    events and artifacts that justified the outcome so consumers do not
+    have to mine raw logs to defend the decision later.
+
+    Attributes:
+        verdict_id: Stable identifier.
+        run_id: Identifier of the owning :class:`RunRecord`.
+        scope: ``"run"`` for run-level verdicts, ``"ac"`` for per-AC.
+        ac_id: Acceptance-criterion identifier when ``scope == "ac"``;
+            must be ``None`` otherwise.
+        outcome: Terminal status from :class:`VerdictOutcome`.
+        rationale: Short structured rationale string. Consumers should
+            treat it as a stable summary, not as the full evidence body.
+        evidence_event_ids: Identifiers of source events backing this
+            verdict.
+        evidence_artifact_ids: Identifiers of artifacts backing this
+            verdict.
+        recorded_at: When the verdict was recorded.
+        metadata: Free-form metadata bag for additive consumer data.
+    """
+
+    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    verdict_id: str = Field(default_factory=lambda: _new_id("verdict"), min_length=1)
+    run_id: str = Field(..., min_length=1)
+    scope: Literal["run", "ac"]
+    ac_id: str | None = Field(default=None)
+    outcome: VerdictOutcome
+    rationale: str = Field(default="")
+    evidence_event_ids: tuple[str, ...] = Field(default_factory=tuple)
+    evidence_artifact_ids: tuple[str, ...] = Field(default_factory=tuple)
+    recorded_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_scope_and_ac(self) -> VerdictRecord:
+        if self.scope == "ac" and not self.ac_id:
+            msg = "VerdictRecord with scope='ac' must include ac_id"
+            raise ValueError(msg)
+        if self.scope == "run" and self.ac_id is not None:
+            msg = "VerdictRecord with scope='run' must not include ac_id"
+            raise ValueError(msg)
+        return self
+
+
+class RunRecord(BaseModel, frozen=True):
+    """A single user-goal / Seed execution envelope.
+
+    A run is the top-level projection unit. It carries the goal, the seed
+    identifier, the stage sequence, and the run-level verdict (when
+    available).
+
+    Attributes:
+        run_id: Stable identifier for the run.
+        seed_id: Identifier of the seed that drove the run.
+        goal: Human-readable goal text.
+        started_at: When the run began.
+        ended_at: When the run finished (``None`` while still active).
+        stage_ids: Stage identifiers in execution order.
+        verdict_id: Optional identifier of the run-level
+            :class:`VerdictRecord`.
+        metadata: Free-form metadata bag for additive consumer data.
+    """
+
+    schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
+    run_id: str = Field(default_factory=lambda: _new_id("run"), min_length=1)
+    seed_id: str = Field(..., min_length=1)
+    goal: str = Field(default="")
+    started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    ended_at: datetime | None = Field(default=None)
+    stage_ids: tuple[str, ...] = Field(default_factory=tuple)
+    verdict_id: str | None = Field(default=None)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_timestamps(self) -> RunRecord:
+        if self.ended_at is not None and self.ended_at < self.started_at:
+            msg = "RunRecord.ended_at cannot precede started_at"
+            raise ValueError(msg)
+        return self
+
+
+__all__ = [
+    "PROJECTION_SCHEMA_VERSION",
+    "ArtifactRecord",
+    "RunRecord",
+    "StageKind",
+    "StageRecord",
+    "StepKind",
+    "StepRecord",
+    "VerdictOutcome",
+    "VerdictRecord",
+]

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -129,10 +129,7 @@ def _normalize_id_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
     normalized: list[str] = []
     for index, value in enumerate(values):
         if not isinstance(value, str):
-            msg = (
-                f"identifier at index {index} must be a string; "
-                f"got {type(value).__name__}"
-            )
+            msg = f"identifier at index {index} must be a string; got {type(value).__name__}"
             raise TypeError(msg)
         stripped = value.strip()
         if not stripped:
@@ -412,9 +409,7 @@ class VerdictRecord(BaseModel, frozen=True):
             return None
         stripped = value.strip()
         if not stripped:
-            msg = (
-                "VerdictRecord.ac_id must be None or a non-blank identifier"
-            )
+            msg = "VerdictRecord.ac_id must be None or a non-blank identifier"
             raise ValueError(msg)
         return stripped
 

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -10,6 +10,10 @@ Design constraints (per the acceptance criteria attached to issue #946):
 
 * Records are immutable Pydantic models (``frozen=True``) so they can be
   treated as values in projections, comparisons, and persistence layers.
+  ``metadata`` mappings are wrapped in :class:`types.MappingProxyType`
+  views to block top-level ``record.metadata[key] = value`` mutation, and
+  tuple-of-identifier fields reject blank or whitespace-only entries so
+  cross-record references remain usable.
 * Every ``StepRecord`` either links to one or more source event IDs via
   :attr:`StepRecord.source_event_ids`, or explicitly marks itself as legacy
   or inferred via :attr:`StepRecord.legacy_inferred`. Projections that
@@ -27,15 +31,122 @@ can be reviewed independently of any wiring.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any, Literal
+from types import MappingProxyType
+from typing import Annotated, Any, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    field_validator,
+    model_validator,
+)
 
 PROJECTION_SCHEMA_VERSION = 1
 """Initial schema version for the projection vocabulary."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — immutable metadata + identifier hygiene
+# ---------------------------------------------------------------------------
+
+
+def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
+    """Normalize the incoming value into an immutable ``MappingProxyType``.
+
+    Accepts ``None``, plain mappings, and existing ``MappingProxyType``
+    views. Anything else is rejected so callers cannot smuggle mutable
+    state in through unexpected types. ``ValueError`` is raised on
+    non-mapping inputs so Pydantic surfaces it as a regular
+    ``ValidationError``.
+    """
+    if value is None:
+        return MappingProxyType({})
+    if isinstance(value, MappingProxyType):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(dict(value))
+    msg = f"metadata must be a mapping, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
+def _empty_frozen_metadata() -> Mapping[str, Any]:
+    """Default factory that returns an empty read-only mapping.
+
+    Returning a ``MappingProxyType`` directly avoids relying on Pydantic
+    running validators against default values; the runtime invariant
+    that ``record.metadata`` is read-only must hold even when no
+    metadata was supplied at construction time.
+    """
+    return MappingProxyType({})
+
+
+def _ensure_frozen_after(value: Any) -> Mapping[str, Any]:
+    """Final-stage wrapper that guarantees a ``MappingProxyType`` view.
+
+    Pydantic's built-in mapping handling may unwrap a ``MappingProxyType``
+    back into a plain dict between the ``BeforeValidator`` and the final
+    field value. This AfterValidator runs last so the stored attribute
+    is always a read-only view regardless of upstream coercion choices.
+    """
+    if isinstance(value, MappingProxyType):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(dict(value))
+    msg = f"metadata must be a mapping, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
+FrozenMetadata = Annotated[
+    Mapping[str, Any],
+    BeforeValidator(_coerce_to_mapping),
+    AfterValidator(_ensure_frozen_after),
+    PlainSerializer(lambda value: dict(value), return_type=dict, when_used="always"),
+]
+"""Metadata field type that blocks top-level dict mutation.
+
+Once a record is constructed the resulting ``Mapping`` is a
+``MappingProxyType`` view, so ``record.metadata[key] = value`` raises
+``TypeError`` at runtime. Serializers convert the view back to a plain
+``dict`` for JSON output.
+"""
+
+
+def _normalize_id_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+    """Reject empty or whitespace-only identifiers inside a tuple field.
+
+    Trims each entry so consumers can rely on the stored value matching
+    the canonical id format used elsewhere in the projection vocabulary.
+    Raises ``TypeError`` on non-string entries and ``ValueError`` on
+    blank or whitespace-only entries.
+    """
+    normalized: list[str] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str):
+            msg = (
+                f"identifier at index {index} must be a string; "
+                f"got {type(value).__name__}"
+            )
+            raise TypeError(msg)
+        stripped = value.strip()
+        if not stripped:
+            msg = (
+                f"identifier at index {index} is empty or whitespace-only; "
+                "projections require usable IDs for cross-record references"
+            )
+            raise ValueError(msg)
+        normalized.append(stripped)
+    return tuple(normalized)
+
+
+IdentifierTuple = Annotated[tuple[str, ...], AfterValidator(_normalize_id_tuple)]
+"""Tuple-of-identifier field type that rejects blank or whitespace entries."""
 
 
 # ---------------------------------------------------------------------------
@@ -116,8 +227,9 @@ class ArtifactRecord(BaseModel, frozen=True):
         digest: Optional content digest (``algorithm:hex``) so artifacts
             can be addressed without holding their payload in memory.
         summary: Short, human-readable description suitable for CLI output.
-        metadata: Free-form metadata bag; consumers must treat it as
-            opaque and additive.
+        metadata: Free-form metadata bag, stored as a read-only
+            ``MappingProxyType`` view. Consumers must treat it as opaque
+            and additive; top-level mutation is blocked at runtime.
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
@@ -129,7 +241,7 @@ class ArtifactRecord(BaseModel, frozen=True):
     size_bytes: int | None = Field(default=None, ge=0)
     digest: str | None = Field(default=None)
     summary: str = Field(default="")
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
 
     @field_validator("kind")
     @classmethod
@@ -162,13 +274,17 @@ class StepRecord(BaseModel, frozen=True):
         ok: Optional success indicator. ``True`` indicates success,
             ``False`` indicates failure, ``None`` means undetermined.
         source_event_ids: Identifiers of the source events that produced
-            this projection. Empty only when ``legacy_inferred`` is True.
+            this projection. Empty only when ``legacy_inferred`` is True;
+            blank or whitespace entries are rejected so projection
+            consumers can rely on every entry being a usable id.
         legacy_inferred: Marks the record as projected from legacy data
             that did not preserve enough metadata to link source events.
             Consumers may filter on this flag when computing audit views.
         artifact_ids: Identifiers of artifacts produced by the step. Each
-            value must match a :attr:`ArtifactRecord.artifact_id`.
-        metadata: Free-form metadata bag for additive consumer data.
+            value must match a :attr:`ArtifactRecord.artifact_id`; blank
+            entries are rejected.
+        metadata: Free-form metadata bag, stored as a read-only
+            ``MappingProxyType`` view.
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
@@ -181,10 +297,24 @@ class StepRecord(BaseModel, frozen=True):
     started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     ended_at: datetime | None = Field(default=None)
     ok: bool | None = Field(default=None)
-    source_event_ids: tuple[str, ...] = Field(default_factory=tuple)
+    source_event_ids: IdentifierTuple = Field(default_factory=tuple)
     legacy_inferred: bool = Field(default=False)
-    artifact_ids: tuple[str, ...] = Field(default_factory=tuple)
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    artifact_ids: IdentifierTuple = Field(default_factory=tuple)
+    metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
+
+    @field_validator("ac_id")
+    @classmethod
+    def _ac_id_not_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            msg = (
+                "StepRecord.ac_id must be None or a non-blank identifier; "
+                "blank strings break cross-record references"
+            )
+            raise ValueError(msg)
+        return stripped
 
     @model_validator(mode="after")
     def _enforce_source_event_invariant(self) -> StepRecord:
@@ -215,8 +345,9 @@ class StageRecord(BaseModel, frozen=True):
         started_at: When the stage entered.
         ended_at: When the stage exited (``None`` while active).
         step_ids: Step identifiers contained in this stage, in execution
-            order.
-        metadata: Free-form metadata bag for additive consumer data.
+            order. Blank entries are rejected.
+        metadata: Free-form metadata bag, stored as a read-only
+            ``MappingProxyType`` view.
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
@@ -225,8 +356,8 @@ class StageRecord(BaseModel, frozen=True):
     kind: StageKind
     started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     ended_at: datetime | None = Field(default=None)
-    step_ids: tuple[str, ...] = Field(default_factory=tuple)
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    step_ids: IdentifierTuple = Field(default_factory=tuple)
+    metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
 
     @model_validator(mode="after")
     def _validate_timestamps(self) -> StageRecord:
@@ -249,16 +380,17 @@ class VerdictRecord(BaseModel, frozen=True):
         run_id: Identifier of the owning :class:`RunRecord`.
         scope: ``"run"`` for run-level verdicts, ``"ac"`` for per-AC.
         ac_id: Acceptance-criterion identifier when ``scope == "ac"``;
-            must be ``None`` otherwise.
+            must be ``None`` otherwise. Blank strings are rejected.
         outcome: Terminal status from :class:`VerdictOutcome`.
         rationale: Short structured rationale string. Consumers should
             treat it as a stable summary, not as the full evidence body.
         evidence_event_ids: Identifiers of source events backing this
-            verdict.
+            verdict. Blank entries are rejected.
         evidence_artifact_ids: Identifiers of artifacts backing this
-            verdict.
+            verdict. Blank entries are rejected.
         recorded_at: When the verdict was recorded.
-        metadata: Free-form metadata bag for additive consumer data.
+        metadata: Free-form metadata bag, stored as a read-only
+            ``MappingProxyType`` view.
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
@@ -268,10 +400,23 @@ class VerdictRecord(BaseModel, frozen=True):
     ac_id: str | None = Field(default=None)
     outcome: VerdictOutcome
     rationale: str = Field(default="")
-    evidence_event_ids: tuple[str, ...] = Field(default_factory=tuple)
-    evidence_artifact_ids: tuple[str, ...] = Field(default_factory=tuple)
+    evidence_event_ids: IdentifierTuple = Field(default_factory=tuple)
+    evidence_artifact_ids: IdentifierTuple = Field(default_factory=tuple)
     recorded_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
+
+    @field_validator("ac_id")
+    @classmethod
+    def _ac_id_not_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            msg = (
+                "VerdictRecord.ac_id must be None or a non-blank identifier"
+            )
+            raise ValueError(msg)
+        return stripped
 
     @model_validator(mode="after")
     def _validate_scope_and_ac(self) -> VerdictRecord:
@@ -297,10 +442,12 @@ class RunRecord(BaseModel, frozen=True):
         goal: Human-readable goal text.
         started_at: When the run began.
         ended_at: When the run finished (``None`` while still active).
-        stage_ids: Stage identifiers in execution order.
+        stage_ids: Stage identifiers in execution order. Blank entries
+            are rejected.
         verdict_id: Optional identifier of the run-level
             :class:`VerdictRecord`.
-        metadata: Free-form metadata bag for additive consumer data.
+        metadata: Free-form metadata bag, stored as a read-only
+            ``MappingProxyType`` view.
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
@@ -309,9 +456,20 @@ class RunRecord(BaseModel, frozen=True):
     goal: str = Field(default="")
     started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     ended_at: datetime | None = Field(default=None)
-    stage_ids: tuple[str, ...] = Field(default_factory=tuple)
+    stage_ids: IdentifierTuple = Field(default_factory=tuple)
     verdict_id: str | None = Field(default=None)
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
+
+    @field_validator("verdict_id")
+    @classmethod
+    def _verdict_id_not_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            msg = "RunRecord.verdict_id must be None or a non-blank identifier"
+            raise ValueError(msg)
+        return stripped
 
     @model_validator(mode="after")
     def _validate_timestamps(self) -> RunRecord:
@@ -324,6 +482,8 @@ class RunRecord(BaseModel, frozen=True):
 __all__ = [
     "PROJECTION_SCHEMA_VERSION",
     "ArtifactRecord",
+    "FrozenMetadata",
+    "IdentifierTuple",
     "RunRecord",
     "StageKind",
     "StageRecord",

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -146,6 +146,22 @@ IdentifierTuple = Annotated[tuple[str, ...], AfterValidator(_normalize_id_tuple)
 """Tuple-of-identifier field type that rejects blank or whitespace entries."""
 
 
+def _normalize_identifier(value: str) -> str:
+    """Trim and reject blank scalar identifiers used for cross-record links."""
+    if not isinstance(value, str):
+        msg = f"identifier must be a string; got {type(value).__name__}"
+        raise TypeError(msg)
+    stripped = value.strip()
+    if not stripped:
+        msg = "identifier is empty or whitespace-only; projections require usable IDs"
+        raise ValueError(msg)
+    return stripped
+
+
+Identifier = Annotated[str, AfterValidator(_normalize_identifier)]
+"""Scalar identifier type that trims whitespace and rejects blank values."""
+
+
 # ---------------------------------------------------------------------------
 # Enumerations
 # ---------------------------------------------------------------------------
@@ -230,8 +246,8 @@ class ArtifactRecord(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
-    artifact_id: str = Field(default_factory=lambda: _new_id("artifact"), min_length=1)
-    step_id: str = Field(..., min_length=1)
+    artifact_id: Identifier = Field(default_factory=lambda: _new_id("artifact"))
+    step_id: Identifier
     kind: str = Field(..., min_length=1)
     path: str | None = Field(default=None)
     media_type: str | None = Field(default=None)
@@ -285,12 +301,12 @@ class StepRecord(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
-    step_id: str = Field(default_factory=lambda: _new_id("step"), min_length=1)
-    run_id: str = Field(..., min_length=1)
-    stage_id: str = Field(..., min_length=1)
+    step_id: Identifier = Field(default_factory=lambda: _new_id("step"))
+    run_id: Identifier
+    stage_id: Identifier
     kind: StepKind
     name: str = Field(default="", description="Short human-readable label")
-    ac_id: str | None = Field(default=None)
+    ac_id: Identifier | None = Field(default=None)
     started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     ended_at: datetime | None = Field(default=None)
     ok: bool | None = Field(default=None)
@@ -348,8 +364,8 @@ class StageRecord(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
-    stage_id: str = Field(default_factory=lambda: _new_id("stage"), min_length=1)
-    run_id: str = Field(..., min_length=1)
+    stage_id: Identifier = Field(default_factory=lambda: _new_id("stage"))
+    run_id: Identifier
     kind: StageKind
     started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     ended_at: datetime | None = Field(default=None)
@@ -391,10 +407,10 @@ class VerdictRecord(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
-    verdict_id: str = Field(default_factory=lambda: _new_id("verdict"), min_length=1)
-    run_id: str = Field(..., min_length=1)
+    verdict_id: Identifier = Field(default_factory=lambda: _new_id("verdict"))
+    run_id: Identifier
     scope: Literal["run", "ac"]
-    ac_id: str | None = Field(default=None)
+    ac_id: Identifier | None = Field(default=None)
     outcome: VerdictOutcome
     rationale: str = Field(default="")
     evidence_event_ids: IdentifierTuple = Field(default_factory=tuple)
@@ -446,13 +462,13 @@ class RunRecord(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=PROJECTION_SCHEMA_VERSION, ge=1)
-    run_id: str = Field(default_factory=lambda: _new_id("run"), min_length=1)
-    seed_id: str = Field(..., min_length=1)
+    run_id: Identifier = Field(default_factory=lambda: _new_id("run"))
+    seed_id: Identifier
     goal: str = Field(default="")
     started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     ended_at: datetime | None = Field(default=None)
     stage_ids: IdentifierTuple = Field(default_factory=tuple)
-    verdict_id: str | None = Field(default=None)
+    verdict_id: Identifier | None = Field(default=None)
     metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
 
     @field_validator("verdict_id")
@@ -478,6 +494,7 @@ __all__ = [
     "PROJECTION_SCHEMA_VERSION",
     "ArtifactRecord",
     "FrozenMetadata",
+    "Identifier",
     "IdentifierTuple",
     "RunRecord",
     "StageKind",

--- a/tests/unit/harness/test_projection_records.py
+++ b/tests/unit/harness/test_projection_records.py
@@ -421,3 +421,82 @@ class TestIdentifierTupleRejectsBlanks:
                 source_event_ids=("evt_1",),
                 ac_id="   ",
             )
+
+
+class TestScalarIdentifiersRejectBlanks:
+    """Required scalar IDs must follow the same hygiene as identifier tuples."""
+
+    def test_artifact_record_rejects_blank_step_id(self) -> None:
+        with pytest.raises(ValidationError):
+            ArtifactRecord(step_id="   ", kind="file")
+
+    def test_artifact_record_rejects_blank_overridden_artifact_id(self) -> None:
+        with pytest.raises(ValidationError):
+            ArtifactRecord(artifact_id="   ", step_id="step_1", kind="file")
+
+    def test_step_record_rejects_blank_run_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(
+                run_id="   ",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("evt_1",),
+            )
+
+    def test_step_record_rejects_blank_stage_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(
+                run_id="run_1",
+                stage_id="   ",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("evt_1",),
+            )
+
+    def test_step_record_rejects_blank_overridden_step_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(
+                step_id="   ",
+                run_id="run_1",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("evt_1",),
+            )
+
+    def test_stage_record_rejects_blank_run_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StageRecord(run_id="   ", kind=StageKind.EXECUTE)
+
+    def test_stage_record_rejects_blank_overridden_stage_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StageRecord(stage_id="   ", run_id="run_1", kind=StageKind.EXECUTE)
+
+    def test_verdict_record_rejects_blank_run_id(self) -> None:
+        with pytest.raises(ValidationError):
+            VerdictRecord(run_id="   ", scope="run", outcome=VerdictOutcome.PASS)
+
+    def test_verdict_record_rejects_blank_overridden_verdict_id(self) -> None:
+        with pytest.raises(ValidationError):
+            VerdictRecord(
+                verdict_id="   ",
+                run_id="run_1",
+                scope="run",
+                outcome=VerdictOutcome.PASS,
+            )
+
+    def test_run_record_rejects_blank_seed_id(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord(seed_id="   ")
+
+    def test_run_record_rejects_blank_overridden_run_id(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord(run_id="   ", seed_id="seed_abc")
+
+    def test_scalar_identifiers_are_trimmed(self) -> None:
+        record = StepRecord(
+            run_id="  run_1  ",
+            stage_id="  stage_1  ",
+            kind=StepKind.TOOL_CALL,
+            source_event_ids=("evt_1",),
+        )
+        assert record.run_id == "run_1"
+        assert record.stage_id == "stage_1"

--- a/tests/unit/harness/test_projection_records.py
+++ b/tests/unit/harness/test_projection_records.py
@@ -527,3 +527,53 @@ class TestScalarIdentifiersRejectBlanks:
         )
         assert record.run_id == "run_1"
         assert record.stage_id == "stage_1"
+
+
+class TestProjectionRecordSchemaStrictness:
+    """Public projection records should reject malformed v1 payloads."""
+
+    def test_extra_fields_are_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord(seed_id="seed_abc", typo_field=True)  # type: ignore[call-arg]
+
+    def test_step_rejects_naive_started_at(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(
+                run_id="run_1",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("evt_1",),
+                started_at=datetime(2026, 1, 1),
+            )
+
+    def test_step_rejects_mixed_naive_ended_at_cleanly(self) -> None:
+        with pytest.raises(ValidationError, match="ended_at must be timezone-aware"):
+            StepRecord(
+                run_id="run_1",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("evt_1",),
+                started_at=datetime.now(UTC),
+                ended_at=datetime(2026, 1, 1),
+            )
+
+    def test_stage_rejects_naive_timestamp(self) -> None:
+        with pytest.raises(ValidationError):
+            StageRecord(
+                run_id="run_1",
+                kind=StageKind.EXECUTE,
+                started_at=datetime(2026, 1, 1),
+            )
+
+    def test_run_rejects_naive_timestamp(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord(seed_id="seed_abc", started_at=datetime(2026, 1, 1))
+
+    def test_verdict_rejects_naive_recorded_at(self) -> None:
+        with pytest.raises(ValidationError):
+            VerdictRecord(
+                run_id="run_1",
+                scope="run",
+                outcome=VerdictOutcome.PASS,
+                recorded_at=datetime(2026, 1, 1),
+            )

--- a/tests/unit/harness/test_projection_records.py
+++ b/tests/unit/harness/test_projection_records.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from types import MappingProxyType
+from typing import Any, cast
 
 from pydantic import ValidationError
 import pytest
@@ -57,6 +58,10 @@ class TestRunRecord:
     def test_default_schema_version(self) -> None:
         record = RunRecord(seed_id="seed_abc")
         assert record.schema_version == PROJECTION_SCHEMA_VERSION
+
+    def test_rejects_unsupported_schema_version(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord(seed_id="seed_abc", schema_version=2)
 
     def test_is_frozen(self) -> None:
         record = RunRecord(seed_id="seed_abc")
@@ -328,6 +333,28 @@ class TestMetadataIsRuntimeImmutable:
         dumped = record.model_dump()
         assert isinstance(dumped["metadata"], dict)
         assert dumped["metadata"] == {"k": "v", "n": 1}
+
+    def test_metadata_copies_existing_mapping_proxy(self) -> None:
+        backing = {"k": "v"}
+        record = RunRecord(seed_id="seed_abc", metadata=MappingProxyType(backing))
+
+        backing["k"] = "tampered"
+
+        assert record.metadata["k"] == "v"
+
+    def test_nested_metadata_is_copied_and_frozen(self) -> None:
+        backing: dict[str, Any] = {"nested": {"k": "v"}, "items": ["a"]}
+        record = RunRecord(seed_id="seed_abc", metadata=backing)
+
+        backing["nested"]["k"] = "tampered"
+        backing["items"].append("b")
+
+        nested = cast(dict[str, Any], record.metadata["nested"])
+        assert nested["k"] == "v"
+        with pytest.raises(TypeError):
+            nested["k"] = "tampered"
+        assert record.metadata["items"] == ("a",)
+        assert record.model_dump()["metadata"] == {"nested": {"k": "v"}, "items": ["a"]}
 
     def test_metadata_rejects_non_mapping_input(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit/harness/test_projection_records.py
+++ b/tests/unit/harness/test_projection_records.py
@@ -1,0 +1,267 @@
+"""Unit tests for the projection record vocabulary.
+
+Covers the contract from issue #946 PR-1a:
+
+* Record models are immutable (Pydantic ``frozen=True``).
+* ID factories produce prefixed identifiers.
+* ``StepRecord`` rejects empty ``source_event_ids`` unless
+  ``legacy_inferred`` is True.
+* ``VerdictRecord`` enforces the ``scope`` ↔ ``ac_id`` invariant.
+* Timestamp invariants reject ``ended_at < started_at``.
+* Schema-version field defaults to ``PROJECTION_SCHEMA_VERSION``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pydantic import ValidationError
+import pytest
+
+from ouroboros.harness.projection import (
+    PROJECTION_SCHEMA_VERSION,
+    ArtifactRecord,
+    RunRecord,
+    StageKind,
+    StageRecord,
+    StepKind,
+    StepRecord,
+    VerdictOutcome,
+    VerdictRecord,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class TestProjectionSchemaVersion:
+    """Sanity checks for the version constant exported by the module."""
+
+    def test_initial_version_is_one(self) -> None:
+        assert PROJECTION_SCHEMA_VERSION == 1
+
+
+class TestRunRecord:
+    """Tests for ``RunRecord``."""
+
+    def test_generates_prefixed_id(self) -> None:
+        record = RunRecord(seed_id="seed_abc")
+        assert record.run_id.startswith("run_")
+        assert len(record.run_id) > len("run_")
+
+    def test_default_schema_version(self) -> None:
+        record = RunRecord(seed_id="seed_abc")
+        assert record.schema_version == PROJECTION_SCHEMA_VERSION
+
+    def test_is_frozen(self) -> None:
+        record = RunRecord(seed_id="seed_abc")
+        with pytest.raises(ValidationError):
+            record.seed_id = "seed_other"  # type: ignore[misc]
+
+    def test_rejects_ended_before_started(self) -> None:
+        start = _now()
+        with pytest.raises(ValidationError):
+            RunRecord(
+                seed_id="seed_abc",
+                started_at=start,
+                ended_at=start - timedelta(seconds=1),
+            )
+
+    def test_seed_id_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord()  # type: ignore[call-arg]
+
+    def test_stage_ids_default_empty_tuple(self) -> None:
+        record = RunRecord(seed_id="seed_abc")
+        assert record.stage_ids == ()
+
+
+class TestStageRecord:
+    """Tests for ``StageRecord``."""
+
+    def test_generates_prefixed_id(self) -> None:
+        record = StageRecord(run_id="run_1", kind=StageKind.EXECUTE)
+        assert record.stage_id.startswith("stage_")
+
+    def test_kind_round_trips_through_enum(self) -> None:
+        record = StageRecord(run_id="run_1", kind="evaluate")  # type: ignore[arg-type]
+        assert record.kind is StageKind.EVALUATE
+
+    def test_step_ids_default_empty(self) -> None:
+        record = StageRecord(run_id="run_1", kind=StageKind.EXECUTE)
+        assert record.step_ids == ()
+
+    def test_rejects_ended_before_started(self) -> None:
+        start = _now()
+        with pytest.raises(ValidationError):
+            StageRecord(
+                run_id="run_1",
+                kind=StageKind.EXECUTE,
+                started_at=start,
+                ended_at=start - timedelta(seconds=1),
+            )
+
+
+class TestStepRecord:
+    """Tests for ``StepRecord`` including the source-event invariant."""
+
+    def test_requires_source_event_or_legacy_flag(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(run_id="run_1", stage_id="stage_1", kind=StepKind.TOOL_CALL)
+
+    def test_accepts_with_source_event_ids(self) -> None:
+        record = StepRecord(
+            run_id="run_1",
+            stage_id="stage_1",
+            kind=StepKind.TOOL_CALL,
+            source_event_ids=("evt_1",),
+        )
+        assert record.source_event_ids == ("evt_1",)
+        assert record.legacy_inferred is False
+
+    def test_accepts_when_legacy_inferred(self) -> None:
+        record = StepRecord(
+            run_id="run_1",
+            stage_id="stage_1",
+            kind=StepKind.SHELL_COMMAND,
+            legacy_inferred=True,
+        )
+        assert record.source_event_ids == ()
+        assert record.legacy_inferred is True
+
+    def test_rejects_ended_before_started(self) -> None:
+        start = _now()
+        with pytest.raises(ValidationError):
+            StepRecord(
+                run_id="run_1",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("evt_1",),
+                started_at=start,
+                ended_at=start - timedelta(seconds=1),
+            )
+
+    def test_is_frozen(self) -> None:
+        record = StepRecord(
+            run_id="run_1",
+            stage_id="stage_1",
+            kind=StepKind.TOOL_CALL,
+            source_event_ids=("evt_1",),
+        )
+        with pytest.raises(ValidationError):
+            record.ok = True  # type: ignore[misc]
+
+
+class TestArtifactRecord:
+    """Tests for ``ArtifactRecord``."""
+
+    def test_generates_prefixed_id(self) -> None:
+        record = ArtifactRecord(step_id="step_1", kind="file", path="/tmp/x.txt")
+        assert record.artifact_id.startswith("artifact_")
+
+    def test_kind_must_not_be_blank(self) -> None:
+        with pytest.raises(ValidationError):
+            ArtifactRecord(step_id="step_1", kind="   ", path="/tmp/x.txt")
+
+    def test_kind_is_stripped(self) -> None:
+        record = ArtifactRecord(step_id="step_1", kind="  patch  ")
+        assert record.kind == "patch"
+
+    def test_optional_fields_default_none(self) -> None:
+        record = ArtifactRecord(step_id="step_1", kind="file")
+        assert record.path is None
+        assert record.media_type is None
+        assert record.size_bytes is None
+        assert record.digest is None
+        assert record.summary == ""
+
+    def test_size_bytes_must_be_non_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            ArtifactRecord(step_id="step_1", kind="file", size_bytes=-1)
+
+
+class TestVerdictRecord:
+    """Tests for ``VerdictRecord`` scope invariants."""
+
+    def test_run_scope_rejects_ac_id(self) -> None:
+        with pytest.raises(ValidationError):
+            VerdictRecord(
+                run_id="run_1",
+                scope="run",
+                ac_id="ac_1",
+                outcome=VerdictOutcome.PASS,
+            )
+
+    def test_ac_scope_requires_ac_id(self) -> None:
+        with pytest.raises(ValidationError):
+            VerdictRecord(
+                run_id="run_1",
+                scope="ac",
+                outcome=VerdictOutcome.PASS,
+            )
+
+    def test_ac_scope_with_ac_id_accepted(self) -> None:
+        record = VerdictRecord(
+            run_id="run_1",
+            scope="ac",
+            ac_id="ac_1",
+            outcome=VerdictOutcome.PASS,
+            evidence_event_ids=("evt_1", "evt_2"),
+        )
+        assert record.scope == "ac"
+        assert record.outcome is VerdictOutcome.PASS
+        assert record.evidence_event_ids == ("evt_1", "evt_2")
+
+    def test_run_scope_without_ac_id_accepted(self) -> None:
+        record = VerdictRecord(
+            run_id="run_1",
+            scope="run",
+            outcome=VerdictOutcome.FAIL,
+        )
+        assert record.ac_id is None
+
+    def test_is_frozen(self) -> None:
+        record = VerdictRecord(
+            run_id="run_1",
+            scope="run",
+            outcome=VerdictOutcome.PASS,
+        )
+        with pytest.raises(ValidationError):
+            record.outcome = VerdictOutcome.FAIL  # type: ignore[misc]
+
+
+class TestEnumerations:
+    """Quick coverage to lock the publicly exported enum values."""
+
+    def test_stage_kind_values(self) -> None:
+        assert {kind.value for kind in StageKind} == {
+            "interview",
+            "seed",
+            "execute",
+            "evaluate",
+            "evolve",
+            "plugin",
+            "hitl",
+        }
+
+    def test_step_kind_values(self) -> None:
+        assert {kind.value for kind in StepKind} == {
+            "model_call",
+            "tool_call",
+            "shell_command",
+            "subagent_dispatch",
+            "plugin_command",
+            "evaluation_check",
+            "evidence_submission",
+            "harness_internal",
+        }
+
+    def test_verdict_outcome_values(self) -> None:
+        assert {outcome.value for outcome in VerdictOutcome} == {
+            "pass",
+            "fail",
+            "escalate_human",
+            "cancelled",
+            "unknown",
+        }

--- a/tests/unit/harness/test_projection_records.py
+++ b/tests/unit/harness/test_projection_records.py
@@ -9,11 +9,15 @@ Covers the contract from issue #946 PR-1a:
 * ``VerdictRecord`` enforces the ``scope`` ↔ ``ac_id`` invariant.
 * Timestamp invariants reject ``ended_at < started_at``.
 * Schema-version field defaults to ``PROJECTION_SCHEMA_VERSION``.
+* ``metadata`` is read-only at runtime (blocks
+  ``record.metadata[key] = value`` mutation).
+* Identifier-tuple fields reject blank or whitespace-only entries.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from types import MappingProxyType
 
 from pydantic import ValidationError
 import pytest
@@ -265,3 +269,155 @@ class TestEnumerations:
             "cancelled",
             "unknown",
         }
+
+
+class TestMetadataIsRuntimeImmutable:
+    """``metadata`` mapping fields must reject in-place mutation.
+
+    ``frozen=True`` only blocks attribute reassignment on the model
+    itself; we additionally wrap ``metadata`` in a ``MappingProxyType``
+    view so consumers cannot quietly poison cached projections through
+    ``record.metadata[key] = value``.
+    """
+
+    def test_run_record_metadata_is_mapping_proxy(self) -> None:
+        record = RunRecord(seed_id="seed_abc", metadata={"k": "v"})
+        assert isinstance(record.metadata, MappingProxyType)
+
+    def test_run_record_metadata_blocks_setitem(self) -> None:
+        record = RunRecord(seed_id="seed_abc", metadata={"k": "v"})
+        with pytest.raises(TypeError):
+            record.metadata["new"] = "value"  # type: ignore[index]
+
+    def test_run_record_metadata_blocks_pop(self) -> None:
+        record = RunRecord(seed_id="seed_abc", metadata={"k": "v"})
+        with pytest.raises((AttributeError, TypeError)):
+            record.metadata.pop("k")  # type: ignore[attr-defined]
+
+    def test_stage_record_metadata_blocks_setitem(self) -> None:
+        record = StageRecord(run_id="run_1", kind=StageKind.EXECUTE)
+        with pytest.raises(TypeError):
+            record.metadata["new"] = "value"  # type: ignore[index]
+
+    def test_step_record_metadata_blocks_setitem(self) -> None:
+        record = StepRecord(
+            run_id="run_1",
+            stage_id="stage_1",
+            kind=StepKind.TOOL_CALL,
+            source_event_ids=("evt_1",),
+        )
+        with pytest.raises(TypeError):
+            record.metadata["new"] = "value"  # type: ignore[index]
+
+    def test_artifact_record_metadata_blocks_setitem(self) -> None:
+        record = ArtifactRecord(step_id="step_1", kind="file")
+        with pytest.raises(TypeError):
+            record.metadata["new"] = "value"  # type: ignore[index]
+
+    def test_verdict_record_metadata_blocks_setitem(self) -> None:
+        record = VerdictRecord(
+            run_id="run_1",
+            scope="run",
+            outcome=VerdictOutcome.PASS,
+        )
+        with pytest.raises(TypeError):
+            record.metadata["new"] = "value"  # type: ignore[index]
+
+    def test_metadata_round_trips_through_model_dump(self) -> None:
+        record = RunRecord(seed_id="seed_abc", metadata={"k": "v", "n": 1})
+        dumped = record.model_dump()
+        assert isinstance(dumped["metadata"], dict)
+        assert dumped["metadata"] == {"k": "v", "n": 1}
+
+    def test_metadata_rejects_non_mapping_input(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord(seed_id="seed_abc", metadata=[("k", "v")])  # type: ignore[arg-type]
+
+
+class TestIdentifierTupleRejectsBlanks:
+    """Tuple-of-identifier fields must reject empty or whitespace-only
+    entries so cross-record references stay usable.
+    """
+
+    def test_step_record_rejects_blank_source_event_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(
+                run_id="run_1",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("   ",),
+            )
+
+    def test_step_record_rejects_empty_source_event_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(
+                run_id="run_1",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("",),
+            )
+
+    def test_step_record_rejects_blank_artifact_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(
+                run_id="run_1",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("evt_1",),
+                artifact_ids=("   ",),
+            )
+
+    def test_step_record_trims_identifier_whitespace(self) -> None:
+        record = StepRecord(
+            run_id="run_1",
+            stage_id="stage_1",
+            kind=StepKind.TOOL_CALL,
+            source_event_ids=("  evt_1  ",),
+        )
+        assert record.source_event_ids == ("evt_1",)
+
+    def test_stage_record_rejects_blank_step_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StageRecord(
+                run_id="run_1",
+                kind=StageKind.EXECUTE,
+                step_ids=("",),
+            )
+
+    def test_run_record_rejects_blank_stage_id(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord(seed_id="seed_abc", stage_ids=("   ",))
+
+    def test_run_record_rejects_blank_verdict_id(self) -> None:
+        with pytest.raises(ValidationError):
+            RunRecord(seed_id="seed_abc", verdict_id="   ")
+
+    def test_verdict_rejects_blank_evidence_event_id(self) -> None:
+        with pytest.raises(ValidationError):
+            VerdictRecord(
+                run_id="run_1",
+                scope="run",
+                outcome=VerdictOutcome.PASS,
+                evidence_event_ids=("",),
+            )
+
+    def test_verdict_rejects_blank_ac_id_when_scope_ac(self) -> None:
+        # Blank ``ac_id`` should be rejected even though scope='ac' would
+        # otherwise allow a non-None value.
+        with pytest.raises(ValidationError):
+            VerdictRecord(
+                run_id="run_1",
+                scope="ac",
+                ac_id="   ",
+                outcome=VerdictOutcome.PASS,
+            )
+
+    def test_step_record_rejects_blank_ac_id(self) -> None:
+        with pytest.raises(ValidationError):
+            StepRecord(
+                run_id="run_1",
+                stage_id="stage_1",
+                kind=StepKind.TOOL_CALL,
+                source_event_ids=("evt_1",),
+                ac_id="   ",
+            )


### PR DESCRIPTION
## Scope

First slice of #946. Introduces the public, schema-versioned projection
vocabulary as immutable Pydantic models. **No EventStore wiring** — the
projection builder lands in a follow-up PR so this schema surface can be
reviewed independently.

This PR is intentionally narrow per #961's Phase C.1 sequencing:
> `#946 PR-1` projection model substrate — `RunRecord` / `StageRecord` /
> `StepRecord` / `ArtifactRecord` / `VerdictRecord` Pydantic models +
> builder skeleton. No CLI yet.

The builder skeleton was further split out into a follow-up so this PR
addresses only the *records* dimension. The builder PR will land once
this schema is accepted.

## What this PR contains

- `src/ouroboros/harness/projection.py`
  - `RunRecord`, `StageRecord`, `StepRecord`, `ArtifactRecord`,
    `VerdictRecord` — all `frozen=True` Pydantic models.
  - `StageKind` (`interview` / `seed` / `execute` / `evaluate` /
    `evolve` / `plugin` / `hitl`).
  - `StepKind` (`model_call` / `tool_call` / `shell_command` /
    `subagent_dispatch` / `plugin_command` / `evaluation_check` /
    `evidence_submission` / `harness_internal`).
  - `VerdictOutcome` (`pass` / `fail` / `escalate_human` / `cancelled`
    / `unknown`).
  - `PROJECTION_SCHEMA_VERSION = 1` constant.
- `src/ouroboros/harness/__init__.py` — public re-exports.
- `tests/unit/harness/test_projection_records.py` — 29 tests covering:
  - Immutability (`frozen=True`) of all five models.
  - Prefixed ID factories (`run_*` / `stage_*` / `step_*` /
    `artifact_*` / `verdict_*`).
  - **`StepRecord` source-event invariant**: rejects empty
    `source_event_ids` unless `legacy_inferred=True`. Maps to #946
    acceptance criterion #3.
  - **`VerdictRecord` scope invariant**: `scope="ac"` requires `ac_id`;
    `scope="run"` rejects `ac_id`.
  - Timestamp ordering (`ended_at >= started_at`).
  - Enum value coverage.

## Acceptance-criterion mapping (#946)

| Criterion | Status in this PR |
|---|---|
| AC1 — documented schema for the 4 record types (+ `VerdictRecord`) | ✅ models + module docstring + per-field docstrings |
| AC2 — projection builder over `EventStore` | ⏭️ next PR |
| AC3 — every `StepRecord` links source event IDs or marks legacy/inferred | ✅ enforced by `model_validator`, covered by tests |
| AC4 — artifacts attach to steps without plugin-specific code paths | ✅ `ArtifactRecord.kind` is open-vocabulary; no plugin coupling |
| AC5 — machine-readable CLI / MCP projection output | ⏭️ next PR |
| AC6 — existing event/status tests still pass | ✅ (verified locally) |
| AC7 — fixture demonstrating projection for mechanical evaluation | ⏭️ next PR |

## Design notes

- Records are projections, not aggregates. They are intended to be
  rebuildable from `EventStore` and existing session state without
  introducing new persistent tables.
- `schema_version` is exposed on every record so plugins and projection
  consumers can detect breaking changes without a separate migration.
- Identifiers use `_new_id(prefix)` for stable, prefixed forms
  (`run_<hex12>` etc.). This matches existing in-repo conventions
  (`seed_` in `core/seed.py`, `ac_` in `core/ac_tree.py`).
- `ArtifactRecord.kind` is deliberately a non-empty string rather than
  an enum so future plugin-defined artifact kinds (#939) can register
  without re-versioning the schema. Validation strips whitespace and
  rejects blanks.

## Non-goals

- No `EventStore` wiring or projection builder logic.
- No CLI surface (`ouroboros status run <id> --json` from #946 AC5).
- No persistence of these records as a new table — they are pure
  projections.
- No coupling to current orchestrator events; that mapping lives in the
  follow-up builder PR.

## Verification

```
$ uv run pytest tests/unit/harness/ -q
.............................                                            [100%]
29 passed in 0.30s

$ uv run pytest tests/unit/core -q
………………………………………………
380 passed in 5.54s
```

## Follow-ups (separate PRs, per #961 Phase C.1)

- `#946 PR-1b` — `ProjectionBuilder` that reconstructs records from
  `EventStore` events; covers AC2.
- `#946 PR-2` — CLI / MCP query surface for projection output; covers
  AC5.
- `#946 PR-3` — fixture demonstrating projection for an execution with
  mechanical evaluation; covers AC7.

Refs #946 · sequenced under #961's "Post-milestone PR sequencing for
Tier 2 work" section.
