### PR TITLE
Enable #920 PR-4 temporary fat-harness opt-in

### DIFF
--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -241,6 +241,25 @@ def _load_skip_completed_markers(
     return resolved
 
 
+def _resolve_fat_harness_mode(seed_data: dict[str, Any]) -> bool:
+    """Resolve the temporary #920 PR-4 fat-harness opt-in mode from seed config."""
+    orchestrator_config = seed_data.get("orchestrator")
+    if not isinstance(orchestrator_config, dict):
+        return False
+
+    execution_mode = orchestrator_config.get("execution_mode", "legacy")
+    if execution_mode in (None, "", "legacy"):
+        return False
+    if execution_mode == "fat_harness":
+        return True
+
+    print_error(
+        "seed.orchestrator.execution_mode must be 'legacy' or 'fat_harness' "
+        f"(got {execution_mode!r})"
+    )
+    raise typer.Exit(1)
+
+
 def _resolve_max_parallel_workers() -> int:
     """Resolve the parallel worker cap from environment, config, then default."""
     env_value = os.environ.get("OUROBOROS_MAX_PARALLEL_WORKERS", "").strip()
@@ -362,6 +381,7 @@ async def _run_orchestrator(
         seed_data,
         max_decomposition_depth,
     )
+    resolved_fat_harness_mode = _resolve_fat_harness_mode(seed_data)
     resolved_max_parallel_workers = _resolve_max_parallel_workers()
     externally_satisfied_acs: dict[int, dict[str, Any]] | None = None
     if skip_completed:
@@ -378,6 +398,8 @@ async def _run_orchestrator(
         print_info(f"Acceptance criteria: {len(seed.acceptance_criteria)}")
         print_info(f"Max decomposition depth: {resolved_max_decomposition_depth}")
         print_info(f"Max parallel workers: {resolved_max_parallel_workers}")
+        if resolved_fat_harness_mode:
+            print_info("Execution mode: fat_harness (temporary opt-in)")
         if externally_satisfied_acs:
             print_info(f"Externally satisfied ACs: {len(externally_satisfied_acs)}")
 
@@ -442,6 +464,7 @@ async def _run_orchestrator(
         task_workspace=workspace,
         max_decomposition_depth=resolved_max_decomposition_depth,
         max_parallel_workers=resolved_max_parallel_workers,
+        fat_harness_mode=resolved_fat_harness_mode,
     )
 
     # Execute

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -499,6 +499,7 @@ class ParallelACExecutor:
         inherited_runtime_handle: RuntimeHandle | None = None,
         task_cwd: str | None = None,
         execution_profile: ExecutionProfile | None = None,
+        fat_harness_mode: bool = False,
     ):
         """Initialize executor.
 
@@ -515,6 +516,8 @@ class ParallelACExecutor:
             task_cwd: Explicit working directory override for task execution metadata.
             execution_profile: Optional profile that makes decomposition split along
                 profile axis/min_unit instead of the legacy generic prompt.
+            fat_harness_mode: Temporary PR-4 opt-in mode that enforces
+                profile typed-evidence validation at atomic AC acceptance.
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -524,6 +527,7 @@ class ParallelACExecutor:
         self._inherited_runtime_handle = inherited_runtime_handle
         self._task_cwd = task_cwd
         self._execution_profile = execution_profile
+        self._fat_harness_mode = fat_harness_mode
         self._coordinator = LevelCoordinator(
             adapter,
             inherited_runtime_handle=inherited_runtime_handle,
@@ -3513,6 +3517,20 @@ When complete, explicitly state: [TASK_COMPLETE]
                 final_message=final_message,
                 success=success,
             )
+            fat_harness_error = self._fat_harness_acceptance_error(
+                runtime_success=success,
+                typed_evidence=typed_evidence,
+                typed_validation=typed_validation,
+                typed_error=typed_error,
+            )
+            result_final_message = final_message
+            if fat_harness_error is not None:
+                success = False
+                result_final_message = (
+                    f"{fat_harness_error}\n\nRuntime final message:\n{final_message}"
+                    if final_message
+                    else fat_harness_error
+                )
             await self._emit_atomic_typed_evidence_event(
                 runtime_identity=runtime_identity,
                 execution_id=execution_context_id,
@@ -3521,6 +3539,7 @@ When complete, explicitly state: [TASK_COMPLETE]
                 typed_evidence=typed_evidence,
                 typed_validation=typed_validation,
                 typed_error=typed_error,
+                enforcement_error=fat_harness_error,
             )
             await self._emit_ac_runtime_event(
                 event_type=(
@@ -3531,9 +3550,13 @@ When complete, explicitly state: [TASK_COMPLETE]
                 runtime_handle=runtime_handle,
                 execution_id=execution_context_id,
                 session_id=ac_session_id,
-                result_summary=final_message or None,
+                result_summary=result_final_message or None,
                 success=success,
-                error=None if success else final_message or "Implementation session failed",
+                error=(
+                    None
+                    if success
+                    else fat_harness_error or final_message or "Implementation session failed"
+                ),
             )
             clear_cached_runtime_handle = True
 
@@ -3551,7 +3574,7 @@ When complete, explicitly state: [TASK_COMPLETE]
                 ac_content=ac_content,
                 success=success,
                 messages=tuple(messages),
-                final_message=final_message,
+                final_message=result_final_message,
                 duration_seconds=duration,
                 session_id=ac_session_id,
                 retry_attempt=retry_attempt,
@@ -3560,6 +3583,7 @@ When complete, explicitly state: [TASK_COMPLETE]
                 typed_evidence=typed_evidence,
                 typed_evidence_validation=typed_validation,
                 typed_evidence_error=typed_error,
+                error=fat_harness_error,
             )
 
         except Exception as e:
@@ -3647,6 +3671,36 @@ When complete, explicitly state: [TASK_COMPLETE]
             return None, None, str(exc)
         return record, validation, None
 
+    def _fat_harness_acceptance_error(
+        self,
+        *,
+        runtime_success: bool,
+        typed_evidence: EvidenceRecord | None,
+        typed_validation: ValidationResult | None,
+        typed_error: str | None,
+    ) -> str | None:
+        """Return the opt-in fat-harness rejection reason for an atomic leaf."""
+        if not self._fat_harness_mode or not runtime_success:
+            return None
+        if self._execution_profile is None:
+            return "Fat-harness mode requires a loaded execution profile."
+        if typed_evidence is None:
+            return typed_error or "Fat-harness mode requires typed evidence."
+        if typed_validation is None:
+            return "Fat-harness mode could not validate typed evidence."
+        if typed_validation.ok:
+            return None
+
+        reasons: list[str] = []
+        if typed_validation.missing_fields:
+            reasons.append("missing fields: " + ", ".join(typed_validation.missing_fields))
+        if typed_validation.rejected_by:
+            reasons.append("rejected by: " + ", ".join(typed_validation.rejected_by))
+        if typed_validation.blocker is not None:
+            reasons.append("blocker: " + typed_validation.blocker.summary())
+        detail = "; ".join(reasons) if reasons else "profile evidence validation failed"
+        return f"Fat-harness typed evidence validation failed ({detail})."
+
     async def _emit_atomic_typed_evidence_event(
         self,
         *,
@@ -3657,8 +3711,9 @@ When complete, explicitly state: [TASK_COMPLETE]
         typed_evidence: EvidenceRecord | None,
         typed_validation: ValidationResult | None,
         typed_error: str | None,
+        enforcement_error: str | None = None,
     ) -> None:
-        """Persist observe-only typed-evidence metadata for atomic AC completion."""
+        """Persist typed-evidence metadata for atomic AC completion."""
         if self._execution_profile is None:
             return
 
@@ -3672,8 +3727,10 @@ When complete, explicitly state: [TASK_COMPLETE]
             "acceptance_criterion": ac_content,
             "profile": self._execution_profile.profile,
             "required_fields": list(self._execution_profile.evidence_schema.required),
-            "observe_only": True,
-            "enforced": False,
+            "observe_only": not self._fat_harness_mode,
+            "enforced": self._fat_harness_mode,
+            "fat_harness_mode": self._fat_harness_mode,
+            "enforcement_error": enforcement_error,
             "typed_evidence_present": typed_evidence is not None,
             "typed_evidence_valid": typed_validation.ok if typed_validation is not None else False,
             "typed_evidence_error": typed_error,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -415,6 +415,7 @@ class OrchestratorRunner:
         checkpoint_store: CheckpointStore | None = None,
         max_decomposition_depth: int = DEFAULT_MAX_DECOMPOSITION_DEPTH,
         max_parallel_workers: int = 3,
+        fat_harness_mode: bool = False,
     ) -> None:
         """Initialize orchestrator runner.
 
@@ -439,6 +440,9 @@ class OrchestratorRunner:
                         and recovery. When provided, enables per-level state snapshots.
             max_decomposition_depth: Maximum recursive AC decomposition depth.
             max_parallel_workers: Maximum concurrent AC workers for parallel execution.
+            fat_harness_mode: Temporary opt-in path that enforces profile
+                typed-evidence validation at atomic AC acceptance before the
+                #920 PR-5 default flip removes the opt-in selection.
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -455,6 +459,7 @@ class OrchestratorRunner:
         self._task_workspace = task_workspace
         self._max_decomposition_depth = max(0, max_decomposition_depth)
         self._max_parallel_workers = max(1, max_parallel_workers)
+        self._fat_harness_mode = fat_harness_mode
         # Track active session for external cancellation by execution_id
         self._active_sessions: dict[str, str] = {}  # execution_id -> session_id
 
@@ -1955,6 +1960,7 @@ class OrchestratorRunner:
         session_id: str | None = None,
         parallel: bool = True,
         externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
+        force_sequential_levels: bool = False,
     ) -> Result[OrchestratorResult, OrchestratorError]:
         """Execute seed via Claude Agent.
 
@@ -1970,6 +1976,8 @@ class OrchestratorRunner:
                      run concurrently. Default: True (parallel execution).
             externally_satisfied_acs: Top-level ACs already satisfied by the
                 current working tree and therefore skipped for re-execution.
+            force_sequential_levels: Preserve --sequential ordering while still
+                using the AC executor, primarily for temporary fat-harness opt-in.
 
         Returns:
             Result containing OrchestratorResult on success.
@@ -1985,6 +1993,8 @@ class OrchestratorRunner:
         }
         if externally_satisfied_acs:
             execute_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+        if force_sequential_levels:
+            execute_kwargs["force_sequential_levels"] = True
 
         return await self.execute_precreated_session(**execute_kwargs)
 
@@ -2038,6 +2048,7 @@ class OrchestratorRunner:
         tracker: SessionTracker,
         parallel: bool = True,
         externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
+        force_sequential_levels: bool = False,
     ) -> Result[OrchestratorResult, OrchestratorError]:
         """Execute a seed using an already-persisted orchestrator session."""
         exec_id = tracker.execution_id
@@ -2096,8 +2107,14 @@ class OrchestratorRunner:
                 activity_map=strategy.get_activity_map(),
             )
 
-            # Check for parallel execution mode
-            if parallel and len(seed.acceptance_criteria) > 1:
+            # Check for fat-harness / parallel execution mode. Fat-harness
+            # uses the AC executor even for single-AC or --sequential runs so
+            # the opt-in evidence gate is never silently bypassed.
+            if (
+                self._fat_harness_mode
+                or force_sequential_levels
+                or (parallel and len(seed.acceptance_criteria) > 1)
+            ):
                 parallel_kwargs: dict[str, Any] = {
                     "seed": seed,
                     "exec_id": exec_id,
@@ -2109,6 +2126,8 @@ class OrchestratorRunner:
                 }
                 if externally_satisfied_acs:
                     parallel_kwargs["externally_satisfied_acs"] = externally_satisfied_acs
+                if force_sequential_levels or (self._fat_harness_mode and not parallel):
+                    parallel_kwargs["force_sequential_levels"] = True
 
                 return await self._execute_parallel(**parallel_kwargs)
         except asyncio.CancelledError:
@@ -2607,6 +2626,7 @@ class OrchestratorRunner:
         system_prompt: str,
         start_time: datetime,
         externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
+        force_sequential_levels: bool = False,
     ) -> Result[OrchestratorResult, OrchestratorError]:
         """Execute seed with parallel AC execution.
 
