### PR TITLE
feat(plugin): add schema v0.3 with v1-only hook enum (#939 PR-3)

### DIFF
--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -47,8 +47,9 @@ except ImportError as exc:  # pragma: no cover
 
 # Support window per Q00/ouroboros-plugins#11 lock: current MAJOR + previous MAJOR.
 # v0.1 is the archived base manifest contract; v0.2 is the local extension
-# that adds optional hook declarations.
-SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1", "0.2")
+# that adds optional hook declarations; v0.3 narrows hooks[].name to the
+# v1 ``HookKind`` vocabulary at the JSON Schema layer.
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1", "0.2", "0.3")
 
 # Source types whose `path` must be a sandboxed relative slug — no absolute
 # paths and no parent-directory traversal. `local_path` resolves relative to

--- a/src/ouroboros/plugin/schemas/0.3/_source.json
+++ b/src/ouroboros/plugin/schemas/0.3/_source.json
@@ -1,0 +1,14 @@
+{
+  "source": "Q00/ouroboros",
+  "purpose": "Local plugin manifest schema v0.3: tightens hook lifecycle vocabulary to v1 names only.",
+  "note": "Iterates on local 0.2 by narrowing hooks[].name to the v1 HookKind set ('before_invocation', 'after_invocation'). Deferred and excluded hook names are no longer accepted at the JSON Schema layer; rejection messages now distinguish between deferred / excluded / unknown in the Python validator. Hook execution/dispatch remains intentionally out of scope.",
+  "local_extensions": {
+    "plugin.schema.json": [
+      "Bumped $id/title/schema_version const from 0.2 to 0.3.",
+      "Narrowed hooks[].name enum to the v1 HookKind set: 'before_invocation' and 'after_invocation'. Deferred candidates (before_tool_call, after_tool_call, before_artifact_write, after_artifact_write, on_error, on_cancel) and excluded candidates (before_runtime_start, after_runtime_start, before_state_commit, after_state_commit, on_event, on_rewind) are no longer accepted at the schema layer; refer to src/ouroboros/plugin/hooks.py for the routing helpers and follow-up RFC slices."
+    ],
+    "audit-event.schema.json": [
+      "Vendored audit-event.schema.json with local 0.3 $id/title/schema_version alignment; audit event shape remains otherwise unchanged from 0.2."
+    ]
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.3/audit-event.schema.json
+++ b/src/ouroboros/plugin/schemas/0.3/audit-event.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros/schemas/local/0.3/audit-event.schema.json",
+  "title": "Ouroboros Plugin Audit Event (v0.3)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "occurred_at",
+    "plugin",
+    "command",
+    "trust_state",
+    "capabilities_used",
+    "permissions_used",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.3"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "plugin.discovered",
+        "plugin.installed",
+        "plugin.trusted",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed"
+      ]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "plugin": {
+      "type": "object",
+      "required": ["name", "version", "source_type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "source_type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["namespace", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": { "type": "string" },
+        "name": { "type": "string" },
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "argv_summary": {
+          "type": "object",
+          "description": "Bounded fingerprint of argv added in step 1 of the audit-fidelity plan. Lets operators size the actual distribution before any cap is chosen and lets consumers correlate identical invocations by sha without dragging the full payload through the index. The argv field itself is unchanged in this step.",
+          "required": ["argc", "byte_length", "sha256"],
+          "additionalProperties": false,
+          "properties": {
+            "argc": { "type": "integer", "minimum": 0 },
+            "byte_length": { "type": "integer", "minimum": 0 },
+            "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          }
+        }
+      }
+    },
+    "trust_state": {
+      "type": "string",
+      "enum": ["discovered", "installed", "trusted", "disabled", "blocked", "first_party"]
+    },
+    "capabilities_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "permissions_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "result": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["success", "blocked", "failed", "trust_subject_changed"]
+        },
+        "message": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.3/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.3/plugin.schema.json
@@ -1,0 +1,291 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros/schemas/local/0.3/plugin.schema.json",
+  "title": "Ouroboros Plugin Manifest (v0.3)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "version",
+    "source",
+    "commands",
+    "capabilities",
+    "permissions",
+    "entrypoint"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.3"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "description": {
+      "type": "string",
+      "default": ""
+    },
+    "source": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"type": {"const": "local_path"}},
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["type", "path"]
+          }
+        },
+        {
+          "if": {
+            "properties": {"type": {"const": "plugin_home"}},
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["type", "path"]
+          }
+        }
+      ]
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["namespace", "name", "summary", "usage", "risk"],
+        "additionalProperties": false,
+        "properties": {
+          "namespace": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "usage": {
+            "type": "string",
+            "minLength": 1
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "requires_confirmation": {
+            "type": "boolean",
+            "default": false
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "type", "required"],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_-]*$"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["string", "boolean", "integer", "path", "url"]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "access"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "seed",
+              "ledger",
+              "state",
+              "provenance",
+              "runtime",
+              "mcp",
+              "handoff",
+              "progress"
+            ]
+          },
+          "access": {
+            "type": "string",
+            "enum": ["read", "write", "execute", "attach"]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scope", "risk", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "scope": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "entrypoint": {
+      "type": "object",
+      "required": ["type", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "command"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": ["events"],
+      "additionalProperties": false,
+      "default": {
+        "events": [
+          "plugin.invoked",
+          "plugin.permission_used",
+          "plugin.completed",
+          "plugin.failed"
+        ]
+      },
+      "properties": {
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "plugin.discovered",
+              "plugin.installed",
+              "plugin.trusted",
+              "plugin.invoked",
+              "plugin.permission_used",
+              "plugin.completed",
+              "plugin.failed"
+            ]
+          },
+          "uniqueItems": true
+        }
+      }
+
+    },
+    "hooks": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": ["name", "entrypoint", "failure_policy"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "before_invocation",
+              "after_invocation"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "entrypoint": {
+            "type": "object",
+            "required": ["type", "command"],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "command"
+              },
+              "command": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+            },
+            "uniqueItems": true,
+            "default": []
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 300
+          },
+          "failure_policy": {
+            "type": "string",
+            "enum": ["fail_open", "fail_closed"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/plugin/test_manifest_schema_0_3.py
+++ b/tests/unit/plugin/test_manifest_schema_0_3.py
@@ -1,0 +1,164 @@
+"""Schema-layer tests for the v0.3 plugin manifest.
+
+Third slice of #939. v0.3 tightens the JSON Schema enum for
+``hooks[].name`` to the v1 ``HookKind`` set, so non-Python loaders get
+the same guard the Python validator added in v0.2 / #985. v0.2
+remains supported with its broader enum for backward compatibility.
+
+What this test file covers:
+
+* 0.3 manifests with v1 hook names load via
+  :func:`ouroboros.plugin.manifest.load_manifest`.
+* 0.3 manifests that reference a deferred or excluded hook name fail
+  with the schema-layer error pointer (``/hooks/0/name``).
+* 0.2 manifests with deferred names still get rejected — by the
+  Python validator added in #985, with the deferred-specific message.
+  This ensures the v0.2 → v0.3 transition does not lose the existing
+  Python guard.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.manifest import (
+    SUPPORTED_SCHEMA_VERSIONS,
+    PluginManifestError,
+    load_manifest,
+)
+
+# Re-use the canonical reference manifest from the existing manifest
+# test module so the schema-compliant payload stays a single source of
+# truth.
+from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
+
+
+def _v03_manifest() -> dict:
+    payload = deepcopy(REFERENCE_MANIFEST)
+    payload["schema_version"] = "0.3"
+    return payload
+
+
+def _v02_manifest() -> dict:
+    payload = deepcopy(REFERENCE_MANIFEST)
+    payload["schema_version"] = "0.2"
+    return payload
+
+
+def _write(tmp_path: Path, payload: dict) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _valid_hook(name: str = "before_invocation", failure_policy: str = "fail_closed") -> dict:
+    return {
+        "name": name,
+        "description": "Inspect invocation metadata.",
+        "entrypoint": {
+            "type": "command",
+            "command": "python -m plugin_hooks before",
+        },
+        "permissions": [],
+        "failure_policy": failure_policy,
+        "timeout_seconds": 5,
+    }
+
+
+class TestSupportedSchemaVersions:
+    def test_0_3_included_in_support_window(self) -> None:
+        assert "0.3" in SUPPORTED_SCHEMA_VERSIONS
+
+    def test_0_2_remains_supported(self) -> None:
+        # v0.2 must stay supported during the transition; otherwise
+        # existing local manifests break on upgrade.
+        assert "0.2" in SUPPORTED_SCHEMA_VERSIONS
+
+
+class TestV03HookEnum:
+    """v0.3 manifests must reject deferred/excluded names at the schema layer."""
+
+    def test_before_invocation_accepted(self, tmp_path: Path) -> None:
+        payload = _v03_manifest()
+        payload["hooks"] = [_valid_hook(name="before_invocation")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.schema_version == "0.3"
+        assert manifest.hooks[0].name == "before_invocation"
+
+    def test_after_invocation_accepted(self, tmp_path: Path) -> None:
+        payload = _v03_manifest()
+        payload["hooks"] = [_valid_hook(name="after_invocation")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].name == "after_invocation"
+
+    @pytest.mark.parametrize(
+        "deferred_name",
+        [
+            "before_tool_call",
+            "after_tool_call",
+            "before_artifact_write",
+            "after_artifact_write",
+            "on_error",
+            "on_cancel",
+        ],
+    )
+    def test_deferred_name_rejected_at_schema_layer(
+        self, tmp_path: Path, deferred_name: str
+    ) -> None:
+        payload = _v03_manifest()
+        payload["hooks"] = [_valid_hook(name=deferred_name)]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/hooks/0/name"
+
+    @pytest.mark.parametrize(
+        "excluded_name",
+        [
+            "before_runtime_start",
+            "after_runtime_start",
+            "before_state_commit",
+            "after_state_commit",
+            "on_event",
+            "on_rewind",
+        ],
+    )
+    def test_excluded_name_rejected_at_schema_layer(
+        self, tmp_path: Path, excluded_name: str
+    ) -> None:
+        payload = _v03_manifest()
+        payload["hooks"] = [_valid_hook(name=excluded_name)]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/hooks/0/name"
+
+
+class TestV02PythonGuardStillFires:
+    """The Python validator added in #985 must still reject deferred /
+    excluded names against v0.2 manifests, so the transition to v0.3
+    does not silently drop the existing guard for downstream tooling
+    that has not yet upgraded its schema_version.
+    """
+
+    def test_v02_deferred_name_rejected_by_python_validator(self, tmp_path: Path) -> None:
+        payload = _v02_manifest()
+        payload["hooks"] = [_valid_hook(name="before_tool_call")]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/name"
+        # The v0.2 message comes from the Python validator's deferred-
+        # specific branch.
+        assert "deferred" in str(err).lower()
+
+    def test_v02_excluded_name_rejected_by_python_validator(self, tmp_path: Path) -> None:
+        payload = _v02_manifest()
+        payload["hooks"] = [_valid_hook(name="before_runtime_start")]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/name"
+        assert "excluded" in str(err).lower()


### PR DESCRIPTION
## Scope

Third slice of #939 (Tier 1 — **not** blocked by the `agentos-substrate-wiring` milestone). #984 and #985 are now merged; this PR is rebased on current `main` and tightens the JSON Schema layer so non-Python loaders get the same v1 hook guard that the Python validator enforces.

## What this PR adds

- `src/ouroboros/plugin/schemas/0.3/plugin.schema.json`
  - Bumps `$id`, `title`, and `schema_version` const to `0.3`.
  - Narrows `hooks[].name` to the v1 hook enum: `before_invocation`, `after_invocation`.
  - Carries forward the existing `failure_policy` enum (`fail_open`, `fail_closed`).
- `src/ouroboros/plugin/schemas/0.3/audit-event.schema.json`
  - Vendored from 0.2 with 0.3 identity alignment; audit shape is unchanged.
- `src/ouroboros/plugin/schemas/0.3/_source.json`
  - Records the 0.2 → 0.3 local delta.
- `src/ouroboros/plugin/manifest.py`
  - Extends `SUPPORTED_SCHEMA_VERSIONS` to include `0.3`.
- `tests/unit/plugin/test_manifest_schema_0_3.py`
  - Covers support-window behavior, accepted v1 hook names, schema-layer rejection of deferred/excluded names, and v0.2 Python-validator continuity.

## What stays the same

- v0.1 and v0.2 schema files remain unchanged.
- `HookSpec` dataclass remains unchanged.
- Runtime hook dispatch remains out of scope.
- Permission and audit-event emission rules remain out of scope.
- No #920 / #946 / #956 / #978 Tier 2 work is included.

## Acceptance-criterion mapping (#939)

| Criterion | Status |
|---|---|
| hook 목록 정의 (v1) | ✅ #984 |
| 제외 / 보류 hook manifest 거부 (Python) | ✅ #985 |
| 제외 / 보류 hook manifest 거부 (JSON Schema) | ✅ this PR |
| manifest schema bump | ✅ this PR |
| hook permission/declaration validation | ⏭️ later |
| HarnessRunner hook dispatch | ⏭️ later |
| first-party test plugin fixture | ⏭️ later |

## Verification

```
$ uv run pytest tests/unit/plugin/test_manifest_schema_0_3.py tests/unit/plugin/test_manifest_hook_validation.py tests/unit/plugin/test_manifest.py -q
77 passed in 0.45s

$ uv run ruff check src/ouroboros/plugin tests/unit/plugin/test_manifest_schema_0_3.py tests/unit/plugin/test_manifest_hook_validation.py tests/unit/plugin/test_manifest.py
All checks passed!
```

## Follow-up PRs

- **#939 PR-4**: hook-specific permission scope + `plugin.permission_used` emission rule.
- **#939 PR-5**: Harness/runtime hook dispatch with deterministic ordering and `plugin.hook.blocked` / `plugin.hook.failed` audit emission.
- **#939 PR-6**: first-party fixture plugin and smoke coverage.

Refs #939 · sequenced under #961's Tier 1 (unblocked) track · #984 and #985 are merged prerequisites.
