### PR TITLE
feat(orchestrator): govern profile leaf context (#920 PR-3)

### DIFF
--- a/src/ouroboros/orchestrator/context_governor.py
+++ b/src/ouroboros/orchestrator/context_governor.py
@@ -77,11 +77,16 @@ class SiblingStatus:
     """
 
     sibling_id: str
-    accepted: bool
+    accepted: bool | None
     headline: str = ""
 
     def to_line(self) -> str:
-        marker = "✓" if self.accepted else "✗"
+        if self.accepted is True:
+            marker = "✓"
+        elif self.accepted is False:
+            marker = "✗"
+        else:
+            marker = "…"
         head = f": {self.headline.strip()}" if self.headline else ""
         return f"{marker} {self.sibling_id}{head}"
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2789,16 +2789,16 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             # how often the hard governor would have rejected a leaf.
             return f"## Your Task ({label})\n{ac_content}", {
                 "context_governed": False,
-                "context_observe_only": True,
-                "context_enforced": False,
+                "context_acceptance_enforced": False,
+                "context_default_flipped": False,
                 "context_governance_error": str(exc),
                 "context_fallback": "legacy_prompt",
             }
         rendered = composed.render()
         audit = {
             "context_governed": True,
-            "context_observe_only": True,
-            "context_enforced": False,
+            "context_acceptance_enforced": False,
+            "context_default_flipped": False,
             "context_rendered_chars": len(rendered),
             "context_truncated": composed.truncated,
             "context_sibling_status_count": len(composed.sibling_lines),

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2761,15 +2761,16 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
 
         sibling_statuses: list[SiblingStatus] = []
         if sibling_acs and len(sibling_acs) > 1:
-            for idx, sibling_ac in enumerate(sibling_acs, start=1):
+            for sibling_ac in sibling_acs:
                 if sibling_ac == ac_content:
                     continue
+                sibling_id = f"sibling-{len(sibling_statuses) + 1}"
                 headline = " ".join(sibling_ac.split())
                 if len(headline) > _SIBLING_HEADLINE_CHARS:
                     headline = headline[:_SIBLING_HEADLINE_CHARS]
                 sibling_statuses.append(
                     SiblingStatus(
-                        sibling_id=f"sibling-{idx}",
+                        sibling_id=sibling_id,
                         accepted=None,
                         headline=headline,
                     )

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -219,6 +219,7 @@ _MEMORY_CHECK_INTERVAL_SECONDS = 5.0
 _MEMORY_WAIT_MAX_SECONDS = 120.0
 _MAX_LEAF_RESULT_CHARS = 1200
 _SIBLING_HEADLINE_CHARS = 80
+_SiblingACRef = tuple[int | None, str]
 
 
 def _get_available_memory_gb() -> float | None:
@@ -1560,8 +1561,10 @@ class ParallelACExecutor:
     ) -> list[ACExecutionResult | BaseException]:
         """Execute one batch of stage-ready ACs using the shared worker pool."""
         batch_results: list[ACExecutionResult | BaseException] = [None] * len(batch_indices)
-        sibling_acs = (
-            [seed.acceptance_criteria[i] for i in batch_indices] if len(batch_indices) > 1 else []
+        sibling_acs: list[_SiblingACRef] = (
+            [(i, seed.acceptance_criteria[i]) for i in batch_indices]
+            if len(batch_indices) > 1
+            else []
         )
 
         async def _run_ac(idx: int, ac_idx: int) -> None:
@@ -2266,7 +2269,7 @@ class ParallelACExecutor:
         depth: int = 0,
         execution_id: str = "",
         level_contexts: list[LevelContext] | None = None,
-        sibling_acs: list[str] | None = None,
+        sibling_acs: list[_SiblingACRef] | None = None,
         retry_attempt: int = 0,
         execution_counters: dict[str, int] | None = None,
         is_sub_ac: bool = False,
@@ -2744,10 +2747,11 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
     def _build_atomic_dispatch_context(
         self,
         *,
+        ac_index: int,
         ac_content: str,
         label: str,
         level_contexts: list[LevelContext] | None,
-        sibling_acs: list[str] | None,
+        sibling_acs: list[_SiblingACRef] | None,
     ) -> tuple[str, dict[str, Any] | None]:
         """Build the task section for an atomic leaf dispatch.
 
@@ -2761,8 +2765,8 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
 
         sibling_statuses: list[SiblingStatus] = []
         if sibling_acs and len(sibling_acs) > 1:
-            for sibling_ac in sibling_acs:
-                if sibling_ac == ac_content:
+            for sibling_index, sibling_ac in sibling_acs:
+                if sibling_index == ac_index:
                     continue
                 sibling_id = f"sibling-{len(sibling_statuses) + 1}"
                 headline = " ".join(sibling_ac.split())
@@ -3107,7 +3111,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         sub_ac_index: int | None = None,
         node_identity: ExecutionNodeIdentity | None = None,
         level_contexts: list[LevelContext] | None = None,
-        sibling_acs: list[str] | None = None,
+        sibling_acs: list[_SiblingACRef] | None = None,
         retry_attempt: int = 0,
         tool_catalog: tuple[MCPToolDefinition, ...] | None = None,
         execution_counters: dict[str, int] | None = None,
@@ -3135,6 +3139,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             indent = "  "
 
         task_section, context_governance_audit = self._build_atomic_dispatch_context(
+            ac_index=ac_index,
             ac_content=ac_content,
             label=label,
             level_contexts=level_contexts,
@@ -3159,7 +3164,9 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         # Build parallel awareness section
         parallel_section = ""
         if sibling_acs and len(sibling_acs) > 1:
-            other_acs = [ac for ac in sibling_acs if ac != ac_content]
+            other_acs = [
+                content for sibling_index, content in sibling_acs if sibling_index != ac_index
+            ]
             if other_acs:
                 context_is_governed = (
                     context_governance_audit is not None

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -51,6 +51,7 @@ from ouroboros.orchestrator.capabilities import (
     build_capability_graph,
     serialize_capability_graph,
 )
+from ouroboros.orchestrator.context_governor import SiblingStatus, compose_context
 from ouroboros.orchestrator.control_plane import (
     build_control_plane_state,
     serialize_control_plane_state,
@@ -217,6 +218,7 @@ _MIN_FREE_MEMORY_GB = 2.0
 _MEMORY_CHECK_INTERVAL_SECONDS = 5.0
 _MEMORY_WAIT_MAX_SECONDS = 120.0
 _MAX_LEAF_RESULT_CHARS = 1200
+_SIBLING_HEADLINE_CHARS = 80
 
 
 def _get_available_memory_gb() -> float | None:
@@ -2739,6 +2741,103 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             }
         }
 
+    def _build_atomic_dispatch_context(
+        self,
+        *,
+        ac_content: str,
+        label: str,
+        level_contexts: list[LevelContext] | None,
+        sibling_acs: list[str] | None,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """Build the task section for an atomic leaf dispatch.
+
+        Legacy execution keeps its historical prompt shape.  When an
+        ExecutionProfile is active, route parent/sibling/AC context through
+        the #830 H6 context governor so profile-backed leaves receive bounded,
+        deterministic context without flipping any evidence/verifier default.
+        """
+        if self._execution_profile is None:
+            return f"## Your Task ({label})\n{ac_content}", None
+
+        sibling_statuses: list[SiblingStatus] = []
+        if sibling_acs and len(sibling_acs) > 1:
+            for idx, sibling_ac in enumerate(sibling_acs, start=1):
+                if sibling_ac == ac_content:
+                    continue
+                headline = " ".join(sibling_ac.split())
+                if len(headline) > _SIBLING_HEADLINE_CHARS:
+                    headline = headline[:_SIBLING_HEADLINE_CHARS]
+                sibling_statuses.append(
+                    SiblingStatus(
+                        sibling_id=f"sibling-{idx}",
+                        accepted=None,
+                        headline=headline,
+                    )
+                )
+
+        try:
+            composed = compose_context(
+                ac=ac_content,
+                parent_summary=build_context_prompt(level_contexts or []),
+                siblings=sibling_statuses,
+            )
+        except ValueError as exc:
+            # This C.3 slice wires the governor into profile-backed dispatch
+            # without making budget failures an acceptance/default gate yet.
+            # Preserve execution by falling back to the legacy prompt shape and
+            # emit auditable metadata so later enforcement work can quantify
+            # how often the hard governor would have rejected a leaf.
+            return f"## Your Task ({label})\n{ac_content}", {
+                "context_governed": False,
+                "context_observe_only": True,
+                "context_enforced": False,
+                "context_governance_error": str(exc),
+                "context_fallback": "legacy_prompt",
+            }
+        rendered = composed.render()
+        audit = {
+            "context_governed": True,
+            "context_observe_only": True,
+            "context_enforced": False,
+            "context_rendered_chars": len(rendered),
+            "context_truncated": composed.truncated,
+            "context_sibling_status_count": len(composed.sibling_lines),
+            "context_parent_summary_present": bool(composed.parent_summary),
+        }
+        return f"## Governed Dispatch Context ({label})\n{rendered}", audit
+
+    async def _emit_atomic_context_governed_event(
+        self,
+        *,
+        runtime_identity: ACRuntimeIdentity,
+        execution_id: str,
+        session_id: str | None,
+        ac_content: str,
+        context_audit: dict[str, Any] | None,
+    ) -> None:
+        """Persist observe-only context-governor metadata for profile-backed leaves."""
+        if self._execution_profile is None or context_audit is None:
+            return
+
+        from ouroboros.events.base import BaseEvent
+
+        await self._safe_emit_event(
+            BaseEvent(
+                type="execution.ac.context_governed",
+                aggregate_type=runtime_identity.runtime_scope.aggregate_type,
+                aggregate_id=runtime_identity.session_scope_id,
+                data={
+                    **runtime_identity.to_metadata(),
+                    **self._decomposition_profile_metadata(),
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "acceptance_criterion": ac_content,
+                    "profile": self._execution_profile.profile,
+                    **context_audit,
+                },
+            )
+        )
+
     @staticmethod
     def _runtime_event_metadata(message: AgentMessage) -> dict[str, Any]:
         """Serialize shared runtime/tool metadata for execution-scoped events."""
@@ -3034,8 +3133,18 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             label = f"AC {ac_index + 1}"
             indent = "  "
 
-        # Build context section from previous levels
-        context_section = build_context_prompt(level_contexts or [])
+        task_section, context_governance_audit = self._build_atomic_dispatch_context(
+            ac_content=ac_content,
+            label=label,
+            level_contexts=level_contexts,
+            sibling_acs=sibling_acs,
+        )
+        legacy_context_section = (
+            ""
+            if context_governance_audit is not None
+            and context_governance_audit.get("context_governed") is True
+            else build_context_prompt(level_contexts or [])
+        )
 
         retry_section = ""
         if retry_attempt > 0:
@@ -3048,7 +3157,14 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
 
         # Build parallel awareness section
         parallel_section = ""
-        if sibling_acs and len(sibling_acs) > 1:
+        if (
+            (
+                context_governance_audit is None
+                or context_governance_audit.get("context_governed") is not True
+            )
+            and sibling_acs
+            and len(sibling_acs) > 1
+        ):
             other_acs = [ac for ac in sibling_acs if ac != ac_content]
             if other_acs:
                 other_list = "\n".join(f"- {ac[:80]}" for ac in other_acs)
@@ -3085,9 +3201,8 @@ Files present:
 ## Goal Context
 {seed_goal}
 
-## Your Task ({label})
-{ac_content}
-{context_section}{retry_section}{parallel_section}
+{task_section}
+{legacy_context_section}{retry_section}{parallel_section}
 Use the available tools to accomplish this task. Report your progress clearly.
 When complete, explicitly state: [TASK_COMPLETE]
 """
@@ -3135,6 +3250,13 @@ When complete, explicitly state: [TASK_COMPLETE]
             sub_ac_index=sub_ac_index,
             node_identity=node_identity,
             retry_attempt=retry_attempt,
+        )
+        await self._emit_atomic_context_governed_event(
+            runtime_identity=runtime_identity,
+            execution_id=execution_context_id,
+            session_id=session_id,
+            ac_content=ac_content,
+            context_audit=context_governance_audit,
         )
         lifecycle_event_type = (
             "execution.session.resumed"

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3158,23 +3158,28 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
 
         # Build parallel awareness section
         parallel_section = ""
-        if (
-            (
-                context_governance_audit is None
-                or context_governance_audit.get("context_governed") is not True
-            )
-            and sibling_acs
-            and len(sibling_acs) > 1
-        ):
+        if sibling_acs and len(sibling_acs) > 1:
             other_acs = [ac for ac in sibling_acs if ac != ac_content]
             if other_acs:
-                other_list = "\n".join(f"- {ac[:80]}" for ac in other_acs)
+                context_is_governed = (
+                    context_governance_audit is not None
+                    and context_governance_audit.get("context_governed") is True
+                )
+                if context_is_governed:
+                    other_list = (
+                        "Sibling tasks in progress are summarized in the governed "
+                        "sibling-status section above."
+                    )
+                else:
+                    other_list = "Sibling tasks in progress:\n" + "\n".join(
+                        f"- {ac[:80]}" for ac in other_acs
+                    )
                 parallel_section = (
                     "\n## Parallel Execution Notice\n"
                     "Other agents are working on sibling tasks concurrently. "
                     "Avoid modifying files that other agents are likely editing. "
                     "Focus on files directly related to YOUR task.\n\n"
-                    f"Sibling tasks in progress:\n{other_list}\n"
+                    f"{other_list}\n"
                 )
 
         # Scan the requested runtime workspace so prompts stay aligned with the actual task cwd.

--- a/tests/unit/orchestrator/test_context_governor.py
+++ b/tests/unit/orchestrator/test_context_governor.py
@@ -44,6 +44,12 @@ class TestSiblingStatus:
         assert "✗" in line
         assert "AC2" in line
 
+    def test_in_progress_marker(self) -> None:
+        line = SiblingStatus("AC3", accepted=None, headline="running").to_line()
+        assert "…" in line
+        assert "AC3" in line
+        assert "running" in line
+
 
 class TestComposedContext:
     def test_render_sections(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -220,7 +220,9 @@ class TestProfileAwareContextGovernance:
         assert "## Sibling status" in prompt
         assert "… sibling-1: Update sibling docs" in prompt
         assert "## AC\nImplement governed leaf" in prompt
-        assert "## Parallel Execution Notice" not in prompt
+        assert "## Parallel Execution Notice" in prompt
+        assert "Avoid modifying files that other agents are likely editing." in prompt
+        assert "summarized in the governed sibling-status section above" in prompt
 
         context_events = [
             event for event in appended_events if event.type == "execution.ac.context_governed"

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -218,7 +218,7 @@ class TestProfileAwareContextGovernance:
         assert "## Parent context" in prompt
         assert "Helper is ready" in prompt
         assert "## Sibling status" in prompt
-        assert "… sibling-2: Update sibling docs" in prompt
+        assert "… sibling-1: Update sibling docs" in prompt
         assert "## AC\nImplement governed leaf" in prompt
         assert "## Parallel Execution Notice" not in prompt
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -200,7 +200,7 @@ class TestProfileAwareContextGovernance:
 
         result = await executor._execute_atomic_ac(
             ac_index=1,
-            ac_content="Implement governed leaf",
+            ac_content="Implement duplicate leaf",
             session_id="sess_context",
             tools=["Read"],
             system_prompt="system",
@@ -209,7 +209,7 @@ class TestProfileAwareContextGovernance:
             start_time=datetime.now(UTC),
             execution_id="exec_context",
             level_contexts=[level_context],
-            sibling_acs=["Implement governed leaf", "Update sibling docs"],
+            sibling_acs=[(1, "Implement duplicate leaf"), (2, "Implement duplicate leaf")],
         )
 
         assert result.success is True
@@ -218,8 +218,8 @@ class TestProfileAwareContextGovernance:
         assert "## Parent context" in prompt
         assert "Helper is ready" in prompt
         assert "## Sibling status" in prompt
-        assert "… sibling-1: Update sibling docs" in prompt
-        assert "## AC\nImplement governed leaf" in prompt
+        assert "… sibling-1: Implement duplicate leaf" in prompt
+        assert "## AC\nImplement duplicate leaf" in prompt
         assert "## Parallel Execution Notice" in prompt
         assert "Avoid modifying files that other agents are likely editing." in prompt
         assert "summarized in the governed sibling-status section above" in prompt
@@ -310,7 +310,7 @@ class TestProfileAwareContextGovernance:
             start_time=datetime.now(UTC),
             execution_id="exec_legacy_context",
             level_contexts=[level_context],
-            sibling_acs=["Implement legacy leaf", "Update sibling docs"],
+            sibling_acs=[(1, "Implement legacy leaf"), (2, "Update sibling docs")],
         )
 
         assert result.success is True

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -227,8 +227,8 @@ class TestProfileAwareContextGovernance:
         ]
         assert len(context_events) == 1
         assert context_events[0].data["context_governed"] is True
-        assert context_events[0].data["context_observe_only"] is True
-        assert context_events[0].data["context_enforced"] is False
+        assert context_events[0].data["context_acceptance_enforced"] is False
+        assert context_events[0].data["context_default_flipped"] is False
         assert context_events[0].data["profile"] == "code"
         assert context_events[0].data["context_sibling_status_count"] == 1
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -131,6 +131,279 @@ class TestProfileAwareDecompositionAudit:
         assert event.data["decomposition_profile"] is None
 
 
+class TestProfileAwareContextGovernance:
+    @pytest.mark.asyncio
+    async def test_profile_backed_atomic_dispatch_uses_context_governor(self) -> None:
+        class _StubRuntime:
+            def __init__(self) -> None:
+                self.calls: list[dict[str, object]] = []
+                self._runtime_handle_backend = "opencode"
+                self._cwd = "/tmp/project"
+                self._permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(
+                self,
+                prompt: str,
+                tools: list[str] | None = None,
+                system_prompt: str | None = None,
+                resume_handle: RuntimeHandle | None = None,
+                resume_session_id: str | None = None,
+            ):
+                self.calls.append(
+                    {
+                        "prompt": prompt,
+                        "tools": tools,
+                        "system_prompt": system_prompt,
+                        "resume_handle": resume_handle,
+                        "resume_session_id": resume_session_id,
+                    }
+                )
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE]",
+                    data={"subtype": "success"},
+                    resume_handle=resume_handle,
+                )
+
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _StubRuntime()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+        )
+        level_context = LevelContext(
+            level_number=0,
+            completed_acs=(
+                ACContextSummary(
+                    ac_index=0,
+                    ac_content="Prepare helper",
+                    success=True,
+                    key_output="Helper is ready",
+                ),
+            ),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=1,
+            ac_content="Implement governed leaf",
+            session_id="sess_context",
+            tools=["Read"],
+            system_prompt="system",
+            seed_goal="Ship context governance",
+            depth=0,
+            start_time=datetime.now(UTC),
+            execution_id="exec_context",
+            level_contexts=[level_context],
+            sibling_acs=["Implement governed leaf", "Update sibling docs"],
+        )
+
+        assert result.success is True
+        prompt = runtime.calls[0]["prompt"]
+        assert "## Governed Dispatch Context (AC 2)" in prompt
+        assert "## Parent context" in prompt
+        assert "Helper is ready" in prompt
+        assert "## Sibling status" in prompt
+        assert "… sibling-2: Update sibling docs" in prompt
+        assert "## AC\nImplement governed leaf" in prompt
+        assert "## Parallel Execution Notice" not in prompt
+
+        context_events = [
+            event for event in appended_events if event.type == "execution.ac.context_governed"
+        ]
+        assert len(context_events) == 1
+        assert context_events[0].data["context_governed"] is True
+        assert context_events[0].data["context_observe_only"] is True
+        assert context_events[0].data["context_enforced"] is False
+        assert context_events[0].data["profile"] == "code"
+        assert context_events[0].data["context_sibling_status_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_legacy_atomic_dispatch_keeps_existing_context_prompt_shape(self) -> None:
+        class _StubRuntime:
+            def __init__(self) -> None:
+                self.calls: list[dict[str, object]] = []
+                self._runtime_handle_backend = "opencode"
+                self._cwd = "/tmp/project"
+                self._permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(
+                self,
+                prompt: str,
+                tools: list[str] | None = None,
+                system_prompt: str | None = None,
+                resume_handle: RuntimeHandle | None = None,
+                resume_session_id: str | None = None,
+            ):
+                self.calls.append(
+                    {
+                        "prompt": prompt,
+                        "tools": tools,
+                        "system_prompt": system_prompt,
+                        "resume_handle": resume_handle,
+                        "resume_session_id": resume_session_id,
+                    }
+                )
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE]",
+                    data={"subtype": "success"},
+                    resume_handle=resume_handle,
+                )
+
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _StubRuntime()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        level_context = LevelContext(
+            level_number=0,
+            completed_acs=(
+                ACContextSummary(
+                    ac_index=0,
+                    ac_content="Prepare helper",
+                    success=True,
+                    key_output="Helper is ready",
+                ),
+            ),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=1,
+            ac_content="Implement legacy leaf",
+            session_id="sess_legacy_context",
+            tools=["Read"],
+            system_prompt="system",
+            seed_goal="Ship legacy context",
+            depth=0,
+            start_time=datetime.now(UTC),
+            execution_id="exec_legacy_context",
+            level_contexts=[level_context],
+            sibling_acs=["Implement legacy leaf", "Update sibling docs"],
+        )
+
+        assert result.success is True
+        prompt = runtime.calls[0]["prompt"]
+        assert "## Your Task (AC 2)\nImplement legacy leaf" in prompt
+        assert "## Previous Work Context" in prompt
+        assert "## Parallel Execution Notice" in prompt
+        assert "## Governed Dispatch Context" not in prompt
+        assert not any(event.type == "execution.ac.context_governed" for event in appended_events)
+
+    @pytest.mark.asyncio
+    async def test_profile_context_governor_budget_error_falls_back_without_failing_ac(
+        self,
+    ) -> None:
+        class _StubRuntime:
+            def __init__(self) -> None:
+                self.calls: list[dict[str, object]] = []
+                self._runtime_handle_backend = "opencode"
+                self._cwd = "/tmp/project"
+                self._permission_mode = "acceptEdits"
+
+            @property
+            def runtime_backend(self) -> str:
+                return self._runtime_handle_backend
+
+            @property
+            def working_directory(self) -> str | None:
+                return self._cwd
+
+            @property
+            def permission_mode(self) -> str | None:
+                return self._permission_mode
+
+            async def execute_task(
+                self,
+                prompt: str,
+                tools: list[str] | None = None,
+                system_prompt: str | None = None,
+                resume_handle: RuntimeHandle | None = None,
+                resume_session_id: str | None = None,
+            ):
+                self.calls.append(
+                    {
+                        "prompt": prompt,
+                        "tools": tools,
+                        "system_prompt": system_prompt,
+                        "resume_handle": resume_handle,
+                        "resume_session_id": resume_session_id,
+                    }
+                )
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE]",
+                    data={"subtype": "success"},
+                    resume_handle=resume_handle,
+                )
+
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _StubRuntime()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+        )
+        oversized_ac = "x" * 13_000
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content=oversized_ac,
+            session_id="sess_context_fallback",
+            tools=["Read"],
+            system_prompt="system",
+            seed_goal="Ship context governance fallback",
+            depth=0,
+            start_time=datetime.now(UTC),
+            execution_id="exec_context_fallback",
+        )
+
+        assert result.success is True
+        prompt = runtime.calls[0]["prompt"]
+        assert "## Your Task (AC 1)" in prompt
+        assert "## Governed Dispatch Context" not in prompt
+        context_events = [
+            event for event in appended_events if event.type == "execution.ac.context_governed"
+        ]
+        assert len(context_events) == 1
+        assert context_events[0].data["context_governed"] is False
+        assert context_events[0].data["context_fallback"] == "legacy_prompt"
+        assert (
+            "AC alone exceeds context budget" in context_events[0].data["context_governance_error"]
+        )
+
+
 class TestParallelACExecutor:
     """Tests for staged hybrid result handling."""
 


### PR DESCRIPTION
## Summary

Implements the #961 C.3 / #920 PR-3 context-governance wiring slice for profile-backed atomic AC dispatch.

What changes:

- Profile-backed atomic leaves now route parent context, sibling status, and the AC body through `compose_context()` before dispatch.
- Legacy non-profile dispatch keeps the existing prompt shape and parallel-awareness section.
- In-progress sibling work is represented with a neutral `…` marker instead of reusing success/failure markers.
- Each profile-backed dispatch emits `execution.ac.context_governed` metadata with rendered size, truncation, sibling count, and profile metadata.
- Context-governor budget errors fall back to the legacy prompt and are recorded as `context_governance_error`; this PR does not make context budgets an acceptance/default gate.

## Milestone boundary

- C.3 only: context governance is wired into profile-backed leaf dispatch.
- No typed-evidence enforcement.
- No verifier/default flip.
- No change to legacy non-profile prompt behavior.
- `context_acceptance_enforced=false` and `context_default_flipped=false` are intentional until later #961 gates.

## Validation

- `uv run ruff check src/ouroboros/orchestrator/context_governor.py src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_context_governor.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run mypy src/ouroboros/orchestrator/context_governor.py src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_context_governor.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run pytest tests/unit/orchestrator/test_context_governor.py tests/unit/orchestrator/test_parallel_executor.py -q`

Part of #961. Advances #920 PR-3.
