### PR TITLE
fix(harness): stabilize evidence manifests

### DIFF
--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -231,7 +231,12 @@ async def load_ac_evidence_manifest(
     manifest = normalize_events(_chronological_events(filtered_events), ac_id=normalized_scope_id)
     if normalized_scope_id == normalized_ac_id:
         return manifest
-    return manifest.model_copy(update={"ac_id": normalized_ac_id})
+    return EvidenceManifest(
+        ac_id=normalized_ac_id,
+        entries=manifest.entries,
+        normalized_at=manifest.normalized_at,
+        metadata=manifest.metadata,
+    )
 
 
 def evaluate_deliver_claim(

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -259,7 +259,7 @@ class EvidenceEntry(BaseModel, frozen=True):
 
     @model_validator(mode="after")
     def _stabilize_generated_handle(self) -> EvidenceEntry:
-        if self.handle != "__auto__":
+        if "handle" in self.model_fields_set:
             return self
         object.__setattr__(
             self,
@@ -308,7 +308,7 @@ class EvidenceManifest(BaseModel, frozen=True):
 
     @model_validator(mode="after")
     def _stabilize_generated_manifest_id(self) -> EvidenceManifest:
-        if self.manifest_id != "__auto__":
+        if "manifest_id" in self.model_fields_set:
             return self
         object.__setattr__(
             self,
@@ -455,6 +455,8 @@ def normalize_events(
     llm_slot_index: dict[str, int] = {}
     memory_tool_call_ids: set[str] = set()
     memory_llm_call_ids: set[str] = set()
+    orphan_tool_slot_index: dict[str, int] = {}
+    orphan_llm_slot_index: dict[str, int] = {}
 
     for event in events:
         # Skip events that carry explicit scope tokens but none of them
@@ -472,11 +474,17 @@ def normalize_events(
                     slot = tool_slot_index.pop(call_id, None)
                     if slot is not None:
                         slots[slot] = None
+                    orphan_slot = orphan_tool_slot_index.pop(call_id, None)
+                    if orphan_slot is not None:
+                        slots[orphan_slot] = None
                 elif event.type in {_LLM_REQUESTED, _LLM_RETURNED}:
                     memory_llm_call_ids.add(call_id)
                     slot = llm_slot_index.pop(call_id, None)
                     if slot is not None:
                         slots[slot] = None
+                    orphan_slot = orphan_llm_slot_index.pop(call_id, None)
+                    if orphan_slot is not None:
+                        slots[orphan_slot] = None
             continue
 
         if event.type == _TOOL_STARTED:
@@ -502,6 +510,8 @@ def normalize_events(
             if slot is not None:
                 slots[slot] = entry
             else:
+                if call_id:
+                    orphan_tool_slot_index[call_id] = len(slots)
                 slots.append(entry)
             continue
 
@@ -528,6 +538,8 @@ def normalize_events(
             if slot is not None:
                 slots[slot] = entry
             else:
+                if call_id:
+                    orphan_llm_slot_index[call_id] = len(slots)
                 slots.append(entry)
             continue
 
@@ -580,28 +592,89 @@ def _event_child_ac_id(*events: BaseEvent | None) -> str | None:
 
 
 def _is_memory_derived_event(event: BaseEvent) -> bool:
-    return (
-        _is_memory_derived_value(event.aggregate_id)
-        or _is_memory_derived_value(event.aggregate_type)
-        or _is_memory_derived_value(event.data)
+    if _looks_like_memory_reference(event.aggregate_id) or _looks_like_memory_reference(
+        event.aggregate_type
+    ):
+        return True
+    if not isinstance(event.data, Mapping):
+        return False
+
+    extra = event.data.get("extra")
+    if _is_memory_provenance_mapping(extra):
+        return True
+
+    if event.type == _TOOL_STARTED:
+        return _is_memory_derived_tool_start(event.data)
+    if event.type == _LLM_REQUESTED:
+        return _is_memory_derived_llm_request(event.data)
+    return _has_memory_provenance_marker(event.data)
+
+
+def _is_memory_derived_tool_start(data: Mapping[str, Any]) -> bool:
+    caller = data.get("caller")
+    if _has_memory_provenance_marker(caller):
+        return True
+
+    tool_name = data.get("tool_name")
+    args_preview = data.get("args_preview")
+    if not isinstance(args_preview, str):
+        return False
+
+    if isinstance(tool_name, str) and tool_name.strip() == "Read":
+        return _looks_like_memory_reference(args_preview)
+    return _looks_like_memory_command(args_preview)
+
+
+def _is_memory_derived_llm_request(data: Mapping[str, Any]) -> bool:
+    return _has_memory_provenance_marker(data.get("caller")) or _has_memory_provenance_marker(
+        data.get("prompt_preview")
     )
 
 
-def _is_memory_derived_value(value: Any) -> bool:
-    if isinstance(value, Mapping):
-        return any(
-            _looks_like_memory_reference(str(key)) or _is_memory_derived_value(item)
-            for key, item in value.items()
-        )
-    if isinstance(value, list | tuple | set | frozenset):
-        return any(_is_memory_derived_value(item) for item in value)
-    if isinstance(value, str):
-        return _looks_like_memory_reference(value)
+def _is_memory_provenance_mapping(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    provenance_keys = {
+        "derived_from",
+        "memory_source",
+        "memory_path",
+        "source_path",
+        "source_file",
+        "provenance",
+        "origin",
+    }
+    for key, item in value.items():
+        normalized_key = str(key).strip().lower()
+        if normalized_key in provenance_keys and _looks_like_memory_reference(item):
+            return True
+        if normalized_key in {"memory_derived", "from_memory"} and item is True:
+            return True
     return False
 
 
-def _looks_like_memory_reference(value: str) -> bool:
-    if not value:
+def _has_memory_provenance_marker(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.lower()
+    return "memory.md-derived" in lowered or ".memory.md-derived" in lowered
+
+
+def _looks_like_memory_command(value: str) -> bool:
+    stripped = value.strip()
+    lowered = stripped.lower()
+    if not any(name.lower() in lowered for name in _MEMORY_FILENAMES):
+        return False
+    return bool(
+        re.search(
+            r"(?:^|[;&|()\s])(?:cat|less|more|head|tail|sed|awk|python|python3|node|ruby|perl)\s+[^;&|]*\.?memory\.md(?:$|[\s;&|)])",
+            stripped,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _looks_like_memory_reference(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
         return False
     if _MEMORY_REFERENCE_RE.search(value):
         return True

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -36,6 +36,7 @@ from enum import StrEnum
 from hashlib import sha256
 import json
 from pathlib import PurePosixPath
+import re
 from types import MappingProxyType
 from typing import Annotated, Any
 
@@ -55,6 +56,7 @@ JOURNAL_SCHEMA_VERSION = 1
 """Initial schema version for the evidence manifest."""
 
 _MEMORY_FILENAMES = frozenset({"MEMORY.md", ".memory.md"})
+_MEMORY_REFERENCE_RE = re.compile(r"(?<![A-Za-z0-9_.])(?:MEMORY\.md|\.memory\.md)(?![A-Za-z0-9_.])")
 
 
 # ---------------------------------------------------------------------------
@@ -601,6 +603,8 @@ def _is_memory_derived_value(value: Any) -> bool:
 def _looks_like_memory_reference(value: str) -> bool:
     if not value:
         return False
+    if _MEMORY_REFERENCE_RE.search(value):
+        return True
     normalized = value.replace("\\", "/")
     for part in normalized.split():
         token = part.strip("`'\".,:;()[]{}")

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -607,6 +607,8 @@ def _is_memory_derived_event(event: BaseEvent) -> bool:
         return _is_memory_derived_tool_start(event.data)
     if event.type == _LLM_REQUESTED:
         return _is_memory_derived_llm_request(event.data)
+    if event.type in {_TOOL_RETURNED, _LLM_RETURNED}:
+        return _is_memory_derived_return(event.data)
     return _has_memory_provenance_marker(event.data)
 
 
@@ -628,6 +630,15 @@ def _is_memory_derived_tool_start(data: Mapping[str, Any]) -> bool:
 def _is_memory_derived_llm_request(data: Mapping[str, Any]) -> bool:
     return _has_memory_provenance_marker(data.get("caller")) or _has_memory_provenance_marker(
         data.get("prompt_preview")
+    )
+
+
+def _is_memory_derived_return(data: Mapping[str, Any]) -> bool:
+    if _is_memory_provenance_mapping(data):
+        return True
+    return any(
+        _has_memory_provenance_marker(data.get(key))
+        for key in ("caller", "args_preview", "prompt_preview")
     )
 
 

--- a/src/ouroboros/harness/journal.py
+++ b/src/ouroboros/harness/journal.py
@@ -33,9 +33,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from enum import StrEnum
+from hashlib import sha256
+import json
+from pathlib import PurePosixPath
 from types import MappingProxyType
 from typing import Annotated, Any
-from uuid import uuid4
 
 from pydantic import (
     AfterValidator,
@@ -51,6 +53,8 @@ from ouroboros.events.base import BaseEvent
 
 JOURNAL_SCHEMA_VERSION = 1
 """Initial schema version for the evidence manifest."""
+
+_MEMORY_FILENAMES = frozenset({"MEMORY.md", ".memory.md"})
 
 
 # ---------------------------------------------------------------------------
@@ -83,11 +87,18 @@ def _deep_thaw(value: Any) -> Any:
     """Convert frozen containers back to JSON-native containers for dumps."""
     if isinstance(value, Mapping):
         return {key: _deep_thaw(item) for key, item in value.items()}
-    if isinstance(value, tuple | frozenset):
+    if isinstance(value, tuple):
         return [_deep_thaw(item) for item in value]
+    if isinstance(value, set | frozenset):
+        thawed = [_deep_thaw(item) for item in value]
+        return sorted(thawed, key=_stable_json_sort_key)
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return value
+
+
+def _stable_json_sort_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
 
 
 def _coerce_to_mapping(value: Any) -> Mapping[str, Any]:
@@ -160,8 +171,42 @@ class EvidenceKind(StrEnum):
     LLM_CALL = "llm_call"
 
 
-def _new_id(prefix: str) -> str:
-    return f"{prefix}_{uuid4().hex[:12]}"
+def _stable_entry_handle(
+    *,
+    kind: EvidenceKind,
+    payload: Mapping[str, Any],
+    source_event_ids: tuple[str, ...],
+) -> str:
+    serialized = json.dumps(
+        {
+            "kind": kind.value,
+            "payload": _deep_thaw(payload),
+            "source_event_ids": source_event_ids,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return f"ev_{sha256(serialized.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _stable_manifest_id(*, ac_id: str, entries: tuple[EvidenceEntry, ...]) -> str:
+    serialized = json.dumps(
+        {
+            "ac_id": ac_id,
+            "entries": [
+                {
+                    "handle": entry.handle,
+                    "kind": entry.kind.value,
+                    "source_event_ids": entry.source_event_ids,
+                }
+                for entry in entries
+            ],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"manifest_{sha256(serialized.encode('utf-8')).hexdigest()[:16]}"
 
 
 class EvidenceEntry(BaseModel, frozen=True):
@@ -169,7 +214,7 @@ class EvidenceEntry(BaseModel, frozen=True):
 
     Attributes:
         handle: Stable, manifest-scoped identifier that the leaf agent
-            can cite in its evidence claim (``ev_<hex12>`` by default).
+            can cite in its evidence claim (``ev_<sha256-prefix>`` by default).
         kind: Discriminator from :class:`EvidenceKind`.
         ok: Tri-valued success flag. ``True`` = succeeded, ``False`` =
             failed, ``None`` = undetermined (e.g. only the start event
@@ -187,7 +232,7 @@ class EvidenceEntry(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=JOURNAL_SCHEMA_VERSION, ge=1)
-    handle: str = Field(default_factory=lambda: _new_id("ev"), min_length=1)
+    handle: str = Field(default="__auto__", min_length=1)
     kind: EvidenceKind
     ok: bool | None = Field(default=None)
     started_at: datetime
@@ -210,6 +255,21 @@ class EvidenceEntry(BaseModel, frozen=True):
             raise ValueError(msg)
         return self
 
+    @model_validator(mode="after")
+    def _stabilize_generated_handle(self) -> EvidenceEntry:
+        if self.handle != "__auto__":
+            return self
+        object.__setattr__(
+            self,
+            "handle",
+            _stable_entry_handle(
+                kind=self.kind,
+                payload=self.payload,
+                source_event_ids=self.source_event_ids,
+            ),
+        )
+        return self
+
 
 class EvidenceManifest(BaseModel, frozen=True):
     """Per-AC evidence manifest derived from the journal.
@@ -220,7 +280,7 @@ class EvidenceManifest(BaseModel, frozen=True):
     its own work.
 
     Attributes:
-        manifest_id: Stable identifier.
+        manifest_id: Stable identifier derived from AC id and entries.
         ac_id: Acceptance-criterion identifier this manifest covers.
         entries: Tuple of :class:`EvidenceEntry` records in observation
             order.
@@ -229,7 +289,7 @@ class EvidenceManifest(BaseModel, frozen=True):
     """
 
     schema_version: int = Field(default=JOURNAL_SCHEMA_VERSION, ge=1)
-    manifest_id: str = Field(default_factory=lambda: _new_id("manifest"), min_length=1)
+    manifest_id: str = Field(default="__auto__", min_length=1)
     ac_id: str = Field(..., min_length=1)
     entries: tuple[EvidenceEntry, ...] = Field(default_factory=tuple)
     normalized_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -243,6 +303,17 @@ class EvidenceManifest(BaseModel, frozen=True):
             msg = "EvidenceManifest.ac_id must be a non-blank identifier"
             raise ValueError(msg)
         return stripped
+
+    @model_validator(mode="after")
+    def _stabilize_generated_manifest_id(self) -> EvidenceManifest:
+        if self.manifest_id != "__auto__":
+            return self
+        object.__setattr__(
+            self,
+            "manifest_id",
+            _stable_manifest_id(ac_id=self.ac_id, entries=self.entries),
+        )
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +451,8 @@ def normalize_events(
     slots: list[BaseEvent | EvidenceEntry | None] = []
     tool_slot_index: dict[str, int] = {}
     llm_slot_index: dict[str, int] = {}
+    memory_tool_call_ids: set[str] = set()
+    memory_llm_call_ids: set[str] = set()
 
     for event in events:
         # Skip events that carry explicit scope tokens but none of them
@@ -389,16 +462,34 @@ def normalize_events(
         if scope_tokens and normalized_ac_id not in scope_tokens:
             continue
 
+        if _is_memory_derived_event(event):
+            call_id = _slot_call_id(event)
+            if call_id:
+                if event.type in {_TOOL_STARTED, _TOOL_RETURNED}:
+                    memory_tool_call_ids.add(call_id)
+                    slot = tool_slot_index.pop(call_id, None)
+                    if slot is not None:
+                        slots[slot] = None
+                elif event.type in {_LLM_REQUESTED, _LLM_RETURNED}:
+                    memory_llm_call_ids.add(call_id)
+                    slot = llm_slot_index.pop(call_id, None)
+                    if slot is not None:
+                        slots[slot] = None
+            continue
+
         if event.type == _TOOL_STARTED:
             call_id = event.data.get("call_id") if isinstance(event.data, dict) else None
-            if isinstance(call_id, str) and call_id.strip():
-                tool_slot_index[call_id.strip()] = len(slots)
+            normalized_call_id = call_id.strip() if isinstance(call_id, str) else ""
+            if normalized_call_id and normalized_call_id not in memory_tool_call_ids:
+                tool_slot_index[normalized_call_id] = len(slots)
                 slots.append(event)
             continue
 
         if event.type == _TOOL_RETURNED:
             call_id_raw = event.data.get("call_id") if isinstance(event.data, dict) else None
             call_id = call_id_raw.strip() if isinstance(call_id_raw, str) else ""
+            if call_id in memory_tool_call_ids:
+                continue
             slot = tool_slot_index.pop(call_id, None) if call_id else None
             start_event: BaseEvent | None = None
             if slot is not None:
@@ -414,14 +505,17 @@ def normalize_events(
 
         if event.type == _LLM_REQUESTED:
             call_id = event.data.get("call_id") if isinstance(event.data, dict) else None
-            if isinstance(call_id, str) and call_id.strip():
-                llm_slot_index[call_id.strip()] = len(slots)
+            normalized_call_id = call_id.strip() if isinstance(call_id, str) else ""
+            if normalized_call_id and normalized_call_id not in memory_llm_call_ids:
+                llm_slot_index[normalized_call_id] = len(slots)
                 slots.append(event)
             continue
 
         if event.type == _LLM_RETURNED:
             call_id_raw = event.data.get("call_id") if isinstance(event.data, dict) else None
             call_id = call_id_raw.strip() if isinstance(call_id_raw, str) else ""
+            if call_id in memory_llm_call_ids:
+                continue
             slot = llm_slot_index.pop(call_id, None) if call_id else None
             requested_event: BaseEvent | None = None
             if slot is not None:
@@ -481,6 +575,41 @@ def _event_child_ac_id(*events: BaseEvent | None) -> str | None:
             if isinstance(value, str) and value.strip():
                 return value.strip()
     return None
+
+
+def _is_memory_derived_event(event: BaseEvent) -> bool:
+    return (
+        _is_memory_derived_value(event.aggregate_id)
+        or _is_memory_derived_value(event.aggregate_type)
+        or _is_memory_derived_value(event.data)
+    )
+
+
+def _is_memory_derived_value(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        return any(
+            _looks_like_memory_reference(str(key)) or _is_memory_derived_value(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list | tuple | set | frozenset):
+        return any(_is_memory_derived_value(item) for item in value)
+    if isinstance(value, str):
+        return _looks_like_memory_reference(value)
+    return False
+
+
+def _looks_like_memory_reference(value: str) -> bool:
+    if not value:
+        return False
+    normalized = value.replace("\\", "/")
+    for part in normalized.split():
+        token = part.strip("`'\".,:;()[]{}")
+        candidates = (token, token.rsplit("=", maxsplit=1)[-1], token.rsplit(":", maxsplit=1)[-1])
+        for candidate in candidates:
+            filename = PurePosixPath(candidate.strip("`'\".,:;()[]{}")).name
+            if filename in _MEMORY_FILENAMES:
+                return True
+    return False
 
 
 def _build_tool_entry_for_returned(

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -395,12 +395,15 @@ class TestLoadAcEvidenceManifest:
             "evt_started_target",
             "evt_returned_target",
         )
-        assert manifest.manifest_id == EvidenceManifest(
-            ac_id="AC-1",
-            entries=manifest.entries,
-            normalized_at=manifest.normalized_at,
-            metadata=manifest.metadata,
-        ).manifest_id
+        assert (
+            manifest.manifest_id
+            == EvidenceManifest(
+                ac_id="AC-1",
+                entries=manifest.entries,
+                normalized_at=manifest.normalized_at,
+                metadata=manifest.metadata,
+            ).manifest_id
+        )
 
     @pytest.mark.asyncio
     async def test_rejects_session_only_query_to_avoid_mixed_execution_manifests(self) -> None:

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -395,6 +395,12 @@ class TestLoadAcEvidenceManifest:
             "evt_started_target",
             "evt_returned_target",
         )
+        assert manifest.manifest_id == EvidenceManifest(
+            ac_id="AC-1",
+            entries=manifest.entries,
+            normalized_at=manifest.normalized_at,
+            metadata=manifest.metadata,
+        ).manifest_id
 
     @pytest.mark.asyncio
     async def test_rejects_session_only_query_to_avoid_mixed_execution_manifests(self) -> None:

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -184,6 +184,16 @@ class TestEvidenceEntry:
 
         assert entry.handle == "ev_caller_supplied"
 
+    def test_explicit_auto_sentinel_handle_is_preserved(self) -> None:
+        entry = EvidenceEntry(
+            handle="__auto__",
+            kind=EvidenceKind.TOOL_INVOCATION,
+            started_at=datetime.now(UTC),
+            source_event_ids=("evt_1",),
+        )
+
+        assert entry.handle == "__auto__"
+
 
 class TestEvidenceManifest:
     def test_ac_id_required(self) -> None:
@@ -213,6 +223,11 @@ class TestEvidenceManifest:
         manifest = EvidenceManifest(ac_id="ac_1", manifest_id="manifest_external")
 
         assert manifest.manifest_id == "manifest_external"
+
+    def test_explicit_auto_sentinel_manifest_id_is_preserved(self) -> None:
+        manifest = EvidenceManifest(ac_id="ac_1", manifest_id="__auto__")
+
+        assert manifest.manifest_id == "__auto__"
 
     def test_is_frozen(self) -> None:
         manifest = EvidenceManifest(ac_id="ac_1")
@@ -385,7 +400,7 @@ class TestNormalizeEventsACScope:
         assert len(manifest.entries) == 1
         assert manifest.entries[0].source_event_ids == ("evt_fresh_start", "evt_fresh_return")
 
-    def test_excludes_pair_when_returned_event_references_memory_file(self) -> None:
+    def test_keeps_pair_when_result_only_mentions_memory_file(self) -> None:
         events = [
             _tool_started(
                 call_id="memory_result",
@@ -403,7 +418,11 @@ class TestNormalizeEventsACScope:
 
         manifest = normalize_events(events, ac_id="ac_1")
 
-        assert manifest.entries == ()
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == (
+            "evt_memory_result_start",
+            "evt_memory_result_return",
+        )
 
     def test_excludes_memory_reference_in_event_aggregate_id(self) -> None:
         event = BaseEvent(
@@ -443,7 +462,7 @@ class TestNormalizeEventsACScope:
 
         assert manifest.entries == ()
 
-    def test_excludes_memory_derived_token_with_suffix_punctuation(self) -> None:
+    def test_excludes_read_memory_derived_token_with_suffix_punctuation(self) -> None:
         event = _tool_started(
             call_id="memory_derived",
             tool_name="Read",
@@ -454,6 +473,27 @@ class TestNormalizeEventsACScope:
         manifest = normalize_events([event], ac_id="ac_1")
 
         assert manifest.entries == ()
+
+    def test_keeps_non_read_args_that_only_mention_memory_file(self) -> None:
+        events = [
+            _tool_started(
+                call_id="grep_docs",
+                tool_name="Bash",
+                args_preview="grep -R MEMORY.md docs tests",
+                event_id="evt_grep_start",
+            ),
+            _tool_returned(
+                call_id="grep_docs",
+                tool_name="Bash",
+                result_preview="docs/setup.md mentions MEMORY.md",
+                event_id="evt_grep_return",
+            ),
+        ]
+
+        manifest = normalize_events(events, ac_id="ac_1")
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == ("evt_grep_start", "evt_grep_return")
 
     def test_memory_event_from_other_ac_does_not_suppress_matching_call_id(self) -> None:
         events = [

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -142,6 +142,48 @@ class TestEvidenceEntry:
         )
         assert entry.handle.startswith("ev_")
 
+    def test_generated_handle_is_stable_from_entry_evidence(self) -> None:
+        first = EvidenceEntry(
+            kind=EvidenceKind.TOOL_INVOCATION,
+            started_at=datetime.now(UTC),
+            payload={"tool_name": "Read", "args_preview": "path=src/app.py"},
+            source_event_ids=("evt_1",),
+        )
+        second = EvidenceEntry(
+            kind=EvidenceKind.TOOL_INVOCATION,
+            started_at=datetime.now(UTC) + timedelta(seconds=10),
+            payload={"tool_name": "Read", "args_preview": "path=src/app.py"},
+            source_event_ids=("evt_1",),
+        )
+
+        assert first.handle == second.handle
+
+    def test_generated_handle_is_stable_for_unordered_payload_sets(self) -> None:
+        first = EvidenceEntry(
+            kind=EvidenceKind.TOOL_INVOCATION,
+            started_at=datetime.now(UTC),
+            payload={"tags": {"write", "test", "review"}},
+            source_event_ids=("evt_1",),
+        )
+        second = EvidenceEntry(
+            kind=EvidenceKind.TOOL_INVOCATION,
+            started_at=datetime.now(UTC),
+            payload={"tags": {"review", "write", "test"}},
+            source_event_ids=("evt_1",),
+        )
+
+        assert first.handle == second.handle
+
+    def test_explicit_handle_is_preserved(self) -> None:
+        entry = EvidenceEntry(
+            handle="ev_caller_supplied",
+            kind=EvidenceKind.TOOL_INVOCATION,
+            started_at=datetime.now(UTC),
+            source_event_ids=("evt_1",),
+        )
+
+        assert entry.handle == "ev_caller_supplied"
+
 
 class TestEvidenceManifest:
     def test_ac_id_required(self) -> None:
@@ -152,6 +194,25 @@ class TestEvidenceManifest:
         manifest = EvidenceManifest(ac_id="ac_1")
         with pytest.raises(TypeError):
             manifest.metadata["k"] = "v"  # type: ignore[index]
+
+    def test_generated_manifest_id_is_stable(self) -> None:
+        entry = EvidenceEntry(
+            kind=EvidenceKind.COMMAND_EXECUTED,
+            started_at=datetime.now(UTC),
+            payload={"tool_name": "Bash", "result_preview": "1 passed"},
+            source_event_ids=("evt_1",),
+        )
+
+        first = EvidenceManifest(ac_id="ac_1", entries=(entry,))
+        second = EvidenceManifest(ac_id="ac_1", entries=(entry,))
+
+        assert first.manifest_id == second.manifest_id
+        assert first.manifest_id.startswith("manifest_")
+
+    def test_explicit_manifest_id_is_preserved(self) -> None:
+        manifest = EvidenceManifest(ac_id="ac_1", manifest_id="manifest_external")
+
+        assert manifest.manifest_id == "manifest_external"
 
     def test_is_frozen(self) -> None:
         manifest = EvidenceManifest(ac_id="ac_1")
@@ -242,6 +303,33 @@ class TestNormalizeEventsToolPairs:
         assert entry.kind is EvidenceKind.COMMAND_EXECUTED
         assert entry.source_event_ids == ("evt_returned_orphan",)
 
+    def test_normalization_is_replay_stable_for_same_journal(self) -> None:
+        start_time = datetime.now(UTC)
+        events = [
+            _tool_started(
+                call_id="stable",
+                tool_name="Bash",
+                event_id="evt_start_stable",
+                when=start_time,
+                args_preview="pytest tests/unit/harness/test_journal_normalizer.py",
+            ),
+            _tool_returned(
+                call_id="stable",
+                tool_name="Bash",
+                event_id="evt_return_stable",
+                when=start_time + timedelta(milliseconds=5),
+                result_preview="1 passed",
+            ),
+        ]
+
+        first = normalize_events(events, ac_id="ac_1")
+        second = normalize_events(events, ac_id="ac_1")
+
+        assert first.manifest_id == second.manifest_id
+        assert [entry.handle for entry in first.entries] == [
+            entry.handle for entry in second.entries
+        ]
+
 
 class TestNormalizeEventsACScope:
     def test_drops_events_belonging_to_other_ac(self) -> None:
@@ -263,6 +351,130 @@ class TestNormalizeEventsACScope:
     def test_trims_ac_id_whitespace(self) -> None:
         manifest = normalize_events([], ac_id="  ac_padded  ")
         assert manifest.ac_id == "ac_padded"
+
+    def test_excludes_memory_file_events_from_evidence_manifest(self) -> None:
+        events = [
+            _tool_started(
+                call_id="memory",
+                tool_name="Read",
+                args_preview="path=MEMORY.md",
+                event_id="evt_memory_start",
+            ),
+            _tool_returned(
+                call_id="memory",
+                tool_name="Read",
+                result_preview="schema prior content",
+                event_id="evt_memory_return",
+            ),
+            _tool_started(
+                call_id="fresh",
+                tool_name="Read",
+                args_preview="path=src/app.py",
+                event_id="evt_fresh_start",
+            ),
+            _tool_returned(
+                call_id="fresh",
+                tool_name="Read",
+                result_preview="fresh run content",
+                event_id="evt_fresh_return",
+            ),
+        ]
+
+        manifest = normalize_events(events, ac_id="ac_1")
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == ("evt_fresh_start", "evt_fresh_return")
+
+    def test_excludes_pair_when_returned_event_references_memory_file(self) -> None:
+        events = [
+            _tool_started(
+                call_id="memory_result",
+                tool_name="Bash",
+                args_preview="pytest tests/unit",
+                event_id="evt_memory_result_start",
+            ),
+            _tool_returned(
+                call_id="memory_result",
+                tool_name="Bash",
+                result_preview="Read MEMORY.md during execution",
+                event_id="evt_memory_result_return",
+            ),
+        ]
+
+        manifest = normalize_events(events, ac_id="ac_1")
+
+        assert manifest.entries == ()
+
+    def test_excludes_memory_reference_in_event_aggregate_id(self) -> None:
+        event = BaseEvent(
+            id="evt_memory_aggregate",
+            type="tool.call.started",
+            timestamp=datetime.now(UTC),
+            aggregate_type="session",
+            aggregate_id="/tmp/MEMORY.md",
+            data={
+                "call_id": "memory_aggregate",
+                "tool_name": "Read",
+                "ac_id": "ac_1",
+            },
+        )
+
+        manifest = normalize_events([event], ac_id="ac_1")
+
+        assert manifest.entries == ()
+
+    def test_excludes_memory_return_before_started_pair(self) -> None:
+        events = [
+            _tool_returned(
+                call_id="memory",
+                tool_name="Read",
+                result_preview="read /tmp/MEMORY.md",
+                event_id="evt_memory_return",
+            ),
+            _tool_started(
+                call_id="memory",
+                tool_name="Read",
+                args_preview="path=/tmp/MEMORY.md",
+                event_id="evt_memory_start",
+            ),
+        ]
+
+        manifest = normalize_events(events, ac_id="ac_1")
+
+        assert manifest.entries == ()
+
+    def test_memory_event_from_other_ac_does_not_suppress_matching_call_id(self) -> None:
+        events = [
+            BaseEvent(
+                id="evt_other_memory",
+                type="tool.call.returned",
+                timestamp=datetime.now(UTC),
+                aggregate_type="ac",
+                aggregate_id="other_ac",
+                data={
+                    "call_id": "reused",
+                    "tool_name": "Read",
+                    "result_preview": "read MEMORY.md",
+                },
+            ),
+            _tool_started(
+                call_id="reused",
+                tool_name="Bash",
+                args_preview="pytest tests/unit",
+                event_id="evt_target_start",
+            ),
+            _tool_returned(
+                call_id="reused",
+                tool_name="Bash",
+                result_preview="1 passed",
+                event_id="evt_target_return",
+            ),
+        ]
+
+        manifest = normalize_events(events, ac_id="ac_1")
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == ("evt_target_start", "evt_target_return")
 
 
 class TestFilterEventsForAC:

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -443,6 +443,18 @@ class TestNormalizeEventsACScope:
 
         assert manifest.entries == ()
 
+    def test_excludes_memory_derived_token_with_suffix_punctuation(self) -> None:
+        event = _tool_started(
+            call_id="memory_derived",
+            tool_name="Read",
+            args_preview="MEMORY.md-derived prior context",
+            event_id="evt_memory_derived",
+        )
+
+        manifest = normalize_events([event], ac_id="ac_1")
+
+        assert manifest.entries == ()
+
     def test_memory_event_from_other_ac_does_not_suppress_matching_call_id(self) -> None:
         events = [
             BaseEvent(
@@ -626,6 +638,32 @@ class TestLLMPairing:
         entry = manifest.entries[0]
         assert entry.kind is EvidenceKind.LLM_CALL
         assert entry.source_event_ids == ("evt_ret_orphan",)
+
+    def test_excludes_memory_derived_llm_pair(self) -> None:
+        events = [
+            BaseEvent(
+                id="evt_req_memory_llm",
+                type="llm.call.requested",
+                timestamp=datetime.now(UTC),
+                aggregate_type="execution",
+                aggregate_id="execution_x",
+                data={
+                    "call_id": "llm_memory",
+                    "model_id": "claude-sonnet-4.6",
+                    "caller": "executor:MEMORY.md-derived-summary",
+                    "execution_id": "ac_1",
+                },
+            ),
+            _llm_returned(
+                call_id="llm_memory",
+                model_id="claude-sonnet-4.6",
+                event_id="evt_ret_memory_llm",
+            ),
+        ]
+
+        manifest = normalize_events(events, ac_id="ac_1")
+
+        assert manifest.entries == ()
 
 
 class TestACScopingMultiChannel:

--- a/tests/unit/harness/test_journal_normalizer.py
+++ b/tests/unit/harness/test_journal_normalizer.py
@@ -495,6 +495,39 @@ class TestNormalizeEventsACScope:
         assert len(manifest.entries) == 1
         assert manifest.entries[0].source_event_ids == ("evt_grep_start", "evt_grep_return")
 
+    def test_excludes_orphan_returned_with_memory_provenance_marker(self) -> None:
+        event = BaseEvent(
+            id="evt_orphan_memory_return",
+            type="tool.call.returned",
+            timestamp=datetime.now(UTC),
+            aggregate_type="session",
+            aggregate_id="session_test",
+            data={
+                "call_id": "orphan_memory",
+                "tool_name": "Read",
+                "caller": "executor:MEMORY.md-derived-summary",
+                "result_preview": "prior context summary",
+                "ac_id": "ac_1",
+            },
+        )
+
+        manifest = normalize_events([event], ac_id="ac_1")
+
+        assert manifest.entries == ()
+
+    def test_keeps_orphan_returned_when_result_only_mentions_memory_file(self) -> None:
+        event = _tool_returned(
+            call_id="orphan_memory_text",
+            tool_name="Bash",
+            result_preview="grep output mentioned MEMORY.md",
+            event_id="evt_orphan_memory_text",
+        )
+
+        manifest = normalize_events([event], ac_id="ac_1")
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == ("evt_orphan_memory_text",)
+
     def test_memory_event_from_other_ac_does_not_suppress_matching_call_id(self) -> None:
         events = [
             BaseEvent(
@@ -678,6 +711,27 @@ class TestLLMPairing:
         entry = manifest.entries[0]
         assert entry.kind is EvidenceKind.LLM_CALL
         assert entry.source_event_ids == ("evt_ret_orphan",)
+
+    def test_excludes_orphan_returned_with_memory_provenance_flag(self) -> None:
+        event = BaseEvent(
+            id="evt_orphan_memory_llm",
+            type="llm.call.returned",
+            timestamp=datetime.now(UTC),
+            aggregate_type="execution",
+            aggregate_id="execution_x",
+            data={
+                "call_id": "llm_orphan_memory",
+                "model_id": "claude-sonnet-4.6",
+                "duration_ms": 1200,
+                "is_error": False,
+                "memory_derived": True,
+                "execution_id": "ac_1",
+            },
+        )
+
+        manifest = normalize_events([event], ac_id="ac_1")
+
+        assert manifest.entries == ()
 
     def test_excludes_memory_derived_llm_pair(self) -> None:
         events = [


### PR DESCRIPTION
## Summary

- Make generated evidence entry handles and manifest IDs deterministic so replayed journals produce stable evidence references.
- Exclude MEMORY.md-derived tool/LLM events from evidence manifests while preserving same-AC scope isolation.
- Recompute manifest IDs when deliver-gate scope IDs are remapped back to public AC IDs.

## Changes

- Replace UUID defaults with SHA-256-derived IDs based on normalized evidence content.
- Add memory-reference detection across event aggregate fields and nested event data, including paired start/return suppression.
- Preserve explicit caller-supplied handles and manifest IDs.
- Add regression coverage for replay stability, unordered payload sets, MEMORY.md filtering, cross-AC call-id isolation, and scope-id manifest remapping.

## Notes

- Benchmark remains fixture-only; this patch does not change the TraceGuard benchmark artifact or live default behavior.
- Semantic misses still require later semantic/harness checks; this patch focuses on evidence replay stability and memory discipline.

## Verification

- uv run pytest tests/unit/harness -q
- uv run pytest tests/unit/orchestrator/test_traceguard_benchmark_capture.py -q
- uv run ruff check src/ouroboros/harness/journal.py src/ouroboros/harness/deliver_gate.py tests/unit/harness/test_journal_normalizer.py tests/unit/harness/test_deliver_gate.py
- uv run mypy src/ouroboros/harness/journal.py src/ouroboros/harness/deliver_gate.py

Refs #978
