### PR TITLE
feat(orchestrator): add human-readable baseline metrics formatter

### DIFF
--- a/src/ouroboros/orchestrator/baseline_metrics_format.py
+++ b/src/ouroboros/orchestrator/baseline_metrics_format.py
@@ -1,0 +1,113 @@
+"""Human-readable formatter for fat-harness baseline metric reports.
+
+Companion to :mod:`ouroboros.orchestrator.baseline_metrics`. The
+report module owns the data model and gate evaluation; this module
+owns presentation. They are kept separate so the JSON contract in
+:meth:`FatHarnessMetricsReport.to_dict` stays untouched by any
+display logic.
+
+The formatter is intentionally a pure function: it takes a frozen
+report and returns a string. No I/O, no LLM, no live execution. It
+is safe to call from CLI handlers, CI summaries, or test assertions.
+
+This module addresses a small but practical gap on the path to
+closing the ``agentos-substrate-wiring`` milestone — the 5 hard-gate
+baseline metrics must be reported in a human-checkable form so a
+maintainer can compare the values against the gate criteria without
+parsing JSON by hand. The report content itself (sample collection,
+fat-harness execution wiring) lives upstream in dedicated PRs; this
+PR adds only the rendering surface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ouroboros.orchestrator.baseline_metrics import (
+    FatHarnessGateResult,
+    FatHarnessGateStatus,
+    FatHarnessMetricsReport,
+)
+
+_STATUS_GLYPH: dict[FatHarnessGateStatus, str] = {
+    FatHarnessGateStatus.PASS: "PASS",
+    FatHarnessGateStatus.FAIL: "FAIL",
+    FatHarnessGateStatus.CAPTURED: "CAPT",
+    FatHarnessGateStatus.NOT_APPLICABLE: " N/A",
+}
+
+
+def render_baseline_report(report: FatHarnessMetricsReport) -> str:
+    """Return a multi-line human-readable rendering of ``report``.
+
+    The output is stable and deterministic — repeat calls against the
+    same report return byte-identical text — so CI fixtures and
+    snapshot tests can rely on it without floating-point fuzzing.
+
+    Format:
+
+    ```
+    Fat-harness baseline report — profile=<name> · acs=<n> · K=<max_retries>
+    --------------------------------------------------------------
+      [PASS] one_shot_pass_rate           : 0.83 (target ≥ ?)
+      [PASS] k_recovery_rate              : 0.71 (target ≥ 0.70)
+      ...
+    ```
+
+    The exact targets shown depend on the gate status field; the
+    formatter never invents thresholds.
+    """
+    header_line = (
+        f"Fat-harness baseline report — profile={report.profile} · "
+        f"acs={report.total_acs} · K={report.max_retries}"
+    )
+    rule = "-" * len(header_line)
+
+    lines: list[str] = [header_line, rule]
+    lines.extend(_render_gate_lines(report.gates))
+    lines.append(rule)
+    lines.extend(_render_metric_summary(report))
+    return "\n".join(lines)
+
+
+def _render_gate_lines(gates: Iterable[FatHarnessGateResult]) -> list[str]:
+    rendered: list[str] = []
+    for gate in gates:
+        glyph = _STATUS_GLYPH.get(gate.status, "????")
+        value = _format_value(gate.value)
+        target_part = _format_target(gate)
+        rendered.append(f"  [{glyph}] {gate.name:<35} : {value}{target_part}")
+    return rendered
+
+
+def _render_metric_summary(report: FatHarnessMetricsReport) -> list[str]:
+    return [
+        f"  one_shot_pass_rate                  : {_format_value(report.one_shot_pass_rate)}",
+        f"  k_recovery_rate                     : {_format_value(report.k_recovery_rate)}",
+        f"  fabrication_per_100_acs             : {_format_value(report.fabrication_incidents_per_100_acs)}",
+        f"  median_chars_per_ac                 : {_format_value(report.median_chars_per_ac)}",
+        f"  new_domain_loc_delta                : {report.new_domain_loc_delta}",
+        f"  new_domain_yaml_delta               : {report.new_domain_yaml_delta}",
+    ]
+
+
+def _format_value(value: float | int | None) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, int):
+        return str(value)
+    if value != value:  # NaN guard — should not arise, but cheap to keep
+        return "nan"
+    return f"{value:.4f}"
+
+
+def _format_target(gate: FatHarnessGateResult) -> str:
+    target = getattr(gate, "target", "")
+    if not target:
+        return ""
+    return f" (target {target})"
+
+
+__all__ = [
+    "render_baseline_report",
+]

--- a/src/ouroboros/orchestrator/baseline_metrics_format.py
+++ b/src/ouroboros/orchestrator/baseline_metrics_format.py
@@ -84,7 +84,7 @@ def _render_metric_summary(report: FatHarnessMetricsReport) -> list[str]:
     return [
         f"  one_shot_pass_rate                  : {_format_value(report.one_shot_pass_rate)}",
         f"  k_recovery_rate                     : {_format_value(report.k_recovery_rate)}",
-        f"  fabrication_per_100_acs             : {_format_value(report.fabrication_incidents_per_100_acs)}",
+        f"  fabrication_incidents_per_100_acs             : {_format_value(report.fabrication_incidents_per_100_acs)}",
         f"  median_chars_per_ac                 : {_format_value(report.median_chars_per_ac)}",
         f"  new_domain_loc_delta                : {report.new_domain_loc_delta}",
         f"  new_domain_yaml_delta               : {report.new_domain_yaml_delta}",

--- a/tests/unit/orchestrator/test_baseline_metrics_format.py
+++ b/tests/unit/orchestrator/test_baseline_metrics_format.py
@@ -91,7 +91,7 @@ class TestRenderBaselineReport:
         for label in (
             "one_shot_pass_rate",
             "k_recovery_rate",
-            "fabrication_per_100_acs",
+            "fabrication_incidents_per_100_acs",
             "median_chars_per_ac",
             "new_domain_loc_delta",
             "new_domain_yaml_delta",

--- a/tests/unit/orchestrator/test_baseline_metrics_format.py
+++ b/tests/unit/orchestrator/test_baseline_metrics_format.py
@@ -1,0 +1,150 @@
+"""Tests for the human-readable baseline-metric report formatter.
+
+The formatter is a pure function over
+:class:`FatHarnessMetricsReport`. It must:
+
+* Produce deterministic output (same report → same string).
+* Show each gate's status glyph and value.
+* Show the summary metric block.
+* Tolerate ``None`` values (gates that are CAPTURED only, not yet
+  PASS / FAIL evaluated).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.baseline_metrics import (
+    FatHarnessGateResult,
+    FatHarnessGateStatus,
+    FatHarnessMetricSample,
+    build_fat_harness_metrics_report,
+)
+from ouroboros.orchestrator.baseline_metrics_format import render_baseline_report
+
+
+def _sample(
+    ac_id: str,
+    *,
+    accepted: bool,
+    attempt_count: int = 1,
+    fabrication_incidents: int = 0,
+    prompt_chars: int = 1000,
+    completion_chars: int = 500,
+) -> FatHarnessMetricSample:
+    return FatHarnessMetricSample(
+        ac_id=ac_id,
+        accepted=accepted,
+        attempt_count=attempt_count,
+        fabrication_incidents=fabrication_incidents,
+        prompt_chars=prompt_chars,
+        completion_chars=completion_chars,
+    )
+
+
+@pytest.fixture
+def green_report():
+    samples = [
+        _sample("ac_1", accepted=True, attempt_count=1),
+        _sample("ac_2", accepted=True, attempt_count=2),
+        _sample("ac_3", accepted=True, attempt_count=1),
+    ]
+    return build_fat_harness_metrics_report(
+        profile="fat_harness",
+        samples=samples,
+        new_domain_loc_delta=40,
+        new_domain_yaml_delta=1,
+    )
+
+
+class TestRenderBaselineReport:
+    def test_returns_multiline_string(self, green_report) -> None:
+        output = render_baseline_report(green_report)
+        assert isinstance(output, str)
+        assert output.count("\n") >= 4
+
+    def test_header_contains_profile_and_ac_count(self, green_report) -> None:
+        output = render_baseline_report(green_report)
+        first_line = output.splitlines()[0]
+        assert "profile=fat_harness" in first_line
+        assert f"acs={green_report.total_acs}" in first_line
+        assert f"K={green_report.max_retries}" in first_line
+
+    def test_output_is_deterministic(self, green_report) -> None:
+        first = render_baseline_report(green_report)
+        second = render_baseline_report(green_report)
+        assert first == second
+
+    def test_every_gate_appears_in_output(self, green_report) -> None:
+        output = render_baseline_report(green_report)
+        for gate in green_report.gates:
+            assert gate.name in output
+
+    def test_status_glyphs_render(self, green_report) -> None:
+        output = render_baseline_report(green_report)
+        glyphs_present = {"[PASS]", "[FAIL]", "[CAPT]", "[ N/A]"}
+        appearing = {g for g in glyphs_present if g in output}
+        assert appearing, f"no status glyph rendered; output was:\n{output}"
+
+    def test_summary_block_lists_each_metric(self, green_report) -> None:
+        output = render_baseline_report(green_report)
+        for label in (
+            "one_shot_pass_rate",
+            "k_recovery_rate",
+            "fabrication_per_100_acs",
+            "median_chars_per_ac",
+            "new_domain_loc_delta",
+            "new_domain_yaml_delta",
+        ):
+            assert label in output, f"missing summary label '{label}'"
+
+    def test_renders_none_metric_values_as_na(self) -> None:
+        # k_recovery_rate is None when every AC succeeded on the first
+        # try (no retries to evaluate). The report should not crash and
+        # must render ``n/a`` rather than blowing up on float
+        # formatting.
+        samples = [_sample("ac_1", accepted=True, attempt_count=1)]
+        report = build_fat_harness_metrics_report(
+            profile="fat_harness",
+            samples=samples,
+            new_domain_loc_delta=40,
+        )
+        output = render_baseline_report(report)
+        assert "k_recovery_rate" in output
+        assert "n/a" in output
+
+
+class TestRenderHandlesAllGateStatuses:
+    """Smoke-test that each FatHarnessGateStatus value has a glyph."""
+
+    def test_glyph_table_covers_all_statuses(self) -> None:
+        from ouroboros.orchestrator.baseline_metrics_format import _STATUS_GLYPH
+
+        for status in FatHarnessGateStatus:
+            assert status in _STATUS_GLYPH, f"missing glyph for {status}"
+
+
+class TestRenderTargetSuffix:
+    def test_empty_target_omits_suffix(self) -> None:
+        from ouroboros.orchestrator.baseline_metrics_format import _format_target
+
+        gate = FatHarnessGateResult(
+            name="x",
+            status=FatHarnessGateStatus.CAPTURED,
+            value=1.0,
+            target="",
+            rationale="",
+        )
+        assert _format_target(gate) == ""
+
+    def test_present_target_renders(self) -> None:
+        from ouroboros.orchestrator.baseline_metrics_format import _format_target
+
+        gate = FatHarnessGateResult(
+            name="x",
+            status=FatHarnessGateStatus.PASS,
+            value=0.8,
+            target=">= 0.70",
+            rationale="",
+        )
+        assert "target >= 0.70" in _format_target(gate)


