### PR TITLE
feat(orchestrator): add typed Workflow IR schema and validator (#956 PR-1)

### DIFF
--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -128,6 +128,26 @@ CapabilityTuple = Annotated[tuple[str, ...], AfterValidator(_normalize_capabilit
 """Capability-envelope tuple type that rejects blank entries."""
 
 
+def _normalize_schema_ref(value: str) -> str:
+    """Trim and reject blank schema-reference strings."""
+    if not isinstance(value, str):
+        msg = f"schema reference must be a string; got {type(value).__name__}"
+        raise TypeError(msg)
+    stripped = value.strip()
+    if not stripped:
+        msg = "schema reference must be non-blank"
+        raise ValueError(msg)
+    return stripped
+
+
+def _has_schema_ref(value: str | None) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+SchemaRef = Annotated[str, AfterValidator(_normalize_schema_ref)]
+"""Schema-reference field type that rejects blank/whitespace-only refs."""
+
+
 # ---------------------------------------------------------------------------
 # Enumerations
 # ---------------------------------------------------------------------------
@@ -216,8 +236,8 @@ class WorkflowNode(BaseModel, frozen=True):
     kind: NodeKind
     owner: NodeOwner
     name: str = Field(default="", description="Short human-readable label")
-    input_schema_ref: str | None = Field(default=None)
-    evidence_schema_ref: str | None = Field(default=None)
+    input_schema_ref: SchemaRef | None = Field(default=None)
+    evidence_schema_ref: SchemaRef | None = Field(default=None)
     capability_envelope: CapabilityTuple = Field(default_factory=tuple)
     runtime_hints: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
     metadata: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
@@ -228,7 +248,7 @@ class WorkflowNode(BaseModel, frozen=True):
         # Harness and human-gate nodes are exempt because they do not emit
         # evidence-bearing artifacts in the fat-harness loop.
         evidence_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN, NodeOwner.VERIFIER}
-        if self.owner in evidence_owners and not self.evidence_schema_ref:
+        if self.owner in evidence_owners and not _has_schema_ref(self.evidence_schema_ref):
             msg = (
                 f"WorkflowNode(owner={self.owner.value}) must declare "
                 "evidence_schema_ref; see #956 validation rule "
@@ -241,7 +261,7 @@ class WorkflowNode(BaseModel, frozen=True):
         # the evidence manifest itself rather than a free-form input.
         # Harness and human-gate nodes do not take a typed input.
         input_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN}
-        if self.owner in input_owners and not self.input_schema_ref:
+        if self.owner in input_owners and not _has_schema_ref(self.input_schema_ref):
             msg = (
                 f"WorkflowNode(owner={self.owner.value}) must declare "
                 "input_schema_ref; the harness must validate the payload "
@@ -415,7 +435,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
     evidence_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN, NodeOwner.VERIFIER}
     input_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN}
     for node in spec.nodes:
-        if node.owner in evidence_owners and not node.evidence_schema_ref:
+        if node.owner in evidence_owners and not _has_schema_ref(node.evidence_schema_ref):
             errors.append(
                 WorkflowValidationError(
                     code="missing_evidence_schema",
@@ -426,7 +446,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                     node_id=node.node_id,
                 )
             )
-        if node.owner in input_owners and not node.input_schema_ref:
+        if node.owner in input_owners and not _has_schema_ref(node.input_schema_ref):
             errors.append(
                 WorkflowValidationError(
                     code="missing_input_schema",
@@ -486,6 +506,21 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                             "from any non-terminal node."
                         ),
                         node_id=terminal.node_id,
+                    )
+                )
+        terminal_reachable_from = _compute_nodes_that_can_reach_terminal(spec)
+        for node in spec.nodes:
+            if node.kind is NodeKind.TERMINAL:
+                continue
+            if node.node_id not in terminal_reachable_from:
+                errors.append(
+                    WorkflowValidationError(
+                        code="unreachable_terminal",
+                        message=(
+                            f"Node '{node.node_id}' has no path to a terminal node; "
+                            "all executable branches must be able to terminate."
+                        ),
+                        node_id=node.node_id,
                     )
                 )
 
@@ -550,6 +585,26 @@ def _compute_reachable(spec: WorkflowSpec) -> set[str]:
     return visited
 
 
+def _compute_nodes_that_can_reach_terminal(spec: WorkflowSpec) -> set[str]:
+    """Return nodes with at least one directed path to a terminal node."""
+    terminal_ids = {node.node_id for node in spec.nodes if node.kind is NodeKind.TERMINAL}
+    reverse_adjacency: dict[str, list[str]] = {}
+    for edge in spec.edges:
+        reverse_adjacency.setdefault(edge.target, []).append(edge.source)
+
+    visited: set[str] = set()
+    stack = list(terminal_ids)
+    while stack:
+        current = stack.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        for predecessor in reverse_adjacency.get(current, ()):  # pragma: no branch
+            if predecessor not in visited:
+                stack.append(predecessor)
+    return visited
+
+
 __all__ = [
     "WORKFLOW_IR_SCHEMA_VERSION",
     "CapabilityTuple",
@@ -557,6 +612,7 @@ __all__ = [
     "FrozenMapping",
     "NodeKind",
     "NodeOwner",
+    "SchemaRef",
     "SourceKind",
     "WorkflowEdge",
     "WorkflowNode",

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -160,6 +160,13 @@ def _normalize_identifier(value: str) -> str:
     return stripped
 
 
+def _canonical_identifier(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 Identifier = Annotated[str, AfterValidator(_normalize_identifier)]
 """Workflow identifier field type that trims and rejects blank values."""
 
@@ -385,6 +392,8 @@ class WorkflowValidationError(BaseModel, frozen=True):
         "missing_evidence_schema",
         "missing_input_schema",
         "missing_condition",
+        "self_loop",
+        "invalid_identifier",
         "isolated_node",
     ]
     message: str
@@ -437,19 +446,30 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
     errors: list[WorkflowValidationError] = []
     warnings: list[WorkflowValidationError] = []
 
-    # 1. Duplicate node ids.
+    # 1. Duplicate node ids. Canonicalize here as a safety net for
+    # specs loaded through model_construct or other untrusted paths.
     seen_node_ids: set[str] = set()
     for node in spec.nodes:
-        if node.node_id in seen_node_ids:
+        node_id = _canonical_identifier(node.node_id)
+        if node_id is None:
+            errors.append(
+                WorkflowValidationError(
+                    code="invalid_identifier",
+                    message=f"Node id '{node.node_id}' is not a usable identifier.",
+                    node_id=str(node.node_id),
+                )
+            )
+            continue
+        if node_id in seen_node_ids:
             errors.append(
                 WorkflowValidationError(
                     code="duplicate_node_id",
-                    message=f"Duplicate node id '{node.node_id}'.",
-                    node_id=node.node_id,
+                    message=f"Duplicate node id '{node_id}'.",
+                    node_id=node_id,
                 )
             )
         else:
-            seen_node_ids.add(node.node_id)
+            seen_node_ids.add(node_id)
 
     # 2. Missing evidence/input schemas (idempotent with per-node validator).
     evidence_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN, NodeOwner.VERIFIER}
@@ -479,19 +499,49 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                 )
             )
 
-    # 3. Edges: duplicate ids, dangling endpoints.
+    # 3. Edges: duplicate ids, dangling endpoints, and model-level
+    # invariants rechecked for model_construct/untrusted loads.
     seen_edge_ids: set[str] = set()
     for edge in spec.edges:
-        if edge.edge_id in seen_edge_ids:
+        edge_id = _canonical_identifier(edge.edge_id)
+        source = _canonical_identifier(edge.source)
+        target = _canonical_identifier(edge.target)
+        if edge_id is None:
+            errors.append(
+                WorkflowValidationError(
+                    code="invalid_identifier",
+                    message=f"Edge id '{edge.edge_id}' is not a usable identifier.",
+                    edge_id=str(edge.edge_id),
+                )
+            )
+        elif edge_id in seen_edge_ids:
             errors.append(
                 WorkflowValidationError(
                     code="duplicate_edge_id",
-                    message=f"Duplicate edge id '{edge.edge_id}'.",
-                    edge_id=edge.edge_id,
+                    message=f"Duplicate edge id '{edge_id}'.",
+                    edge_id=edge_id,
                 )
             )
         else:
-            seen_edge_ids.add(edge.edge_id)
+            seen_edge_ids.add(edge_id)
+        if source is None or target is None:
+            errors.append(
+                WorkflowValidationError(
+                    code="invalid_identifier",
+                    message=f"Edge '{edge.edge_id}' has an unusable endpoint identifier.",
+                    edge_id=str(edge.edge_id),
+                )
+            )
+            continue
+        if source == target:
+            errors.append(
+                WorkflowValidationError(
+                    code="self_loop",
+                    message=f"Edge '{edge.edge_id}' forms a self-loop ({source} -> {target}).",
+                    edge_id=str(edge.edge_id),
+                    node_id=source,
+                )
+            )
         if edge.kind is EdgeKind.CONDITIONAL and not edge.condition:
             errors.append(
                 WorkflowValidationError(
@@ -499,10 +549,10 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                     message=(
                         f"Conditional edge '{edge.edge_id}' must include a condition payload."
                     ),
-                    edge_id=edge.edge_id,
+                    edge_id=str(edge.edge_id),
                 )
             )
-        for endpoint, role in ((edge.source, "source"), (edge.target, "target")):
+        for endpoint, role in ((source, "source"), (target, "target")):
             if endpoint not in seen_node_ids:
                 errors.append(
                     WorkflowValidationError(
@@ -510,7 +560,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                         message=(
                             f"Edge '{edge.edge_id}' references unknown {role} node '{endpoint}'."
                         ),
-                        edge_id=edge.edge_id,
+                        edge_id=str(edge.edge_id),
                         node_id=endpoint,
                     )
                 )
@@ -527,50 +577,57 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
     else:
         reachable = _compute_reachable(spec)
         for terminal in terminal_nodes:
-            if terminal.node_id not in reachable:
+            terminal_id = _canonical_identifier(terminal.node_id)
+            if terminal_id is not None and terminal_id not in reachable:
                 errors.append(
                     WorkflowValidationError(
                         code="unreachable_terminal",
                         message=(
-                            f"Terminal node '{terminal.node_id}' is unreachable "
+                            f"Terminal node '{terminal_id}' is unreachable "
                             "from any non-terminal node."
                         ),
-                        node_id=terminal.node_id,
+                        node_id=terminal_id,
                     )
                 )
         terminal_reachable_from = _compute_nodes_that_can_reach_terminal(spec)
         for node in spec.nodes:
             if node.kind is NodeKind.TERMINAL:
                 continue
