### PR TITLE
feat(orchestrator): observe typed evidence at atomic AC completion (#920 PR-2)

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -65,6 +65,13 @@ from ouroboros.orchestrator.events import (
     create_ac_stall_detected_event,
     create_heartbeat_event,
 )
+from ouroboros.orchestrator.evidence_schema import (
+    EvidenceError,
+    EvidenceRecord,
+    ValidationResult,
+    extract_evidence,
+    validate_evidence,
+)
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
     ExecutionNodeIdentity,
@@ -3380,6 +3387,19 @@ When complete, explicitly state: [TASK_COMPLETE]
                 error=None if success else final_message or "Implementation session failed",
             )
             clear_cached_runtime_handle = True
+            typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
+                final_message=final_message,
+                success=success,
+            )
+            await self._emit_atomic_typed_evidence_event(
+                runtime_identity=runtime_identity,
+                execution_id=execution_context_id,
+                session_id=ac_session_id,
+                ac_content=ac_content,
+                typed_evidence=typed_evidence,
+                typed_validation=typed_validation,
+                typed_error=typed_error,
+            )
 
             log.info(
                 "parallel_executor.ac.completed",
@@ -3401,6 +3421,9 @@ When complete, explicitly state: [TASK_COMPLETE]
                 retry_attempt=retry_attempt,
                 depth=depth,
                 runtime_handle=runtime_handle,
+                typed_evidence=typed_evidence,
+                typed_evidence_validation=typed_validation,
+                typed_evidence_error=typed_error,
             )
 
         except Exception as e:
@@ -3462,6 +3485,78 @@ When complete, explicitly state: [TASK_COMPLETE]
                     node_identity=node_identity,
                     retry_attempt=retry_attempt,
                 )
+
+    def _observe_atomic_typed_evidence(
+        self,
+        *,
+        final_message: str,
+        success: bool,
+    ) -> tuple[EvidenceRecord | None, ValidationResult | None, str | None]:
+        """Parse and validate typed evidence at the atomic AC acceptance boundary.
+
+        This is observe-only for #920 PR-2: it records whether a successful
+        atomic leaf emitted profile-shaped evidence, but it does not change the
+        legacy success value returned by the runtime. Enforcement belongs to a
+        later sequenced evidence-loop/default-gate PR.
+        """
+        if not success or self._execution_profile is None:
+            return None, None, None
+
+        try:
+            record = extract_evidence(final_message)
+            validation = validate_evidence(self._execution_profile, record)
+        except EvidenceError as exc:
+            return None, None, str(exc)
+        return record, validation, None
+
+    async def _emit_atomic_typed_evidence_event(
+        self,
+        *,
+        runtime_identity: ACRuntimeIdentity,
+        execution_id: str,
+        session_id: str | None,
+        ac_content: str,
+        typed_evidence: EvidenceRecord | None,
+        typed_validation: ValidationResult | None,
+        typed_error: str | None,
+    ) -> None:
+        """Persist observe-only typed-evidence metadata for atomic AC completion."""
+        if self._execution_profile is None:
+            return
+
+        from ouroboros.events.base import BaseEvent
+
+        data: dict[str, Any] = {
+            **runtime_identity.to_metadata(),
+            **self._decomposition_profile_metadata(),
+            "execution_id": execution_id,
+            "session_id": session_id,
+            "acceptance_criterion": ac_content,
+            "profile": self._execution_profile.profile,
+            "required_fields": list(self._execution_profile.evidence_schema.required),
+            "observe_only": True,
+            "enforced": False,
+            "typed_evidence_present": typed_evidence is not None,
+            "typed_evidence_valid": typed_validation.ok if typed_validation is not None else False,
+            "typed_evidence_error": typed_error,
+        }
+        if typed_evidence is not None:
+            data["typed_evidence_fields"] = sorted(typed_evidence.data)
+        if typed_validation is not None:
+            data["missing_fields"] = list(typed_validation.missing_fields)
+            data["rejected_by"] = list(typed_validation.rejected_by)
+            data["blocker"] = (
+                typed_validation.blocker.summary() if typed_validation.blocker is not None else None
+            )
+
+        await self._event_store.append(
+            BaseEvent(
+                type="execution.ac.typed_evidence.observed",
+                aggregate_type=runtime_identity.runtime_scope.aggregate_type,
+                aggregate_id=runtime_identity.session_scope_id,
+                data=data,
+            )
+        )
 
     async def _emit_subtask_event(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3549,7 +3549,7 @@ When complete, explicitly state: [TASK_COMPLETE]
                 typed_validation.blocker.summary() if typed_validation.blocker is not None else None
             )
 
