### PR TITLE
feat(harness): adapt AC deliver claims to TraceGuard verdicts (#978 P2)

### DIFF
--- a/src/ouroboros/harness/__init__.py
+++ b/src/ouroboros/harness/__init__.py
@@ -6,7 +6,14 @@ journal-to-evidence-manifest normalizer for #978.
 """
 
 from ouroboros.harness.deliver_gate import (
+    DeliverEvidenceClaim,
+    DeliverEvidenceFact,
+    DeliverGateVerdict,
     EventStoreEvidenceReader,
+    TraceGuardEvidenceInput,
+    TraceGuardResultLike,
+    TraceGuardValidator,
+    evaluate_deliver_claim,
     load_ac_evidence_manifest,
 )
 from ouroboros.harness.journal import (
@@ -29,6 +36,9 @@ from ouroboros.harness.projection import (
 
 __all__ = [
     "ArtifactRecord",
+    "DeliverEvidenceClaim",
+    "DeliverEvidenceFact",
+    "DeliverGateVerdict",
     "EvidenceEntry",
     "EvidenceKind",
     "EventStoreEvidenceReader",
@@ -38,8 +48,12 @@ __all__ = [
     "StageRecord",
     "StepKind",
     "StepRecord",
+    "TraceGuardEvidenceInput",
+    "TraceGuardResultLike",
+    "TraceGuardValidator",
     "VerdictOutcome",
     "VerdictRecord",
+    "evaluate_deliver_claim",
     "filter_events_for_ac",
     "load_ac_evidence_manifest",
     "normalize_events",

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -123,6 +123,12 @@ class DeliverEvidenceClaim(BaseModel, frozen=True):
         if not value:
             msg = "DeliverEvidenceClaim requires at least one fact"
             raise ValueError(msg)
+        seen: set[str] = set()
+        for fact in value:
+            if fact.fact_id in seen:
+                msg = f"DeliverEvidenceClaim fact_id {fact.fact_id!r} is duplicated"
+                raise ValueError(msg)
+            seen.add(fact.fact_id)
         return value
 
 
@@ -250,7 +256,7 @@ def evaluate_deliver_claim(
         )
         raise ValueError(msg)
 
-    traceguard_manifest, source_events_by_handle = _traceguard_manifest(manifest)
+    traceguard_manifest, source_events_by_handle = _traceguard_manifest(manifest, claim)
     parent_synthesis = _parent_synthesis_from_claim(claim)
     raw_result = traceguard_validator(
         evidence_manifest=traceguard_manifest,
@@ -337,17 +343,20 @@ def _normalize_optional_anchor(name: str, value: str | None) -> str | None:
 
 def _traceguard_manifest(
     manifest: EvidenceManifest,
+    claim: DeliverEvidenceClaim,
 ) -> tuple[tuple[TraceGuardEvidenceInput, ...], dict[str, tuple[str, ...]]]:
+    entries_by_handle = {entry.handle: entry for entry in manifest.entries if entry.ok is True}
     entries: list[TraceGuardEvidenceInput] = []
     source_events_by_handle: dict[str, tuple[str, ...]] = {}
-    for entry in manifest.entries:
-        if entry.ok is not True:
+    for fact in claim.facts:
+        entry = entries_by_handle.get(fact.evidence_handle)
+        if entry is None:
             continue
         text = _evidence_text(entry.payload)
         entries.append(
             TraceGuardEvidenceInput(
-                fact_id=entry.handle,
-                chunk_id=entry.handle,
+                fact_id=fact.fact_id,
+                chunk_id=fact.evidence_handle,
                 text=text,
                 child_call_id=",".join(entry.source_event_ids),
             )

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -265,11 +265,11 @@ def evaluate_deliver_claim(
     rejected = _rejected_claim_summaries(raw_result)
     accepted_claims = getattr(raw_result, "accepted_claims", ())
     accepted_fact_ids = _claim_fact_ids(accepted_claims)
-    if not accepted_fact_ids and bool(raw_result.accepted):
+    if not accepted_fact_ids:
         accepted_fact_ids = _string_tuple(getattr(raw_result, "allowed_fact_ids", ()))
     rejected_fact_ids = tuple(fact_id for fact_id, _, _ in rejected if fact_id is not None)
     accepted_handles = _claim_chunk_ids(accepted_claims)
-    if not accepted_handles and bool(raw_result.accepted):
+    if not accepted_handles:
         accepted_handles = _string_tuple(getattr(raw_result, "allowed_chunk_ids", ()))
 
     return DeliverGateVerdict(
@@ -448,6 +448,10 @@ def _iter_result_items(value: object) -> tuple[object, ...]:
     if isinstance(value, tuple):
         return value
     if isinstance(value, list):
+        return tuple(value)
+    if isinstance(value, str | bytes | Mapping):
+        return ()
+    if isinstance(value, Iterable):
         return tuple(value)
     return ()
 

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -1,16 +1,20 @@
-"""Read-only EventStore input loader for the #978 evidence deliver gate.
+"""Read-only helpers for the #978 evidence deliver gate.
 
 This module is the first P2-safe bridge between the journal normalizer and the
-future TraceGuard verdict call. It deliberately does **not** change AC success
-semantics: callers receive an :class:`EvidenceManifest` they can pass to an
-observe-only or A/B verifier, while legacy completion remains untouched until a
-later gate PR explicitly owns behavior changes.
+TraceGuard verdict call. It deliberately does **not** change AC success
+semantics: callers receive an :class:`EvidenceManifest` and can evaluate an
+explicit deliver claim through an injected TraceGuard-compatible validator while
+legacy completion remains untouched until a later gate PR explicitly owns
+behavior changes.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Protocol
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from ouroboros.events.base import BaseEvent
 from ouroboros.harness.journal import EvidenceManifest, normalize_events
@@ -37,6 +41,118 @@ class EventStoreEvidenceReader(Protocol):
         offset: int = 0,
     ) -> list[BaseEvent]:
         raise NotImplementedError
+
+
+class TraceGuardResultLike(Protocol):
+    """Subset returned by ``rlm_forge.traceguard.validate_parent_synthesis``."""
+
+    accepted: bool
+    accepted_claims: object
+    rejected_claims: object
+    allowed_fact_ids: object
+    allowed_chunk_ids: object
+
+    @property
+    def unsupported_claim_rate(self) -> float:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True, slots=True)
+class TraceGuardEvidenceInput:
+    """Duck-typed input compatible with ``TraceGuardEvidence``."""
+
+    fact_id: str
+    chunk_id: str
+    text: str
+    child_call_id: str | None = None
+
+
+class TraceGuardValidator(Protocol):
+    """Callable shape for the injected deterministic TraceGuard validator."""
+
+    def __call__(
+        self,
+        *,
+        evidence_manifest: tuple[TraceGuardEvidenceInput, ...],
+        parent_synthesis: dict[str, Any],
+    ) -> TraceGuardResultLike:
+        raise NotImplementedError
+
+
+class DeliverEvidenceFact(BaseModel, frozen=True):
+    """One leaf-delivery fact the agent claims is backed by evidence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fact_id: str = Field(..., min_length=1)
+    evidence_handle: str = Field(..., min_length=1)
+    statement: str = Field(default="")
+
+    @field_validator("fact_id", "evidence_handle")
+    @classmethod
+    def _identifier_not_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            msg = "deliver evidence fact identifiers must be non-blank"
+            raise ValueError(msg)
+        return stripped
+
+
+class DeliverEvidenceClaim(BaseModel, frozen=True):
+    """Structured AC completion claim passed to the deliver gate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ac_id: str = Field(..., min_length=1)
+    facts: tuple[DeliverEvidenceFact, ...] = Field(default_factory=tuple)
+
+    @field_validator("ac_id")
+    @classmethod
+    def _ac_id_not_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            msg = "DeliverEvidenceClaim.ac_id must be non-blank"
+            raise ValueError(msg)
+        return stripped
+
+    @field_validator("facts")
+    @classmethod
+    def _facts_not_empty(
+        cls, value: tuple[DeliverEvidenceFact, ...]
+    ) -> tuple[DeliverEvidenceFact, ...]:
+        if not value:
+            msg = "DeliverEvidenceClaim requires at least one fact"
+            raise ValueError(msg)
+        return value
+
+
+class DeliverGateVerdict(BaseModel, frozen=True):
+    """TraceGuard-derived verdict for one AC deliver claim.
+
+    The verdict is intentionally a read-model value. It does not mark the AC
+    complete by itself; later #920/#978 PRs can A/B record it or use it to drive
+    retry / redispatch / escalation routing.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ac_id: str = Field(..., min_length=1)
+    accepted: bool
+    unsupported_claim_rate: float = Field(..., ge=0.0, le=1.0)
+    accepted_fact_ids: tuple[str, ...] = Field(default_factory=tuple)
+    rejected_fact_ids: tuple[str, ...] = Field(default_factory=tuple)
+    rejected_reasons: tuple[str, ...] = Field(default_factory=tuple)
+    evidence_event_ids: tuple[str, ...] = Field(default_factory=tuple)
+
+    @model_validator(mode="after")
+    def _accepted_verdict_has_no_rejections(self) -> DeliverGateVerdict:
+        if self.accepted and (self.rejected_fact_ids or self.rejected_reasons):
+            msg = "accepted DeliverGateVerdict cannot carry rejected claims"
+            raise ValueError(msg)
+        if not self.accepted and not self.rejected_reasons:
+            msg = "rejected DeliverGateVerdict must include rejection reasons"
+            raise ValueError(msg)
+        return self
 
 
 async def load_ac_evidence_manifest(
@@ -112,6 +228,53 @@ async def load_ac_evidence_manifest(
     return manifest.model_copy(update={"ac_id": normalized_ac_id})
 
 
+def evaluate_deliver_claim(
+    manifest: EvidenceManifest,
+    claim: DeliverEvidenceClaim,
+    *,
+    traceguard_validator: TraceGuardValidator,
+) -> DeliverGateVerdict:
+    """Evaluate a typed AC deliver claim with a TraceGuard-compatible validator.
+
+    This is the narrow verdict-adapter slice for #978 P2. It converts
+    Ouroboros' journal-derived :class:`EvidenceManifest` into TraceGuard's
+    canonical ``fact_id`` / ``chunk_id`` manifest shape and converts the leaf
+    claim into TraceGuard's ``parent_synthesis`` claim surface. The deterministic
+    validator is injected so this PR does not add a hard runtime dependency or
+    alter live AC success semantics.
+    """
+    if manifest.ac_id != claim.ac_id:
+        msg = (
+            "DeliverEvidenceClaim.ac_id must match EvidenceManifest.ac_id "
+            f"({claim.ac_id!r} != {manifest.ac_id!r})"
+        )
+        raise ValueError(msg)
+
+    traceguard_manifest, source_events_by_handle = _traceguard_manifest(manifest)
+    parent_synthesis = _parent_synthesis_from_claim(claim)
+    raw_result = traceguard_validator(
+        evidence_manifest=traceguard_manifest,
+        parent_synthesis=parent_synthesis,
+    )
+    rejected = _rejected_claim_summaries(raw_result)
+    accepted_fact_ids = _claim_fact_ids(getattr(raw_result, "accepted_claims", ()))
+    rejected_fact_ids = tuple(fact_id for fact_id, _, _ in rejected if fact_id is not None)
+    accepted_handles = _claim_chunk_ids(getattr(raw_result, "accepted_claims", ()))
+
+    return DeliverGateVerdict(
+        ac_id=manifest.ac_id,
+        accepted=bool(raw_result.accepted),
+        unsupported_claim_rate=float(raw_result.unsupported_claim_rate),
+        accepted_fact_ids=accepted_fact_ids,
+        rejected_fact_ids=rejected_fact_ids,
+        rejected_reasons=tuple(reason for _, _, reason in rejected),
+        evidence_event_ids=_evidence_event_ids_for_handles(
+            accepted_handles,
+            source_events_by_handle=source_events_by_handle,
+        ),
+    )
+
+
 def _filter_events_by_anchors(
     events: Iterable[BaseEvent],
     *,
@@ -172,6 +335,130 @@ def _normalize_optional_anchor(name: str, value: str | None) -> str | None:
     return stripped
 
 
+def _traceguard_manifest(
+    manifest: EvidenceManifest,
+) -> tuple[tuple[TraceGuardEvidenceInput, ...], dict[str, tuple[str, ...]]]:
+    entries: list[TraceGuardEvidenceInput] = []
+    source_events_by_handle: dict[str, tuple[str, ...]] = {}
+    for entry in manifest.entries:
+        if entry.ok is not True:
+            continue
+        text = _evidence_text(entry.payload)
+        entries.append(
+            TraceGuardEvidenceInput(
+                fact_id=entry.handle,
+                chunk_id=entry.handle,
+                text=text,
+                child_call_id=",".join(entry.source_event_ids),
+            )
+        )
+        source_events_by_handle[entry.handle] = entry.source_event_ids
+    return tuple(entries), source_events_by_handle
+
+
+def _evidence_text(payload: object) -> str:
+    if not isinstance(payload, Mapping):
+        return str(payload)
+    for key in ("result_preview", "args_preview", "tool_name"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return str(dict(payload))
+
+
+def _parent_synthesis_from_claim(claim: DeliverEvidenceClaim) -> dict[str, Any]:
+    return {
+        "result": {
+            "observed_facts": [
+                {
+                    "fact_id": fact.fact_id,
+                    "chunk_id": fact.evidence_handle,
+                    "statement": fact.statement,
+                }
+                for fact in claim.facts
+            ]
+        }
+    }
+
+
+def _claim_fact_ids(claims: object) -> tuple[str, ...]:
+    return tuple(
+        fact_id
+        for fact_id in (_claim_attr(claim, "fact_id") for claim in _iter_result_items(claims))
+        if fact_id is not None
+    )
+
+
+def _claim_chunk_ids(claims: object) -> tuple[str, ...]:
+    return tuple(
+        chunk_id
+        for chunk_id in (_claim_attr(claim, "chunk_id") for claim in _iter_result_items(claims))
+        if chunk_id is not None
+    )
+
+
+def _rejected_claim_summaries(
+    result: TraceGuardResultLike,
+) -> tuple[tuple[str | None, str | None, str], ...]:
+    summaries: list[tuple[str | None, str | None, str]] = []
+    for rejection in _iter_result_items(getattr(result, "rejected_claims", ())):
+        claim = _object_value(rejection, "claim")
+        reason = _object_value(rejection, "reason")
+        detail = _object_value(rejection, "detail")
+        summaries.append(
+            (
+                _claim_attr(claim, "fact_id"),
+                _claim_attr(claim, "chunk_id"),
+                _join_reason(reason, detail),
+            )
+        )
+    return tuple(summaries)
+
+
+def _evidence_event_ids_for_handles(
+    handles: tuple[str, ...],
+    *,
+    source_events_by_handle: dict[str, tuple[str, ...]],
+) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for handle in handles:
+        for event_id in source_events_by_handle.get(handle, ()):
+            if event_id not in seen:
+                ordered.append(event_id)
+                seen.add(event_id)
+    return tuple(ordered)
+
+
+def _iter_result_items(value: object) -> tuple[object, ...]:
+    if isinstance(value, tuple):
+        return value
+    if isinstance(value, list):
+        return tuple(value)
+    return ()
+
+
+def _claim_attr(claim: object, name: str) -> str | None:
+    value = _object_value(claim, name)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _object_value(item: object, name: str) -> object:
+    if isinstance(item, dict):
+        return item.get(name)
+    return getattr(item, name, None)
+
+
+def _join_reason(reason: object, detail: object) -> str:
+    reason_text = reason if isinstance(reason, str) and reason.strip() else "traceguard_rejected"
+    detail_text = detail if isinstance(detail, str) and detail.strip() else ""
+    if detail_text:
+        return f"{reason_text}: {detail_text}"
+    return reason_text
+
+
 def _chronological_events(events: Iterable[BaseEvent]) -> tuple[BaseEvent, ...]:
     """Return events oldest-first regardless of EventStore query ordering.
 
@@ -195,6 +482,13 @@ def _event_phase_order(event_type: str) -> int:
 
 
 __all__ = [
+    "DeliverEvidenceClaim",
+    "DeliverEvidenceFact",
+    "DeliverGateVerdict",
     "EventStoreEvidenceReader",
+    "TraceGuardResultLike",
+    "TraceGuardEvidenceInput",
+    "TraceGuardValidator",
+    "evaluate_deliver_claim",
     "load_ac_evidence_manifest",
 ]

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -263,9 +263,14 @@ def evaluate_deliver_claim(
         parent_synthesis=parent_synthesis,
     )
     rejected = _rejected_claim_summaries(raw_result)
-    accepted_fact_ids = _claim_fact_ids(getattr(raw_result, "accepted_claims", ()))
+    accepted_claims = getattr(raw_result, "accepted_claims", ())
+    accepted_fact_ids = _claim_fact_ids(accepted_claims)
+    if not accepted_fact_ids and bool(raw_result.accepted):
+        accepted_fact_ids = _string_tuple(getattr(raw_result, "allowed_fact_ids", ()))
     rejected_fact_ids = tuple(fact_id for fact_id, _, _ in rejected if fact_id is not None)
-    accepted_handles = _claim_chunk_ids(getattr(raw_result, "accepted_claims", ()))
+    accepted_handles = _claim_chunk_ids(accepted_claims)
+    if not accepted_handles and bool(raw_result.accepted):
+        accepted_handles = _string_tuple(getattr(raw_result, "allowed_chunk_ids", ()))
 
     return DeliverGateVerdict(
         ac_id=manifest.ac_id,
@@ -445,6 +450,12 @@ def _iter_result_items(value: object) -> tuple[object, ...]:
     if isinstance(value, list):
         return tuple(value)
     return ()
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    return tuple(
+        item.strip() for item in _iter_result_items(value) if isinstance(item, str) and item.strip()
+    )
 
 
 def _claim_attr(claim: object, name: str) -> str | None:

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -141,8 +141,8 @@ class _TraceGuardResult:
         accepted: bool,
         accepted_claims: tuple[_TraceGuardClaim, ...] = (),
         rejected_claims: tuple[_TraceGuardRejection, ...] = (),
-        allowed_fact_ids: tuple[str, ...] | None = None,
-        allowed_chunk_ids: tuple[str, ...] | None = None,
+        allowed_fact_ids: object | None = None,
+        allowed_chunk_ids: object | None = None,
     ) -> None:
         self.accepted = accepted
         self.accepted_claims = accepted_claims
@@ -558,6 +558,49 @@ class TestEvaluateDeliverClaim:
 
         assert verdict.accepted is True
         assert verdict.accepted_fact_ids == ("fact_actual",)
+        assert verdict.evidence_event_ids == ("evt_1",)
+
+    def test_rejected_verdict_preserves_allowed_id_provenance_without_claim_objects(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(_manifest_entry(handle="ev_actual", ok=True, source_event_ids=("evt_1",)),),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="fact_actual",
+                    evidence_handle="ev_actual",
+                    statement="Supported claim.",
+                ),
+                DeliverEvidenceFact(
+                    fact_id="fact_missing",
+                    evidence_handle="ev_missing",
+                    statement="Unsupported claim.",
+                ),
+            ),
+        )
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=lambda **_: _TraceGuardResult(
+                accepted=False,
+                allowed_fact_ids=frozenset({"fact_actual"}),
+                allowed_chunk_ids=frozenset({"ev_actual"}),
+                rejected_claims=(
+                    _TraceGuardRejection(
+                        reason="unsupported_fact_id",
+                        claim=_TraceGuardClaim(fact_id="fact_missing", chunk_id="ev_missing"),
+                        detail="fact is not present in manifest",
+                    ),
+                ),
+            ),
+        )
+
+        assert verdict.accepted is False
+        assert verdict.accepted_fact_ids == ("fact_actual",)
+        assert verdict.rejected_fact_ids == ("fact_missing",)
         assert verdict.evidence_event_ids == ("evt_1",)
 
     def test_claim_ac_id_must_match_manifest_scope(self) -> None:

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.harness.deliver_gate import load_ac_evidence_manifest
-from ouroboros.harness.journal import EvidenceKind
+from ouroboros.harness.deliver_gate import (
+    DeliverEvidenceClaim,
+    DeliverEvidenceFact,
+    TraceGuardEvidenceInput,
+    evaluate_deliver_claim,
+    load_ac_evidence_manifest,
+)
+from ouroboros.harness.journal import EvidenceEntry, EvidenceKind, EvidenceManifest
 
 
 def _tool_started(
@@ -112,6 +119,106 @@ class _FakeEventStore:
             }
         )
         return self.events
+
+
+class _TraceGuardClaim:
+    def __init__(self, *, fact_id: str | None, chunk_id: str | None) -> None:
+        self.fact_id = fact_id
+        self.chunk_id = chunk_id
+
+
+class _TraceGuardRejection:
+    def __init__(self, *, reason: str, claim: _TraceGuardClaim, detail: str) -> None:
+        self.reason = reason
+        self.claim = claim
+        self.detail = detail
+
+
+class _TraceGuardResult:
+    def __init__(
+        self,
+        *,
+        accepted: bool,
+        accepted_claims: tuple[_TraceGuardClaim, ...] = (),
+        rejected_claims: tuple[_TraceGuardRejection, ...] = (),
+    ) -> None:
+        self.accepted = accepted
+        self.accepted_claims = accepted_claims
+        self.rejected_claims = rejected_claims
+        self.allowed_fact_ids = tuple(claim.fact_id for claim in accepted_claims)
+        self.allowed_chunk_ids = tuple(claim.chunk_id for claim in accepted_claims)
+
+    @property
+    def unsupported_claim_rate(self) -> float:
+        total = len(self.accepted_claims) + len(self.rejected_claims)
+        if total == 0:
+            return 0.0
+        return len(self.rejected_claims) / total
+
+
+class _RecordingTraceGuardValidator:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        *,
+        evidence_manifest: tuple[TraceGuardEvidenceInput, ...],
+        parent_synthesis: dict[str, Any],
+    ) -> _TraceGuardResult:
+        self.calls.append(
+            {
+                "evidence_manifest": evidence_manifest,
+                "parent_synthesis": parent_synthesis,
+            }
+        )
+        allowed = {entry.fact_id: entry for entry in evidence_manifest}
+        accepted: list[_TraceGuardClaim] = []
+        rejected: list[_TraceGuardRejection] = []
+        for item in parent_synthesis["result"]["observed_facts"]:
+            fact_id = item.get("fact_id")
+            chunk_id = item.get("chunk_id")
+            expected = allowed.get(fact_id)
+            if expected is None:
+                rejected.append(
+                    _TraceGuardRejection(
+                        reason="unsupported_fact_id",
+                        claim=_TraceGuardClaim(fact_id=fact_id, chunk_id=chunk_id),
+                        detail="fact is not present in manifest",
+                    )
+                )
+                continue
+            if chunk_id != expected.chunk_id:
+                rejected.append(
+                    _TraceGuardRejection(
+                        reason="evidence_handle_mismatch",
+                        claim=_TraceGuardClaim(fact_id=fact_id, chunk_id=chunk_id),
+                        detail="claim cited the wrong evidence handle",
+                    )
+                )
+                continue
+            accepted.append(_TraceGuardClaim(fact_id=fact_id, chunk_id=chunk_id))
+        return _TraceGuardResult(
+            accepted=not rejected,
+            accepted_claims=tuple(accepted),
+            rejected_claims=tuple(rejected),
+        )
+
+
+def _manifest_entry(
+    *,
+    handle: str,
+    ok: bool | None,
+    source_event_ids: tuple[str, ...],
+) -> EvidenceEntry:
+    return EvidenceEntry(
+        handle=handle,
+        kind=EvidenceKind.COMMAND_EXECUTED,
+        ok=ok,
+        started_at=datetime.now(UTC),
+        payload={"tool_name": "Bash", "result_preview": f"result for {handle}"},
+        source_event_ids=source_event_ids,
+    )
 
 
 class TestLoadAcEvidenceManifest:
@@ -330,3 +437,110 @@ class TestLoadAcEvidenceManifest:
             await load_ac_evidence_manifest(store, ac_id="  ", execution_id="exec_1")
 
         assert store.execution_queries == []
+
+
+class TestEvaluateDeliverClaim:
+    def test_builds_traceguard_envelope_and_returns_accepted_verdict(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(
+                _manifest_entry(handle="ev_pass", ok=True, source_event_ids=("evt_1", "evt_2")),
+                _manifest_entry(handle="ev_failed", ok=False, source_event_ids=("evt_failed",)),
+            ),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="ev_pass",
+                    evidence_handle="ev_pass",
+                    statement="The AC passed because the command succeeded.",
+                ),
+            ),
+        )
+        validator = _RecordingTraceGuardValidator()
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=validator,
+        )
+
+        assert verdict.accepted is True
+        assert verdict.accepted_fact_ids == ("ev_pass",)
+        assert verdict.rejected_fact_ids == ()
+        assert verdict.evidence_event_ids == ("evt_1", "evt_2")
+        assert validator.calls == [
+            {
+                "evidence_manifest": (
+                    TraceGuardEvidenceInput(
+                        fact_id="ev_pass",
+                        chunk_id="ev_pass",
+                        text="result for ev_pass",
+                        child_call_id="evt_1,evt_2",
+                    ),
+                ),
+                "parent_synthesis": {
+                    "result": {
+                        "observed_facts": [
+                            {
+                                "fact_id": "ev_pass",
+                                "chunk_id": "ev_pass",
+                                "statement": ("The AC passed because the command succeeded."),
+                            }
+                        ]
+                    }
+                },
+            }
+        ]
+
+    def test_rejected_traceguard_result_is_preserved_for_routing(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(_manifest_entry(handle="ev_actual", ok=True, source_event_ids=("evt_1",)),),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="ev_missing",
+                    evidence_handle="ev_missing",
+                    statement="Unsupported claim.",
+                ),
+            ),
+        )
+        validator = _RecordingTraceGuardValidator()
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=validator,
+        )
+
+        assert verdict.accepted is False
+        assert verdict.unsupported_claim_rate == 1.0
+        assert verdict.accepted_fact_ids == ()
+        assert verdict.rejected_fact_ids == ("ev_missing",)
+        assert verdict.rejected_reasons == ("unsupported_fact_id: fact is not present in manifest",)
+        assert verdict.evidence_event_ids == ()
+
+    def test_claim_ac_id_must_match_manifest_scope(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(_manifest_entry(handle="ev_pass", ok=True, source_event_ids=("evt_1",)),),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-2",
+            facts=(DeliverEvidenceFact(fact_id="ev_pass", evidence_handle="ev_pass"),),
+        )
+
+        with pytest.raises(ValueError, match="must match EvidenceManifest.ac_id"):
+            evaluate_deliver_claim(
+                manifest,
+                claim,
+                traceguard_validator=_RecordingTraceGuardValidator(),
+            )
+
+    def test_claim_requires_at_least_one_fact(self) -> None:
+        with pytest.raises(ValueError, match="requires at least one fact"):
+            DeliverEvidenceClaim(ac_id="AC-1", facts=())

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -452,7 +452,7 @@ class TestEvaluateDeliverClaim:
             ac_id="AC-1",
             facts=(
                 DeliverEvidenceFact(
-                    fact_id="ev_pass",
+                    fact_id="fact_admin_check",
                     evidence_handle="ev_pass",
                     statement="The AC passed because the command succeeded.",
                 ),
@@ -467,14 +467,14 @@ class TestEvaluateDeliverClaim:
         )
 
         assert verdict.accepted is True
-        assert verdict.accepted_fact_ids == ("ev_pass",)
+        assert verdict.accepted_fact_ids == ("fact_admin_check",)
         assert verdict.rejected_fact_ids == ()
         assert verdict.evidence_event_ids == ("evt_1", "evt_2")
         assert validator.calls == [
             {
                 "evidence_manifest": (
                     TraceGuardEvidenceInput(
-                        fact_id="ev_pass",
+                        fact_id="fact_admin_check",
                         chunk_id="ev_pass",
                         text="result for ev_pass",
                         child_call_id="evt_1,evt_2",
@@ -484,7 +484,7 @@ class TestEvaluateDeliverClaim:
                     "result": {
                         "observed_facts": [
                             {
-                                "fact_id": "ev_pass",
+                                "fact_id": "fact_admin_check",
                                 "chunk_id": "ev_pass",
                                 "statement": ("The AC passed because the command succeeded."),
                             }

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -141,12 +141,18 @@ class _TraceGuardResult:
         accepted: bool,
         accepted_claims: tuple[_TraceGuardClaim, ...] = (),
         rejected_claims: tuple[_TraceGuardRejection, ...] = (),
+        allowed_fact_ids: tuple[str, ...] | None = None,
+        allowed_chunk_ids: tuple[str, ...] | None = None,
     ) -> None:
         self.accepted = accepted
         self.accepted_claims = accepted_claims
         self.rejected_claims = rejected_claims
-        self.allowed_fact_ids = tuple(claim.fact_id for claim in accepted_claims)
-        self.allowed_chunk_ids = tuple(claim.chunk_id for claim in accepted_claims)
+        self.allowed_fact_ids = allowed_fact_ids or tuple(
+            claim.fact_id for claim in accepted_claims if claim.fact_id is not None
+        )
+        self.allowed_chunk_ids = allowed_chunk_ids or tuple(
+            claim.chunk_id for claim in accepted_claims if claim.chunk_id is not None
+        )
 
     @property
     def unsupported_claim_rate(self) -> float:
@@ -523,6 +529,36 @@ class TestEvaluateDeliverClaim:
         assert verdict.rejected_fact_ids == ("ev_missing",)
         assert verdict.rejected_reasons == ("unsupported_fact_id: fact is not present in manifest",)
         assert verdict.evidence_event_ids == ()
+
+    def test_accepted_verdict_can_use_allowed_ids_without_claim_objects(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(_manifest_entry(handle="ev_actual", ok=True, source_event_ids=("evt_1",)),),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="fact_actual",
+                    evidence_handle="ev_actual",
+                    statement="Supported claim.",
+                ),
+            ),
+        )
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=lambda **_: _TraceGuardResult(
+                accepted=True,
+                allowed_fact_ids=("fact_actual",),
+                allowed_chunk_ids=("ev_actual",),
+            ),
+        )
+
+        assert verdict.accepted is True
+        assert verdict.accepted_fact_ids == ("fact_actual",)
+        assert verdict.evidence_event_ids == ("evt_1",)
 
     def test_claim_ac_id_must_match_manifest_scope(self) -> None:
         manifest = EvidenceManifest(


### PR DESCRIPTION
## Summary
- Adds a read-only `DeliverEvidenceClaim` / `DeliverGateVerdict` contract for #978 P2 deliver-gate checks.
- Converts `EvidenceManifest` entries into duck-typed TraceGuard evidence inputs (`fact_id`, `chunk_id`, `text`, `child_call_id`) and converts AC deliver claims into TraceGuard `parent_synthesis` shape.
- Requires an injected TraceGuard-compatible validator, so this PR does not add a hard `rlm-forge` dependency and does not change live AC success/default semantics.

## #961 sequencing / scope
This is the next safe #978 P2 follow-up after #993's read-only EventStore→EvidenceManifest loader foundation.

What this PR intentionally does **not** do:
- No TraceGuard default flip.
- No live `parallel_executor` acceptance change.
- No retry / redispatch / escalation routing yet (#978 P3 / #920 follow-up).
- No legacy self-report removal.

## Validation
- [x] `uv run ruff check src/ouroboros/harness/deliver_gate.py src/ouroboros/harness/__init__.py tests/unit/harness/test_deliver_gate.py`
- [x] `uv run mypy src/ouroboros/harness/deliver_gate.py tests/unit/harness/test_deliver_gate.py`
- [x] `uv run pytest tests/unit/harness/test_deliver_gate.py tests/unit/harness/test_journal_normalizer.py -q`
- [x] Local smoke against the current `rlm-forge` `traceguard.py` implementation loaded from a temporary checkout: `evaluate_deliver_claim(..., traceguard_validator=validate_parent_synthesis)` returns an accepted verdict for a matching claim.

Refs #978
Refs #961