@@ -2622,11 +2642,13 @@ class OrchestratorRunner:
             start_time: Execution start time.
             externally_satisfied_acs: Top-level ACs already satisfied by the
                 current working tree and therefore skipped for re-execution.
+            force_sequential_levels: Preserve --sequential ordering while still
+                using the AC executor, primarily for temporary fat-harness opt-in.
 
         Returns:
             Result containing OrchestratorResult on success.
         """
-        from ouroboros.orchestrator.dependency_analyzer import ACNode
+        from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
         from ouroboros.orchestrator.parallel_executor import (
             ParallelACExecutor,
             render_parallel_completion_message,
@@ -2641,30 +2663,38 @@ class OrchestratorRunner:
         )
 
         # Analyze dependencies
-        self._console.print("\n[cyan]Analyzing AC dependencies...[/cyan]")
-
-        analyzer = self._build_dependency_analyzer()
-        dep_result = await analyzer.analyze(seed.acceptance_criteria)
-
-        if dep_result.is_err:
-            log.warning(
-                "orchestrator.runner.dependency_analysis_failed",
-                execution_id=exec_id,
-                error=str(dep_result.error),
-            )
-            # Fallback: run all ACs in a single parallel level
-            from ouroboros.orchestrator.dependency_analyzer import DependencyGraph
-
-            all_indices = tuple(range(len(seed.acceptance_criteria)))
+        if force_sequential_levels:
+            self._console.print("\n[cyan]Preparing sequential AC execution plan...[/cyan]")
             dependency_graph = DependencyGraph(
                 nodes=tuple(
-                    ACNode(index=i, content=ac, depends_on=())
+                    ACNode(index=i, content=ac, depends_on=tuple(range(i)))
                     for i, ac in enumerate(seed.acceptance_criteria)
                 ),
-                execution_levels=(all_indices,) if all_indices else (),
+                execution_levels=tuple((i,) for i in range(len(seed.acceptance_criteria))),
             )
         else:
-            dependency_graph = dep_result.value
+            self._console.print("\n[cyan]Analyzing AC dependencies...[/cyan]")
+
+            analyzer = self._build_dependency_analyzer()
+            dep_result = await analyzer.analyze(seed.acceptance_criteria)
+
+            if dep_result.is_err:
+                log.warning(
+                    "orchestrator.runner.dependency_analysis_failed",
+                    execution_id=exec_id,
+                    error=str(dep_result.error),
+                )
+                # Fallback: run all ACs in a single parallel level
+                all_indices = tuple(range(len(seed.acceptance_criteria)))
+                dependency_graph = DependencyGraph(
+                    nodes=tuple(
+                        ACNode(index=i, content=ac, depends_on=())
+                        for i, ac in enumerate(seed.acceptance_criteria)
+                    ),
+                    execution_levels=(all_indices,) if all_indices else (),
+                )
+            else:
+                dependency_graph = dep_result.value
 
         execution_plan = dependency_graph.to_execution_plan()
 
@@ -2700,6 +2730,7 @@ class OrchestratorRunner:
             task_cwd=self._effective_cwd(),
             checkpoint_store=self._checkpoint_store,
             execution_profile=execution_profile,
+            fat_harness_mode=self._fat_harness_mode,
         )
 
         # Check for cancellation before starting parallel execution

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -11,6 +11,7 @@ import typer
 
 from ouroboros.cli.commands.run import (
     _load_skip_completed_markers,
+    _resolve_fat_harness_mode,
     _resolve_max_decomposition_depth,
     _resolve_max_parallel_workers,
     _run_orchestrator,
@@ -73,6 +74,25 @@ FAKE_VERIFICATION_ARTIFACTS = VerificationArtifacts(
     artifact_dir="/tmp/ouroboros-artifacts/exec-test",
     manifest_path="/tmp/ouroboros-artifacts/exec-test/manifest.json",
 )
+
+
+def test_resolve_fat_harness_mode_defaults_to_legacy() -> None:
+    """The temporary fat-harness path must not flip on by default."""
+    assert _resolve_fat_harness_mode(VALID_SEED_DATA) is False
+
+
+def test_resolve_fat_harness_mode_accepts_seed_execution_mode() -> None:
+    """PR-4 exposes opt-in mode through seed execution_mode, not a CLI flag."""
+    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "fat_harness"}}
+
+    assert _resolve_fat_harness_mode(seed_data) is True
+
+
+def test_resolve_fat_harness_mode_rejects_unknown_mode() -> None:
+    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "mystery"}}
+
+    with pytest.raises(typer.Exit):
+        _resolve_fat_harness_mode(seed_data)
 
 
 def test_resolve_max_decomposition_depth_defaults_to_two(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -260,6 +280,51 @@ async def test_run_orchestrator_passes_resolved_execution_caps_to_runner(tmp_pat
 
     assert mock_runner_cls.call_args.kwargs["max_decomposition_depth"] == 3
     assert mock_runner_cls.call_args.kwargs["max_parallel_workers"] == 7
+    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_orchestrator_passes_fat_harness_mode_to_runner(tmp_path: Path) -> None:
+    """Seed execution_mode selects the temporary #920 PR-4 fat-harness path."""
+    seed_file = tmp_path / "seed.yaml"
+    seed_file.write_text("goal: ignored\n", encoding="utf-8")
+
+    fake_exec = SimpleNamespace(
+        success=True,
+        session_id="sess-test",
+        messages_processed=5,
+        duration_seconds=1.0,
+        execution_id="exec-test",
+        summary={"verification_report": "Parallel Execution Verification Report"},
+        final_message="fallback final message",
+    )
+    mock_runner = MagicMock()
+    mock_runner.execute_seed = AsyncMock(return_value=Result.ok(fake_exec))
+    mock_runner.resume_session = AsyncMock()
+    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "fat_harness"}}
+
+    with (
+        patch("ouroboros.cli.commands.run._load_seed_from_yaml", return_value=seed_data),
+        patch("ouroboros.orchestrator.create_agent_runtime"),
+        patch(
+            "ouroboros.orchestrator.OrchestratorRunner", return_value=mock_runner
+        ) as mock_runner_cls,
+        patch("ouroboros.persistence.event_store.EventStore") as mock_event_store_cls,
+        patch(
+            "ouroboros.cli.commands.run.build_verification_artifacts",
+            new_callable=AsyncMock,
+            return_value=FAKE_VERIFICATION_ARTIFACTS,
+        ),
+        patch(
+            "ouroboros.mcp.tools.qa.QAHandler.handle",
+            new_callable=AsyncMock,
+            return_value=FAKE_QA_RESULT,
+        ),
+    ):
+        mock_event_store_cls.return_value.initialize = AsyncMock()
+        await _run_orchestrator(seed_file)
+
+    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -83,6 +83,52 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
     return event_store, appended_events
 
 
