### PR TITLE
feat(harness): add ProjectionBuilder over the EventStore (#946 PR-1b)

### DIFF
--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -1,0 +1,445 @@
+"""Projection builder over the EventStore.
+
+This module is the second slice of issue #946. It walks an ordered
+sequence of :class:`ouroboros.events.base.BaseEvent` records and
+produces the public projection vocabulary delivered by
+:mod:`ouroboros.harness.projection`. The builder is intentionally
+small in this PR — it covers the substrate (one builder class plus the
+event families already emitted by the canonical I/O recorder) and
+leaves CLI / MCP query surfaces and richer event-family coverage to
+follow-up PRs.
+
+Recognized event families in PR-1b:
+
+* ``tool.call.started`` / ``tool.call.returned`` — paired by ``call_id``
+  into a :class:`StepRecord` of kind :attr:`StepKind.TOOL_CALL`.
+  ``Bash`` tool calls are classified as :attr:`StepKind.SHELL_COMMAND`.
+* ``llm.call.requested`` / ``llm.call.returned`` — paired by ``call_id``
+  into a :class:`StepRecord` of kind :attr:`StepKind.MODEL_CALL`.
+* Stage / verdict events are not mapped yet. The builder produces a
+  single default :class:`StageRecord` of kind
+  :attr:`StageKind.EXECUTE` that owns every step; richer stage
+  detection is deferred to a future PR.
+
+The builder is a **pure read** transformation: it never persists the
+records and never mutates the events it walks.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.harness.projection import (
+    PROJECTION_SCHEMA_VERSION,
+    RunRecord,
+    StageKind,
+    StageRecord,
+    StepKind,
+    StepRecord,
+)
+
+_TOOL_STARTED = "tool.call.started"
+_TOOL_RETURNED = "tool.call.returned"
+_LLM_REQUESTED = "llm.call.requested"
+_LLM_RETURNED = "llm.call.returned"
+
+_SHELL_TOOL_NAMES = frozenset({"Bash"})
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionBuildResult:
+    """Bundle of records produced from a single event sweep.
+
+    Attributes:
+        run: Top-level :class:`RunRecord`.
+        stages: Stage records owned by the run.
+        steps: Step records owned by the stages.
+    """
+
+    run: RunRecord
+    stages: tuple[StageRecord, ...]
+    steps: tuple[StepRecord, ...]
+
+
+class ProjectionBuilder:
+    """Walk events and emit the projection record bundle.
+
+    The builder is constructed with a ``seed_id`` (and optional goal
+    text) and accepts events incrementally via :meth:`add_event`, or in
+    bulk via :meth:`add_events`. :meth:`build` finalizes the records.
+
+    The same builder instance can be replayed multiple times: each call
+    to :meth:`build` produces a fresh record bundle reflecting the
+    events ingested so far. The builder does not deduplicate replayed
+    events — callers must ensure each event is fed once per build.
+    """
+
+    def __init__(
+        self,
+        *,
+        seed_id: str,
+        goal: str = "",
+        run_id: str | None = None,
+        stage_id: str | None = None,
+    ) -> None:
+        if not seed_id.strip():
+            msg = "ProjectionBuilder requires a non-blank seed_id"
+            raise ValueError(msg)
+        self._seed_id = seed_id.strip()
+        self._goal = goal
+        self._run_id = run_id
+        self._stage_id = stage_id
+        self._tool_started: OrderedDict[str, BaseEvent] = OrderedDict()
+        self._llm_started: OrderedDict[str, BaseEvent] = OrderedDict()
+        self._steps: list[StepRecord] = []
+        self._first_event_at: datetime | None = None
+        self._last_event_at: datetime | None = None
+
+    # -- public API -----------------------------------------------------
+
+    def add_events(self, events: Iterable[BaseEvent]) -> ProjectionBuilder:
+        """Ingest a batch of events. Returns self for chaining."""
+        for event in events:
+            self.add_event(event)
+        return self
+
+    def add_event(self, event: BaseEvent) -> ProjectionBuilder:
+        """Ingest a single event. Returns self for chaining."""
+        self._update_timestamps(event)
+
+        if event.type == _TOOL_STARTED:
+            call_id = _extract_call_id(event)
+            if call_id is not None:
+                self._tool_started[call_id] = event
+            return self
+
+        if event.type == _TOOL_RETURNED:
+            self._handle_tool_returned(event)
+            return self
+
+        if event.type == _LLM_REQUESTED:
+            call_id = _extract_call_id(event)
+            if call_id is not None:
+                self._llm_started[call_id] = event
+            return self
+
+        if event.type == _LLM_RETURNED:
+            self._handle_llm_returned(event)
+            return self
+
+        # Other event types are ignored in PR-1b; they will be mapped
+        # in follow-up PRs alongside their dedicated kinds.
+        return self
+
+    def build(self) -> ProjectionBuildResult:
+        """Finalize the record bundle from ingested events.
+
+        Repeated calls return identical ``run_id`` / ``stage_id`` so
+        replayable projections stay stable.
+        """
+        if self._run_id is None:
+            self._run_id = RunRecord(seed_id=self._seed_id).run_id
+        if self._stage_id is None:
+            self._stage_id = StageRecord(run_id=self._run_id, kind=StageKind.EXECUTE).stage_id
+        run_id = self._run_id
+        stage_id = self._stage_id
+
+        started_at = self._first_event_at or datetime.now(UTC)
+        ended_at = self._last_event_at
+
+        steps_for_stage = tuple(
+            StepRecord(
+                schema_version=step.schema_version,
+                step_id=step.step_id,
+                run_id=run_id,
+                stage_id=stage_id,
+                kind=step.kind,
+                name=step.name,
+                ac_id=step.ac_id,
+                started_at=step.started_at,
+                ended_at=step.ended_at,
+                ok=step.ok,
+                source_event_ids=step.source_event_ids,
+                legacy_inferred=step.legacy_inferred,
+                artifact_ids=step.artifact_ids,
+                metadata=step.metadata,
+            )
+            for step in self._steps
+        )
+
+        # Emit unpaired starts as in-flight steps so callers can detect
+        # dangling work.
+        for call_id, start_event in self._tool_started.items():
+            steps_for_stage = (
+                *steps_for_stage,
+                _step_from_start_only(
+                    call_id=call_id,
+                    start_event=start_event,
+                    run_id=run_id,
+                    stage_id=stage_id,
+                    kind=_tool_kind(start_event),
+                ),
+            )
+        for call_id, start_event in self._llm_started.items():
+            steps_for_stage = (
+                *steps_for_stage,
+                _step_from_start_only(
+                    call_id=call_id,
+                    start_event=start_event,
+                    run_id=run_id,
+                    stage_id=stage_id,
+                    kind=StepKind.MODEL_CALL,
+                ),
+            )
+
+        stage = StageRecord(
+            schema_version=PROJECTION_SCHEMA_VERSION,
+            stage_id=stage_id,
+            run_id=run_id,
+            kind=StageKind.EXECUTE,
+            started_at=started_at,
+            ended_at=ended_at,
+            step_ids=tuple(step.step_id for step in steps_for_stage),
+        )
+
+        run = RunRecord(
+            schema_version=PROJECTION_SCHEMA_VERSION,
+            run_id=run_id,
+            seed_id=self._seed_id,
+            goal=self._goal,
+            started_at=started_at,
+            ended_at=ended_at,
+            stage_ids=(stage_id,),
+        )
+
+        return ProjectionBuildResult(
+            run=run,
+            stages=(stage,),
+            steps=steps_for_stage,
+        )
+
+    # -- internals ------------------------------------------------------
+
+    def _update_timestamps(self, event: BaseEvent) -> None:
+        if self._first_event_at is None or event.timestamp < self._first_event_at:
+            self._first_event_at = event.timestamp
+        if self._last_event_at is None or event.timestamp > self._last_event_at:
+            self._last_event_at = event.timestamp
+
+    def _handle_tool_returned(self, returned_event: BaseEvent) -> None:
+        call_id = _extract_call_id(returned_event)
+        if call_id is None:
+            return
+        start_event = self._tool_started.pop(call_id, None)
+        kind = _tool_kind(start_event or returned_event)
+        tool_name = _extract_tool_name(start_event or returned_event)
+        if not tool_name:
+            return
+
+        source_event_ids = tuple(
+            event.id for event in (start_event, returned_event) if event is not None
+        )
+        if not source_event_ids:
+            return
+
+        is_error = _safe_bool(returned_event.data.get("is_error"))
+        ok = (not is_error) if is_error is not None else None
+
+        step = StepRecord(
+            schema_version=PROJECTION_SCHEMA_VERSION,
+            run_id="run_placeholder",  # rewritten in build()
+            stage_id="stage_placeholder",
+            kind=kind,
+            name=tool_name,
+            ac_id=_extract_ac_id(start_event or returned_event),
+            started_at=(start_event or returned_event).timestamp,
+            ended_at=returned_event.timestamp,
+            ok=ok,
+            source_event_ids=source_event_ids,
+            metadata=_tool_step_metadata(start_event, returned_event),
+        )
+        self._steps.append(step)
+
+    def _handle_llm_returned(self, returned_event: BaseEvent) -> None:
+        call_id = _extract_call_id(returned_event)
+        if call_id is None:
+            return
+        start_event = self._llm_started.pop(call_id, None)
+        model_id = _extract_model_id(returned_event) or _extract_model_id(start_event)
+        if not model_id:
+            return
+
+        source_event_ids = tuple(
+            event.id for event in (start_event, returned_event) if event is not None
+        )
+        if not source_event_ids:
+            return
+
+        is_error = _safe_bool(returned_event.data.get("is_error"))
+        ok = (not is_error) if is_error is not None else None
+
+        step = StepRecord(
+            schema_version=PROJECTION_SCHEMA_VERSION,
+            run_id="run_placeholder",  # rewritten in build()
+            stage_id="stage_placeholder",
+            kind=StepKind.MODEL_CALL,
+            name=model_id,
+            ac_id=_extract_ac_id(start_event or returned_event),
+            started_at=(start_event or returned_event).timestamp,
+            ended_at=returned_event.timestamp,
+            ok=ok,
+            source_event_ids=source_event_ids,
+            metadata=_llm_step_metadata(start_event, returned_event),
+        )
+        self._steps.append(step)
+
+
+# ---------------------------------------------------------------------------
+# Convenience entry points + helpers
+# ---------------------------------------------------------------------------
+
+
+def build_projection(
+    events: Sequence[BaseEvent],
+    *,
+    seed_id: str,
+    goal: str = "",
+) -> ProjectionBuildResult:
+    """One-shot projection from a sequence of events."""
+    return ProjectionBuilder(seed_id=seed_id, goal=goal).add_events(events).build()
+
+
+def _extract_call_id(event: BaseEvent) -> str | None:
+    if not isinstance(event.data, dict):
+        return None
+    value = event.data.get("call_id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _extract_tool_name(event: BaseEvent | None) -> str | None:
+    if event is None or not isinstance(event.data, dict):
+        return None
+    value = event.data.get("tool_name")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _extract_model_id(event: BaseEvent | None) -> str | None:
+    if event is None or not isinstance(event.data, dict):
+        return None
+    value = event.data.get("model_id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _extract_ac_id(event: BaseEvent | None) -> str | None:
+    if event is None or not isinstance(event.data, dict):
+        return None
+    value = event.data.get("ac_id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _tool_kind(event: BaseEvent | None) -> StepKind:
+    tool_name = _extract_tool_name(event)
+    if tool_name in _SHELL_TOOL_NAMES:
+        return StepKind.SHELL_COMMAND
+    return StepKind.TOOL_CALL
+
+
+def _safe_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _tool_step_metadata(
+    start_event: BaseEvent | None,
+    returned_event: BaseEvent,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if start_event is not None and isinstance(start_event.data, dict):
+        preview = start_event.data.get("args_preview")
+        if isinstance(preview, str) and preview:
+            metadata["args_preview"] = preview
+    if isinstance(returned_event.data, dict):
+        result_preview = returned_event.data.get("result_preview")
+        if isinstance(result_preview, str) and result_preview:
+            metadata["result_preview"] = result_preview
+        duration = returned_event.data.get("duration_ms")
+        if isinstance(duration, int):
+            metadata["duration_ms"] = duration
+        error_kind = returned_event.data.get("error_kind")
+        if isinstance(error_kind, str) and error_kind:
+            metadata["error_kind"] = error_kind
+    return metadata
+
+
+def _llm_step_metadata(
+    start_event: BaseEvent | None,
+    returned_event: BaseEvent,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if start_event is not None and isinstance(start_event.data, dict):
+        caller = start_event.data.get("caller")
+        if isinstance(caller, str) and caller:
+            metadata["caller"] = caller
+    if isinstance(returned_event.data, dict):
+        duration = returned_event.data.get("duration_ms")
+        if isinstance(duration, int):
+            metadata["duration_ms"] = duration
+        error_kind = returned_event.data.get("error_kind")
+        if isinstance(error_kind, str) and error_kind:
+            metadata["error_kind"] = error_kind
+    return metadata
+
+
+def _step_from_start_only(
+    *,
+    call_id: str,
+    start_event: BaseEvent,
+    run_id: str,
+    stage_id: str,
+    kind: StepKind,
+) -> StepRecord:
+    del call_id  # reserved for future correlation logging
+    name = (
+        _extract_tool_name(start_event)
+        if kind in (StepKind.TOOL_CALL, StepKind.SHELL_COMMAND)
+        else _extract_model_id(start_event)
+    ) or kind.value
+    metadata: dict[str, Any] = {}
+    if isinstance(start_event.data, dict):
+        preview = start_event.data.get("args_preview")
+        if isinstance(preview, str) and preview:
+            metadata["args_preview"] = preview
+    return StepRecord(
+        schema_version=PROJECTION_SCHEMA_VERSION,
+        run_id=run_id,
+        stage_id=stage_id,
+        kind=kind,
+        name=name,
+        ac_id=_extract_ac_id(start_event),
+        started_at=start_event.timestamp,
+        ended_at=None,
+        ok=None,
+        source_event_ids=(start_event.id,),
+        metadata=metadata,
+    )
+
+
+__all__ = [
+    "ProjectionBuildResult",
+    "ProjectionBuilder",
+    "build_projection",
+]

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -32,6 +32,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
+from uuid import NAMESPACE_URL, uuid5
 
 from ouroboros.events.base import BaseEvent
 from ouroboros.harness.projection import (
@@ -96,7 +97,7 @@ class ProjectionBuilder:
         self._stage_id = stage_id
         self._tool_started: OrderedDict[str, BaseEvent] = OrderedDict()
         self._llm_started: OrderedDict[str, BaseEvent] = OrderedDict()
-        self._steps: list[StepRecord] = []
+        self._steps: OrderedDict[str, StepRecord] = OrderedDict()
         self._first_event_at: datetime | None = None
         self._last_event_at: datetime | None = None
 
@@ -116,6 +117,15 @@ class ProjectionBuilder:
             call_id = _extract_call_id(event)
             if call_id is not None:
                 self._tool_started[call_id] = event
+                key = _slot_key("tool", call_id)
+                self._steps[key] = _step_from_start_only(
+                    call_id=call_id,
+                    start_event=event,
+                    run_id="run_placeholder",
+                    stage_id="stage_placeholder",
+                    kind=_tool_kind(event),
+                    family="tool",
+                )
             return self
 
         if event.type == _TOOL_RETURNED:
@@ -126,6 +136,15 @@ class ProjectionBuilder:
             call_id = _extract_call_id(event)
             if call_id is not None:
                 self._llm_started[call_id] = event
+                key = _slot_key("llm", call_id)
+                self._steps[key] = _step_from_start_only(
+                    call_id=call_id,
+                    start_event=event,
+                    run_id="run_placeholder",
+                    stage_id="stage_placeholder",
+                    kind=StepKind.MODEL_CALL,
+                    family="llm",
+                )
             return self
 
         if event.type == _LLM_RETURNED:
@@ -153,49 +172,9 @@ class ProjectionBuilder:
         ended_at = self._last_event_at
 
         steps_for_stage = tuple(
-            StepRecord(
-                schema_version=step.schema_version,
-                step_id=step.step_id,
-                run_id=run_id,
-                stage_id=stage_id,
-                kind=step.kind,
-                name=step.name,
-                ac_id=step.ac_id,
-                started_at=step.started_at,
-                ended_at=step.ended_at,
-                ok=step.ok,
-                source_event_ids=step.source_event_ids,
-                legacy_inferred=step.legacy_inferred,
-                artifact_ids=step.artifact_ids,
-                metadata=step.metadata,
-            )
-            for step in self._steps
+            _rewrite_step_run_stage(step, run_id=run_id, stage_id=stage_id)
+            for step in self._steps.values()
         )
-
-        # Emit unpaired starts as in-flight steps so callers can detect
-        # dangling work.
-        for call_id, start_event in self._tool_started.items():
-            steps_for_stage = (
-                *steps_for_stage,
-                _step_from_start_only(
-                    call_id=call_id,
-                    start_event=start_event,
-                    run_id=run_id,
-                    stage_id=stage_id,
-                    kind=_tool_kind(start_event),
-                ),
-            )
-        for call_id, start_event in self._llm_started.items():
-            steps_for_stage = (
-                *steps_for_stage,
-                _step_from_start_only(
-                    call_id=call_id,
-                    start_event=start_event,
-                    run_id=run_id,
-                    stage_id=stage_id,
-                    kind=StepKind.MODEL_CALL,
-                ),
-            )
 
         stage = StageRecord(
             schema_version=PROJECTION_SCHEMA_VERSION,
@@ -250,8 +229,11 @@ class ProjectionBuilder:
         is_error = _safe_bool(returned_event.data.get("is_error"))
         ok = (not is_error) if is_error is not None else None
 
+        key = _slot_key("tool", call_id)
+        previous = self._steps.get(key)
         step = StepRecord(
             schema_version=PROJECTION_SCHEMA_VERSION,
+            step_id=previous.step_id if previous is not None else _stable_step_id("tool", call_id),
             run_id="run_placeholder",  # rewritten in build()
             stage_id="stage_placeholder",
             kind=kind,
@@ -263,7 +245,7 @@ class ProjectionBuilder:
             source_event_ids=source_event_ids,
             metadata=_tool_step_metadata(start_event, returned_event),
         )
-        self._steps.append(step)
+        self._steps[key] = step
 
     def _handle_llm_returned(self, returned_event: BaseEvent) -> None:
         call_id = _extract_call_id(returned_event)
@@ -283,8 +265,11 @@ class ProjectionBuilder:
         is_error = _safe_bool(returned_event.data.get("is_error"))
         ok = (not is_error) if is_error is not None else None
 
+        key = _slot_key("llm", call_id)
+        previous = self._steps.get(key)
         step = StepRecord(
             schema_version=PROJECTION_SCHEMA_VERSION,
+            step_id=previous.step_id if previous is not None else _stable_step_id("llm", call_id),
             run_id="run_placeholder",  # rewritten in build()
             stage_id="stage_placeholder",
             kind=StepKind.MODEL_CALL,
@@ -296,7 +281,7 @@ class ProjectionBuilder:
             source_event_ids=source_event_ids,
             metadata=_llm_step_metadata(start_event, returned_event),
         )
-        self._steps.append(step)
+        self._steps[key] = step
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +389,34 @@ def _llm_step_metadata(
     return metadata
 
 
+def _slot_key(family: str, call_id: str) -> str:
+    return f"{family}:{call_id}"
+
+
+def _stable_step_id(family: str, call_id: str) -> str:
+    digest = uuid5(NAMESPACE_URL, f"ouroboros:harness:{family}:{call_id}").hex[:12]
+    return f"step_{family}_{digest}"
+
+
+def _rewrite_step_run_stage(step: StepRecord, *, run_id: str, stage_id: str) -> StepRecord:
+    return StepRecord(
+        schema_version=step.schema_version,
+        step_id=step.step_id,
+        run_id=run_id,
+        stage_id=stage_id,
+        kind=step.kind,
+        name=step.name,
+        ac_id=step.ac_id,
+        started_at=step.started_at,
+        ended_at=step.ended_at,
+        ok=step.ok,
+        source_event_ids=step.source_event_ids,
+        legacy_inferred=step.legacy_inferred,
+        artifact_ids=step.artifact_ids,
+        metadata=step.metadata,
+    )
+
+
 def _step_from_start_only(
     *,
     call_id: str,
@@ -411,8 +424,8 @@ def _step_from_start_only(
     run_id: str,
     stage_id: str,
     kind: StepKind,
+    family: str,
 ) -> StepRecord:
-    del call_id  # reserved for future correlation logging
     name = (
         _extract_tool_name(start_event)
         if kind in (StepKind.TOOL_CALL, StepKind.SHELL_COMMAND)
@@ -425,6 +438,7 @@ def _step_from_start_only(
             metadata["args_preview"] = preview
     return StepRecord(
         schema_version=PROJECTION_SCHEMA_VERSION,
+        step_id=_stable_step_id(family, call_id),
         run_id=run_id,
         stage_id=stage_id,
         kind=kind,

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -98,6 +98,7 @@ class ProjectionBuilder:
         self._tool_started: OrderedDict[str, BaseEvent] = OrderedDict()
         self._llm_started: OrderedDict[str, BaseEvent] = OrderedDict()
         self._steps: OrderedDict[str, StepRecord] = OrderedDict()
+        self._idle_started_at = datetime.now(UTC)
         self._first_event_at: datetime | None = None
         self._last_event_at: datetime | None = None
 
@@ -168,7 +169,7 @@ class ProjectionBuilder:
         run_id = self._run_id
         stage_id = self._stage_id
 
-        started_at = self._first_event_at or datetime.now(UTC)
+        started_at = self._first_event_at or self._idle_started_at
         ended_at = self._last_event_at
 
         steps_for_stage = tuple(

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -301,3 +301,69 @@ class TestIncrementalIngestion:
         # Step content matches (run id stable across rebuilds).
         assert first.run.run_id == second.run.run_id
         assert first.steps[0].step_id == second.steps[0].step_id
+
+    def test_in_flight_step_id_stays_stable_across_builds_and_completion(self) -> None:
+        t0 = datetime.now(UTC)
+        builder = ProjectionBuilder(seed_id="seed_abc")
+        builder.add_event(
+            _tool_started(
+                call_id="stable",
+                tool_name="Bash",
+                when=t0,
+                event_id="evt_start_stable",
+            )
+        )
+
+        first = builder.build()
+        second = builder.build()
+        assert len(first.steps) == len(second.steps) == 1
+        assert first.steps[0].step_id == second.steps[0].step_id
+        assert first.steps[0].ended_at is None
+
+        builder.add_event(
+            _tool_returned(
+                call_id="stable",
+                tool_name="Bash",
+                when=t0 + timedelta(milliseconds=10),
+                event_id="evt_ret_stable",
+            )
+        )
+        completed = builder.build()
+        assert completed.steps[0].step_id == first.steps[0].step_id
+        assert completed.steps[0].source_event_ids == (
+            "evt_start_stable",
+            "evt_ret_stable",
+        )
+        assert completed.steps[0].ended_at == t0 + timedelta(milliseconds=10)
+
+    def test_steps_remain_in_execution_start_order_not_completion_order(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            _tool_started(call_id="slow", tool_name="Edit", when=t0, event_id="evt_slow_start"),
+            _tool_started(
+                call_id="fast",
+                tool_name="Bash",
+                when=t0 + timedelta(milliseconds=1),
+                event_id="evt_fast_start",
+            ),
+            _tool_returned(
+                call_id="fast",
+                tool_name="Bash",
+                when=t0 + timedelta(milliseconds=2),
+                event_id="evt_fast_ret",
+            ),
+            _tool_returned(
+                call_id="slow",
+                tool_name="Edit",
+                when=t0 + timedelta(milliseconds=3),
+                event_id="evt_slow_ret",
+            ),
+        ]
+
+        result = build_projection(events, seed_id="seed_abc")
+
+        assert [step.name for step in result.steps] == ["Edit", "Bash"]
+        assert [step.source_event_ids for step in result.steps] == [
+            ("evt_slow_start", "evt_slow_ret"),
+            ("evt_fast_start", "evt_fast_ret"),
+        ]

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -132,6 +132,14 @@ class TestProjectionBuilderConstruction:
         assert result.stages[0].kind is StageKind.EXECUTE
         assert result.steps == ()
 
+    def test_empty_build_timestamps_are_stable(self) -> None:
+        builder = ProjectionBuilder(seed_id="seed_abc")
+        first = builder.build()
+        second = builder.build()
+
+        assert first.run.started_at == second.run.started_at
+        assert first.stages[0].started_at == second.stages[0].started_at
+
 
 class TestToolProjection:
     def test_paired_tool_emits_one_step(self) -> None:

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -1,0 +1,303 @@
+"""Unit tests for the projection builder.
+
+Covers the contract from issue #946 PR-1b:
+
+* ``ProjectionBuilder`` produces a single ``RunRecord`` with a default
+  ``EXECUTE`` stage and one ``StepRecord`` per paired tool/LLM call.
+* Tool / LLM pairing is by ``call_id`` and uses the canonical recorder
+  field names (``tool_name`` / ``model_id``).
+* ``Bash`` tool calls are projected as ``StepKind.SHELL_COMMAND``;
+  other tool calls as ``StepKind.TOOL_CALL``.
+* Unpaired start events surface as dangling steps so callers can
+  detect in-flight work.
+* Every projected ``StepRecord`` links its source event ids.
+* ``build_projection`` is the convenience one-shot wrapper.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.harness.projection import StageKind, StepKind
+from ouroboros.harness.projection_builder import (
+    ProjectionBuilder,
+    ProjectionBuildResult,
+    build_projection,
+)
+
+
+def _tool_started(
+    *,
+    call_id: str,
+    tool_name: str,
+    when: datetime | None = None,
+    event_id: str | None = None,
+    args_preview: str | None = None,
+) -> BaseEvent:
+    return BaseEvent(
+        id=event_id or f"evt_start_{call_id}",
+        type="tool.call.started",
+        timestamp=when or datetime.now(UTC),
+        aggregate_type="execution",
+        aggregate_id="exec_1",
+        data={
+            "call_id": call_id,
+            "tool_name": tool_name,
+            "args_preview": args_preview,
+        },
+    )
+
+
+def _tool_returned(
+    *,
+    call_id: str,
+    tool_name: str,
+    when: datetime | None = None,
+    event_id: str | None = None,
+    is_error: bool = False,
+    duration_ms: int = 12,
+    result_preview: str | None = None,
+) -> BaseEvent:
+    return BaseEvent(
+        id=event_id or f"evt_ret_{call_id}",
+        type="tool.call.returned",
+        timestamp=when or datetime.now(UTC),
+        aggregate_type="execution",
+        aggregate_id="exec_1",
+        data={
+            "call_id": call_id,
+            "tool_name": tool_name,
+            "is_error": is_error,
+            "duration_ms": duration_ms,
+            "result_preview": result_preview,
+        },
+    )
+
+
+def _llm_requested(
+    *,
+    call_id: str,
+    model_id: str,
+    when: datetime | None = None,
+    event_id: str | None = None,
+    caller: str | None = None,
+) -> BaseEvent:
+    return BaseEvent(
+        id=event_id or f"evt_llm_req_{call_id}",
+        type="llm.call.requested",
+        timestamp=when or datetime.now(UTC),
+        aggregate_type="execution",
+        aggregate_id="exec_1",
+        data={"call_id": call_id, "model_id": model_id, "caller": caller},
+    )
+
+
+def _llm_returned(
+    *,
+    call_id: str,
+    model_id: str,
+    when: datetime | None = None,
+    event_id: str | None = None,
+    is_error: bool = False,
+    duration_ms: int = 800,
+) -> BaseEvent:
+    return BaseEvent(
+        id=event_id or f"evt_llm_ret_{call_id}",
+        type="llm.call.returned",
+        timestamp=when or datetime.now(UTC),
+        aggregate_type="execution",
+        aggregate_id="exec_1",
+        data={
+            "call_id": call_id,
+            "model_id": model_id,
+            "is_error": is_error,
+            "duration_ms": duration_ms,
+        },
+    )
+
+
+class TestProjectionBuilderConstruction:
+    def test_seed_id_required(self) -> None:
+        with pytest.raises(ValueError):
+            ProjectionBuilder(seed_id="   ")
+
+    def test_empty_run_has_single_default_stage(self) -> None:
+        result = ProjectionBuilder(seed_id="seed_abc").build()
+        assert isinstance(result, ProjectionBuildResult)
+        assert result.run.seed_id == "seed_abc"
+        assert result.run.stage_ids == (result.stages[0].stage_id,)
+        assert result.stages[0].kind is StageKind.EXECUTE
+        assert result.steps == ()
+
+
+class TestToolProjection:
+    def test_paired_tool_emits_one_step(self) -> None:
+        start_time = datetime.now(UTC)
+        events = [
+            _tool_started(
+                call_id="c1",
+                tool_name="Edit",
+                when=start_time,
+                event_id="evt_start_c1",
+                args_preview="path=src/foo.py",
+            ),
+            _tool_returned(
+                call_id="c1",
+                tool_name="Edit",
+                when=start_time + timedelta(milliseconds=12),
+                event_id="evt_ret_c1",
+                result_preview="ok",
+            ),
+        ]
+        result = build_projection(events, seed_id="seed_abc")
+        assert len(result.steps) == 1
+        step = result.steps[0]
+        assert step.kind is StepKind.TOOL_CALL
+        assert step.name == "Edit"
+        assert step.ok is True
+        assert step.source_event_ids == ("evt_start_c1", "evt_ret_c1")
+        assert step.metadata["args_preview"] == "path=src/foo.py"
+        assert step.metadata["result_preview"] == "ok"
+        assert step.metadata["duration_ms"] == 12
+
+    def test_bash_tool_is_shell_command(self) -> None:
+        events = [
+            _tool_started(call_id="c2", tool_name="Bash"),
+            _tool_returned(call_id="c2", tool_name="Bash"),
+        ]
+        result = build_projection(events, seed_id="seed_abc")
+        assert result.steps[0].kind is StepKind.SHELL_COMMAND
+
+    def test_error_returned_sets_ok_false(self) -> None:
+        events = [
+            _tool_started(call_id="c3", tool_name="Bash"),
+            _tool_returned(call_id="c3", tool_name="Bash", is_error=True),
+        ]
+        result = build_projection(events, seed_id="seed_abc")
+        assert result.steps[0].ok is False
+
+    def test_unpaired_start_emits_dangling_step(self) -> None:
+        events = [_tool_started(call_id="c4", tool_name="Bash")]
+        result = build_projection(events, seed_id="seed_abc")
+        assert len(result.steps) == 1
+        step = result.steps[0]
+        assert step.ok is None
+        assert step.ended_at is None
+        assert step.source_event_ids == ("evt_start_c4",)
+
+    def test_completion_only_pair_still_emitted(self) -> None:
+        events = [_tool_returned(call_id="orphan", tool_name="Bash")]
+        result = build_projection(events, seed_id="seed_abc")
+        assert len(result.steps) == 1
+        step = result.steps[0]
+        assert step.source_event_ids == ("evt_ret_orphan",)
+
+
+class TestLLMProjection:
+    def test_paired_llm_emits_one_model_call_step(self) -> None:
+        start_time = datetime.now(UTC)
+        events = [
+            _llm_requested(
+                call_id="llm1",
+                model_id="claude-sonnet-4.6",
+                caller="executor:deliver",
+                when=start_time,
+                event_id="evt_llm_req",
+            ),
+            _llm_returned(
+                call_id="llm1",
+                model_id="claude-sonnet-4.6",
+                duration_ms=750,
+                when=start_time + timedelta(milliseconds=750),
+                event_id="evt_llm_ret",
+            ),
+        ]
+        result = build_projection(events, seed_id="seed_abc")
+        assert len(result.steps) == 1
+        step = result.steps[0]
+        assert step.kind is StepKind.MODEL_CALL
+        assert step.name == "claude-sonnet-4.6"
+        assert step.source_event_ids == ("evt_llm_req", "evt_llm_ret")
+        assert step.metadata["caller"] == "executor:deliver"
+        assert step.metadata["duration_ms"] == 750
+
+
+class TestRunRecordAggregation:
+    def test_run_started_and_ended_span_event_range(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            _tool_started(call_id="c1", tool_name="Bash", when=t0, event_id="evt_a"),
+            _tool_returned(
+                call_id="c1",
+                tool_name="Bash",
+                when=t0 + timedelta(milliseconds=10),
+                event_id="evt_b",
+            ),
+            _llm_requested(
+                call_id="llm1",
+                model_id="claude-sonnet-4.6",
+                when=t0 + timedelta(milliseconds=20),
+                event_id="evt_c",
+            ),
+            _llm_returned(
+                call_id="llm1",
+                model_id="claude-sonnet-4.6",
+                when=t0 + timedelta(milliseconds=120),
+                event_id="evt_d",
+            ),
+        ]
+        result = build_projection(events, seed_id="seed_abc")
+        assert result.run.started_at == t0
+        assert result.run.ended_at == t0 + timedelta(milliseconds=120)
+        assert result.stages[0].started_at == t0
+        assert result.stages[0].ended_at == t0 + timedelta(milliseconds=120)
+        # All steps reference the stage and run id.
+        assert all(s.stage_id == result.stages[0].stage_id for s in result.steps)
+        assert all(s.run_id == result.run.run_id for s in result.steps)
+
+    def test_step_ids_match_stage_step_ids(self) -> None:
+        events = [
+            _tool_started(call_id="c1", tool_name="Bash"),
+            _tool_returned(call_id="c1", tool_name="Bash"),
+            _tool_started(call_id="c2", tool_name="Edit"),
+            _tool_returned(call_id="c2", tool_name="Edit"),
+        ]
+        result = build_projection(events, seed_id="seed_abc")
+        assert tuple(s.step_id for s in result.steps) == result.stages[0].step_ids
+
+
+class TestIncrementalIngestion:
+    def test_add_event_is_chainable(self) -> None:
+        builder = ProjectionBuilder(seed_id="seed_abc")
+        events = [
+            _tool_started(call_id="c1", tool_name="Bash"),
+            _tool_returned(call_id="c1", tool_name="Bash"),
+        ]
+        builder.add_event(events[0]).add_event(events[1])
+        result = builder.build()
+        assert len(result.steps) == 1
+
+    def test_add_events_is_chainable(self) -> None:
+        builder = ProjectionBuilder(seed_id="seed_abc")
+        events = [
+            _tool_started(call_id="c1", tool_name="Bash"),
+            _tool_returned(call_id="c1", tool_name="Bash"),
+        ]
+        result = builder.add_events(events).build()
+        assert len(result.steps) == 1
+
+    def test_replay_build_is_independent(self) -> None:
+        builder = ProjectionBuilder(seed_id="seed_abc")
+        events = [
+            _tool_started(call_id="c1", tool_name="Bash"),
+            _tool_returned(call_id="c1", tool_name="Bash"),
+        ]
+        builder.add_events(events)
+        first = builder.build()
+        second = builder.build()
+        # Step content matches (run id stable across rebuilds).
+        assert first.run.run_id == second.run.run_id
+        assert first.steps[0].step_id == second.steps[0].step_id


### PR DESCRIPTION
## Scope

Second slice of #946. Stacks on #980 (`#946 PR-1a` projection records)
and introduces the `ProjectionBuilder` that walks an event sequence
into a single `RunRecord` plus its default `EXECUTE` stage and the
per-call `StepRecord`s paired by `call_id`.

This PR is **stacked on #980**. The diff against `main` therefore
includes the PR-1a records; against `feat/946-projection-records` the
diff is only the new builder module and its tests.

Tracks #961's Phase C.1 → C.2 bridge: the builder is the natural
prerequisite for the CLI/MCP query surface that lands as `#946 PR-2`.

## What this PR adds (delta vs PR-1a)

- `src/ouroboros/harness/projection_builder.py`
  - `ProjectionBuilder` class with `add_event` / `add_events` / `build`
    chainable APIs.
  - `build_projection(events, *, seed_id, goal)` one-shot wrapper.
  - `ProjectionBuildResult` dataclass bundling the produced
    `RunRecord` + `StageRecord`s + `StepRecord`s.
  - Stable `run_id` / `stage_id` across replayed builds.
- `tests/unit/harness/test_projection_builder.py` — 13 tests covering:
  - Construction guards (`seed_id` required).
  - Empty-builder default `EXECUTE` stage with no steps.
  - Paired tool / LLM call projection (single step per pair, source
    event ids captured, error propagates to `ok=False`).
  - `Bash` tool call → `StepKind.SHELL_COMMAND`.
  - Unpaired starts surface as dangling steps with `ok=None`.
  - Completion-only pairs still emit (legacy traces remain
    observable).
  - Run / stage timestamps span the ingested event range.
  - Stage's `step_ids` mirror the produced `StepRecord` ids.
  - `add_event` / `add_events` chainable; replayed `build()` is
    stable.

## Acceptance-criterion mapping (#946)

| Criterion | Status |
|---|---|
| AC1 — documented schema for the record types | ✅ from PR-1a |
| AC2 — projection builder over `EventStore` | ✅ this PR |
| AC3 — every projected `StepRecord` links source event ids | ✅ enforced + tested |
| AC4 — artifacts attach to steps without plugin-specific code paths | ✅ from PR-1a |
| AC5 — machine-readable CLI / MCP projection output | ⏭️ next PR |
| AC6 — existing event/status tests still pass | ✅ (verified locally) |
| AC7 — fixture demonstrating projection for mechanical evaluation | ⏭️ next PR |

## Recognized event families in this slice

| Event type | Builder action |
|---|---|
| `tool.call.started` | Buffered by `call_id`. |
| `tool.call.returned` | Paired with the buffered start; emitted as one `StepRecord` of `StepKind.TOOL_CALL` (`Bash` is upgraded to `StepKind.SHELL_COMMAND`). |
| `llm.call.requested` | Buffered by `call_id`. |
| `llm.call.returned` | Paired and emitted as one `StepRecord` of `StepKind.MODEL_CALL`. |
| Anything else | Ignored in this PR; mapped in follow-up PRs alongside their dedicated kinds (artifact emission, stage markers, verdict records). |

The field names (`call_id`, `tool_name`, `model_id`, `is_error`,
`duration_ms`) match the canonical recorder factories in
`src/ouroboros/events/io.py`, matching the alignment that was
landed for the journal normalizer (#982).

## Design notes

- The builder is a **pure read** transformation. It does not persist
  records and does not mutate events.
- `run_id` and `stage_id` memoize on first `build()` so replayable
  projections stay stable.
- Stage detection is intentionally trivial in this PR — every step
  lives under a single default `EXECUTE` stage. Multi-stage
  inference, artifact production from file-modifying tools, and
  verdict-event mapping are all deferred to dedicated follow-up
  PRs so this PR stays small.
- `metadata` is populated additively (`args_preview` /
  `result_preview` / `duration_ms` / `error_kind`) and remains
  immutable at runtime via the `FrozenMetadata` invariant from
  PR-1a.

## Non-goals

- No `EventStore` query path — the builder accepts an iterable. The
  EventStore-backed entry point lives in `#946 PR-2`.
- No CLI or MCP surface (`#946 PR-2`).
- No fixture for mechanical evaluation (`#946 PR-3`).
- No multi-stage detection beyond the default `EXECUTE`.
- No artifact emission for `Write` / `Edit` tools — artifacts are a
  follow-up slice once the recorder exposes the produced paths
  reliably.

## Verification

```
$ uv run pytest tests/unit/harness/ -q
.............................................................            [100%]
61 passed in 0.23s

$ uv run ruff check src/ tests/
All checks passed!

$ uv run ruff format --check src/ tests/
779 files already formatted
```

## Stack notes

This PR is opened against `main` but logically depends on #980
(`feat/946-projection-records`). Once #980 merges, the diff here
collapses to only the new builder files. If #980 lands with rebase /
squash, this branch will need a routine fast-forward — no logical
conflict expected because the only shared file is
`src/ouroboros/harness/__init__.py`, and PR-1b does not modify it.

Refs #946 · sequenced under #961's "Post-milestone PR sequencing for
Tier 2 work" section · stacked on #980.
