### PR TITLE
feat(plugin): enforce v1 hook contract in manifest validator (#939 PR-2)

### DIFF
--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -30,6 +30,13 @@ import json
 from pathlib import Path
 from typing import Any
 
+from ouroboros.plugin.hooks import (
+    is_deferred_hook_kind,
+    is_excluded_hook_kind,
+    is_v1_failure_policy,
+    is_v1_hook_kind,
+)
+
 try:
     from jsonschema import Draft202012Validator
 except ImportError as exc:  # pragma: no cover
@@ -349,6 +356,16 @@ def _build_hook(
     hook_index: int,
     manifest_path: str | Path,
 ) -> HookSpec:
+    hook_name = raw["name"]
+    _validate_hook_name(hook_name, hook_index=hook_index, manifest_path=manifest_path)
+
+    failure_policy = raw["failure_policy"]
+    _validate_failure_policy(
+        failure_policy,
+        hook_index=hook_index,
+        manifest_path=manifest_path,
+    )
+
     for permission_index, scope in enumerate(raw.get("permissions", ())):
         if scope not in declared_permission_scopes:
             raise PluginManifestError(
@@ -364,15 +381,85 @@ def _build_hook(
 
     entrypoint_raw = raw["entrypoint"]
     return HookSpec(
-        name=raw["name"],
+        name=hook_name,
         entrypoint=Entrypoint(
             type=entrypoint_raw["type"],
             command=entrypoint_raw["command"],
         ),
-        failure_policy=raw["failure_policy"],
+        failure_policy=failure_policy,
         timeout_seconds=raw.get("timeout_seconds"),
         permissions=tuple(raw.get("permissions", ())),
         description=raw.get("description", ""),
+    )
+
+
+def _validate_hook_name(
+    name: Any,
+    *,
+    hook_index: int,
+    manifest_path: str | Path,
+) -> None:
+    """Reject hook names that are not in the v1 ``HookKind`` vocabulary.
+
+    Deferred and explicitly-excluded names get specific error messages
+    so manifest authors can tell whether the name is "wait for a later
+    RFC slice" or "this name will never be accepted".
+    """
+    json_pointer = f"/hooks/{hook_index}/name"
+    if not isinstance(name, str) or not name:
+        raise PluginManifestError(
+            "hook name must be a non-empty string",
+            path=str(manifest_path),
+            json_pointer=json_pointer,
+            expected="non-empty string drawn from the v1 hook vocabulary",
+            got=repr(name),
+        )
+
+    if is_v1_hook_kind(name):
+        return
+
+    if is_deferred_hook_kind(name):
+        raise PluginManifestError(
+            "hook name is deferred to a follow-up RFC slice",
+            path=str(manifest_path),
+            json_pointer=json_pointer,
+            expected="v1 hook name (see ouroboros.plugin.hooks.HookKind)",
+            got=name,
+        )
+
+    if is_excluded_hook_kind(name):
+        raise PluginManifestError(
+            "hook name is excluded from the v1 plugin lifecycle contract",
+            path=str(manifest_path),
+            json_pointer=json_pointer,
+            expected="v1 hook name (see ouroboros.plugin.hooks.HookKind)",
+            got=name,
+        )
+
+    raise PluginManifestError(
+        "unknown hook name",
+        path=str(manifest_path),
+        json_pointer=json_pointer,
+        expected="v1 hook name (see ouroboros.plugin.hooks.HookKind)",
+        got=name,
+    )
+
+
+def _validate_failure_policy(
+    failure_policy: Any,
+    *,
+    hook_index: int,
+    manifest_path: str | Path,
+) -> None:
+    """Reject failure_policy values outside the v1 vocabulary."""
+    if isinstance(failure_policy, str) and is_v1_failure_policy(failure_policy):
+        return
+    raise PluginManifestError(
+        "hook failure_policy must be a v1 policy",
+        path=str(manifest_path),
+        json_pointer=f"/hooks/{hook_index}/failure_policy",
+        expected="'fail_open' or 'fail_closed'",
+        got=repr(failure_policy),
     )
 
 

--- a/tests/unit/plugin/test_manifest_hook_validation.py
+++ b/tests/unit/plugin/test_manifest_hook_validation.py
@@ -1,0 +1,131 @@
+"""Manifest validator tests for the v1 hook contract.
+
+Second slice of #939. Validates that ``load_manifest`` rejects
+manifests whose ``hooks[].name`` is not in the v1
+:class:`ouroboros.plugin.hooks.HookKind` vocabulary, and whose
+``hooks[].failure_policy`` is not one of ``fail_open`` /
+``fail_closed``.
+
+Existing hook tests in ``test_manifest.py`` cover the happy path and
+the top-level permission requirement; this file only adds the new
+rejection paths so the diff is focused on the new behaviour.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.manifest import PluginManifestError, load_manifest
+
+# Re-use the canonical reference manifest from the existing manifest
+# test module so the schema-compliant shape stays a single source of
+# truth across the two test files.
+from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
+
+
+def _hook_manifest() -> dict:
+    payload = deepcopy(REFERENCE_MANIFEST)
+    payload["schema_version"] = "0.2"
+    return payload
+
+
+def _write(tmp_path: Path, payload: dict | str) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    if isinstance(payload, str):
+        target.write_text(payload)
+    else:
+        target.write_text(json.dumps(payload))
+    return target
+
+
+def _valid_hook(name: str = "before_invocation", failure_policy: str = "fail_closed") -> dict:
+    return {
+        "name": name,
+        "description": "Inspect invocation metadata.",
+        "entrypoint": {
+            "type": "command",
+            "command": "python -m plugin_hooks before",
+        },
+        "permissions": [],
+        "failure_policy": failure_policy,
+        "timeout_seconds": 5,
+    }
+
+
+class TestV1HookVocabulary:
+    """Manifest validator must enforce the v1 ``HookKind`` set."""
+
+    def test_v1_hook_name_accepted(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(name="before_invocation")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].name == "before_invocation"
+
+    def test_after_invocation_accepted(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(name="after_invocation")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].name == "after_invocation"
+
+    def test_deferred_hook_name_rejected(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(name="before_tool_call")]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/name"
+        assert "deferred" in str(err).lower()
+
+    def test_excluded_hook_name_rejected(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(name="before_runtime_start")]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/name"
+        assert "excluded" in str(err).lower()
+
+    def test_unknown_hook_name_rejected(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(name="made_up_hook")]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/name"
+        assert "unknown" in str(err).lower()
+
+    def test_empty_hook_name_rejected(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(name="")]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/name"
+
+
+class TestHookFailurePolicy:
+    """Manifest validator must enforce the v1 failure-policy vocabulary."""
+
+    def test_fail_open_accepted(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(failure_policy="fail_open")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].failure_policy == "fail_open"
+
+    def test_fail_closed_accepted(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(failure_policy="fail_closed")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].failure_policy == "fail_closed"
+
+    def test_unknown_failure_policy_rejected(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook(failure_policy="retry")]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/failure_policy"


### PR DESCRIPTION
## Scope

Second slice of #939 (Tier 1 — **not** blocked by the `agentos-substrate-wiring` milestone). #984 is now merged; this PR is rebased on current `main` and the diff is intentionally limited to manifest-validator enforcement plus tests.

`manifest._build_hook` now enforces the v1 hook vocabulary and the v1 failure-policy vocabulary at manifest-load time by consuming the routing helpers introduced by #984. Specific error classes distinguish between **deferred**, **excluded**, and **unknown** hook names so manifest authors can tell whether a name is "wait for a later RFC slice" or "this name will never be accepted".

## What this PR changes

- `src/ouroboros/plugin/manifest.py`
  - `_validate_hook_name(name, hook_index, manifest_path)` emits `PluginManifestError` with `/hooks/<i>/name` for deferred / excluded / unknown / non-string hook names; accepts only `before_invocation` and `after_invocation`.
  - `_validate_failure_policy(failure_policy, hook_index, manifest_path)` emits `PluginManifestError` with `/hooks/<i>/failure_policy` for anything other than `fail_open` / `fail_closed`.
  - `_build_hook` calls both validators before constructing `HookSpec`.
- `tests/unit/plugin/test_manifest_hook_validation.py`
  - Rejection-path tests for deferred, excluded, unknown, empty, and non-string hook names.
  - Acceptance tests for the two v1 hook names and the two v1 failure policies.
  - Invalid failure-policy pointer coverage.

## What this PR does NOT change

- `HookSpec` dataclass shape: `failure_policy` stays a `str`; validation guarantees the value is in the v1 set without changing downstream storage type.
- Plugin JSON Schema: schema-level tightening is the next #939 slice (#986).
- Harness/runtime hook dispatch.
- Permission emission or audit-event emission rules.
- Any Tier 2 #920 / #946 / #956 / #978 Phase C surface.

## Acceptance-criterion mapping (#939)

| Criterion | Status |
|---|---|
| hook 목록 정의 (v1) | ✅ #984 |
| 제외 / 보류 hook manifest 거부 (Python validator) | ✅ this PR |
| hook timeout/error 정책 enum | ✅ #984 (`HookFailurePolicy`) |
| manifest validator consumes the enum | ✅ this PR |
| JSON Schema enum tightening | ⏭️ #986 |
| hook permission/declaration validation | ⏭️ later |
| HarnessRunner hook dispatch | ⏭️ later |
| first-party test plugin fixture | ⏭️ later |

## Verification

```
$ uv run pytest tests/unit/plugin/test_manifest_hook_validation.py tests/unit/plugin/test_hooks_contract.py -q
22 passed in 0.33s

$ uv run ruff check src/ouroboros/plugin tests/unit/plugin/test_manifest_hook_validation.py tests/unit/plugin/test_hooks_contract.py
All checks passed!
```

## Follow-up PRs

- **#986 / #939 PR-3**: schema v0.3 with v1-only `hooks[].name` enum so non-Python loaders get the same guard.
- **#939 PR-4**: hook-specific permission scope + `plugin.permission_used` emission rule.
- **#939 PR-5**: Harness/runtime hook dispatch with ordering and `plugin.hook.blocked` / `plugin.hook.failed` audit emission.

Refs #939 · sequenced under #961's Tier 1 (unblocked) track · #984 merged prerequisite.
