### PR TITLE
feat(harness): add journal → evidence-manifest normalizer (#978 P1)

### DIFF
--- a/src/ouroboros/harness/__init__.py
+++ b/src/ouroboros/harness/__init__.py
@@ -1,12 +1,17 @@
-"""Harness projection vocabulary for Ouroboros.
+"""Harness projection and evidence-manifest vocabulary for Ouroboros.
 
-This module hosts the public Run / Stage / Step / Artifact / Verdict
-projection vocabulary derived from the canonical event store. The records
-are read-models, not a replacement for the underlying ``EventStore``.
-
-See ``ouroboros.harness.projection`` for the schema.
+This package hosts read-only projections over the canonical ``EventStore``:
+Run / Stage / Step / Artifact / Verdict records for #946 plus the
+journal-to-evidence-manifest normalizer for #978.
 """
 
+from ouroboros.harness.journal import (
+    EvidenceEntry,
+    EvidenceKind,
+    EvidenceManifest,
+    filter_events_for_ac,
+    normalize_events,
+)
 from ouroboros.harness.projection import (
     ArtifactRecord,
     RunRecord,
@@ -20,6 +25,9 @@ from ouroboros.harness.projection import (
 
 __all__ = [
     "ArtifactRecord",
+    "EvidenceEntry",
+    "EvidenceKind",
+    "EvidenceManifest",
     "RunRecord",
     "StageKind",
     "StageRecord",
@@ -27,4 +35,6 @@ __all__ = [
     "StepRecord",
     "VerdictOutcome",
     "VerdictRecord",
+    "filter_events_for_ac",
+    "normalize_events",
 ]

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -79,6 +79,17 @@ def _deep_freeze(value: Any) -> Any:
     return value
 
 
+def _deep_thaw(value: Any) -> Any:
+    """Convert frozen containers back to JSON-native containers for dumps."""
+    if isinstance(value, Mapping):
+        return {key: _deep_thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple | frozenset):
+        return [_deep_thaw(item) for item in value]
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
     """Normalize mapping-shaped input into a freshly deep-frozen view."""
     if value is None:
@@ -105,7 +116,7 @@ FrozenMapping = Annotated[
     Mapping[str, Any],
     BeforeValidator(_coerce_to_mapping),
     AfterValidator(_ensure_frozen_after),
-    PlainSerializer(lambda value: dict(value), return_type=dict, when_used="always"),
+    PlainSerializer(lambda value: _deep_thaw(value), return_type=dict, when_used="always"),
 ]
 
 

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -1,0 +1,481 @@
+"""Journal → evidence-manifest normalization.
+
+The journal normalizer is the first slice of issue #978 (the AgentOS
+Evidence Gate spine). It walks an ordered sequence of ``EventStore``
+events for a single acceptance-criterion scope and produces a typed
+:class:`EvidenceManifest` that downstream verifiers — including the
+``TraceGuard`` deliver gate — can consult without re-mining raw logs.
+
+Design constraints:
+
+* The normalizer is a **pure read** function. It does not write to
+  ``EventStore`` and does not mutate the events it walks.
+* Each manifest entry carries a stable ``handle`` that the leaf agent
+  can cite in its evidence claim, and the ``source_event_ids`` that
+  produced it so verdicts remain replayable.
+* Manifest mappings are immutable
+  (:class:`types.MappingProxyType`) so cached projections cannot
+  silently drift when consumers stash a reference.
+* No EventStore wiring lives here yet. The downstream harness hook
+  that pulls events out of ``EventStore`` and feeds them to this
+  normalizer lands in the P2 deliver-gate PR.
+
+The set of event types the normalizer recognizes in this PR is small
+on purpose — it covers the canonical ``tool.call.started`` /
+``tool.call.returned`` pair and the conventional ``Bash`` / ``Write``
+/ ``Edit`` tool names that already drive the existing executor. Plugin
+-defined evidence types (#939) and additional kinds arrive in later
+slices.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import UTC, datetime
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Annotated, Any
+from uuid import uuid4
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    field_validator,
+    model_validator,
+)
+
+from ouroboros.events.base import BaseEvent
+
+JOURNAL_SCHEMA_VERSION = 1
+"""Initial schema version for the evidence manifest."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — immutable mappings + identifier hygiene
+# ---------------------------------------------------------------------------
+
+
+def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
+    """Normalize mapping-shaped input into a fresh proxy view."""
+    if value is None:
+        return MappingProxyType({})
+    if isinstance(value, MappingProxyType):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(dict(value))
+    msg = f"mapping field must be a mapping, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
+def _ensure_frozen_after(value: Any) -> Mapping[str, Any]:
+    """Final-stage wrapper guaranteeing ``MappingProxyType`` identity."""
+    if isinstance(value, MappingProxyType):
+        return value
+    if isinstance(value, Mapping):
+        return MappingProxyType(dict(value))
+    msg = f"mapping field must be a mapping, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
+def _empty_frozen_mapping() -> Mapping[str, Any]:
+    return MappingProxyType({})
+
+
+FrozenMapping = Annotated[
+    Mapping[str, Any],
+    BeforeValidator(_coerce_to_mapping),
+    AfterValidator(_ensure_frozen_after),
+    PlainSerializer(lambda value: dict(value), return_type=dict, when_used="always"),
+]
+
+
+def _normalize_id_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str):
+            msg = (
+                f"identifier at index {index} must be a string; "
+                f"got {type(value).__name__}"
+            )
+            raise TypeError(msg)
+        stripped = value.strip()
+        if not stripped:
+            msg = (
+                f"identifier at index {index} is empty or whitespace-only; "
+                "the journal normalizer requires usable provenance ids"
+            )
+            raise ValueError(msg)
+        normalized.append(stripped)
+    return tuple(normalized)
+
+
+IdentifierTuple = Annotated[tuple[str, ...], AfterValidator(_normalize_id_tuple)]
+
+
+# ---------------------------------------------------------------------------
+# Manifest models
+# ---------------------------------------------------------------------------
+
+
+class EvidenceKind(StrEnum):
+    """Manifest entry classification.
+
+    The set is intentionally small in PR-1; plugin-defined kinds are
+    added in #939's lifecycle work and are validated against the same
+    open-vocabulary pattern :class:`ouroboros.harness.projection.ArtifactRecord`
+    uses today.
+    """
+
+    TOOL_INVOCATION = "tool_invocation"
+    COMMAND_EXECUTED = "command_executed"
+    FILE_MODIFIED = "file_modified"
+    LLM_CALL = "llm_call"
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex[:12]}"
+
+
+class EvidenceEntry(BaseModel, frozen=True):
+    """A single piece of evidence in an :class:`EvidenceManifest`.
+
+    Attributes:
+        handle: Stable, manifest-scoped identifier that the leaf agent
+            can cite in its evidence claim (``ev_<hex12>`` by default).
+        kind: Discriminator from :class:`EvidenceKind`.
+        ok: Tri-valued success flag. ``True`` = succeeded, ``False`` =
+            failed, ``None`` = undetermined (e.g. only the start event
+            was observed).
+        started_at: When the underlying work began. Falls back to the
+            earliest source event's timestamp when no explicit start is
+            available.
+        ended_at: When the underlying work finished. ``None`` for
+            entries observed only via a start event.
+        payload: Structured details (tool name, command, file path,
+            etc.). Immutable at runtime.
+        source_event_ids: One or more event ids that produced this
+            entry. Empty tuples are rejected — every entry must be
+            traceable back to the journal.
+    """
+
+    schema_version: int = Field(default=JOURNAL_SCHEMA_VERSION, ge=1)
+    handle: str = Field(default_factory=lambda: _new_id("ev"), min_length=1)
+    kind: EvidenceKind
+    ok: bool | None = Field(default=None)
+    started_at: datetime
+    ended_at: datetime | None = Field(default=None)
+    payload: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
+    source_event_ids: IdentifierTuple
+
+    @field_validator("source_event_ids")
+    @classmethod
+    def _source_events_non_empty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            msg = (
+                "EvidenceEntry.source_event_ids must reference at least "
+                "one journal event"
+            )
+            raise ValueError(msg)
+        return value
+
+    @model_validator(mode="after")
+    def _validate_timestamps(self) -> EvidenceEntry:
+        if self.ended_at is not None and self.ended_at < self.started_at:
+            msg = "EvidenceEntry.ended_at cannot precede started_at"
+            raise ValueError(msg)
+        return self
+
+
+class EvidenceManifest(BaseModel, frozen=True):
+    """Per-AC evidence manifest derived from the journal.
+
+    Manifests are the ``evidence_manifest`` input to the TraceGuard
+    deliver gate. They are scoped to a single acceptance criterion so a
+    leaf agent's claim can be compared against the observable trace of
+    its own work.
+
+    Attributes:
+        manifest_id: Stable identifier.
+        ac_id: Acceptance-criterion identifier this manifest covers.
+        entries: Tuple of :class:`EvidenceEntry` records in observation
+            order.
+        normalized_at: When the manifest was produced.
+        metadata: Free-form metadata bag (immutable at runtime).
+    """
+
+    schema_version: int = Field(default=JOURNAL_SCHEMA_VERSION, ge=1)
+    manifest_id: str = Field(default_factory=lambda: _new_id("manifest"), min_length=1)
+    ac_id: str = Field(..., min_length=1)
+    entries: tuple[EvidenceEntry, ...] = Field(default_factory=tuple)
+    normalized_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    metadata: FrozenMapping = Field(default_factory=_empty_frozen_mapping)
+
+    @field_validator("ac_id")
+    @classmethod
+    def _ac_id_not_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            msg = "EvidenceManifest.ac_id must be a non-blank identifier"
+            raise ValueError(msg)
+        return stripped
+
+
+# ---------------------------------------------------------------------------
+# Normalizer
+# ---------------------------------------------------------------------------
+
+
+_TOOL_STARTED = "tool.call.started"
+_TOOL_RETURNED = "tool.call.returned"
+_LLM_REQUESTED = "llm.call.requested"
+_LLM_RETURNED = "llm.call.returned"
+
+_FILE_MODIFY_TOOL_NAMES = frozenset({"Write", "Edit", "NotebookEdit"})
+_COMMAND_TOOL_NAMES = frozenset({"Bash"})
+
+
+def _event_ac_id(event: BaseEvent) -> str | None:
+    """Best-effort AC scope extraction from an event."""
+    raw_ac_id = event.data.get("ac_id") if isinstance(event.data, dict) else None
+    if isinstance(raw_ac_id, str) and raw_ac_id.strip():
+        return raw_ac_id.strip()
+    return None
+
+
+def _classify_tool_kind(tool_name: str) -> EvidenceKind:
+    if tool_name in _COMMAND_TOOL_NAMES:
+        return EvidenceKind.COMMAND_EXECUTED
+    if tool_name in _FILE_MODIFY_TOOL_NAMES:
+        return EvidenceKind.FILE_MODIFIED
+    return EvidenceKind.TOOL_INVOCATION
+
+
+def _tool_payload(
+    *,
+    tool_name: str,
+    args_preview: str | None,
+    result_preview: str | None,
+    duration_ms: int | None,
+    is_error: bool | None,
+    error_kind: str | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"tool_name": tool_name}
+    if args_preview is not None:
+        payload["args_preview"] = args_preview
+    if result_preview is not None:
+        payload["result_preview"] = result_preview
+    if duration_ms is not None:
+        payload["duration_ms"] = duration_ms
+    if is_error is not None:
+        payload["is_error"] = is_error
+    if error_kind is not None:
+        payload["error_kind"] = error_kind
+    return payload
+
+
+def normalize_events(
+    events: Iterable[BaseEvent],
+    ac_id: str,
+) -> EvidenceManifest:
+    """Walk an event sequence and produce an :class:`EvidenceManifest`.
+
+    The normalizer pairs ``tool.call.started`` and ``tool.call.returned``
+    events by ``call_id`` and emits a single entry per pair. Unpaired
+    start events are emitted with ``ok=None`` and ``ended_at=None`` so
+    long-running work that has not yet completed is still observable.
+    Returned events with no matching start are emitted as completion-only
+    entries; this matches the behaviour of legacy traces where the start
+    record was lost or never persisted.
+
+    Args:
+        events: Ordered iterable of :class:`BaseEvent` records, typically
+            already filtered to the AC scope by the caller.
+        ac_id: Acceptance-criterion identifier the manifest belongs to.
+            Used both to populate :attr:`EvidenceManifest.ac_id` and to
+            filter events whose payload explicitly references a
+            different ``ac_id``.
+
+    Returns:
+        An :class:`EvidenceManifest` containing the normalized entries
+        in observation order.
+    """
+    normalized_ac_id = ac_id.strip()
+    if not normalized_ac_id:
+        msg = "normalize_events requires a non-blank ac_id"
+        raise ValueError(msg)
+
+    started: OrderedDict[str, BaseEvent] = OrderedDict()
+    entries: list[EvidenceEntry] = []
+
+    for event in events:
+        # Discard events that explicitly belong to a different AC scope.
+        observed_ac = _event_ac_id(event)
+        if observed_ac is not None and observed_ac != normalized_ac_id:
+            continue
+
+        if event.type == _TOOL_STARTED:
+            call_id = event.data.get("call_id") if isinstance(event.data, dict) else None
+            if isinstance(call_id, str) and call_id.strip():
+                started[call_id.strip()] = event
+            continue
+
+        if event.type == _TOOL_RETURNED:
+            entry = _build_tool_entry_from_pair(started, event)
+            if entry is not None:
+                entries.append(entry)
+            continue
+
+        if event.type in (_LLM_REQUESTED, _LLM_RETURNED):
+            entry = _build_llm_entry(event)
+            if entry is not None:
+                entries.append(entry)
+            continue
+
+    # Surface unmatched start events as "still running" entries so the
+    # caller can detect dangling work.
+    for call_id, start_event in started.items():
+        entry = _build_tool_entry_from_start_only(call_id, start_event)
+        if entry is not None:
+            entries.append(entry)
+
+    return EvidenceManifest(
+        ac_id=normalized_ac_id,
+        entries=tuple(entries),
+    )
+
+
+def _build_tool_entry_from_pair(
+    started: OrderedDict[str, BaseEvent],
+    returned_event: BaseEvent,
+) -> EvidenceEntry | None:
+    if not isinstance(returned_event.data, dict):
+        return None
+    call_id = returned_event.data.get("call_id")
+    if not isinstance(call_id, str) or not call_id.strip():
+        return None
+    call_id = call_id.strip()
+    start_event = started.pop(call_id, None)
+
+    tool_name = returned_event.data.get("tool_name") or (
+        start_event.data.get("tool_name") if start_event else None
+    )
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        return None
+
+    started_at = start_event.timestamp if start_event else returned_event.timestamp
+    is_error = returned_event.data.get("is_error")
+    ok = (not bool(is_error)) if isinstance(is_error, bool) else None
+
+    payload = _tool_payload(
+        tool_name=tool_name.strip(),
+        args_preview=(
+            start_event.data.get("args_preview")
+            if start_event and isinstance(start_event.data, dict)
+            else None
+        ),
+        result_preview=returned_event.data.get("result_preview"),
+        duration_ms=returned_event.data.get("duration_ms"),
+        is_error=is_error if isinstance(is_error, bool) else None,
+        error_kind=returned_event.data.get("error_kind"),
+    )
+
+    source_event_ids: list[str] = []
+    if start_event is not None:
+        source_event_ids.append(start_event.id)
+    source_event_ids.append(returned_event.id)
+
+    return EvidenceEntry(
+        kind=_classify_tool_kind(tool_name.strip()),
+        ok=ok,
+        started_at=started_at,
+        ended_at=returned_event.timestamp,
+        payload=payload,
+        source_event_ids=tuple(source_event_ids),
+    )
+
+
+def _build_tool_entry_from_start_only(
+    call_id: str,
+    start_event: BaseEvent,
+) -> EvidenceEntry | None:
+    del call_id  # reserved for future correlation logging
+    if not isinstance(start_event.data, dict):
+        return None
+    tool_name = start_event.data.get("tool_name")
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        return None
+    payload = _tool_payload(
+        tool_name=tool_name.strip(),
+        args_preview=start_event.data.get("args_preview"),
+        result_preview=None,
+        duration_ms=None,
+        is_error=None,
+        error_kind=None,
+    )
+    return EvidenceEntry(
+        kind=_classify_tool_kind(tool_name.strip()),
+        ok=None,
+        started_at=start_event.timestamp,
+        ended_at=None,
+        payload=payload,
+        source_event_ids=(start_event.id,),
+    )
+
+
+def _build_llm_entry(event: BaseEvent) -> EvidenceEntry | None:
+    if not isinstance(event.data, dict):
+        return None
+    payload: dict[str, Any] = {}
+    model = event.data.get("model")
+    if isinstance(model, str) and model.strip():
+        payload["model"] = model.strip()
+    role = event.data.get("role")
+    if isinstance(role, str) and role.strip():
+        payload["role"] = role.strip()
+    is_error = event.data.get("is_error")
+    ok = (not bool(is_error)) if isinstance(is_error, bool) else None
+    if isinstance(is_error, bool):
+        payload["is_error"] = is_error
+
+    return EvidenceEntry(
+        kind=EvidenceKind.LLM_CALL,
+        ok=ok,
+        started_at=event.timestamp,
+        ended_at=event.timestamp if event.type == _LLM_RETURNED else None,
+        payload=payload,
+        source_event_ids=(event.id,),
+    )
+
+
+def filter_events_for_ac(
+    events: Sequence[BaseEvent],
+    ac_id: str,
+) -> tuple[BaseEvent, ...]:
+    """Return events whose payload references the given AC scope.
+
+    Convenience helper for callers that hold a flat list of events and
+    want the AC-scoped subset before calling :func:`normalize_events`.
+    Events without an explicit ``ac_id`` payload field are excluded so
+    only events the journal explicitly attributed to the AC flow through.
+    """
+    normalized = ac_id.strip()
+    if not normalized:
+        msg = "filter_events_for_ac requires a non-blank ac_id"
+        raise ValueError(msg)
+    return tuple(event for event in events if _event_ac_id(event) == normalized)
+
+
+__all__ = [
+    "JOURNAL_SCHEMA_VERSION",
+    "EvidenceEntry",
+    "EvidenceKind",
+    "EvidenceManifest",
+    "FrozenMapping",
+    "IdentifierTuple",
+    "filter_events_for_ac",
+    "normalize_events",
+]

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -97,10 +97,7 @@ def _normalize_id_tuple(values: tuple[str, ...]) -> tuple[str, ...]:
     normalized: list[str] = []
     for index, value in enumerate(values):
         if not isinstance(value, str):
-            msg = (
-                f"identifier at index {index} must be a string; "
-                f"got {type(value).__name__}"
-            )
+            msg = f"identifier at index {index} must be a string; got {type(value).__name__}"
             raise TypeError(msg)
         stripped = value.strip()
         if not stripped:
@@ -175,10 +172,7 @@ class EvidenceEntry(BaseModel, frozen=True):
     @classmethod
     def _source_events_non_empty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
         if not value:
-            msg = (
-                "EvidenceEntry.source_event_ids must reference at least "
-                "one journal event"
-            )
+            msg = "EvidenceEntry.source_event_ids must reference at least one journal event"
             raise ValueError(msg)
         return value
 

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -65,12 +65,17 @@ def _deep_freeze(value: Any) -> Any:
     ``__setitem__``; nested ``dict``/``list`` values remain mutable and
     can be reached through the proxy. To honour the "cached projections
     cannot silently drift" contract we deep-copy + freeze every layer,
-    converting dicts to ``MappingProxyType`` views and lists to tuples.
+    converting dicts to ``MappingProxyType`` views, lists to tuples,
+    sets to ``frozenset`` values, and mutable byte arrays to ``bytes``.
     """
     if isinstance(value, Mapping):
         return MappingProxyType({key: _deep_freeze(item) for key, item in value.items()})
     if isinstance(value, list | tuple):
         return tuple(_deep_freeze(item) for item in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_deep_freeze(item) for item in value)
