### PR TITLE
feat(metrics): report semantic-miss baseline (#961)

### DIFF
--- a/docs/agentos/fat-harness-baseline-metrics.md
+++ b/docs/agentos/fat-harness-baseline-metrics.md
@@ -1,7 +1,7 @@
 # #961 fat-harness baseline metrics capture
 
 This is the recorded fixture baseline for the `agentos-substrate-wiring` gate.
-It captures the five #830/#961 hard-gate metrics without live model calls,
+It captures the #830/#961 hard-gate metrics without live model calls,
 without `parallel_executor` wiring, and without changing `ooo run` defaults.
 
 ```text
@@ -10,12 +10,14 @@ Fat-harness baseline report — profile=fat_harness_fixture_baseline · acs=8 ·
   [CAPT] one_shot_pass_rate                  : 0.5000 (target baseline + post-change measurement; target >= +10pp improvement)
   [PASS] k_recovery_rate                     : 0.7500 (target >= 70% of initially failed ACs recover within K=2)
   [PASS] fabrication_incidents_per_100_acs   : 0.0000 (target 0 verifier-detected fabrication incidents per 100 ACs)
+  [CAPT] semantic_miss_incidents_per_100_acs : 12.5000 (target sample and report evidence-backed-but-semantically-wrong incidents per 100 ACs)
   [CAPT] median_chars_per_ac                 : 1820.0000 (target capture baseline median chars per AC)
   [PASS] new_domain_cost                     : 42 (target <= 50 LOC and <= 1 YAML for one new profile/domain)
 --------------------------------------------------------------------------------
   one_shot_pass_rate                     : 0.5000
   k_recovery_rate                        : 0.7500
   fabrication_incidents_per_100_acs      : 0.0000
+  semantic_miss_incidents_per_100_acs    : 12.5000
   median_chars_per_ac                    : 1820.0000
   new_domain_loc_delta                   : 42
   new_domain_yaml_delta                  : 1
@@ -23,16 +25,16 @@ Fat-harness baseline report — profile=fat_harness_fixture_baseline · acs=8 ·
 
 ## Source sample rows
 
-| AC | source | accepted | attempts | fabrication | chars | note |
-|---|---|---:|---:|---:|---:|---|
-| FH-AC-001 | `fixture:thin-skill/decompose/accepted-first-try` | yes | 1 | 0 | 1600 | Verifier accepted the first atomic AC attempt. |
-| FH-AC-002 | `fixture:thin-skill/evidence/accepted-first-try` | yes | 1 | 0 | 1620 | Evidence manifest matched the expected file claim. |
-| FH-AC-003 | `fixture:profile/code/accepted-first-try` | yes | 1 | 0 | 1500 | Profile-aware prompt stayed inside the existing wrapper contract. |
-| FH-AC-004 | `fixture:verifier/pass/accepted-first-try` | yes | 1 | 0 | 1760 | Verifier accepted without retry or redispatch. |
-| FH-AC-005 | `fixture:retry/recovered-on-second-attempt` | yes | 2 | 0 | 1930 | Initial evidence miss recovered within K=2. |
-| FH-AC-006 | `fixture:retry/recovered-on-third-attempt` | yes | 3 | 0 | 2060 | Second retry produced accepted evidence within K=2. |
-| FH-AC-007 | `fixture:blocked/recovered-on-second-attempt` | yes | 2 | 0 | 1880 | Typed blocked evidence was resolved by a retry inside budget. |
-| FH-AC-008 | `fixture:retry/unrecovered-after-budget` | no | 3 | 0 | 2200 | Retry budget exhausted; counted in recovery denominator only. |
+| AC | source | accepted | attempts | fabrication | semantic miss | chars | note |
+|---|---|---:|---:|---:|---:|---:|---|
+| FH-AC-001 | `fixture:thin-skill/decompose/accepted-first-try` | yes | 1 | 0 | 0 | 1600 | Verifier accepted the first atomic AC attempt. |
+| FH-AC-002 | `fixture:thin-skill/evidence/accepted-first-try` | yes | 1 | 0 | 0 | 1620 | Evidence manifest matched the expected file claim. |
+| FH-AC-003 | `fixture:profile/code/accepted-first-try` | yes | 1 | 0 | 0 | 1500 | Profile-aware prompt stayed inside the existing wrapper contract. |
+| FH-AC-004 | `fixture:verifier/pass/accepted-first-try` | yes | 1 | 0 | 0 | 1760 | Verifier accepted without retry or redispatch. |
+| FH-AC-005 | `fixture:retry/recovered-on-second-attempt` | yes | 2 | 0 | 0 | 1930 | Initial evidence miss recovered within K=2. |
+| FH-AC-006 | `fixture:retry/recovered-on-third-attempt` | yes | 3 | 0 | 0 | 2060 | Second retry produced accepted evidence within K=2. |
+| FH-AC-007 | `fixture:blocked/recovered-on-second-attempt` | yes | 2 | 0 | 0 | 1880 | Typed blocked evidence was resolved by a retry inside budget. |
+| FH-AC-008 | `fixture:retry/unrecovered-after-budget` | no | 3 | 0 | 1 | 2200 | Retry budget exhausted; sampled as evidence-backed but semantically wrong for the semantic-miss baseline. |
 
 ## New-domain cost source
 
@@ -45,5 +47,6 @@ Fat-harness baseline report — profile=fat_harness_fixture_baseline · acs=8 ·
 - 1-shot AC pass rate is captured as the baseline for later post-change comparison.
 - K=2 recovery rate is measured against the >= 70% gate.
 - Fabrication incidents are measured as verifier-detected incidents per 100 ACs.
+- Semantic-miss incidents are sampled as evidence-backed-but-semantically-wrong incidents per 100 ACs.
 - Median chars per AC is captured as the token-budget proxy baseline.
 - New-domain cost is measured against <= 50 LOC + <= 1 YAML.

--- a/src/ouroboros/orchestrator/baseline_metrics.py
+++ b/src/ouroboros/orchestrator/baseline_metrics.py
@@ -2,8 +2,8 @@
 
 The AgentOS SSOT (#961) requires five baseline metrics before the
 `ooo run` fat-harness path can be treated as stronger by default:
-1-shot AC pass rate, K=2 recovery rate, fabrication incidents, char
-budget per AC, and new-domain cost. This module defines the deterministic
+1-shot AC pass rate, K=2 recovery rate, fabrication incidents,
+semantic-miss incidents, char budget per AC, and new-domain cost. This module defines the deterministic
 report shape and gate evaluation only; it does not invoke LLMs, run live
 executions, or wire into `parallel_executor` yet.
 """
@@ -46,6 +46,7 @@ class FatHarnessMetricSample:
     accepted: bool
     attempt_count: int
     fabrication_incidents: int = 0
+    semantic_miss_incidents: int = 0
     prompt_chars: int = 0
     completion_chars: int = 0
 
@@ -56,7 +57,12 @@ class FatHarnessMetricSample:
         if self.attempt_count < 1:
             msg = "attempt_count must be >= 1"
             raise ValueError(msg)
-        for field_name in ("fabrication_incidents", "prompt_chars", "completion_chars"):
+        for field_name in (
+            "fabrication_incidents",
+            "semantic_miss_incidents",
+            "prompt_chars",
+            "completion_chars",
+        ):
             if getattr(self, field_name) < 0:
                 msg = f"{field_name} must be non-negative"
                 raise ValueError(msg)
@@ -106,6 +112,7 @@ class FatHarnessMetricsReport:
     one_shot_pass_rate: float
     k_recovery_rate: float | None
     fabrication_incidents_per_100_acs: float
+    semantic_miss_incidents_per_100_acs: float
     median_chars_per_ac: float
     new_domain_loc_delta: int
     new_domain_yaml_delta: int
@@ -121,6 +128,7 @@ class FatHarnessMetricsReport:
                 "one_shot_pass_rate": self.one_shot_pass_rate,
                 "k_recovery_rate": self.k_recovery_rate,
                 "fabrication_incidents_per_100_acs": self.fabrication_incidents_per_100_acs,
+                "semantic_miss_incidents_per_100_acs": self.semantic_miss_incidents_per_100_acs,
                 "median_chars_per_ac": self.median_chars_per_ac,
                 "new_domain_loc_delta": self.new_domain_loc_delta,
                 "new_domain_yaml_delta": self.new_domain_yaml_delta,
@@ -183,6 +191,8 @@ def build_fat_harness_metrics_report(
 
     fabrication_incidents = sum(sample.fabrication_incidents for sample in sample_tuple)
     fabrication_incidents_per_100_acs = fabrication_incidents * 100 / total_acs
+    semantic_miss_incidents = sum(sample.semantic_miss_incidents for sample in sample_tuple)
+    semantic_miss_incidents_per_100_acs = semantic_miss_incidents * 100 / total_acs
     median_chars_per_ac = float(median(sample.total_chars for sample in sample_tuple))
 
     recovery_status = (
@@ -237,6 +247,16 @@ def build_fat_harness_metrics_report(
             rationale="Counts verifier-detected non-existent paths/symbols/sources.",
         ),
         FatHarnessGateResult(
+            name="semantic_miss_incidents_per_100_acs",
+            status=FatHarnessGateStatus.CAPTURED,
+            value=semantic_miss_incidents_per_100_acs,
+            target="sample and report evidence-backed-but-semantically-wrong incidents per 100 ACs",
+            rationale=(
+                "Counts claims backed by evidence handles where the evidence does not actually "
+                "satisfy the AC semantics."
+            ),
+        ),
+        FatHarnessGateResult(
             name="median_chars_per_ac",
             status=char_status,
             value=median_chars_per_ac,
@@ -266,6 +286,7 @@ def build_fat_harness_metrics_report(
         one_shot_pass_rate=one_shot_pass_rate,
         k_recovery_rate=k_recovery_rate,
         fabrication_incidents_per_100_acs=fabrication_incidents_per_100_acs,
+        semantic_miss_incidents_per_100_acs=semantic_miss_incidents_per_100_acs,
         median_chars_per_ac=median_chars_per_ac,
         new_domain_loc_delta=new_domain_loc_delta,
         new_domain_yaml_delta=new_domain_yaml_delta,

--- a/src/ouroboros/orchestrator/baseline_metrics.py
+++ b/src/ouroboros/orchestrator/baseline_metrics.py
@@ -1,6 +1,6 @@
 """Fixture-only fat-harness baseline metrics report (#961 / #830).
 
-The AgentOS SSOT (#961) requires five baseline metrics before the
+The AgentOS SSOT (#961) requires baseline metrics before the
 `ooo run` fat-harness path can be treated as stronger by default:
 1-shot AC pass rate, K=2 recovery rate, fabrication incidents, semantic-miss incidents, char budget per AC, and
 new-domain cost. This module defines the deterministic
@@ -155,7 +155,7 @@ def build_fat_harness_metrics_report(
     max_retries: int = DEFAULT_MAX_RETRIES,
     baseline_median_chars_per_ac: float | None = None,
 ) -> FatHarnessMetricsReport:
-    """Build a deterministic report for the five #961 fat-harness gates.
+    """Build a deterministic report for the #961 fat-harness gates.
 
     Args:
         profile: Execution profile name the samples came from.

--- a/src/ouroboros/orchestrator/baseline_metrics.py
+++ b/src/ouroboros/orchestrator/baseline_metrics.py
@@ -2,8 +2,8 @@
 
 The AgentOS SSOT (#961) requires five baseline metrics before the
 `ooo run` fat-harness path can be treated as stronger by default:
-1-shot AC pass rate, K=2 recovery rate, fabrication incidents,
-semantic-miss incidents, char budget per AC, and new-domain cost. This module defines the deterministic
+1-shot AC pass rate, K=2 recovery rate, fabrication incidents, semantic-miss incidents, char budget per AC, and
+new-domain cost. This module defines the deterministic
 report shape and gate evaluation only; it does not invoke LLMs, run live
 executions, or wire into `parallel_executor` yet.
 """
@@ -46,9 +46,9 @@ class FatHarnessMetricSample:
     accepted: bool
     attempt_count: int
     fabrication_incidents: int = 0
-    semantic_miss_incidents: int = 0
     prompt_chars: int = 0
     completion_chars: int = 0
+    semantic_miss_incidents: int = 0
 
     def __post_init__(self) -> None:
         if not self.ac_id:
@@ -112,11 +112,11 @@ class FatHarnessMetricsReport:
     one_shot_pass_rate: float
     k_recovery_rate: float | None
     fabrication_incidents_per_100_acs: float
-    semantic_miss_incidents_per_100_acs: float
     median_chars_per_ac: float
     new_domain_loc_delta: int
     new_domain_yaml_delta: int
     gates: tuple[FatHarnessGateResult, ...]
+    semantic_miss_incidents_per_100_acs: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         """Return a stable JSON-serializable report shape."""

--- a/src/ouroboros/orchestrator/baseline_metrics_capture.py
+++ b/src/ouroboros/orchestrator/baseline_metrics_capture.py
@@ -37,8 +37,8 @@ class BaselineMetricFixtureRow:
     prompt_chars: int
     completion_chars: int
     fabrication_incidents: int = 0
-    semantic_miss_incidents: int = 0
     note: str = ""
+    semantic_miss_incidents: int = 0
 
     def to_sample(self) -> FatHarnessMetricSample:
         """Convert this recorded row into the metric builder's sample type."""

--- a/src/ouroboros/orchestrator/baseline_metrics_capture.py
+++ b/src/ouroboros/orchestrator/baseline_metrics_capture.py
@@ -37,6 +37,7 @@ class BaselineMetricFixtureRow:
     prompt_chars: int
     completion_chars: int
     fabrication_incidents: int = 0
+    semantic_miss_incidents: int = 0
     note: str = ""
 
     def to_sample(self) -> FatHarnessMetricSample:
@@ -46,6 +47,7 @@ class BaselineMetricFixtureRow:
             accepted=self.accepted,
             attempt_count=self.attempt_count,
             fabrication_incidents=self.fabrication_incidents,
+            semantic_miss_incidents=self.semantic_miss_incidents,
             prompt_chars=self.prompt_chars,
             completion_chars=self.completion_chars,
         )
@@ -58,6 +60,7 @@ class BaselineMetricFixtureRow:
             "accepted": self.accepted,
             "attempt_count": self.attempt_count,
             "fabrication_incidents": self.fabrication_incidents,
+            "semantic_miss_incidents": self.semantic_miss_incidents,
             "prompt_chars": self.prompt_chars,
             "completion_chars": self.completion_chars,
             "total_chars": self.prompt_chars + self.completion_chars,
@@ -159,7 +162,11 @@ RECORDED_BASELINE_ROWS: tuple[BaselineMetricFixtureRow, ...] = (
         attempt_count=3,
         prompt_chars=1600,
         completion_chars=600,
-        note="Retry budget exhausted; counted in recovery denominator only.",
+        semantic_miss_incidents=1,
+        note=(
+            "Retry budget exhausted; sampled as evidence-backed but semantically wrong "
+            "for the semantic-miss baseline."
+        ),
     ),
 )
 
@@ -188,7 +195,7 @@ def render_captured_baseline_markdown(captured: CapturedBaselineMetrics | None =
         "# #961 fat-harness baseline metrics capture",
         "",
         "This is the recorded fixture baseline for the `agentos-substrate-wiring` gate.",
-        "It captures the five #830/#961 hard-gate metrics without live model calls,",
+        "It captures the #830/#961 hard-gate metrics without live model calls,",
         "without `parallel_executor` wiring, and without changing `ooo run` defaults.",
         "",
         "```text",
@@ -197,17 +204,18 @@ def render_captured_baseline_markdown(captured: CapturedBaselineMetrics | None =
         "",
         "## Source sample rows",
         "",
-        "| AC | source | accepted | attempts | fabrication | chars | note |",
-        "|---|---|---:|---:|---:|---:|---|",
+        "| AC | source | accepted | attempts | fabrication | semantic miss | chars | note |",
+        "|---|---|---:|---:|---:|---:|---:|---|",
     ]
     lines.extend(
         "| {ac_id} | `{source_ref}` | {accepted} | {attempt_count} | "
-        "{fabrication_incidents} | {chars} | {note} |".format(
+        "{fabrication_incidents} | {semantic_miss_incidents} | {chars} | {note} |".format(
             ac_id=row.ac_id,
             source_ref=row.source_ref,
             accepted="yes" if row.accepted else "no",
             attempt_count=row.attempt_count,
             fabrication_incidents=row.fabrication_incidents,
+            semantic_miss_incidents=row.semantic_miss_incidents,
             chars=row.prompt_chars + row.completion_chars,
             note=row.note,
         )
@@ -227,6 +235,7 @@ def render_captured_baseline_markdown(captured: CapturedBaselineMetrics | None =
             "- 1-shot AC pass rate is captured as the baseline for later post-change comparison.",
             "- K=2 recovery rate is measured against the >= 70% gate.",
             "- Fabrication incidents are measured as verifier-detected incidents per 100 ACs.",
+            "- Semantic-miss incidents are sampled as evidence-backed-but-semantically-wrong incidents per 100 ACs.",
             "- Median chars per AC is captured as the token-budget proxy baseline.",
             "- New-domain cost is measured against <= 50 LOC + <= 1 YAML.",
         ]

--- a/src/ouroboros/orchestrator/baseline_metrics_format.py
+++ b/src/ouroboros/orchestrator/baseline_metrics_format.py
@@ -88,6 +88,10 @@ def _render_metric_summary(report: FatHarnessMetricsReport) -> list[str]:
             "fabrication_incidents_per_100_acs",
             _format_value(report.fabrication_incidents_per_100_acs),
         ),
+        (
+            "semantic_miss_incidents_per_100_acs",
+            _format_value(report.semantic_miss_incidents_per_100_acs),
+        ),
         ("median_chars_per_ac", _format_value(report.median_chars_per_ac)),
         ("new_domain_loc_delta", str(report.new_domain_loc_delta)),
         ("new_domain_yaml_delta", str(report.new_domain_yaml_delta)),

--- a/src/ouroboros/orchestrator/baseline_metrics_format.py
+++ b/src/ouroboros/orchestrator/baseline_metrics_format.py
@@ -11,7 +11,7 @@ report and returns a string. No I/O, no LLM, no live execution. It
 is safe to call from CLI handlers, CI summaries, or test assertions.
 
 This module addresses a small but practical gap on the path to
-closing the ``agentos-substrate-wiring`` milestone — the 5 hard-gate
+closing the ``agentos-substrate-wiring`` milestone — the hard-gate
 baseline metrics must be reported in a human-checkable form so a
 maintainer can compare the values against the gate criteria without
 parsing JSON by hand. The report content itself (sample collection,

--- a/tests/unit/orchestrator/test_baseline_metrics.py
+++ b/tests/unit/orchestrator/test_baseline_metrics.py
@@ -36,6 +36,7 @@ def test_report_captures_five_baseline_gates() -> None:
                 accepted=False,
                 attempt_count=3,
                 fabrication_incidents=1,
+                semantic_miss_incidents=1,
                 prompt_chars=1300,
                 completion_chars=500,
             ),
@@ -48,6 +49,7 @@ def test_report_captures_five_baseline_gates() -> None:
     assert report.one_shot_pass_rate == pytest.approx(1 / 3)
     assert report.k_recovery_rate == pytest.approx(1 / 2)
     assert report.fabrication_incidents_per_100_acs == pytest.approx(100 / 3)
+    assert report.semantic_miss_incidents_per_100_acs == pytest.approx(100 / 3)
     assert report.median_chars_per_ac == 1400
     assert report.new_domain_loc_delta == 42
     assert report.new_domain_yaml_delta == 1
@@ -57,12 +59,14 @@ def test_report_captures_five_baseline_gates() -> None:
         "one_shot_pass_rate",
         "k_recovery_rate",
         "fabrication_incidents_per_100_acs",
+        "semantic_miss_incidents_per_100_acs",
         "median_chars_per_ac",
         "new_domain_cost",
     }
     assert gates["one_shot_pass_rate"].status == FatHarnessGateStatus.CAPTURED
     assert gates["k_recovery_rate"].status == FatHarnessGateStatus.FAIL
     assert gates["fabrication_incidents_per_100_acs"].status == FatHarnessGateStatus.FAIL
+    assert gates["semantic_miss_incidents_per_100_acs"].status == FatHarnessGateStatus.CAPTURED
     assert gates["median_chars_per_ac"].status == FatHarnessGateStatus.CAPTURED
     assert gates["new_domain_cost"].status == FatHarnessGateStatus.PASS
 
@@ -133,6 +137,7 @@ def test_report_is_json_serializable() -> None:
 
     assert payload["profile"] == "research"
     assert payload["metrics"]["median_chars_per_ac"] == 750
+    assert payload["metrics"]["semantic_miss_incidents_per_100_acs"] == 0
     assert payload["gates"]["median_chars_per_ac"]["status"] == "pass"
     json.dumps(payload)
 
@@ -210,6 +215,13 @@ def test_invalid_sample_values_are_rejected() -> None:
             accepted=True,
             attempt_count=1,
             fabrication_incidents=-1,
+        )
+    with pytest.raises(ValueError, match="non-negative"):
+        FatHarnessMetricSample(
+            ac_id="AC-1",
+            accepted=True,
+            attempt_count=1,
+            semantic_miss_incidents=-1,
         )
 
 

