### PR TITLE
feat(plugin): add v1 lifecycle hook contract types (#939)

### DIFF
--- a/src/ouroboros/plugin/hooks.py
+++ b/src/ouroboros/plugin/hooks.py
@@ -70,10 +70,18 @@ class HookKind(StrEnum):
 class DeferredHookKind(StrEnum):
     """Hook names deferred to follow-up RFC slices.
 
-    Listing them as a separate enum makes scope-creep auditable:
-    manifest validators MUST reject ``hooks[].name`` values from this
-    set in v1, and any future PR that promotes one of these must do so
-    explicitly by adding it to :class:`HookKind`.
+    Listing these as a separate enum makes scope-creep auditable.
+    This module exposes the routing helper :func:`is_deferred_hook_kind`
+    so manifest validators and downstream consumers can detect the
+    intent; this PR (the types-only slice) **does not** itself reject
+    these names at manifest load — the live rejection wiring lands in
+    the follow-up manifest-validator slice and the JSON-schema enum
+    tightening slice. Until those land, the existing v0.2 JSON Schema
+    still accepts deferred names as plain strings.
+
+    Any future PR that promotes one of these names into v1 must do so
+    by moving the value into :class:`HookKind`, which is a visible
+    diff in review.
     """
 
     BEFORE_TOOL_CALL = "before_tool_call"
@@ -88,11 +96,13 @@ class ExcludedHookKind(StrEnum):
     """Candidate hook names explicitly excluded from the v1 vocabulary.
 
     The RFC enumerates these to prevent ``ouroboros-plugins`` authors
-    from inferring that ``HookKind`` will be extended toward an
-    open-ended interception bus. They MUST NOT be accepted in v1
-    manifests; promotion requires substrate work tracked under other
-    canonical issues (#920 runtime adapters, #946 state/replay,
-    eventing surfaces).
+    from inferring that :class:`HookKind` will be extended toward an
+    open-ended interception bus. Like :class:`DeferredHookKind`, this
+    PR exposes them as a routing surface only; the live manifest /
+    schema-level rejection of these names lands in the follow-up
+    validator and schema-enum slices. Promoting any of these
+    requires substrate work tracked under other canonical issues
+    (#920 runtime adapters, #946 state/replay, eventing surfaces).
     """
 
     BEFORE_RUNTIME_START = "before_runtime_start"

--- a/src/ouroboros/plugin/hooks.py
+++ b/src/ouroboros/plugin/hooks.py
@@ -1,0 +1,166 @@
+"""Plugin lifecycle hook contract types.
+
+This module is the first reviewable slice of issue #939. It introduces
+the typed vocabulary the harness will use to dispatch plugin lifecycle
+hooks — without changing runtime behavior, manifest schema validation,
+or audit emission yet. The shape mirrors the contract documented in
+``docs/rfc/userlevel-plugins.md`` (the boundary doc that landed in
+``f718ef89e``).
+
+What this module owns:
+
+* :class:`HookKind` — the v1 hook vocabulary. Only the hooks listed as
+  "Included" in the RFC are enumerated; deferred hooks are exposed
+  separately via :class:`DeferredHookKind` so we can keep an
+  explicit, audit-friendly record of v1 vs future scope without
+  silently accepting them at manifest-validation time.
+* :class:`HookFailurePolicy` — the v1 failure policies (``fail_open``
+  / ``fail_closed``).
+* :data:`HOOK_AUDIT_EVENTS` — the audit event names the wrapper emits
+  for hook execution outcomes (``plugin.hook.blocked`` /
+  ``plugin.hook.failed``).
+* :func:`is_v1_hook_kind` / :func:`is_v1_failure_policy` — helpers
+  consumed by manifest validators in follow-up PRs. They live here so
+  the contract is the single source of truth.
+
+What this module does **not** do:
+
+* Wire hook dispatch into ``HarnessRunner`` or any runtime path.
+* Change the manifest schema or the existing :class:`HookSpec`
+  dataclass (validators that consume these helpers land in a follow-up
+  PR).
+* Emit audit events. The event names are exported as constants only.
+* Add or remove permissions. Hook-specific permission emission is a
+  future extension per the RFC.
+
+Routes to #939. The full lifecycle slate lands incrementally; this
+module is intentionally narrow enough to review as a typed contract
+before any wiring change.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final
+
+
+class HookKind(StrEnum):
+    """V1 plugin lifecycle hook vocabulary.
+
+    Values match the keys ``ouroboros-plugins`` manifests will use in
+    their ``hooks[].name`` field. Only hooks listed as "Included" in
+    ``docs/rfc/userlevel-plugins.md`` are enumerated here — deferred
+    candidates are kept separate in :class:`DeferredHookKind` so a
+    manifest cannot quietly opt into a hook before its runtime
+    semantics are nailed down.
+    """
+
+    #: Runs after trust check and confirmation gate, before
+    #: ``plugin.invoked`` is emitted. Intended for read-only
+    #: inspection or ``fail_closed`` policy decisions.
+    BEFORE_INVOCATION = "before_invocation"
+
+    #: Runs after ``plugin.completed`` / ``plugin.failed`` is known,
+    #: before the wrapper returns to the caller. Intended for
+    #: observability or summary emission. Scoped to started command
+    #: entrypoint invocations only.
+    AFTER_INVOCATION = "after_invocation"
+
+
+class DeferredHookKind(StrEnum):
+    """Hook names deferred to follow-up RFC slices.
+
+    Listing them as a separate enum makes scope-creep auditable:
+    manifest validators MUST reject ``hooks[].name`` values from this
+    set in v1, and any future PR that promotes one of these must do so
+    explicitly by adding it to :class:`HookKind`.
+    """
+
+    BEFORE_TOOL_CALL = "before_tool_call"
+    AFTER_TOOL_CALL = "after_tool_call"
+    BEFORE_ARTIFACT_WRITE = "before_artifact_write"
+    AFTER_ARTIFACT_WRITE = "after_artifact_write"
+    ON_ERROR = "on_error"
+    ON_CANCEL = "on_cancel"
+
+
+class ExcludedHookKind(StrEnum):
+    """Candidate hook names explicitly excluded from the v1 vocabulary.
+
+    The RFC enumerates these to prevent ``ouroboros-plugins`` authors
+    from inferring that ``HookKind`` will be extended toward an
+    open-ended interception bus. They MUST NOT be accepted in v1
+    manifests; promotion requires substrate work tracked under other
+    canonical issues (#920 runtime adapters, #946 state/replay,
+    eventing surfaces).
+    """
+
+    BEFORE_RUNTIME_START = "before_runtime_start"
+    AFTER_RUNTIME_START = "after_runtime_start"
+    BEFORE_STATE_COMMIT = "before_state_commit"
+    AFTER_STATE_COMMIT = "after_state_commit"
+    ON_EVENT = "on_event"
+    ON_REWIND = "on_rewind"
+
+
+class HookFailurePolicy(StrEnum):
+    """Failure handling stance for a hook declaration."""
+
+    #: Record the failure and continue the original invocation.
+    #: Permitted only for observability-only hooks whose output cannot
+    #: authorize or mutate work.
+    FAIL_OPEN = "fail_open"
+
+    #: Stop the original invocation and emit a failed/blocked audit
+    #: result. Required for policy, security, mutating, or authority-
+    #: bearing hooks.
+    FAIL_CLOSED = "fail_closed"
+
+
+#: Audit event names the wrapper emits for hook execution outcomes.
+#: These are exported as constants so manifest validators and audit
+#: consumers reference the same string set the wrapper will emit when
+#: dispatch lands in a follow-up PR.
+HOOK_BLOCKED_EVENT: Final[str] = "plugin.hook.blocked"
+HOOK_FAILED_EVENT: Final[str] = "plugin.hook.failed"
+HOOK_AUDIT_EVENTS: Final[frozenset[str]] = frozenset({HOOK_BLOCKED_EVENT, HOOK_FAILED_EVENT})
+
+
+def is_v1_hook_kind(value: str) -> bool:
+    """Return True iff ``value`` names a hook included in v1.
+
+    Use this in manifest validators rather than touching
+    :class:`HookKind` membership directly so the contract intent
+    (deferred vs excluded vs accepted) is preserved at the call site.
+    """
+    return value in {kind.value for kind in HookKind}
+
+
+def is_deferred_hook_kind(value: str) -> bool:
+    """Return True iff ``value`` names a deferred candidate hook."""
+    return value in {kind.value for kind in DeferredHookKind}
+
+
+def is_excluded_hook_kind(value: str) -> bool:
+    """Return True iff ``value`` names an explicitly excluded hook."""
+    return value in {kind.value for kind in ExcludedHookKind}
+
+
+def is_v1_failure_policy(value: str) -> bool:
+    """Return True iff ``value`` names a v1 failure policy."""
+    return value in {policy.value for policy in HookFailurePolicy}
+
+
+__all__ = [
+    "HOOK_AUDIT_EVENTS",
+    "HOOK_BLOCKED_EVENT",
+    "HOOK_FAILED_EVENT",
+    "DeferredHookKind",
+    "ExcludedHookKind",
+    "HookFailurePolicy",
+    "HookKind",
+    "is_deferred_hook_kind",
+    "is_excluded_hook_kind",
+    "is_v1_failure_policy",
+    "is_v1_hook_kind",
+]

--- a/tests/unit/plugin/test_hooks_contract.py
+++ b/tests/unit/plugin/test_hooks_contract.py
@@ -1,0 +1,120 @@
+"""Unit tests for the plugin lifecycle hook contract types.
+
+Covers the v1 contract from issue #939 (first slice — types only):
+
+* ``HookKind`` contains exactly the v1 "Included" hooks from the RFC.
+* ``DeferredHookKind`` and ``ExcludedHookKind`` enumerate the remaining
+  candidate sets without overlapping ``HookKind``.
+* ``HookFailurePolicy`` exposes the two v1 policies the RFC defines.
+* ``HOOK_AUDIT_EVENTS`` matches the wrapper event names the RFC
+  references (``plugin.hook.blocked`` / ``plugin.hook.failed``).
+* The ``is_*`` helpers route any candidate string to exactly one of
+  v1 / deferred / excluded / unknown.
+"""
+
+from __future__ import annotations
+
+from ouroboros.plugin.hooks import (
+    HOOK_AUDIT_EVENTS,
+    HOOK_BLOCKED_EVENT,
+    HOOK_FAILED_EVENT,
+    DeferredHookKind,
+    ExcludedHookKind,
+    HookFailurePolicy,
+    HookKind,
+    is_deferred_hook_kind,
+    is_excluded_hook_kind,
+    is_v1_failure_policy,
+    is_v1_hook_kind,
+)
+
+
+class TestHookKindEnumeration:
+    def test_v1_hook_set_is_exact(self) -> None:
+        # The RFC lists exactly these two hooks as "Included" in v1.
+        assert {kind.value for kind in HookKind} == {
+            "before_invocation",
+            "after_invocation",
+        }
+
+    def test_deferred_hook_set_is_exact(self) -> None:
+        assert {kind.value for kind in DeferredHookKind} == {
+            "before_tool_call",
+            "after_tool_call",
+            "before_artifact_write",
+            "after_artifact_write",
+            "on_error",
+            "on_cancel",
+        }
+
+    def test_excluded_hook_set_is_exact(self) -> None:
+        assert {kind.value for kind in ExcludedHookKind} == {
+            "before_runtime_start",
+            "after_runtime_start",
+            "before_state_commit",
+            "after_state_commit",
+            "on_event",
+            "on_rewind",
+        }
+
+    def test_hook_sets_are_disjoint(self) -> None:
+        v1 = {kind.value for kind in HookKind}
+        deferred = {kind.value for kind in DeferredHookKind}
+        excluded = {kind.value for kind in ExcludedHookKind}
+        assert v1.isdisjoint(deferred)
+        assert v1.isdisjoint(excluded)
+        assert deferred.isdisjoint(excluded)
+
+
+class TestFailurePolicy:
+    def test_v1_failure_policies(self) -> None:
+        assert {policy.value for policy in HookFailurePolicy} == {
+            "fail_open",
+            "fail_closed",
+        }
+
+    def test_is_v1_failure_policy(self) -> None:
+        assert is_v1_failure_policy("fail_open")
+        assert is_v1_failure_policy("fail_closed")
+        assert not is_v1_failure_policy("retry")
+        assert not is_v1_failure_policy("")
+
+
+class TestAuditEventConstants:
+    def test_audit_event_set(self) -> None:
+        assert frozenset({"plugin.hook.blocked", "plugin.hook.failed"}) == HOOK_AUDIT_EVENTS
+
+    def test_blocked_event_constant(self) -> None:
+        assert HOOK_BLOCKED_EVENT == "plugin.hook.blocked"
+        assert HOOK_BLOCKED_EVENT in HOOK_AUDIT_EVENTS
+
+    def test_failed_event_constant(self) -> None:
+        assert HOOK_FAILED_EVENT == "plugin.hook.failed"
+        assert HOOK_FAILED_EVENT in HOOK_AUDIT_EVENTS
+
+
+class TestRoutingHelpers:
+    def test_v1_hook_kind_router(self) -> None:
+        assert is_v1_hook_kind("before_invocation")
+        assert is_v1_hook_kind("after_invocation")
+        assert not is_v1_hook_kind("before_tool_call")
+        assert not is_v1_hook_kind("on_event")
+        assert not is_v1_hook_kind("unknown_hook")
+
+    def test_deferred_hook_kind_router(self) -> None:
+        assert is_deferred_hook_kind("before_tool_call")
+        assert is_deferred_hook_kind("after_artifact_write")
+        assert not is_deferred_hook_kind("before_invocation")
+        assert not is_deferred_hook_kind("on_event")
+
+    def test_excluded_hook_kind_router(self) -> None:
+        assert is_excluded_hook_kind("before_runtime_start")
+        assert is_excluded_hook_kind("on_rewind")
+        assert not is_excluded_hook_kind("before_invocation")
+        assert not is_excluded_hook_kind("before_tool_call")
+
+    def test_unknown_hook_routes_to_none(self) -> None:
+        unknown = "made_up_hook_name"
+        assert not is_v1_hook_kind(unknown)
+        assert not is_deferred_hook_kind(unknown)
+        assert not is_excluded_hook_kind(unknown)


### PR DESCRIPTION
## Scope

First reviewable slice of #939 (Tier 1 — **not** blocked by the
`agentos-substrate-wiring` milestone). Pure-types follow-up to the
boundary documentation that landed in `f718ef89e`
(`docs/rfc/userlevel-plugins.md`).

This PR introduces the typed vocabulary the harness will use to
dispatch plugin lifecycle hooks. It **does not**:
- change the manifest schema (validators land in a follow-up PR),
- wire hook dispatch into `HarnessRunner`,
- emit any new audit events,
- add or remove permissions.

The scope is intentionally narrow per the boundary doc's
"Constraint" line:
> "Tier 1 #939 should advance plugin extensibility without changing
> runtime behavior or manifest compatibility in this PR."

## What this PR contains

- `src/ouroboros/plugin/hooks.py`
  - `HookKind` — v1 hook vocabulary (`before_invocation`,
    `after_invocation`).
  - `DeferredHookKind` — candidate hooks the RFC marks as deferred
    (`before_tool_call`, `after_tool_call`,
    `before_artifact_write`, `after_artifact_write`, `on_error`,
    `on_cancel`).
  - `ExcludedHookKind` — candidate hooks the RFC explicitly excludes
    from v1 (`before_runtime_start` / `after_runtime_start`,
    `before_state_commit` / `after_state_commit`, `on_event`,
    `on_rewind`).
  - `HookFailurePolicy` (`fail_open` / `fail_closed`).
  - `HOOK_BLOCKED_EVENT` / `HOOK_FAILED_EVENT` / `HOOK_AUDIT_EVENTS`
    constants matching the wrapper event names from the RFC.
  - Routing helpers: `is_v1_hook_kind`, `is_deferred_hook_kind`,
    `is_excluded_hook_kind`, `is_v1_failure_policy`.
- `tests/unit/plugin/test_hooks_contract.py` — 13 tests covering:
  - exactness of each hook set (v1 / deferred / excluded),
  - mutual disjointness of the three sets,
  - failure-policy round-trip,
  - audit event constant identity,
  - routing-helper coverage including the unknown-name fallback.

## Why three enums instead of one

Listing deferred and excluded hooks as separate enums makes scope
creep auditable. Manifest validators in the follow-up PR can route
any candidate hook name to exactly one of v1 / deferred / excluded /
unknown without touching membership of `HookKind` directly. A future
PR that promotes a deferred hook into v1 must do so explicitly by
moving the value from `DeferredHookKind` to `HookKind`, which is a
visible diff in review.

## Acceptance-criterion mapping (#939)

The full acceptance set in #939 spans hook contract + schema +
permissions + audit + fixtures. This first PR delivers:

| Criterion | Status |
|---|---|
| hook 목록 정의 (v1) | ✅ `HookKind` |
| 제외 / 보류 hook 명시 | ✅ `ExcludedHookKind` / `DeferredHookKind` |
| hook timeout/error 정책 enum | ✅ `HookFailurePolicy` |
| audit event 표준화 (hook 결과) | ✅ `HOOK_AUDIT_EVENTS` constants |
| hook permission/declaration 검증 wiring | ⏭️ follow-up PR |
| manifest schema bump (0.2 → 0.3?) | ⏭️ follow-up PR |
| hook lifecycle wiring in `HarnessRunner` | ⏭️ later PR |
| first-party test plugin fixture | ⏭️ later PR |

## Non-goals

- No new permissions or capability registrations.
- No change to `src/ouroboros/plugin/manifest.py` (`HookSpec` /
  `AuditSpec` / `PluginManifest` are untouched).
- No JSON Schema bump.
- No `HarnessRunner` integration.

## Verification

```
$ uv run pytest tests/unit/plugin/test_hooks_contract.py -q
.............                                                            [100%]
13 passed in 0.30s

$ uv run ruff check src/ tests/
All checks passed!
```

## Follow-up PRs

- **#939 PR-2**: manifest validator that consumes
  `is_v1_hook_kind` / `is_v1_failure_policy`; rejects manifests that
  reference deferred or excluded hook names; tightens `HookSpec`
  `failure_policy` to `HookFailurePolicy`.
- **#939 PR-3**: hook permission declaration shape +
  `plugin.permission_used` emission rule for hook-specific
  permissions.
- **#939 PR-4**: `HarnessRunner` integration that actually dispatches
  the v1 hooks, including the deterministic ordering and
  `plugin.hook.blocked` / `plugin.hook.failed` emission.

Refs #939 · sequenced under #961's Tier 1 (unblocked) track · this
PR does **not** target the Tier 2 substrate behind
`agentos-substrate-wiring`.