+    if isinstance(value, bytearray):
+        return bytes(value)
     return value
 
 

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -232,12 +232,50 @@ _FILE_MODIFY_TOOL_NAMES = frozenset({"Write", "Edit", "NotebookEdit"})
 _COMMAND_TOOL_NAMES = frozenset({"Bash"})
 
 
-def _event_ac_id(event: BaseEvent) -> str | None:
-    """Best-effort AC scope extraction from an event."""
-    raw_ac_id = event.data.get("ac_id") if isinstance(event.data, dict) else None
-    if isinstance(raw_ac_id, str) and raw_ac_id.strip():
-        return raw_ac_id.strip()
-    return None
+def _event_scope_tokens(event: BaseEvent) -> tuple[str, ...]:
+    """Return all scope tokens an event can be attributed to.
+
+    The Ouroboros I/O recorders (``src/ouroboros/events/io.py``) emit
+    tool / LLM events using ``aggregate_type`` / ``aggregate_id`` for
+    the target plus correlation fields (``session_id``,
+    ``execution_id``, ``phase``, ``lineage_id``). They do not currently
+    emit a dedicated ``ac_id`` payload. This helper returns every
+    channel an event could plausibly belong to so the normalizer can
+    accept matches against any of them.
+
+    Channels considered, in priority order:
+    1. ``event.data["ac_id"]`` — explicit attribution if the producer
+       chose to embed it.
+    2. ``event.aggregate_id`` — the recorder's configured target id.
+    3. ``event.data["execution_id"]`` — correlation field; an AC's
+       execution typically owns a single execution id.
+    4. ``event.data["phase"]`` — correlation field; used by some
+       executors to carry the AC identifier.
+    """
+    tokens: list[str] = []
+    if isinstance(event.data, dict):
+        for key in ("ac_id", "execution_id", "phase"):
+            value = event.data.get(key)
+            if isinstance(value, str) and value.strip():
+                tokens.append(value.strip())
+    if isinstance(event.aggregate_id, str) and event.aggregate_id.strip():
+        tokens.append(event.aggregate_id.strip())
+    return tuple(tokens)
+
+
+def _event_matches_ac(event: BaseEvent, ac_id: str) -> bool:
+    """Return True when any scope channel on the event matches ``ac_id``.
+
+    Used both for filtering inside :func:`normalize_events` and by the
+    :func:`filter_events_for_ac` helper. Returns ``False`` when no
+    channel on the event references the AC at all — pre-filtered event
+    iterables should therefore be acceptable inputs to
+    :func:`normalize_events`.
+    """
+    target = ac_id.strip()
+    if not target:
+        return False
+    return target in _event_scope_tokens(event)
 
 
 def _classify_tool_kind(tool_name: str) -> EvidenceKind:
