### PR TITLE
fix(interview): guard isinstance against patched non-type InterviewEngine

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1452,14 +1452,24 @@ class InterviewHandler:
         # unchanged: they cannot leak under concurrency because they are not
         # shared across production requests, and tests inject them to observe
         # the question-generation flow.
-        # NOTE: `isinstance(..., InterviewEngine)` must NOT be reached when
+        # NOTE: ``isinstance(..., InterviewEngine)`` must NOT be reached when
         # ``InterviewEngine`` has been monkey-patched in tests to a non-type
         # (e.g. ``patch("authoring_handlers.InterviewEngine", return_value=...)``
-        # replaces the name with a MagicMock instance). Guard with an explicit
-        # ``is not None`` short-circuit so the isinstance arm only runs when a
-        # caller actually supplied an engine template.
+        # replaces the name with a MagicMock instance). The previous short-
+        # circuit only guarded the left operand: once ``template`` was non-None,
+        # ``isinstance(template, InterviewEngine)`` still ran and raised
+        # ``TypeError: isinstance() arg 2 must be a type``, turning a supported
+        # dependency-injection / test-harness path into a hard failure.
+        # Add an ``isinstance(InterviewEngine, type)`` guard so the clone arm
+        # is only taken when the bound name is still a real class, and any
+        # patched non-type value falls through to the ``elif template is not
+        # None`` passthrough branch.
         template = self.interview_engine
-        if template is not None and isinstance(template, InterviewEngine):
+        if (
+            template is not None
+            and isinstance(InterviewEngine, type)
+            and isinstance(template, InterviewEngine)
+        ):
             engine = InterviewEngine(
                 llm_adapter=llm_adapter,
                 state_dir=template.state_dir,

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1722,14 +1722,9 @@ def test_handle_falls_through_when_interview_engine_is_patched_to_non_type(
     handler._initialized = True
 
     async def _run() -> None:
-        try:
-            await handler.handle({"initial_context": "Test goal"})
-        except TypeError as exc:
-            raise AssertionError(
-                f"handle() must not crash on patched non-type InterviewEngine: {exc}"
-            ) from exc
-        except Exception:
-            pass
+        result = await handler.handle({"initial_context": "Test goal"})
+        assert result.is_err
+        assert "forced stop after engine selection is observed" in str(result.error)
 
     with (
         patch(

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1679,3 +1679,70 @@ def test_authoring_interview_handler_preserves_explicit_llm_adapter() -> None:
         "different-backend rebuild must still preserve the caller-supplied llm_adapter"
     )
     assert different_backend.suppress_tool_use_prompt_cues is True
+
+
+def test_handle_falls_through_when_interview_engine_is_patched_to_non_type(
+    tmp_path: Path,
+) -> None:
+    """``handle()`` must not crash when ``InterviewEngine`` is patched to a non-type.
+
+    Regression for the PR #979 follow-up review: even with the
+    ``template is not None`` short-circuit, once ``template`` is non-None the
+    inner ``isinstance(template, InterviewEngine)`` still runs. When other
+    tests (or a caller's dependency-injection harness) have monkey-patched
+    ``ouroboros.mcp.tools.authoring_handlers.InterviewEngine`` to a non-type
+    such as a ``MagicMock`` instance, that ``isinstance`` call raises
+    ``TypeError: isinstance() arg 2 must be a type``. The guard must check
+    ``isinstance(InterviewEngine, type)`` first and otherwise fall through to
+    the passthrough branch.
+    """
+    from unittest.mock import AsyncMock
+
+    from ouroboros.mcp.tools import authoring_handlers
+    from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+    supplied_engine = MagicMock(name="supplied_engine")
+    supplied_engine.start_interview = AsyncMock(
+        side_effect=RuntimeError("forced stop after engine selection is observed")
+    )
+    supplied_engine.resume_interview = AsyncMock()
+    supplied_engine.score_interview = AsyncMock()
+
+    handler = InterviewHandler(
+        interview_engine=supplied_engine,
+        event_store=MagicMock(),
+        llm_adapter=None,
+        llm_backend="claude_code",
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+        data_dir=tmp_path,
+        suppress_tool_use_prompt_cues=True,
+    )
+    handler._owns_event_store = False
+    handler._initialized = True
+
+    async def _run() -> None:
+        try:
+            await handler.handle({"initial_context": "Test goal"})
+        except TypeError as exc:
+            raise AssertionError(
+                f"handle() must not crash on patched non-type InterviewEngine: {exc}"
+            ) from exc
+        except Exception:
+            pass
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=MagicMock(name="isolated_adapter"),
+        ),
+        patch.object(authoring_handlers, "InterviewEngine", MagicMock(name="patched_non_type")),
+    ):
+        asyncio.run(_run())
+
+    # The supplied engine must have been used directly (passthrough), since
+    # ``InterviewEngine`` was patched to a non-type and the clone arm cannot
+    # safely fire. ``start_interview`` is the first method the handler calls
+    # on the engine after selection, so its invocation proves the passthrough
+    # branch was taken.
+    supplied_engine.start_interview.assert_awaited()


### PR DESCRIPTION
Follow-up to #979 (ouroboros-agent warning on commit `8ea1c8c3`). #979 has merged, so this PR is now the narrow two-file follow-up for the remaining patched-`InterviewEngine` guard issue.

## Problem

The clone-arm guard introduced in PR #979 only short-circuited on the left operand:

```python
if template is not None and isinstance(template, InterviewEngine):
```

Once `template` is non-None, `isinstance(template, InterviewEngine)` still runs. When other tests (or a caller's dependency-injection harness) have monkey-patched `ouroboros.mcp.tools.authoring_handlers.InterviewEngine` to a non-type — e.g. `patch("authoring_handlers.InterviewEngine", return_value=MagicMock())` — `isinstance` raises:

```text
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

That turns a supported test / DI path into a hard failure instead of falling through to the `elif template is not None` passthrough branch the inline comment promises.

## Fix

Add `isinstance(InterviewEngine, type)` before the inner `isinstance` call. The clone arm is then only entered when the bound name is still a real class; any patched non-type value falls through to the passthrough branch.

```python
if (
    template is not None
    and isinstance(InterviewEngine, type)
    and isinstance(template, InterviewEngine)
):
```

## Regression test

`test_handle_falls_through_when_interview_engine_is_patched_to_non_type` patches `authoring_handlers.InterviewEngine` to a `MagicMock` instance and supplies a `MagicMock` engine. The handler must not raise `TypeError` and must take the passthrough branch — verified by asserting the supplied engine's `start_interview` was awaited.

## Test plan

- [x] `uv run pytest -q tests/unit/mcp/tools/test_auto_interview_construction.py` — 16 passed (including the new test)
- [x] Combined regression (`test_auto_interview_construction`, `test_claude_code_adapter`, `test_interview`, `test_interview_done_streak`, `test_interview_reopen_seed_ready`) — 144 passed
- [x] `uv run ruff format --check src/ouroboros/mcp/tools/authoring_handlers.py tests/unit/mcp/tools/test_auto_interview_construction.py` — clean
- [x] `uv run ruff check src/ouroboros/mcp/tools/authoring_handlers.py tests/unit/mcp/tools/test_auto_interview_construction.py` — clean
- [x] `uv run mypy src/ouroboros/mcp/tools/authoring_handlers.py` — clean

## Non-goals

- Does not alter the #979 per-call engine cloning design.
- Does not change auto sub-interview prompt/tool-envelope behavior.
- Does not touch unrelated #920/#978 harness or AgentOS sequencing work.

Refs #979.