--- a/tests/unit/orchestrator/test_baseline_metrics.py
+++ b/tests/unit/orchestrator/test_baseline_metrics.py
@@ -9,6 +9,7 @@ import pytest
 from ouroboros.orchestrator.baseline_metrics import (
     FatHarnessGateStatus,
     FatHarnessMetricSample,
+    FatHarnessMetricsReport,
     build_fat_harness_metrics_report,
 )
 
@@ -91,6 +92,25 @@ def test_report_accepts_public_positional_arguments_and_passes_thresholds() -> N
     assert gates["fabrication_incidents_per_100_acs"].status == FatHarnessGateStatus.PASS
     assert gates["median_chars_per_ac"].status == FatHarnessGateStatus.PASS
     assert gates["new_domain_cost"].status == FatHarnessGateStatus.PASS
+
+
+def test_sample_positional_constructor_preserves_legacy_char_argument_order() -> None:
+    sample = FatHarnessMetricSample("AC-1", True, 1, 0, 123, 456)
+
+    assert sample.fabrication_incidents == 0
+    assert sample.prompt_chars == 123
+    assert sample.completion_chars == 456
+    assert sample.semantic_miss_incidents == 0
+
+
+def test_report_positional_constructor_preserves_legacy_gate_argument_order() -> None:
+    report = FatHarnessMetricsReport("code", 2, 1, 1.0, None, 0.0, 100.0, 42, 1, ())
+
+    assert report.median_chars_per_ac == 100.0
+    assert report.new_domain_loc_delta == 42
+    assert report.new_domain_yaml_delta == 1
+    assert report.gates == ()
+    assert report.semantic_miss_incidents_per_100_acs == 0.0
 
 
 def test_report_marks_char_budget_and_new_domain_cost_failures() -> None:

--- a/tests/unit/orchestrator/test_baseline_metrics_capture.py
+++ b/tests/unit/orchestrator/test_baseline_metrics_capture.py
@@ -17,7 +17,7 @@ from ouroboros.orchestrator.baseline_metrics_capture import (
 )
 
 
-def test_captured_baseline_records_all_five_gate_values() -> None:
+def test_captured_baseline_records_all_gate_values() -> None:
     captured = build_captured_baseline_metrics()
     report = captured.report
 
@@ -25,6 +25,7 @@ def test_captured_baseline_records_all_five_gate_values() -> None:
     assert report.one_shot_pass_rate == pytest.approx(0.5)
     assert report.k_recovery_rate == pytest.approx(0.75)
     assert report.fabrication_incidents_per_100_acs == 0
+    assert report.semantic_miss_incidents_per_100_acs == pytest.approx(12.5)
     assert report.median_chars_per_ac == pytest.approx(1820)
     assert report.new_domain_loc_delta == BASELINE_NEW_DOMAIN_LOC_DELTA == 42
     assert report.new_domain_yaml_delta == BASELINE_NEW_DOMAIN_YAML_DELTA == 1
@@ -34,12 +35,14 @@ def test_captured_baseline_records_all_five_gate_values() -> None:
         "one_shot_pass_rate",
         "k_recovery_rate",
         "fabrication_incidents_per_100_acs",
