### PR TITLE
Require verifier PASS for fat-harness AC acceptance

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -32,6 +32,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 import json
 import os
+from pathlib import Path
 import platform
 import re
 import subprocess
@@ -106,6 +107,12 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_message_projection import (
     project_runtime_message,
 )
+from ouroboros.orchestrator.verifier import (
+    Verifier,
+    VerifierContractError,
+    VerifierVerdict,
+    verifier_operational_failure_verdict,
+)
 
 if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
@@ -135,6 +142,122 @@ def _subtask_event_label(content: str, *, max_length: int = 50) -> str:
     if len(normalized) <= max_length:
         return normalized
     return normalized[:max_length]
+
+
+def _flatten_evidence_values(value: object) -> tuple[str, ...]:
+    """Return concrete string claims from a typed evidence field."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        stripped = value.strip()
+        return (stripped,) if stripped else ()
+    if isinstance(value, (int, float, bool)):
+        return (str(value),)
+    if isinstance(value, dict):
+        flattened: list[str] = []
+        for item in value.values():
+            flattened.extend(_flatten_evidence_values(item))
+        return tuple(flattened)
+    if isinstance(value, (list, tuple, set)):
+        flattened_sequence: list[str] = []
+        for item in value:
+            flattened_sequence.extend(_flatten_evidence_values(item))
+        return tuple(flattened_sequence)
+    return (str(value),)
+
+
+def _runtime_message_search_text(message: AgentMessage) -> str:
+    """Build searchable transcript text for one non-final runtime message."""
+    parts: list[str] = [message.content]
+    if message.tool_name:
+        parts.append(message.tool_name)
+    tool_input = message.data.get("tool_input")
+    if isinstance(tool_input, dict):
+        parts.extend(str(value) for value in tool_input.values() if value is not None)
+    parts.extend(_flatten_evidence_values(message.data))
+    return "\n".join(parts).lower()
+
+
+def _runtime_support_messages_for_field(
+    field_name: str,
+    messages: tuple[AgentMessage, ...],
+) -> tuple[AgentMessage, ...]:
+    """Narrow support messages for profile-known evidence fields."""
+    normalized = field_name.lower()
+    if normalized == "files_touched":
+        return messages
+    if normalized in {"commands_run", "tests_passed"}:
+        return tuple(message for message in messages if message.tool_name == "Bash")
+    return messages
+
+
+def _runtime_messages_support_claim(value: str, messages: tuple[AgentMessage, ...]) -> bool:
+    """Return True when a non-final runtime message backs a claim string."""
+    needle = value.strip().lower()
+    return bool(needle) and any(
+        needle in _runtime_message_search_text(message) for message in messages
+    )
+
+
+def _looks_like_test_command(command: str) -> bool:
+    """Return True for common whole-suite or targeted test invocations."""
+    normalized = command.strip().lower()
+    if not normalized:
+        return False
+    return bool(
+        re.search(
+            r"(^|[\s;&|])("
+            r"pytest|py\.test|tox|nox|npm\s+test|pnpm\s+test|yarn\s+test|"
+            r"uv\s+run\s+pytest|python\s+-m\s+pytest"
+            r")($|[\s;&|])",
+            normalized,
+        )
+    )
+
+
+def _message_contains_test_success(message: AgentMessage) -> bool:
+    """Return True when one message says a test command passed."""
+    parts = [message.content]
+    for key in ("result_preview", "output", "stdout"):
+        value = message.data.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    text = "\n".join(parts).lower()
+    if re.search(r"\b(failed|failure|error|errors)\b|exit\s*code\s*[1-9]", text):
+        return False
+    return bool(re.search(r"\b(passed|pass|success|succeeded)\b|exit\s*code\s*0|0\s+failed", text))
+
+
+def _runtime_messages_support_test_claim(
+    *,
+    value: str,
+    backed_commands: tuple[str, ...],
+    messages: tuple[AgentMessage, ...],
+) -> bool:
+    """Return True when a backed test command chunk proves one test claim."""
+    needle = value.strip().lower()
+    if not needle:
+        return False
+    for index, message in enumerate(messages):
+        if message.tool_name != "Bash":
+            continue
+        if not any(
+            _looks_like_test_command(candidate)
+            and _runtime_messages_support_claim(candidate, (message,))
+            for candidate in backed_commands
+        ):
+            continue
+        chunk = [message]
+        for following in messages[index + 1 :]:
+            if following.tool_name == "Bash":
+                break
+            chunk.append(following)
+        chunk_text = "\n".join(_runtime_message_search_text(item) for item in chunk)
+        if needle not in chunk_text:
+            continue
+        if any(_message_contains_test_success(item) for item in chunk):
+            return True
+    return False
 
 
 _REUSABLE_RUNTIME_EVENT_TYPES = frozenset(
@@ -500,6 +623,7 @@ class ParallelACExecutor:
         task_cwd: str | None = None,
         execution_profile: ExecutionProfile | None = None,
         fat_harness_mode: bool = False,
+        atomic_verifier: Verifier | None = None,
     ):
         """Initialize executor.
 
