### PR TITLE
feat(harness): expose projection records through MCP query (#946 PR-2)

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1175,6 +1175,7 @@ def create_ouroboros_server(
         LateralThinkHandler,
         LineageStatusHandler,
         MeasureDriftHandler,
+        ProjectionQueryHandler,
         QueryEventsHandler,
         RalphHandler,
         SessionStatusHandler,
@@ -1724,6 +1725,9 @@ def create_ouroboros_server(
             job_manager=job_manager,
         ),
         QueryEventsHandler(
+            event_store=event_store,
+        ),
+        ProjectionQueryHandler(
             event_store=event_store,
         ),
         GenerateSeedHandler(

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -8,6 +8,7 @@ the default handler tuple for MCP registration.
 Handler modules:
 - execution_handlers: ExecuteSeedHandler, StartExecuteSeedHandler
 - query_handlers: SessionStatusHandler, QueryEventsHandler, ACDashboardHandler
+- projection_handlers: ProjectionQueryHandler
 - authoring_handlers: GenerateSeedHandler, InterviewHandler
 - evaluation_handlers: MeasureDriftHandler, EvaluateHandler, LateralThinkHandler
 - evolution_handlers: EvolveStepHandler, StartEvolveStepHandler,
@@ -51,6 +52,7 @@ from ouroboros.mcp.tools.job_handlers import (
     JobStatusHandler,
     JobWaitHandler,
 )
+from ouroboros.mcp.tools.projection_handlers import ProjectionQueryHandler
 from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.query_handlers import (
     ACDashboardHandler,  # noqa: F401 — re-exported for adapter.py
@@ -180,6 +182,11 @@ def cancel_job_handler() -> CancelJobHandler:
 def query_events_handler() -> QueryEventsHandler:
     """Create a QueryEventsHandler instance."""
     return QueryEventsHandler()
+
+
+def projection_query_handler() -> ProjectionQueryHandler:
+    """Create a ProjectionQueryHandler instance."""
+    return ProjectionQueryHandler()
 
 
 def generate_seed_handler(
@@ -388,6 +395,7 @@ OuroborosToolHandlers = tuple[
     | ACTreeHUDHandler
     | CancelJobHandler
     | QueryEventsHandler
+    | ProjectionQueryHandler
     | GenerateSeedHandler
     | MeasureDriftHandler
     | InterviewHandler
@@ -502,6 +510,7 @@ def get_ouroboros_tools(
         ACTreeHUDHandler(),
         CancelJobHandler(),
         QueryEventsHandler(),
+        ProjectionQueryHandler(),
         generate_seed,
         MeasureDriftHandler(),
         interview,

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -25,8 +25,6 @@ from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
 
-_DEFAULT_LIMIT = 1000
-
 
 @dataclass
 class ProjectionQueryHandler:
@@ -77,10 +75,11 @@ class ProjectionQueryHandler:
                     name="limit",
                     type=ToolInputType.INTEGER,
                     description=(
-                        "Maximum related events to inspect for session queries. Default: 1000."
+                        "Optional safety cap for related events. If the run has "
+                        "more events than this cap, the tool fails instead of "
+                        "returning a partial projection."
                     ),
                     required=False,
-                    default=_DEFAULT_LIMIT,
                 ),
             ),
         )
@@ -93,7 +92,8 @@ class ProjectionQueryHandler:
         session_id = _string_argument(arguments, "session_id")
         execution_id = _string_argument(arguments, "execution_id")
         seed_id_override = _string_argument(arguments, "seed_id")
-        limit = _positive_int_argument(arguments.get("limit", _DEFAULT_LIMIT))
+        raw_limit = arguments.get("limit")
+        limit = _optional_positive_int_argument(raw_limit)
 
         if session_id is None and execution_id is None:
             return Result.err(
@@ -102,7 +102,7 @@ class ProjectionQueryHandler:
                     tool_name="ouroboros_query_projection",
                 )
             )
-        if limit is None:
+        if raw_limit is not None and limit is None:
             return Result.err(
                 MCPToolError(
                     "limit must be a positive integer",
@@ -130,7 +130,6 @@ class ProjectionQueryHandler:
                 store,
                 session_id=session_id,
                 execution_id=execution_id,
-                limit=limit,
             )
             ordered_events = tuple(
                 sorted(
@@ -138,6 +137,16 @@ class ProjectionQueryHandler:
                     key=lambda event: (event.timestamp, event.id),
                 )
             )
+            if limit is not None and len(ordered_events) > limit:
+                return Result.err(
+                    MCPToolError(
+                        (
+                            f"Projection event count {len(ordered_events)} exceeds "
+                            f"limit {limit}; rerun without limit for a complete projection."
+                        ),
+                        tool_name="ouroboros_query_projection",
+                    )
+                )
             seed_id = seed_id_override or _derive_seed_id(ordered_events, session_id, execution_id)
             goal = _derive_goal(ordered_events)
             projection = build_projection(ordered_events, seed_id=seed_id, goal=goal)
@@ -179,18 +188,17 @@ async def _load_projection_events(
     *,
     session_id: str | None,
     execution_id: str | None,
-    limit: int,
 ) -> list[BaseEvent]:
     if session_id is not None:
         return await store.query_session_related_events(
             session_id=session_id,
             execution_id=execution_id,
-            limit=limit,
+            limit=None,
         )
     if execution_id is not None:
         return await store.query_execution_related_events(
             execution_id=execution_id,
-            limit=limit,
+            limit=None,
         )
     return []
 
@@ -202,7 +210,7 @@ def _projection_meta(
     execution_id: str | None,
     seed_id: str,
     event_count: int,
-    limit: int,
+    limit: int | None,
 ) -> dict[str, Any]:
     return {
         "session_id": session_id,
@@ -260,7 +268,7 @@ def _derive_goal(events: Sequence[BaseEvent]) -> str:
     for event in events:
         if not isinstance(event.data, dict):
             continue
-        for key in ("goal", "objective"):
+        for key in ("seed_goal", "goal", "objective"):
             value = event.data.get(key)
             if isinstance(value, str) and value.strip():
                 return value.strip()
@@ -274,7 +282,9 @@ def _string_argument(arguments: dict[str, Any], name: str) -> str | None:
     return None
 
 
-def _positive_int_argument(value: Any) -> int | None:
+def _optional_positive_int_argument(value: Any) -> int | None:
+    if value is None:
+        return None
     if isinstance(value, int) and value > 0:
         return value
     return None

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -77,8 +77,7 @@ class ProjectionQueryHandler:
                     name="limit",
                     type=ToolInputType.INTEGER,
                     description=(
-                        "Maximum related events to inspect for session queries. "
-                        "Default: 1000."
+                        "Maximum related events to inspect for session queries. Default: 1000."
                     ),
                     required=False,
                     default=_DEFAULT_LIMIT,
@@ -189,7 +188,10 @@ async def _load_projection_events(
             limit=limit,
         )
     if execution_id is not None:
-        return await store.replay("execution", execution_id)
+        return await store.query_execution_related_events(
+            execution_id=execution_id,
+            limit=limit,
+        )
     return []
 
 

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -1,0 +1,281 @@
+"""Read-only MCP query surface for harness projections."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC
+from typing import Any
+
+import structlog
+
+from ouroboros.core.types import Result
+from ouroboros.events.base import BaseEvent
+from ouroboros.harness.projection_builder import ProjectionBuildResult, build_projection
+from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.types import (
+    ContentType,
+    MCPContentItem,
+    MCPToolDefinition,
+    MCPToolParameter,
+    MCPToolResult,
+    ToolInputType,
+)
+from ouroboros.persistence.event_store import EventStore
+
+log = structlog.get_logger(__name__)
+
+_DEFAULT_LIMIT = 1000
+
+
+@dataclass
+class ProjectionQueryHandler:
+    """Build a Run/Stage/Step projection from persisted events.
+
+    This is the #946 PR-2 read-only MCP surface. It intentionally computes
+    projections on demand from the EventStore rather than caching or mutating
+    any rows.
+    """
+
+    event_store: EventStore | None = field(default=None, repr=False)
+
+    @property
+    def definition(self) -> MCPToolDefinition:
+        """Return the MCP tool definition."""
+        return MCPToolDefinition(
+            name="ouroboros_query_projection",
+            description=(
+                "Build a read-only Run/Stage/Step projection from persisted "
+                "Ouroboros events for a session or execution aggregate."
+            ),
+            parameters=(
+                MCPToolParameter(
+                    name="session_id",
+                    type=ToolInputType.STRING,
+                    description="Optional orchestrator session ID to project.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="execution_id",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "Optional execution aggregate ID. When session_id is also "
+                        "provided, this narrows related session-event lookup."
+                    ),
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="seed_id",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "Optional seed ID override. If omitted, the handler derives "
+                        "one from events and falls back to the queried ID."
+                    ),
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="limit",
+                    type=ToolInputType.INTEGER,
+                    description=(
+                        "Maximum related events to inspect for session queries. "
+                        "Default: 1000."
+                    ),
+                    required=False,
+                    default=_DEFAULT_LIMIT,
+                ),
+            ),
+        )
+
+    async def handle(
+        self,
+        arguments: dict[str, Any],
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Handle a projection query request."""
+        session_id = _string_argument(arguments, "session_id")
+        execution_id = _string_argument(arguments, "execution_id")
+        seed_id_override = _string_argument(arguments, "seed_id")
+        limit = _positive_int_argument(arguments.get("limit", _DEFAULT_LIMIT))
+
+        if session_id is None and execution_id is None:
+            return Result.err(
+                MCPToolError(
+                    "session_id or execution_id is required",
+                    tool_name="ouroboros_query_projection",
+                )
+            )
+        if limit is None:
+            return Result.err(
+                MCPToolError(
+                    "limit must be a positive integer",
+                    tool_name="ouroboros_query_projection",
+                )
+            )
+
+        log.info(
+            "mcp.tool.query_projection",
+            session_id=session_id,
+            execution_id=execution_id,
+            limit=limit,
+        )
+
+        store = self.event_store
+        owns_event_store = False
+
+        try:
+            if store is None:
+                store = EventStore(read_only=True)
+                owns_event_store = True
+            await store.initialize(create_schema=False if owns_event_store else None)
+
+            events = await _load_projection_events(
+                store,
+                session_id=session_id,
+                execution_id=execution_id,
+                limit=limit,
+            )
+            ordered_events = tuple(
+                sorted(
+                    (_ensure_aware_timestamp(event) for event in events),
+                    key=lambda event: (event.timestamp, event.id),
+                )
+            )
+            seed_id = seed_id_override or _derive_seed_id(ordered_events, session_id, execution_id)
+            goal = _derive_goal(ordered_events)
+            projection = build_projection(ordered_events, seed_id=seed_id, goal=goal)
+
+            return Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text=_format_projection_text(projection, len(ordered_events)),
+                        ),
+                    ),
+                    is_error=False,
+                    meta=_projection_meta(
+                        projection,
+                        session_id=session_id,
+                        execution_id=execution_id,
+                        seed_id=seed_id,
+                        event_count=len(ordered_events),
+                        limit=limit,
+                    ),
+                )
+            )
+        except Exception as exc:
+            log.error("mcp.tool.query_projection.error", error=str(exc))
+            return Result.err(
+                MCPToolError(
+                    f"Failed to query projection: {exc}",
+                    tool_name="ouroboros_query_projection",
+                )
+            )
+        finally:
+            if owns_event_store and store is not None:
+                await store.close()
+
+
+async def _load_projection_events(
+    store: EventStore,
+    *,
+    session_id: str | None,
+    execution_id: str | None,
+    limit: int,
+) -> list[BaseEvent]:
+    if session_id is not None:
+        return await store.query_session_related_events(
+            session_id=session_id,
+            execution_id=execution_id,
+            limit=limit,
+        )
+    if execution_id is not None:
+        return await store.replay("execution", execution_id)
+    return []
+
+
+def _projection_meta(
+    projection: ProjectionBuildResult,
+    *,
+    session_id: str | None,
+    execution_id: str | None,
+    seed_id: str,
+    event_count: int,
+    limit: int,
+) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "execution_id": execution_id,
+        "seed_id": seed_id,
+        "event_count": event_count,
+        "limit": limit,
+        "run": projection.run.model_dump(mode="json"),
+        "stages": [stage.model_dump(mode="json") for stage in projection.stages],
+        "steps": [step.model_dump(mode="json") for step in projection.steps],
+        "artifacts": [],
+        "verdicts": [],
+    }
+
+
+def _format_projection_text(projection: ProjectionBuildResult, event_count: int) -> str:
+    lines = [
+        "Run Projection",
+        "=" * 60,
+        f"Run: {projection.run.run_id}",
+        f"Seed: {projection.run.seed_id}",
+        f"Events inspected: {event_count}",
+        f"Stages: {len(projection.stages)}",
+        f"Steps: {len(projection.steps)}",
+    ]
+    if projection.steps:
+        lines.append("")
+        lines.append("Steps:")
+        for step in projection.steps:
+            status = "pending" if step.ok is None else ("ok" if step.ok else "error")
+            lines.append(f"- {step.step_id} [{step.kind.value}] {step.name}: {status}")
+    return "\n".join(lines)
+
+
+def _derive_seed_id(
+    events: Sequence[BaseEvent],
+    session_id: str | None,
+    execution_id: str | None,
+) -> str:
+    for event in events:
+        value = event.data.get("seed_id") if isinstance(event.data, dict) else None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    fallback = execution_id or session_id or "projection"
+    return fallback.strip() or "projection"
+
+
+def _ensure_aware_timestamp(event: BaseEvent) -> BaseEvent:
+    if event.timestamp.tzinfo is not None:
+        return event
+    return event.model_copy(update={"timestamp": event.timestamp.replace(tzinfo=UTC)})
+
+
+def _derive_goal(events: Sequence[BaseEvent]) -> str:
+    for event in events:
+        if not isinstance(event.data, dict):
+            continue
+        for key in ("goal", "objective"):
+            value = event.data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _string_argument(arguments: dict[str, Any], name: str) -> str | None:
+    value = arguments.get(name)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _positive_int_argument(value: Any) -> int | None:
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+__all__ = ["ProjectionQueryHandler"]

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -124,7 +124,7 @@ class ProjectionQueryHandler:
             if store is None:
                 store = EventStore(read_only=True)
                 owns_event_store = True