+        "semantic_miss_incidents_per_100_acs",
         "median_chars_per_ac",
         "new_domain_cost",
     }
     assert gates["one_shot_pass_rate"].status == FatHarnessGateStatus.CAPTURED
     assert gates["k_recovery_rate"].status == FatHarnessGateStatus.PASS
     assert gates["fabrication_incidents_per_100_acs"].status == FatHarnessGateStatus.PASS
+    assert gates["semantic_miss_incidents_per_100_acs"].status == FatHarnessGateStatus.CAPTURED
     assert gates["median_chars_per_ac"].status == FatHarnessGateStatus.CAPTURED
     assert gates["new_domain_cost"].status == FatHarnessGateStatus.PASS
 
@@ -63,6 +66,7 @@ def test_markdown_artifact_matches_renderer_output() -> None:
         "one_shot_pass_rate",
         "k_recovery_rate",
         "fabrication_incidents_per_100_acs",
+        "semantic_miss_incidents_per_100_acs",
         "median_chars_per_ac",
         "new_domain_cost",
     ):

--- a/tests/unit/orchestrator/test_baseline_metrics_capture.py
+++ b/tests/unit/orchestrator/test_baseline_metrics_capture.py
@@ -12,6 +12,7 @@ from ouroboros.orchestrator.baseline_metrics_capture import (
     BASELINE_NEW_DOMAIN_LOC_DELTA,
     BASELINE_NEW_DOMAIN_YAML_DELTA,
     RECORDED_BASELINE_ROWS,
+    BaselineMetricFixtureRow,
     build_captured_baseline_metrics,
     render_captured_baseline_markdown,
 )