-            if node.node_id not in terminal_reachable_from:
+            node_id = _canonical_identifier(node.node_id)
+            if node_id is not None and node_id not in terminal_reachable_from:
                 errors.append(
                     WorkflowValidationError(
                         code="unreachable_terminal",
                         message=(
-                            f"Node '{node.node_id}' has no path to a terminal node; "
+                            f"Node '{node_id}' has no path to a terminal node; "
                             "all executable branches must be able to terminate."
                         ),
-                        node_id=node.node_id,
+                        node_id=node_id,
                     )
                 )
 
     # 5. Warnings — isolated non-terminal nodes (degree 0).
     incident_nodes: set[str] = set()
     for edge in spec.edges:
-        incident_nodes.add(edge.source)
-        incident_nodes.add(edge.target)
+        source = _canonical_identifier(edge.source)
+        target = _canonical_identifier(edge.target)
+        if source is not None:
+            incident_nodes.add(source)
+        if target is not None:
+            incident_nodes.add(target)
     for node in spec.nodes:
         if node.kind is NodeKind.TERMINAL:
             continue
         if len(spec.nodes) == 1:
             # no_terminal_node is already emitted for this degenerate stub.
             continue
-        if node.node_id not in incident_nodes:
+        node_id = _canonical_identifier(node.node_id)
+        if node_id is not None and node_id not in incident_nodes:
             warnings.append(
                 WorkflowValidationError(
                     code="isolated_node",
-                    message=(f"Node '{node.node_id}' is isolated (no incident edges)."),
-                    node_id=node.node_id,
+                    message=(f"Node '{node_id}' is isolated (no incident edges)."),
+                    node_id=node_id,
                 )
             )
 
