### PR TITLE
feat(orchestrator): audit profile-aware AC decomposition (#920 PR-1)

### DIFF
--- a/src/ouroboros/orchestrator/decomposition_params.py
+++ b/src/ouroboros/orchestrator/decomposition_params.py
@@ -4,15 +4,10 @@ H4 reframes decomposition from "free prose system prompt" to "structured
 parameters consumed by a uniform decomposer". Adding a new domain becomes
 a YAML edit, not a prompt-engineering pass.
 
-The current `parallel_executor._try_decompose_ac` runs with a hardcoded
-`system_prompt="You are a task decomposition expert..."` — the splitter
-has no notion of which profile it is splitting for. After PR 9 wires
-this module in, the decomposer will receive a `DecompositionParams`
-built from the active `ExecutionProfile` and use the axis/min_unit/
-cut_signal verbatim.
-
-This PR ships the parameter shape and the prompt builder only.
-parallel_executor is unchanged.
+`parallel_executor._try_decompose_ac` consumes these parameters when
+the live runner supplies an `ExecutionProfile`, while preserving the
+legacy generic prompt when no profile is available. This keeps the
+profile-aware path additive and auditable before any default flip.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2561,6 +2561,7 @@ class ParallelACExecutor:
         )
         min_sub_acs = MIN_SUB_ACS
         max_sub_acs = MAX_SUB_ACS
+        profile_metadata = self._decomposition_profile_metadata()
         if self._execution_profile is not None:
             params = params_from_profile(
                 self._execution_profile,
@@ -2626,6 +2627,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 log.info(
                     "parallel_executor.decomposition.atomic",
                     ac_index=ac_index,
+                    **profile_metadata,
                 )
                 return None
 
@@ -2639,6 +2641,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                             "parallel_executor.decomposition.success",
                             ac_index=ac_index,
                             sub_ac_count=len(sub_acs),
+                            **profile_metadata,
                         )
                         return sub_acs
 
@@ -2646,6 +2649,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 "parallel_executor.decomposition.parse_failed",
                 ac_index=ac_index,
                 response_preview=response_text[:100],
+                **profile_metadata,
             )
             return None
 
@@ -2654,6 +2658,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 "parallel_executor.decomposition.timeout",
                 ac_index=ac_index,
                 timeout_seconds=DECOMPOSITION_TIMEOUT_SECONDS,
+                **profile_metadata,
             )
             return None
         except Exception as e:
@@ -2661,6 +2666,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 "parallel_executor.decomposition.error",
                 ac_index=ac_index,
                 error=str(e),
+                **profile_metadata,
             )
             return None
 
@@ -2704,6 +2710,26 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             await asyncio.sleep(_MEMORY_CHECK_INTERVAL_SECONDS)
             elapsed += _MEMORY_CHECK_INTERVAL_SECONDS
         log.warning("memory_pressure.timeout", label=label)
+
+    def _decomposition_profile_metadata(self) -> dict[str, Any]:
+        """Return audit metadata for profile-aware decomposition decisions.
+
+        The metadata is intentionally descriptive only. It lets projections,
+        tests, and reviewers prove which profile shaped decomposition without
+        changing dispatch behavior or flipping the fat-harness default path.
+        """
+        profile = self._execution_profile
+        if profile is None:
+            return {"decomposition_profile": None}
+        return {
+            "decomposition_profile": {
+                "profile": profile.profile,
+                "axis": profile.axis,
+                "min_unit": profile.min_unit,
+                "cut_signal": profile.cut_signal,
+                "max_branching": profile.max_branching,
+            }
+        }
 
     @staticmethod
     def _runtime_event_metadata(message: AgentMessage) -> dict[str, Any]:
@@ -3512,6 +3538,7 @@ When complete, explicitly state: [TASK_COMPLETE]
                 "total_levels": total_levels,
                 "child_indices": ac_indices,  # TUI expects this field name
                 "ac_count": len(ac_indices),
+                **self._decomposition_profile_metadata(),
             },
         )
         await self._event_store.append(event)