@@ -516,8 +640,11 @@ class ParallelACExecutor:
             task_cwd: Explicit working directory override for task execution metadata.
             execution_profile: Optional profile that makes decomposition split along
                 profile axis/min_unit instead of the legacy generic prompt.
-            fat_harness_mode: Temporary PR-4 opt-in mode that enforces
-                profile typed-evidence validation at atomic AC acceptance.
+            fat_harness_mode: Enforce profile typed evidence plus a verifier
+                PASS at atomic AC acceptance.
+            atomic_verifier: Optional verifier callable for the separate
+                atomic evidence PASS gate. Defaults to the harness-owned
+                structural verifier.
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -528,6 +655,7 @@ class ParallelACExecutor:
         self._task_cwd = task_cwd
         self._execution_profile = execution_profile
         self._fat_harness_mode = fat_harness_mode
+        self._atomic_verifier = atomic_verifier
         self._coordinator = LevelCoordinator(
             adapter,
             inherited_runtime_handle=inherited_runtime_handle,
@@ -3517,11 +3645,20 @@ When complete, explicitly state: [TASK_COMPLETE]
                 final_message=final_message,
                 success=success,
             )
+            verifier_verdict = self._run_atomic_verifier_pass(
+                ac_content=ac_content,
+                final_message=final_message,
+                success=success,
+                messages=tuple(messages),
+                typed_evidence=typed_evidence,
+                typed_validation=typed_validation,
+            )
             fat_harness_error = self._fat_harness_acceptance_error(
                 runtime_success=success,
                 typed_evidence=typed_evidence,
                 typed_validation=typed_validation,
                 typed_error=typed_error,
+                verifier_verdict=verifier_verdict,
             )
             result_final_message = final_message
             if fat_harness_error is not None:
@@ -3539,6 +3676,7 @@ When complete, explicitly state: [TASK_COMPLETE]
                 typed_evidence=typed_evidence,
                 typed_validation=typed_validation,
                 typed_error=typed_error,
+                verifier_verdict=verifier_verdict,
                 enforcement_error=fat_harness_error,
             )
             await self._emit_ac_runtime_event(
@@ -3583,6 +3721,7 @@ When complete, explicitly state: [TASK_COMPLETE]
                 typed_evidence=typed_evidence,
                 typed_evidence_validation=typed_validation,
                 typed_evidence_error=typed_error,
+                atomic_verifier_verdict=verifier_verdict,
                 error=fat_harness_error,
             )
 
@@ -3654,10 +3793,10 @@ When complete, explicitly state: [TASK_COMPLETE]
     ) -> tuple[EvidenceRecord | None, ValidationResult | None, str | None]:
         """Parse and validate typed evidence at the atomic AC acceptance boundary.
 
-        This is observe-only for #920 PR-2: it records whether a successful
-        atomic leaf emitted profile-shaped evidence, but it does not change the
-        legacy success value returned by the runtime. Enforcement belongs to a
-        later sequenced evidence-loop/default-gate PR.
+        In observe-only mode this only records whether a successful atomic
+        leaf emitted profile-shaped evidence. In fat-harness mode, the caller
+        subsequently requires both this validation result and a separate
+        verifier PASS before accepting the AC.
         """
         if not success or self._execution_profile is None:
             return None, None, None
@@ -3678,8 +3817,9 @@ When complete, explicitly state: [TASK_COMPLETE]
         typed_evidence: EvidenceRecord | None,
         typed_validation: ValidationResult | None,
         typed_error: str | None,
+        verifier_verdict: VerifierVerdict | None,
     ) -> str | None:
-        """Return the opt-in fat-harness rejection reason for an atomic leaf."""
+        """Return the fat-harness rejection reason for an atomic leaf."""
         if not self._fat_harness_mode or not runtime_success:
             return None
         if self._execution_profile is None:
@@ -3689,7 +3829,12 @@ When complete, explicitly state: [TASK_COMPLETE]
         if typed_validation is None:
             return "Fat-harness mode could not validate typed evidence."
         if typed_validation.ok:
-            return None
+            if verifier_verdict is None:
+                return "Fat-harness mode requires verifier PASS before atomic acceptance."
+            if verifier_verdict.passed:
+                return None
+            detail = "; ".join(verifier_verdict.reasons) or "verifier rejected atomic evidence"
+            return f"Fat-harness verifier failed ({detail})."
 
         reasons: list[str] = []
         if typed_validation.missing_fields:
@@ -3701,6 +3846,124 @@ When complete, explicitly state: [TASK_COMPLETE]
         detail = "; ".join(reasons) if reasons else "profile evidence validation failed"
         return f"Fat-harness typed evidence validation failed ({detail})."
 