@@ -591,16 +648,26 @@ def _compute_reachable(spec: WorkflowSpec) -> set[str]:
     when no terminals exist; a sole terminal is treated as reachable.
     """
     non_terminal_starts = {
-        node.node_id for node in spec.nodes if node.kind is not NodeKind.TERMINAL
+        node_id
+        for node in spec.nodes
+        if node.kind is not NodeKind.TERMINAL
+        for node_id in (_canonical_identifier(node.node_id),)
+        if node_id is not None
     }
     if not non_terminal_starts:
-        # Sole-terminal degenerate case: treat the terminal as reachable so
-        # we do not over-flag minimal stubs used by tests.
-        return {node.node_id for node in spec.nodes}
+        # Only a single terminal-only stub is considered reachable. Multiple
+        # isolated terminals are invalid because there is no execution path.
+        if len(spec.nodes) == 1 and spec.nodes[0].kind is NodeKind.TERMINAL:
+            node_id = _canonical_identifier(spec.nodes[0].node_id)
+            return {node_id} if node_id is not None else set()
+        return set()
 
     adjacency: dict[str, list[str]] = {}
     for edge in spec.edges:
-        adjacency.setdefault(edge.source, []).append(edge.target)
+        source = _canonical_identifier(edge.source)
+        target = _canonical_identifier(edge.target)
+        if source is not None and target is not None:
+            adjacency.setdefault(source, []).append(target)
 
     visited: set[str] = set()
     stack = list(non_terminal_starts)
@@ -617,10 +684,19 @@ def _compute_reachable(spec: WorkflowSpec) -> set[str]:
 
 def _compute_nodes_that_can_reach_terminal(spec: WorkflowSpec) -> set[str]:
     """Return nodes with at least one directed path to a terminal node."""
-    terminal_ids = {node.node_id for node in spec.nodes if node.kind is NodeKind.TERMINAL}
+    terminal_ids = {
+        node_id
+        for node in spec.nodes
+        if node.kind is NodeKind.TERMINAL
+        for node_id in (_canonical_identifier(node.node_id),)
+        if node_id is not None
+    }
     reverse_adjacency: dict[str, list[str]] = {}
     for edge in spec.edges:
-        reverse_adjacency.setdefault(edge.target, []).append(edge.source)
+        source = _canonical_identifier(edge.source)
+        target = _canonical_identifier(edge.target)
+        if source is not None and target is not None:
+            reverse_adjacency.setdefault(target, []).append(source)
 
     visited: set[str] = set()
     stack = list(terminal_ids)

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -203,7 +203,7 @@ class WorkflowNode(BaseModel, frozen=True):
     metadata: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
 
     @model_validator(mode="after")
-    def _validate_evidence_requirement(self) -> WorkflowNode:
+    def _validate_schema_requirements(self) -> WorkflowNode:
         # Owners that produce evidence MUST declare an evidence_schema_ref.
         # Harness and human-gate nodes are exempt because they do not emit
         # evidence-bearing artifacts in the fat-harness loop.
@@ -213,6 +213,19 @@ class WorkflowNode(BaseModel, frozen=True):
                 f"WorkflowNode(owner={self.owner.value}) must declare "
                 "evidence_schema_ref; see #956 validation rule "
                 "'missing required evidence/output schema metadata'."
+            )
+            raise ValueError(msg)
+        # Owners that consume a typed input payload MUST declare an
+        # input_schema_ref so the harness can validate the payload shape
+        # before dispatch. Verifier nodes are exempt because they consume
+        # the evidence manifest itself rather than a free-form input.
+        # Harness and human-gate nodes do not take a typed input.
+        input_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN}
+        if self.owner in input_owners and not self.input_schema_ref:
+            msg = (
+                f"WorkflowNode(owner={self.owner.value}) must declare "
+                "input_schema_ref; the harness must validate the payload "
+                "shape before dispatching agent/plugin work."
             )
             raise ValueError(msg)
         return self
@@ -311,6 +324,7 @@ class WorkflowValidationError(BaseModel, frozen=True):
         "unreachable_terminal",
         "no_terminal_node",
         "missing_evidence_schema",
+        "missing_input_schema",
         "isolated_node",
     ]
     message: str
@@ -377,8 +391,9 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
         else:
             seen_node_ids.add(node.node_id)
 
-    # 2. Missing evidence schema (idempotent with per-node validator).
+    # 2. Missing evidence/input schemas (idempotent with per-node validator).
     evidence_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN, NodeOwner.VERIFIER}
+    input_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN}
     for node in spec.nodes:
         if node.owner in evidence_owners and not node.evidence_schema_ref:
             errors.append(
@@ -387,6 +402,18 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                     message=(
                         f"Node '{node.node_id}' (owner={node.owner.value}) is "
                         "missing evidence_schema_ref."
+                    ),
+                    node_id=node.node_id,
+                )
+            )
+        if node.owner in input_owners and not node.input_schema_ref:
+            errors.append(
+                WorkflowValidationError(
+                    code="missing_input_schema",
+                    message=(
+                        f"Node '{node.node_id}' (owner={node.owner.value}) is "
+                        "missing input_schema_ref; agent/plugin nodes must "
+                        "declare the payload contract before dispatch."
                     ),
                     node_id=node.node_id,
                 )

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -94,16 +94,11 @@ def _normalize_capability_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
     normalized: list[str] = []
     for index, value in enumerate(values):
         if not isinstance(value, str):
-            msg = (
-                f"capability name at index {index} must be a string; "
-                f"got {type(value).__name__}"
-            )
+            msg = f"capability name at index {index} must be a string; got {type(value).__name__}"
             raise TypeError(msg)
         stripped = value.strip()
         if not stripped:
-            msg = (
-                f"capability name at index {index} is empty or whitespace-only"
-            )
+            msg = f"capability name at index {index} is empty or whitespace-only"
             raise ValueError(msg)
         normalized.append(stripped)
     return tuple(normalized)
@@ -416,8 +411,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                     WorkflowValidationError(
                         code="dangling_edge",
                         message=(
-                            f"Edge '{edge.edge_id}' references unknown {role} "
-                            f"node '{endpoint}'."
+                            f"Edge '{edge.edge_id}' references unknown {role} node '{endpoint}'."
                         ),
                         edge_id=edge.edge_id,
                         node_id=endpoint,
@@ -463,9 +457,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
             warnings.append(
                 WorkflowValidationError(
                     code="isolated_node",
-                    message=(
-                        f"Node '{node.node_id}' is isolated (no incident edges)."
-                    ),
+                    message=(f"Node '{node.node_id}' is isolated (no incident edges)."),
                     node_id=node.node_id,
                 )
             )

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -1,0 +1,451 @@
+"""Typed Workflow IR for fat-harness execution planning.
+
+This module introduces a small, repo-native intermediate representation
+that the orchestrator can validate **before** dispatching work. The shape
+is deliberately minimal and additive:
+
+* :class:`WorkflowSpec` — a versioned envelope with a list of nodes and
+  edges plus optional source metadata.
+* :class:`WorkflowNode` — a typed unit of work owned by the harness, an
+  agent, a plugin, a verifier, or a human gate.
+* :class:`WorkflowEdge` — a typed transition between nodes (direct,
+  conditional, fan-out, fan-in / barrier, terminal).
+* :func:`validate_workflow` — a deterministic validator that rejects
+  invalid graphs (dangling edges, duplicate node ids, unreachable
+  terminal state, missing required evidence/output schemas) and returns a
+  :class:`WorkflowValidationResult`.
+
+The IR is a harness substrate, not a user-facing workflow product. It
+does not import or depend on Microsoft Agent Framework or any external
+workflow SDK; the goal is to learn the harness pattern, not adopt a
+framework.
+
+This PR contains *only* the schema and validator. Read-only adapters
+from Seed/AC into Workflow IR — and the runtime wiring that consumes the
+IR — land in follow-up PRs so this surface can be reviewed
+independently. See issue #956 for the full design context.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+WORKFLOW_IR_SCHEMA_VERSION = 1
+"""Initial schema version for the Workflow IR."""
+
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class NodeOwner(StrEnum):
+    """Who executes a node when dispatched."""
+
+    HARNESS = "harness"
+    AGENT = "agent"
+    PLUGIN = "plugin"
+    HUMAN_GATE = "human_gate"
+    VERIFIER = "verifier"
+
+
+class NodeKind(StrEnum):
+    """Discriminator for the kind of work a node represents.
+
+    The set is small on purpose. New kinds are added in follow-up PRs as
+    runtime support arrives; the IR itself does not assign semantics
+    beyond carrying the discriminator.
+    """
+
+    TASK = "task"
+    DECISION = "decision"
+    FAN_OUT = "fan_out"
+    FAN_IN = "fan_in"
+    TERMINAL = "terminal"
+
+
+class EdgeKind(StrEnum):
+    """How an edge transitions between nodes."""
+
+    DIRECT = "direct"
+    CONDITIONAL = "conditional"
+    FAN_OUT = "fan_out"
+    FAN_IN = "fan_in"
+    TERMINAL = "terminal"
+
+
+class SourceKind(StrEnum):
+    """Where a ``WorkflowSpec`` originated from."""
+
+    SEED = "seed"
+    PLUGIN = "plugin"
+    FIRST_PARTY_PROGRAM = "first_party_program"
+    SYNTHETIC = "synthetic"
+
+
+# ---------------------------------------------------------------------------
+# Model models
+# ---------------------------------------------------------------------------
+
+
+def _new_id(prefix: str) -> str:
+    """Return a stable, prefixed identifier for IR nodes / specs."""
+    return f"{prefix}_{uuid4().hex[:12]}"
+
+
+class WorkflowNode(BaseModel, frozen=True):
+    """A typed unit of work in the workflow graph.
+
+    Attributes:
+        node_id: Stable identifier; referenced by :class:`WorkflowEdge`.
+        kind: Discriminator from :class:`NodeKind`.
+        owner: Who executes the node (harness / agent / plugin / verifier
+            / human gate).
+        name: Short human-readable label for inspection tooling.
+        input_schema_ref: Optional reference (URI or short id) to the
+            input shape this node accepts. Required for agent / plugin
+            owners that materialize work from an input payload; harness
+            and human-gate nodes may omit it.
+        evidence_schema_ref: Required when the node produces evidence (in
+            practice: agent, plugin, verifier owners). Mirrors the typed
+            evidence contract used downstream by the fat-harness loop.
+        capability_envelope: Tuple of capability names the node may rely
+            on; empty means no extra capabilities are requested.
+        runtime_hints: Free-form hints for the runtime (model tier,
+            timeouts, retry budgets). Hints are advisory; the runtime is
+            authoritative.
+        metadata: Free-form metadata bag; additive.
+    """
+
+    schema_version: int = Field(default=WORKFLOW_IR_SCHEMA_VERSION, ge=1)
+    node_id: str = Field(default_factory=lambda: _new_id("node"), min_length=1)
+    kind: NodeKind
+    owner: NodeOwner
+    name: str = Field(default="", description="Short human-readable label")
+    input_schema_ref: str | None = Field(default=None)
+    evidence_schema_ref: str | None = Field(default=None)
+    capability_envelope: tuple[str, ...] = Field(default_factory=tuple)
+    runtime_hints: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_evidence_requirement(self) -> WorkflowNode:
+        # Owners that produce evidence MUST declare an evidence_schema_ref.
+        # Harness and human-gate nodes are exempt because they do not emit
+        # evidence-bearing artifacts in the fat-harness loop.
+        evidence_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN, NodeOwner.VERIFIER}
+        if self.owner in evidence_owners and not self.evidence_schema_ref:
+            msg = (
+                f"WorkflowNode(owner={self.owner.value}) must declare "
+                "evidence_schema_ref; see #956 validation rule "
+                "'missing required evidence/output schema metadata'."
+            )
+            raise ValueError(msg)
+        return self
+
+
+class WorkflowEdge(BaseModel, frozen=True):
+    """A typed transition between two nodes.
+
+    Attributes:
+        edge_id: Stable identifier for the edge.
+        source: Source ``node_id``.
+        target: Target ``node_id``.
+        kind: Discriminator from :class:`EdgeKind`.
+        condition: Optional structured condition payload evaluated by the
+            harness for ``CONDITIONAL`` edges. The shape is opaque to the
+            IR; concrete condition grammars are owned by the runtime
+            evaluator.
+        metadata: Free-form metadata bag; additive.
+    """
+
+    schema_version: int = Field(default=WORKFLOW_IR_SCHEMA_VERSION, ge=1)
+    edge_id: str = Field(default_factory=lambda: _new_id("edge"), min_length=1)
+    source: str = Field(..., min_length=1)
+    target: str = Field(..., min_length=1)
+    kind: EdgeKind = Field(default=EdgeKind.DIRECT)
+    condition: dict[str, Any] | None = Field(default=None)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("source", "target")
+    @classmethod
+    def _non_blank(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            msg = "WorkflowEdge endpoints must be non-empty node ids"
+            raise ValueError(msg)
+        return normalized
+
+    @model_validator(mode="after")
+    def _no_self_loop(self) -> WorkflowEdge:
+        if self.source == self.target:
+            msg = (
+                f"WorkflowEdge {self.edge_id} forms a self-loop "
+                f"({self.source} -> {self.target}); use a barrier or "
+                "explicit cycle structure instead."
+            )
+            raise ValueError(msg)
+        return self
+
+
+class WorkflowSpec(BaseModel, frozen=True):
+    """A complete typed workflow graph.
+
+    Attributes:
+        spec_id: Stable identifier for the workflow instance.
+        source: Where the spec originated from (Seed projection, plugin,
+            first-party program, synthetic test).
+        source_ref: Optional reference to the originating artifact (a
+            ``seed_id``, plugin id, etc.).
+        nodes: Tuple of :class:`WorkflowNode` instances.
+        edges: Tuple of :class:`WorkflowEdge` instances.
+        metadata: Free-form metadata bag; additive.
+    """
+
+    schema_version: int = Field(default=WORKFLOW_IR_SCHEMA_VERSION, ge=1)
+    spec_id: str = Field(default_factory=lambda: _new_id("wfspec"), min_length=1)
+    source: SourceKind
+    source_ref: str | None = Field(default=None)
+    nodes: tuple[WorkflowNode, ...] = Field(default_factory=tuple)
+    edges: tuple[WorkflowEdge, ...] = Field(default_factory=tuple)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class WorkflowValidationError(BaseModel, frozen=True):
+    """One concrete validation problem detected in a :class:`WorkflowSpec`.
+
+    The validator collects all problems into a
+    :class:`WorkflowValidationResult` rather than raising on the first
+    issue so callers can surface a complete report.
+
+    Attributes:
+        code: Short stable string identifying the rule.
+        message: Human-readable explanation suitable for CLI output.
+        node_id: Optional node identifier the error refers to.
+        edge_id: Optional edge identifier the error refers to.
+    """
+
+    code: Literal[
+        "duplicate_node_id",
+        "duplicate_edge_id",
+        "dangling_edge",
+        "unreachable_terminal",
+        "no_terminal_node",
+        "missing_evidence_schema",
+        "isolated_node",
+    ]
+    message: str
+    node_id: str | None = None
+    edge_id: str | None = None
+
+
+class WorkflowValidationResult(BaseModel, frozen=True):
+    """Result of validating a :class:`WorkflowSpec`.
+
+    ``ok`` is True iff ``errors`` is empty. ``warnings`` carries
+    non-fatal observations (e.g., isolated nodes that are reachable but
+    contribute nothing).
+    """
+
+    ok: bool
+    errors: tuple[WorkflowValidationError, ...] = Field(default_factory=tuple)
+    warnings: tuple[WorkflowValidationError, ...] = Field(default_factory=tuple)
+
+
+def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
+    """Validate a workflow specification.
+
+    The validator enforces the rules listed in #956:
+
+    * No duplicate node ids.
+    * No duplicate edge ids.
+    * No dangling edges (every edge endpoint must reference a known
+      node).
+    * At least one ``TERMINAL`` node exists.
+    * Every ``TERMINAL`` node is reachable from at least one node, or is
+      itself the only node.
+    * Nodes that own evidence (agent / plugin / verifier) declare an
+      ``evidence_schema_ref``. This duplicates the per-node validator so
+      a fully-constructed spec is independently checkable from
+      potentially-mutated dict input.
+
+    Warnings (non-fatal):
+
+    * Isolated nodes: nodes with no incident edges that are also not
+      ``TERMINAL`` are surfaced as warnings.
+
+    Args:
+        spec: The workflow specification to validate.
+
+    Returns:
+        A :class:`WorkflowValidationResult` containing the verdict and
+        the full list of errors and warnings.
+    """
+    errors: list[WorkflowValidationError] = []
+    warnings: list[WorkflowValidationError] = []
+
+    # 1. Duplicate node ids.
+    seen_node_ids: set[str] = set()
+    for node in spec.nodes:
+        if node.node_id in seen_node_ids:
+            errors.append(
+                WorkflowValidationError(
+                    code="duplicate_node_id",
+                    message=f"Duplicate node id '{node.node_id}'.",
+                    node_id=node.node_id,
+                )
+            )
+        else:
+            seen_node_ids.add(node.node_id)
+
+    # 2. Missing evidence schema (idempotent with per-node validator).
+    evidence_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN, NodeOwner.VERIFIER}
+    for node in spec.nodes:
+        if node.owner in evidence_owners and not node.evidence_schema_ref:
+            errors.append(
+                WorkflowValidationError(
+                    code="missing_evidence_schema",
+                    message=(
+                        f"Node '{node.node_id}' (owner={node.owner.value}) is "
+                        "missing evidence_schema_ref."
+                    ),
+                    node_id=node.node_id,
+                )
+            )
+
+    # 3. Edges: duplicate ids, dangling endpoints.
+    seen_edge_ids: set[str] = set()
+    for edge in spec.edges:
+        if edge.edge_id in seen_edge_ids:
+            errors.append(
+                WorkflowValidationError(
+                    code="duplicate_edge_id",
+                    message=f"Duplicate edge id '{edge.edge_id}'.",
+                    edge_id=edge.edge_id,
+                )
+            )
+        else:
+            seen_edge_ids.add(edge.edge_id)
+        for endpoint, role in ((edge.source, "source"), (edge.target, "target")):
+            if endpoint not in seen_node_ids:
+                errors.append(
+                    WorkflowValidationError(
+                        code="dangling_edge",
+                        message=(
+                            f"Edge '{edge.edge_id}' references unknown {role} "
+                            f"node '{endpoint}'."
+                        ),
+                        edge_id=edge.edge_id,
+                        node_id=endpoint,
+                    )
+                )
+
+    # 4. Terminal coverage and reachability.
+    terminal_nodes = tuple(n for n in spec.nodes if n.kind is NodeKind.TERMINAL)
+    if not terminal_nodes:
+        errors.append(
+            WorkflowValidationError(
+                code="no_terminal_node",
+                message="WorkflowSpec must contain at least one terminal node.",
+            )
+        )
+    else:
+        reachable = _compute_reachable(spec)
+        for terminal in terminal_nodes:
+            if terminal.node_id not in reachable:
+                errors.append(
+                    WorkflowValidationError(
+                        code="unreachable_terminal",
+                        message=(
+                            f"Terminal node '{terminal.node_id}' is unreachable "
+                            "from any non-terminal node."
+                        ),
+                        node_id=terminal.node_id,
+                    )
+                )
+
+    # 5. Warnings — isolated non-terminal nodes (degree 0).
+    incident_nodes: set[str] = set()
+    for edge in spec.edges:
+        incident_nodes.add(edge.source)
+        incident_nodes.add(edge.target)
+    for node in spec.nodes:
+        if node.kind is NodeKind.TERMINAL:
+            continue
+        if len(spec.nodes) == 1:
+            # A single non-terminal node is degenerate but valid as a stub.
+            continue
+        if node.node_id not in incident_nodes:
+            warnings.append(
+                WorkflowValidationError(
+                    code="isolated_node",
+                    message=(
+                        f"Node '{node.node_id}' is isolated (no incident edges)."
+                    ),
+                    node_id=node.node_id,
+                )
+            )
+
+    return WorkflowValidationResult(
+        ok=not errors,
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )
+
+
+def _compute_reachable(spec: WorkflowSpec) -> set[str]:
+    """Return the set of nodes reachable from any non-terminal node.
+
+    The reachability check is intentionally lenient: terminal nodes are
+    reachable iff at least one non-terminal node leads to them through
+    the graph. A spec consisting of a single terminal node fails the
+    ``no_terminal_node`` check earlier in :func:`validate_workflow` only
+    when no terminals exist; a sole terminal is treated as reachable.
+    """
+    non_terminal_starts = {
+        node.node_id for node in spec.nodes if node.kind is not NodeKind.TERMINAL
+    }
+    if not non_terminal_starts:
+        # Sole-terminal degenerate case: treat the terminal as reachable so
+        # we do not over-flag minimal stubs used by tests.
+        return {node.node_id for node in spec.nodes}
+
+    adjacency: dict[str, list[str]] = {}
+    for edge in spec.edges:
+        adjacency.setdefault(edge.source, []).append(edge.target)
+
+    visited: set[str] = set()
+    stack = list(non_terminal_starts)
+    while stack:
+        current = stack.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        for neighbor in adjacency.get(current, ()):
+            if neighbor not in visited:
+                stack.append(neighbor)
+    return visited
+
+
+__all__ = [
+    "WORKFLOW_IR_SCHEMA_VERSION",
+    "EdgeKind",
+    "NodeKind",
+    "NodeOwner",
+    "SourceKind",
+    "WorkflowEdge",
+    "WorkflowNode",
+    "WorkflowSpec",
+    "WorkflowValidationError",
+    "WorkflowValidationResult",
+    "validate_workflow",
+]

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -160,6 +160,21 @@ def _normalize_identifier(value: str) -> str:
     return stripped
 
 