-        await self._event_store.append(
+        await self._safe_emit_event(
             BaseEvent(
                 type="execution.ac.typed_evidence.observed",
                 aggregate_type=runtime_identity.runtime_scope.aggregate_type,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3374,6 +3374,19 @@ When complete, explicitly state: [TASK_COMPLETE]
 
             duration = (datetime.now(UTC) - start_time).total_seconds()
 
+            typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
+                final_message=final_message,
+                success=success,
+            )
+            await self._emit_atomic_typed_evidence_event(
+                runtime_identity=runtime_identity,
+                execution_id=execution_context_id,
+                session_id=ac_session_id,
+                ac_content=ac_content,
+                typed_evidence=typed_evidence,
+                typed_validation=typed_validation,
+                typed_error=typed_error,
+            )
             await self._emit_ac_runtime_event(
                 event_type=(
                     "execution.session.completed" if success else "execution.session.failed"
@@ -3388,19 +3401,6 @@ When complete, explicitly state: [TASK_COMPLETE]
                 error=None if success else final_message or "Implementation session failed",
             )
             clear_cached_runtime_handle = True
-            typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
-                final_message=final_message,
-                success=success,
-            )
-            await self._emit_atomic_typed_evidence_event(
-                runtime_identity=runtime_identity,
-                execution_id=execution_context_id,
-                session_id=ac_session_id,
-                ac_content=ac_content,
-                typed_evidence=typed_evidence,
-                typed_validation=typed_validation,
-                typed_error=typed_error,
-            )
 
             log.info(
                 "parallel_executor.ac.completed",

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -68,6 +68,7 @@ from ouroboros.orchestrator.events import (
 from ouroboros.orchestrator.evidence_schema import (
     EvidenceError,
     EvidenceRecord,
+    ProfileEvidenceConfigError,
     ValidationResult,
     extract_evidence,
     validate_evidence,
@@ -3505,6 +3506,8 @@ When complete, explicitly state: [TASK_COMPLETE]
         try:
             record = extract_evidence(final_message)
             validation = validate_evidence(self._execution_profile, record)
+        except ProfileEvidenceConfigError:
+            raise
         except EvidenceError as exc:
             return None, None, str(exc)
         return record, validation, None

--- a/src/ouroboros/orchestrator/parallel_executor_models.py
+++ b/src/ouroboros/orchestrator/parallel_executor_models.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
     from ouroboros.orchestrator.coordinator import CoordinatorReview
+    from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
     from ouroboros.orchestrator.level_context import LevelContext
 
 
@@ -52,6 +53,12 @@ class ACExecutionResult:
             the soft depth safety net forced atomic execution.
         outcome: Normalized result classification for aggregation.
         runtime_handle: Backend-neutral runtime handle for same-attempt resume.
+        typed_evidence: Parsed leaf evidence record observed at atomic
+            completion. Observe-only until the sequenced verifier/default gates.
+        typed_evidence_validation: Profile-schema validation result for
+            typed_evidence, if parsing succeeded.
+        typed_evidence_error: Parse/validation error observed at atomic
+            completion, if any. Does not change success semantics yet.
     """
 
     ac_index: int
@@ -69,6 +76,9 @@ class ACExecutionResult:
     decomposition_depth_warning: bool = False
     outcome: ACExecutionOutcome | None = None
     runtime_handle: RuntimeHandle | None = None
+    typed_evidence: EvidenceRecord | None = None
+    typed_evidence_validation: ValidationResult | None = None
+    typed_evidence_error: str | None = None
 
     def __post_init__(self) -> None:
         """Normalize outcome so callers do not infer from error strings."""

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -669,7 +669,7 @@ class TestParallelACExecutor:
                     ).bind_controls(terminate_callback=_terminate),
                 )
 
-        event_store, _ = _make_replaying_event_store()
+        event_store, appended_events = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=_StubImplementationRuntime(),
             event_store=event_store,
@@ -1023,7 +1023,7 @@ class TestParallelACExecutor:
                 )
             }
         )
-        event_store, _ = _make_replaying_event_store()
+        event_store, appended_events = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=_StubImplementationRuntime(),
             event_store=event_store,
@@ -1047,6 +1047,8 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error is not None
         assert "Unsupported rejected_if expression" in result.error
+        assert "execution.session.completed" not in {event.type for event in appended_events}
+        assert "execution.session.failed" in {event.type for event in appended_events}
 
     @pytest.mark.asyncio
     async def test_remembered_runtime_handle_preserves_live_controls(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -30,7 +30,7 @@ from ouroboros.orchestrator.parallel_executor import (
     render_parallel_completion_message,
     render_parallel_verification_report,
 )
-from ouroboros.orchestrator.profile_loader import load_profile
+from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
 
 
 def _make_seed(*acceptance_criteria: str) -> Seed:
@@ -962,6 +962,91 @@ class TestParallelACExecutor:
         assert all(
             event.type != "execution.ac.typed_evidence.observed" for event in appended_events
         )
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_profile_evidence_config_error_remains_loud(self) -> None:
+        """Profile-authored evidence-schema bugs must not be downgraded to telemetry."""
+
+        class _StubImplementationRuntime:
+            _runtime_handle_backend = "opencode"
+            _cwd = "/tmp/project"
+            _permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(
+                self,
+                prompt: str,
+                tools: list[str] | None = None,
+                system_prompt: str | None = None,
+                resume_handle: RuntimeHandle | None = None,
+                resume_session_id: str | None = None,
+            ):
+                del prompt, tools, system_prompt, resume_session_id
+                yield AgentMessage(
+                    type="result",
+                    content=(
+                        "Done.\n"
+                        "```json\n"
+                        '{"files_touched":["src/app.py"],'
+                        '"commands_run":["pytest"],'
+                        '"tests_passed":["tests/test_app.py"]}\n'
+                        "```"
+                    ),
+                    data={"subtype": "success"},
+                    resume_handle=RuntimeHandle(
+                        backend=resume_handle.backend if resume_handle is not None else "opencode",
+                        kind=resume_handle.kind
+                        if resume_handle is not None
+                        else "implementation_session",
+                        native_session_id="opencode-session-evidence",
+                        cwd=resume_handle.cwd if resume_handle is not None else "/tmp/project",
+                        metadata=dict(resume_handle.metadata) if resume_handle is not None else {},
+                    ),
+                )
+
+        profile = load_profile("code").model_copy(
+            update={
+                "evidence_schema": EvidenceSchema(
+                    required=("files_touched", "commands_run", "tests_passed"),
+                    rejected_if=("tests_passed != []",),
+                )
+            }
+        )
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_StubImplementationRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=profile,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Unsupported rejected_if expression" in result.error
 
     @pytest.mark.asyncio
     async def test_remembered_runtime_handle_preserves_live_controls(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -695,6 +695,188 @@ class TestParallelACExecutor:
         assert terminate_calls == 1
 
     @pytest.mark.asyncio
+    async def test_atomic_ac_observes_profile_typed_evidence_without_changing_success(self) -> None:
+        """Profile-backed atomic completion records typed evidence observe-only."""
+
+        class _StubImplementationRuntime:
+            _runtime_handle_backend = "opencode"
+            _cwd = "/tmp/project"
+            _permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(
+                self,
+                prompt: str,
+                tools: list[str] | None = None,
+                system_prompt: str | None = None,
+                resume_handle: RuntimeHandle | None = None,
+                resume_session_id: str | None = None,
+            ):
+                del prompt, tools, system_prompt, resume_session_id
+                yield AgentMessage(
+                    type="result",
+                    content=(
+                        "Done.\n"
+                        "```json\n"
+                        '{"files_touched":["src/app.py"],'
+                        '"commands_run":["pytest"],'
+                        '"tests_passed":["tests/test_app.py"]}\n'
+                        "```"
+                    ),
+                    data={"subtype": "success"},
+                    resume_handle=RuntimeHandle(
+                        backend=resume_handle.backend if resume_handle is not None else "opencode",
+                        kind=resume_handle.kind
+                        if resume_handle is not None
+                        else "implementation_session",
+                        native_session_id="opencode-session-evidence",
+                        cwd=resume_handle.cwd if resume_handle is not None else "/tmp/project",
+                        metadata=dict(resume_handle.metadata) if resume_handle is not None else {},
+                    ),
+                )
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_StubImplementationRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.typed_evidence is not None
+        assert result.typed_evidence.data["files_touched"] == ["src/app.py"]
+        assert result.typed_evidence_validation is not None
+        assert result.typed_evidence_validation.ok is True
+        assert result.typed_evidence_error is None
+
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["observe_only"] is True
+        assert evidence_event.data["enforced"] is False
+        assert evidence_event.data["typed_evidence_present"] is True
+        assert evidence_event.data["typed_evidence_valid"] is True
+        assert evidence_event.data["required_fields"] == [
+            "files_touched",
+            "commands_run",
+            "tests_passed",
+        ]
+        assert evidence_event.data["typed_evidence_fields"] == [
+            "commands_run",
+            "files_touched",
+            "tests_passed",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_records_typed_evidence_error_without_default_flip(self) -> None:
+        """Malformed typed evidence is observed but does not change legacy success."""
+
+        class _StubImplementationRuntime:
+            _runtime_handle_backend = "opencode"
+            _cwd = "/tmp/project"
+            _permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(
+                self,
+                prompt: str,
+                tools: list[str] | None = None,
+                system_prompt: str | None = None,
+                resume_handle: RuntimeHandle | None = None,
+                resume_session_id: str | None = None,
+            ):
+                del prompt, tools, system_prompt, resume_session_id
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE] no JSON evidence yet",
+                    data={"subtype": "success"},
+                    resume_handle=RuntimeHandle(
+                        backend=resume_handle.backend if resume_handle is not None else "opencode",
+                        kind=resume_handle.kind
+                        if resume_handle is not None
+                        else "implementation_session",
+                        native_session_id="opencode-session-no-evidence",
+                        cwd=resume_handle.cwd if resume_handle is not None else "/tmp/project",
+                        metadata=dict(resume_handle.metadata) if resume_handle is not None else {},
+                    ),
+                )
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_StubImplementationRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.typed_evidence is None
+        assert result.typed_evidence_validation is None
+        assert result.typed_evidence_error is not None
+
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["observe_only"] is True
+        assert evidence_event.data["enforced"] is False
+        assert evidence_event.data["typed_evidence_present"] is False
+        assert evidence_event.data["typed_evidence_valid"] is False
+        assert "Evidence is not valid JSON" in evidence_event.data["typed_evidence_error"]
+
+    @pytest.mark.asyncio
     async def test_remembered_runtime_handle_preserves_live_controls(self) -> None:
         """AC-scope rebinding should preserve live observe/terminate callbacks."""
         executor = _make_executor()

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -877,6 +877,93 @@ class TestParallelACExecutor:
         assert "Evidence is not valid JSON" in evidence_event.data["typed_evidence_error"]
 
     @pytest.mark.asyncio
+    async def test_atomic_ac_typed_evidence_event_failure_does_not_fail_success(self) -> None:
+        """Observe-only typed-evidence telemetry must not change AC success."""
+
+        class _StubImplementationRuntime:
+            _runtime_handle_backend = "opencode"
+            _cwd = "/tmp/project"
+            _permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(
+                self,
+                prompt: str,
+                tools: list[str] | None = None,
+                system_prompt: str | None = None,
+                resume_handle: RuntimeHandle | None = None,
+                resume_session_id: str | None = None,
+            ):
+                del prompt, tools, system_prompt, resume_session_id
+                yield AgentMessage(
+                    type="result",
+                    content=(
+                        "Done.\n"
+                        "```json\n"
+                        '{"files_touched":["src/app.py"],'
+                        '"commands_run":["pytest"],'
+                        '"tests_passed":["tests/test_app.py"]}\n'
+                        "```"
+                    ),
+                    data={"subtype": "success"},
+                    resume_handle=RuntimeHandle(
+                        backend=resume_handle.backend if resume_handle is not None else "opencode",
+                        kind=resume_handle.kind
+                        if resume_handle is not None
+                        else "implementation_session",
+                        native_session_id="opencode-session-evidence",
+                        cwd=resume_handle.cwd if resume_handle is not None else "/tmp/project",
+                        metadata=dict(resume_handle.metadata) if resume_handle is not None else {},
+                    ),
+                )
+
+        event_store, appended_events = _make_replaying_event_store()
+        original_append = event_store.append
+
+        async def _append(event: BaseEvent) -> None:
+            if event.type == "execution.ac.typed_evidence.observed":
+                raise RuntimeError("typed evidence telemetry failed")
+            await original_append(event)
+
+        event_store.append = AsyncMock(side_effect=_append)
+        executor = ParallelACExecutor(
+            adapter=_StubImplementationRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.typed_evidence is not None
+        assert all(
+            event.type != "execution.ac.typed_evidence.observed" for event in appended_events
+        )
+
+    @pytest.mark.asyncio
     async def test_remembered_runtime_handle_preserves_live_controls(self) -> None:
         """AC-scope rebinding should preserve live observe/terminate callbacks."""
         executor = _make_executor()


### PR DESCRIPTION
## Summary
- Observes typed evidence at the atomic AC completion boundary when an `ExecutionProfile` is active.
- Attaches parsed `EvidenceRecord`, `ValidationResult`, or parse/validation error metadata to `ACExecutionResult`.
- Emits `execution.ac.typed_evidence.observed` with `observe_only=true` and `enforced=false` so the harness can audit typed evidence without changing success semantics.

## #961 / #920 scope
This is the C.3 `#920 PR-2` slice after the #978 P2/P3 lineage:
- #993: EventStore→EvidenceManifest loader foundation
- #994: TraceGuard-compatible deliver-claim verdict adapter
- #996: read-only failure-taxonomy routing primitive

This PR intentionally does **not** enforce typed evidence, does not wire TraceGuard/default acceptance, and does not change live `ooo run` success behavior. It creates the atomic acceptance observation point needed before a later evidence-loop enforcement PR.

## Validation
- [x] `uv run ruff format src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py tests/unit/orchestrator/test_parallel_executor.py`
- [x] `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py tests/unit/orchestrator/test_parallel_executor.py`
- [x] `uv run mypy src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py tests/unit/orchestrator/test_parallel_executor.py`
- [x] `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q`
- [x] `uv run pytest tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_evidence_schema.py tests/unit/orchestrator/test_verifier.py -q`

Refs #920
Refs #961