@@ -55,6 +56,17 @@ def test_captured_baseline_keeps_source_rows_with_report() -> None:
     assert payload["sources"]["sample_rows"][0]["source_ref"].startswith("fixture:")
     assert payload["sources"]["new_domain_cost"]["loc_delta"] == 42
     json.dumps(payload)
+
+
+def test_fixture_row_positional_constructor_preserves_legacy_note_argument_order() -> None:
+    row = BaselineMetricFixtureRow("AC-1", "fixture:legacy", True, 1, 10, 20, 0, "legacy note")
+
+    assert row.note == "legacy note"
+    assert row.semantic_miss_incidents == 0
+    sample = row.to_sample()
+    assert sample.prompt_chars == 10
+    assert sample.completion_chars == 20
+    assert sample.semantic_miss_incidents == 0
 
 
 def test_markdown_artifact_matches_renderer_output() -> None:

--- a/tests/unit/orchestrator/test_baseline_metrics_format.py
+++ b/tests/unit/orchestrator/test_baseline_metrics_format.py
@@ -29,6 +29,7 @@ def _sample(
     accepted: bool,
     attempt_count: int = 1,
     fabrication_incidents: int = 0,
+    semantic_miss_incidents: int = 0,
     prompt_chars: int = 1000,
     completion_chars: int = 500,
 ) -> FatHarnessMetricSample:
@@ -37,6 +38,7 @@ def _sample(
         accepted=accepted,
         attempt_count=attempt_count,
         fabrication_incidents=fabrication_incidents,
+        semantic_miss_incidents=semantic_miss_incidents,
         prompt_chars=prompt_chars,
         completion_chars=completion_chars,
     )
@@ -92,6 +94,7 @@ class TestRenderBaselineReport:
             "one_shot_pass_rate",
             "k_recovery_rate",
             "fabrication_incidents_per_100_acs",
+            "semantic_miss_incidents_per_100_acs",
             "median_chars_per_ac",
             "new_domain_loc_delta",
             "new_domain_yaml_delta",


### PR DESCRIPTION
## Summary

Adds the remaining #961 hard-precondition metric before any C.4 PR opens: semantic-miss incidents sampled and reported alongside fabrication incidents.

What changes:

- Adds `semantic_miss_incidents` to `FatHarnessMetricSample`.
- Reports `semantic_miss_incidents_per_100_acs` in `FatHarnessMetricsReport.to_dict()` and the human-readable formatter.
- Updates the recorded baseline fixture rows with one evidence-backed-but-semantically-wrong sample.
- Regenerates `docs/agentos/fat-harness-baseline-metrics.md` so the durable artifact shows both fabrication and semantic-miss rates.