+def _enum_value(value: Any) -> Any:
+    if isinstance(value, StrEnum):
+        return value.value
+    return value
+
+
+def _enum_is(value: Any, member: StrEnum) -> bool:
+    return _enum_value(value) == member.value
+
+
+def _enum_in(value: Any, members: set[StrEnum]) -> bool:
+    raw = _enum_value(value)
+    return raw in {member.value for member in members}
+
+
 def _canonical_identifier(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
@@ -475,23 +490,23 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
     evidence_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN, NodeOwner.VERIFIER}
     input_owners = {NodeOwner.AGENT, NodeOwner.PLUGIN}
     for node in spec.nodes:
-        if node.owner in evidence_owners and not _has_schema_ref(node.evidence_schema_ref):
+        if _enum_in(node.owner, evidence_owners) and not _has_schema_ref(node.evidence_schema_ref):
             errors.append(
                 WorkflowValidationError(
                     code="missing_evidence_schema",
                     message=(
-                        f"Node '{node.node_id}' (owner={node.owner.value}) is "
+                        f"Node '{node.node_id}' (owner={_enum_value(node.owner)}) is "
                         "missing evidence_schema_ref."
                     ),
                     node_id=node.node_id,
                 )
             )
-        if node.owner in input_owners and not _has_schema_ref(node.input_schema_ref):
+        if _enum_in(node.owner, input_owners) and not _has_schema_ref(node.input_schema_ref):
             errors.append(
                 WorkflowValidationError(
                     code="missing_input_schema",
                     message=(
-                        f"Node '{node.node_id}' (owner={node.owner.value}) is "
+                        f"Node '{node.node_id}' (owner={_enum_value(node.owner)}) is "
                         "missing input_schema_ref; agent/plugin nodes must "
                         "declare the payload contract before dispatch."
                     ),
@@ -542,7 +557,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                     node_id=source,
                 )
             )
-        if edge.kind is EdgeKind.CONDITIONAL and not edge.condition:
+        if _enum_is(edge.kind, EdgeKind.CONDITIONAL) and not edge.condition:
             errors.append(
                 WorkflowValidationError(
                     code="missing_condition",
@@ -566,7 +581,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                 )
 
     # 4. Terminal coverage and reachability.
-    terminal_nodes = tuple(n for n in spec.nodes if n.kind is NodeKind.TERMINAL)
+    terminal_nodes = tuple(n for n in spec.nodes if _enum_is(n.kind, NodeKind.TERMINAL))
     if not terminal_nodes:
         errors.append(
             WorkflowValidationError(
@@ -591,7 +606,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
                 )
         terminal_reachable_from = _compute_nodes_that_can_reach_terminal(spec)
         for node in spec.nodes:
-            if node.kind is NodeKind.TERMINAL:
+            if _enum_is(node.kind, NodeKind.TERMINAL):
                 continue
             node_id = _canonical_identifier(node.node_id)
             if node_id is not None and node_id not in terminal_reachable_from:
@@ -616,7 +631,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
         if target is not None:
             incident_nodes.add(target)
     for node in spec.nodes:
-        if node.kind is NodeKind.TERMINAL:
+        if _enum_is(node.kind, NodeKind.TERMINAL):
             continue
         if len(spec.nodes) == 1:
             # no_terminal_node is already emitted for this degenerate stub.
@@ -650,14 +665,14 @@ def _compute_reachable(spec: WorkflowSpec) -> set[str]:
     non_terminal_starts = {
         node_id
         for node in spec.nodes
-        if node.kind is not NodeKind.TERMINAL
+        if not _enum_is(node.kind, NodeKind.TERMINAL)
         for node_id in (_canonical_identifier(node.node_id),)
         if node_id is not None
     }
     if not non_terminal_starts:
         # Only a single terminal-only stub is considered reachable. Multiple
         # isolated terminals are invalid because there is no execution path.
-        if len(spec.nodes) == 1 and spec.nodes[0].kind is NodeKind.TERMINAL:
+        if len(spec.nodes) == 1 and _enum_is(spec.nodes[0].kind, NodeKind.TERMINAL):
             node_id = _canonical_identifier(spec.nodes[0].node_id)
             return {node_id} if node_id is not None else set()
         return set()

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -28,14 +28,89 @@ independently. See issue #956 for the full design context.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from enum import StrEnum
-from typing import Any, Literal
+from types import MappingProxyType
+from typing import Annotated, Any, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    field_validator,
+    model_validator,
+)
 
 WORKFLOW_IR_SCHEMA_VERSION = 1
 """Initial schema version for the Workflow IR."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — immutable metadata / hints + identifier hygiene
+# ---------------------------------------------------------------------------
+
+
+def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
+    """Normalize incoming mapping-shaped input into a fresh proxy view."""
+    if value is None:
+        return MappingProxyType({})
+    if isinstance(value, MappingProxyType):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(dict(value))
+    msg = f"mapping field must be a mapping, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
+def _ensure_frozen_after(value: Any) -> Mapping[str, Any]:
+    """Final-stage wrapper guaranteeing ``MappingProxyType`` identity."""
+    if isinstance(value, MappingProxyType):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(dict(value))
+    msg = f"mapping field must be a mapping, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
+def _empty_frozen_mapping() -> Mapping[str, Any]:
+    """Default factory that returns an empty read-only mapping."""
+    return MappingProxyType({})
+
+
+FrozenMapping = Annotated[
+    Mapping[str, Any],
+    BeforeValidator(_coerce_to_mapping),
+    AfterValidator(_ensure_frozen_after),
+    PlainSerializer(lambda value: dict(value), return_type=dict, when_used="always"),
+]
+"""Mapping field that blocks top-level mutation (``__setitem__`` etc.)."""
+
+
+def _normalize_capability_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+    """Reject blank capability names while trimming surrounding whitespace."""
+    normalized: list[str] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str):
+            msg = (
+                f"capability name at index {index} must be a string; "
+                f"got {type(value).__name__}"
+            )
+            raise TypeError(msg)
+        stripped = value.strip()
+        if not stripped:
+            msg = (
+                f"capability name at index {index} is empty or whitespace-only"
+            )
+            raise ValueError(msg)
+        normalized.append(stripped)
+    return tuple(normalized)
+
+
+CapabilityTuple = Annotated[tuple[str, ...], AfterValidator(_normalize_capability_tuple)]
+"""Capability-envelope tuple type that rejects blank entries."""
 
 
 # ---------------------------------------------------------------------------
@@ -128,9 +203,9 @@ class WorkflowNode(BaseModel, frozen=True):
     name: str = Field(default="", description="Short human-readable label")
     input_schema_ref: str | None = Field(default=None)
     evidence_schema_ref: str | None = Field(default=None)
-    capability_envelope: tuple[str, ...] = Field(default_factory=tuple)
-    runtime_hints: dict[str, Any] = Field(default_factory=dict)
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    capability_envelope: CapabilityTuple = Field(default_factory=tuple)
+    runtime_hints: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
+    metadata: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
 
     @model_validator(mode="after")
     def _validate_evidence_requirement(self) -> WorkflowNode:
@@ -168,8 +243,8 @@ class WorkflowEdge(BaseModel, frozen=True):
     source: str = Field(..., min_length=1)
     target: str = Field(..., min_length=1)
     kind: EdgeKind = Field(default=EdgeKind.DIRECT)
-    condition: dict[str, Any] | None = Field(default=None)
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    condition: FrozenMapping | None = Field(default=None)
+    metadata: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
 
     @field_validator("source", "target")
     @classmethod
@@ -212,7 +287,7 @@ class WorkflowSpec(BaseModel, frozen=True):
     source_ref: str | None = Field(default=None)
     nodes: tuple[WorkflowNode, ...] = Field(default_factory=tuple)
     edges: tuple[WorkflowEdge, ...] = Field(default_factory=tuple)
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
 
 
 # ---------------------------------------------------------------------------
@@ -438,7 +513,9 @@ def _compute_reachable(spec: WorkflowSpec) -> set[str]:
 
 __all__ = [
     "WORKFLOW_IR_SCHEMA_VERSION",
+    "CapabilityTuple",
     "EdgeKind",
+    "FrozenMapping",
     "NodeKind",
     "NodeOwner",
     "SourceKind",

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -53,24 +53,44 @@ WORKFLOW_IR_SCHEMA_VERSION = 1
 # ---------------------------------------------------------------------------
 
 
+def _freeze_value(value: Any) -> Any:
+    """Recursively copy common JSON-like containers into immutable views."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_freeze_value(item) for item in value)
+    return value
+
+
+def _thaw_value(value: Any) -> Any:
+    """Convert immutable container views back to JSON-serializable containers."""
+    if isinstance(value, Mapping):
+        return {key: _thaw_value(item) for key, item in value.items()}
+    if isinstance(value, tuple | frozenset):
+        return [_thaw_value(item) for item in value]
+    return value
+
+
 def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
-    """Normalize incoming mapping-shaped input into a fresh proxy view."""
+    """Normalize incoming mapping-shaped input into a recursively frozen view."""
     if value is None:
         return MappingProxyType({})
-    if isinstance(value, MappingProxyType):
-        return value
     if isinstance(value, Mapping):
-        return MappingProxyType(dict(value))
+        frozen = _freeze_value(value)
+        if isinstance(frozen, MappingProxyType):
+            return frozen
     msg = f"mapping field must be a mapping, got {type(value).__name__}"
     raise ValueError(msg)
 
 
 def _ensure_frozen_after(value: Any) -> Mapping[str, Any]:
-    """Final-stage wrapper guaranteeing ``MappingProxyType`` identity."""
-    if isinstance(value, MappingProxyType):
-        return value
+    """Final-stage wrapper guaranteeing recursively immutable mapping values."""
     if isinstance(value, Mapping):
-        return MappingProxyType(dict(value))
+        frozen = _freeze_value(value)
+        if isinstance(frozen, MappingProxyType):
+            return frozen
     msg = f"mapping field must be a mapping, got {type(value).__name__}"
     raise ValueError(msg)
 
@@ -84,7 +104,7 @@ FrozenMapping = Annotated[
     Mapping[str, Any],
     BeforeValidator(_coerce_to_mapping),
     AfterValidator(_ensure_frozen_after),
-    PlainSerializer(lambda value: dict(value), return_type=dict, when_used="always"),
+    PlainSerializer(lambda value: _thaw_value(value), return_type=dict, when_used="always"),
 ]
 """Mapping field that blocks top-level mutation (``__setitem__`` etc.)."""
 

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -702,7 +702,7 @@ def _compute_nodes_that_can_reach_terminal(spec: WorkflowSpec) -> set[str]:
     terminal_ids = {
         node_id
         for node in spec.nodes
-        if node.kind is NodeKind.TERMINAL
+        if _enum_is(node.kind, NodeKind.TERMINAL)
         for node_id in (_canonical_identifier(node.node_id),)
         if node_id is not None
     }

--- a/src/ouroboros/orchestrator/workflow_ir.py
+++ b/src/ouroboros/orchestrator/workflow_ir.py
@@ -148,6 +148,22 @@ SchemaRef = Annotated[str, AfterValidator(_normalize_schema_ref)]
 """Schema-reference field type that rejects blank/whitespace-only refs."""
 
 
+def _normalize_identifier(value: str) -> str:
+    """Trim and reject blank workflow identifiers."""
+    if not isinstance(value, str):
+        msg = f"identifier must be a string; got {type(value).__name__}"
+        raise TypeError(msg)
+    stripped = value.strip()
+    if not stripped:
+        msg = "identifier must be non-blank"
+        raise ValueError(msg)
+    return stripped
+
+
+Identifier = Annotated[str, AfterValidator(_normalize_identifier)]
+"""Workflow identifier field type that trims and rejects blank values."""
+
+
 # ---------------------------------------------------------------------------
 # Enumerations
 # ---------------------------------------------------------------------------
@@ -232,7 +248,7 @@ class WorkflowNode(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=WORKFLOW_IR_SCHEMA_VERSION, ge=1)
-    node_id: str = Field(default_factory=lambda: _new_id("node"), min_length=1)
+    node_id: Identifier = Field(default_factory=lambda: _new_id("node"))
     kind: NodeKind
     owner: NodeOwner
     name: str = Field(default="", description="Short human-readable label")
@@ -287,9 +303,9 @@ class WorkflowEdge(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=WORKFLOW_IR_SCHEMA_VERSION, ge=1)
-    edge_id: str = Field(default_factory=lambda: _new_id("edge"), min_length=1)
-    source: str = Field(..., min_length=1)
-    target: str = Field(..., min_length=1)
+    edge_id: Identifier = Field(default_factory=lambda: _new_id("edge"))
+    source: Identifier
+    target: Identifier
     kind: EdgeKind = Field(default=EdgeKind.DIRECT)
     condition: FrozenMapping | None = Field(default=None)
     metadata: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
@@ -304,13 +320,16 @@ class WorkflowEdge(BaseModel, frozen=True):
         return normalized
 
     @model_validator(mode="after")
-    def _no_self_loop(self) -> WorkflowEdge:
+    def _validate_edge_contract(self) -> WorkflowEdge:
         if self.source == self.target:
             msg = (
                 f"WorkflowEdge {self.edge_id} forms a self-loop "
                 f"({self.source} -> {self.target}); use a barrier or "
                 "explicit cycle structure instead."
             )
+            raise ValueError(msg)
+        if self.kind is EdgeKind.CONDITIONAL and not self.condition:
+            msg = "WorkflowEdge(kind=conditional) must include a condition payload"
             raise ValueError(msg)
         return self
 
@@ -330,7 +349,7 @@ class WorkflowSpec(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=WORKFLOW_IR_SCHEMA_VERSION, ge=1)
-    spec_id: str = Field(default_factory=lambda: _new_id("wfspec"), min_length=1)
+    spec_id: Identifier = Field(default_factory=lambda: _new_id("wfspec"))
     source: SourceKind
     source_ref: str | None = Field(default=None)
     nodes: tuple[WorkflowNode, ...] = Field(default_factory=tuple)
@@ -365,6 +384,7 @@ class WorkflowValidationError(BaseModel, frozen=True):
         "no_terminal_node",
         "missing_evidence_schema",
         "missing_input_schema",
+        "missing_condition",
         "isolated_node",
     ]
     message: str
