### PR TITLE
feat(harness): route TraceGuard deliver failures (#978 P3)

### DIFF
--- a/src/ouroboros/harness/__init__.py
+++ b/src/ouroboros/harness/__init__.py
@@ -16,6 +16,7 @@ from ouroboros.harness.deliver_gate import (
     evaluate_deliver_claim,
     load_ac_evidence_manifest,
 )
+from ouroboros.harness.deliver_routing import DeliverGateRoute, route_deliver_gate_verdict
 from ouroboros.harness.journal import (
     EvidenceEntry,
     EvidenceKind,
@@ -39,6 +40,7 @@ __all__ = [
     "DeliverEvidenceClaim",
     "DeliverEvidenceFact",
     "DeliverGateVerdict",
+    "DeliverGateRoute",
     "EvidenceEntry",
     "EvidenceKind",
     "EventStoreEvidenceReader",
@@ -57,4 +59,5 @@ __all__ = [
     "filter_events_for_ac",
     "load_ac_evidence_manifest",
     "normalize_events",
+    "route_deliver_gate_verdict",
 ]

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -277,11 +277,16 @@ def evaluate_deliver_claim(
     accepted_handles = _claim_chunk_ids(accepted_claims)
     if not accepted_handles:
         accepted_handles = _string_tuple(getattr(raw_result, "allowed_chunk_ids", ()))
+    unsupported_claim_rate = _unsupported_claim_rate(
+        raw_rate=float(raw_result.unsupported_claim_rate),
+        rejected=rejected,
+        total_claims=len(claim.facts),
+    )
 
     return DeliverGateVerdict(
         ac_id=manifest.ac_id,
         accepted=bool(raw_result.accepted) and not missing_evidence,
-        unsupported_claim_rate=float(raw_result.unsupported_claim_rate),
+        unsupported_claim_rate=unsupported_claim_rate,
         accepted_fact_ids=accepted_fact_ids,
         rejected_fact_ids=rejected_fact_ids,
         rejected_reasons=_dedupe_strings(reason for _, _, reason in rejected),
@@ -449,6 +454,18 @@ def _missing_evidence_summaries(
         for fact in claim.facts
         if fact.evidence_handle not in available_handles
     )
+
+
+def _unsupported_claim_rate(
+    *,
+    raw_rate: float,
+    rejected: tuple[tuple[str | None, str | None, str], ...],
+    total_claims: int,
+) -> float:
+    if total_claims <= 0:
+        return raw_rate
+    local_rate = min(1.0, len(rejected) / total_claims)
+    return max(raw_rate, round(local_rate, 4))
 
 
 def _evidence_event_ids_for_handles(

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -257,28 +257,34 @@ def evaluate_deliver_claim(
         raise ValueError(msg)
 
     traceguard_manifest, source_events_by_handle = _traceguard_manifest(manifest, claim)
+    missing_evidence = _missing_evidence_summaries(
+        claim,
+        available_handles=frozenset(source_events_by_handle),
+    )
     parent_synthesis = _parent_synthesis_from_claim(claim)
     raw_result = traceguard_validator(
         evidence_manifest=traceguard_manifest,
         parent_synthesis=parent_synthesis,
     )
-    rejected = _rejected_claim_summaries(raw_result)
+    rejected = missing_evidence + _rejected_claim_summaries(raw_result)
     accepted_claims = getattr(raw_result, "accepted_claims", ())
     accepted_fact_ids = _claim_fact_ids(accepted_claims)
     if not accepted_fact_ids:
         accepted_fact_ids = _string_tuple(getattr(raw_result, "allowed_fact_ids", ()))
-    rejected_fact_ids = tuple(fact_id for fact_id, _, _ in rejected if fact_id is not None)
+    rejected_fact_ids = _dedupe_strings(
+        fact_id for fact_id, _, _ in rejected if fact_id is not None
+    )
     accepted_handles = _claim_chunk_ids(accepted_claims)
     if not accepted_handles:
         accepted_handles = _string_tuple(getattr(raw_result, "allowed_chunk_ids", ()))
 
     return DeliverGateVerdict(
         ac_id=manifest.ac_id,
-        accepted=bool(raw_result.accepted),
+        accepted=bool(raw_result.accepted) and not missing_evidence,
         unsupported_claim_rate=float(raw_result.unsupported_claim_rate),
         accepted_fact_ids=accepted_fact_ids,
         rejected_fact_ids=rejected_fact_ids,
-        rejected_reasons=tuple(reason for _, _, reason in rejected),
+        rejected_reasons=_dedupe_strings(reason for _, _, reason in rejected),
         evidence_event_ids=_evidence_event_ids_for_handles(
             accepted_handles,
             source_events_by_handle=source_events_by_handle,
@@ -429,6 +435,22 @@ def _rejected_claim_summaries(
     return tuple(summaries)
 
 
+def _missing_evidence_summaries(
+    claim: DeliverEvidenceClaim,
+    *,
+    available_handles: frozenset[str],
+) -> tuple[tuple[str, str, str], ...]:
+    return tuple(
+        (
+            fact.fact_id,
+            fact.evidence_handle,
+            f"missing_evidence_handle: {fact.evidence_handle} is not present in manifest",
+        )
+        for fact in claim.facts
+        if fact.evidence_handle not in available_handles
+    )
+
+
 def _evidence_event_ids_for_handles(
     handles: tuple[str, ...],
     *,
@@ -460,6 +482,16 @@ def _string_tuple(value: object) -> tuple[str, ...]:
     return tuple(
         item.strip() for item in _iter_result_items(value) if isinstance(item, str) and item.strip()
     )
+
+
+def _dedupe_strings(values: Iterable[str]) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            ordered.append(value)
+            seen.add(value)
+    return tuple(ordered)
 
 
 def _claim_attr(claim: object, name: str) -> str | None:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -464,8 +464,11 @@ def _unsupported_claim_rate(
 ) -> float:
     if total_claims <= 0:
         return raw_rate
-    local_rate = min(1.0, len(rejected) / total_claims)
-    return max(raw_rate, round(local_rate, 4))
+    rejected_fact_ids = {fact_id for fact_id, _, _ in rejected if fact_id is not None}
+    rejected_count = len(rejected_fact_ids) if rejected_fact_ids else len(rejected)
+    if rejected_count:
+        return round(min(1.0, rejected_count / total_claims), 4)
+    return raw_rate
 
 
 def _evidence_event_ids_for_handles(

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -464,11 +464,20 @@ def _unsupported_claim_rate(
 ) -> float:
     if total_claims <= 0:
         return raw_rate
-    rejected_fact_ids = {fact_id for fact_id, _, _ in rejected if fact_id is not None}
-    rejected_count = len(rejected_fact_ids) if rejected_fact_ids else len(rejected)
+    rejected_keys = {_rejection_key(item) for item in rejected}
+    rejected_count = len(rejected_keys)
     if rejected_count:
         return round(min(1.0, rejected_count / total_claims), 4)
     return raw_rate
+
+
+def _rejection_key(item: tuple[str | None, str | None, str]) -> tuple[str, str]:
+    fact_id, chunk_id, reason = item
+    if fact_id is not None:
+        return ("fact", fact_id)
+    if chunk_id is not None:
+        return ("chunk", chunk_id)
+    return ("reason", reason)
 
 
 def _evidence_event_ids_for_handles(

--- a/src/ouroboros/harness/deliver_routing.py
+++ b/src/ouroboros/harness/deliver_routing.py
@@ -1,0 +1,142 @@
+"""Failure-taxonomy routing for #978 deliver-gate verdicts.
+
+This module is the read-only #978 P3 routing primitive. It converts a
+TraceGuard-derived :class:`ouroboros.harness.deliver_gate.DeliverGateVerdict`
+into the existing recovery action vocabulary without mutating runtime state or
+changing AC success semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.harness.deliver_gate import DeliverGateVerdict
+from ouroboros.orchestrator.failure_taxonomy import RecoveryAction
+
+
+@dataclass(frozen=True, slots=True)
+class DeliverGateRoute:
+    """Routing decision for one deliver-gate verdict."""
+
+    accepted: bool
+    action: RecoveryAction | None
+    reason: str
+    source_reasons: tuple[str, ...] = ()
+
+
+_RETRY_REASONS = frozenset(
+    {
+        "evidence_missing",
+        "missing_evidence_handle",
+        "runtime_tool_error",
+        "tool_error",
+        "verifier_unavailable",
+    }
+)
+_REDISPATCH_REASONS = frozenset(
+    {
+        "unsupported_fact_id",
+        "chunk_handle_without_fact",
+        "evidence_handle_mismatch",
+        "malformed_evidence_claim",
+    }
+)
+_HITL_REASONS = frozenset(
+    {
+        "external_dependency_missing",
+        "approval_required",
+        "policy_blocked",
+        "human_input_required",
+    }
+)
+
+
+def route_deliver_gate_verdict(
+    verdict: DeliverGateVerdict,
+    *,
+    rejection_count: int = 1,
+    model_escalation_threshold: int = 2,
+) -> DeliverGateRoute:
+    """Map a deliver-gate verdict to the next recovery action.
+
+    Args:
+        verdict: TraceGuard-derived AC deliver-gate verdict.
+        rejection_count: Number of consecutive rejected verdicts for the same
+            AC attempt lineage. ``1`` means the first rejection.
+        model_escalation_threshold: Rejection count at which repeated
+            non-HITL/non-retry verification failures escalate to a stronger
+            model rather than redispatching again.
+    """
+    if rejection_count < 1:
+        msg = f"rejection_count must be >= 1, got {rejection_count}"
+        raise ValueError(msg)
+    if model_escalation_threshold < 1:
+        msg = f"model_escalation_threshold must be >= 1, got {model_escalation_threshold}"
+        raise ValueError(msg)
+
+    if verdict.accepted:
+        return DeliverGateRoute(
+            accepted=True,
+            action=None,
+            reason="deliver_gate_accepted",
+            source_reasons=(),
+        )
+
+    reasons = verdict.rejected_reasons
+    reason_codes = tuple(_reason_code(reason) for reason in reasons)
+    if not reason_codes:
+        return DeliverGateRoute(
+            accepted=False,
+            action=RecoveryAction.REDISPATCH,
+            reason="deliver_gate_rejected_without_reason",
+            source_reasons=(),
+        )
+
+    if any(reason in _HITL_REASONS for reason in reason_codes):
+        return DeliverGateRoute(
+            accepted=False,
+            action=RecoveryAction.ESCALATE_HUMAN,
+            reason="deliver_gate_requires_human",
+            source_reasons=reasons,
+        )
+
+    if any(reason in _RETRY_REASONS for reason in reason_codes):
+        return DeliverGateRoute(
+            accepted=False,
+            action=RecoveryAction.RETRY,
+            reason="deliver_gate_retryable_evidence_gap",
+            source_reasons=reasons,
+        )
+
+    if rejection_count >= model_escalation_threshold:
+        return DeliverGateRoute(
+            accepted=False,
+            action=RecoveryAction.ESCALATE_MODEL,
+            reason="deliver_gate_repeated_rejection",
+            source_reasons=reasons,
+        )
+
+    if any(reason in _REDISPATCH_REASONS for reason in reason_codes):
+        return DeliverGateRoute(
+            accepted=False,
+            action=RecoveryAction.REDISPATCH,
+            reason="deliver_gate_redispatch_required",
+            source_reasons=reasons,
+        )
+
+    return DeliverGateRoute(
+        accepted=False,
+        action=RecoveryAction.REDISPATCH,
+        reason="deliver_gate_unknown_rejection",
+        source_reasons=reasons,
+    )
+
+
+def _reason_code(reason: str) -> str:
+    return reason.split(":", maxsplit=1)[0].strip()
+
+
+__all__ = [
+    "DeliverGateRoute",
+    "route_deliver_gate_verdict",
+]

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -527,7 +527,10 @@ class TestEvaluateDeliverClaim:
         assert verdict.unsupported_claim_rate == 1.0
         assert verdict.accepted_fact_ids == ()
         assert verdict.rejected_fact_ids == ("ev_missing",)
-        assert verdict.rejected_reasons == ("unsupported_fact_id: fact is not present in manifest",)
+        assert verdict.rejected_reasons == (
+            "missing_evidence_handle: ev_missing is not present in manifest",
+            "unsupported_fact_id: fact is not present in manifest",
+        )
         assert verdict.evidence_event_ids == ()
 
     def test_accepted_verdict_can_use_allowed_ids_without_claim_objects(self) -> None:

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -653,6 +653,51 @@ class TestEvaluateDeliverClaim:
             "unsupported_fact_id: fact is not present in manifest",
         )
 
+    def test_unsupported_claim_rate_counts_factless_rejections(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(_manifest_entry(handle="ev_actual", ok=True, source_event_ids=("evt_1",)),),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="fact_actual",
+                    evidence_handle="ev_actual",
+                    statement="Supported claim.",
+                ),
+                DeliverEvidenceFact(
+                    fact_id="fact_missing",
+                    evidence_handle="ev_missing",
+                    statement="Missing claim.",
+                ),
+            ),
+        )
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=lambda **_: _TraceGuardResult(
+                accepted=False,
+                allowed_fact_ids=("fact_actual",),
+                allowed_chunk_ids=("ev_actual",),
+                rejected_claims=(
+                    _TraceGuardRejection(
+                        reason="chunk_handle_without_fact",
+                        claim=_TraceGuardClaim(fact_id=None, chunk_id="ev_orphan"),
+                        detail="chunk was cited without a supported fact",
+                    ),
+                ),
+            ),
+        )
+
+        assert verdict.unsupported_claim_rate == 1.0
+        assert verdict.rejected_fact_ids == ("fact_missing",)
+        assert verdict.rejected_reasons == (
+            "missing_evidence_handle: ev_missing is not present in manifest",
+            "chunk_handle_without_fact: chunk was cited without a supported fact",
+        )
+
     def test_claim_ac_id_must_match_manifest_scope(self) -> None:
         manifest = EvidenceManifest(
             ac_id="AC-1",

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -606,6 +606,42 @@ class TestEvaluateDeliverClaim:
         assert verdict.rejected_fact_ids == ("fact_missing",)
         assert verdict.evidence_event_ids == ("evt_1",)
 
+    def test_missing_evidence_recomputes_unsupported_claim_rate(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(_manifest_entry(handle="ev_actual", ok=True, source_event_ids=("evt_1",)),),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="fact_actual",
+                    evidence_handle="ev_actual",
+                    statement="Supported claim.",
+                ),
+                DeliverEvidenceFact(
+                    fact_id="fact_missing",
+                    evidence_handle="ev_missing",
+                    statement="Missing claim.",
+                ),
+            ),
+        )
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=lambda **_: _TraceGuardResult(
+                accepted=True,
+                allowed_fact_ids=("fact_actual",),
+                allowed_chunk_ids=("ev_actual",),
+            ),
+        )
+
+        assert verdict.accepted is False
+        assert verdict.unsupported_claim_rate == 0.5
+        assert verdict.accepted_fact_ids == ("fact_actual",)
+        assert verdict.rejected_fact_ids == ("fact_missing",)
+
     def test_claim_ac_id_must_match_manifest_scope(self) -> None:
         manifest = EvidenceManifest(
             ac_id="AC-1",

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -631,9 +631,16 @@ class TestEvaluateDeliverClaim:
             manifest,
             claim,
             traceguard_validator=lambda **_: _TraceGuardResult(
-                accepted=True,
+                accepted=False,
                 allowed_fact_ids=("fact_actual",),
                 allowed_chunk_ids=("ev_actual",),
+                rejected_claims=(
+                    _TraceGuardRejection(
+                        reason="unsupported_fact_id",
+                        claim=_TraceGuardClaim(fact_id="fact_missing", chunk_id="ev_missing"),
+                        detail="fact is not present in manifest",
+                    ),
+                ),
             ),
         )
 
@@ -641,6 +648,10 @@ class TestEvaluateDeliverClaim:
         assert verdict.unsupported_claim_rate == 0.5
         assert verdict.accepted_fact_ids == ("fact_actual",)
         assert verdict.rejected_fact_ids == ("fact_missing",)
+        assert verdict.rejected_reasons == (
+            "missing_evidence_handle: ev_missing is not present in manifest",
+            "unsupported_fact_id: fact is not present in manifest",
+        )
 
     def test_claim_ac_id_must_match_manifest_scope(self) -> None:
         manifest = EvidenceManifest(

--- a/tests/unit/harness/test_deliver_routing.py
+++ b/tests/unit/harness/test_deliver_routing.py
@@ -1,0 +1,80 @@
+"""Tests for #978 P3 deliver-gate failure-taxonomy routing."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.harness.deliver_gate import DeliverGateVerdict
+from ouroboros.harness.deliver_routing import route_deliver_gate_verdict
+from ouroboros.orchestrator.failure_taxonomy import RecoveryAction
+
+
+def _verdict(*, accepted: bool, reasons: tuple[str, ...] = ()) -> DeliverGateVerdict:
+    return DeliverGateVerdict(
+        ac_id="AC-1",
+        accepted=accepted,
+        unsupported_claim_rate=0.0 if accepted else 1.0,
+        rejected_fact_ids=() if accepted else ("fact_1",),
+        rejected_reasons=reasons,
+    )
+
+
+def test_accepted_verdict_has_no_recovery_action() -> None:
+    route = route_deliver_gate_verdict(_verdict(accepted=True))
+
+    assert route.accepted is True
+    assert route.action is None
+    assert route.reason == "deliver_gate_accepted"
+
+
+def test_missing_evidence_routes_to_retry() -> None:
+    route = route_deliver_gate_verdict(
+        _verdict(accepted=False, reasons=("missing_evidence_handle: ev_1 was not found",))
+    )
+
+    assert route.action is RecoveryAction.RETRY
+    assert route.reason == "deliver_gate_retryable_evidence_gap"
+
+
+def test_unsupported_fact_routes_to_redispatch_before_escalation_threshold() -> None:
+    route = route_deliver_gate_verdict(
+        _verdict(accepted=False, reasons=("unsupported_fact_id: fact_1 is not present",)),
+        rejection_count=1,
+        model_escalation_threshold=2,
+    )
+
+    assert route.action is RecoveryAction.REDISPATCH
+    assert route.reason == "deliver_gate_redispatch_required"
+
+
+def test_repeated_traceguard_rejections_route_to_model_escalation() -> None:
+    route = route_deliver_gate_verdict(
+        _verdict(accepted=False, reasons=("unsupported_fact_id: fact_1 is not present",)),
+        rejection_count=2,
+        model_escalation_threshold=2,
+    )
+
+    assert route.action is RecoveryAction.ESCALATE_MODEL
+    assert route.reason == "deliver_gate_repeated_rejection"
+
+
+def test_external_dependency_routes_to_hitl() -> None:
+    route = route_deliver_gate_verdict(
+        _verdict(accepted=False, reasons=("external_dependency_missing: API key missing",))
+    )
+
+    assert route.action is RecoveryAction.ESCALATE_HUMAN
+    assert route.reason == "deliver_gate_requires_human"
+
+
+def test_rejects_invalid_routing_counters() -> None:
+    with pytest.raises(ValueError, match="rejection_count"):
+        route_deliver_gate_verdict(
+            _verdict(accepted=False, reasons=("unsupported_fact_id",)), rejection_count=0
+        )
+
+    with pytest.raises(ValueError, match="model_escalation_threshold"):
+        route_deliver_gate_verdict(
+            _verdict(accepted=False, reasons=("unsupported_fact_id",)),
+            model_escalation_threshold=0,
+        )

--- a/tests/unit/harness/test_deliver_routing.py
+++ b/tests/unit/harness/test_deliver_routing.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
-from ouroboros.harness.deliver_gate import DeliverGateVerdict
+from ouroboros.harness.deliver_gate import (
+    DeliverEvidenceClaim,
+    DeliverEvidenceFact,
+    DeliverGateVerdict,
+    evaluate_deliver_claim,
+)
 from ouroboros.harness.deliver_routing import route_deliver_gate_verdict
+from ouroboros.harness.journal import EvidenceEntry, EvidenceKind, EvidenceManifest
 from ouroboros.orchestrator.failure_taxonomy import RecoveryAction
 
 
@@ -34,6 +42,54 @@ def test_missing_evidence_routes_to_retry() -> None:
 
     assert route.action is RecoveryAction.RETRY
     assert route.reason == "deliver_gate_retryable_evidence_gap"
+
+
+def test_missing_claim_handle_from_real_verdict_producer_routes_to_retry() -> None:
+    manifest = EvidenceManifest(
+        ac_id="AC-1",
+        entries=(
+            EvidenceEntry(
+                handle="ev_actual",
+                kind=EvidenceKind.COMMAND_EXECUTED,
+                ok=True,
+                started_at=datetime.now(UTC),
+                source_event_ids=("evt_1",),
+            ),
+        ),
+    )
+    claim = DeliverEvidenceClaim(
+        ac_id="AC-1",
+        facts=(
+            DeliverEvidenceFact(
+                fact_id="fact_missing",
+                evidence_handle="ev_missing",
+                statement="Missing evidence claim.",
+            ),
+        ),
+    )
+    verdict = evaluate_deliver_claim(
+        manifest,
+        claim,
+        traceguard_validator=lambda **_: type(
+            "TraceGuardResult",
+            (),
+            {
+                "accepted": False,
+                "unsupported_claim_rate": 1.0,
+                "accepted_claims": (),
+                "rejected_claims": (),
+                "allowed_fact_ids": (),
+                "allowed_chunk_ids": (),
+            },
+        )(),
+    )
+
+    route = route_deliver_gate_verdict(verdict)
+
+    assert verdict.rejected_reasons == (
+        "missing_evidence_handle: ev_missing is not present in manifest",
+    )
+    assert route.action is RecoveryAction.RETRY
 
 
 def test_unsupported_fact_routes_to_redispatch_before_escalation_threshold() -> None:


### PR DESCRIPTION
## Summary
- Adds a read-only `DeliverGateRoute` decision value for #978 P3 failure-taxonomy routing.
- Maps TraceGuard/deliver-gate rejection reason codes into the existing `RecoveryAction` vocabulary: retry, redispatch, model escalation, or human escalation.
- Keeps routing pure and un-wired: no `parallel_executor` behavior change, no AC acceptance/default flip, and no legacy path removal.

## #961 sequencing / scope
This follows the completed #978 P2 lineage:
- #993: read-only EventStore→EvidenceManifest loader foundation
- #994: injected-validator/TraceGuard deliver-claim verdict adapter

This PR is the smallest C.3-safe routing primitive before any live #920 evidence-loop wiring.

## Validation
- [x] `uv run ruff format src/ouroboros/harness/deliver_routing.py src/ouroboros/harness/__init__.py tests/unit/harness/test_deliver_routing.py`
- [x] `uv run ruff check src/ouroboros/harness/deliver_routing.py src/ouroboros/harness/__init__.py tests/unit/harness/test_deliver_routing.py`
- [x] `uv run mypy src/ouroboros/harness/deliver_routing.py tests/unit/harness/test_deliver_routing.py`
- [x] `uv run pytest tests/unit/harness/test_deliver_routing.py tests/unit/harness/test_deliver_gate.py -q`

Refs #978
Refs #961