@@ -302,37 +340,50 @@ def normalize_events(
         msg = "normalize_events requires a non-blank ac_id"
         raise ValueError(msg)
 
-    started: OrderedDict[str, BaseEvent] = OrderedDict()
+    tool_started: OrderedDict[str, BaseEvent] = OrderedDict()
+    llm_started: OrderedDict[str, BaseEvent] = OrderedDict()
     entries: list[EvidenceEntry] = []
 
     for event in events:
-        # Discard events that explicitly belong to a different AC scope.
-        observed_ac = _event_ac_id(event)
-        if observed_ac is not None and observed_ac != normalized_ac_id:
+        # Skip events that carry explicit scope tokens but none of them
+        # references this AC. Events without any scope token are allowed
+        # through so pre-filtered iterables remain valid inputs.
+        scope_tokens = _event_scope_tokens(event)
+        if scope_tokens and normalized_ac_id not in scope_tokens:
             continue
 
         if event.type == _TOOL_STARTED:
             call_id = event.data.get("call_id") if isinstance(event.data, dict) else None
             if isinstance(call_id, str) and call_id.strip():
-                started[call_id.strip()] = event
+                tool_started[call_id.strip()] = event
             continue
 
         if event.type == _TOOL_RETURNED:
-            entry = _build_tool_entry_from_pair(started, event)
+            entry = _build_tool_entry_from_pair(tool_started, event)
             if entry is not None:
                 entries.append(entry)
             continue
 
-        if event.type in (_LLM_REQUESTED, _LLM_RETURNED):
-            entry = _build_llm_entry(event)
+        if event.type == _LLM_REQUESTED:
+            call_id = event.data.get("call_id") if isinstance(event.data, dict) else None
+            if isinstance(call_id, str) and call_id.strip():
+                llm_started[call_id.strip()] = event
+            continue
+
+        if event.type == _LLM_RETURNED:
+            entry = _build_llm_entry_from_pair(llm_started, event)
             if entry is not None:
                 entries.append(entry)
             continue
 
     # Surface unmatched start events as "still running" entries so the
     # caller can detect dangling work.
-    for call_id, start_event in started.items():
+    for call_id, start_event in tool_started.items():
         entry = _build_tool_entry_from_start_only(call_id, start_event)
+        if entry is not None:
+            entries.append(entry)
+    for call_id, start_event in llm_started.items():
+        entry = _build_llm_entry_from_start_only(call_id, start_event)
         if entry is not None:
             entries.append(entry)
 
@@ -420,28 +471,113 @@ def _build_tool_entry_from_start_only(
     )
 
 
-def _build_llm_entry(event: BaseEvent) -> EvidenceEntry | None:
-    if not isinstance(event.data, dict):
-        return None
+def _llm_payload(
+    *,
+    model_id: str | None,
+    caller: str | None,
+    duration_ms: int | None,
+    is_error: bool | None,
+    error_kind: str | None,
+) -> dict[str, Any]:
     payload: dict[str, Any] = {}
-    model = event.data.get("model")
-    if isinstance(model, str) and model.strip():
-        payload["model"] = model.strip()
-    role = event.data.get("role")
-    if isinstance(role, str) and role.strip():
-        payload["role"] = role.strip()
-    is_error = event.data.get("is_error")
-    ok = (not bool(is_error)) if isinstance(is_error, bool) else None
-    if isinstance(is_error, bool):
+    if model_id is not None:
+        payload["model_id"] = model_id
+    if caller is not None:
+        payload["caller"] = caller
+    if duration_ms is not None:
+        payload["duration_ms"] = duration_ms
+    if is_error is not None:
         payload["is_error"] = is_error
+    if error_kind is not None:
+        payload["error_kind"] = error_kind
+    return payload
+
+
+def _build_llm_entry_from_pair(
+    started: OrderedDict[str, BaseEvent],
+    returned_event: BaseEvent,
+) -> EvidenceEntry | None:
+    if not isinstance(returned_event.data, dict):
+        return None
+    call_id = returned_event.data.get("call_id")
+    if not isinstance(call_id, str) or not call_id.strip():
+        return None
+    call_id = call_id.strip()
+    start_event = started.pop(call_id, None)
+
+    model_id = returned_event.data.get("model_id") or (
+        start_event.data.get("model_id") if start_event else None
+    )
+    if isinstance(model_id, str):
+        model_id = model_id.strip() or None
+
+    caller = (
+        start_event.data.get("caller")
+        if start_event and isinstance(start_event.data, dict)
+        else None
+    )
+    if isinstance(caller, str):
+        caller = caller.strip() or None
+
+    is_error = returned_event.data.get("is_error")
+    ok = (not bool(is_error)) if isinstance(is_error, bool) else None
+    duration_ms = returned_event.data.get("duration_ms")
+    error_kind = returned_event.data.get("error_kind")
+    if isinstance(error_kind, str):
+        error_kind = error_kind.strip() or None
+
+    payload = _llm_payload(
+        model_id=model_id if isinstance(model_id, str) else None,
+        caller=caller if isinstance(caller, str) else None,
+        duration_ms=duration_ms if isinstance(duration_ms, int) else None,
+        is_error=is_error if isinstance(is_error, bool) else None,
+        error_kind=error_kind if isinstance(error_kind, str) else None,
+    )
+
+    source_event_ids: list[str] = []
+    if start_event is not None:
+        source_event_ids.append(start_event.id)
+    source_event_ids.append(returned_event.id)
+
+    started_at = start_event.timestamp if start_event else returned_event.timestamp
 
     return EvidenceEntry(
         kind=EvidenceKind.LLM_CALL,
         ok=ok,
-        started_at=event.timestamp,
-        ended_at=event.timestamp if event.type == _LLM_RETURNED else None,
+        started_at=started_at,
+        ended_at=returned_event.timestamp,
         payload=payload,
-        source_event_ids=(event.id,),
+        source_event_ids=tuple(source_event_ids),
+    )
+
+
+def _build_llm_entry_from_start_only(
+    call_id: str,
+    start_event: BaseEvent,
+) -> EvidenceEntry | None:
+    del call_id  # reserved for future correlation logging
+    if not isinstance(start_event.data, dict):
+        return None
+    model_id = start_event.data.get("model_id")
+    if isinstance(model_id, str):
+        model_id = model_id.strip() or None
+    caller = start_event.data.get("caller")
+    if isinstance(caller, str):
+        caller = caller.strip() or None
+    payload = _llm_payload(
+        model_id=model_id if isinstance(model_id, str) else None,
+        caller=caller if isinstance(caller, str) else None,
+        duration_ms=None,
+        is_error=None,
+        error_kind=None,
+    )
+    return EvidenceEntry(
+        kind=EvidenceKind.LLM_CALL,
+        ok=None,
+        started_at=start_event.timestamp,
+        ended_at=None,
+        payload=payload,
+        source_event_ids=(start_event.id,),
     )
 
 
@@ -449,18 +585,26 @@ def filter_events_for_ac(
     events: Sequence[BaseEvent],
     ac_id: str,
 ) -> tuple[BaseEvent, ...]:
-    """Return events whose payload references the given AC scope.
+    """Return events whose scope channels reference the given AC.
 
     Convenience helper for callers that hold a flat list of events and
     want the AC-scoped subset before calling :func:`normalize_events`.
-    Events without an explicit ``ac_id`` payload field are excluded so
-    only events the journal explicitly attributed to the AC flow through.
+    The match is multi-channel and considers, in priority order:
+
+    1. ``event.data["ac_id"]``
+    2. ``event.aggregate_id``
+    3. ``event.data["execution_id"]``
+    4. ``event.data["phase"]``
+
+    Events with no scope tokens that match the target ``ac_id`` are
+    excluded. See :func:`_event_scope_tokens` for the precise set of
+    channels considered.
     """
     normalized = ac_id.strip()
     if not normalized:
         msg = "filter_events_for_ac requires a non-blank ac_id"
         raise ValueError(msg)
-    return tuple(event for event in events if _event_ac_id(event) == normalized)
+    return tuple(event for event in events if _event_matches_ac(event, normalized))
 
 
 __all__ = [

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -30,7 +30,6 @@ slices.
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -59,26 +58,38 @@ JOURNAL_SCHEMA_VERSION = 1
 # ---------------------------------------------------------------------------
 
 
+def _deep_freeze(value: Any) -> Any:
+    """Recursively convert mappings/lists into immutable views.
+
+    Bare :class:`types.MappingProxyType` only blocks top-level
+    ``__setitem__``; nested ``dict``/``list`` values remain mutable and
+    can be reached through the proxy. To honour the "cached projections
+    cannot silently drift" contract we deep-copy + freeze every layer,
+    converting dicts to ``MappingProxyType`` views and lists to tuples.
+    """
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _deep_freeze(item) for key, item in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_deep_freeze(item) for item in value)
+    return value
+
+
 def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
-    """Normalize mapping-shaped input into a fresh proxy view."""
+    """Normalize mapping-shaped input into a freshly deep-frozen view."""
     if value is None:
         return MappingProxyType({})
-    if isinstance(value, MappingProxyType):
-        return value
-    if isinstance(value, Mapping):
-        return MappingProxyType(dict(value))
-    msg = f"mapping field must be a mapping, got {type(value).__name__}"
-    raise ValueError(msg)
+    if not isinstance(value, Mapping):
+        msg = f"mapping field must be a mapping, got {type(value).__name__}"
+        raise ValueError(msg)
+    return _deep_freeze(value)
 
 
 def _ensure_frozen_after(value: Any) -> Mapping[str, Any]:
-    """Final-stage wrapper guaranteeing ``MappingProxyType`` identity."""
-    if isinstance(value, MappingProxyType):
-        return value
-    if isinstance(value, Mapping):
-        return MappingProxyType(dict(value))
-    msg = f"mapping field must be a mapping, got {type(value).__name__}"
-    raise ValueError(msg)
+    """Final-stage deep-freeze guaranteeing nested immutability."""
+    if not isinstance(value, Mapping):
+        msg = f"mapping field must be a mapping, got {type(value).__name__}"
+        raise ValueError(msg)
+    return _deep_freeze(value)
 
 
 def _empty_frozen_mapping() -> Mapping[str, Any]:
@@ -340,9 +351,16 @@ def normalize_events(
         msg = "normalize_events requires a non-blank ac_id"
         raise ValueError(msg)
 
-    tool_started: OrderedDict[str, BaseEvent] = OrderedDict()
-    llm_started: OrderedDict[str, BaseEvent] = OrderedDict()
-    entries: list[EvidenceEntry] = []
+    # ``slots`` preserves observation order: a started event reserves a
+    # slot at its observed index, and the matching returned event fills
+    # that slot in place. Returned-only events append a new slot. Slots
+    # left as :class:`BaseEvent` at the end are finalized as pending /
+    # dangling entries. This stops unmatched start events from being
+    # shuffled to the tail of the manifest after later pairs complete
+    # (the previous append-pending-at-end strategy reordered the trace).
+    slots: list[BaseEvent | EvidenceEntry | None] = []
+    tool_slot_index: dict[str, int] = {}
+    llm_slot_index: dict[str, int] = {}
 
     for event in events:
         # Skip events that carry explicit scope tokens but none of them
@@ -355,37 +373,68 @@ def normalize_events(
         if event.type == _TOOL_STARTED:
             call_id = event.data.get("call_id") if isinstance(event.data, dict) else None
             if isinstance(call_id, str) and call_id.strip():
-                tool_started[call_id.strip()] = event
+                tool_slot_index[call_id.strip()] = len(slots)
+                slots.append(event)
             continue
 
         if event.type == _TOOL_RETURNED:
-            entry = _build_tool_entry_from_pair(tool_started, event)
-            if entry is not None:
-                entries.append(entry)
+            call_id_raw = event.data.get("call_id") if isinstance(event.data, dict) else None
+            call_id = call_id_raw.strip() if isinstance(call_id_raw, str) else ""
+            slot = tool_slot_index.pop(call_id, None) if call_id else None
+            start_event: BaseEvent | None = None
+            if slot is not None:
+                start_event = slots[slot]  # type: ignore[assignment]
+            entry = _build_tool_entry_for_returned(start_event, event)
+            if entry is None:
+                continue
+            if slot is not None:
+                slots[slot] = entry
+            else:
+                slots.append(entry)
             continue
 
         if event.type == _LLM_REQUESTED:
             call_id = event.data.get("call_id") if isinstance(event.data, dict) else None
             if isinstance(call_id, str) and call_id.strip():
-                llm_started[call_id.strip()] = event
+                llm_slot_index[call_id.strip()] = len(slots)
+                slots.append(event)
             continue
 
         if event.type == _LLM_RETURNED:
-            entry = _build_llm_entry_from_pair(llm_started, event)
-            if entry is not None:
-                entries.append(entry)
+            call_id_raw = event.data.get("call_id") if isinstance(event.data, dict) else None
+            call_id = call_id_raw.strip() if isinstance(call_id_raw, str) else ""
+            slot = llm_slot_index.pop(call_id, None) if call_id else None
+            requested_event: BaseEvent | None = None
+            if slot is not None:
+                requested_event = slots[slot]  # type: ignore[assignment]
+            entry = _build_llm_entry_for_returned(requested_event, event)
+            if entry is None:
+                continue
+            if slot is not None:
+                slots[slot] = entry
+            else:
+                slots.append(entry)
             continue
 
-    # Surface unmatched start events as "still running" entries so the
-    # caller can detect dangling work.
-    for call_id, start_event in tool_started.items():
-        entry = _build_tool_entry_from_start_only(call_id, start_event)
-        if entry is not None:
-            entries.append(entry)
-    for call_id, start_event in llm_started.items():
-        entry = _build_llm_entry_from_start_only(call_id, start_event)
-        if entry is not None:
-            entries.append(entry)
+    # Finalize: every remaining slot is either an already-built
+    # EvidenceEntry or a dangling start/requested BaseEvent that we
+    # surface as a still-running entry so the caller can detect
+    # incomplete work.
+    entries: list[EvidenceEntry] = []
+    for slot in slots:
+        if slot is None:
+            continue
+        if isinstance(slot, EvidenceEntry):
+            entries.append(slot)
+            continue
+        if slot.type == _TOOL_STARTED:
+            pending = _build_tool_entry_from_start_only(_slot_call_id(slot), slot)
+            if pending is not None:
+                entries.append(pending)
+        elif slot.type == _LLM_REQUESTED:
+            pending = _build_llm_entry_from_start_only(_slot_call_id(slot), slot)
+            if pending is not None:
+                entries.append(pending)
 
     return EvidenceManifest(
         ac_id=normalized_ac_id,
@@ -393,17 +442,19 @@ def normalize_events(
     )
 
 
-def _build_tool_entry_from_pair(
-    started: OrderedDict[str, BaseEvent],
+def _slot_call_id(event: BaseEvent) -> str:
+    if not isinstance(event.data, dict):
+        return ""
+    call_id = event.data.get("call_id")
+    return call_id.strip() if isinstance(call_id, str) else ""
+
+
+def _build_tool_entry_for_returned(
+    start_event: BaseEvent | None,
     returned_event: BaseEvent,
 ) -> EvidenceEntry | None:
     if not isinstance(returned_event.data, dict):
         return None
-    call_id = returned_event.data.get("call_id")
-    if not isinstance(call_id, str) or not call_id.strip():
-        return None
-    call_id = call_id.strip()
-    start_event = started.pop(call_id, None)
 
     tool_name = returned_event.data.get("tool_name") or (
         start_event.data.get("tool_name") if start_event else None
@@ -493,17 +544,12 @@ def _llm_payload(
     return payload
 
 
-def _build_llm_entry_from_pair(
-    started: OrderedDict[str, BaseEvent],
+def _build_llm_entry_for_returned(
+    start_event: BaseEvent | None,
     returned_event: BaseEvent,
 ) -> EvidenceEntry | None:
     if not isinstance(returned_event.data, dict):
         return None
-    call_id = returned_event.data.get("call_id")
-    if not isinstance(call_id, str) or not call_id.strip():
-        return None
-    call_id = call_id.strip()
-    start_event = started.pop(call_id, None)
 
     model_id = returned_event.data.get("model_id") or (
         start_event.data.get("model_id") if start_event else None

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -1,0 +1,325 @@
+"""Unit tests for the journal → evidence-manifest normalizer.
+
+Covers the contract from issue #978 P1:
+
+* ``normalize_events`` pairs ``tool.call.started`` / ``tool.call.returned``
+  events by ``call_id`` and emits one entry per pair.
+* Tool name maps to the appropriate :class:`EvidenceKind`
+  (``Bash`` → ``command_executed``, ``Write`` / ``Edit`` →
+  ``file_modified``, other → ``tool_invocation``).
+* Each entry references its source event ids via ``source_event_ids``.
+* Unpaired start events surface as ``ok=None`` entries with
+  ``ended_at=None`` so dangling work is observable.
+* Events explicitly attributed to a different ``ac_id`` are filtered
+  out.
+* Manifest mappings reject in-place mutation (``MappingProxyType``).
+* ``filter_events_for_ac`` returns only events whose payload references
+  the target AC.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import MappingProxyType
+
+from pydantic import ValidationError
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.harness.journal import (
+    JOURNAL_SCHEMA_VERSION,
+    EvidenceEntry,
+    EvidenceKind,
+    EvidenceManifest,
+    filter_events_for_ac,
+    normalize_events,
+)
+
+
+def _tool_started(
+    *,
+    call_id: str,
+    tool_name: str,
+    ac_id: str = "ac_1",
+    args_preview: str | None = None,
+    when: datetime | None = None,
+    event_id: str | None = None,
+) -> BaseEvent:
+    return BaseEvent(
+        id=event_id or f"evt_started_{call_id}",
+        type="tool.call.started",
+        timestamp=when or datetime.now(UTC),
+        aggregate_type="session",
+        aggregate_id="session_test",
+        data={
+            "call_id": call_id,
+            "tool_name": tool_name,
+            "args_preview": args_preview,
+            "ac_id": ac_id,
+        },
+    )
+
+
+def _tool_returned(
+    *,
+    call_id: str,
+    tool_name: str,
+    is_error: bool = False,
+    duration_ms: int = 5,
+    ac_id: str = "ac_1",
+    result_preview: str | None = None,
+    error_kind: str | None = None,
+    when: datetime | None = None,
+    event_id: str | None = None,
+) -> BaseEvent:
+    return BaseEvent(
+        id=event_id or f"evt_returned_{call_id}",
+        type="tool.call.returned",
+        timestamp=when or datetime.now(UTC),
+        aggregate_type="session",
+        aggregate_id="session_test",
+        data={
+            "call_id": call_id,
+            "tool_name": tool_name,
+            "is_error": is_error,
+            "duration_ms": duration_ms,
+            "result_preview": result_preview,
+            "error_kind": error_kind,
+            "ac_id": ac_id,
+        },
+    )
+
+
+class TestSchemaVersion:
+    def test_initial_version_is_one(self) -> None:
+        assert JOURNAL_SCHEMA_VERSION == 1
+
+
+class TestEvidenceEntry:
+    def test_requires_non_empty_source_event_ids(self) -> None:
+        with pytest.raises(ValidationError):
+            EvidenceEntry(
+                kind=EvidenceKind.TOOL_INVOCATION,
+                started_at=datetime.now(UTC),
+                source_event_ids=(),
+            )
+
+    def test_rejects_blank_source_event_id(self) -> None:
+        with pytest.raises(ValidationError):
+            EvidenceEntry(
+                kind=EvidenceKind.TOOL_INVOCATION,
+                started_at=datetime.now(UTC),
+                source_event_ids=("   ",),
+            )
+
+    def test_rejects_ended_before_started(self) -> None:
+        now = datetime.now(UTC)
+        with pytest.raises(ValidationError):
+            EvidenceEntry(
+                kind=EvidenceKind.TOOL_INVOCATION,
+                started_at=now,
+                ended_at=now - timedelta(seconds=1),
+                source_event_ids=("evt_1",),
+            )
+
+    def test_payload_blocks_setitem(self) -> None:
+        entry = EvidenceEntry(
+            kind=EvidenceKind.TOOL_INVOCATION,
+            started_at=datetime.now(UTC),
+            payload={"tool_name": "Bash"},
+            source_event_ids=("evt_1",),
+        )
+        assert isinstance(entry.payload, MappingProxyType)
+        with pytest.raises(TypeError):
+            entry.payload["tool_name"] = "Edit"  # type: ignore[index]
+
+    def test_generates_prefixed_handle(self) -> None:
+        entry = EvidenceEntry(
+            kind=EvidenceKind.TOOL_INVOCATION,
+            started_at=datetime.now(UTC),
+            source_event_ids=("evt_1",),
+        )
+        assert entry.handle.startswith("ev_")
+
+
+class TestEvidenceManifest:
+    def test_ac_id_required(self) -> None:
+        with pytest.raises(ValidationError):
+            EvidenceManifest(ac_id="   ")
+
+    def test_metadata_blocks_setitem(self) -> None:
+        manifest = EvidenceManifest(ac_id="ac_1")
+        with pytest.raises(TypeError):
+            manifest.metadata["k"] = "v"  # type: ignore[index]
+
+    def test_is_frozen(self) -> None:
+        manifest = EvidenceManifest(ac_id="ac_1")
+        with pytest.raises(ValidationError):
+            manifest.ac_id = "ac_2"  # type: ignore[misc]
+
+
+class TestNormalizeEventsToolPairs:
+    def test_pairs_started_and_returned_by_call_id(self) -> None:
+        start_time = datetime.now(UTC)
+        events = [
+            _tool_started(
+                call_id="c1",
+                tool_name="Edit",
+                event_id="evt_start_c1",
+                when=start_time,
+                args_preview="path=src/foo.py",
+            ),
+            _tool_returned(
+                call_id="c1",
+                tool_name="Edit",
+                event_id="evt_return_c1",
+                when=start_time + timedelta(milliseconds=5),
+                duration_ms=5,
+                is_error=False,
+                result_preview="ok",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_1")
+        assert len(manifest.entries) == 1
+        entry = manifest.entries[0]
+        assert entry.kind is EvidenceKind.FILE_MODIFIED
+        assert entry.ok is True
+        assert entry.source_event_ids == ("evt_start_c1", "evt_return_c1")
+        assert entry.payload["tool_name"] == "Edit"
+        assert entry.payload["args_preview"] == "path=src/foo.py"
+        assert entry.payload["result_preview"] == "ok"
+        assert entry.payload["duration_ms"] == 5
+
+    def test_bash_tool_emits_command_executed(self) -> None:
+        events = [
+            _tool_started(call_id="c2", tool_name="Bash"),
+            _tool_returned(call_id="c2", tool_name="Bash"),
+        ]
+        manifest = normalize_events(events, ac_id="ac_1")
+        assert manifest.entries[0].kind is EvidenceKind.COMMAND_EXECUTED
+
+    def test_unknown_tool_falls_back_to_tool_invocation(self) -> None:
+        events = [
+            _tool_started(call_id="c3", tool_name="WebFetch"),
+            _tool_returned(call_id="c3", tool_name="WebFetch"),
+        ]
+        manifest = normalize_events(events, ac_id="ac_1")
+        assert manifest.entries[0].kind is EvidenceKind.TOOL_INVOCATION
+
+    def test_returned_with_error_sets_ok_false(self) -> None:
+        events = [
+            _tool_started(call_id="c4", tool_name="Bash"),
+            _tool_returned(
+                call_id="c4",
+                tool_name="Bash",
+                is_error=True,
+                error_kind="non_zero_exit",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_1")
+        entry = manifest.entries[0]
+        assert entry.ok is False
+        assert entry.payload["is_error"] is True
+        assert entry.payload["error_kind"] == "non_zero_exit"
+
+    def test_unpaired_start_surfaces_as_running(self) -> None:
+        events = [_tool_started(call_id="c5", tool_name="Bash")]
+        manifest = normalize_events(events, ac_id="ac_1")
+        assert len(manifest.entries) == 1
+        entry = manifest.entries[0]
+        assert entry.ok is None
+        assert entry.ended_at is None
+        assert entry.source_event_ids == ("evt_started_c5",)
+
+    def test_completion_only_pair_still_emitted(self) -> None:
+        # A `returned` event without a matching `started` is still
+        # emitted so legacy traces remain observable.
+        events = [_tool_returned(call_id="orphan", tool_name="Bash")]
+        manifest = normalize_events(events, ac_id="ac_1")
+        assert len(manifest.entries) == 1
+        entry = manifest.entries[0]
+        assert entry.kind is EvidenceKind.COMMAND_EXECUTED
+        assert entry.source_event_ids == ("evt_returned_orphan",)
+
+
+class TestNormalizeEventsACScope:
+    def test_drops_events_belonging_to_other_ac(self) -> None:
+        events = [
+            _tool_started(call_id="c1", tool_name="Bash", ac_id="ac_other"),
+            _tool_returned(call_id="c1", tool_name="Bash", ac_id="ac_other"),
+            _tool_started(call_id="c2", tool_name="Bash", ac_id="ac_target"),
+            _tool_returned(call_id="c2", tool_name="Bash", ac_id="ac_target"),
+        ]
+        manifest = normalize_events(events, ac_id="ac_target")
+        assert len(manifest.entries) == 1
+        entry = manifest.entries[0]
+        assert "ac_other" not in str(entry.source_event_ids)
+
+    def test_rejects_blank_ac_id(self) -> None:
+        with pytest.raises(ValueError):
+            normalize_events([], ac_id="   ")
+
+    def test_trims_ac_id_whitespace(self) -> None:
+        manifest = normalize_events([], ac_id="  ac_padded  ")
+        assert manifest.ac_id == "ac_padded"
+
+
+class TestFilterEventsForAC:
+    def test_returns_only_matching_ac(self) -> None:
+        events = [
+            _tool_started(call_id="c1", tool_name="Bash", ac_id="ac_a"),
+            _tool_started(call_id="c2", tool_name="Bash", ac_id="ac_b"),
+        ]
+        filtered = filter_events_for_ac(events, ac_id="ac_a")
+        assert len(filtered) == 1
+        assert filtered[0].data["call_id"] == "c1"
+
+    def test_excludes_events_without_ac_id(self) -> None:
+        bare = BaseEvent(
+            id="evt_bare",
+            type="tool.call.started",
+            timestamp=datetime.now(UTC),
+            aggregate_type="session",
+            aggregate_id="session_test",
+            data={"call_id": "c1", "tool_name": "Bash"},
+        )
+        filtered = filter_events_for_ac([bare], ac_id="ac_a")
+        assert filtered == ()
+
+    def test_rejects_blank_ac_id(self) -> None:
+        with pytest.raises(ValueError):
+            filter_events_for_ac([], ac_id="   ")
+
+
+class TestLLMEntries:
+    def test_llm_returned_emits_entry(self) -> None:
+        event = BaseEvent(
+            id="evt_llm_1",
+            type="llm.call.returned",
+            timestamp=datetime.now(UTC),
+            aggregate_type="session",
+            aggregate_id="session_test",
+            data={
+                "model": "claude-sonnet-4.6",
+                "role": "deliver",
+                "is_error": False,
+                "ac_id": "ac_1",
+            },
+        )
+        manifest = normalize_events([event], ac_id="ac_1")
+        assert len(manifest.entries) == 1
+        entry = manifest.entries[0]
+        assert entry.kind is EvidenceKind.LLM_CALL
+        assert entry.ok is True
+        assert entry.payload["model"] == "claude-sonnet-4.6"
+        assert entry.payload["role"] == "deliver"
+
+
+class TestEnumerations:
+    def test_evidence_kind_values(self) -> None:
+        assert {kind.value for kind in EvidenceKind} == {
+            "tool_invocation",
+            "command_executed",
+            "file_modified",
+            "llm_call",
+        }

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from types import MappingProxyType
+from typing import Any
 
 from pydantic import ValidationError
 import pytest
@@ -495,3 +496,65 @@ class TestEnumerations:
             "file_modified",
             "llm_call",
         }
+
+
+class TestObservationOrdering:
+    def test_pending_start_keeps_observed_position(self) -> None:
+        """``start(A)``, ``start(B)``, ``return(B)`` must yield ``[A, B]``.
+
+        Regression for PR #982 review: the previous implementation
+        appended unmatched start events at the end of the manifest,
+        flipping the visible order to ``[B, A]`` and distorting
+        partial-trace consumers.
+        """
+        base = datetime.now(UTC)
+        events = [
+            _tool_started(call_id="cA", tool_name="Bash", when=base),
+            _tool_started(call_id="cB", tool_name="Edit", when=base + timedelta(milliseconds=1)),
+            _tool_returned(call_id="cB", tool_name="Edit", when=base + timedelta(milliseconds=2)),
+        ]
+        manifest = normalize_events(events, ac_id="ac_1")
+        kinds = [entry.payload["tool_name"] for entry in manifest.entries]
+        assert kinds == ["Bash", "Edit"], (
+            "manifest entries must reflect observation order even when a "
+            "later call completes before an earlier one"
+        )
+        # First entry is dangling (started only); second is paired.
+        assert manifest.entries[0].ok is None
+        assert manifest.entries[0].ended_at is None
+        assert manifest.entries[1].ok is True
+
+
+class TestDeepImmutability:
+    def test_external_dict_mutation_does_not_leak_into_payload(self) -> None:
+        """Mutating an externally-held dict after construction must not
+        change ``EvidenceEntry.payload``. This guards the contract that
+        cached projections cannot silently drift."""
+        outer: dict[str, Any] = {"tool_name": "Bash", "nested": {"k": "v"}}
+        entry = EvidenceEntry(
+            kind=EvidenceKind.COMMAND_EXECUTED,
+            started_at=datetime.now(UTC),
+            payload=outer,
+            source_event_ids=("evt_1",),
+        )
+        outer["tool_name"] = "Tampered"
+        outer["nested"]["k"] = "tampered"
+        assert entry.payload["tool_name"] == "Bash"
+        assert entry.payload["nested"]["k"] == "v"
+
+    def test_proxy_wrapping_mutable_dict_is_deep_frozen(self) -> None:
+        from types import MappingProxyType
+
+        inner: dict[str, Any] = {"tool_name": "Bash", "nested": {"k": "v"}}
+        proxy = MappingProxyType(inner)
+        entry = EvidenceEntry(
+            kind=EvidenceKind.COMMAND_EXECUTED,
+            started_at=datetime.now(UTC),
+            payload=proxy,
+            source_event_ids=("evt_1",),
+        )
+        # Mutating the original underlying dict must not bleed through.
+        inner["tool_name"] = "Tampered"
+        inner["nested"]["k"] = "tampered"
+        assert entry.payload["tool_name"] == "Bash"
+        assert entry.payload["nested"]["k"] == "v"

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -291,28 +291,200 @@ class TestFilterEventsForAC:
             filter_events_for_ac([], ac_id="   ")
 
 
-class TestLLMEntries:
-    def test_llm_returned_emits_entry(self) -> None:
-        event = BaseEvent(
-            id="evt_llm_1",
-            type="llm.call.returned",
-            timestamp=datetime.now(UTC),
-            aggregate_type="session",
-            aggregate_id="session_test",
-            data={
-                "model": "claude-sonnet-4.6",
-                "role": "deliver",
-                "is_error": False,
-                "ac_id": "ac_1",
-            },
-        )
-        manifest = normalize_events([event], ac_id="ac_1")
+def _llm_requested(
+    *,
+    call_id: str,
+    model_id: str,
+    caller: str | None = None,
+    when: datetime | None = None,
+    event_id: str | None = None,
+    ac_scope_field: str = "execution_id",
+    ac_scope_value: str = "ac_1",
+) -> BaseEvent:
+    """Build an ``llm.call.requested`` event matching the recorder shape.
+
+    The recorder populates ``model_id`` (not ``model``), pairs by
+    ``call_id``, and uses correlation fields like ``execution_id`` /
+    ``phase`` rather than an ``ac_id`` payload field.
+    """
+    return BaseEvent(
+        id=event_id or f"evt_llm_req_{call_id}",
+        type="llm.call.requested",
+        timestamp=when or datetime.now(UTC),
+        aggregate_type="execution",
+        aggregate_id=ac_scope_value if ac_scope_field == "aggregate_id" else "execution_x",
+        data={
+            "call_id": call_id,
+            "model_id": model_id,
+            "caller": caller,
+            ac_scope_field: ac_scope_value,
+        },
+    )
+
+
+def _llm_returned(
+    *,
+    call_id: str,
+    model_id: str,
+    duration_ms: int = 1200,
+    is_error: bool = False,
+    when: datetime | None = None,
+    event_id: str | None = None,
+    ac_scope_field: str = "execution_id",
+    ac_scope_value: str = "ac_1",
+) -> BaseEvent:
+    return BaseEvent(
+        id=event_id or f"evt_llm_ret_{call_id}",
+        type="llm.call.returned",
+        timestamp=when or datetime.now(UTC),
+        aggregate_type="execution",
+        aggregate_id=ac_scope_value if ac_scope_field == "aggregate_id" else "execution_x",
+        data={
+            "call_id": call_id,
+            "model_id": model_id,
+            "duration_ms": duration_ms,
+            "is_error": is_error,
+            ac_scope_field: ac_scope_value,
+        },
+    )
+
+
+class TestLLMPairing:
+    """LLM calls must be paired by ``call_id`` and use ``model_id``
+    (not ``model``) — matches the canonical recorder factories in
+    ``src/ouroboros/events/io.py``.
+    """
+
+    def test_paired_llm_emits_single_entry(self) -> None:
+        start_time = datetime.now(UTC)
+        events = [
+            _llm_requested(
+                call_id="llm1",
+                model_id="claude-sonnet-4.6",
+                caller="executor:deliver",
+                when=start_time,
+                event_id="evt_req_llm1",
+            ),
+            _llm_returned(
+                call_id="llm1",
+                model_id="claude-sonnet-4.6",
+                duration_ms=900,
+                is_error=False,
+                when=start_time + timedelta(milliseconds=900),
+                event_id="evt_ret_llm1",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_1")
         assert len(manifest.entries) == 1
         entry = manifest.entries[0]
         assert entry.kind is EvidenceKind.LLM_CALL
         assert entry.ok is True
-        assert entry.payload["model"] == "claude-sonnet-4.6"
-        assert entry.payload["role"] == "deliver"
+        assert entry.payload["model_id"] == "claude-sonnet-4.6"
+        assert entry.payload["caller"] == "executor:deliver"
+        assert entry.payload["duration_ms"] == 900
+        assert entry.source_event_ids == ("evt_req_llm1", "evt_ret_llm1")
+
+    def test_unpaired_request_surfaces_as_running(self) -> None:
+        events = [
+            _llm_requested(
+                call_id="llm2",
+                model_id="claude-haiku-4.5",
+                event_id="evt_req_llm2",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_1")
+        assert len(manifest.entries) == 1
+        entry = manifest.entries[0]
+        assert entry.kind is EvidenceKind.LLM_CALL
+        assert entry.ok is None
+        assert entry.ended_at is None
+        assert entry.source_event_ids == ("evt_req_llm2",)
+
+    def test_completion_only_pair_still_emitted(self) -> None:
+        events = [
+            _llm_returned(
+                call_id="llm_orphan",
+                model_id="claude-sonnet-4.6",
+                event_id="evt_ret_orphan",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_1")
+        assert len(manifest.entries) == 1
+        entry = manifest.entries[0]
+        assert entry.kind is EvidenceKind.LLM_CALL
+        assert entry.source_event_ids == ("evt_ret_orphan",)
+
+
+class TestACScopingMultiChannel:
+    """AC scoping must accept every channel a recorder populates
+    (``aggregate_id``, correlation ``execution_id`` / ``phase``, and the
+    explicit ``ac_id`` payload when present)."""
+
+    def test_match_via_aggregate_id(self) -> None:
+        events = [
+            _llm_requested(
+                call_id="llm_a",
+                model_id="claude-sonnet-4.6",
+                ac_scope_field="aggregate_id",
+                ac_scope_value="ac_target",
+            ),
+            _llm_returned(
+                call_id="llm_a",
+                model_id="claude-sonnet-4.6",
+                ac_scope_field="aggregate_id",
+                ac_scope_value="ac_target",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_target")
+        assert len(manifest.entries) == 1
+
+    def test_match_via_execution_id_correlation(self) -> None:
+        events = [
+            _llm_requested(
+                call_id="llm_a",
+                model_id="claude-sonnet-4.6",
+                ac_scope_field="execution_id",
+                ac_scope_value="ac_target",
+            ),
+            _llm_returned(
+                call_id="llm_a",
+                model_id="claude-sonnet-4.6",
+                ac_scope_field="execution_id",
+                ac_scope_value="ac_target",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_target")
+        assert len(manifest.entries) == 1
+
+    def test_match_via_phase_correlation(self) -> None:
+        events = [
+            _llm_requested(
+                call_id="llm_a",
+                model_id="claude-sonnet-4.6",
+                ac_scope_field="phase",
+                ac_scope_value="ac_target",
+            ),
+            _llm_returned(
+                call_id="llm_a",
+                model_id="claude-sonnet-4.6",
+                ac_scope_field="phase",
+                ac_scope_value="ac_target",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_target")
+        assert len(manifest.entries) == 1
+
+    def test_no_matching_channel_excludes_event(self) -> None:
+        events = [
+            _llm_requested(
+                call_id="llm_a",
+                model_id="claude-sonnet-4.6",
+                ac_scope_field="execution_id",
+                ac_scope_value="other_ac",
+            ),
+        ]
+        manifest = normalize_events(events, ac_id="ac_target")
+        assert manifest.entries == ()
 
 
 class TestEnumerations:

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -558,3 +558,25 @@ class TestDeepImmutability:
         inner["nested"]["k"] = "tampered"
         assert entry.payload["tool_name"] == "Bash"
         assert entry.payload["nested"]["k"] == "v"
+
+
+def test_free_form_payload_freezes_sets_and_bytearrays() -> None:
+    mutable_bytes = bytearray(b"abc")
+    entry = EvidenceEntry(
+        handle="ev_1",
+        kind=EvidenceKind.TOOL_INVOCATION,
+        source_event_ids=("evt_1",),
+        started_at=datetime.now(UTC),
+        payload={"tags": {"a", "b"}, "blob": mutable_bytes},
+    )
+
+    mutable_bytes[0] = ord("z")
+
+    assert entry.payload["tags"] == frozenset({"a", "b"})
+    assert entry.payload["blob"] == b"abc"
+
+
+def test_manifest_metadata_freezes_sets() -> None:
+    manifest = EvidenceManifest(ac_id="AC-1", metadata={"tags": {"x"}})
+
+    assert manifest.metadata["tags"] == frozenset({"x"})

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -580,3 +580,23 @@ def test_manifest_metadata_freezes_sets() -> None:
     manifest = EvidenceManifest(ac_id="AC-1", metadata={"tags": {"x"}})
 
     assert manifest.metadata["tags"] == frozenset({"x"})
+
+
+def test_free_form_payload_model_dump_thaws_nested_containers() -> None:
+    entry = EvidenceEntry(
+        handle="ev_1",
+        kind=EvidenceKind.TOOL_INVOCATION,
+        source_event_ids=("evt_1",),
+        started_at=datetime.now(UTC),
+        payload={"nested": {"tags": {"a"}}, "blob": bytearray(b"abc")},
+    )
+
+    dumped = entry.model_dump()
+
+    assert dumped["payload"] == {"nested": {"tags": ["a"]}, "blob": "abc"}
+
+
+def test_manifest_metadata_model_dump_thaws_nested_containers() -> None:
+    manifest = EvidenceManifest(ac_id="AC-1", metadata={"nested": {"tags": {"x"}}})
+
+    assert manifest.model_dump()["metadata"] == {"nested": {"tags": ["x"]}}


### PR DESCRIPTION
## Scope

First slice of #978 (the AgentOS Evidence Gate spine). Introduces the
read-only journal normalizer that turns ordered ``EventStore`` events
for a single acceptance criterion into a typed ``EvidenceManifest`` for
downstream verifiers. **No EventStore wiring** and **no deliver-gate
hook** — those land in P2 so this surface can be reviewed in isolation.

Tracks #961's Phase C.1:
> `#978 P1` journal normalizer — EventStore → evidence-manifest
> projection. Read-only, no deliver-path change.

## What this PR contains

- `src/ouroboros/harness/journal.py`
  - `EvidenceManifest`, `EvidenceEntry` — `frozen=True` Pydantic
    models.
  - `EvidenceKind` enum (`tool_invocation` / `command_executed` /
    `file_modified` / `llm_call`). Open vocabulary; plugin-defined
    kinds land via #939's lifecycle work.
  - `normalize_events(events, ac_id) -> EvidenceManifest`:
    - Pairs `tool.call.started` / `tool.call.returned` events by
      `call_id`.
    - Classifies tool name into `EvidenceKind` — `Bash` →
      `command_executed`, `Write` / `Edit` / `NotebookEdit` →
      `file_modified`, others → `tool_invocation`.
    - Drops events whose payload's `ac_id` belongs to a different
      acceptance criterion.
    - Surfaces unpaired start events as `ok=None` / `ended_at=None`
      entries so dangling work remains observable.
    - Emits `llm.call.requested` / `llm.call.returned` as `llm_call`
      entries.
    - Carries `source_event_ids` on every entry so verdicts replay
      cleanly.
  - `filter_events_for_ac` helper for callers that hold a flat event
    list.
  - `FrozenMapping` / `IdentifierTuple` patterns mirror the ones used
    in #946 PR-1a / #956 PR-1 (immutable `MappingProxyType` views;
    blank-identifier rejection).
- `src/ouroboros/harness/__init__.py` — public re-exports.
- `tests/unit/harness/test_journal_normalizer.py` — 23 tests covering
  pairing, classification, AC scoping, dangling-work observability,
  frozen-mapping invariants, identifier hygiene, `model_dump`
  round-trip, and the `filter_events_for_ac` helper.

## Acceptance-criterion mapping (#978)

| Phasing item | Status in this PR |
|---|---|
| P1 — journal normalizer (`EventStore` → evidence manifest projection); pure read, no behavior change | ✅ |
| P2 — TraceGuard wire-up at AC deliver | ⏭️ next PR |
| P3 — failure-taxonomy routing | ⏭️ |
| P4 — baseline benchmark | ⏭️ |
| P5 — default flip (no opt-in flag) | ⏭️ |

## Design notes

- The normalizer is a **pure function** over an event iterable. It
  does not import `EventStore` and does not hold runtime state, so it
  can be exercised against synthetic event lists in tests and the
  future P2 hook can feed it directly from a query.
- Each `EvidenceEntry` requires non-empty `source_event_ids`. This
  matches the projection contract in #946 PR-1a — every projected
  unit of work links back to the source events that produced it.
- `MappingProxyType` is used for both `EvidenceEntry.payload` and
  `EvidenceManifest.metadata` so cached projections cannot silently
  drift through `record.payload[key] = value`-style mutation. The
  pattern is identical to the hardening landed for the projection
  records — bot reviewer's blocking finding from #980 is pre-empted.
- AC scoping is conservative: events without an explicit `ac_id`
  payload field are excluded from the manifest. Callers can broaden
  this in P2 once we decide how implicit-scope events (e.g. session-
  level) should attribute.

## Non-goals

- No `EventStore` query path — the input is an iterable of events.
- No TraceGuard call site — that's P2.
- No coverage for evaluation events (`stage1.*`, `stage2.*`, etc.) —
  the projection layer (#946) covers those; the journal manifest is
  specifically for the deliver-gate inputs.
- No plugin-defined evidence types (deferred to #939).
- No persistence of manifest records.

## Verification

```
$ uv run pytest tests/unit/harness/test_journal_normalizer.py -q
.......................                                                  [100%]
23 passed in 0.19s

$ uv run pytest tests/unit/core tests/unit/harness/ tests/unit/events -q
529 passed in 2.36s
```

## Coordination with sibling Phase C.1 PRs

- `src/ouroboros/harness/__init__.py` in this PR re-exports only the
  journal module. #946 PR-1a (#980) also adds re-exports to the same
  file. The merge between the two PRs is a straightforward additive
  union of `__all__`; whichever PR lands second handles the merge
  with a one-line diff.
- Both PRs use the same `FrozenMapping` / `IdentifierTuple`
  Annotated-alias pattern. A future refactor PR may centralize these
  in `ouroboros.harness._immutables`; that consolidation is
  deliberately deferred so each substrate PR remains independently
  reviewable.

## Follow-ups (separate PRs)

- `#978 P2` — pull events from `EventStore` for an AC scope and
  feed the normalizer at the deliver gate; replace summary-based
  scoring with `validate_parent_synthesis` against the resulting
  manifest. Legacy path retained behind an internal flag for the
  A/B baseline.
- `#978 P3` — wire failure-taxonomy classifications to the recovery
  router (`retry` / `redispatch` / `model_escalation` / `blocker`).
- `#978 P4` — capture baseline benchmark for the #961 hard gates.
- `#978 P5` — default flip + legacy removal (two separate PRs per
  the SSOT split rule).

Refs #978 · sequenced under #961's "Post-milestone PR sequencing for
Tier 2 work" section.