@@ -472,6 +492,16 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
             )
         else:
             seen_edge_ids.add(edge.edge_id)
+        if edge.kind is EdgeKind.CONDITIONAL and not edge.condition:
+            errors.append(
+                WorkflowValidationError(
+                    code="missing_condition",
+                    message=(
+                        f"Conditional edge '{edge.edge_id}' must include a condition payload."
+                    ),
+                    edge_id=edge.edge_id,
+                )
+            )
         for endpoint, role in ((edge.source, "source"), (edge.target, "target")):
             if endpoint not in seen_node_ids:
                 errors.append(
@@ -533,7 +563,7 @@ def validate_workflow(spec: WorkflowSpec) -> WorkflowValidationResult:
         if node.kind is NodeKind.TERMINAL:
             continue
         if len(spec.nodes) == 1:
-            # A single non-terminal node is degenerate but valid as a stub.
+            # no_terminal_node is already emitted for this degenerate stub.
             continue
         if node.node_id not in incident_nodes:
             warnings.append(
@@ -610,6 +640,7 @@ __all__ = [
     "CapabilityTuple",
     "EdgeKind",
     "FrozenMapping",
+    "Identifier",
     "NodeKind",
     "NodeOwner",
     "SchemaRef",

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -77,6 +77,14 @@ class TestWorkflowNode:
         assert node.node_id == "node_a"
         assert default_node.node_id.startswith("node_")
 
+    def test_node_id_trims_whitespace(self) -> None:
+        node = _make_task("  node_a  ")
+        assert node.node_id == "node_a"
+
+    def test_blank_node_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_task("   ")
+
     def test_is_frozen(self) -> None:
         node = _make_task("node_a")
         with pytest.raises(ValidationError):
@@ -214,6 +222,26 @@ class TestWorkflowEdge:
         assert edge.source == "node_a"
         assert edge.target == "node_b"
 
+    def test_conditional_edge_requires_condition(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowEdge(
+                edge_id="edge_x",
+                source="node_a",
+                target="node_b",
+                kind=EdgeKind.CONDITIONAL,
+            )
+
+    def test_conditional_edge_accepts_condition(self) -> None:
+        edge = WorkflowEdge(
+            edge_id="edge_x",
+            source="node_a",
+            target="node_b",
+            kind=EdgeKind.CONDITIONAL,
+            condition={"field": "status", "equals": "pass"},
+        )
+        assert edge.kind is EdgeKind.CONDITIONAL
+        assert edge.condition is not None
+
 
 class TestValidateWorkflow:
     def test_minimal_valid_spec(self) -> None:
@@ -298,6 +326,29 @@ class TestValidateWorkflow:
             e.code == "unreachable_terminal" and e.node_id == "orphan" for e in result.errors
         )
         assert any(w.code == "isolated_node" for w in result.warnings)
+
+    def test_missing_condition_detected_by_validator(self) -> None:
+        bad_edge = WorkflowEdge.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            edge_id="edge_cond",
+            source="a",
+            target="end",
+            kind=EdgeKind.CONDITIONAL,
+            condition=None,
+            metadata={},
+        )
+        spec = WorkflowSpec.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            spec_id="wfspec_test",
+            source=SourceKind.SYNTHETIC,
+            source_ref=None,
+            nodes=(_make_task("a"), _make_terminal("end")),
+            edges=(bad_edge,),
+            metadata={},
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "missing_condition" for e in result.errors)
 
     def test_missing_terminal_path_for_non_terminal_branch(self) -> None:
         spec = WorkflowSpec(

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -310,6 +310,97 @@ class TestFanOutFanInRepresentation:
         assert result.ok is True, result.errors
 
 
+class TestMetadataIsRuntimeImmutable:
+    """``metadata`` / ``runtime_hints`` / ``condition`` must reject
+    in-place mutation so cached projections cannot silently drift."""
+
+    def test_node_metadata_blocks_setitem(self) -> None:
+        node = _make_task("node_a")
+        with pytest.raises(TypeError):
+            node.metadata["k"] = "v"  # type: ignore[index]
+
+    def test_node_runtime_hints_blocks_setitem(self) -> None:
+        node = WorkflowNode(
+            node_id="node_a",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HARNESS,
+            runtime_hints={"timeout": 30},
+        )
+        with pytest.raises(TypeError):
+            node.runtime_hints["timeout"] = 60  # type: ignore[index]
+
+    def test_edge_metadata_blocks_setitem(self) -> None:
+        edge = _edge("a", "b")
+        with pytest.raises(TypeError):
+            edge.metadata["k"] = "v"  # type: ignore[index]
+
+    def test_edge_condition_blocks_setitem(self) -> None:
+        edge = WorkflowEdge(
+            edge_id="edge_x",
+            source="a",
+            target="b",
+            kind=EdgeKind.CONDITIONAL,
+            condition={"op": "eq", "field": "status"},
+        )
+        assert edge.condition is not None
+        with pytest.raises(TypeError):
+            edge.condition["op"] = "ne"  # type: ignore[index]
+
+    def test_spec_metadata_blocks_setitem(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(_make_task("a"), _make_terminal("end")),
+            edges=(_edge("a", "end", kind=EdgeKind.TERMINAL),),
+            metadata={"origin": "test"},
+        )
+        with pytest.raises(TypeError):
+            spec.metadata["origin"] = "tampered"  # type: ignore[index]
+
+    def test_metadata_round_trips_through_model_dump(self) -> None:
+        node = WorkflowNode(
+            node_id="node_a",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HARNESS,
+            metadata={"k": "v", "n": 1},
+        )
+        dumped = node.model_dump()
+        assert isinstance(dumped["metadata"], dict)
+        assert dumped["metadata"] == {"k": "v", "n": 1}
+
+
+class TestCapabilityEnvelopeHygiene:
+    """``capability_envelope`` must reject blank or whitespace-only
+    entries so the dispatch policy cannot accept silently empty tokens.
+    """
+
+    def test_blank_capability_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_a",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.HARNESS,
+                capability_envelope=("",),
+            )
+
+    def test_whitespace_capability_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_a",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.HARNESS,
+                capability_envelope=("   ",),
+            )
+
+    def test_capability_envelope_strips_whitespace(self) -> None:
+        node = WorkflowNode(
+            node_id="node_a",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HARNESS,
+            capability_envelope=("  read  ", "write"),
+        )
+        assert node.capability_envelope == ("read", "write")
+
+
 class TestNoExternalFrameworkDependency:
     """Smoke-test that the IR module does not import MAF / DurableTask /
     Azure workflow SDKs at runtime. Acceptance criterion #6 of #956."""

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -1,0 +1,331 @@
+"""Unit tests for the Workflow IR schema and validator.
+
+Covers the acceptance contract from issue #956 PR-1:
+
+* Workflow IR models exist with a versioned schema.
+* Validation rejects dangling edges, duplicate node ids, missing
+  terminal paths, and missing required evidence/output schema metadata.
+* Fan-out / fan-in / barrier metadata can be represented.
+* No Microsoft Agent Framework or external workflow SDK dependency
+  enters core. (This is enforced by ``pyproject.toml``; this test file
+  only exercises the Python module imports to verify the surface remains
+  framework-agnostic.)
+"""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+import pytest
+
+from ouroboros.orchestrator.workflow_ir import (
+    WORKFLOW_IR_SCHEMA_VERSION,
+    EdgeKind,
+    NodeKind,
+    NodeOwner,
+    SourceKind,
+    WorkflowEdge,
+    WorkflowNode,
+    WorkflowSpec,
+    WorkflowValidationResult,
+    validate_workflow,
+)
+
+
+def _make_task(
+    node_id: str,
+    *,
+    owner: NodeOwner = NodeOwner.HARNESS,
+    evidence_schema_ref: str | None = None,
+) -> WorkflowNode:
+    return WorkflowNode(
+        node_id=node_id,
+        kind=NodeKind.TASK,
+        owner=owner,
+        evidence_schema_ref=evidence_schema_ref,
+    )
+
+
+def _make_terminal(node_id: str) -> WorkflowNode:
+    return WorkflowNode(
+        node_id=node_id,
+        kind=NodeKind.TERMINAL,
+        owner=NodeOwner.HARNESS,
+    )
+
+
+def _edge(source: str, target: str, *, kind: EdgeKind = EdgeKind.DIRECT) -> WorkflowEdge:
+    return WorkflowEdge(
+        edge_id=f"edge_{source}_{target}",
+        source=source,
+        target=target,
+        kind=kind,
+    )
+
+
+class TestSchemaVersion:
+    def test_initial_version_is_one(self) -> None:
+        assert WORKFLOW_IR_SCHEMA_VERSION == 1
+
+
+class TestWorkflowNode:
+    def test_generates_prefixed_id(self) -> None:
+        node = _make_task("node_a")
+        # explicit id retained, but default factory uses the node_ prefix
+        default_node = WorkflowNode(kind=NodeKind.TASK, owner=NodeOwner.HARNESS)
+        assert node.node_id == "node_a"
+        assert default_node.node_id.startswith("node_")
+
+    def test_is_frozen(self) -> None:
+        node = _make_task("node_a")
+        with pytest.raises(ValidationError):
+            node.name = "renamed"  # type: ignore[misc]
+
+    def test_evidence_required_for_agent(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_agent",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.AGENT,
+            )
+
+    def test_evidence_required_for_plugin(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_plugin",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.PLUGIN,
+            )
+
+    def test_evidence_required_for_verifier(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_verifier",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.VERIFIER,
+            )
+
+    def test_harness_owner_omits_evidence_ok(self) -> None:
+        node = WorkflowNode(
+            node_id="node_h",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HARNESS,
+        )
+        assert node.evidence_schema_ref is None
+
+    def test_human_gate_omits_evidence_ok(self) -> None:
+        node = WorkflowNode(
+            node_id="node_gate",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HUMAN_GATE,
+        )
+        assert node.evidence_schema_ref is None
+
+
+class TestWorkflowEdge:
+    def test_self_loop_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowEdge(edge_id="edge_x", source="node_a", target="node_a")
+
+    def test_blank_endpoint_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowEdge(edge_id="edge_x", source="  ", target="node_a")
+
+    def test_endpoints_trimmed(self) -> None:
+        edge = WorkflowEdge(
+            edge_id="edge_x",
+            source="  node_a  ",
+            target="  node_b  ",
+        )
+        assert edge.source == "node_a"
+        assert edge.target == "node_b"
+
+
+class TestValidateWorkflow:
+    def test_minimal_valid_spec(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(_make_task("a"), _make_terminal("end")),
+            edges=(_edge("a", "end", kind=EdgeKind.TERMINAL),),
+        )
+        result = validate_workflow(spec)
+        assert isinstance(result, WorkflowValidationResult)
+        assert result.ok is True
+        assert result.errors == ()
+
+    def test_duplicate_node_id(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(_make_task("a"), _make_task("a"), _make_terminal("end")),
+            edges=(_edge("a", "end"),),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        codes = {e.code for e in result.errors}
+        assert "duplicate_node_id" in codes
+
+    def test_duplicate_edge_id(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(_make_task("a"), _make_task("b"), _make_terminal("end")),
+            edges=(
+                WorkflowEdge(edge_id="dup", source="a", target="b"),
+                WorkflowEdge(edge_id="dup", source="b", target="end"),
+            ),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "duplicate_edge_id" for e in result.errors)
+
+    def test_dangling_edge(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(_make_task("a"), _make_terminal("end")),
+            edges=(_edge("a", "ghost"),),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "dangling_edge" for e in result.errors)
+
+    def test_no_terminal_node(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(_make_task("a"), _make_task("b")),
+            edges=(_edge("a", "b"),),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "no_terminal_node" for e in result.errors)
+
+    def test_unreachable_terminal(self) -> None:
+        # Two tasks loop to each other; terminal sits alone with no incoming.
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(_make_task("a"), _make_task("b"), _make_terminal("end")),
+            edges=(_edge("a", "b"), _edge("b", "a")),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "unreachable_terminal" for e in result.errors)
+
+    def test_isolated_node_warning(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(
+                _make_task("a"),
+                _make_task("orphan"),
+                _make_terminal("end"),
+            ),
+            edges=(_edge("a", "end"),),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is True  # warning, not error
+        assert any(w.code == "isolated_node" for w in result.warnings)
+
+    def test_missing_evidence_schema_detected_by_validator(self) -> None:
+        # Build a spec that bypasses Pydantic re-validation (mirrors a future
+        # load-from-untrusted-JSON path). Both the node and the enclosing
+        # spec are constructed with ``model_construct`` so the per-node
+        # validator does not pre-empt the dedicated validator rule.
+        bad_node = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id="agent_bad",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.AGENT,
+            evidence_schema_ref=None,
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+            input_schema_ref=None,
+        )
+        end_node = _make_terminal("end")
+        edge = _edge("agent_bad", "end")
+        spec = WorkflowSpec.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            spec_id="wfspec_test",
+            source=SourceKind.SYNTHETIC,
+            source_ref=None,
+            nodes=(bad_node, end_node),
+            edges=(edge,),
+            metadata={},
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "missing_evidence_schema" for e in result.errors)
+
+
+class TestFanOutFanInRepresentation:
+    """#956 acceptance criterion #4 — fan-out / fan-in / barrier
+    metadata must be representable even if not fully executed yet."""
+
+    def test_fan_out_fan_in_round_trip(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(
+                _make_task("root"),
+                WorkflowNode(
+                    node_id="split",
+                    kind=NodeKind.FAN_OUT,
+                    owner=NodeOwner.HARNESS,
+                ),
+                _make_task("left"),
+                _make_task("right"),
+                WorkflowNode(
+                    node_id="join",
+                    kind=NodeKind.FAN_IN,
+                    owner=NodeOwner.HARNESS,
+                ),
+                _make_terminal("end"),
+            ),
+            edges=(
+                _edge("root", "split"),
+                WorkflowEdge(
+                    edge_id="fanout_left",
+                    source="split",
+                    target="left",
+                    kind=EdgeKind.FAN_OUT,
+                ),
+                WorkflowEdge(
+                    edge_id="fanout_right",
+                    source="split",
+                    target="right",
+                    kind=EdgeKind.FAN_OUT,
+                ),
+                WorkflowEdge(
+                    edge_id="fanin_left",
+                    source="left",
+                    target="join",
+                    kind=EdgeKind.FAN_IN,
+                ),
+                WorkflowEdge(
+                    edge_id="fanin_right",
+                    source="right",
+                    target="join",
+                    kind=EdgeKind.FAN_IN,
+                ),
+                _edge("join", "end", kind=EdgeKind.TERMINAL),
+            ),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is True, result.errors
+
+
+class TestNoExternalFrameworkDependency:
+    """Smoke-test that the IR module does not import MAF / DurableTask /
+    Azure workflow SDKs at runtime. Acceptance criterion #6 of #956."""
+
+    def test_module_imports_are_repo_local(self) -> None:
+        import ouroboros.orchestrator.workflow_ir as wf_ir
+
+        # The module's top-level imports must not pull in forbidden SDKs.
+        forbidden_prefixes = (
+            "agent_framework",
+            "azure.durabletask",
+            "microsoft.agent",
+        )
+        for module_name in list(__import__("sys").modules):
+            assert not any(
+                module_name.startswith(prefix) for prefix in forbidden_prefixes
+            ), f"Forbidden dependency loaded transitively: {module_name}"
+        # Tautological assertion to keep the import alive in the test body.
+        assert wf_ir.WORKFLOW_IR_SCHEMA_VERSION == 1

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -14,6 +14,8 @@ Covers the acceptance contract from issue #956 PR-1:
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from pydantic import ValidationError
 import pytest
 
@@ -440,6 +442,57 @@ class TestMetadataIsRuntimeImmutable:
         dumped = node.model_dump()
         assert isinstance(dumped["metadata"], dict)
         assert dumped["metadata"] == {"k": "v", "n": 1}
+
+    def test_nested_metadata_blocks_mutation(self) -> None:
+        original: dict[str, Any] = {"outer": {"inner": "v"}, "items": ["a", "b"]}
+        node = WorkflowNode(
+            node_id="node_a",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HARNESS,
+            metadata=original,
+        )
+
+        original["outer"]["inner"] = "tampered"
+        original["items"].append("c")
+
+        nested = cast(dict[str, Any], node.metadata["outer"])
+        assert nested["inner"] == "v"
+        with pytest.raises(TypeError):
+            nested["inner"] = "tampered"
+
+        items = cast(tuple[str, ...], node.metadata["items"])
+        assert items == ("a", "b")
+        with pytest.raises(AttributeError):
+            items.append("c")  # type: ignore[attr-defined]
+
+    def test_nested_runtime_hints_round_trip_as_plain_containers(self) -> None:
+        node = WorkflowNode(
+            node_id="node_a",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HARNESS,
+            runtime_hints={"retry": {"max": 2}, "models": ["fast", "deep"]},
+        )
+
+        dumped = node.model_dump()
+        assert dumped["runtime_hints"] == {
+            "retry": {"max": 2},
+            "models": ["fast", "deep"],
+        }
+
+    def test_edge_condition_nested_mapping_blocks_mutation(self) -> None:
+        edge = WorkflowEdge(
+            edge_id="edge_x",
+            source="a",
+            target="b",
+            kind=EdgeKind.CONDITIONAL,
+            condition={"all": [{"field": "status", "op": "eq"}]},
+        )
+
+        assert edge.condition is not None
+        clauses = cast(tuple[dict[str, str], ...], edge.condition["all"])
+        assert clauses == ({"field": "status", "op": "eq"},)
+        with pytest.raises(TypeError):
+            clauses[0]["op"] = "ne"
 
 
 class TestCapabilityEnvelopeHygiene:

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -516,6 +516,53 @@ class TestValidateWorkflow:
         assert "missing_input_schema" in codes
         assert "missing_condition" in codes
 
+    def test_model_construct_raw_terminal_kind_counts_for_terminal_paths(self) -> None:
+        start = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id="agent_valid",
+            kind="task",
+            owner="agent",
+            evidence_schema_ref="schemas/evidence.agent.json",
+            input_schema_ref="schemas/input.agent.json",
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+        )
+        terminal = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id="end",
+            kind="terminal",
+            owner="harness",
+            input_schema_ref=None,
+            evidence_schema_ref=None,
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+        )
+        edge = WorkflowEdge.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            edge_id="edge_end",
+            source="agent_valid",
+            target="end",
+            kind="terminal",
+            condition=None,
+            metadata={},
+        )
+        spec = WorkflowSpec.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            spec_id="wfspec_test",
+            source=SourceKind.SYNTHETIC,
+            source_ref=None,
+            nodes=(start, terminal),
+            edges=(edge,),
+            metadata={},
+        )
+        result = validate_workflow(spec)
+        assert result.ok is True
+        assert result.errors == ()
+
     def test_blank_schema_refs_detected_by_validator(self) -> None:
         bad_node = WorkflowNode.model_construct(
             schema_version=WORKFLOW_IR_SCHEMA_VERSION,

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -415,8 +415,8 @@ class TestNoExternalFrameworkDependency:
             "microsoft.agent",
         )
         for module_name in list(__import__("sys").modules):