-            await store.initialize(create_schema=False if owns_event_store else None)
+            await store.initialize(create_schema=False)
 
             events = await _load_projection_events(
                 store,

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -25,6 +25,15 @@ from ouroboros.persistence.event_store import EventStore
 
 log = structlog.get_logger(__name__)
 
+_SESSION_TERMINAL_EVENT_TYPES = frozenset(
+    {
+        "orchestrator.session.cancelled",
+        "orchestrator.session.completed",
+        "orchestrator.session.failed",
+        "orchestrator.session.paused",
+    }
+)
+
 
 @dataclass
 class ProjectionQueryHandler:
@@ -220,6 +229,7 @@ async def _load_projection_events(
                         session_id,
                         execution_id=declared_execution_id,
                     )
+                    or _is_session_terminal_event(event, session_id)
                     or _event_links_execution(event, declared_execution_id)
                 ]
             return events
@@ -230,6 +240,7 @@ async def _load_projection_events(
             event
             for event in events
             if _is_session_metadata_event(event, session_id, execution_id=execution_id)
+            or _is_session_terminal_event(event, session_id)
             or _event_links_execution(event, execution_id)
         ]
     if execution_id is not None:
@@ -337,6 +348,14 @@ def _is_session_metadata_event(
         return False
     value = event.data.get("execution_id")
     return isinstance(value, str) and value.strip() == execution_id
+
+
+def _is_session_terminal_event(event: BaseEvent, session_id: str) -> bool:
+    return (
+        event.aggregate_type == "session"
+        and event.aggregate_id == session_id
+        and event.type in _SESSION_TERMINAL_EVENT_TYPES
+    )
 
 
 def _event_links_execution(event: BaseEvent, execution_id: str) -> bool:

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -210,6 +210,18 @@ async def _load_projection_events(
                     "provide execution_id for an unambiguous projection"
                 )
                 raise ValueError(msg)
+            if len(declared_execution_ids) == 1:
+                declared_execution_id = next(iter(declared_execution_ids))
+                return [
+                    event
+                    for event in events
+                    if _is_session_metadata_event(
+                        event,
+                        session_id,
+                        execution_id=declared_execution_id,
+                    )
+                    or _event_links_execution(event, declared_execution_id)
+                ]
             return events
         if not _session_declares_execution(events, session_id, execution_id):
             msg = f"execution_id {execution_id!r} does not belong to session_id {session_id!r}"
@@ -328,7 +340,9 @@ def _is_session_metadata_event(
 
 
 def _event_links_execution(event: BaseEvent, execution_id: str) -> bool:
-    if event.aggregate_type == "execution" and event.aggregate_id == execution_id:
+    if event.aggregate_type != "execution":
+        return False
+    if event.aggregate_id == execution_id:
         return True
     if not isinstance(event.data, dict):
         return False

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -203,6 +203,13 @@ async def _load_projection_events(
             limit=None,
         )
         if execution_id is None:
+            declared_execution_ids = _session_execution_ids(events, session_id)
+            if len(declared_execution_ids) > 1:
+                msg = (
+                    f"session_id {session_id!r} declares multiple executions; "
+                    "provide execution_id for an unambiguous projection"
+                )
+                raise ValueError(msg)
             return events
         if not _session_declares_execution(events, session_id, execution_id):
             msg = f"execution_id {execution_id!r} does not belong to session_id {session_id!r}"
@@ -291,6 +298,17 @@ def _session_declares_execution(
         if _is_session_metadata_event(event, session_id, execution_id=execution_id):
             return True
     return False
+
+
+def _session_execution_ids(events: Sequence[BaseEvent], session_id: str) -> frozenset[str]:
+    execution_ids: set[str] = set()
+    for event in events:
+        if not _is_session_metadata_event(event, session_id):
+            continue
+        value = event.data.get("execution_id") if isinstance(event.data, dict) else None
+        if isinstance(value, str) and value.strip():
+            execution_ids.add(value.strip())
+    return frozenset(execution_ids)
 
 
 def _is_session_metadata_event(

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -199,6 +199,7 @@ async def _load_projection_events(
     if session_id is not None:
         events = await store.query_session_related_events(
             session_id=session_id,
+            execution_id=execution_id,
             limit=None,
         )
         if execution_id is None:

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -209,7 +209,7 @@ async def _load_projection_events(
         return [
             event
             for event in events
-            if _is_session_metadata_event(event, session_id)
+            if _is_session_metadata_event(event, session_id, execution_id=execution_id)
             or _event_links_execution(event, execution_id)
         ]
     if execution_id is not None:
@@ -287,16 +287,25 @@ def _session_declares_execution(
     execution_id: str,
 ) -> bool:
     for event in events:
-        if not _is_session_metadata_event(event, session_id):
-            continue
-        value = event.data.get("execution_id") if isinstance(event.data, dict) else None
-        if isinstance(value, str) and value.strip() == execution_id:
+        if _is_session_metadata_event(event, session_id, execution_id=execution_id):
             return True
     return False
 
 
-def _is_session_metadata_event(event: BaseEvent, session_id: str) -> bool:
-    return event.aggregate_type == "session" and event.aggregate_id == session_id
+def _is_session_metadata_event(
+    event: BaseEvent,
+    session_id: str,
+    *,
+    execution_id: str | None = None,
+) -> bool:
+    if event.aggregate_type != "session" or event.aggregate_id != session_id:
+        return False
+    if execution_id is None:
+        return True
+    if not isinstance(event.data, dict):
+        return False
+    value = event.data.get("execution_id")
+    return isinstance(value, str) and value.strip() == execution_id
 
 
 def _event_links_execution(event: BaseEvent, execution_id: str) -> bool:

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -137,6 +137,13 @@ class ProjectionQueryHandler:
                     key=lambda event: (event.timestamp, event.id),
                 )
             )
+            if not ordered_events:
+                return Result.err(
+                    MCPToolError(
+                        "No events found for projection query",
+                        tool_name="ouroboros_query_projection",
+                    )
+                )
             if limit is not None and len(ordered_events) > limit:
                 return Result.err(
                     MCPToolError(
@@ -190,11 +197,21 @@ async def _load_projection_events(
     execution_id: str | None,
 ) -> list[BaseEvent]:
     if session_id is not None:
-        return await store.query_session_related_events(
+        events = await store.query_session_related_events(
             session_id=session_id,
-            execution_id=execution_id,
             limit=None,
         )
+        if execution_id is None:
+            return events
+        if not _session_declares_execution(events, session_id, execution_id):
+            msg = f"execution_id {execution_id!r} does not belong to session_id {session_id!r}"
+            raise ValueError(msg)
+        return [
+            event
+            for event in events
+            if _is_session_metadata_event(event, session_id)
+            or _event_links_execution(event, execution_id)
+        ]
     if execution_id is not None:
         return await store.query_execution_related_events(
             execution_id=execution_id,
@@ -262,6 +279,36 @@ def _ensure_aware_timestamp(event: BaseEvent) -> BaseEvent:
     if event.timestamp.tzinfo is not None:
         return event
     return event.model_copy(update={"timestamp": event.timestamp.replace(tzinfo=UTC)})
+
+
+def _session_declares_execution(
+    events: Sequence[BaseEvent],
+    session_id: str,
+    execution_id: str,
+) -> bool:
+    for event in events:
+        if not _is_session_metadata_event(event, session_id):
+            continue
+        value = event.data.get("execution_id") if isinstance(event.data, dict) else None
+        if isinstance(value, str) and value.strip() == execution_id:
+            return True
+    return False
+
+
+def _is_session_metadata_event(event: BaseEvent, session_id: str) -> bool:
+    return event.aggregate_type == "session" and event.aggregate_id == session_id
+
+
+def _event_links_execution(event: BaseEvent, execution_id: str) -> bool:
+    if event.aggregate_type == "execution" and event.aggregate_id == execution_id:
+        return True
+    if not isinstance(event.data, dict):
+        return False
+    for key in ("execution_id", "parent_execution_id"):
+        value = event.data.get(key)
+        if isinstance(value, str) and value.strip() == execution_id:
+            return True
+    return False
 
 
 def _derive_goal(events: Sequence[BaseEvent]) -> str:

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -853,6 +853,64 @@ class EventStore:
                 },
             ) from e
 
+    async def query_execution_related_events(
+        self,
+        execution_id: str,
+        event_type: str | None = None,
+        limit: int | None = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        """Query events for an execution and its child/runtime scopes.
+
+        This is the execution-only counterpart to
+        :meth:`query_session_related_events`: it includes the root execution
+        aggregate plus events whose payload links back through ``execution_id``
+        or ``parent_execution_id``.
+        """
+        if self._engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="query_execution_related_events",
+            )
+
+        conditions = [
+            events_table.c.aggregate_id == execution_id,
+            func.json_extract(events_table.c.payload, "$.execution_id") == execution_id,
+            func.json_extract(events_table.c.payload, "$.parent_execution_id") == execution_id,
+        ]
+
+        try:
+            async with self._engine.begin() as conn:
+                query = (
+                    select(events_table)
+                    .where(or_(*conditions))
+                    .order_by(events_table.c.timestamp.desc())
+                )
+
+                if event_type:
+                    query = query.where(events_table.c.event_type == event_type)
+
+                if limit is not None:
+                    query = query.limit(limit).offset(offset)
+                elif offset:
+                    query = query.offset(offset)
+
+                result = await conn.execute(query)
+                rows = result.mappings().all()
+                return [BaseEvent.from_db_row(dict(row)) for row in rows]
+        except Exception as e:
+            raise PersistenceError(
+                f"Failed to query execution-related events: {e}",
+                operation="select",
+                table="events",
+                details={
+                    "execution_id": execution_id,
+                    "event_type": event_type,
+                    "limit": limit,
+                    "offset": offset,
+                },
+            ) from e
+
     async def query_session_related_events_after(
         self,
         session_id: str,

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -883,6 +883,7 @@ class EventStore:
             async with self._engine.begin() as conn:
                 query = (
                     select(events_table)
+                    .where(events_table.c.aggregate_type == "execution")
                     .where(or_(*conditions))
                     .order_by(events_table.c.timestamp.desc())
                 )

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -498,6 +498,7 @@ class TestCreateOuroborosServer:
         "ouroboros_pm_interview",
         "ouroboros_qa",
         "ouroboros_query_events",
+        "ouroboros_query_projection",
         "ouroboros_ralph",
         "ouroboros_session_status",
         "ouroboros_start_auto",

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -30,6 +30,7 @@ from ouroboros.mcp.tools.definitions import (
     LateralThinkHandler,
     LineageStatusHandler,
     MeasureDriftHandler,
+    ProjectionQueryHandler,
     QueryEventsHandler,
     RalphHandler,
     SessionStatusHandler,
@@ -506,6 +507,134 @@ class TestQueryEventsHandler:
         assert "exec_parallel_123_sub_ac_0_0" in text
 
 
+class TestProjectionQueryHandler:
+    """Test ProjectionQueryHandler class."""
+
+    def test_definition_name(self) -> None:
+        handler = ProjectionQueryHandler()
+        assert handler.definition.name == "ouroboros_query_projection"
+
+    def test_definition_has_read_only_query_parameters(self) -> None:
+        handler = ProjectionQueryHandler()
+        param_names = {p.name for p in handler.definition.parameters}
+        assert param_names == {"session_id", "execution_id", "seed_id", "limit"}
+        assert all(p.required is False for p in handler.definition.parameters)
+
+    async def test_handle_requires_session_or_execution_id(self) -> None:
+        handler = ProjectionQueryHandler()
+        result = await handler.handle({})
+
+        assert result.is_err
+        assert "session_id or execution_id is required" in str(result.error)
+
+    async def test_handle_projects_execution_events(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Execution aggregate queries expose machine-readable projection records."""
+        from datetime import UTC, datetime, timedelta
+
+        from ouroboros.events.base import BaseEvent
+
+        t0 = datetime(2026, 1, 1, tzinfo=UTC)
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_proj_start",
+                type="tool.call.started",
+                timestamp=t0,
+                aggregate_type="execution",
+                aggregate_id="exec_projection_123",
+                data={
+                    "call_id": "call_1",
+                    "tool_name": "Bash",
+                    "seed_id": "seed_projection_123",
+                    "goal": "Inspect projection",
+                    "args_preview": "pytest -q",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_proj_return",
+                type="tool.call.returned",
+                timestamp=t0 + timedelta(milliseconds=10),
+                aggregate_type="execution",
+                aggregate_id="exec_projection_123",
+                data={
+                    "call_id": "call_1",
+                    "tool_name": "Bash",
+                    "is_error": False,
+                    "duration_ms": 10,
+                    "result_preview": "ok",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"execution_id": "exec_projection_123"})
+
+        assert result.is_ok
+        assert "Run Projection" in result.value.text_content
+        assert result.value.meta["execution_id"] == "exec_projection_123"
+        assert result.value.meta["seed_id"] == "seed_projection_123"
+        assert result.value.meta["event_count"] == 2
+        assert result.value.meta["run"]["goal"] == "Inspect projection"
+        assert len(result.value.meta["stages"]) == 1
+        assert len(result.value.meta["steps"]) == 1
+        step = result.value.meta["steps"][0]
+        assert step["kind"] == "shell_command"
+        assert step["ok"] is True
+        assert step["source_event_ids"] == ["evt_proj_start", "evt_proj_return"]
+
+    async def test_handle_projects_session_related_events(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Session queries include execution events connected by execution_id."""
+        from datetime import UTC, datetime
+
+        from ouroboros.events.base import BaseEvent
+
+        t0 = datetime(2026, 1, 1, tzinfo=UTC)
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_session_start",
+                type="orchestrator.session.started",
+                timestamp=t0,
+                aggregate_type="session",
+                aggregate_id="orch_projection_123",
+                data={
+                    "execution_id": "exec_projection_456",
+                    "seed_id": "seed_projection_456",
+                    "goal": "Project session",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_session_tool",
+                type="tool.call.started",
+                timestamp=t0,
+                aggregate_type="execution",
+                aggregate_id="exec_projection_456",
+                data={
+                    "execution_id": "exec_projection_456",
+                    "call_id": "call_session",
+                    "tool_name": "Read",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"session_id": "orch_projection_123"})
+
+        assert result.is_ok
+        assert result.value.meta["session_id"] == "orch_projection_123"
+        assert result.value.meta["seed_id"] == "seed_projection_456"
+        assert result.value.meta["event_count"] == 2
+        assert result.value.meta["steps"][0]["name"] == "Read"
+
+
 class TestOuroborosTools:
     """Test OUROBOROS_TOOLS constant."""
 
@@ -530,6 +659,7 @@ class TestOuroborosTools:
         "ouroboros_measure_drift",
         "ouroboros_pm_interview",
         "ouroboros_qa",
+        "ouroboros_query_projection",
         "ouroboros_query_events",
         "ouroboros_ralph",
         "ouroboros_session_status",
@@ -556,6 +686,7 @@ class TestOuroborosTools:
         assert JobResultHandler in handler_types
         assert CancelJobHandler in handler_types
         assert QueryEventsHandler in handler_types
+        assert ProjectionQueryHandler in handler_types
         assert GenerateSeedHandler in handler_types
         assert MeasureDriftHandler in handler_types
         assert InterviewHandler in handler_types

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -537,6 +537,45 @@ class TestProjectionQueryHandler:
         assert result.is_err
         assert "No events found" in str(result.error)
 
+    async def test_handle_never_initializes_injected_store_with_schema_creation(self) -> None:
+        """Read-only projection queries must not create schema on shared stores."""
+        from datetime import UTC, datetime
+
+        from ouroboros.events.base import BaseEvent
+
+        class FakeEventStore:
+            create_schema_values: list[bool | None]
+
+            def __init__(self) -> None:
+                self.create_schema_values = []
+
+            async def initialize(self, *, create_schema: bool | None = None) -> None:
+                self.create_schema_values.append(create_schema)
+
+            async def query_execution_related_events(
+                self,
+                *,
+                execution_id: str,
+                limit: int | None = None,
+            ) -> list[BaseEvent]:
+                return [
+                    BaseEvent(
+                        id="evt_read_only_init",
+                        type="tool.call.started",
+                        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+                        aggregate_type="execution",
+                        aggregate_id=execution_id,
+                        data={"call_id": "read_only", "tool_name": "Bash"},
+                    )
+                ]
+
+        store = FakeEventStore()
+        handler = ProjectionQueryHandler(event_store=store)  # type: ignore[arg-type]
+        result = await handler.handle({"execution_id": "exec_read_only_init"})
+
+        assert result.is_ok
+        assert store.create_schema_values == [False]
+
     async def test_handle_projects_execution_events(
         self,
         memory_event_store: EventStore,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -527,6 +527,16 @@ class TestProjectionQueryHandler:
         assert result.is_err
         assert "session_id or execution_id is required" in str(result.error)
 
+    async def test_handle_rejects_empty_event_set(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"execution_id": "exec_missing_projection"})
+
+        assert result.is_err
+        assert "No events found" in str(result.error)
+
     async def test_handle_projects_execution_events(
         self,
         memory_event_store: EventStore,
@@ -649,6 +659,46 @@ class TestProjectionQueryHandler:
         assert result.value.meta["run"]["goal"] == "Project session"
         assert result.value.meta["event_count"] == 2
         assert result.value.meta["steps"][0]["name"] == "Read"
+
+    async def test_handle_rejects_mismatched_session_execution(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Explicit execution_id must belong to the requested session."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_session_declares_a",
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="orch_projection_mismatch",
+                data={
+                    "execution_id": "exec_projection_a",
+                    "seed_id": "seed_projection_a",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_unrelated_exec_b",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_projection_b",
+                data={"execution_id": "exec_projection_b", "call_id": "b", "tool_name": "Bash"},
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle(
+            {
+                "session_id": "orch_projection_mismatch",
+                "execution_id": "exec_projection_b",
+            }
+        )
+
+        assert result.is_err
+        assert "does not belong" in str(result.error)
 
     async def test_handle_limit_is_fail_closed_safety_cap(
         self,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -569,6 +569,20 @@ class TestProjectionQueryHandler:
                 },
             )
         )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_proj_child",
+                type="tool.call.started",
+                timestamp=t0 + timedelta(milliseconds=20),
+                aggregate_type="execution",
+                aggregate_id="exec_projection_123_child_0",
+                data={
+                    "parent_execution_id": "exec_projection_123",
+                    "call_id": "call_child",
+                    "tool_name": "Read",
+                },
+            )
+        )
 
         handler = ProjectionQueryHandler(event_store=memory_event_store)
         result = await handler.handle({"execution_id": "exec_projection_123"})
@@ -577,14 +591,15 @@ class TestProjectionQueryHandler:
         assert "Run Projection" in result.value.text_content
         assert result.value.meta["execution_id"] == "exec_projection_123"
         assert result.value.meta["seed_id"] == "seed_projection_123"
-        assert result.value.meta["event_count"] == 2
+        assert result.value.meta["event_count"] == 3
         assert result.value.meta["run"]["goal"] == "Inspect projection"
         assert len(result.value.meta["stages"]) == 1
-        assert len(result.value.meta["steps"]) == 1
+        assert len(result.value.meta["steps"]) == 2
         step = result.value.meta["steps"][0]
         assert step["kind"] == "shell_command"
         assert step["ok"] is True
         assert step["source_event_ids"] == ["evt_proj_start", "evt_proj_return"]
+        assert result.value.meta["steps"][1]["name"] == "Read"
 
     async def test_handle_projects_session_related_events(
         self,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -814,6 +814,38 @@ class TestProjectionQueryHandler:
         assert result.value.meta["event_count"] == 3
         assert [step["name"] for step in result.value.meta["steps"]] == ["Bash", "Read"]
 
+    async def test_handle_rejects_session_only_reused_session(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Session-only queries must fail when a session declares multiple executions."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_reused_session_a",
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="orch_projection_reused",
+                data={"execution_id": "exec_reused_a", "seed_id": "seed_reused_a"},
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_reused_session_b",
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="orch_projection_reused",
+                data={"execution_id": "exec_reused_b", "seed_id": "seed_reused_b"},
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"session_id": "orch_projection_reused"})
+
+        assert result.is_err
+        assert "declares multiple executions" in str(result.error)
+
     async def test_handle_limit_is_fail_closed_safety_cap(
         self,
         memory_event_store: EventStore,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -688,6 +688,20 @@ class TestProjectionQueryHandler:
                 },
             )
         )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_session_foreign",
+                type="tool.call.started",
+                aggregate_type="lineage",
+                aggregate_id="lineage_projection_456",
+                data={
+                    "session_id": "orch_projection_123",
+                    "execution_id": "exec_projection_456",
+                    "call_id": "foreign",
+                    "tool_name": "Bash",
+                },
+            )
+        )
 
         handler = ProjectionQueryHandler(event_store=memory_event_store)
         result = await handler.handle({"session_id": "orch_projection_123"})
@@ -796,6 +810,19 @@ class TestProjectionQueryHandler:
                     "parent_execution_id": "exec_projection_b",
                     "call_id": "b_child",
                     "tool_name": "Read",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_exec_b_foreign",
+                type="tool.call.started",
+                aggregate_type="lineage",
+                aggregate_id="lineage_projection_b",
+                data={
+                    "execution_id": "exec_projection_b",
+                    "call_id": "b_foreign",
+                    "tool_name": "Write",
                 },
             )
         )

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -655,7 +655,7 @@ class TestProjectionQueryHandler:
         memory_event_store: EventStore,
     ) -> None:
         """Session queries include execution events connected by execution_id."""
-        from datetime import UTC, datetime
+        from datetime import UTC, datetime, timedelta
 
         from ouroboros.events.base import BaseEvent
 
@@ -690,6 +690,16 @@ class TestProjectionQueryHandler:
         )
         await memory_event_store.append(
             BaseEvent(
+                id="evt_session_completed",
+                type="orchestrator.session.completed",
+                timestamp=t0 + timedelta(milliseconds=100),
+                aggregate_type="session",
+                aggregate_id="orch_projection_123",
+                data={"status": "completed"},
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
                 id="evt_session_foreign",
                 type="tool.call.started",
                 aggregate_type="lineage",
@@ -710,7 +720,8 @@ class TestProjectionQueryHandler:
         assert result.value.meta["session_id"] == "orch_projection_123"
         assert result.value.meta["seed_id"] == "seed_projection_456"
         assert result.value.meta["run"]["goal"] == "Project session"
-        assert result.value.meta["event_count"] == 2
+        assert result.value.meta["event_count"] == 3
+        assert result.value.meta["run"]["ended_at"] == "2026-01-01T00:00:00.100000Z"
         assert result.value.meta["steps"][0]["name"] == "Read"
 
     async def test_handle_rejects_mismatched_session_execution(

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -621,7 +621,7 @@ class TestProjectionQueryHandler:
                 data={
                     "execution_id": "exec_projection_456",
                     "seed_id": "seed_projection_456",
-                    "goal": "Project session",
+                    "seed_goal": "Project session",
                 },
             )
         )
@@ -646,8 +646,41 @@ class TestProjectionQueryHandler:
         assert result.is_ok
         assert result.value.meta["session_id"] == "orch_projection_123"
         assert result.value.meta["seed_id"] == "seed_projection_456"
+        assert result.value.meta["run"]["goal"] == "Project session"
         assert result.value.meta["event_count"] == 2
         assert result.value.meta["steps"][0]["name"] == "Read"
+
+    async def test_handle_limit_is_fail_closed_safety_cap(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Projection queries reject caps that would create partial projections."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_cap_1",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_projection_cap",
+                data={"call_id": "cap_1", "tool_name": "Bash"},
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_cap_2",
+                type="tool.call.returned",
+                aggregate_type="execution",
+                aggregate_id="exec_projection_cap",
+                data={"call_id": "cap_1", "tool_name": "Bash", "is_error": False},
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"execution_id": "exec_projection_cap", "limit": 1})
+
+        assert result.is_err
+        assert "exceeds limit 1" in str(result.error)
 
 
 class TestOuroborosTools:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -786,6 +786,19 @@ class TestProjectionQueryHandler:
                 },
             )
         )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_exec_b_child",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_projection_b_child",
