### PR TITLE
feat(metrics): publish TraceGuard A/B benchmark (#978 P4)

### DIFF
--- a/docs/agentos/traceguard-vs-legacy-benchmark.md
+++ b/docs/agentos/traceguard-vs-legacy-benchmark.md
@@ -55,4 +55,5 @@ Fat-harness baseline report — profile=traceguard_deliver_gate_fixture · acs=8
 
 - TraceGuard reduces fixture fabrication incidents to 0 per 100 ACs.
 - Semantic misses remain visible and must be handled by later harness/semantic checks.
+- One-shot pass rate drops because unsupported legacy self-reports are rejected instead of counted as accepted.
 - Median chars stay within the <= 1.5x C.4 budget guardrail.

--- a/docs/agentos/traceguard-vs-legacy-benchmark.md
+++ b/docs/agentos/traceguard-vs-legacy-benchmark.md
@@ -1,0 +1,58 @@
+# #978 P4 TraceGuard vs legacy baseline benchmark
+
+Fixture-only A/B benchmark. No live model calls, no default flip,
+and no legacy self-report removal.
+
+## Legacy self-report
+
+```text
+Fat-harness baseline report — profile=legacy_self_report_fixture · acs=8 · K=2
+------------------------------------------------------------------------------
+  [CAPT] one_shot_pass_rate                  : 0.8750 (target baseline + post-change measurement; target >= +10pp improvement)
+  [FAIL] k_recovery_rate                     : 0.0000 (target >= 70% of initially failed ACs recover within K=2)
+  [FAIL] fabrication_incidents_per_100_acs   : 25.0000 (target 0 verifier-detected fabrication incidents per 100 ACs)
+  [CAPT] semantic_miss_incidents_per_100_acs : 25.0000 (target sample and report evidence-backed-but-semantically-wrong incidents per 100 ACs)
+  [CAPT] median_chars_per_ac                 : 1295.0000 (target capture baseline median chars per AC)
+  [PASS] new_domain_cost                     : 42 (target <= 50 LOC and <= 1 YAML for one new profile/domain)
+------------------------------------------------------------------------------
+  one_shot_pass_rate                     : 0.8750
+  k_recovery_rate                        : 0.0000
+  fabrication_incidents_per_100_acs      : 25.0000
+  semantic_miss_incidents_per_100_acs    : 25.0000
+  median_chars_per_ac                    : 1295.0000
+  new_domain_loc_delta                   : 42
+  new_domain_yaml_delta                  : 1
+```
+
+## TraceGuard deliver gate
+
+```text
+Fat-harness baseline report — profile=traceguard_deliver_gate_fixture · acs=8 · K=2
+-----------------------------------------------------------------------------------
+  [CAPT] one_shot_pass_rate                  : 0.5000 (target baseline + post-change measurement; target >= +10pp improvement)
+  [PASS] k_recovery_rate                     : 0.7500 (target >= 70% of initially failed ACs recover within K=2)
+  [PASS] fabrication_incidents_per_100_acs   : 0.0000 (target 0 verifier-detected fabrication incidents per 100 ACs)
+  [CAPT] semantic_miss_incidents_per_100_acs : 12.5000 (target sample and report evidence-backed-but-semantically-wrong incidents per 100 ACs)
+  [CAPT] median_chars_per_ac                 : 1820.0000 (target capture baseline median chars per AC)
+  [PASS] new_domain_cost                     : 42 (target <= 50 LOC and <= 1 YAML for one new profile/domain)
+-----------------------------------------------------------------------------------
+  one_shot_pass_rate                     : 0.5000
+  k_recovery_rate                        : 0.7500
+  fabrication_incidents_per_100_acs      : 0.0000
+  semantic_miss_incidents_per_100_acs    : 12.5000
+  median_chars_per_ac                    : 1820.0000
+  new_domain_loc_delta                   : 42
+  new_domain_yaml_delta                  : 1
+```
+
+## Delta
+
+- Fabrication incidents per 100 ACs: -25.0000
+- Semantic-miss incidents per 100 ACs: -12.5000
+- Median chars ratio: 1.4054
+
+## Gate interpretation
+
+- TraceGuard reduces fixture fabrication incidents to 0 per 100 ACs.
+- Semantic misses remain visible and must be handled by later harness/semantic checks.
+- Median chars stay within the <= 1.5x C.4 budget guardrail.

--- a/src/ouroboros/orchestrator/traceguard_benchmark_capture.py
+++ b/src/ouroboros/orchestrator/traceguard_benchmark_capture.py
@@ -1,0 +1,221 @@
+"""Offline TraceGuard-vs-legacy baseline benchmark for #978 P4.
+
+This module publishes the first C.4 benchmark surface required by #961.
+It is deliberately fixture-only: no live model calls, no `ooo run` default
+flip, and no removal of the legacy self-report path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ouroboros.orchestrator.baseline_metrics import (
+    DEFAULT_MAX_RETRIES,
+    FatHarnessMetricsReport,
+    build_fat_harness_metrics_report,
+)
+from ouroboros.orchestrator.baseline_metrics_capture import (
+    BASELINE_NEW_DOMAIN_LOC_DELTA,
+    BASELINE_NEW_DOMAIN_YAML_DELTA,
+    RECORDED_BASELINE_ROWS,
+    BaselineMetricFixtureRow,
+)
+from ouroboros.orchestrator.baseline_metrics_format import render_baseline_report
+
+BENCHMARK_PROFILE_LEGACY = "legacy_self_report_fixture"
+BENCHMARK_PROFILE_TRACEGUARD = "traceguard_deliver_gate_fixture"
+
+
+LEGACY_SELF_REPORT_ROWS: tuple[BaselineMetricFixtureRow, ...] = (
+    BaselineMetricFixtureRow(
+        "LEG-AC-001",
+        "fixture:legacy/self-report/accepted-unsupported-file",
+        True,
+        1,
+        900,
+        280,
+        fabrication_incidents=1,
+        note="Legacy self-report accepted a claim for a file absent from evidence.",
+    ),
+    BaselineMetricFixtureRow(
+        "LEG-AC-002",
+        "fixture:legacy/self-report/accepted-empty-test",
+        True,
+        1,
+        940,
+        260,
+        note="Evidence existed, but the cited test did not exercise the AC semantics.",
+        semantic_miss_incidents=1,
+    ),
+    BaselineMetricFixtureRow(
+        "LEG-AC-003",
+        "fixture:legacy/self-report/accepted-first-try",
+        True,
+        1,
+        1000,
+        300,
+        note="Ordinary accepted self-report.",
+    ),
+    BaselineMetricFixtureRow(
+        "LEG-AC-004",
+        "fixture:legacy/self-report/accepted-unsupported-symbol",
+        True,
+        1,
+        980,
+        310,
+        fabrication_incidents=1,
+        note="Legacy self-report accepted a non-existent symbol claim.",
+    ),
+    BaselineMetricFixtureRow(
+        "LEG-AC-005",
+        "fixture:legacy/self-report/accepted-semantic-miss",
+        True,
+        1,
+        1020,
+        330,
+        note="Evidence handle existed but did not satisfy the requested behavior.",
+        semantic_miss_incidents=1,
+    ),
+    BaselineMetricFixtureRow(
+        "LEG-AC-006",
+        "fixture:legacy/self-report/accepted-first-try",
+        True,
+        1,
+        1010,
+        340,
+        note="Ordinary accepted self-report.",
+    ),
+    BaselineMetricFixtureRow(
+        "LEG-AC-007",
+        "fixture:legacy/self-report/accepted-first-try",
+        True,
+        1,
+        970,
+        300,
+        note="Ordinary accepted self-report.",
+    ),
+    BaselineMetricFixtureRow(
+        "LEG-AC-008",
+        "fixture:legacy/self-report/failed",
+        False,
+        1,
+        1040,
+        350,
+        note="Legacy path failed without recovery routing.",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class TraceGuardBenchmarkCapture:
+    """A/B benchmark report for legacy self-report vs TraceGuard deliver gate."""
+
+    legacy_report: FatHarnessMetricsReport
+    traceguard_report: FatHarnessMetricsReport
+    legacy_rows: tuple[BaselineMetricFixtureRow, ...]
+    traceguard_rows: tuple[BaselineMetricFixtureRow, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "legacy": {
+                "report": self.legacy_report.to_dict(),
+                "rows": [row.to_dict() for row in self.legacy_rows],
+            },
+            "traceguard": {
+                "report": self.traceguard_report.to_dict(),
+                "rows": [row.to_dict() for row in self.traceguard_rows],
+            },
+            "delta": {
+                "fabrication_incidents_per_100_acs": (
+                    self.traceguard_report.fabrication_incidents_per_100_acs
+                    - self.legacy_report.fabrication_incidents_per_100_acs
+                ),
+                "semantic_miss_incidents_per_100_acs": (
+                    self.traceguard_report.semantic_miss_incidents_per_100_acs
+                    - self.legacy_report.semantic_miss_incidents_per_100_acs
+                ),
+                "median_chars_ratio": (
+                    self.traceguard_report.median_chars_per_ac
+                    / self.legacy_report.median_chars_per_ac
+                ),
+            },
+        }
+
+
+def _report(profile: str, rows: tuple[BaselineMetricFixtureRow, ...]) -> FatHarnessMetricsReport:
+    return build_fat_harness_metrics_report(
+        profile=profile,
+        samples=(row.to_sample() for row in rows),
+        new_domain_loc_delta=BASELINE_NEW_DOMAIN_LOC_DELTA,
+        new_domain_yaml_delta=BASELINE_NEW_DOMAIN_YAML_DELTA,
+        max_retries=DEFAULT_MAX_RETRIES,
+    )
+
+
+def build_traceguard_benchmark_capture() -> TraceGuardBenchmarkCapture:
+    """Build the recorded #978 P4 fixture benchmark."""
+    traceguard_rows = RECORDED_BASELINE_ROWS
+    return TraceGuardBenchmarkCapture(
+        legacy_report=_report(BENCHMARK_PROFILE_LEGACY, LEGACY_SELF_REPORT_ROWS),
+        traceguard_report=_report(BENCHMARK_PROFILE_TRACEGUARD, traceguard_rows),
+        legacy_rows=LEGACY_SELF_REPORT_ROWS,
+        traceguard_rows=traceguard_rows,
+    )
+
+
+def render_traceguard_benchmark_markdown(
+    capture: TraceGuardBenchmarkCapture | None = None,
+) -> str:
+    """Render the benchmark artifact for maintainer review."""
+    capture = build_traceguard_benchmark_capture() if capture is None else capture
+    data = capture.to_dict()["delta"]
+    lines = [
+        "# #978 P4 TraceGuard vs legacy baseline benchmark",
+        "",
+        "Fixture-only A/B benchmark. No live model calls, no default flip,",
+        "and no legacy self-report removal.",
+        "",
+        "## Legacy self-report",
+        "",
+        "```text",
+        render_baseline_report(capture.legacy_report),
+        "```",
+        "",
+        "## TraceGuard deliver gate",
+        "",
+        "```text",
+        render_baseline_report(capture.traceguard_report),
+        "```",
+        "",
+        "## Delta",
+        "",
+        f"- Fabrication incidents per 100 ACs: {data['fabrication_incidents_per_100_acs']:.4f}",
+        f"- Semantic-miss incidents per 100 ACs: {data['semantic_miss_incidents_per_100_acs']:.4f}",
+        f"- Median chars ratio: {data['median_chars_ratio']:.4f}",
+        "",
+        "## Gate interpretation",
+        "",
+        "- TraceGuard reduces fixture fabrication incidents to 0 per 100 ACs.",
+        "- Semantic misses remain visible and must be handled by later harness/semantic checks.",
+        "- Median chars stay within the <= 1.5x C.4 budget guardrail.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    print(render_traceguard_benchmark_markdown(), end="")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+
+
+__all__ = [
+    "BENCHMARK_PROFILE_LEGACY",
+    "BENCHMARK_PROFILE_TRACEGUARD",
+    "LEGACY_SELF_REPORT_ROWS",
+    "TraceGuardBenchmarkCapture",
+    "build_traceguard_benchmark_capture",
+    "render_traceguard_benchmark_markdown",
+]

--- a/src/ouroboros/orchestrator/traceguard_benchmark_capture.py
+++ b/src/ouroboros/orchestrator/traceguard_benchmark_capture.py
@@ -198,6 +198,7 @@ def render_traceguard_benchmark_markdown(
         "",
         "- TraceGuard reduces fixture fabrication incidents to 0 per 100 ACs.",
         "- Semantic misses remain visible and must be handled by later harness/semantic checks.",
+        "- One-shot pass rate drops because unsupported legacy self-reports are rejected instead of counted as accepted.",
         "- Median chars stay within the <= 1.5x C.4 budget guardrail.",
     ]
     return "\n".join(lines) + "\n"

--- a/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
+++ b/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
@@ -1,0 +1,46 @@
+"""Tests for the #978 P4 TraceGuard-vs-legacy fixture benchmark."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.orchestrator.traceguard_benchmark_capture import (
+    LEGACY_SELF_REPORT_ROWS,
+    build_traceguard_benchmark_capture,
+    render_traceguard_benchmark_markdown,
+)
+
+
+def test_traceguard_benchmark_reports_required_ab_metrics() -> None:
+    capture = build_traceguard_benchmark_capture()
+
+    assert capture.legacy_report.total_acs == len(LEGACY_SELF_REPORT_ROWS) == 8
+    assert capture.traceguard_report.total_acs == 8
+    assert capture.legacy_report.fabrication_incidents_per_100_acs == pytest.approx(25.0)
+    assert capture.traceguard_report.fabrication_incidents_per_100_acs == 0.0
+    assert capture.legacy_report.semantic_miss_incidents_per_100_acs == pytest.approx(25.0)
+    assert capture.traceguard_report.semantic_miss_incidents_per_100_acs == pytest.approx(12.5)
+    assert (
+        capture.traceguard_report.median_chars_per_ac / capture.legacy_report.median_chars_per_ac
+    ) <= 1.5
+
+
+def test_traceguard_benchmark_delta_is_json_serializable() -> None:
+    payload = build_traceguard_benchmark_capture().to_dict()
+
+    assert payload["delta"]["fabrication_incidents_per_100_acs"] == pytest.approx(-25.0)
+    assert payload["delta"]["semantic_miss_incidents_per_100_acs"] == pytest.approx(-12.5)
+    assert payload["delta"]["median_chars_ratio"] <= 1.5
+    json.dumps(payload)
+
+
+def test_traceguard_benchmark_markdown_artifact_matches_renderer() -> None:
+    expected = render_traceguard_benchmark_markdown()
+    artifact = Path("docs/agentos/traceguard-vs-legacy-benchmark.md").read_text()
+
+    assert artifact == expected
+    assert "Fabrication incidents per 100 ACs" in artifact
+    assert "Semantic-miss incidents per 100 ACs" in artifact


### PR DESCRIPTION
## Summary

Implements #978 P4 as an offline TraceGuard-vs-legacy A/B benchmark artifact.

What changes:

- Adds `traceguard_benchmark_capture.py` with deterministic fixture rows for legacy self-report vs TraceGuard deliver gate.
- Publishes fabrication-rate, semantic-miss-rate, and median-char-ratio deltas.
- Adds durable markdown artifact: `docs/agentos/traceguard-vs-legacy-benchmark.md`.
- Adds tests proving the benchmark reports the required C.4 metrics and stays JSON/render stable.

## Milestone boundary

- C.4 benchmark publication only.
- No live `parallel_executor` enforcement wiring.
- No `ooo run` default flip.
- No legacy self-report removal.

## Validation

- `uv run ruff check src/ouroboros/orchestrator/traceguard_benchmark_capture.py tests/unit/orchestrator/test_traceguard_benchmark_capture.py`
- `uv run mypy src/ouroboros/orchestrator/traceguard_benchmark_capture.py tests/unit/orchestrator/test_traceguard_benchmark_capture.py`
- `uv run pytest tests/unit/orchestrator/test_traceguard_benchmark_capture.py tests/unit/orchestrator/test_baseline_metrics.py tests/unit/orchestrator/test_baseline_metrics_capture.py -q`

Part of #961. Advances #978 P4 after #999 and #1000 satisfied the hard preconditions.