-            assert not any(
-                module_name.startswith(prefix) for prefix in forbidden_prefixes
-            ), f"Forbidden dependency loaded transitively: {module_name}"
+            assert not any(module_name.startswith(prefix) for prefix in forbidden_prefixes), (
+                f"Forbidden dependency loaded transitively: {module_name}"
+            )
         # Tautological assertion to keep the import alive in the test body.
         assert wf_ir.WORKFLOW_IR_SCHEMA_VERSION == 1

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -266,6 +266,44 @@ class TestValidateWorkflow:
         codes = {e.code for e in result.errors}
         assert "duplicate_node_id" in codes
 
+    def test_model_construct_identifier_whitespace_is_canonicalized(self) -> None:
+        node_a = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id=" a ",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HARNESS,
+            input_schema_ref=None,
+            evidence_schema_ref=None,
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+        )
+        node_dup = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id="a",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.HARNESS,
+            input_schema_ref=None,
+            evidence_schema_ref=None,
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+        )
+        spec = WorkflowSpec.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            spec_id="wfspec_test",
+            source=SourceKind.SYNTHETIC,
+            source_ref=None,
+            nodes=(node_a, node_dup, _make_terminal("end")),
+            edges=(_edge("a", "end"),),
+            metadata={},
+        )
+        result = validate_workflow(spec)
+        assert any(e.code == "duplicate_node_id" for e in result.errors)
+        assert not any(e.code == "dangling_edge" and e.node_id == "a" for e in result.errors)
+
     def test_duplicate_edge_id(self) -> None:
         spec = WorkflowSpec(
             source=SourceKind.SYNTHETIC,
@@ -326,6 +364,38 @@ class TestValidateWorkflow:
             e.code == "unreachable_terminal" and e.node_id == "orphan" for e in result.errors
         )
         assert any(w.code == "isolated_node" for w in result.warnings)