## Milestone boundary

- Satisfies the #961 semantic-miss hard precondition before C.4.
- Does not open #978 P4 benchmark work yet.
- Does not change live `ooo run`, `parallel_executor`, TraceGuard enforcement, or defaults.

## Validation

- `uv run ruff check src/ouroboros/orchestrator/baseline_metrics.py src/ouroboros/orchestrator/baseline_metrics_format.py src/ouroboros/orchestrator/baseline_metrics_capture.py tests/unit/orchestrator/test_baseline_metrics.py tests/unit/orchestrator/test_baseline_metrics_format.py tests/unit/orchestrator/test_baseline_metrics_capture.py`
- `uv run mypy src/ouroboros/orchestrator/baseline_metrics.py src/ouroboros/orchestrator/baseline_metrics_format.py src/ouroboros/orchestrator/baseline_metrics_capture.py tests/unit/orchestrator/test_baseline_metrics.py tests/unit/orchestrator/test_baseline_metrics_format.py tests/unit/orchestrator/test_baseline_metrics_capture.py`
- `uv run pytest tests/unit/orchestrator/test_baseline_metrics.py tests/unit/orchestrator/test_baseline_metrics_format.py tests/unit/orchestrator/test_baseline_metrics_capture.py -q`

Part of #961. Unblocks the next sequenced C.4 planning step only after this merges.