+                data={
+                    "parent_execution_id": "exec_projection_b",
+                    "call_id": "b_child",
+                    "tool_name": "Read",
+                },
+            )
+        )
 
         handler = ProjectionQueryHandler(event_store=memory_event_store)
         result = await handler.handle(
@@ -798,7 +811,8 @@ class TestProjectionQueryHandler:
         assert result.is_ok
         assert result.value.meta["seed_id"] == "seed_projection_b"
         assert result.value.meta["run"]["goal"] == "Requested execution"
-        assert result.value.meta["event_count"] == 2
+        assert result.value.meta["event_count"] == 3
+        assert [step["name"] for step in result.value.meta["steps"]] == ["Bash", "Read"]
 
     async def test_handle_limit_is_fail_closed_safety_cap(
         self,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -700,6 +700,67 @@ class TestProjectionQueryHandler:
         assert result.is_err
         assert "does not belong" in str(result.error)
 
+    async def test_handle_narrows_session_metadata_to_requested_execution(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Combined selectors must not reuse older metadata from the same session."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_session_exec_a",
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="orch_projection_multi",
+                data={
+                    "execution_id": "exec_projection_a",
+                    "seed_id": "seed_projection_a",
+                    "seed_goal": "Older execution",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_session_exec_b",
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="orch_projection_multi",
+                data={
+                    "execution_id": "exec_projection_b",
+                    "seed_id": "seed_projection_b",
+                    "seed_goal": "Requested execution",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_exec_b_tool",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_projection_b",
+                data={
+                    "session_id": "orch_projection_multi",
+                    "execution_id": "exec_projection_b",
+                    "call_id": "b",
+                    "tool_name": "Bash",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle(
+            {
+                "session_id": "orch_projection_multi",
+                "execution_id": "exec_projection_b",
+            }
+        )
+
+        assert result.is_ok
+        assert result.value.meta["seed_id"] == "seed_projection_b"
+        assert result.value.meta["run"]["goal"] == "Requested execution"
+        assert result.value.meta["event_count"] == 2
+
     async def test_handle_limit_is_fail_closed_safety_cap(
         self,
         memory_event_store: EventStore,

--- a/tests/unit/mcp/tools/test_round5_fixes.py
+++ b/tests/unit/mcp/tools/test_round5_fixes.py
@@ -237,8 +237,9 @@ class TestGetOuroborosToolsPluginWiring:
 
         tools = get_ouroboros_tools()
         names = {tool.definition.name for tool in tools}
-        assert len(tools) == 27
+        assert len(tools) == 28
         assert "ouroboros_auto" in names
+        assert "ouroboros_query_projection" in names
         assert "ouroboros_start_auto" in names
         assert "ouroboros_start_evaluate" in names
         assert "ouroboros_channel_workflow" not in names

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -809,6 +809,12 @@ class TestSessionRelatedEvents:
                 aggregate_id="other-execution-child",
                 data={"parent_execution_id": "other-execution"},
             ),
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="sess-related-only",
+                data={"execution_id": execution_id, "seed_id": "seed-related-only"},
+            ),
         ]
         for event in events:
             await event_store.append(event)
@@ -822,6 +828,7 @@ class TestSessionRelatedEvents:
         assert execution_id in aggregate_ids
         assert "exec-related-only-child" in aggregate_ids
         assert "other-execution-child" not in aggregate_ids
+        assert "sess-related-only" not in aggregate_ids
 
     async def test_session_related_events_do_not_join_on_lossy_normalized_scope(
         self,

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -784,6 +784,45 @@ class TestSessionRelatedEvents:
         assert f"{execution_scope}_child_0" in aggregate_ids
         assert "other_evolve_ac_0" not in aggregate_ids
 
+    async def test_execution_related_events_include_child_scopes(
+        self,
+        event_store: EventStore,
+    ) -> None:
+        """Execution-only queries include child/runtime aggregates."""
+        execution_id = "exec-related-only"
+        events = [
+            BaseEvent(
+                type="workflow.progress.updated",
+                aggregate_type="execution",
+                aggregate_id=execution_id,
+                data={"execution_id": execution_id},
+            ),
+            BaseEvent(
+                type="execution.subagent.started",
+                aggregate_type="execution",
+                aggregate_id="exec-related-only-child",
+                data={"parent_execution_id": execution_id},
+            ),
+            BaseEvent(
+                type="execution.ac.heartbeat",
+                aggregate_type="execution",
+                aggregate_id="other-execution-child",
+                data={"parent_execution_id": "other-execution"},
+            ),
+        ]
+        for event in events:
+            await event_store.append(event)
+
+        result = await event_store.query_execution_related_events(
+            execution_id,
+            limit=None,
+        )
+        aggregate_ids = {event.aggregate_id for event in result}
+
+        assert execution_id in aggregate_ids
+        assert "exec-related-only-child" in aggregate_ids
+        assert "other-execution-child" not in aggregate_ids
+
     async def test_session_related_events_do_not_join_on_lossy_normalized_scope(
         self,
         event_store: EventStore,


### PR DESCRIPTION
## Summary

Refs #946 and #961 Phase C.2 (`#946 PR-2`).

This PR adds a narrow read-only MCP query surface for the harness projection vocabulary introduced in #980/#983:

- adds `ProjectionQueryHandler` as `ouroboros_query_projection`
- computes `RunRecord` / `StageRecord` / `StepRecord` output on demand from existing `EventStore` events
- supports `execution_id` direct replay and `session_id` related-event lookup
- returns both human-readable text and machine-readable `meta` records
- registers the tool in static definitions and the MCP composition root

## Scope control

- No recorder changes
- No projection caching
- No CLI command in this slice; #946 acceptance allows a machine-readable CLI **or MCP** query path, and MCP keeps this PR small
- No default-path behavior change
- Artifact/Verdict arrays remain empty until a later mapping PR owns those event families

## Validation

- `uv run pytest tests/unit/mcp/tools/test_definitions.py tests/integration/mcp/test_server_adapter.py tests/unit/harness/test_projection_builder.py tests/unit/harness/test_projection_records.py -q` → 223 passed
- `uv run mypy src/ouroboros/mcp/tools/projection_handlers.py src/ouroboros/mcp/tools/definitions.py src/ouroboros/mcp/server/adapter.py tests/unit/mcp/tools/test_definitions.py` → passed
- `uv run ruff check src/ouroboros/mcp/tools/projection_handlers.py src/ouroboros/mcp/tools/definitions.py src/ouroboros/mcp/server/adapter.py tests/unit/mcp/tools/test_definitions.py tests/integration/mcp/test_server_adapter.py` → passed