+
+    def test_self_loop_detected_by_validator(self) -> None:
+        bad_edge = WorkflowEdge.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            edge_id="edge_loop",
+            source="a",
+            target=" a ",
+            kind=EdgeKind.DIRECT,
+            condition=None,
+            metadata={},
+        )
+        spec = WorkflowSpec.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            spec_id="wfspec_test",
+            source=SourceKind.SYNTHETIC,
+            source_ref=None,
+            nodes=(_make_task("a"), _make_terminal("end")),
+            edges=(bad_edge, _edge("a", "end")),
+            metadata={},
+        )
+        result = validate_workflow(spec)
+        assert any(e.code == "self_loop" for e in result.errors)
+
+    def test_all_terminal_multi_node_spec_is_invalid(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(_make_terminal("done_a"), _make_terminal("done_b")),
+            edges=(),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "unreachable_terminal" for e in result.errors)
 
     def test_missing_condition_detected_by_validator(self) -> None:
         bad_edge = WorkflowEdge.model_construct(

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -467,6 +467,55 @@ class TestValidateWorkflow:
         assert result.ok is False
         assert any(e.code == "missing_input_schema" for e in result.errors)
 
+    def test_model_construct_raw_enum_strings_are_validated(self) -> None:
+        bad_node = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id="agent_raw",
+            kind="task",
+            owner="agent",
+            evidence_schema_ref="   ",
+            input_schema_ref="   ",
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+        )
+        terminal = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id="end",
+            kind="terminal",
+            owner="harness",
+            input_schema_ref=None,
+            evidence_schema_ref=None,
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+        )
+        bad_edge = WorkflowEdge.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            edge_id="edge_cond",
+            source="agent_raw",
+            target="end",
+            kind="conditional",
+            condition=None,
+            metadata={},
+        )
+        spec = WorkflowSpec.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            spec_id="wfspec_test",
+            source=SourceKind.SYNTHETIC,
+            source_ref=None,
+            nodes=(bad_node, terminal),
+            edges=(bad_edge,),
+            metadata={},
+        )
+        result = validate_workflow(spec)
+        codes = [e.code for e in result.errors]
+        assert "missing_evidence_schema" in codes
+        assert "missing_input_schema" in codes
+        assert "missing_condition" in codes
+
     def test_blank_schema_refs_detected_by_validator(self) -> None:
         bad_node = WorkflowNode.model_construct(
             schema_version=WORKFLOW_IR_SCHEMA_VERSION,

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -104,6 +104,47 @@ class TestWorkflowNode:
                 owner=NodeOwner.VERIFIER,
             )
 
+    def test_input_required_for_agent(self) -> None:
+        # Agent has evidence_schema_ref but is still missing input_schema_ref.
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_agent",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.AGENT,
+                evidence_schema_ref="evidence://agent_default",
+            )
+
+    def test_input_required_for_plugin(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_plugin",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.PLUGIN,
+                evidence_schema_ref="evidence://plugin_default",
+            )
+
+    def test_verifier_does_not_require_input_schema(self) -> None:
+        # Verifier consumes the evidence manifest, not a typed input
+        # payload — input_schema_ref must remain optional for it.
+        node = WorkflowNode(
+            node_id="node_verifier",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.VERIFIER,
+            evidence_schema_ref="evidence://verifier_default",
+        )
+        assert node.input_schema_ref is None
+
+    def test_agent_with_both_schemas_accepted(self) -> None:
+        node = WorkflowNode(
+            node_id="node_agent",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.AGENT,
+            evidence_schema_ref="evidence://agent_default",
+            input_schema_ref="input://agent_default",
+        )
+        assert node.evidence_schema_ref == "evidence://agent_default"
+        assert node.input_schema_ref == "input://agent_default"
+
     def test_harness_owner_omits_evidence_ok(self) -> None:
         node = WorkflowNode(
             node_id="node_h",
@@ -111,6 +152,7 @@ class TestWorkflowNode:
             owner=NodeOwner.HARNESS,
         )
         assert node.evidence_schema_ref is None
+        assert node.input_schema_ref is None
 
     def test_human_gate_omits_evidence_ok(self) -> None:
         node = WorkflowNode(
@@ -119,6 +161,7 @@ class TestWorkflowNode:
             owner=NodeOwner.HUMAN_GATE,
         )
         assert node.evidence_schema_ref is None
+        assert node.input_schema_ref is None
 
 
 class TestWorkflowEdge:
@@ -220,6 +263,37 @@ class TestValidateWorkflow:
         result = validate_workflow(spec)
         assert result.ok is True  # warning, not error
         assert any(w.code == "isolated_node" for w in result.warnings)
+
+    def test_missing_input_schema_detected_by_validator(self) -> None:
+        # Construct an agent node with evidence but no input via
+        # ``model_construct`` to bypass the per-node validator, then
+        # verify the spec-level rule flags it.
+        bad_node = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id="agent_no_input",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.AGENT,
+            evidence_schema_ref="evidence://agent_default",
+            input_schema_ref=None,
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+        )
+        end_node = _make_terminal("end")
+        edge = _edge("agent_no_input", "end")
+        spec = WorkflowSpec.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            spec_id="wfspec_test",
+            source=SourceKind.SYNTHETIC,
+            source_ref=None,
+            nodes=(bad_node, end_node),
+            edges=(edge,),
+            metadata={},
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "missing_input_schema" for e in result.errors)
 
     def test_missing_evidence_schema_detected_by_validator(self) -> None:
         # Build a spec that bypasses Pydantic re-validation (mirrors a future