--- a/src/ouroboros/orchestrator/profile_loader.py
+++ b/src/ouroboros/orchestrator/profile_loader.py
@@ -4,9 +4,9 @@ Loads structured per-domain profiles consumed by harness invariants
 (verifier focus, decomposition axis, evidence schema, suggested tools).
 
 This module is wiring-only: it defines the schema and loads YAML files.
-No existing caller is modified by this module — downstream PRs wire the
-loaded profile into `execution_strategy`, `parallel_executor`, and the
-forthcoming verifier loop.
+The live runner now passes loaded profiles into `parallel_executor`
+for decomposition. Evidence/verifier-loop consumption remains staged for
+follow-up PRs.
 
 Usage:
     from ouroboros.orchestrator.profile_loader import load_profile

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -30,6 +30,7 @@ from ouroboros.orchestrator.parallel_executor import (
     render_parallel_completion_message,
     render_parallel_verification_report,
 )
+from ouroboros.orchestrator.profile_loader import load_profile
 
 
 def _make_seed(*acceptance_criteria: str) -> Seed:
@@ -80,6 +81,54 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
     event_store.append.side_effect = _append
     event_store.replay.side_effect = _replay
     return event_store, appended_events
+
+
+class TestProfileAwareDecompositionAudit:
+    @pytest.mark.asyncio
+    async def test_level_started_event_records_active_decomposition_profile(self) -> None:
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=MagicMock(),
+            event_store=event_store,
+            console=MagicMock(),
+            execution_profile=load_profile("code"),
+        )
+
+        await executor._emit_level_started(
+            session_id="sess_profile",
+            level=1,
+            ac_indices=[0, 1],
+            total_levels=2,
+        )
+
+        event = event_store.append.await_args.args[0]
+        assert event.type == "execution.decomposition.level_started"
+        assert event.data["decomposition_profile"] == {
+            "profile": "code",
+            "axis": "testable_unit",
+            "min_unit": "single function or module with at least one runnable test",
+            "cut_signal": "sub-AC produces an independently runnable test",
+            "max_branching": 5,
+        }
+
+    @pytest.mark.asyncio
+    async def test_level_started_event_records_legacy_decomposition_fallback(self) -> None:
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=MagicMock(),
+            event_store=event_store,
+            console=MagicMock(),
+        )
+
+        await executor._emit_level_started(
+            session_id="sess_legacy",
+            level=1,
+            ac_indices=[0],
+            total_levels=1,
+        )
+
+        event = event_store.append.await_args.args[0]
+        assert event.data["decomposition_profile"] is None
 
 
 class TestParallelACExecutor:


### PR DESCRIPTION
## Summary

Implements a narrow #920 PR-1 follow-up for profile-aware decomposition wiring: the live `ParallelACExecutor` path now records which `ExecutionProfile` shaped decomposition decisions in audit metadata, without changing dispatch behavior or flipping defaults.

## What changed

- Adds `decomposition_profile` metadata to:
  - decomposition decision logs (`atomic`, `success`, parse/timeout/error cases)
  - `execution.decomposition.level_started` events
- Records the active profile name, axis, min unit, cut signal, and max branching.
- Records `decomposition_profile: null` for the legacy fallback path so A/B comparisons stay explicit.
- Updates stale module docs that previously said profile wiring had not reached `parallel_executor`.
- Adds unit tests proving both active-profile and legacy-fallback event metadata.

## Scope controls

- No `ooo run` default flip.
- No evidence/verifier acceptance loop wiring.
- No TraceGuard integration in this PR.
- No removal of the legacy generic decomposition fallback.

## Verification

- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/profile_loader.py src/ouroboros/orchestrator/decomposition_params.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/profile_loader.py src/ouroboros/orchestrator/decomposition_params.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_parallel_executor_atomic_judgment.py tests/unit/orchestrator/test_decomposition_params.py tests/unit/orchestrator/test_runner.py -q`

Part of #920 PR-1 under the #961 SSOT C.2 sequence.
