### PR TITLE
feat(harness): load AC manifests for TraceGuard deliver gate (#978 P2)

### DIFF
--- a/src/ouroboros/harness/__init__.py
+++ b/src/ouroboros/harness/__init__.py
@@ -5,6 +5,10 @@ Run / Stage / Step / Artifact / Verdict records for #946 plus the
 journal-to-evidence-manifest normalizer for #978.
 """
 
+from ouroboros.harness.deliver_gate import (
+    EventStoreEvidenceReader,
+    load_ac_evidence_manifest,
+)
 from ouroboros.harness.journal import (
     EvidenceEntry,
     EvidenceKind,
@@ -27,6 +31,7 @@ __all__ = [
     "ArtifactRecord",
     "EvidenceEntry",
     "EvidenceKind",
+    "EventStoreEvidenceReader",
     "EvidenceManifest",
     "RunRecord",
     "StageKind",
@@ -36,5 +41,6 @@ __all__ = [
     "VerdictOutcome",
     "VerdictRecord",
     "filter_events_for_ac",
+    "load_ac_evidence_manifest",
     "normalize_events",
 ]

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -74,24 +74,36 @@ async def load_ac_evidence_manifest(
     if not normalized_ac_id:
         msg = "load_ac_evidence_manifest requires a non-blank ac_id"
         raise ValueError(msg)
-    if execution_id is None and session_id is None:
+    normalized_execution_id = _normalize_optional_anchor("execution_id", execution_id)
+    normalized_session_id = _normalize_optional_anchor("session_id", session_id)
+    if normalized_execution_id is None and normalized_session_id is None:
         msg = "load_ac_evidence_manifest requires execution_id or session_id"
         raise ValueError(msg)
 
-    if execution_id is not None:
+    if normalized_execution_id is not None:
         events = await event_store.query_execution_related_events(
-            execution_id,
+            normalized_execution_id,
             limit=limit,
         )
     else:
-        assert session_id is not None
+        assert normalized_session_id is not None
         events = await event_store.query_session_related_events(
-            session_id,
-            execution_id=execution_id,
+            normalized_session_id,
+            execution_id=normalized_execution_id,
             limit=limit,
         )
 
     return normalize_events(_chronological_events(events), ac_id=normalized_ac_id)
+
+
+def _normalize_optional_anchor(name: str, value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        msg = f"load_ac_evidence_manifest received blank {name}"
+        raise ValueError(msg)
+    return stripped
 
 
 def _chronological_events(events: Iterable[BaseEvent]) -> tuple[BaseEvent, ...]:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -50,10 +50,11 @@ async def load_ac_evidence_manifest(
 ) -> EvidenceManifest:
     """Load and normalize EventStore evidence for one AC deliver-gate check.
 
-    ``execution_id`` is preferred because it avoids accidentally splicing a
-    reused session's unrelated runs. ``session_id`` is retained for consumers
-    that only know the top-level session while the deliver gate is still in
-    observe-only/A-B wiring.
+    When both ``session_id`` and ``execution_id`` are available the loader
+    uses the session-related query with the execution correlation filter. That
+    includes session-aggregate I/O events as well as execution/runtime-scope
+    rows. ``execution_id``-only reads remain supported for callers that do not
+    know the session anchor.
 
     Args:
         event_store: Read-capable EventStore or test double.
@@ -85,16 +86,16 @@ async def load_ac_evidence_manifest(
         msg = "load_ac_evidence_manifest requires execution_id or session_id"
         raise ValueError(msg)
 
-    if normalized_execution_id is not None:
-        events = await event_store.query_execution_related_events(
-            normalized_execution_id,
-            limit=limit,
-        )
-    else:
-        assert normalized_session_id is not None
+    if normalized_session_id is not None:
         events = await event_store.query_session_related_events(
             normalized_session_id,
             execution_id=normalized_execution_id,
+            limit=limit,
+        )
+    else:
+        assert normalized_execution_id is not None
+        events = await event_store.query_execution_related_events(
+            normalized_execution_id,
             limit=limit,
         )
 

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -60,7 +60,7 @@ async def load_ac_evidence_manifest(
     Args:
         event_store: Read-capable EventStore or test double.
         ac_id: Acceptance-criterion identifier to normalize.
-        execution_id: Optional execution aggregate anchor.
+        execution_id: Required execution aggregate anchor.
         session_id: Optional session aggregate anchor used as an additional
             ownership filter.
         scope_id: Optional event-scope token to filter by when the public AC
@@ -71,8 +71,8 @@ async def load_ac_evidence_manifest(
             before TraceGuard sees it.
 
     Raises:
-        ValueError: If ``ac_id`` is blank or neither execution nor session
-            anchor is provided.
+        ValueError: If ``ac_id`` is blank, if ``execution_id`` is missing
+            or blank, or if optional anchors are whitespace-only.
 
     Returns:
         A per-AC :class:`EvidenceManifest` in chronological event order.

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -50,17 +50,19 @@ async def load_ac_evidence_manifest(
 ) -> EvidenceManifest:
     """Load and normalize EventStore evidence for one AC deliver-gate check.
 
-    When both ``session_id`` and ``execution_id`` are available the loader
-    uses the session-related query with the execution correlation filter. That
-    includes session-aggregate I/O events as well as execution/runtime-scope
-    rows. ``execution_id``-only reads remain supported for callers that do not
-    know the session anchor.
+    ``execution_id`` is required so the deliver-gate input is bounded to one
+    execution. When ``session_id`` is also available the loader uses the
+    session-related query with the execution correlation filter; otherwise it
+    uses the execution-only query. Session-only reads are rejected because a
+    session can contain multiple executions/retries that must not be spliced
+    into one verifier input.
 
     Args:
         event_store: Read-capable EventStore or test double.
         ac_id: Acceptance-criterion identifier to normalize.
         execution_id: Optional execution aggregate anchor.
-        session_id: Optional session aggregate anchor.
+        session_id: Optional session aggregate anchor used as an additional
+            ownership filter.
         scope_id: Optional event-scope token to filter by when the public AC
             id differs from the runtime aggregate/phase token used by the
             recorder. Defaults to ``ac_id``.
@@ -82,8 +84,8 @@ async def load_ac_evidence_manifest(
     normalized_execution_id = _normalize_optional_anchor("execution_id", execution_id)
     normalized_session_id = _normalize_optional_anchor("session_id", session_id)
     normalized_scope_id = _normalize_optional_anchor("scope_id", scope_id) or normalized_ac_id
-    if normalized_execution_id is None and normalized_session_id is None:
-        msg = "load_ac_evidence_manifest requires execution_id or session_id"
+    if normalized_execution_id is None:
+        msg = "load_ac_evidence_manifest requires execution_id"
         raise ValueError(msg)
 
     if normalized_session_id is not None:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -95,8 +95,25 @@ async def load_ac_evidence_manifest(
 
 
 def _chronological_events(events: Iterable[BaseEvent]) -> tuple[BaseEvent, ...]:
-    """Return events oldest-first regardless of EventStore query ordering."""
-    return tuple(sorted(events, key=lambda event: (event.timestamp, event.id)))
+    """Return events oldest-first regardless of EventStore query ordering.
+
+    Timestamp ties must preserve causal start-before-return ordering for
+    journal pairs. ``BaseEvent.id`` is a UUID-like string, not a monotonic
+    sequence, so it must never be used as a causality tie-breaker.
+    """
+    return tuple(sorted(events, key=_event_chronology_key))
+
+
+def _event_chronology_key(event: BaseEvent) -> tuple[object, int]:
+    return (event.timestamp, _event_phase_order(event.type))
+
+
+def _event_phase_order(event_type: str) -> int:
+    if event_type in {"tool.call.started", "llm.call.requested"}:
+        return 0
+    if event_type in {"tool.call.returned", "llm.call.returned"}:
+        return 1
+    return 2
 
 
 __all__ = [

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -99,10 +99,65 @@ async def load_ac_evidence_manifest(
             limit=limit,
         )
 
-    manifest = normalize_events(_chronological_events(events), ac_id=normalized_scope_id)
+    filtered_events = _filter_events_by_anchors(
+        events,
+        execution_id=normalized_execution_id,
+        session_id=normalized_session_id,
+    )
+    manifest = normalize_events(_chronological_events(filtered_events), ac_id=normalized_scope_id)
     if normalized_scope_id == normalized_ac_id:
         return manifest
     return manifest.model_copy(update={"ac_id": normalized_ac_id})
+
+
+def _filter_events_by_anchors(
+    events: Iterable[BaseEvent],
+    *,
+    execution_id: str | None,
+    session_id: str | None,
+) -> tuple[BaseEvent, ...]:
+    return tuple(
+        event
+        for event in events
+        if _event_matches_required_anchors(
+            event,
+            execution_id=execution_id,
+            session_id=session_id,
+        )
+    )
+
+
+def _event_matches_required_anchors(
+    event: BaseEvent,
+    *,
+    execution_id: str | None,
+    session_id: str | None,
+) -> bool:
+    if execution_id is not None and not _event_matches_anchor(
+        event,
+        execution_id,
+        keys=("execution_id", "parent_execution_id"),
+    ):
+        return False
+    return not (
+        session_id is not None
+        and not _event_matches_anchor(
+            event,
+            session_id,
+            keys=("session_id",),
+        )
+    )
+
+
+def _event_matches_anchor(event: BaseEvent, anchor: str, *, keys: tuple[str, ...]) -> bool:
+    if event.aggregate_id == anchor:
+        return True
+    if isinstance(event.data, dict):
+        for key in keys:
+            value = event.data.get(key)
+            if isinstance(value, str) and value.strip() == anchor:
+                return True
+    return False
 
 
 def _normalize_optional_anchor(name: str, value: str | None) -> str | None:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -1,0 +1,105 @@
+"""Read-only EventStore input loader for the #978 evidence deliver gate.
+
+This module is the first P2-safe bridge between the journal normalizer and the
+future TraceGuard verdict call. It deliberately does **not** change AC success
+semantics: callers receive an :class:`EvidenceManifest` they can pass to an
+observe-only or A/B verifier, while legacy completion remains untouched until a
+later gate PR explicitly owns behavior changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.harness.journal import EvidenceManifest, normalize_events
+
+
+class EventStoreEvidenceReader(Protocol):
+    """EventStore read subset required by the deliver-gate manifest loader."""
+
+    async def query_execution_related_events(
+        self,
+        execution_id: str,
+        event_type: str | None = None,
+        limit: int | None = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        raise NotImplementedError
+
+    async def query_session_related_events(
+        self,
+        session_id: str,
+        execution_id: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        raise NotImplementedError
+
+
+async def load_ac_evidence_manifest(
+    event_store: EventStoreEvidenceReader,
+    *,
+    ac_id: str,
+    execution_id: str | None = None,
+    session_id: str | None = None,
+    limit: int | None = None,
+) -> EvidenceManifest:
+    """Load and normalize EventStore evidence for one AC deliver-gate check.
+
+    ``execution_id`` is preferred because it avoids accidentally splicing a
+    reused session's unrelated runs. ``session_id`` is retained for consumers
+    that only know the top-level session while the deliver gate is still in
+    observe-only/A-B wiring.
+
+    Args:
+        event_store: Read-capable EventStore or test double.
+        ac_id: Acceptance-criterion identifier to normalize.
+        execution_id: Optional execution aggregate anchor.
+        session_id: Optional session aggregate anchor.
+        limit: Optional EventStore query cap. The default ``None`` reads the
+            full related event set so the manifest is not silently truncated
+            before TraceGuard sees it.
+
+    Raises:
+        ValueError: If ``ac_id`` is blank or neither execution nor session
+            anchor is provided.
+
+    Returns:
+        A per-AC :class:`EvidenceManifest` in chronological event order.
+    """
+    normalized_ac_id = ac_id.strip()
+    if not normalized_ac_id:
+        msg = "load_ac_evidence_manifest requires a non-blank ac_id"
+        raise ValueError(msg)
+    if execution_id is None and session_id is None:
+        msg = "load_ac_evidence_manifest requires execution_id or session_id"
+        raise ValueError(msg)
+
+    if execution_id is not None:
+        events = await event_store.query_execution_related_events(
+            execution_id,
+            limit=limit,
+        )
+    else:
+        assert session_id is not None
+        events = await event_store.query_session_related_events(
+            session_id,
+            execution_id=execution_id,
+            limit=limit,
+        )
+
+    return normalize_events(_chronological_events(events), ac_id=normalized_ac_id)
+
+
+def _chronological_events(events: Iterable[BaseEvent]) -> tuple[BaseEvent, ...]:
+    """Return events oldest-first regardless of EventStore query ordering."""
+    return tuple(sorted(events, key=lambda event: (event.timestamp, event.id)))
+
+
+__all__ = [
+    "EventStoreEvidenceReader",
+    "load_ac_evidence_manifest",
+]

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -45,6 +45,7 @@ async def load_ac_evidence_manifest(
     ac_id: str,
     execution_id: str | None = None,
     session_id: str | None = None,
+    scope_id: str | None = None,
     limit: int | None = None,
 ) -> EvidenceManifest:
     """Load and normalize EventStore evidence for one AC deliver-gate check.
@@ -59,6 +60,9 @@ async def load_ac_evidence_manifest(
         ac_id: Acceptance-criterion identifier to normalize.
         execution_id: Optional execution aggregate anchor.
         session_id: Optional session aggregate anchor.
+        scope_id: Optional event-scope token to filter by when the public AC
+            id differs from the runtime aggregate/phase token used by the
+            recorder. Defaults to ``ac_id``.
         limit: Optional EventStore query cap. The default ``None`` reads the
             full related event set so the manifest is not silently truncated
             before TraceGuard sees it.
@@ -76,6 +80,7 @@ async def load_ac_evidence_manifest(
         raise ValueError(msg)
     normalized_execution_id = _normalize_optional_anchor("execution_id", execution_id)
     normalized_session_id = _normalize_optional_anchor("session_id", session_id)
+    normalized_scope_id = _normalize_optional_anchor("scope_id", scope_id) or normalized_ac_id
     if normalized_execution_id is None and normalized_session_id is None:
         msg = "load_ac_evidence_manifest requires execution_id or session_id"
         raise ValueError(msg)
@@ -93,7 +98,10 @@ async def load_ac_evidence_manifest(
             limit=limit,
         )
 
-    return normalize_events(_chronological_events(events), ac_id=normalized_ac_id)
+    manifest = normalize_events(_chronological_events(events), ac_id=normalized_scope_id)
+    if normalized_scope_id == normalized_ac_id:
+        return manifest
+    return manifest.model_copy(update={"ac_id": normalized_ac_id})
 
 
 def _normalize_optional_anchor(name: str, value: str | None) -> str | None:

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -104,7 +104,9 @@ class _FakeEventStore:
 
 class TestLoadAcEvidenceManifest:
     @pytest.mark.asyncio
-    async def test_execution_id_query_is_full_read_and_normalizes_chronologically(self) -> None:
+    async def test_execution_id_only_query_is_full_read_and_normalizes_chronologically(
+        self,
+    ) -> None:
         now = datetime.now(UTC)
         returned = _tool_returned(call_id="c1", when=now + timedelta(seconds=1))
         started = _tool_started(call_id="c1", when=now)
@@ -121,6 +123,30 @@ class TestLoadAcEvidenceManifest:
         assert entry.kind is EvidenceKind.COMMAND_EXECUTED
         assert entry.ok is True
         assert entry.source_event_ids == ("evt_started_c1", "evt_returned_c1")
+
+    @pytest.mark.asyncio
+    async def test_session_query_is_preferred_when_both_scope_anchors_exist(self) -> None:
+        now = datetime.now(UTC)
+        store = _FakeEventStore([_tool_started(call_id="c1", when=now)])
+
+        manifest = await load_ac_evidence_manifest(
+            store,
+            ac_id="ac_1",
+            session_id="sess_1",
+            execution_id="exec_1",
+        )
+
+        assert store.execution_queries == []
+        assert store.session_queries == [
+            {
+                "session_id": "sess_1",
+                "execution_id": "exec_1",
+                "event_type": None,
+                "limit": None,
+                "offset": 0,
+            }
+        ]
+        assert manifest.entries[0].source_event_ids == ("evt_started_c1",)
 
     @pytest.mark.asyncio
     async def test_identical_timestamps_keep_started_before_returned(self) -> None:

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -1,0 +1,162 @@
+"""Tests for the #978 P2 read-only deliver-gate manifest loader."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.harness.deliver_gate import load_ac_evidence_manifest
+from ouroboros.harness.journal import EvidenceKind
+
+
+def _tool_started(
+    *,
+    call_id: str,
+    ac_id: str = "ac_1",
+    when: datetime,
+) -> BaseEvent:
+    return BaseEvent(
+        id=f"evt_started_{call_id}",
+        type="tool.call.started",
+        timestamp=when,
+        aggregate_type="execution",
+        aggregate_id="exec_1",
+        data={"call_id": call_id, "tool_name": "Bash", "ac_id": ac_id},
+    )
+
+
+def _tool_returned(
+    *,
+    call_id: str,
+    ac_id: str = "ac_1",
+    when: datetime,
+) -> BaseEvent:
+    return BaseEvent(
+        id=f"evt_returned_{call_id}",
+        type="tool.call.returned",
+        timestamp=when,
+        aggregate_type="execution",
+        aggregate_id="exec_1",
+        data={
+            "call_id": call_id,
+            "tool_name": "Bash",
+            "ac_id": ac_id,
+            "is_error": False,
+            "duration_ms": 7,
+        },
+    )
+
+
+class _FakeEventStore:
+    def __init__(self, events: list[BaseEvent]) -> None:
+        self.events = events
+        self.execution_queries: list[dict[str, object]] = []
+        self.session_queries: list[dict[str, object]] = []
+
+    async def query_execution_related_events(
+        self,
+        execution_id: str,
+        event_type: str | None = None,
+        limit: int | None = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        self.execution_queries.append(
+            {
+                "execution_id": execution_id,
+                "event_type": event_type,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        return self.events
+
+    async def query_session_related_events(
+        self,
+        session_id: str,
+        execution_id: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        self.session_queries.append(
+            {
+                "session_id": session_id,
+                "execution_id": execution_id,
+                "event_type": event_type,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        return self.events
+
+
+class TestLoadAcEvidenceManifest:
+    @pytest.mark.asyncio
+    async def test_execution_id_query_is_full_read_and_normalizes_chronologically(self) -> None:
+        now = datetime.now(UTC)
+        returned = _tool_returned(call_id="c1", when=now + timedelta(seconds=1))
+        started = _tool_started(call_id="c1", when=now)
+        store = _FakeEventStore([returned, started])
+
+        manifest = await load_ac_evidence_manifest(store, ac_id="ac_1", execution_id="exec_1")
+
+        assert store.execution_queries == [
+            {"execution_id": "exec_1", "event_type": None, "limit": None, "offset": 0}
+        ]
+        assert store.session_queries == []
+        assert len(manifest.entries) == 1
+        entry = manifest.entries[0]
+        assert entry.kind is EvidenceKind.COMMAND_EXECUTED
+        assert entry.ok is True
+        assert entry.source_event_ids == ("evt_started_c1", "evt_returned_c1")
+
+    @pytest.mark.asyncio
+    async def test_session_fallback_query_is_supported_for_observe_only_wiring(self) -> None:
+        now = datetime.now(UTC)
+        store = _FakeEventStore([_tool_started(call_id="c1", when=now)])
+
+        manifest = await load_ac_evidence_manifest(store, ac_id="ac_1", session_id="sess_1")
+
+        assert store.execution_queries == []
+        assert store.session_queries == [
+            {
+                "session_id": "sess_1",
+                "execution_id": None,
+                "event_type": None,
+                "limit": None,
+                "offset": 0,
+            }
+        ]
+        assert manifest.ac_id == "ac_1"
+        assert manifest.entries[0].ok is None
+
+    @pytest.mark.asyncio
+    async def test_events_from_other_ac_are_filtered_by_normalizer(self) -> None:
+        now = datetime.now(UTC)
+        store = _FakeEventStore(
+            [
+                _tool_started(call_id="other", ac_id="ac_2", when=now),
+                _tool_started(call_id="target", ac_id="ac_1", when=now + timedelta(seconds=1)),
+            ]
+        )
+
+        manifest = await load_ac_evidence_manifest(store, ac_id="ac_1", execution_id="exec_1")
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == ("evt_started_target",)
+
+    @pytest.mark.asyncio
+    async def test_requires_scope_anchor(self) -> None:
+        with pytest.raises(ValueError, match="execution_id or session_id"):
+            await load_ac_evidence_manifest(_FakeEventStore([]), ac_id="ac_1")
+
+    @pytest.mark.asyncio
+    async def test_rejects_blank_ac_id_before_query(self) -> None:
+        store = _FakeEventStore([])
+
+        with pytest.raises(ValueError, match="non-blank ac_id"):
+            await load_ac_evidence_manifest(store, ac_id="  ", execution_id="exec_1")
+
+        assert store.execution_queries == []

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -266,24 +266,14 @@ class TestLoadAcEvidenceManifest:
         )
 
     @pytest.mark.asyncio
-    async def test_session_fallback_query_is_supported_for_observe_only_wiring(self) -> None:
-        now = datetime.now(UTC)
-        store = _FakeEventStore([_tool_started(call_id="c1", aggregate_id="sess_1", when=now)])
+    async def test_rejects_session_only_query_to_avoid_mixed_execution_manifests(self) -> None:
+        store = _FakeEventStore([])
 
-        manifest = await load_ac_evidence_manifest(store, ac_id="ac_1", session_id="sess_1")
+        with pytest.raises(ValueError, match="requires execution_id"):
+            await load_ac_evidence_manifest(store, ac_id="ac_1", session_id="sess_1")
 
         assert store.execution_queries == []
-        assert store.session_queries == [
-            {
-                "session_id": "sess_1",
-                "execution_id": None,
-                "event_type": None,
-                "limit": None,
-                "offset": 0,
-            }
-        ]
-        assert manifest.ac_id == "ac_1"
-        assert manifest.entries[0].ok is None
+        assert store.session_queries == []
 
     @pytest.mark.asyncio
     async def test_events_from_other_ac_are_filtered_by_normalizer(self) -> None:
@@ -301,8 +291,8 @@ class TestLoadAcEvidenceManifest:
         assert manifest.entries[0].source_event_ids == ("evt_started_target",)
 
     @pytest.mark.asyncio
-    async def test_requires_scope_anchor(self) -> None:
-        with pytest.raises(ValueError, match="execution_id or session_id"):
+    async def test_requires_execution_anchor(self) -> None:
+        with pytest.raises(ValueError, match="requires execution_id"):
             await load_ac_evidence_manifest(_FakeEventStore([]), ac_id="ac_1")
 
     @pytest.mark.asyncio
@@ -325,7 +315,9 @@ class TestLoadAcEvidenceManifest:
         store = _FakeEventStore([])
 
         with pytest.raises(ValueError, match="blank session_id"):
-            await load_ac_evidence_manifest(store, ac_id="ac_1", session_id="  ")
+            await load_ac_evidence_manifest(
+                store, ac_id="ac_1", execution_id="exec_1", session_id="  "
+            )
 
         assert store.execution_queries == []
         assert store.session_queries == []

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -14,7 +14,8 @@ from ouroboros.harness.journal import EvidenceKind
 def _tool_started(
     *,
     call_id: str,
-    ac_id: str = "ac_1",
+    ac_id: str | None = "ac_1",
+    aggregate_id: str = "exec_1",
     when: datetime,
 ) -> BaseEvent:
     return BaseEvent(
@@ -22,15 +23,20 @@ def _tool_started(
         type="tool.call.started",
         timestamp=when,
         aggregate_type="execution",
-        aggregate_id="exec_1",
-        data={"call_id": call_id, "tool_name": "Bash", "ac_id": ac_id},
+        aggregate_id=aggregate_id,
+        data={
+            key: value
+            for key, value in {"call_id": call_id, "tool_name": "Bash", "ac_id": ac_id}.items()
+            if value is not None
+        },
     )
 
 
 def _tool_returned(
     *,
     call_id: str,
-    ac_id: str = "ac_1",
+    ac_id: str | None = "ac_1",
+    aggregate_id: str = "exec_1",
     when: datetime,
 ) -> BaseEvent:
     return BaseEvent(
@@ -38,13 +44,17 @@ def _tool_returned(
         type="tool.call.returned",
         timestamp=when,
         aggregate_type="execution",
-        aggregate_id="exec_1",
+        aggregate_id=aggregate_id,
         data={
-            "call_id": call_id,
-            "tool_name": "Bash",
-            "ac_id": ac_id,
-            "is_error": False,
-            "duration_ms": 7,
+            key: value
+            for key, value in {
+                "call_id": call_id,
+                "tool_name": "Bash",
+                "ac_id": ac_id,
+                "is_error": False,
+                "duration_ms": 7,
+            }.items()
+            if value is not None
         },
     )
 
@@ -128,6 +138,46 @@ class TestLoadAcEvidenceManifest:
         assert manifest.entries[0].source_event_ids == (
             "evt_started_same",
             "evt_returned_same",
+        )
+
+    @pytest.mark.asyncio
+    async def test_scope_id_filters_production_shaped_events_without_ac_payload(self) -> None:
+        now = datetime.now(UTC)
+        store = _FakeEventStore(
+            [
+                _tool_started(
+                    call_id="target",
+                    ac_id=None,
+                    aggregate_id="ac_runtime_scope",
+                    when=now,
+                ),
+                _tool_returned(
+                    call_id="target",
+                    ac_id=None,
+                    aggregate_id="ac_runtime_scope",
+                    when=now + timedelta(seconds=1),
+                ),
+                _tool_started(
+                    call_id="other",
+                    ac_id=None,
+                    aggregate_id="other_runtime_scope",
+                    when=now + timedelta(seconds=2),
+                ),
+            ]
+        )
+
+        manifest = await load_ac_evidence_manifest(
+            store,
+            ac_id="AC-1",
+            scope_id="ac_runtime_scope",
+            execution_id="exec_1",
+        )
+
+        assert manifest.ac_id == "AC-1"
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == (
+            "evt_started_target",
+            "evt_returned_target",
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -16,6 +16,8 @@ def _tool_started(
     call_id: str,
     ac_id: str | None = "ac_1",
     aggregate_id: str = "exec_1",
+    session_id: str | None = None,
+    execution_id: str | None = None,
     when: datetime,
 ) -> BaseEvent:
     return BaseEvent(
@@ -26,7 +28,13 @@ def _tool_started(
         aggregate_id=aggregate_id,
         data={
             key: value
-            for key, value in {"call_id": call_id, "tool_name": "Bash", "ac_id": ac_id}.items()
+            for key, value in {
+                "call_id": call_id,
+                "tool_name": "Bash",
+                "ac_id": ac_id,
+                "session_id": session_id,
+                "execution_id": execution_id,
+            }.items()
             if value is not None
         },
     )
@@ -37,6 +45,8 @@ def _tool_returned(
     call_id: str,
     ac_id: str | None = "ac_1",
     aggregate_id: str = "exec_1",
+    session_id: str | None = None,
+    execution_id: str | None = None,
     when: datetime,
 ) -> BaseEvent:
     return BaseEvent(
@@ -53,6 +63,8 @@ def _tool_returned(
                 "ac_id": ac_id,
                 "is_error": False,
                 "duration_ms": 7,
+                "session_id": session_id,
+                "execution_id": execution_id,
             }.items()
             if value is not None
         },
@@ -127,7 +139,9 @@ class TestLoadAcEvidenceManifest:
     @pytest.mark.asyncio
     async def test_session_query_is_preferred_when_both_scope_anchors_exist(self) -> None:
         now = datetime.now(UTC)
-        store = _FakeEventStore([_tool_started(call_id="c1", when=now)])
+        store = _FakeEventStore(
+            [_tool_started(call_id="c1", session_id="sess_1", execution_id="exec_1", when=now)]
+        )
 
         manifest = await load_ac_evidence_manifest(
             store,
@@ -167,6 +181,44 @@ class TestLoadAcEvidenceManifest:
         )
 
     @pytest.mark.asyncio
+    async def test_mismatched_session_execution_events_are_post_filtered(self) -> None:
+        now = datetime.now(UTC)
+        store = _FakeEventStore(
+            [
+                _tool_started(
+                    call_id="wrong_exec",
+                    aggregate_id="other_exec",
+                    session_id="sess_1",
+                    execution_id="other_exec",
+                    when=now,
+                ),
+                _tool_started(
+                    call_id="wrong_session",
+                    aggregate_id="exec_1",
+                    session_id="other_sess",
+                    execution_id="exec_1",
+                    when=now + timedelta(seconds=1),
+                ),
+                _tool_started(
+                    call_id="target",
+                    session_id="sess_1",
+                    execution_id="exec_1",
+                    when=now + timedelta(seconds=2),
+                ),
+            ]
+        )
+
+        manifest = await load_ac_evidence_manifest(
+            store,
+            ac_id="ac_1",
+            session_id="sess_1",
+            execution_id="exec_1",
+        )
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == ("evt_started_target",)
+
+    @pytest.mark.asyncio
     async def test_scope_id_filters_production_shaped_events_without_ac_payload(self) -> None:
         now = datetime.now(UTC)
         store = _FakeEventStore(
@@ -175,18 +227,24 @@ class TestLoadAcEvidenceManifest:
                     call_id="target",
                     ac_id=None,
                     aggregate_id="ac_runtime_scope",
+                    session_id="sess_1",
+                    execution_id="exec_1",
                     when=now,
                 ),
                 _tool_returned(
                     call_id="target",
                     ac_id=None,
                     aggregate_id="ac_runtime_scope",
+                    session_id="sess_1",
+                    execution_id="exec_1",
                     when=now + timedelta(seconds=1),
                 ),
                 _tool_started(
                     call_id="other",
                     ac_id=None,
                     aggregate_id="other_runtime_scope",
+                    session_id="sess_1",
+                    execution_id="exec_1",
                     when=now + timedelta(seconds=2),
                 ),
             ]
@@ -197,6 +255,7 @@ class TestLoadAcEvidenceManifest:
             ac_id="AC-1",
             scope_id="ac_runtime_scope",
             execution_id="exec_1",
+            session_id="sess_1",
         )
 
         assert manifest.ac_id == "AC-1"
@@ -209,7 +268,7 @@ class TestLoadAcEvidenceManifest:
     @pytest.mark.asyncio
     async def test_session_fallback_query_is_supported_for_observe_only_wiring(self) -> None:
         now = datetime.now(UTC)
-        store = _FakeEventStore([_tool_started(call_id="c1", when=now)])
+        store = _FakeEventStore([_tool_started(call_id="c1", aggregate_id="sess_1", when=now)])
 
         manifest = await load_ac_evidence_manifest(store, ac_id="ac_1", session_id="sess_1")
 

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -113,6 +113,24 @@ class TestLoadAcEvidenceManifest:
         assert entry.source_event_ids == ("evt_started_c1", "evt_returned_c1")
 
     @pytest.mark.asyncio
+    async def test_identical_timestamps_keep_started_before_returned(self) -> None:
+        when = datetime.now(UTC)
+        started = _tool_started(call_id="same", when=when)
+        returned = _tool_returned(call_id="same", when=when)
+        # EventStore query APIs return newest-first, and UUID/string ids do not
+        # encode causality. The loader must still feed start before return.
+        store = _FakeEventStore([returned, started])
+
+        manifest = await load_ac_evidence_manifest(store, ac_id="ac_1", execution_id="exec_1")
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].ok is True
+        assert manifest.entries[0].source_event_ids == (
+            "evt_started_same",
+            "evt_returned_same",
+        )
+
+    @pytest.mark.asyncio
     async def test_session_fallback_query_is_supported_for_observe_only_wiring(self) -> None:
         now = datetime.now(UTC)
         store = _FakeEventStore([_tool_started(call_id="c1", when=now)])

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -171,6 +171,31 @@ class TestLoadAcEvidenceManifest:
             await load_ac_evidence_manifest(_FakeEventStore([]), ac_id="ac_1")
 
     @pytest.mark.asyncio
+    async def test_rejects_blank_execution_id_instead_of_session_fallback(self) -> None:
+        store = _FakeEventStore([])
+
+        with pytest.raises(ValueError, match="blank execution_id"):
+            await load_ac_evidence_manifest(
+                store,
+                ac_id="ac_1",
+                execution_id="  ",
+                session_id="sess_1",
+            )
+
+        assert store.execution_queries == []
+        assert store.session_queries == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_blank_session_id(self) -> None:
+        store = _FakeEventStore([])
+
+        with pytest.raises(ValueError, match="blank session_id"):
+            await load_ac_evidence_manifest(store, ac_id="ac_1", session_id="  ")
+
+        assert store.execution_queries == []
+        assert store.session_queries == []
+
+    @pytest.mark.asyncio
     async def test_rejects_blank_ac_id_before_query(self) -> None:
         store = _FakeEventStore([])
 


### PR DESCRIPTION
## Summary

Adds the first A/B-safe #978 P2 bridge from EventStore journal reads to the evidence-manifest input expected by the future TraceGuard deliver gate.

This intentionally does **not** enforce TraceGuard verdicts or alter AC success semantics. It gives the P2 deliver-gate path a deterministic, read-only loader that can be used by observe-only wiring and later verdict enforcement.

## What changed

- Adds `src/ouroboros/harness/deliver_gate.py` with `load_ac_evidence_manifest()`.
- Prefers `execution_id` reads via `query_execution_related_events()` to avoid reused-session splicing.
- Supports session fallback for observe-only consumers that only know a session id.
- Uses `limit=None` by default so the manifest is not truncated before verification.
- Sorts queried events oldest-first before feeding the #978 P1 normalizer.
- Exports the loader from `ouroboros.harness`.
- Adds unit coverage for execution-scoped reads, session fallback, AC filtering, full-read default, chronological normalization, and input validation.

## Scope controls

- No default AC acceptance change.
- No TraceGuard verdict enforcement yet.
- No retry/redispatch/failure-taxonomy routing yet.
- No live LLM/API calls.

## Verification

- `uv run ruff check src/ouroboros/harness/deliver_gate.py src/ouroboros/harness/__init__.py tests/unit/harness/test_deliver_gate.py`
- `uv run mypy src/ouroboros/harness/deliver_gate.py tests/unit/harness/test_deliver_gate.py`
- `uv run pytest tests/unit/harness/test_deliver_gate.py tests/unit/harness/test_journal_normalizer.py -q`

Part of #978 P2 under the #961 SSOT C.2 sequence.