+    def _run_atomic_verifier_pass(
+        self,
+        *,
+        ac_content: str,
+        final_message: str,
+        success: bool,
+        messages: tuple[AgentMessage, ...],
+        typed_evidence: EvidenceRecord | None,
+        typed_validation: ValidationResult | None,
+    ) -> VerifierVerdict | None:
+        """Run the separate verifier pass once typed evidence is schema-valid."""
+        if (
+            not success
+            or not self._fat_harness_mode
+            or self._execution_profile is None
+            or typed_evidence is None
+            or typed_validation is None
+            or not typed_validation.ok
+        ):
+            return None
+
+        verifier = self._atomic_verifier
+        try:
+            verdict = (
+                verifier(
+                    profile=self._execution_profile,
+                    ac=ac_content,
+                    leaf_output=final_message,
+                    record=typed_evidence,
+                )
+                if verifier is not None
+                else self._verify_atomic_evidence_against_runtime_messages(
+                    messages=messages,
+                    typed_evidence=typed_evidence,
+                )
+            )
+        except VerifierContractError:
+            raise
+        except Exception as exc:
+            verdict = verifier_operational_failure_verdict(exc)
+        if not isinstance(verdict, VerifierVerdict):
+            msg = f"Atomic verifier returned {type(verdict).__name__}, expected VerifierVerdict."
+            raise VerifierContractError(msg)
+        return verdict
+
+    def _verify_atomic_evidence_against_runtime_messages(
+        self,
+        *,
+        messages: tuple[AgentMessage, ...],
+        typed_evidence: EvidenceRecord,
+    ) -> VerifierVerdict:
+        """Verify leaf evidence is backed by runtime transcript events.
+
+        The verifier deliberately ignores the final result message so the
+        accepted evidence cannot be supported only by the leaf's self-report.
+        """
+        support_messages = tuple(messages[:-1] if messages and messages[-1].is_final else messages)
+        if not support_messages:
+            return VerifierVerdict(
+                passed=False,
+                reasons=("no runtime transcript evidence supports the typed evidence claims",),
+                failure_class="EVIDENCE_MISSING",
+            )
+
+        unsupported: list[str] = []
+        backed_commands = tuple(
+            command
+            for command in _flatten_evidence_values(typed_evidence.get("commands_run"))
+            if _runtime_messages_support_claim(
+                command,
+                _runtime_support_messages_for_field("commands_run", support_messages),
+            )
+        )
+        for field_name in self._execution_profile.evidence_schema.required:
+            values = tuple(_flatten_evidence_values(typed_evidence.get(field_name)))
+            if not values:
+                unsupported.append(f"{field_name}: no concrete claim values")
+                continue
+            field_messages = _runtime_support_messages_for_field(field_name, support_messages)
+            for value in values:
+                if field_name == "files_touched" and self._evidence_path_exists(value):
+                    continue
+                if field_name == "tests_passed" and _runtime_messages_support_test_claim(
+                    value=value,
+                    backed_commands=backed_commands,
+                    messages=support_messages,
+                ):
+                    continue
+                if not _runtime_messages_support_claim(value, field_messages):
+                    unsupported.append(f"{field_name}: {value}")
+
+        if unsupported:
+            return VerifierVerdict(
+                passed=False,
+                reasons=("unsupported evidence claims: " + "; ".join(unsupported),),
+                failure_class="FABRICATION_SUSPECTED",
+            )
+
+        return VerifierVerdict(passed=True)
+
+    def _evidence_path_exists(self, value: str) -> bool:
+        """Return True when a file claim exists under the task working directory."""
+        task_cwd = self._task_cwd or self._adapter.working_directory
+        if task_cwd is None:
+            return False
+        candidate = Path(value)
+        if candidate.is_absolute():
+            return False
+        if ".." in candidate.parts:
+            return False
+        base = Path(task_cwd).resolve()
+        resolved = (base / candidate).resolve()
+        try:
+            resolved.relative_to(base)
+        except ValueError:
+            return False
+        return resolved.exists()
+
     async def _emit_atomic_typed_evidence_event(
         self,
         *,
@@ -3711,6 +3974,7 @@ When complete, explicitly state: [TASK_COMPLETE]
         typed_evidence: EvidenceRecord | None,
         typed_validation: ValidationResult | None,
         typed_error: str | None,
+        verifier_verdict: VerifierVerdict | None = None,
         enforcement_error: str | None = None,
     ) -> None:
         """Persist typed-evidence metadata for atomic AC completion."""
@@ -3734,7 +3998,12 @@ When complete, explicitly state: [TASK_COMPLETE]
             "typed_evidence_present": typed_evidence is not None,
             "typed_evidence_valid": typed_validation.ok if typed_validation is not None else False,
             "typed_evidence_error": typed_error,
+            "verifier_ran": verifier_verdict is not None,
+            "verifier_passed": verifier_verdict.passed if verifier_verdict is not None else False,
         }
