### PR TITLE
test(harness): pin TraceGuard deliver fixtures (#978 Q4/Q5)

### DIFF
--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -384,10 +384,28 @@ def _traceguard_manifest(
 def _evidence_text(payload: object) -> str:
     if not isinstance(payload, Mapping):
         return str(payload)
+    context_parts: list[str] = []
+    child_ac_id = payload.get("child_ac_id")
+    if isinstance(child_ac_id, str) and child_ac_id.strip():
+        context_parts.append(f"child_ac_id={child_ac_id.strip()}")
+
+    tool_name = payload.get("tool_name")
+    if isinstance(tool_name, str) and tool_name in {"Edit", "Write", "NotebookEdit"}:
+        for key in ("args_preview", "result_preview"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                context_parts.append(value.strip())
+        if context_parts:
+            return "; ".join(context_parts)
+
     for key in ("result_preview", "args_preview", "tool_name"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
+            if context_parts:
+                return "; ".join([*context_parts, value.strip()])
             return value.strip()
+    if context_parts:
+        return "; ".join(context_parts)
     return str(dict(payload))
 
 

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -475,6 +475,11 @@ def _event_child_ac_id(*events: BaseEvent | None) -> str | None:
         value = event.data.get("child_ac_id")
         if isinstance(value, str) and value.strip():
             return value.strip()
+        extra = event.data.get("extra")
+        if isinstance(extra, Mapping):
+            value = extra.get("child_ac_id")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
     return None
 
 

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -321,8 +321,11 @@ def _tool_payload(
     duration_ms: int | None,
     is_error: bool | None,
     error_kind: str | None,
+    child_ac_id: str | None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {"tool_name": tool_name}
+    if child_ac_id is not None:
+        payload["child_ac_id"] = child_ac_id
     if args_preview is not None:
         payload["args_preview"] = args_preview
     if result_preview is not None:
@@ -465,6 +468,16 @@ def _slot_call_id(event: BaseEvent) -> str:
     return call_id.strip() if isinstance(call_id, str) else ""
 
 
+def _event_child_ac_id(*events: BaseEvent | None) -> str | None:
+    for event in events:
+        if event is None or not isinstance(event.data, dict):
+            continue
+        value = event.data.get("child_ac_id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def _build_tool_entry_for_returned(
     start_event: BaseEvent | None,
     returned_event: BaseEvent,
@@ -493,6 +506,7 @@ def _build_tool_entry_for_returned(
         duration_ms=returned_event.data.get("duration_ms"),
         is_error=is_error if isinstance(is_error, bool) else None,
         error_kind=returned_event.data.get("error_kind"),
+        child_ac_id=_event_child_ac_id(returned_event, start_event),
     )
 
     source_event_ids: list[str] = []
@@ -527,6 +541,7 @@ def _build_tool_entry_from_start_only(
         duration_ms=None,
         is_error=None,
         error_kind=None,
+        child_ac_id=_event_child_ac_id(start_event),
     )
     return EvidenceEntry(
         kind=_classify_tool_kind(tool_name.strip()),

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -512,7 +512,7 @@ class TestEvaluateDeliverClaim:
             TraceGuardEvidenceInput(
                 fact_id="file_modified:src/middleware/auth.ts:role_matrix_added",
                 chunk_id="ev_file_auth_middleware",
-                text="role_matrix_added",
+                text="path=src/middleware/auth.ts; scope=whole_file; role_matrix_added",
                 child_call_id="evt_edit_start,evt_edit_return",
             ),
         )
@@ -528,7 +528,7 @@ class TestEvaluateDeliverClaim:
                     ok=True,
                     payload={
                         "tool_name": "Bash",
-                        "result_preview": "AC-1 tests passed",
+                        "result_preview": "tests passed",
                         "child_ac_id": "AC-1",
                     },
                     source_event_ids=("evt_ac1_test",),
@@ -539,7 +539,8 @@ class TestEvaluateDeliverClaim:
                     kind=EvidenceKind.FILE_MODIFIED,
                     payload={
                         "tool_name": "Edit",
-                        "result_preview": "AC-2 docs updated",
+                        "args_preview": "path=docs/ac2.md; scope=whole_file",
+                        "result_preview": "docs updated",
                         "child_ac_id": "AC-2",
                     },
                     source_event_ids=("evt_ac2_edit",),
@@ -587,6 +588,20 @@ class TestEvaluateDeliverClaim:
                 "statement": "child_ac=AC-2 result=file_modified",
             },
         ]
+        assert validator.calls[0]["evidence_manifest"] == (
+            TraceGuardEvidenceInput(
+                fact_id="child_ac:AC-1:test_passed",
+                chunk_id="ev_child_ac_1",
+                text="child_ac_id=AC-1; tests passed",
+                child_call_id="evt_ac1_test",
+            ),
+            TraceGuardEvidenceInput(
+                fact_id="child_ac:AC-2:file_modified",
+                chunk_id="ev_child_ac_2",
+                text="child_ac_id=AC-2; path=docs/ac2.md; scope=whole_file; docs updated",
+                child_call_id="evt_ac2_edit",
+            ),
+        )
 
     def test_builds_traceguard_envelope_and_returns_accepted_verdict(self) -> None:
         manifest = EvidenceManifest(

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -48,7 +48,7 @@ def _tool_started(
                 "tool_name": tool_name,
                 "ac_id": ac_id,
                 "args_preview": args_preview,
-                "child_ac_id": child_ac_id,
+                "extra": {"child_ac_id": child_ac_id} if child_ac_id is not None else None,
                 "session_id": session_id,
                 "execution_id": execution_id,
             }.items()
@@ -85,7 +85,7 @@ def _tool_returned(
                 "is_error": False,
                 "duration_ms": 7,
                 "result_preview": result_preview,
-                "child_ac_id": child_ac_id,
+                "extra": {"child_ac_id": child_ac_id} if child_ac_id is not None else None,
                 "session_id": session_id,
                 "execution_id": execution_id,
             }.items()

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -15,7 +15,12 @@ from ouroboros.harness.deliver_gate import (
     evaluate_deliver_claim,
     load_ac_evidence_manifest,
 )
-from ouroboros.harness.journal import EvidenceEntry, EvidenceKind, EvidenceManifest
+from ouroboros.harness.journal import (
+    EvidenceEntry,
+    EvidenceKind,
+    EvidenceManifest,
+    normalize_events,
+)
 
 
 def _tool_started(
@@ -25,6 +30,9 @@ def _tool_started(
     aggregate_id: str = "exec_1",
     session_id: str | None = None,
     execution_id: str | None = None,
+    tool_name: str = "Bash",
+    args_preview: str | None = None,
+    child_ac_id: str | None = None,
     when: datetime,
 ) -> BaseEvent:
     return BaseEvent(
@@ -37,8 +45,10 @@ def _tool_started(
             key: value
             for key, value in {
                 "call_id": call_id,
-                "tool_name": "Bash",
+                "tool_name": tool_name,
                 "ac_id": ac_id,
+                "args_preview": args_preview,
+                "child_ac_id": child_ac_id,
                 "session_id": session_id,
                 "execution_id": execution_id,
             }.items()
@@ -54,10 +64,14 @@ def _tool_returned(
     aggregate_id: str = "exec_1",
     session_id: str | None = None,
     execution_id: str | None = None,
+    tool_name: str = "Bash",
+    result_preview: str | None = None,
+    child_ac_id: str | None = None,
+    event_id: str | None = None,
     when: datetime,
 ) -> BaseEvent:
     return BaseEvent(
-        id=f"evt_returned_{call_id}",
+        id=event_id or f"evt_returned_{call_id}",
         type="tool.call.returned",
         timestamp=when,
         aggregate_type="execution",
@@ -66,10 +80,12 @@ def _tool_returned(
             key: value
             for key, value in {
                 "call_id": call_id,
-                "tool_name": "Bash",
+                "tool_name": tool_name,
                 "ac_id": ac_id,
                 "is_error": False,
                 "duration_ms": 7,
+                "result_preview": result_preview,
+                "child_ac_id": child_ac_id,
                 "session_id": session_id,
                 "execution_id": execution_id,
             }.items()
@@ -519,33 +535,51 @@ class TestEvaluateDeliverClaim:
 
     def test_q5_fixture_parent_synthesis_lifts_multiple_child_ac_facts(self) -> None:
         """#978 Q5 fixture: parent synthesis can cite child AC evidence handles."""
-        manifest = EvidenceManifest(
+        base = datetime.now(UTC)
+        manifest = normalize_events(
+            [
+                _tool_started(
+                    call_id="ac1_test",
+                    ac_id="AC-PARENT",
+                    child_ac_id="AC-1",
+                    when=base,
+                ),
+                _tool_returned(
+                    call_id="ac1_test",
+                    ac_id="AC-PARENT",
+                    child_ac_id="AC-1",
+                    result_preview="tests passed",
+                    event_id="evt_ac1_test",
+                    when=base + timedelta(milliseconds=1),
+                ),
+                _tool_started(
+                    call_id="ac2_edit",
+                    ac_id="AC-PARENT",
+                    child_ac_id="AC-2",
+                    tool_name="Edit",
+                    args_preview="path=docs/ac2.md; scope=whole_file",
+                    when=base + timedelta(milliseconds=2),
+                ),
+                _tool_returned(
+                    call_id="ac2_edit",
+                    ac_id="AC-PARENT",
+                    child_ac_id="AC-2",
+                    tool_name="Edit",
+                    result_preview="docs updated",
+                    event_id="evt_ac2_edit",
+                    when=base + timedelta(milliseconds=3),
+                ),
+            ],
             ac_id="AC-PARENT",
-            metadata={"child_ac_ids": ("AC-1", "AC-2")},
-            entries=(
-                _manifest_entry(
-                    handle="ev_child_ac_1",
-                    ok=True,
-                    payload={
-                        "tool_name": "Bash",
-                        "result_preview": "tests passed",
-                        "child_ac_id": "AC-1",
-                    },
-                    source_event_ids=("evt_ac1_test",),
+        )
+        manifest = manifest.model_copy(
+            update={
+                "metadata": {"child_ac_ids": ("AC-1", "AC-2")},
+                "entries": (
+                    manifest.entries[0].model_copy(update={"handle": "ev_child_ac_1"}),
+                    manifest.entries[1].model_copy(update={"handle": "ev_child_ac_2"}),
                 ),
-                _manifest_entry(
-                    handle="ev_child_ac_2",
-                    ok=True,
-                    kind=EvidenceKind.FILE_MODIFIED,
-                    payload={
-                        "tool_name": "Edit",
-                        "args_preview": "path=docs/ac2.md; scope=whole_file",
-                        "result_preview": "docs updated",
-                        "child_ac_id": "AC-2",
-                    },
-                    source_event_ids=("evt_ac2_edit",),
-                ),
-            ),
+            }
         )
         claim = DeliverEvidenceClaim(
             ac_id="AC-PARENT",
@@ -575,7 +609,12 @@ class TestEvaluateDeliverClaim:
             "child_ac:AC-1:test_passed",
             "child_ac:AC-2:file_modified",
         )
-        assert verdict.evidence_event_ids == ("evt_ac1_test", "evt_ac2_edit")
+        assert verdict.evidence_event_ids == (
+            "evt_started_ac1_test",
+            "evt_ac1_test",
+            "evt_started_ac2_edit",
+            "evt_ac2_edit",
+        )
         assert validator.calls[0]["parent_synthesis"]["result"]["observed_facts"] == [
             {
                 "fact_id": "child_ac:AC-1:test_passed",
@@ -593,13 +632,13 @@ class TestEvaluateDeliverClaim:
                 fact_id="child_ac:AC-1:test_passed",
                 chunk_id="ev_child_ac_1",
                 text="child_ac_id=AC-1; tests passed",
-                child_call_id="evt_ac1_test",
+                child_call_id="evt_started_ac1_test,evt_ac1_test",
             ),
             TraceGuardEvidenceInput(
                 fact_id="child_ac:AC-2:file_modified",
                 chunk_id="ev_child_ac_2",
                 text="child_ac_id=AC-2; path=docs/ac2.md; scope=whole_file; docs updated",
-                child_call_id="evt_ac2_edit",
+                child_call_id="evt_started_ac2_edit,evt_ac2_edit",
             ),
         )
 

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -216,13 +216,15 @@ def _manifest_entry(
     handle: str,
     ok: bool | None,
     source_event_ids: tuple[str, ...],
+    kind: EvidenceKind = EvidenceKind.COMMAND_EXECUTED,
+    payload: dict[str, Any] | None = None,
 ) -> EvidenceEntry:
     return EvidenceEntry(
         handle=handle,
-        kind=EvidenceKind.COMMAND_EXECUTED,
+        kind=kind,
         ok=ok,
         started_at=datetime.now(UTC),
-        payload={"tool_name": "Bash", "result_preview": f"result for {handle}"},
+        payload=payload or {"tool_name": "Bash", "result_preview": f"result for {handle}"},
         source_event_ids=source_event_ids,
     )
 
@@ -446,6 +448,146 @@ class TestLoadAcEvidenceManifest:
 
 
 class TestEvaluateDeliverClaim:
+    def test_q4_fixture_file_modified_claim_uses_whole_file_path_scope(self) -> None:
+        """#978 Q4 fixture: file_modified claims cite a path-scoped edit handle.
+
+        The starter claim shape represents the brownfield boundary as a
+        whole-file path plus expected change. Diff-level validation belongs to a
+        later semantic/harness-check layer; this fixture pins the TraceGuard
+        structural surface that must exist before any C.4 default-flip work.
+        """
+        manifest = EvidenceManifest(
+            ac_id="AC-Q4",
+            entries=(
+                _manifest_entry(
+                    handle="ev_file_auth_middleware",
+                    ok=True,
+                    kind=EvidenceKind.FILE_MODIFIED,
+                    payload={
+                        "tool_name": "Edit",
+                        "args_preview": "path=src/middleware/auth.ts; scope=whole_file",
+                        "result_preview": "role_matrix_added",
+                    },
+                    source_event_ids=("evt_edit_start", "evt_edit_return"),
+                ),
+            ),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-Q4",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="file_modified:src/middleware/auth.ts:role_matrix_added",
+                    evidence_handle="ev_file_auth_middleware",
+                    statement=(
+                        "file_modified path=src/middleware/auth.ts "
+                        "scope=whole_file expected_change=role_matrix_added"
+                    ),
+                ),
+            ),
+        )
+        validator = _RecordingTraceGuardValidator()
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=validator,
+        )
+
+        assert verdict.accepted is True
+        assert verdict.accepted_fact_ids == (
+            "file_modified:src/middleware/auth.ts:role_matrix_added",
+        )
+        assert verdict.evidence_event_ids == ("evt_edit_start", "evt_edit_return")
+        assert validator.calls[0]["parent_synthesis"]["result"]["observed_facts"] == [
+            {
+                "fact_id": "file_modified:src/middleware/auth.ts:role_matrix_added",
+                "chunk_id": "ev_file_auth_middleware",
+                "statement": (
+                    "file_modified path=src/middleware/auth.ts "
+                    "scope=whole_file expected_change=role_matrix_added"
+                ),
+            }
+        ]
+        assert validator.calls[0]["evidence_manifest"] == (
+            TraceGuardEvidenceInput(
+                fact_id="file_modified:src/middleware/auth.ts:role_matrix_added",
+                chunk_id="ev_file_auth_middleware",
+                text="role_matrix_added",
+                child_call_id="evt_edit_start,evt_edit_return",
+            ),
+        )
+
+    def test_q5_fixture_parent_synthesis_lifts_multiple_child_ac_facts(self) -> None:
+        """#978 Q5 fixture: parent synthesis can cite child AC evidence handles."""
+        manifest = EvidenceManifest(
+            ac_id="AC-PARENT",
+            metadata={"child_ac_ids": ("AC-1", "AC-2")},
+            entries=(
+                _manifest_entry(
+                    handle="ev_child_ac_1",
+                    ok=True,
+                    payload={
+                        "tool_name": "Bash",
+                        "result_preview": "AC-1 tests passed",
+                        "child_ac_id": "AC-1",
+                    },
+                    source_event_ids=("evt_ac1_test",),
+                ),
+                _manifest_entry(
+                    handle="ev_child_ac_2",
+                    ok=True,
+                    kind=EvidenceKind.FILE_MODIFIED,
+                    payload={
+                        "tool_name": "Edit",
+                        "result_preview": "AC-2 docs updated",
+                        "child_ac_id": "AC-2",
+                    },
+                    source_event_ids=("evt_ac2_edit",),
+                ),
+            ),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-PARENT",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="child_ac:AC-1:test_passed",
+                    evidence_handle="ev_child_ac_1",
+                    statement="child_ac=AC-1 result=test_passed",
+                ),
+                DeliverEvidenceFact(
+                    fact_id="child_ac:AC-2:file_modified",
+                    evidence_handle="ev_child_ac_2",
+                    statement="child_ac=AC-2 result=file_modified",
+                ),
+            ),
+        )
+        validator = _RecordingTraceGuardValidator()
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=validator,
+        )
+
+        assert verdict.accepted is True
+        assert verdict.accepted_fact_ids == (
+            "child_ac:AC-1:test_passed",
+            "child_ac:AC-2:file_modified",
+        )
+        assert verdict.evidence_event_ids == ("evt_ac1_test", "evt_ac2_edit")
+        assert validator.calls[0]["parent_synthesis"]["result"]["observed_facts"] == [
+            {
+                "fact_id": "child_ac:AC-1:test_passed",
+                "chunk_id": "ev_child_ac_1",
+                "statement": "child_ac=AC-1 result=test_passed",
+            },
+            {
+                "fact_id": "child_ac:AC-2:file_modified",
+                "chunk_id": "ev_child_ac_2",
+                "statement": "child_ac=AC-2 result=file_modified",
+            },
+        ]
+
     def test_builds_traceguard_envelope_and_returns_accepted_verdict(self) -> None:
         manifest = EvidenceManifest(
             ac_id="AC-1",


### PR DESCRIPTION
## Summary

Adds the #961 hard-precondition fixtures for #978 Q4/Q5 before any C.4 PR opens.

What changes:

- Adds a Q4 `file_modified` deliver-gate fixture that pins the starter claim format as path-scoped whole-file evidence with an expected change.
- Adds a Q5 multi-AC parent-synthesis fixture proving a parent claim can lift facts from multiple child AC evidence handles through the deliver-gate adapter.
- Keeps this as deterministic test coverage only: no live `parallel_executor` wiring, no enforcement/default flip, and no benchmark/default-gate behavior change.

## Milestone boundary

- Satisfies the #961 hard precondition requiring one merged Q4 fixture and one merged Q5 fixture before C.4 work.
- Does not open #978 P4 benchmark work yet.
- Does not remove legacy self-report.

## Validation

- `uv run ruff check tests/unit/harness/test_deliver_gate.py`
- `uv run mypy tests/unit/harness/test_deliver_gate.py`
- `uv run pytest tests/unit/harness/test_deliver_gate.py tests/unit/harness/test_deliver_routing.py -q`

Part of #961. Advances #978 Q4/Q5 hard preconditions.