+class _FinalMessageRuntime:
+    """Minimal runtime that returns one successful final message with a handle."""
+
+    _runtime_handle_backend = "opencode"
+    _cwd = "/tmp/project"
+    _permission_mode = "acceptEdits"
+
+    def __init__(self, final_message: str, *, native_session_id: str) -> None:
+        self._final_message = final_message
+        self._native_session_id = native_session_id
+
+    @property
+    def runtime_backend(self) -> str:
+        return self._runtime_handle_backend
+
+    @property
+    def working_directory(self) -> str | None:
+        return self._cwd
+
+    @property
+    def permission_mode(self) -> str | None:
+        return self._permission_mode
+
+    async def execute_task(
+        self,
+        prompt: str,
+        tools: list[str] | None = None,
+        system_prompt: str | None = None,
+        resume_handle: RuntimeHandle | None = None,
+        resume_session_id: str | None = None,
+    ):
+        del prompt, tools, system_prompt, resume_session_id
+        yield AgentMessage(
+            type="result",
+            content=self._final_message,
+            data={"subtype": "success"},
+            resume_handle=RuntimeHandle(
+                backend=resume_handle.backend if resume_handle is not None else "opencode",
+                kind=resume_handle.kind if resume_handle is not None else "implementation_session",
+                native_session_id=self._native_session_id,
+                cwd=resume_handle.cwd if resume_handle is not None else "/tmp/project",
+                metadata=dict(resume_handle.metadata) if resume_handle is not None else {},
+            ),
+        )
+
+
 class TestProfileAwareDecompositionAudit:
     @pytest.mark.asyncio
     async def test_level_started_event_records_active_decomposition_profile(self) -> None:
@@ -1056,6 +1102,8 @@ class TestParallelACExecutor:
         )
         assert evidence_event.data["observe_only"] is True
         assert evidence_event.data["enforced"] is False
+        assert evidence_event.data["fat_harness_mode"] is False
+        assert evidence_event.data["enforcement_error"] is None
         assert evidence_event.data["typed_evidence_present"] is True
         assert evidence_event.data["typed_evidence_valid"] is True
         assert evidence_event.data["required_fields"] == [
@@ -1150,6 +1198,113 @@ class TestParallelACExecutor:
         assert evidence_event.data["typed_evidence_present"] is False
         assert evidence_event.data["typed_evidence_valid"] is False
         assert "Evidence is not valid JSON" in evidence_event.data["typed_evidence_error"]
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_mode_rejects_missing_typed_evidence(self) -> None:
+        """Temporary opt-in mode gates atomic success on profile evidence."""
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "[TASK_COMPLETE] no JSON evidence yet",
+                native_session_id="opencode-session-no-evidence",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Evidence is not valid JSON" in result.error
+        assert result.final_message.startswith("Evidence is not valid JSON")
+
+        report = render_parallel_verification_report(
+            ParallelExecutionResult(
+                results=(result,),
+                success_count=0,
+                failure_count=1,
+                total_messages=len(result.messages),
+            ),
+            total_acceptance_criteria=1,
+        )
+        assert "[FAILED]" in report
+        assert "Evidence is not valid JSON" in report
+        assert "Runtime final message:" in report
+
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["observe_only"] is False
+        assert evidence_event.data["enforced"] is True
+        assert evidence_event.data["fat_harness_mode"] is True
+        assert "Evidence is not valid JSON" in evidence_event.data["enforcement_error"]
+
+        terminal_event = next(
+            event for event in appended_events if event.type == "execution.session.failed"
+        )
+        assert "Evidence is not valid JSON" in terminal_event.data["error"]
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_mode_accepts_valid_typed_evidence(self) -> None:
+        """Valid profile evidence keeps the opt-in fat-harness leaf accepted."""
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/app.py"],'
+                '"commands_run":["pytest"],'
+                '"tests_passed":["tests/test_app.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["observe_only"] is False
+        assert evidence_event.data["enforced"] is True
+        assert evidence_event.data["fat_harness_mode"] is True
+        assert evidence_event.data["enforcement_error"] is None
+        assert evidence_event.data["typed_evidence_valid"] is True
 
     @pytest.mark.asyncio
     async def test_atomic_ac_typed_evidence_event_failure_does_not_fail_success(self) -> None:

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2104,6 +2104,263 @@ class TestOrchestratorRunner:
         assert profile is not None
         assert profile.profile == sample_seed.task_type == "code"
         assert profile.axis == "testable_unit"
+        assert captured_init["fat_harness_mode"] is False
+
+    @pytest.mark.asyncio
+    async def test_execute_parallel_passes_fat_harness_mode_to_executor(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Runner opt-in should reach the atomic executor without changing defaults."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            fat_harness_mode=True,
+        )
+        tracker = SessionTracker.create("exec_parallel", sample_seed.metadata.seed_id)
+        dependency_graph = DependencyGraph(
+            nodes=(ACNode(index=0, content=sample_seed.acceptance_criteria[0]),),
+            execution_levels=((0,),),
+        )
+        parallel_result = ParallelExecutionResult(
+            results=(
+                ACExecutionResult(
+                    ac_index=0,
+                    ac_content=sample_seed.acceptance_criteria[0],
+                    success=True,
+                    final_message="done",
+                ),
+            ),
+            success_count=1,
+            failure_count=0,
+            total_messages=1,
+        )
+        captured_init: dict[str, Any] = {}
+
+        class _FakeParallelExecutor:
+            def __init__(self, **kwargs: Any) -> None:
+                captured_init.update(kwargs)
+
+            async def execute_parallel(self, **kwargs: Any) -> ParallelExecutionResult:  # noqa: ARG002
+                return parallel_result
+
+        with (
+            patch(
+                "ouroboros.orchestrator.dependency_analyzer.DependencyAnalyzer.analyze",
+                AsyncMock(return_value=Result.ok(dependency_graph)),
+            ),
+            patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner._session_repo,
+                "mark_completed",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch(
+                "ouroboros.orchestrator.parallel_executor.ParallelACExecutor",
+                _FakeParallelExecutor,
+            ),
+        ):
+            result = await runner._execute_parallel(
+                seed=sample_seed,
+                exec_id="exec_parallel",
+                tracker=tracker,
+                merged_tools=["Read"],
+                tool_catalog=assemble_session_tool_catalog(["Read"]),
+                system_prompt="system",
+                start_time=tracker.start_time,
+            )
+
+        assert result.is_ok
+        assert captured_init["fat_harness_mode"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_single_ac_uses_ac_executor_path(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Single-AC fat-harness runs must not bypass the typed-evidence gate."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        single_ac_seed = sample_seed.model_copy(
+            update={"acceptance_criteria": (sample_seed.acceptance_criteria[0],)}
+        )
+        tracker = SessionTracker.create("exec_single", single_ac_seed.metadata.seed_id)
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            fat_harness_mode=True,
+        )
+        expected = Result.ok(
+            OrchestratorResult(
+                success=True,
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+        )
+
+        with (
+            patch.object(runner, "_check_startup_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner,
+                "_get_merged_tools",
+                AsyncMock(return_value=(["Read"], None, assemble_session_tool_catalog(["Read"]))),
+            ),
+            patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
+        ):
+            result = await runner.execute_precreated_session(
+                single_ac_seed,
+                tracker,
+                parallel=True,
+            )
+
+        assert result is expected
+        assert execute.await_args.kwargs["seed"] is single_ac_seed
+        assert "force_sequential_levels" not in execute.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_sequential_run_uses_sequential_ac_executor_plan(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """--sequential plus fat-harness should preserve ordering and enforce AC gates."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        tracker = SessionTracker.create("exec_sequential", sample_seed.metadata.seed_id)
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            fat_harness_mode=True,
+        )
+        expected = Result.ok(
+            OrchestratorResult(
+                success=True,
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+        )
+
+        with (
+            patch.object(runner, "_check_startup_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner,
+                "_get_merged_tools",
+                AsyncMock(return_value=(["Read"], None, assemble_session_tool_catalog(["Read"]))),
+            ),
+            patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
+        ):
+            result = await runner.execute_precreated_session(sample_seed, tracker, parallel=False)
+
+        assert result is expected
+        assert execute.await_args.kwargs["force_sequential_levels"] is True
+
+    @pytest.mark.asyncio
+    async def test_force_sequential_levels_direct_caller_uses_ac_executor_path(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Direct runner callers can request one-AC-per-stage executor routing."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        tracker = SessionTracker.create("exec_forced", sample_seed.metadata.seed_id)
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        expected = Result.ok(
+            OrchestratorResult(
+                success=True,
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+        )
+
+        with (
+            patch.object(runner, "_check_startup_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner,
+                "_get_merged_tools",
+                AsyncMock(return_value=(["Read"], None, assemble_session_tool_catalog(["Read"]))),
+            ),
+            patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
+        ):
+            result = await runner.execute_precreated_session(
+                sample_seed,
+                tracker,
+                force_sequential_levels=True,
+            )
+
+        assert result is expected
+        assert execute.await_args.kwargs["force_sequential_levels"] is True
+
+    @pytest.mark.asyncio
+    async def test_force_sequential_levels_preserves_one_ac_per_stage(
+        self,
+        runner: OrchestratorRunner,
+        sample_seed: Seed,
+    ) -> None:
+        """The AC executor can honor --sequential without dependency analysis."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        tracker = SessionTracker.create("exec_parallel", sample_seed.metadata.seed_id)
+        parallel_result = ParallelExecutionResult(
+            results=(
+                ACExecutionResult(
+                    ac_index=0,
+                    ac_content=sample_seed.acceptance_criteria[0],
+                    success=True,
+                    final_message="done",
+                ),
+            ),
+            success_count=1,
+            failure_count=0,
+            total_messages=1,
+        )
+
+        with (
+            patch.object(runner, "_check_cancellation", AsyncMock(return_value=False)),
+            patch.object(
+                runner._session_repo,
+                "mark_completed",
+                AsyncMock(return_value=Result.ok(None)),
+            ),
+            patch(
+                "ouroboros.orchestrator.parallel_executor.ParallelACExecutor.execute_parallel",
+                AsyncMock(return_value=parallel_result),
+            ) as execute,
+            patch.object(runner, "_build_dependency_analyzer") as analyzer_factory,
+        ):
+            result = await runner._execute_parallel(
+                seed=sample_seed,
+                exec_id="exec_parallel",
+                tracker=tracker,
+                merged_tools=["Read"],
+                tool_catalog=assemble_session_tool_catalog(["Read"]),
+                system_prompt="system",
+                start_time=tracker.start_time,
+                force_sequential_levels=True,
+            )
+
+        assert result.is_ok
+        analyzer_factory.assert_not_called()
+        execution_plan = execute.await_args.kwargs["execution_plan"]
+        assert execution_plan.execution_levels == ((0,), (1,), (2,))
+        assert execution_plan.get_dependencies(0) == ()
+        assert execution_plan.get_dependencies(1) == (0,)
+        assert execution_plan.get_dependencies(2) == (0, 1)
 
     @pytest.mark.asyncio
     async def test_execute_parallel_builds_dependency_analyzer_with_llm_adapter(


### PR DESCRIPTION
## Summary

Implements the #920 PR-4 temporary opt-in fat-harness mode after the #978 P4 benchmark gate:

- adds seed-scoped `orchestrator.execution_mode: fat_harness` routing for `ooo run` without adding a public CLI flag
- threads that mode through `OrchestratorRunner` into `ParallelACExecutor`
- enforces the profile typed-evidence validation result at atomic AC acceptance only when the temporary mode is selected
- keeps the default `ooo run` path legacy/observe-only until #920 PR-5 performs the default flip

Refs #920 and #961.

## Milestone / sequencing notes

This intentionally does **not** default-flip `ooo run` and does **not** remove the legacy self-report path. The temporary seed-scoped opt-in is meant to support last-mile A/B before #920 PR-5; the commit directive records that this selection should be removed when fat-harness becomes the default.

## Validation

- `PYTHONPATH=src pytest -q tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py`
- `PYTHONPATH=src ruff check src/ouroboros/cli/commands/run.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py`
- `git diff --check`

## Not tested

- Live `ooo run` against a real agent backend.
