### PR TITLE
Harden atomic verifier runtime evidence support

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -213,8 +213,6 @@ def _runtime_messages_support_file_claim(
     claimed relative path resolves inside the active workspace, which covers
     tool outputs that report ``generated.py`` instead of ``src/generated.py``.
     """
-    if _runtime_messages_support_claim(value, messages):
-        return True
     if task_cwd is None:
         return False
     candidate = Path(value)
@@ -226,29 +224,34 @@ def _runtime_messages_support_file_claim(
         resolved.relative_to(base)
     except ValueError:
         return False
+    if any(_runtime_message_supports_file_reference(value, message) for message in messages):
+        return True
     if not resolved.exists():
         return False
     basename = candidate.name.strip().lower()
     return bool(basename) and any(
-        _runtime_message_supports_file_basename(basename, message) for message in messages
+        _runtime_message_supports_file_reference(basename, message) for message in messages
     )
 
 
-def _runtime_message_supports_file_basename(basename: str, message: AgentMessage) -> bool:
-    """Return True when one message plausibly reports touching a basename."""
+def _runtime_message_supports_file_reference(reference: str, message: AgentMessage) -> bool:
+    """Return True when one message plausibly reports touching a file reference."""
+    normalized_reference = reference.strip().lower()
+    if not normalized_reference:
+        return False
     text = _runtime_message_search_text(message)
-    basename_pattern = re.compile(rf"(?<![\w.-]){re.escape(basename)}(?![\w.-])")
-    if not basename_pattern.search(text):
+    reference_pattern = re.compile(rf"(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-])")
+    if not reference_pattern.search(text):
         return False
     if message.tool_name in {"Edit", "Write", "NotebookEdit"}:
         return True
     return bool(
         re.search(
-            rf"(?<![\w.-]){re.escape(basename)}(?![\w.-]).*\b("
+            rf"(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-]).*\b("
             r"updated|modified|changed|created|generated|wrote|written|patched"
             r")\b|\b("
             r"updated|modified|changed|created|generated|wrote|written|patched"
-            rf")\b.*(?<![\w.-]){re.escape(basename)}(?![\w.-])",
+            rf")\b.*(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-])",
             text,
         )
     )
@@ -289,7 +292,11 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
         text,
     ):
         return False
-    return bool(re.search(r"\b(passed|pass|success|succeeded)\b|exit\s*code\s*0|0\s+failed", text))
+    if re.search(r"\b0\s+passed\b", text) and not re.search(r"\b[1-9]\d*\s+passed\b", text):
+        return False
+    return bool(
+        re.search(r"\b([1-9]\d*\s+passed|passed|pass|success|succeeded)\b|exit\s*code\s*0", text)
+    )
 
 
 def _runtime_messages_support_test_claim(
@@ -3990,11 +3997,14 @@ When complete, explicitly state: [TASK_COMPLETE]
                 continue
             field_messages = _runtime_support_messages_for_field(field_name, support_messages)
             for value in values:
-                if field_name == "files_touched" and _runtime_messages_support_file_claim(
-                    value,
-                    field_messages,
-                    task_cwd=self._task_cwd or self._adapter.working_directory,
-                ):
+                if field_name == "files_touched":
+                    if _runtime_messages_support_file_claim(
+                        value,
+                        field_messages,
+                        task_cwd=self._task_cwd or self._adapter.working_directory,
+                    ):
+                        continue
+                    unsupported.append(f"{field_name}: {value}")
                     continue
                 if field_name == "tests_passed":
                     if _runtime_messages_support_test_claim(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1559,6 +1559,11 @@ class TestParallelACExecutor:
                 native_session_id="opencode-session-evidence",
                 support_messages=(
                     AgentMessage(
+                        type="result",
+                        content="Read src/preexisting.py for context only.",
+                        data={"subtype": "success"},
+                    ),
+                    AgentMessage(
                         type="tool",
                         content="Bash: pytest tests/test_preexisting.py",
                         tool_name="Bash",
@@ -1600,6 +1605,73 @@ class TestParallelACExecutor:
             if event.type == "execution.ac.typed_evidence.observed"
         )
         assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_read_only_file_reference(self, tmp_path) -> None:
+        """Mentioning a path in a read-only command is not files_touched proof."""
+        preexisting_file = tmp_path / "src" / "preexisting.py"
+        preexisting_file.parent.mkdir()
+        preexisting_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/preexisting.py"],'
+                '"commands_run":["pytest tests/test_preexisting.py"],'
+                '"tests_passed":["tests/test_preexisting.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: cat src/preexisting.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "cat src/preexisting.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_preexisting.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_preexisting.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_preexisting.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "files_touched: src/preexisting.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
         assert evidence_event.data["verifier_passed"] is False
 
     @pytest.mark.asyncio
@@ -1663,6 +1735,73 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error is not None
         assert "tests_passed: tests/test_b.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_zero_passed_test_output(self, tmp_path) -> None:
+        """A zero-passed test run is not proof for a claimed passing test."""
+        touched_file = tmp_path / "src" / "generated.py"
+        touched_file.parent.mkdir()
+        touched_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/generated.py"],'
+                '"commands_run":["pytest tests/test_generated.py"],'
+                '"tests_passed":["tests/test_generated.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Edit: src/generated.py",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": "src/generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_generated.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_generated.py collected, 0 passed, 0 failed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed: tests/test_generated.py" in result.error
         evidence_event = next(
             event
             for event in appended_events


### PR DESCRIPTION
## Summary

Post-merge hardening follow-up after #1006. #1006 correctly added the fat-harness atomic verifier PASS boundary, but the runtime-support matcher still accepted a few weak structural proofs:

- `files_touched` could be satisfied by a generic path mention rather than a plausible write/generate/edit transcript.
- `tests_passed` could treat `0 passed, 0 failed` as success because `0 failed` was accepted as a success marker.

This PR keeps the #1006 boundary intact while tightening the support rules so verifier PASS proves current-run evidence rather than stale/read-only mentions.

## What changed

- Replaces generic file substring support with `_runtime_message_supports_file_reference()`.
- Allows file evidence only when transcript text plausibly reports a write/generate/update/patch action, or comes from `Edit` / `Write` / `NotebookEdit`.
- Keeps basename fallback only for in-workspace relative paths that exist and have plausible touch transcript evidence.
- Rejects zero-passed test output for `tests_passed` claims.
- Adds regressions for:
  - stale preexisting file read in context only,
  - read-only `cat src/preexisting.py`,
  - `0 passed, 0 failed` test output.

## Boundary

- Does not reopen #1006 scope beyond verifier support hardening.
- Does not remove legacy self-report fallback.
- Does not start #978 P5.
- Keeps #961/#920 release-cycle observation boundary intact.

## Validation

- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_verifier.py -q` → 109 passed
- `PYTHONPATH=src pytest -q tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_verifier.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py` → 237 passed, 1 skipped, 1 warning
- `uv run mypy src/ouroboros/orchestrator/verifier.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py` → passed
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` → passed
- `uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` → passed

Follow-up to #1006; refs #920, #961.
