### PR TITLE
Flip #920 fat-harness mode to default

### DIFF
--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -242,22 +242,25 @@ def _load_skip_completed_markers(
 
 
 def _resolve_fat_harness_mode(seed_data: dict[str, Any]) -> bool:
-    """Resolve the temporary #920 PR-4 fat-harness opt-in mode from seed config."""
+    """Default CLI runs to fat-harness after #920 PR-5.
+
+    ``seed.orchestrator.execution_mode`` was the temporary #920 PR-4 opt-in
+    selector. After the default flip it is accepted only as a no-op
+    compatibility shim so existing seeds and resumptions are not stranded.
+    """
     orchestrator_config = seed_data.get("orchestrator")
     if not isinstance(orchestrator_config, dict):
-        return False
-
-    execution_mode = orchestrator_config.get("execution_mode", "legacy")
-    if execution_mode in (None, "", "legacy"):
-        return False
-    if execution_mode == "fat_harness":
         return True
 
-    print_error(
-        "seed.orchestrator.execution_mode must be 'legacy' or 'fat_harness' "
-        f"(got {execution_mode!r})"
-    )
-    raise typer.Exit(1)
+    execution_mode = orchestrator_config.get("execution_mode")
+    if execution_mode not in (None, "", "fat_harness", "legacy"):
+        print_error(
+            "seed.orchestrator.execution_mode is no longer configurable after "
+            f"the fat-harness default flip (got {execution_mode!r})."
+        )
+        raise typer.Exit(1)
+
+    return True
 
 
 def _resolve_max_parallel_workers() -> int:
@@ -399,7 +402,7 @@ async def _run_orchestrator(
         print_info(f"Max decomposition depth: {resolved_max_decomposition_depth}")
         print_info(f"Max parallel workers: {resolved_max_parallel_workers}")
         if resolved_fat_harness_mode:
-            print_info("Execution mode: fat_harness (temporary opt-in)")
+            print_info("Execution mode: fat_harness (default)")
         if externally_satisfied_acs:
             print_info(f"Externally satisfied ACs: {len(externally_satisfied_acs)}")
 

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -76,19 +76,20 @@ FAKE_VERIFICATION_ARTIFACTS = VerificationArtifacts(
 )
 
 
-def test_resolve_fat_harness_mode_defaults_to_legacy() -> None:
-    """The temporary fat-harness path must not flip on by default."""
-    assert _resolve_fat_harness_mode(VALID_SEED_DATA) is False
+def test_resolve_fat_harness_mode_defaults_to_enabled() -> None:
+    """The #920 PR-5 default flip enables fat-harness without seed opt-in."""
+    assert _resolve_fat_harness_mode(VALID_SEED_DATA) is True
 
 
-def test_resolve_fat_harness_mode_accepts_seed_execution_mode() -> None:
-    """PR-4 exposes opt-in mode through seed execution_mode, not a CLI flag."""
-    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "fat_harness"}}
+def test_resolve_fat_harness_mode_accepts_old_execution_mode_as_noop() -> None:
+    """Old PR-4 seeds should resume, but the selector no longer changes mode."""
+    for execution_mode in ("fat_harness", "legacy"):
+        seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": execution_mode}}
 
-    assert _resolve_fat_harness_mode(seed_data) is True
+        assert _resolve_fat_harness_mode(seed_data) is True
 
 
-def test_resolve_fat_harness_mode_rejects_unknown_mode() -> None:
+def test_resolve_fat_harness_mode_rejects_unknown_execution_mode() -> None:
     seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "mystery"}}
 
     with pytest.raises(typer.Exit):
@@ -280,12 +281,12 @@ async def test_run_orchestrator_passes_resolved_execution_caps_to_runner(tmp_pat
 
     assert mock_runner_cls.call_args.kwargs["max_decomposition_depth"] == 3
     assert mock_runner_cls.call_args.kwargs["max_parallel_workers"] == 7
-    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is False
+    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is True
 
 
 @pytest.mark.asyncio
-async def test_run_orchestrator_passes_fat_harness_mode_to_runner(tmp_path: Path) -> None:
-    """Seed execution_mode selects the temporary #920 PR-4 fat-harness path."""
+async def test_run_orchestrator_passes_default_fat_harness_mode_to_runner(tmp_path: Path) -> None:
+    """The default #920 PR-5 path selects fat-harness without seed opt-in."""
     seed_file = tmp_path / "seed.yaml"
     seed_file.write_text("goal: ignored\n", encoding="utf-8")
 
@@ -301,7 +302,7 @@ async def test_run_orchestrator_passes_fat_harness_mode_to_runner(tmp_path: Path
     mock_runner = MagicMock()
     mock_runner.execute_seed = AsyncMock(return_value=Result.ok(fake_exec))
     mock_runner.resume_session = AsyncMock()
-    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "fat_harness"}}
+    seed_data = {**VALID_SEED_DATA, "orchestrator": {"max_decomposition_depth": 2}}
 
     with (
         patch("ouroboros.cli.commands.run._load_seed_from_yaml", return_value=seed_data),


### PR DESCRIPTION
## Summary

Implements a narrowed #920 PR-5 default flip for the `ooo run` CLI path after the #978 P4 benchmark and #920 PR-4 opt-in gates:

- makes CLI `ooo run` select `fat_harness_mode=True` by default
- leaves `OrchestratorRunner`'s internal default/override surface intact so the legacy path remains available as the required emergency fallback
- treats the PR-4 seed-scoped `orchestrator.execution_mode` selector as a no-op compatibility shim for existing seeds/resumptions, not as a functional flag
- keeps the default CLI path on the AC-executor/fat-harness route without adding a public CLI flag

Refs #920 and #961.

## Milestone / sequencing notes

This is intentionally **only** the #920 PR-5 default flip for `ooo run`. It does **not** remove the legacy self-report/executor path; #978 P5 remains separate and blocked on one release cycle of safe production data.

## Validation

- `PYTHONPATH=src pytest -q tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py`
- `PYTHONPATH=src ruff check src/ouroboros/cli/commands/run.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py`
- `PYTHONPATH=src ruff format --check src/ouroboros/cli/commands/run.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py`
- `git diff --check`

## Not tested

- Live `ooo run` against a real agent backend.