### PR DESCRIPTION
## Scope

Companion utility to the baseline metrics module added in #977
(merged). That module owns the data model + gate evaluation; this
PR adds a pure-function presentation layer so a maintainer can read
a fat-harness report without parsing JSON.

Tier 1 work — **not** blocked by the `agentos-substrate-wiring`
milestone. Does not touch `parallel_executor`, LLM calls, or live
execution. The actual measurement captures (sample collection,
fat-harness execution wiring) live in separate PRs; this PR adds
only the rendering surface so the eventual baseline-metric
publication has a human-readable target.

## What this PR adds

- `src/ouroboros/orchestrator/baseline_metrics_format.py`
  - `render_baseline_report(report) -> str` — deterministic
    multi-line rendering of a `FatHarnessMetricsReport`.
  - Status glyphs for every `FatHarnessGateStatus` (`[PASS]` /
    `[FAIL]` / `[CAPT]` / `[ N/A]`).
  - Per-gate line: status glyph + name (left-aligned 35 cols) +
    value + optional `(target …)` suffix.
  - Summary block listing every metric in the report dataclass.
- `tests/unit/orchestrator/test_baseline_metrics_format.py` — 10
  tests covering deterministic output, header content, every-gate
  presence, glyph rendering, summary-block coverage, `None`-value
  rendering as `n/a`, glyph-table completeness, target-suffix
  formatting.

## Why this is useful for the milestone path

`#961`'s gate close criteria require the 5 hard-gate metrics to be
**measured and reported**. Today the report shape exists (#977) and
the JSON contract via `to_dict()` is stable, but there is no
canonical human readout. Adding a deterministic formatter:

- gives the eventual baseline-publication PR a clean stdout/CI
  target,
- lets test fixtures snapshot-test rendered reports without
  floating-point fuzzing,
- decouples display from data so the JSON contract stays
  unchanged.

This PR does **not** measure anything. Measurement plumbing lands
in dedicated PRs alongside fat-harness execution wiring.

## Non-goals

- No new sample-collection logic.
- No CLI command surface yet (rendering is a building block; the
  CLI subcommand can wrap it in a follow-up).
- No JSON-contract change in `baseline_metrics.py`.
- No fat-harness execution wiring.

## Verification

```
$ uv run pytest tests/unit/orchestrator/test_baseline_metrics_format.py -q
..........                                                               [100%]
10 passed in 0.37s

$ uv run ruff check src/ tests/
All checks passed!
```

Refs #961 hard-gate publication path. Tier 1 utility — independent
of the Phase C dependency graph.