@@ -403,20 +477,50 @@ class TestCapabilityEnvelopeHygiene:
 
 class TestNoExternalFrameworkDependency:
     """Smoke-test that the IR module does not import MAF / DurableTask /
-    Azure workflow SDKs at runtime. Acceptance criterion #6 of #956."""
+    Azure workflow SDKs. Acceptance criterion #6 of #956.
+
+    Inspects the IR module's direct imports rather than a global
+    ``sys.modules`` snapshot so the check stays order-independent —
+    an earlier test pulling in a forbidden SDK cannot falsely fail
+    this assertion.
+    """
+
+    @staticmethod
+    def _module_direct_imports(module: object) -> set[str]:
+        """Return the set of top-level package names imported by ``module``."""
+        import ast
+        import inspect
+
+        try:
+            source = inspect.getsource(module)  # type: ignore[arg-type]
+        except (OSError, TypeError):
+            return set()
+
+        tree = ast.parse(source)
+        imports: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.add(node.module.split(".")[0])
+        return imports
 
     def test_module_imports_are_repo_local(self) -> None:
         import ouroboros.orchestrator.workflow_ir as wf_ir
 
-        # The module's top-level imports must not pull in forbidden SDKs.
-        forbidden_prefixes = (
+        direct_imports = self._module_direct_imports(wf_ir)
+
+        forbidden = {
             "agent_framework",
-            "azure.durabletask",
-            "microsoft.agent",
+            "microsoft",
+            "azure",
+            "durabletask",
+            "msrest",
+        }
+        leaked = forbidden & direct_imports
+        assert not leaked, (
+            "Forbidden external workflow SDK imported by "
+            f"ouroboros.orchestrator.workflow_ir: {leaked}"
         )
-        for module_name in list(__import__("sys").modules):
-            assert not any(module_name.startswith(prefix) for prefix in forbidden_prefixes), (
-                f"Forbidden dependency loaded transitively: {module_name}"
-            )
-        # Tautological assertion to keep the import alive in the test body.
         assert wf_ir.WORKFLOW_IR_SCHEMA_VERSION == 1

--- a/tests/unit/orchestrator/test_workflow_ir.py
+++ b/tests/unit/orchestrator/test_workflow_ir.py
@@ -147,6 +147,36 @@ class TestWorkflowNode:
         assert node.evidence_schema_ref == "evidence://agent_default"
         assert node.input_schema_ref == "input://agent_default"
 
+    def test_agent_schema_refs_are_trimmed(self) -> None:
+        node = WorkflowNode(
+            node_id="node_agent",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.AGENT,
+            evidence_schema_ref="  evidence://agent_default  ",
+            input_schema_ref="  input://agent_default  ",
+        )
+        assert node.evidence_schema_ref == "evidence://agent_default"
+        assert node.input_schema_ref == "input://agent_default"
+
+    def test_agent_rejects_blank_input_schema_ref(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_agent",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.AGENT,
+                evidence_schema_ref="evidence://agent_default",
+                input_schema_ref="   ",
+            )
+
+    def test_verifier_rejects_blank_evidence_schema_ref(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowNode(
+                node_id="node_verifier",
+                kind=NodeKind.TASK,
+                owner=NodeOwner.VERIFIER,
+                evidence_schema_ref="   ",
+            )
+
     def test_harness_owner_omits_evidence_ok(self) -> None:
         node = WorkflowNode(
             node_id="node_h",
@@ -252,7 +282,7 @@ class TestValidateWorkflow:
         assert result.ok is False
         assert any(e.code == "unreachable_terminal" for e in result.errors)
 
-    def test_isolated_node_warning(self) -> None:
+    def test_isolated_node_without_terminal_path_is_error_and_warning(self) -> None:
         spec = WorkflowSpec(
             source=SourceKind.SYNTHETIC,
             nodes=(
@@ -263,8 +293,27 @@ class TestValidateWorkflow:
             edges=(_edge("a", "end"),),
         )
         result = validate_workflow(spec)
-        assert result.ok is True  # warning, not error
+        assert result.ok is False
+        assert any(
+            e.code == "unreachable_terminal" and e.node_id == "orphan" for e in result.errors
+        )
         assert any(w.code == "isolated_node" for w in result.warnings)
+
+    def test_missing_terminal_path_for_non_terminal_branch(self) -> None:
+        spec = WorkflowSpec(
+            source=SourceKind.SYNTHETIC,
+            nodes=(
+                _make_task("a"),
+                _make_task("b"),
+                _make_task("c"),
+                _make_terminal("end"),
+            ),
+            edges=(_edge("a", "b"), _edge("c", "end")),
+        )
+        result = validate_workflow(spec)
+        assert result.ok is False
+        assert any(e.code == "unreachable_terminal" and e.node_id == "a" for e in result.errors)
+        assert any(e.code == "unreachable_terminal" and e.node_id == "b" for e in result.errors)
 
     def test_missing_input_schema_detected_by_validator(self) -> None:
         # Construct an agent node with evidence but no input via
@@ -296,6 +345,34 @@ class TestValidateWorkflow:
         result = validate_workflow(spec)
         assert result.ok is False
         assert any(e.code == "missing_input_schema" for e in result.errors)
+
+    def test_blank_schema_refs_detected_by_validator(self) -> None:
+        bad_node = WorkflowNode.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            node_id="agent_blank_refs",
+            kind=NodeKind.TASK,
+            owner=NodeOwner.AGENT,
+            evidence_schema_ref="   ",
+            input_schema_ref="   ",
+            capability_envelope=(),
+            runtime_hints={},
+            metadata={},
+            name="",
+        )
+        end_node = _make_terminal("end")
+        spec = WorkflowSpec.model_construct(
+            schema_version=WORKFLOW_IR_SCHEMA_VERSION,
+            spec_id="wfspec_test",
+            source=SourceKind.SYNTHETIC,
+            source_ref=None,
+            nodes=(bad_node, end_node),
+            edges=(_edge("agent_blank_refs", "end"),),
+            metadata={},
+        )
+        result = validate_workflow(spec)
+        codes = [e.code for e in result.errors]
+        assert "missing_evidence_schema" in codes
+        assert "missing_input_schema" in codes
 
     def test_missing_evidence_schema_detected_by_validator(self) -> None:
         # Build a spec that bypasses Pydantic re-validation (mirrors a future


### PR DESCRIPTION
## Scope

First slice of #956. Introduces the typed graph + validator substrate
that the harness can validate **before** dispatching work. No runtime
path consumes this yet; the read-only adapter from Seed/AC into
Workflow IR lands in a follow-up PR so this schema surface can be
reviewed independently.

Tracks #961's Phase C.1:
> `#956 PR-1` Workflow IR schema + validation tests — models + validator
> only. Adapter PR is C.2.

## What this PR contains

- `src/ouroboros/orchestrator/workflow_ir.py`
  - `WorkflowSpec`, `WorkflowNode`, `WorkflowEdge`,
    `WorkflowValidationError`, `WorkflowValidationResult` — all
    `frozen=True` Pydantic models.
  - `NodeOwner` (`harness` / `agent` / `plugin` / `human_gate` /
    `verifier`).
  - `NodeKind` (`task` / `decision` / `fan_out` / `fan_in` /
    `terminal`).
  - `EdgeKind` (`direct` / `conditional` / `fan_out` / `fan_in` /
    `terminal`).
  - `SourceKind` (`seed` / `plugin` / `first_party_program` /
    `synthetic`).
  - `WORKFLOW_IR_SCHEMA_VERSION = 1`.
  - `validate_workflow(spec)` — deterministic validator that catches:
    - `duplicate_node_id`
    - `duplicate_edge_id`
    - `dangling_edge`
    - `no_terminal_node`
    - `unreachable_terminal`
    - `missing_evidence_schema` (for agent / plugin / verifier owners)
    - `isolated_node` (warning, not error)
- `tests/unit/orchestrator/test_workflow_ir.py` — 21 tests covering
  every validator rule, fan-out/fan-in/barrier representability, frozen
  semantics, and a smoke check that no external workflow framework
  loads transitively.

## Acceptance-criterion mapping (#956)

| Criterion | Status in this PR |
|---|---|
| AC1 — Workflow IR models exist with a versioned schema | ✅ `WORKFLOW_IR_SCHEMA_VERSION = 1` on every record |
| AC2 — validation rejects dangling edges, duplicate ids, missing terminals, missing evidence/output metadata | ✅ `validate_workflow` enforces all four classes |
| AC3 — current Seed/AC fixture can be projected into Workflow IR without changing execution behavior | ⏭️ next PR (read-only adapter) |
| AC4 — at least one test demonstrates fan-out / fan-in / barrier metadata | ✅ `TestFanOutFanInRepresentation.test_fan_out_fan_in_round_trip` |
| AC5 — docs state this is harness substrate, not user-facing product | ✅ module docstring is explicit |
| AC6 — no Microsoft Agent Framework dependency in core | ✅ no SDK import; smoke test asserts forbidden prefixes are not transitively loaded |

## Design notes

- Models live under `src/ouroboros/orchestrator/` per the
  recommendation in the issue body — the current execution strategy
  code can consume the IR without importing plugin-specific modules.
- Pydantic models export JSON Schema automatically (acceptance
  decision #2); we do not commit to a separate JSON-Schema file in
  this PR.
- The validator's `missing_evidence_schema` rule is intentionally
  duplicated between the per-node `model_validator` and the spec-level
  validator. The per-node rule fires when records are constructed via
  ordinary Pydantic validation; the validator-level rule fires when
  records are loaded via `model_construct` (mirrors a future
  load-from-untrusted-JSON path).
- `NodeKind` and `EdgeKind` are both small enums on purpose; new
  kinds are added additively as runtime support arrives. Owner-policy
  decisions (which owner may execute which kind) are deliberately not
  encoded here — they belong to the runtime adapter PR.

## Folded scope acknowledgement

This PR is the substrate for the Phase 1 surface of #956. Phase 2
(durable node lifecycle events, originally #957) and Phase 3
(conformance harness, originally #959) are deferred to follow-up PRs
under the same canonical issue per the consolidated acceptance.

## Non-goals

- No adapter that projects a current Seed/AC plan into Workflow IR
  (deferred to next PR; acceptance #3).
- No runtime path consumes the IR yet — the orchestrator continues to
  use its existing AC-tree dispatch.
- No persistence of `WorkflowSpec` instances; the IR is a logical
  contract over existing state in this PR.
- No JSON-Schema artifact emission script (deferred).
- No plugin-defined node kinds (deferred to #939 lifecycle PRs).
- **No MAF / DurableTask / Azure dependency added** — verified by the
  module's imports and by the explicit smoke test.

## Verification

```
$ uv run pytest tests/unit/orchestrator/test_workflow_ir.py -q
.....................                                                    [100%]
21 passed in 0.28s

$ uv run pytest tests/unit/core tests/unit/orchestrator/test_workflow_ir.py -q
………………………………………………
401 passed in 2.26s
```

## Follow-ups (separate PRs, per #961 Phase C.1 / C.2)

- `#956 PR-2` — read-only adapter that projects a current `Seed` /
  AC plan into a `WorkflowSpec`; covers AC3. Depends on the #956
  boundary decisions (Q1/Q3) currently pending on
  [this comment thread](https://github.com/Q00/ouroboros/issues/956#issuecomment-4442125989).
- `#956 PR-3` — durable node lifecycle events (folded #957 scope).
- `#956 PR-4` — conformance harness with fixtures (folded #959 scope).

Refs #956 · sequenced under #961's "Post-milestone PR sequencing for
Tier 2 work" section · routes alongside #946 PR-1 (#980).
