### PR TITLE
feat(orchestrator): add read-only Seed to Workflow IR adapter (#956 PR-2)

### DIFF
--- a/src/ouroboros/orchestrator/workflow_ir_adapter.py
+++ b/src/ouroboros/orchestrator/workflow_ir_adapter.py
@@ -41,9 +41,10 @@ def workflow_spec_from_seed(
 
     The adapter intentionally does not mutate or migrate ``Seed``. Each
     non-blank acceptance criterion becomes one agent-owned task node with
-    schema refs required by the Workflow IR validator. All task nodes point
-    to a shared terminal node so every branch has an explicit termination
-    path while preserving the current string-AC execution vocabulary.
+    schema refs required by the Workflow IR validator. All task nodes flow
+    into an explicit fan-in barrier before the shared terminal node so the
+    graph preserves all-acceptance-criteria completion semantics while
+    keeping the current string-AC execution vocabulary.
 
     Args:
         seed: Immutable Seed to project.
@@ -71,11 +72,18 @@ def workflow_spec_from_seed(
         msg = "Seed must contain at least one acceptance criterion to project Workflow IR"
         raise ValueError(msg)
 
+    join_node = WorkflowNode(
+        node_id="seed_ac_join",
+        kind=NodeKind.FAN_IN,
+        owner=NodeOwner.HARNESS,
+        name="All seed acceptance criteria complete",
+        metadata={"seed_id": seed_id, "barrier": "all_acceptance_criteria"},
+    )
     terminal_node = WorkflowNode(
         node_id="seed_terminal",
         kind=NodeKind.TERMINAL,
         owner=NodeOwner.HARNESS,
-        name="Seed acceptance criteria complete",
+        name="Seed workflow complete",
         metadata={"seed_id": seed_id},
     )
     nodes: list[WorkflowNode] = []
@@ -109,10 +117,10 @@ def workflow_spec_from_seed(
         )
         edges.append(
             WorkflowEdge(
-                edge_id=f"edge_{node_id}_terminal",
+                edge_id=f"edge_{node_id}_join",
                 source=node_id,
-                target=terminal_node.node_id,
-                kind=EdgeKind.TERMINAL,
+                target=join_node.node_id,
+                kind=EdgeKind.FAN_IN,
                 metadata={"acceptance_criterion_index": ac_index, "seed_id": seed_id},
             )
         )
@@ -135,8 +143,17 @@ def workflow_spec_from_seed(
         spec_id=f"wfspec_{seed_id}",
         source=SourceKind.SEED,
         source_ref=seed_id,
-        nodes=(*nodes, terminal_node),
-        edges=tuple(edges),
+        nodes=(*nodes, join_node, terminal_node),
+        edges=(
+            *edges,
+            WorkflowEdge(
+                edge_id="edge_seed_ac_join_terminal",
+                source=join_node.node_id,
+                target=terminal_node.node_id,
+                kind=EdgeKind.TERMINAL,
+                metadata={"seed_id": seed_id, "barrier": "all_acceptance_criteria"},
+            ),
+        ),
         metadata=spec_metadata,
     )
     validation = validate_workflow(spec)

--- a/src/ouroboros/orchestrator/workflow_ir_adapter.py
+++ b/src/ouroboros/orchestrator/workflow_ir_adapter.py
@@ -1,0 +1,172 @@
+"""Read-only adapters into the typed Workflow IR.
+
+This module owns the narrow #956 PR-2 boundary: translate today's immutable
+``Seed`` shape into a validated ``WorkflowSpec`` without changing Seed schema,
+runtime dispatch, persistence, or projection records.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ouroboros.core.seed import Seed
+from ouroboros.orchestrator.workflow_ir import (
+    EdgeKind,
+    NodeKind,
+    NodeOwner,
+    SourceKind,
+    WorkflowEdge,
+    WorkflowNode,
+    WorkflowSpec,
+    validate_workflow,
+)
+
+DEFAULT_SEED_AC_INPUT_SCHEMA_REF = "ouroboros://schemas/seed-acceptance-criterion-input/v1"
+"""Canonical input-schema reference used for current string AC dispatch nodes."""
+
+DEFAULT_SEED_AC_EVIDENCE_SCHEMA_REF = "ouroboros://schemas/seed-acceptance-evidence/v1"
+"""Canonical evidence-schema reference used for current string AC dispatch nodes."""
+
+
+def workflow_spec_from_seed(
+    seed: Seed,
+    *,
+    input_schema_ref: str = DEFAULT_SEED_AC_INPUT_SCHEMA_REF,
+    evidence_schema_ref: str = DEFAULT_SEED_AC_EVIDENCE_SCHEMA_REF,
+    profile_ref: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> WorkflowSpec:
+    """Project a current ``Seed`` into a read-only ``WorkflowSpec``.
+
+    The adapter intentionally does not mutate or migrate ``Seed``. Each
+    non-blank acceptance criterion becomes one agent-owned task node with
+    schema refs required by the Workflow IR validator. All task nodes point
+    to a shared terminal node so every branch has an explicit termination
+    path while preserving the current string-AC execution vocabulary.
+
+    Args:
+        seed: Immutable Seed to project.
+        input_schema_ref: Contract ref for each AC task input payload.
+        evidence_schema_ref: Contract ref for evidence emitted for each AC.
+        profile_ref: Optional runtime/profile anchor carried as metadata and
+            runtime hint; not interpreted by this adapter.
+        metadata: Optional additive spec metadata. Values are copied into the
+            immutable ``WorkflowSpec.metadata`` mapping by the IR model.
+
+    Raises:
+        ValueError: If the Seed has no acceptance criteria, contains blank ACs,
+            has no usable seed id, or if the emitted spec fails IR validation.
+
+    Returns:
+        A validated ``WorkflowSpec`` with ``source=SourceKind.SEED``.
+    """
+    seed_id = seed.metadata.seed_id.strip()
+    if not seed_id:
+        msg = "Seed metadata.seed_id must be non-blank to project Workflow IR"
+        raise ValueError(msg)
+
+    criteria = tuple(_normalize_acceptance_criteria(seed.acceptance_criteria))
+    if not criteria:
+        msg = "Seed must contain at least one acceptance criterion to project Workflow IR"
+        raise ValueError(msg)
+
+    terminal_node = WorkflowNode(
+        node_id="seed_terminal",
+        kind=NodeKind.TERMINAL,
+        owner=NodeOwner.HARNESS,
+        name="Seed acceptance criteria complete",
+        metadata={"seed_id": seed_id},
+    )
+    nodes: list[WorkflowNode] = []
+    edges: list[WorkflowEdge] = []
+    for zero_based_index, criterion in enumerate(criteria):
+        ac_index = zero_based_index + 1
+        node_id = f"seed_ac_{ac_index:03d}"
+        node_metadata: dict[str, Any] = {
+            "seed_id": seed_id,
+            "seed_version": seed.metadata.version,
+            "task_type": seed.task_type,
+            "acceptance_criterion_index": ac_index,
+            "acceptance_criterion": criterion,
+        }
+        runtime_hints: dict[str, Any] = {}
+        if profile_ref is not None:
+            runtime_hints["profile_ref"] = profile_ref
+            node_metadata["profile_ref"] = profile_ref
+
+        nodes.append(
+            WorkflowNode(
+                node_id=node_id,
+                kind=NodeKind.TASK,
+                owner=NodeOwner.AGENT,
+                name=f"Acceptance criterion {ac_index}",
+                input_schema_ref=input_schema_ref,
+                evidence_schema_ref=evidence_schema_ref,
+                runtime_hints=runtime_hints,
+                metadata=node_metadata,
+            )
+        )
+        edges.append(
+            WorkflowEdge(
+                edge_id=f"edge_{node_id}_terminal",
+                source=node_id,
+                target=terminal_node.node_id,
+                kind=EdgeKind.TERMINAL,
+                metadata={"acceptance_criterion_index": ac_index, "seed_id": seed_id},
+            )
+        )
+
+    spec_metadata: dict[str, Any] = dict(metadata or {})
+    spec_metadata.update(
+        {
+            "seed_id": seed_id,
+            "seed_version": seed.metadata.version,
+            "task_type": seed.task_type,
+            "acceptance_criteria_count": len(criteria),
+        }
+    )
+    if seed.metadata.interview_id is not None:
+        spec_metadata["interview_id"] = seed.metadata.interview_id
+    if profile_ref is not None:
+        spec_metadata["profile_ref"] = profile_ref
+
+    spec = WorkflowSpec(
+        spec_id=f"wfspec_{seed_id}",
+        source=SourceKind.SEED,
+        source_ref=seed_id,
+        nodes=(*nodes, terminal_node),
+        edges=tuple(edges),
+        metadata=spec_metadata,
+    )
+    validation = validate_workflow(spec)
+    if not validation.ok:
+        details = ", ".join(error.code for error in validation.errors)
+        msg = f"Seed projected to invalid WorkflowSpec: {details}"
+        raise ValueError(msg)
+    return spec
+
+
+def _normalize_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for zero_based_index, criterion in enumerate(criteria):
+        if not isinstance(criterion, str):
+            msg = (
+                "Seed acceptance_criteria must contain only strings before the "
+                f"PlannedAC migration; item {zero_based_index + 1} is "
+                f"{type(criterion).__name__}"
+            )
+            raise ValueError(msg)
+        stripped = criterion.strip()
+        if not stripped:
+            msg = f"Seed acceptance criterion {zero_based_index + 1} must be non-blank"
+            raise ValueError(msg)
+        normalized.append(stripped)
+    return tuple(normalized)
+
+
+__all__ = [
+    "DEFAULT_SEED_AC_EVIDENCE_SCHEMA_REF",
+    "DEFAULT_SEED_AC_INPUT_SCHEMA_REF",
+    "workflow_spec_from_seed",
+]

--- a/tests/unit/orchestrator/test_workflow_ir_adapter.py
+++ b/tests/unit/orchestrator/test_workflow_ir_adapter.py
@@ -81,8 +81,8 @@ class TestWorkflowSpecFromSeed:
         assert spec.metadata["seed_id"] == "seed_test_001"
         assert spec.metadata["interview_id"] == "interview_123"
         assert spec.metadata["profile_ref"] == "profile://default"
-        assert len(spec.nodes) == 3
-        assert len(spec.edges) == 2
+        assert len(spec.nodes) == 4
+        assert len(spec.edges) == 3
 
     def test_each_acceptance_criterion_becomes_agent_task_with_schema_refs(self) -> None:
         spec = workflow_spec_from_seed(_seed("  Criterion with padding  "))
@@ -97,15 +97,26 @@ class TestWorkflowSpecFromSeed:
         assert task.metadata["acceptance_criterion"] == "Criterion with padding"
         assert task.metadata["task_type"] == "code"
 
-    def test_terminal_edges_preserve_independent_ac_branches(self) -> None:
+    def test_fan_in_barrier_preserves_all_ac_completion_semantics(self) -> None:
         spec = workflow_spec_from_seed(_seed("A", "B", "C"))
 
+        join = spec.nodes[-2]
         terminal = spec.nodes[-1]
+        assert join.node_id == "seed_ac_join"
+        assert join.kind is NodeKind.FAN_IN
+        assert join.metadata["barrier"] == "all_acceptance_criteria"
         assert terminal.node_id == "seed_terminal"
         assert terminal.kind is NodeKind.TERMINAL
-        assert all(edge.target == "seed_terminal" for edge in spec.edges)
-        assert {edge.kind for edge in spec.edges} == {EdgeKind.TERMINAL}
-        assert [edge.source for edge in spec.edges] == ["seed_ac_001", "seed_ac_002", "seed_ac_003"]
+        assert [edge.source for edge in spec.edges[:3]] == [
+            "seed_ac_001",
+            "seed_ac_002",
+            "seed_ac_003",
+        ]
+        assert all(edge.target == "seed_ac_join" for edge in spec.edges[:3])
+        assert {edge.kind for edge in spec.edges[:3]} == {EdgeKind.FAN_IN}
+        assert spec.edges[-1].source == "seed_ac_join"
+        assert spec.edges[-1].target == "seed_terminal"
+        assert spec.edges[-1].kind is EdgeKind.TERMINAL
 
     def test_custom_schema_refs_and_metadata_are_additive(self) -> None:
         spec = workflow_spec_from_seed(

--- a/tests/unit/orchestrator/test_workflow_ir_adapter.py
+++ b/tests/unit/orchestrator/test_workflow_ir_adapter.py
@@ -1,0 +1,144 @@
+"""Unit tests for the read-only Seed -> Workflow IR adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+from ouroboros.orchestrator.workflow_ir import (
+    EdgeKind,
+    NodeKind,
+    NodeOwner,
+    SourceKind,
+    validate_workflow,
+)
+from ouroboros.orchestrator.workflow_ir_adapter import (
+    DEFAULT_SEED_AC_EVIDENCE_SCHEMA_REF,
+    DEFAULT_SEED_AC_INPUT_SCHEMA_REF,
+    workflow_spec_from_seed,
+)
+
+
+def _seed(*acceptance_criteria: str) -> Seed:
+    return Seed(
+        goal="Ship a typed workflow plan",
+        task_type="code",
+        constraints=("Keep runtime behavior unchanged",),
+        acceptance_criteria=acceptance_criteria,
+        ontology_schema=OntologySchema(
+            name="WorkflowPlan",
+            description="Plan ontology",
+            fields=(
+                OntologyField(
+                    name="workflow",
+                    field_type="object",
+                    description="Workflow graph",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="correctness",
+                description="All ACs are satisfied",
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="all_ac_met",
+                description="All acceptance criteria pass",
+                evaluation_criteria="Every AC reports evidence",
+            ),
+        ),
+        metadata=SeedMetadata(
+            seed_id="seed_test_001",
+            version="1.0.0",
+            ambiguity_score=0.1,
+            interview_id="interview_123",
+        ),
+    )
+
+
+class TestWorkflowSpecFromSeed:
+    def test_projects_current_string_acceptance_criteria_to_valid_workflow_spec(self) -> None:
+        spec = workflow_spec_from_seed(
+            _seed("First criterion", "Second criterion"),
+            profile_ref="profile://default",
+        )
+
+        result = validate_workflow(spec)
+
+        assert result.ok is True
+        assert spec.source is SourceKind.SEED
+        assert spec.source_ref == "seed_test_001"
+        assert spec.spec_id == "wfspec_seed_test_001"
+        assert spec.metadata["seed_id"] == "seed_test_001"
+        assert spec.metadata["interview_id"] == "interview_123"
+        assert spec.metadata["profile_ref"] == "profile://default"
+        assert len(spec.nodes) == 3
+        assert len(spec.edges) == 2
+
+    def test_each_acceptance_criterion_becomes_agent_task_with_schema_refs(self) -> None:
+        spec = workflow_spec_from_seed(_seed("  Criterion with padding  "))
+
+        task = spec.nodes[0]
+        assert task.node_id == "seed_ac_001"
+        assert task.kind is NodeKind.TASK
+        assert task.owner is NodeOwner.AGENT
+        assert task.input_schema_ref == DEFAULT_SEED_AC_INPUT_SCHEMA_REF
+        assert task.evidence_schema_ref == DEFAULT_SEED_AC_EVIDENCE_SCHEMA_REF
+        assert task.metadata["acceptance_criterion_index"] == 1
+        assert task.metadata["acceptance_criterion"] == "Criterion with padding"
+        assert task.metadata["task_type"] == "code"
+
+    def test_terminal_edges_preserve_independent_ac_branches(self) -> None:
+        spec = workflow_spec_from_seed(_seed("A", "B", "C"))
+
+        terminal = spec.nodes[-1]
+        assert terminal.node_id == "seed_terminal"
+        assert terminal.kind is NodeKind.TERMINAL
+        assert all(edge.target == "seed_terminal" for edge in spec.edges)
+        assert {edge.kind for edge in spec.edges} == {EdgeKind.TERMINAL}
+        assert [edge.source for edge in spec.edges] == ["seed_ac_001", "seed_ac_002", "seed_ac_003"]
+
+    def test_custom_schema_refs_and_metadata_are_additive(self) -> None:
+        spec = workflow_spec_from_seed(
+            _seed("A"),
+            input_schema_ref="input://custom",
+            evidence_schema_ref="evidence://custom",
+            metadata={"source_comment": "#956 boundary decision"},
+        )
+
+        assert spec.nodes[0].input_schema_ref == "input://custom"
+        assert spec.nodes[0].evidence_schema_ref == "evidence://custom"
+        assert spec.metadata["source_comment"] == "#956 boundary decision"
+        assert spec.metadata["acceptance_criteria_count"] == 1
+
+    def test_metadata_cannot_override_canonical_seed_anchors(self) -> None:
+        spec = workflow_spec_from_seed(_seed("A"), metadata={"seed_id": "tampered"})
+
+        assert spec.metadata["seed_id"] == "seed_test_001"
+
+    def test_rejects_empty_acceptance_criteria(self) -> None:
+        with pytest.raises(ValueError, match="at least one acceptance criterion"):
+            workflow_spec_from_seed(_seed())
+
+    def test_rejects_blank_acceptance_criteria(self) -> None:
+        with pytest.raises(ValueError, match="criterion 2 must be non-blank"):
+            workflow_spec_from_seed(_seed("A", "   "))
+
+    def test_does_not_import_projection_records_or_runtime_paths(self) -> None:
+        import ouroboros.orchestrator.workflow_ir_adapter as adapter
+
+        imported_names = set(adapter.__dict__)
+        assert "RunRecord" not in imported_names
+        assert "StepRecord" not in imported_names
+        assert "ArtifactRecord" not in imported_names
+        assert "OrchestratorRunner" not in imported_names
+        assert "ParallelACExecutor" not in imported_names


### PR DESCRIPTION
## Summary

Implements #956 PR-2 as a narrow read-only adapter from the current immutable `Seed` model into the typed `WorkflowSpec` introduced by #981.

This follows the boundary decision posted on #956 before opening this PR:
- Workflow IR does not consume #946 projection records directly.
- #956 references schema contracts through `input_schema_ref` / `evidence_schema_ref`.
- Context/profile anchors are carried as metadata/runtime hints only.
- This PR does not migrate `Seed.acceptance_criteria` to `PlannedAC` and does not wire runtime dispatch.

## What changed

- Adds `workflow_spec_from_seed()` in `src/ouroboros/orchestrator/workflow_ir_adapter.py`.
- Projects each non-blank string acceptance criterion into one agent-owned task node with required schema refs.
- Adds one shared terminal node and terminal edges so every AC branch has an explicit termination path.
- Preserves seed/profile anchors in immutable IR metadata without touching runtime execution, persistence, or #946 projections.
- Adds unit coverage for valid projection, schema refs, branch shape, additive metadata, malformed/empty AC rejection, and no projection/runtime imports.

## Scope controls

- No changes to `Seed` schema.
- No changes to `ooo run`, `ParallelACExecutor`, persistence, MCP tools, or runtime dispatch.
- No dependency on #946 `RunRecord` / `StepRecord` / `ArtifactRecord` projection vocabulary.

## Verification

- `uv run ruff check src/ouroboros/orchestrator/workflow_ir_adapter.py tests/unit/orchestrator/test_workflow_ir_adapter.py`
- `uv run mypy src/ouroboros/orchestrator/workflow_ir_adapter.py tests/unit/orchestrator/test_workflow_ir_adapter.py`
- `uv run pytest tests/unit/orchestrator/test_workflow_ir_adapter.py tests/unit/orchestrator/test_workflow_ir.py -q`

Part of #956 under the #961 SSOT milestone.