+        if verifier_verdict is not None:
+            data["verifier_reasons"] = list(verifier_verdict.reasons)
+            data["verifier_failure_class"] = verifier_verdict.failure_class
         if typed_evidence is not None:
             data["typed_evidence_fields"] = sorted(typed_evidence.data)
         if typed_validation is not None:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -199,6 +199,61 @@ def _runtime_messages_support_claim(value: str, messages: tuple[AgentMessage, ..
     )
 
 
+def _runtime_messages_support_file_claim(
+    value: str,
+    messages: tuple[AgentMessage, ...],
+    *,
+    task_cwd: str | None,
+) -> bool:
+    """Return True when runtime transcript evidence backs a workspace file claim.
+
+    Existence alone is not sufficient for ``files_touched``: a stale file in the
+    workspace must not prove that this run created or modified it. Exact
+    transcript support is preferred; basename support is accepted only when the
+    claimed relative path resolves inside the active workspace, which covers
+    tool outputs that report ``generated.py`` instead of ``src/generated.py``.
+    """
+    if _runtime_messages_support_claim(value, messages):
+        return True
+    if task_cwd is None:
+        return False
+    candidate = Path(value)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return False
+    base = Path(task_cwd).resolve()
+    resolved = (base / candidate).resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        return False
+    if not resolved.exists():
+        return False
+    basename = candidate.name.strip().lower()
+    return bool(basename) and any(
+        _runtime_message_supports_file_basename(basename, message) for message in messages
+    )
+
+
+def _runtime_message_supports_file_basename(basename: str, message: AgentMessage) -> bool:
+    """Return True when one message plausibly reports touching a basename."""
+    text = _runtime_message_search_text(message)
+    basename_pattern = re.compile(rf"(?<![\w.-]){re.escape(basename)}(?![\w.-])")
+    if not basename_pattern.search(text):
+        return False
+    if message.tool_name in {"Edit", "Write", "NotebookEdit"}:
+        return True
+    return bool(
+        re.search(
+            rf"(?<![\w.-]){re.escape(basename)}(?![\w.-]).*\b("
+            r"updated|modified|changed|created|generated|wrote|written|patched"
+            r")\b|\b("
+            r"updated|modified|changed|created|generated|wrote|written|patched"
+            rf")\b.*(?<![\w.-]){re.escape(basename)}(?![\w.-])",
+            text,
+        )
+    )
+
+
 def _looks_like_test_command(command: str) -> bool:
     """Return True for common whole-suite or targeted test invocations."""
     normalized = command.strip().lower()
@@ -223,7 +278,16 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
         if isinstance(value, str):
             parts.append(value)
     text = "\n".join(parts).lower()
-    if re.search(r"\b(failed|failure|error|errors)\b|exit\s*code\s*[1-9]", text):
+    failure_scan_text = re.sub(r"\b0\s+(failed|failures|error|errors)\b", "", text)
+    if re.search(
+        r"\b[1-9]\d*\s+failed\b|\b(failure|error|errors)\b|exit\s*code\s*[1-9]",
+        failure_scan_text,
+    ):
+        return False
+    if re.search(r"\bfailed\b", text) and not re.search(
+        r"\b0\s+failed\b|\bno\s+tests?\s+failed\b",
+        text,
+    ):
         return False
     return bool(re.search(r"\b(passed|pass|success|succeeded)\b|exit\s*code\s*0|0\s+failed", text))
 
@@ -3926,13 +3990,20 @@ When complete, explicitly state: [TASK_COMPLETE]
                 continue
             field_messages = _runtime_support_messages_for_field(field_name, support_messages)
             for value in values:
-                if field_name == "files_touched" and self._evidence_path_exists(value):
-                    continue
-                if field_name == "tests_passed" and _runtime_messages_support_test_claim(
-                    value=value,
-                    backed_commands=backed_commands,
-                    messages=support_messages,
+                if field_name == "files_touched" and _runtime_messages_support_file_claim(
+                    value,
+                    field_messages,
+                    task_cwd=self._task_cwd or self._adapter.working_directory,
                 ):
+                    continue
+                if field_name == "tests_passed":
+                    if _runtime_messages_support_test_claim(
+                        value=value,
+                        backed_commands=backed_commands,
+                        messages=support_messages,
+                    ):
+                        continue
+                    unsupported.append(f"{field_name}: {value}")
                     continue
                 if not _runtime_messages_support_claim(value, field_messages):
                     unsupported.append(f"{field_name}: {value}")
@@ -3945,24 +4016,6 @@ When complete, explicitly state: [TASK_COMPLETE]
             )
 
         return VerifierVerdict(passed=True)
-
-    def _evidence_path_exists(self, value: str) -> bool:
-        """Return True when a file claim exists under the task working directory."""
-        task_cwd = self._task_cwd or self._adapter.working_directory
-        if task_cwd is None:
-            return False
-        candidate = Path(value)
-        if candidate.is_absolute():
-            return False
-        if ".." in candidate.parts:
-            return False
-        base = Path(task_cwd).resolve()
-        resolved = (base / candidate).resolve()
-        try:
-            resolved.relative_to(base)
-        except ValueError:
-            return False
-        return resolved.exists()
 
     async def _emit_atomic_typed_evidence_event(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor_models.py
+++ b/src/ouroboros/orchestrator/parallel_executor_models.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from ouroboros.orchestrator.coordinator import CoordinatorReview
     from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
     from ouroboros.orchestrator.level_context import LevelContext
+    from ouroboros.orchestrator.verifier import VerifierVerdict
 
 
 class ACExecutionOutcome(str, Enum):  # noqa: UP042
@@ -58,7 +59,9 @@ class ACExecutionResult:
         typed_evidence_validation: Profile-schema validation result for
             typed_evidence, if parsing succeeded.
         typed_evidence_error: Parse/validation error observed at atomic
-            completion, if any. Does not change success semantics yet.
+            completion, if any.
+        atomic_verifier_verdict: Separate verifier pass verdict for the
+            parsed typed evidence at atomic completion, when available.
     """
 
     ac_index: int
@@ -79,6 +82,7 @@ class ACExecutionResult:
     typed_evidence: EvidenceRecord | None = None
     typed_evidence_validation: ValidationResult | None = None
     typed_evidence_error: str | None = None
+    atomic_verifier_verdict: VerifierVerdict | None = None
 
     def __post_init__(self) -> None:
         """Normalize outcome so callers do not infer from error strings."""

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -6,11 +6,11 @@ layer: it is any callable that, given the active profile, the leaf's
 parsed evidence record, the AC text, and the raw leaf output, returns a
 VerifierVerdict.
 
-This module is wiring-only at the orchestrator seam — `parallel_executor`
-is not yet routed through `run_with_verifier`. The integration PR follows
-once the failure taxonomy (H7) and routing (H5) hooks are in place. For
-now this gives downstream PRs a stable, fully-tested loop they can plug
-the real LLM-backed verifier into.
+This module owns the verifier verdict contract consumed at the
+`parallel_executor` atomic acceptance boundary. The full bounded retry
+helper (`run_with_verifier`) remains available for the future live retry
+loop once the failure taxonomy (H7) and routing (H5) hooks are promoted
+into redispatch decisions.
 
 Loop semantics:
     1. Executor produces a leaf output.
@@ -162,6 +162,24 @@ class Verifier(Protocol):
     ) -> VerifierVerdict: ...
 
 
+def verifier_operational_failure_verdict(exc: BaseException) -> VerifierVerdict:
+    """Convert an operational verifier failure into a retryable verdict.
+
+    Programming bugs are deliberately not accepted here; callers should let
+    those propagate so broken verifier implementations are fixed instead of
+    silently consuming the acceptance boundary.
+    """
+    if isinstance(exc, VerifierContractError):
+        raise exc
+    if isinstance(exc, _OPERATIONAL_VERIFIER_ERRORS):
+        return VerifierVerdict(
+            passed=False,
+            reasons=(f"verifier raised {type(exc).__name__}: {exc}",),
+            failure_class="STALL",
+        )
+    raise exc
+
+
 class LeafExecutor(Protocol):
     """Callable that runs the leaf executor for a given AC.
 
@@ -171,6 +189,53 @@ class LeafExecutor(Protocol):
     """
 
     def __call__(self, *, ac: str, feedback: tuple[str, ...]) -> str: ...
+
+
+def structural_atomic_verifier(
+    *,
+    profile: ExecutionProfile,
+    ac: str,
+    leaf_output: str,
+    record: EvidenceRecord,
+) -> VerifierVerdict:
+    """Harness-owned structural verifier helper for atomic acceptance seams.
+
+    This verifier is intentionally narrower than the future TraceGuard /
+    test-runner verifier: it provides a separate, typed ``VerifierVerdict``
+    PASS/FAIL boundary over the parsed evidence contract without making
+    live model calls or removing the legacy fallback. The live
+    ``parallel_executor`` default adds runtime-transcript support checks on
+    top; profile-specific semantic/test verification can still replace this
+    callable through the `Verifier` protocol without changing the acceptance
+    boundary.
+    """
+    del ac
+    if record.source and record.source not in leaf_output:
+        return VerifierVerdict(
+            passed=False,
+            reasons=("parsed evidence source is not present in the leaf output",),
+            failure_class="FABRICATION_SUSPECTED",
+        )
+
+    try:
+        validation = validate_evidence(profile, record)
+    except EvidenceError as exc:
+        return VerifierVerdict(
+            passed=False,
+            reasons=(f"profile evidence validation failed: {exc}",),
+            failure_class="EVIDENCE_MISSING",
+        )
+
+    if not validation.ok:
+        reasons = validation.reasons() or ("profile evidence validation failed",)
+        failure_class = "BLOCKED" if validation.blocker is not None else "EVIDENCE_MISSING"
+        return VerifierVerdict(
+            passed=False,
+            reasons=tuple(reasons),
+            failure_class=failure_class,
+        )
+
+    return VerifierVerdict(passed=True)
 
 
 @dataclass(frozen=True)
@@ -305,11 +370,7 @@ def run_with_verifier(
                     # are NOT in the catch list — they propagate so the
                     # operator can fix the broken verifier instead of
                     # watching it silently exhaust retries.
-                    verdict = VerifierVerdict(
-                        passed=False,
-                        reasons=(f"verifier raised {type(exc).__name__}: {exc}",),
-                        failure_class="STALL",
-                    )
+                    verdict = verifier_operational_failure_verdict(exc)
                 else:
                     # Verifier is only a static Protocol — Python won't
                     # enforce the return type at runtime. A buggy impl
@@ -355,4 +416,6 @@ __all__ = [
     "VerifierContractError",
     "VerifierVerdict",
     "run_with_verifier",
+    "structural_atomic_verifier",
+    "verifier_operational_failure_verdict",
 ]

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -31,6 +31,7 @@ from ouroboros.orchestrator.parallel_executor import (
     render_parallel_verification_report,
 )
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
+from ouroboros.orchestrator.verifier import VerifierVerdict
 
 
 def _make_seed(*acceptance_criteria: str) -> Seed:
@@ -90,9 +91,18 @@ class _FinalMessageRuntime:
     _cwd = "/tmp/project"
     _permission_mode = "acceptEdits"
 
-    def __init__(self, final_message: str, *, native_session_id: str) -> None:
+    def __init__(
+        self,
+        final_message: str,
+        *,
+        native_session_id: str,
+        support_messages: tuple[AgentMessage, ...] = (),
+        cwd: str = "/tmp/project",
+    ) -> None:
         self._final_message = final_message
         self._native_session_id = native_session_id
+        self._support_messages = support_messages
+        self._cwd = cwd
 
     @property
     def runtime_backend(self) -> str:
@@ -115,6 +125,8 @@ class _FinalMessageRuntime:
         resume_session_id: str | None = None,
     ):
         del prompt, tools, system_prompt, resume_session_id
+        for message in self._support_messages:
+            yield message
         yield AgentMessage(
             type="result",
             content=self._final_message,
@@ -1106,6 +1118,8 @@ class TestParallelACExecutor:
         assert evidence_event.data["enforcement_error"] is None
         assert evidence_event.data["typed_evidence_present"] is True
         assert evidence_event.data["typed_evidence_valid"] is True
+        assert evidence_event.data["verifier_ran"] is False
+        assert evidence_event.data["verifier_passed"] is False
         assert evidence_event.data["required_fields"] == [
             "files_touched",
             "commands_run",
@@ -1197,6 +1211,7 @@ class TestParallelACExecutor:
         assert evidence_event.data["enforced"] is False
         assert evidence_event.data["typed_evidence_present"] is False
         assert evidence_event.data["typed_evidence_valid"] is False
+        assert evidence_event.data["verifier_ran"] is False
         assert "Evidence is not valid JSON" in evidence_event.data["typed_evidence_error"]
 
     @pytest.mark.asyncio
@@ -1254,6 +1269,7 @@ class TestParallelACExecutor:
         assert evidence_event.data["enforced"] is True
         assert evidence_event.data["fat_harness_mode"] is True
         assert "Evidence is not valid JSON" in evidence_event.data["enforcement_error"]
+        assert evidence_event.data["verifier_ran"] is False
 
         terminal_event = next(
             event for event in appended_events if event.type == "execution.session.failed"
@@ -1263,6 +1279,70 @@ class TestParallelACExecutor:
     @pytest.mark.asyncio
     async def test_fat_harness_mode_accepts_valid_typed_evidence(self) -> None:
         """Valid profile evidence keeps the opt-in fat-harness leaf accepted."""
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/app.py"],'
+                '"commands_run":["pytest"],'
+                '"tests_passed":["tests/test_app.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Edit: src/app.py",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": "src/app.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_app.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_app.py"}},
+                    ),
+                ),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        assert result.atomic_verifier_verdict is not None
+        assert result.atomic_verifier_verdict.passed is True
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["observe_only"] is False
+        assert evidence_event.data["enforced"] is True
+        assert evidence_event.data["fat_harness_mode"] is True
+        assert evidence_event.data["enforcement_error"] is None
+        assert evidence_event.data["typed_evidence_valid"] is True
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_mode_rejects_unbacked_typed_evidence(self) -> None:
+        """Default verifier rejects final-message-only self-reported evidence."""
         event_store, appended_events = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=_FinalMessageRuntime(
@@ -1293,6 +1373,83 @@ class TestParallelACExecutor:
             start_time=datetime.now(UTC),
         )
 
+        assert result.success is False
+        assert result.error is not None
+        assert "Fat-harness verifier failed" in result.error
+        assert "no runtime transcript evidence supports" in result.error
+
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["typed_evidence_valid"] is True
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is False
+        assert evidence_event.data["verifier_failure_class"] == "EVIDENCE_MISSING"
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_allows_bash_generated_file_and_whole_suite_test(
+        self, tmp_path
+    ) -> None:
+        """Bash-backed generation plus whole-suite pytest can support evidence."""
+        generated_file = tmp_path / "src" / "generated.py"
+        generated_file.parent.mkdir()
+        generated_file.write_text("VALUE = 1\n", encoding="utf-8")
+        generated_test = tmp_path / "tests" / "test_generated.py"
+        generated_test.parent.mkdir()
+        generated_test.write_text("def test_generated():\n    assert True\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/generated.py"],'
+                '"commands_run":["python scripts/generate.py","pytest"],'
+                '"tests_passed":["tests/test_generated.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: python scripts/generate.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "python scripts/generate.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="generated.py updated; tests/test_generated.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
         assert result.success is True
         assert result.error is None
         evidence_event = next(
@@ -1300,11 +1457,310 @@ class TestParallelACExecutor:
             for event in appended_events
             if event.type == "execution.ac.typed_evidence.observed"
         )
-        assert evidence_event.data["observe_only"] is False
-        assert evidence_event.data["enforced"] is True
-        assert evidence_event.data["fat_harness_mode"] is True
-        assert evidence_event.data["enforcement_error"] is None
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_unscoped_file_and_failed_test_command(
+        self, tmp_path
+    ) -> None:
+        """Workspace path scope and test success are required for verifier support."""
+        outside_file = tmp_path.parent / "outside.py"
+        outside_file.write_text("VALUE = 1\n", encoding="utf-8")
+        test_file = tmp_path / "tests" / "test_generated.py"
+        test_file.parent.mkdir()
+        test_file.write_text("def test_generated():\n    assert False\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                f'{{"files_touched":["{outside_file}"],'
+                '"commands_run":["pytest"],'
+                '"tests_passed":["tests/test_generated.py"]}}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="1 failed, 3 passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "files_touched:" in result.error
+        assert "tests_passed: tests/test_generated.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_test_not_covered_by_success_chunk(
+        self, tmp_path
+    ) -> None:
+        """A successful test command must cover the claimed tests_passed entry."""
+        touched_file = tmp_path / "src" / "generated.py"
+        touched_file.parent.mkdir()
+        touched_file.write_text("VALUE = 1\n", encoding="utf-8")
+        test_a = tmp_path / "tests" / "test_a.py"
+        test_b = tmp_path / "tests" / "test_b.py"
+        test_a.parent.mkdir()
+        test_a.write_text("def test_a():\n    assert True\n", encoding="utf-8")
+        test_b.write_text("def test_b():\n    assert True\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/generated.py"],'
+                '"commands_run":["pytest tests/test_a.py"],'
+                '"tests_passed":["tests/test_b.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_a.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_a.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_a.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed: tests/test_b.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_mode_rejects_verifier_fail(self) -> None:
+        """Fat harness requires a separate verifier PASS after typed evidence."""
+
+        def _rejecting_verifier(**kwargs: object) -> VerifierVerdict:
+            del kwargs
+            return VerifierVerdict(
+                passed=False,
+                reasons=("claimed test command did not support the AC",),
+                failure_class="FABRICATION_SUSPECTED",
+            )
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/app.py"],'
+                '"commands_run":["pytest"],'
+                '"tests_passed":["tests/test_app.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            atomic_verifier=_rejecting_verifier,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Fat-harness verifier failed" in result.error
+        assert "claimed test command did not support the AC" in result.error
+        assert result.atomic_verifier_verdict is not None
+        assert result.atomic_verifier_verdict.passed is False
+
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
         assert evidence_event.data["typed_evidence_valid"] is True
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is False
+        assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+        assert evidence_event.data["verifier_reasons"] == [
+            "claimed test command did not support the AC"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_mode_surfaces_operational_verifier_error(self) -> None:
+        """Operational verifier failures remain typed verifier rejections."""
+
+        def _timeout_verifier(**kwargs: object) -> VerifierVerdict:
+            del kwargs
+            raise TimeoutError("verifier timed out")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/app.py"],'
+                '"commands_run":["pytest"],'
+                '"tests_passed":["tests/test_app.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            atomic_verifier=_timeout_verifier,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "verifier raised TimeoutError: verifier timed out" in result.error
+        assert result.atomic_verifier_verdict is not None
+        assert result.atomic_verifier_verdict.failure_class == "STALL"
+
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is False
+        assert evidence_event.data["verifier_failure_class"] == "STALL"
+        assert evidence_event.data["verifier_reasons"] == [
+            "verifier raised TimeoutError: verifier timed out"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_observe_only_mode_does_not_run_injected_verifier(self) -> None:
+        """Non-enforced profile evidence telemetry must stay observe-only."""
+
+        def _raising_verifier(**kwargs: object) -> VerifierVerdict:
+            del kwargs
+            raise AssertionError("observe-only mode must not invoke the verifier")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/app.py"],'
+                '"commands_run":["pytest"],'
+                '"tests_passed":["tests/test_app.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            atomic_verifier=_raising_verifier,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.atomic_verifier_verdict is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_ran"] is False
 
     @pytest.mark.asyncio
     async def test_atomic_ac_typed_evidence_event_failure_does_not_fail_success(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1302,6 +1302,11 @@ class TestParallelACExecutor:
                         tool_name="Bash",
                         data={"tool_input": {"command": "pytest tests/test_app.py"}},
                     ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_app.py passed",
+                        data={"subtype": "success"},
+                    ),
                 ),
             ),
             event_store=event_store,
@@ -1425,7 +1430,10 @@ class TestParallelACExecutor:
                     ),
                     AgentMessage(
                         type="result",
-                        content="generated.py updated; tests/test_generated.py passed",
+                        content=(
+                            "generated.py updated; tests/test_generated.py passed; "
+                            "0 failed, 0 errors, 1 passed"
+                        ),
                         data={"subtype": "success"},
                     ),
                 ),
@@ -1528,6 +1536,73 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is False
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_preexisting_file_without_transcript_support(
+        self, tmp_path
+    ) -> None:
+        """A stale workspace file must not prove this run touched that file."""
+        preexisting_file = tmp_path / "src" / "preexisting.py"
+        preexisting_file.parent.mkdir()
+        preexisting_file.write_text("VALUE = 1\n", encoding="utf-8")
+        test_file = tmp_path / "tests" / "test_preexisting.py"
+        test_file.parent.mkdir()
+        test_file.write_text("def test_preexisting():\n    assert True\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/preexisting.py"],'
+                '"commands_run":["pytest tests/test_preexisting.py"],'
+                '"tests_passed":["tests/test_preexisting.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_preexisting.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_preexisting.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_preexisting.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "files_touched: src/preexisting.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_test_not_covered_by_success_chunk(
         self, tmp_path
     ) -> None:
@@ -1588,6 +1663,72 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error is not None
         assert "tests_passed: tests/test_b.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_targeted_failed_test_command(
+        self, tmp_path
+    ) -> None:
+        """A targeted test command mentioning the claim is not proof without success."""
+        touched_file = tmp_path / "src" / "generated.py"
+        touched_file.parent.mkdir()
+        touched_file.write_text("VALUE = 1\n", encoding="utf-8")
+        test_file = tmp_path / "tests" / "test_generated.py"
+        test_file.parent.mkdir()
+        test_file.write_text("def test_generated():\n    assert False\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/generated.py"],'
+                '"commands_run":["pytest tests/test_generated.py"],'
+                '"tests_passed":["tests/test_generated.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_generated.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_generated.py failed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed: tests/test_generated.py" in result.error
         evidence_event = next(
             event
             for event in appended_events


### PR DESCRIPTION
## Summary

Clean replacement for #1004. Completes the remaining #920 atomic acceptance invariant by requiring a separate verifier PASS after profile typed-evidence validation in the live `parallel_executor` atomic AC boundary.

## Scope

- Adds atomic verifier verdict telemetry to `ACExecutionResult` and `execution.ac.typed_evidence.observed`.
- Fat-harness acceptance now requires:
  1. runtime success,
  2. profile typed evidence present,
  3. profile evidence validation passing,
  4. a separate `VerifierVerdict.passed == true`.
- Keeps observe-only mode isolated: injected verifiers do not run unless fat-harness enforcement is active.
- Converts operational verifier failures (`TimeoutError`, `OSError`, subprocess errors) into typed STALL verifier verdicts while still surfacing verifier programming bugs.
- Default verifier rejects final-message-only self-reporting and supports evidence only through non-final runtime transcript evidence or active-workspace file evidence.
- Bounds file proof to the active workspace (`task_cwd` or adapter working directory), rejecting absolute paths and parent traversal.
- Verifies `tests_passed` per claim against the adjacent transcript chunk of a backed successful test command; failed mixed output such as `1 failed, 3 passed` remains rejected.

## Milestone boundaries

- This is a narrow #920 completion slice for the unchecked success criterion: typed evidence **and verifier PASS** before atomic AC acceptance.
- It does not remove the legacy self-report fallback.
- It does not start #978 P5; legacy removal remains blocked on the #961 release-cycle observation window.
- #1004 is superseded only to give bots a clean, single-commit review surface after the iterative review loop became stale.

## Validation

- `PYTHONPATH=src pytest -q tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_verifier.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py` → 233 passed, 1 skipped
- `uv run mypy src/ouroboros/orchestrator/verifier.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py`
- `uv run ruff check src/ouroboros/orchestrator/verifier.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run ruff format --check src/ouroboros/orchestrator/verifier.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py tests/unit/orchestrator/test_parallel_executor.py`
