### PR TITLE
feat(harness): add claim-term semantic guard

### DIFF
--- a/docs/agentos/traceguard-vs-legacy-benchmark.md
+++ b/docs/agentos/traceguard-vs-legacy-benchmark.md
@@ -45,15 +45,38 @@ Fat-harness baseline report — profile=traceguard_deliver_gate_fixture · acs=8
   new_domain_yaml_delta                  : 1
 ```
 
+## TraceGuard + claim-term guard
+
+```text
+Fat-harness baseline report — profile=traceguard_plus_claim_term_guard_fixture · acs=8 · K=2
+--------------------------------------------------------------------------------------------
+  [CAPT] one_shot_pass_rate                  : 0.5000 (target baseline + post-change measurement; target >= +10pp improvement)
+  [PASS] k_recovery_rate                     : 0.7500 (target >= 70% of initially failed ACs recover within K=2)
+  [PASS] fabrication_incidents_per_100_acs   : 0.0000 (target 0 verifier-detected fabrication incidents per 100 ACs)
+  [CAPT] semantic_miss_incidents_per_100_acs : 0.0000 (target sample and report evidence-backed-but-semantically-wrong incidents per 100 ACs)
+  [CAPT] median_chars_per_ac                 : 1820.0000 (target capture baseline median chars per AC)
+  [PASS] new_domain_cost                     : 42 (target <= 50 LOC and <= 1 YAML for one new profile/domain)
+--------------------------------------------------------------------------------------------
+  one_shot_pass_rate                     : 0.5000
+  k_recovery_rate                        : 0.7500
+  fabrication_incidents_per_100_acs      : 0.0000
+  semantic_miss_incidents_per_100_acs    : 0.0000
+  median_chars_per_ac                    : 1820.0000
+  new_domain_loc_delta                   : 42
+  new_domain_yaml_delta                  : 1
+```
+
 ## Delta
 
 - Fabrication incidents per 100 ACs: -25.0000
 - Semantic-miss incidents per 100 ACs: -12.5000
 - Median chars ratio: 1.4054
+- Claim-term guard semantic-miss incidents per 100 ACs: -12.5000
+- Claim-term guard median chars ratio: 1.4054
 
 ## Gate interpretation
 
 - TraceGuard reduces fixture fabrication incidents to 0 per 100 ACs.
-- Semantic misses remain visible and must be handled by later harness/semantic checks.
+- The deterministic claim-term guard rejects the fixture semantic miss without reintroducing fabrication.
 - One-shot pass rate drops because unsupported legacy self-reports are rejected instead of counted as accepted.
 - Median chars stay within the <= 1.5x C.4 budget guardrail.

--- a/src/ouroboros/harness/__init__.py
+++ b/src/ouroboros/harness/__init__.py
@@ -5,6 +5,12 @@ Run / Stage / Step / Artifact / Verdict records for #946 plus the
 journal-to-evidence-manifest normalizer for #978.
 """
 
+from ouroboros.harness.claim_term_guard import (
+    ClaimTermGuard,
+    ClaimTermGuardFact,
+    ClaimTermGuardVerdict,
+    deterministic_claim_term_guard,
+)
 from ouroboros.harness.deliver_gate import (
     DeliverEvidenceClaim,
     DeliverEvidenceFact,
@@ -46,6 +52,9 @@ __all__ = [
     "EventStoreEvidenceReader",
     "EvidenceManifest",
     "RunRecord",
+    "ClaimTermGuard",
+    "ClaimTermGuardFact",
+    "ClaimTermGuardVerdict",
     "StageKind",
     "StageRecord",
     "StepKind",
@@ -55,6 +64,7 @@ __all__ = [
     "TraceGuardValidator",
     "VerdictOutcome",
     "VerdictRecord",
+    "deterministic_claim_term_guard",
     "evaluate_deliver_claim",
     "filter_events_for_ac",
     "load_ac_evidence_manifest",

--- a/src/ouroboros/harness/claim_term_guard.py
+++ b/src/ouroboros/harness/claim_term_guard.py
@@ -108,10 +108,11 @@ def _missing_structured_terms(*, statement: str, evidence_text: str) -> tuple[st
     if not terms:
         return ()
 
-    normalized_evidence = _normalize_text(evidence_text)
+    evidence_tokens = _normalize_tokens(evidence_text)
     missing: list[str] = []
     for term in terms:
-        if _normalize_text(term.value) not in normalized_evidence:
+        term_tokens = _normalize_tokens(term.value)
+        if not term_tokens or not _contains_token_sequence(evidence_tokens, term_tokens):
             missing.append(f"{term.key}={term.value}")
     return tuple(missing)
 
@@ -136,8 +137,17 @@ def _strip_literal(value: str) -> str:
     return value.strip().strip("`'\"")
 
 
-def _normalize_text(value: str) -> str:
-    return " ".join(_tokenize(value))
+def _normalize_tokens(value: str) -> tuple[str, ...]:
+    return tuple(_tokenize(value))
+
+
+def _contains_token_sequence(tokens: tuple[str, ...], needle: tuple[str, ...]) -> bool:
+    if len(needle) > len(tokens):
+        return False
+    return any(
+        tokens[index : index + len(needle)] == needle
+        for index in range(len(tokens) - len(needle) + 1)
+    )
 
 
 def _tokenize(value: str) -> Iterable[str]:

--- a/src/ouroboros/harness/claim_term_guard.py
+++ b/src/ouroboros/harness/claim_term_guard.py
@@ -111,8 +111,14 @@ def _missing_structured_terms(*, statement: str, evidence_text: str) -> tuple[st
     evidence_tokens = _normalize_tokens(evidence_text)
     missing: list[str] = []
     for term in terms:
-        term_tokens = _normalize_tokens(term.value)
-        if not term_tokens or not _contains_token_sequence(evidence_tokens, term_tokens):
+        alternatives = tuple(
+            tokens
+            for value in _term_value_alternatives(term)
+            if (tokens := _normalize_tokens(value))
+        )
+        if not alternatives or not any(
+            _contains_token_sequence(evidence_tokens, tokens) for tokens in alternatives
+        ):
             missing.append(f"{term.key}={term.value}")
     return tuple(missing)
 
@@ -135,6 +141,24 @@ def _structured_terms(statement: str) -> tuple[_StructuredTerm, ...]:
 
 def _strip_literal(value: str) -> str:
     return value.strip().strip("`'\"")
+
+
+def _term_value_alternatives(term: _StructuredTerm) -> tuple[str, ...]:
+    alternatives = [term.value, term.value.replace("_", " ")]
+    normalized_key = term.key.lower()
+    normalized_value = term.value.lower()
+    if normalized_key == "result":
+        alternatives.extend(_RESULT_VALUE_ALIASES.get(normalized_value, ()))
+    return tuple(dict.fromkeys(alternatives))
+
+
+_RESULT_VALUE_ALIASES: dict[str, tuple[str, ...]] = {
+    # Existing deliver-claim vocabulary records outcome labels in the claim while
+    # journal evidence often stores natural-language previews. Keep aliases
+    # narrow and result-key scoped so behavior/path terms remain exact.
+    "test_passed": ("tests passed", "test passed", "pytest passed"),
+    "file_modified": ("file modified", "modified file", "file updated", "docs updated"),
+}
 
 
 def _normalize_tokens(value: str) -> tuple[str, ...]:

--- a/src/ouroboros/harness/claim_term_guard.py
+++ b/src/ouroboros/harness/claim_term_guard.py
@@ -140,7 +140,10 @@ def _structured_terms(statement: str) -> tuple[_StructuredTerm, ...]:
 
 
 def _strip_literal(value: str) -> str:
-    return value.strip().strip("`'\"")
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in "`'\"":
+        return stripped[1:-1].strip()
+    return stripped.rstrip(".,;:!?")
 
 
 def _term_value_alternatives(term: _StructuredTerm) -> tuple[str, ...]:

--- a/src/ouroboros/harness/claim_term_guard.py
+++ b/src/ouroboros/harness/claim_term_guard.py
@@ -1,0 +1,152 @@
+"""Deterministic claim-term guard for evidence-backed deliver claims.
+
+TraceGuard answers the structural question: did the claim cite an admissible
+evidence handle? This module adds a small, read-only harness check for the next
+question: does the cited evidence text contain the structured term values the
+claim itself says are required?
+
+The guard is intentionally deterministic and conservative. It only enforces
+explicit ``key=value`` terms in claim statements, so prose-only claims are left
+to later LLM or profile-specific semantic evaluators. The ``key`` identifies the
+required term in diagnostics; only the normalized ``value`` is required to
+appear in evidence text because journal evidence often stores compressed
+``args_preview`` / ``result_preview`` text without the original claim key.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+import re
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimTermGuardFact:
+    """One evidence-backed fact checked by the claim-term guard."""
+
+    fact_id: str
+    evidence_handle: str
+    statement: str
+    evidence_text: str
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimTermGuardVerdict:
+    """Claim-term guard result for an already TraceGuard-backed claim."""
+
+    accepted: bool
+    rejected_fact_ids: tuple[str, ...] = ()
+    rejected_reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.accepted and (self.rejected_fact_ids or self.rejected_reasons):
+            msg = "accepted ClaimTermGuardVerdict cannot carry rejections"
+            raise ValueError(msg)
+        if not self.accepted and not self.rejected_reasons:
+            msg = "rejected ClaimTermGuardVerdict must include rejection reasons"
+            raise ValueError(msg)
+
+
+class ClaimTermGuard(Protocol):
+    """Callable shape for deterministic or profile-specific claim-term guards."""
+
+    def __call__(
+        self,
+        *,
+        ac_id: str,
+        facts: tuple[ClaimTermGuardFact, ...],
+    ) -> ClaimTermGuardVerdict:
+        raise NotImplementedError
+
+
+_STRUCTURED_TERM_RE = re.compile(
+    r"(?P<key>[A-Za-z][A-Za-z0-9_.:-]*)=(?P<value>`[^`]+`|\"[^\"]+\"|'[^']+'|[^\s;,\)\]\}]+)"
+)
+
+
+def deterministic_claim_term_guard(
+    *,
+    ac_id: str,
+    facts: tuple[ClaimTermGuardFact, ...],
+) -> ClaimTermGuardVerdict:
+    """Reject evidence-backed claims whose structured term values are absent.
+
+    ``ac_id`` is accepted for parity with richer future guards. The current
+    deterministic implementation is fact-local and does not inspect global AC
+    context.
+    """
+    del ac_id
+    rejected_fact_ids: list[str] = []
+    rejected_reasons: list[str] = []
+
+    for fact in facts:
+        missing = _missing_structured_terms(
+            statement=fact.statement,
+            evidence_text=fact.evidence_text,
+        )
+        if not missing:
+            continue
+        rejected_fact_ids.append(fact.fact_id)
+        rejected_reasons.append(
+            "semantic_miss: "
+            f"{fact.fact_id} cites {fact.evidence_handle} but evidence text lacks "
+            f"required term(s): {', '.join(missing)}"
+        )
+
+    if rejected_reasons:
+        return ClaimTermGuardVerdict(
+            accepted=False,
+            rejected_fact_ids=tuple(rejected_fact_ids),
+            rejected_reasons=tuple(rejected_reasons),
+        )
+    return ClaimTermGuardVerdict(accepted=True)
+
+
+def _missing_structured_terms(*, statement: str, evidence_text: str) -> tuple[str, ...]:
+    terms = _structured_terms(statement)
+    if not terms:
+        return ()
+
+    normalized_evidence = _normalize_text(evidence_text)
+    missing: list[str] = []
+    for term in terms:
+        if _normalize_text(term.value) not in normalized_evidence:
+            missing.append(f"{term.key}={term.value}")
+    return tuple(missing)
+
+
+@dataclass(frozen=True, slots=True)
+class _StructuredTerm:
+    key: str
+    value: str
+
+
+def _structured_terms(statement: str) -> tuple[_StructuredTerm, ...]:
+    terms: list[_StructuredTerm] = []
+    for match in _STRUCTURED_TERM_RE.finditer(statement):
+        key = match.group("key").strip()
+        value = _strip_literal(match.group("value"))
+        if key and value:
+            terms.append(_StructuredTerm(key=key, value=value))
+    return tuple(terms)
+
+
+def _strip_literal(value: str) -> str:
+    return value.strip().strip("`'\"")
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(_tokenize(value))
+
+
+def _tokenize(value: str) -> Iterable[str]:
+    return re.findall(r"[a-z0-9_./:-]+", value.lower())
+
+
+__all__ = [
+    "ClaimTermGuard",
+    "ClaimTermGuardFact",
+    "ClaimTermGuardVerdict",
+    "deterministic_claim_term_guard",
+]

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -567,11 +567,21 @@ def _unsupported_claim_rate(
 ) -> float:
     if total_claims <= 0:
         return raw_rate
-    rejected_keys = {_rejection_key(item) for item in rejected}
+    rejected_keys = {
+        _rejection_key(item)
+        for item in rejected
+        if _counts_toward_unsupported_claim_rate(item)
+    }
     rejected_count = len(rejected_keys)
     if rejected_count:
         return round(min(1.0, rejected_count / total_claims), 4)
     return raw_rate
+
+
+def _counts_toward_unsupported_claim_rate(
+    item: tuple[str | None, str | None, str],
+) -> bool:
+    return _reason_code(item[2]) != "semantic_miss"
 
 
 def _rejection_key(item: tuple[str | None, str | None, str]) -> tuple[str, str]:
@@ -581,6 +591,10 @@ def _rejection_key(item: tuple[str | None, str | None, str]) -> tuple[str, str]:
     if chunk_id is not None:
         return ("chunk", chunk_id)
     return ("reason", reason)
+
+
+def _reason_code(reason: str) -> str:
+    return reason.split(":", maxsplit=1)[0].strip()
 
 
 def _evidence_event_ids_for_handles(

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -321,6 +321,16 @@ def evaluate_deliver_claim(
         rejected=rejected,
         total_claims=len(claim.facts),
     )
+    final_accepted_fact_ids = _final_accepted_fact_ids(
+        accepted_fact_ids=accepted_fact_ids,
+        rejected_fact_ids=rejected_fact_ids,
+    )
+    final_accepted_handles = _final_accepted_handles(
+        claim,
+        accepted_fact_ids=accepted_fact_ids,
+        final_accepted_fact_ids=final_accepted_fact_ids,
+        accepted_handles=accepted_handles,
+    )
 
     return DeliverGateVerdict(
         ac_id=manifest.ac_id,
@@ -330,13 +340,41 @@ def evaluate_deliver_claim(
             and (claim_term_guard_verdict is None or claim_term_guard_verdict.accepted)
         ),
         unsupported_claim_rate=unsupported_claim_rate,
-        accepted_fact_ids=accepted_fact_ids,
+        accepted_fact_ids=final_accepted_fact_ids,
         rejected_fact_ids=rejected_fact_ids,
         rejected_reasons=_dedupe_strings(reason for _, _, reason in rejected),
         evidence_event_ids=_evidence_event_ids_for_handles(
-            accepted_handles,
+            final_accepted_handles,
             source_events_by_handle=source_events_by_handle,
         ),
+    )
+
+
+def _final_accepted_fact_ids(
+    *,
+    accepted_fact_ids: tuple[str, ...],
+    rejected_fact_ids: tuple[str, ...],
+) -> tuple[str, ...]:
+    rejected_fact_set = frozenset(rejected_fact_ids)
+    return tuple(fact_id for fact_id in accepted_fact_ids if fact_id not in rejected_fact_set)
+
+
+def _final_accepted_handles(
+    claim: DeliverEvidenceClaim,
+    *,
+    accepted_fact_ids: tuple[str, ...],
+    final_accepted_fact_ids: tuple[str, ...],
+    accepted_handles: tuple[str, ...],
+) -> tuple[str, ...]:
+    if not accepted_fact_ids:
+        return accepted_handles
+    final_accepted_fact_set = frozenset(final_accepted_fact_ids)
+    accepted_handle_set = frozenset(accepted_handles)
+    return tuple(
+        fact.evidence_handle
+        for fact in claim.facts
+        if fact.fact_id in final_accepted_fact_set
+        and (not accepted_handle_set or fact.evidence_handle in accepted_handle_set)
     )
 
 

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -285,7 +285,10 @@ def evaluate_deliver_claim(
     if not accepted_handles:
         accepted_handles = _string_tuple(getattr(raw_result, "allowed_chunk_ids", ()))
     claim_term_guard_verdict = None
-    if claim_term_guard is not None and bool(raw_result.accepted) and not missing_evidence:
+    should_run_claim_term_guard = bool(raw_result.accepted) or bool(
+        accepted_fact_ids or accepted_handles
+    )
+    if claim_term_guard is not None and should_run_claim_term_guard:
         claim_term_guard_verdict = claim_term_guard(
             ac_id=manifest.ac_id,
             facts=_claim_term_guard_facts(

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -521,12 +521,17 @@ def _evidence_text(payload: object) -> str:
         if context_parts:
             return "; ".join(context_parts)
 
-    for key in ("result_preview", "args_preview", "tool_name"):
+    preview_parts: list[str] = []
+    for key in ("result_preview", "args_preview"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
-            if context_parts:
-                return "; ".join([*context_parts, value.strip()])
-            return value.strip()
+            preview_parts.append(value.strip())
+    if preview_parts:
+        return "; ".join([*context_parts, *preview_parts])
+
+    tool_name = payload.get("tool_name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        return "; ".join([*context_parts, tool_name.strip()])
     if context_parts:
         return "; ".join(context_parts)
     return str(dict(payload))
@@ -606,9 +611,7 @@ def _unsupported_claim_rate(
     if total_claims <= 0:
         return raw_rate
     rejected_keys = {
-        _rejection_key(item)
-        for item in rejected
-        if _counts_toward_unsupported_claim_rate(item)
+        _rejection_key(item) for item in rejected if _counts_toward_unsupported_claim_rate(item)
     }
     rejected_count = len(rejected_keys)
     if rejected_count:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -17,6 +17,7 @@ from typing import Any, Protocol
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.harness.claim_term_guard import ClaimTermGuard, ClaimTermGuardFact
 from ouroboros.harness.journal import EvidenceManifest, normalize_events
 
 
@@ -244,6 +245,7 @@ def evaluate_deliver_claim(
     claim: DeliverEvidenceClaim,
     *,
     traceguard_validator: TraceGuardValidator,
+    claim_term_guard: ClaimTermGuard | None = None,
 ) -> DeliverGateVerdict:
     """Evaluate a typed AC deliver claim with a TraceGuard-compatible validator.
 
@@ -262,6 +264,9 @@ def evaluate_deliver_claim(
         raise ValueError(msg)
 
     traceguard_manifest, source_events_by_handle = _traceguard_manifest(manifest, claim)
+    evidence_text_by_handle = {
+        entry.chunk_id: entry.text for entry in traceguard_manifest if entry.chunk_id
+    }
     missing_evidence = _missing_evidence_summaries(
         claim,
         available_handles=frozenset(source_events_by_handle),
@@ -276,12 +281,37 @@ def evaluate_deliver_claim(
     accepted_fact_ids = _claim_fact_ids(accepted_claims)
     if not accepted_fact_ids:
         accepted_fact_ids = _string_tuple(getattr(raw_result, "allowed_fact_ids", ()))
-    rejected_fact_ids = _dedupe_strings(
-        fact_id for fact_id, _, _ in rejected if fact_id is not None
-    )
     accepted_handles = _claim_chunk_ids(accepted_claims)
     if not accepted_handles:
         accepted_handles = _string_tuple(getattr(raw_result, "allowed_chunk_ids", ()))
+    claim_term_guard_verdict = None
+    if claim_term_guard is not None and bool(raw_result.accepted) and not missing_evidence:
+        claim_term_guard_verdict = claim_term_guard(
+            ac_id=manifest.ac_id,
+            facts=_claim_term_guard_facts(
+                claim,
+                accepted_fact_ids=accepted_fact_ids,
+                accepted_handles=accepted_handles,
+                evidence_text_by_handle=evidence_text_by_handle,
+            ),
+        )
+        if not claim_term_guard_verdict.accepted:
+            rejected_fact_ids_by_index = claim_term_guard_verdict.rejected_fact_ids
+            rejected += tuple(
+                (
+                    (
+                        rejected_fact_ids_by_index[index]
+                        if index < len(rejected_fact_ids_by_index)
+                        else None
+                    ),
+                    None,
+                    reason,
+                )
+                for index, reason in enumerate(claim_term_guard_verdict.rejected_reasons)
+            )
+    rejected_fact_ids = _dedupe_strings(
+        fact_id for fact_id, _, _ in rejected if fact_id is not None
+    )
     unsupported_claim_rate = _unsupported_claim_rate(
         raw_rate=float(raw_result.unsupported_claim_rate),
         rejected=rejected,
@@ -290,7 +320,11 @@ def evaluate_deliver_claim(
 
     return DeliverGateVerdict(
         ac_id=manifest.ac_id,
-        accepted=bool(raw_result.accepted) and not missing_evidence,
+        accepted=(
+            bool(raw_result.accepted)
+            and not missing_evidence
+            and (claim_term_guard_verdict is None or claim_term_guard_verdict.accepted)
+        ),
         unsupported_claim_rate=unsupported_claim_rate,
         accepted_fact_ids=accepted_fact_ids,
         rejected_fact_ids=rejected_fact_ids,
@@ -397,6 +431,35 @@ def _traceguard_manifest(
         )
         source_events_by_handle[entry.handle] = entry.source_event_ids
     return tuple(entries), source_events_by_handle
+
+
+def _claim_term_guard_facts(
+    claim: DeliverEvidenceClaim,
+    *,
+    accepted_fact_ids: tuple[str, ...],
+    accepted_handles: tuple[str, ...],
+    evidence_text_by_handle: dict[str, str],
+) -> tuple[ClaimTermGuardFact, ...]:
+    accepted_fact_set = frozenset(accepted_fact_ids)
+    accepted_handle_set = frozenset(accepted_handles)
+    facts: list[ClaimTermGuardFact] = []
+    for fact in claim.facts:
+        if accepted_fact_set and fact.fact_id not in accepted_fact_set:
+            continue
+        if accepted_handle_set and fact.evidence_handle not in accepted_handle_set:
+            continue
+        evidence_text = evidence_text_by_handle.get(fact.evidence_handle)
+        if evidence_text is None:
+            continue
+        facts.append(
+            ClaimTermGuardFact(
+                fact_id=fact.fact_id,
+                evidence_handle=fact.evidence_handle,
+                statement=fact.statement,
+                evidence_text=evidence_text,
+            )
+        )
+    return tuple(facts)
 
 
 def _evidence_text(payload: object) -> str:

--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -285,9 +285,10 @@ def evaluate_deliver_claim(
     if not accepted_handles:
         accepted_handles = _string_tuple(getattr(raw_result, "allowed_chunk_ids", ()))
     claim_term_guard_verdict = None
-    should_run_claim_term_guard = bool(raw_result.accepted) or bool(
-        accepted_fact_ids or accepted_handles
-    )
+    # In mixed rejected TraceGuard results, chunk-only fallbacks are provenance,
+    # not per-fact acceptance. Semantic checks must not fan out to every claim
+    # sharing a structurally allowed evidence handle.
+    should_run_claim_term_guard = bool(raw_result.accepted) or bool(accepted_fact_ids)
     if claim_term_guard is not None and should_run_claim_term_guard:
         claim_term_guard_verdict = claim_term_guard(
             ac_id=manifest.ac_id,

--- a/src/ouroboros/harness/deliver_routing.py
+++ b/src/ouroboros/harness/deliver_routing.py
@@ -39,6 +39,7 @@ _REDISPATCH_REASONS = frozenset(
         "chunk_handle_without_fact",
         "evidence_handle_mismatch",
         "malformed_evidence_claim",
+        "semantic_miss",
     }
 )
 _HITL_REASONS = frozenset(

--- a/src/ouroboros/orchestrator/traceguard_benchmark_capture.py
+++ b/src/ouroboros/orchestrator/traceguard_benchmark_capture.py
@@ -25,6 +25,7 @@ from ouroboros.orchestrator.baseline_metrics_format import render_baseline_repor
 
 BENCHMARK_PROFILE_LEGACY = "legacy_self_report_fixture"
 BENCHMARK_PROFILE_TRACEGUARD = "traceguard_deliver_gate_fixture"
+BENCHMARK_PROFILE_TRACEGUARD_CLAIM_TERM_GUARD = "traceguard_plus_claim_term_guard_fixture"
 
 
 LEGACY_SELF_REPORT_ROWS: tuple[BaselineMetricFixtureRow, ...] = (
@@ -113,8 +114,10 @@ class TraceGuardBenchmarkCapture:
 
     legacy_report: FatHarnessMetricsReport
     traceguard_report: FatHarnessMetricsReport
+    claim_term_guard_report: FatHarnessMetricsReport
     legacy_rows: tuple[BaselineMetricFixtureRow, ...]
     traceguard_rows: tuple[BaselineMetricFixtureRow, ...]
+    claim_term_guard_rows: tuple[BaselineMetricFixtureRow, ...]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -125,6 +128,10 @@ class TraceGuardBenchmarkCapture:
             "traceguard": {
                 "report": self.traceguard_report.to_dict(),
                 "rows": [row.to_dict() for row in self.traceguard_rows],
+            },
+            "claim_term_guard": {
+                "report": self.claim_term_guard_report.to_dict(),
+                "rows": [row.to_dict() for row in self.claim_term_guard_rows],
             },
             "delta": {
                 "fabrication_incidents_per_100_acs": (
@@ -137,6 +144,14 @@ class TraceGuardBenchmarkCapture:
                 ),
                 "median_chars_ratio": (
                     self.traceguard_report.median_chars_per_ac
+                    / self.legacy_report.median_chars_per_ac
+                ),
+                "claim_term_guard_semantic_miss_incidents_per_100_acs": (
+                    self.claim_term_guard_report.semantic_miss_incidents_per_100_acs
+                    - self.traceguard_report.semantic_miss_incidents_per_100_acs
+                ),
+                "claim_term_guard_median_chars_ratio": (
+                    self.claim_term_guard_report.median_chars_per_ac
                     / self.legacy_report.median_chars_per_ac
                 ),
             },
@@ -156,12 +171,45 @@ def _report(profile: str, rows: tuple[BaselineMetricFixtureRow, ...]) -> FatHarn
 def build_traceguard_benchmark_capture() -> TraceGuardBenchmarkCapture:
     """Build the recorded #978 P4 fixture benchmark."""
     traceguard_rows = RECORDED_BASELINE_ROWS
+    claim_term_guard_rows = _claim_term_guard_rows(traceguard_rows)
     return TraceGuardBenchmarkCapture(
         legacy_report=_report(BENCHMARK_PROFILE_LEGACY, LEGACY_SELF_REPORT_ROWS),
         traceguard_report=_report(BENCHMARK_PROFILE_TRACEGUARD, traceguard_rows),
+        claim_term_guard_report=_report(
+            BENCHMARK_PROFILE_TRACEGUARD_CLAIM_TERM_GUARD,
+            claim_term_guard_rows,
+        ),
         legacy_rows=LEGACY_SELF_REPORT_ROWS,
         traceguard_rows=traceguard_rows,
+        claim_term_guard_rows=claim_term_guard_rows,
     )
+
+
+def _claim_term_guard_rows(
+    rows: tuple[BaselineMetricFixtureRow, ...],
+) -> tuple[BaselineMetricFixtureRow, ...]:
+    guarded: list[BaselineMetricFixtureRow] = []
+    for row in rows:
+        if row.semantic_miss_incidents == 0:
+            guarded.append(row)
+            continue
+        guarded.append(
+            BaselineMetricFixtureRow(
+                ac_id=row.ac_id,
+                source_ref="fixture:claim-term-guard/rejected-semantic-miss",
+                accepted=False,
+                attempt_count=row.attempt_count,
+                prompt_chars=row.prompt_chars,
+                completion_chars=row.completion_chars,
+                fabrication_incidents=row.fabrication_incidents,
+                semantic_miss_incidents=0,
+                note=(
+                    "Semantic guard rejected the evidence-backed-but-wrong claim "
+                    "instead of counting it as an accepted semantic miss."
+                ),
+            )
+        )
+    return tuple(guarded)
 
 
 def render_traceguard_benchmark_markdown(
@@ -188,16 +236,25 @@ def render_traceguard_benchmark_markdown(
         render_baseline_report(capture.traceguard_report),
         "```",
         "",
+        "## TraceGuard + claim-term guard",
+        "",
+        "```text",
+        render_baseline_report(capture.claim_term_guard_report),
+        "```",
+        "",
         "## Delta",
         "",
         f"- Fabrication incidents per 100 ACs: {data['fabrication_incidents_per_100_acs']:.4f}",
         f"- Semantic-miss incidents per 100 ACs: {data['semantic_miss_incidents_per_100_acs']:.4f}",
         f"- Median chars ratio: {data['median_chars_ratio']:.4f}",
+        "- Claim-term guard semantic-miss incidents per 100 ACs: "
+        f"{data['claim_term_guard_semantic_miss_incidents_per_100_acs']:.4f}",
+        f"- Claim-term guard median chars ratio: {data['claim_term_guard_median_chars_ratio']:.4f}",
         "",
         "## Gate interpretation",
         "",
         "- TraceGuard reduces fixture fabrication incidents to 0 per 100 ACs.",
-        "- Semantic misses remain visible and must be handled by later harness/semantic checks.",
+        "- The deterministic claim-term guard rejects the fixture semantic miss without reintroducing fabrication.",
         "- One-shot pass rate drops because unsupported legacy self-reports are rejected instead of counted as accepted.",
         "- Median chars stay within the <= 1.5x C.4 budget guardrail.",
     ]
@@ -215,6 +272,7 @@ if __name__ == "__main__":  # pragma: no cover
 __all__ = [
     "BENCHMARK_PROFILE_LEGACY",
     "BENCHMARK_PROFILE_TRACEGUARD",
+    "BENCHMARK_PROFILE_TRACEGUARD_CLAIM_TERM_GUARD",
     "LEGACY_SELF_REPORT_ROWS",
     "TraceGuardBenchmarkCapture",
     "build_traceguard_benchmark_capture",

--- a/tests/unit/harness/test_claim_term_guard.py
+++ b/tests/unit/harness/test_claim_term_guard.py
@@ -65,6 +65,22 @@ def test_accepts_existing_child_ac_result_vocabulary() -> None:
     assert verdict.accepted is True
 
 
+def test_accepts_unquoted_structured_term_with_sentence_punctuation() -> None:
+    verdict = deterministic_claim_term_guard(
+        ac_id="AC-1",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="test_passed:admin_delete_denied",
+                evidence_handle="ev_1",
+                statement="test_passed behavior=admin_delete_denied.",
+                evidence_text="pytest passed: admin_delete_denied",
+            ),
+        ),
+    )
+
+    assert verdict.accepted is True
+
+
 def test_rejects_when_structured_statement_terms_are_missing_from_evidence() -> None:
     verdict = deterministic_claim_term_guard(
         ac_id="AC-1",

--- a/tests/unit/harness/test_claim_term_guard.py
+++ b/tests/unit/harness/test_claim_term_guard.py
@@ -43,6 +43,28 @@ def test_accepts_when_structured_term_value_is_present_without_key() -> None:
     assert verdict.accepted is True
 
 
+def test_accepts_existing_child_ac_result_vocabulary() -> None:
+    verdict = deterministic_claim_term_guard(
+        ac_id="AC-PARENT",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="child_ac:AC-1:test_passed",
+                evidence_handle="ev_child_ac_1",
+                statement="child_ac=AC-1 result=test_passed",
+                evidence_text="child_ac_id=AC-1; tests passed",
+            ),
+            ClaimTermGuardFact(
+                fact_id="child_ac:AC-2:file_modified",
+                evidence_handle="ev_child_ac_2",
+                statement="child_ac=AC-2 result=file_modified",
+                evidence_text="child_ac_id=AC-2; path=docs/ac2.md; scope=whole_file; docs updated",
+            ),
+        ),
+    )
+
+    assert verdict.accepted is True
+
+
 def test_rejects_when_structured_statement_terms_are_missing_from_evidence() -> None:
     verdict = deterministic_claim_term_guard(
         ac_id="AC-1",

--- a/tests/unit/harness/test_claim_term_guard.py
+++ b/tests/unit/harness/test_claim_term_guard.py
@@ -117,8 +117,7 @@ def test_rejects_partial_numeric_token_match() -> None:
 
     assert verdict.accepted is False
     assert verdict.rejected_reasons == (
-        "semantic_miss: user_check cites ev_1 but evidence text lacks required term(s): "
-        "user_id=1",
+        "semantic_miss: user_check cites ev_1 but evidence text lacks required term(s): user_id=1",
     )
 
 

--- a/tests/unit/harness/test_claim_term_guard.py
+++ b/tests/unit/harness/test_claim_term_guard.py
@@ -1,0 +1,85 @@
+"""Tests for deterministic semantic-miss guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.harness.claim_term_guard import (
+    ClaimTermGuardFact,
+    ClaimTermGuardVerdict,
+    deterministic_claim_term_guard,
+)
+
+
+def test_accepts_when_structured_statement_terms_are_present_in_evidence() -> None:
+    verdict = deterministic_claim_term_guard(
+        ac_id="AC-1",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="file_modified:src/app.py:role_matrix_added",
+                evidence_handle="ev_1",
+                statement="file_modified path=src/app.py expected_change=role_matrix_added",
+                evidence_text="path=src/app.py; scope=whole_file; role_matrix_added",
+            ),
+        ),
+    )
+
+    assert verdict.accepted is True
+
+
+def test_accepts_when_structured_term_value_is_present_without_key() -> None:
+    verdict = deterministic_claim_term_guard(
+        ac_id="AC-1",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="test_passed:admin_delete_denied",
+                evidence_handle="ev_1",
+                statement="test_passed behavior=admin_delete_denied",
+                evidence_text="pytest passed: admin_delete_denied",
+            ),
+        ),
+    )
+
+    assert verdict.accepted is True
+
+
+def test_rejects_when_structured_statement_terms_are_missing_from_evidence() -> None:
+    verdict = deterministic_claim_term_guard(
+        ac_id="AC-1",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="test_passed:admin_delete_denied",
+                evidence_handle="ev_1",
+                statement="test_passed behavior=admin_delete_denied",
+                evidence_text="pytest passed for user profile update",
+            ),
+        ),
+    )
+
+    assert verdict.accepted is False
+    assert verdict.rejected_fact_ids == ("test_passed:admin_delete_denied",)
+    assert verdict.rejected_reasons == (
+        "semantic_miss: test_passed:admin_delete_denied cites ev_1 but evidence text lacks "
+        "required term(s): behavior=admin_delete_denied",
+    )
+
+
+def test_prose_only_claims_are_left_to_later_semantic_evaluators() -> None:
+    verdict = deterministic_claim_term_guard(
+        ac_id="AC-1",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="fact_1",
+                evidence_handle="ev_1",
+                statement="The AC passed because the command succeeded.",
+                evidence_text="result for ev_1",
+            ),
+        ),
+    )
+
+    assert verdict.accepted is True
+
+
+def test_rejected_verdict_requires_reason() -> None:
+    with pytest.raises(ValueError, match="must include rejection reasons"):
+        ClaimTermGuardVerdict(accepted=False)

--- a/tests/unit/harness/test_claim_term_guard.py
+++ b/tests/unit/harness/test_claim_term_guard.py
@@ -80,6 +80,46 @@ def test_prose_only_claims_are_left_to_later_semantic_evaluators() -> None:
     assert verdict.accepted is True
 
 
+def test_rejects_partial_numeric_token_match() -> None:
+    verdict = deterministic_claim_term_guard(
+        ac_id="AC-1",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="user_check",
+                evidence_handle="ev_1",
+                statement="validated user_id=1",
+                evidence_text="validated user_id=10",
+            ),
+        ),
+    )
+
+    assert verdict.accepted is False
+    assert verdict.rejected_reasons == (
+        "semantic_miss: user_check cites ev_1 but evidence text lacks required term(s): "
+        "user_id=1",
+    )
+
+
+def test_rejects_partial_path_token_match() -> None:
+    verdict = deterministic_claim_term_guard(
+        ac_id="AC-1",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="file_modified:src/app.py",
+                evidence_handle="ev_1",
+                statement="file_modified path=src/app.py",
+                evidence_text="wrote backup path=src/app.py.bak",
+            ),
+        ),
+    )
+
+    assert verdict.accepted is False
+    assert verdict.rejected_reasons == (
+        "semantic_miss: file_modified:src/app.py cites ev_1 but evidence text lacks "
+        "required term(s): path=src/app.py",
+    )
+
+
 def test_rejected_verdict_requires_reason() -> None:
     with pytest.raises(ValueError, match="must include rejection reasons"):
         ClaimTermGuardVerdict(accepted=False)

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -596,6 +596,7 @@ class TestEvaluateDeliverClaim:
             manifest,
             claim,
             traceguard_validator=validator,
+            claim_term_guard=deterministic_claim_term_guard,
         )
 
         assert verdict.accepted is True
@@ -691,6 +692,7 @@ class TestEvaluateDeliverClaim:
             manifest,
             claim,
             traceguard_validator=validator,
+            claim_term_guard=deterministic_claim_term_guard,
         )
 
         assert verdict.accepted is True

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -821,7 +821,7 @@ class TestEvaluateDeliverClaim:
         )
 
         assert verdict.accepted is False
-        assert verdict.unsupported_claim_rate == 1.0
+        assert verdict.unsupported_claim_rate == 0.0
         assert verdict.accepted_fact_ids == ("test_passed:admin_delete_denied",)
         assert verdict.rejected_fact_ids == ("test_passed:admin_delete_denied",)
         assert verdict.rejected_reasons == (
@@ -881,7 +881,7 @@ class TestEvaluateDeliverClaim:
         )
 
         assert verdict.accepted is False
-        assert verdict.unsupported_claim_rate == 1.0
+        assert verdict.unsupported_claim_rate == 0.5
         assert verdict.accepted_fact_ids == ("fact_actual",)
         assert verdict.rejected_fact_ids == ("fact_missing", "fact_actual")
         assert verdict.rejected_reasons == (

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -828,6 +828,68 @@ class TestEvaluateDeliverClaim:
         )
         assert verdict.evidence_event_ids == ("evt_test",)
 
+
+    def test_claim_term_guard_checks_mixed_traceguard_allowed_facts(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(
+                _manifest_entry(
+                    handle="ev_actual",
+                    ok=True,
+                    payload={
+                        "tool_name": "Bash",
+                        "result_preview": "pytest passed for user profile update",
+                    },
+                    source_event_ids=("evt_1",),
+                ),
+            ),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="fact_actual",
+                    evidence_handle="ev_actual",
+                    statement="test_passed behavior=admin_delete_denied",
+                ),
+                DeliverEvidenceFact(
+                    fact_id="fact_missing",
+                    evidence_handle="ev_missing",
+                    statement="Unsupported claim.",
+                ),
+            ),
+        )
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=lambda **_: _TraceGuardResult(
+                accepted=False,
+                allowed_fact_ids=("fact_actual",),
+                allowed_chunk_ids=("ev_actual",),
+                rejected_claims=(
+                    _TraceGuardRejection(
+                        reason="unsupported_fact_id",
+                        claim=_TraceGuardClaim(fact_id="fact_missing", chunk_id="ev_missing"),
+                        detail="fact is not present in manifest",
+                    ),
+                ),
+            ),
+            claim_term_guard=deterministic_claim_term_guard,
+        )
+
+        assert verdict.accepted is False
+        assert verdict.unsupported_claim_rate == 1.0
+        assert verdict.accepted_fact_ids == ("fact_actual",)
+        assert verdict.rejected_fact_ids == ("fact_missing", "fact_actual")
+        assert verdict.rejected_reasons == (
+            "missing_evidence_handle: ev_missing is not present in manifest",
+            "unsupported_fact_id: fact is not present in manifest",
+            "semantic_miss: fact_actual cites ev_actual but evidence text lacks "
+            "required term(s): behavior=admin_delete_denied",
+        )
+        assert verdict.evidence_event_ids == ("evt_1",)
+
     def test_rejected_traceguard_result_is_preserved_for_routing(self) -> None:
         manifest = EvidenceManifest(
             ac_id="AC-1",

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from ouroboros.events.base import BaseEvent
+from ouroboros.harness.claim_term_guard import deterministic_claim_term_guard
 from ouroboros.harness.deliver_gate import (
     DeliverEvidenceClaim,
     DeliverEvidenceFact,
@@ -783,6 +784,49 @@ class TestEvaluateDeliverClaim:
                 },
             }
         ]
+
+    def test_claim_term_guard_rejects_traceguard_accepted_semantic_miss(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(
+                _manifest_entry(
+                    handle="ev_test",
+                    ok=True,
+                    payload={
+                        "tool_name": "Bash",
+                        "result_preview": "pytest passed for user profile update",
+                    },
+                    source_event_ids=("evt_test",),
+                ),
+            ),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="test_passed:admin_delete_denied",
+                    evidence_handle="ev_test",
+                    statement="test_passed behavior=admin_delete_denied",
+                ),
+            ),
+        )
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=_RecordingTraceGuardValidator(),
+            claim_term_guard=deterministic_claim_term_guard,
+        )
+
+        assert verdict.accepted is False
+        assert verdict.unsupported_claim_rate == 1.0
+        assert verdict.accepted_fact_ids == ("test_passed:admin_delete_denied",)
+        assert verdict.rejected_fact_ids == ("test_passed:admin_delete_denied",)
+        assert verdict.rejected_reasons == (
+            "semantic_miss: test_passed:admin_delete_denied cites ev_test but evidence text lacks "
+            "required term(s): behavior=admin_delete_denied",
+        )
+        assert verdict.evidence_event_ids == ("evt_test",)
 
     def test_rejected_traceguard_result_is_preserved_for_routing(self) -> None:
         manifest = EvidenceManifest(

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -822,13 +822,13 @@ class TestEvaluateDeliverClaim:
 
         assert verdict.accepted is False
         assert verdict.unsupported_claim_rate == 0.0
-        assert verdict.accepted_fact_ids == ("test_passed:admin_delete_denied",)
+        assert verdict.accepted_fact_ids == ()
         assert verdict.rejected_fact_ids == ("test_passed:admin_delete_denied",)
         assert verdict.rejected_reasons == (
             "semantic_miss: test_passed:admin_delete_denied cites ev_test but evidence text lacks "
             "required term(s): behavior=admin_delete_denied",
         )
-        assert verdict.evidence_event_ids == ("evt_test",)
+        assert verdict.evidence_event_ids == ()
 
 
     def test_claim_term_guard_checks_mixed_traceguard_allowed_facts(self) -> None:
@@ -882,7 +882,7 @@ class TestEvaluateDeliverClaim:
 
         assert verdict.accepted is False
         assert verdict.unsupported_claim_rate == 0.5
-        assert verdict.accepted_fact_ids == ("fact_actual",)
+        assert verdict.accepted_fact_ids == ()
         assert verdict.rejected_fact_ids == ("fact_missing", "fact_actual")
         assert verdict.rejected_reasons == (
             "missing_evidence_handle: ev_missing is not present in manifest",
@@ -890,7 +890,7 @@ class TestEvaluateDeliverClaim:
             "semantic_miss: fact_actual cites ev_actual but evidence text lacks "
             "required term(s): behavior=admin_delete_denied",
         )
-        assert verdict.evidence_event_ids == ("evt_1",)
+        assert verdict.evidence_event_ids == ()
 
     def test_claim_term_guard_skips_chunk_only_fallback_for_mixed_rejection(self) -> None:
         manifest = EvidenceManifest(

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -890,6 +890,67 @@ class TestEvaluateDeliverClaim:
         )
         assert verdict.evidence_event_ids == ("evt_1",)
 
+    def test_claim_term_guard_skips_chunk_only_fallback_for_mixed_rejection(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(
+                _manifest_entry(
+                    handle="ev_shared",
+                    ok=True,
+                    payload={
+                        "tool_name": "Bash",
+                        "result_preview": "pytest passed for behavior=supported_update",
+                    },
+                    source_event_ids=("evt_shared",),
+                ),
+            ),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="fact_supported",
+                    evidence_handle="ev_shared",
+                    statement="test_passed behavior=supported_update",
+                ),
+                DeliverEvidenceFact(
+                    fact_id="fact_unsupported",
+                    evidence_handle="ev_shared",
+                    statement="test_passed behavior=unsupported_delete",
+                ),
+            ),
+        )
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=lambda **_: _TraceGuardResult(
+                accepted=False,
+                allowed_fact_ids=(),
+                allowed_chunk_ids=("ev_shared",),
+                rejected_claims=(
+                    _TraceGuardRejection(
+                        reason="unsupported_fact_id",
+                        claim=_TraceGuardClaim(
+                            fact_id="fact_unsupported",
+                            chunk_id="ev_shared",
+                        ),
+                        detail="fact was not structurally accepted",
+                    ),
+                ),
+            ),
+            claim_term_guard=deterministic_claim_term_guard,
+        )
+
+        assert verdict.accepted is False
+        assert verdict.unsupported_claim_rate == 0.5
+        assert verdict.accepted_fact_ids == ()
+        assert verdict.rejected_fact_ids == ("fact_unsupported",)
+        assert verdict.rejected_reasons == (
+            "unsupported_fact_id: fact was not structurally accepted",
+        )
+        assert verdict.evidence_event_ids == ("evt_shared",)
+
     def test_rejected_traceguard_result_is_preserved_for_routing(self) -> None:
         manifest = EvidenceManifest(
             ac_id="AC-1",

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -787,6 +787,52 @@ class TestEvaluateDeliverClaim:
             }
         ]
 
+    def test_claim_term_guard_sees_non_edit_args_when_result_preview_exists(self) -> None:
+        manifest = EvidenceManifest(
+            ac_id="AC-1",
+            entries=(
+                _manifest_entry(
+                    handle="ev_test",
+                    ok=True,
+                    payload={
+                        "tool_name": "Bash",
+                        "args_preview": "uv run pytest -k admin_delete_denied",
+                        "result_preview": "pytest passed",
+                    },
+                    source_event_ids=("evt_test",),
+                ),
+            ),
+        )
+        claim = DeliverEvidenceClaim(
+            ac_id="AC-1",
+            facts=(
+                DeliverEvidenceFact(
+                    fact_id="test_passed:admin_delete_denied",
+                    evidence_handle="ev_test",
+                    statement="test_passed behavior=admin_delete_denied",
+                ),
+            ),
+        )
+        validator = _RecordingTraceGuardValidator()
+
+        verdict = evaluate_deliver_claim(
+            manifest,
+            claim,
+            traceguard_validator=validator,
+            claim_term_guard=deterministic_claim_term_guard,
+        )
+
+        assert verdict.accepted is True
+        assert verdict.accepted_fact_ids == ("test_passed:admin_delete_denied",)
+        assert validator.calls[0]["evidence_manifest"] == (
+            TraceGuardEvidenceInput(
+                fact_id="test_passed:admin_delete_denied",
+                chunk_id="ev_test",
+                text="pytest passed; uv run pytest -k admin_delete_denied",
+                child_call_id="evt_test",
+            ),
+        )
+
     def test_claim_term_guard_rejects_traceguard_accepted_semantic_miss(self) -> None:
         manifest = EvidenceManifest(
             ac_id="AC-1",
@@ -829,7 +875,6 @@ class TestEvaluateDeliverClaim:
             "required term(s): behavior=admin_delete_denied",
         )
         assert verdict.evidence_event_ids == ()
-
 
     def test_claim_term_guard_checks_mixed_traceguard_allowed_facts(self) -> None:
         manifest = EvidenceManifest(

--- a/tests/unit/harness/test_deliver_routing.py
+++ b/tests/unit/harness/test_deliver_routing.py
@@ -103,6 +103,20 @@ def test_unsupported_fact_routes_to_redispatch_before_escalation_threshold() -> 
     assert route.reason == "deliver_gate_redispatch_required"
 
 
+def test_semantic_miss_routes_to_redispatch_before_escalation_threshold() -> None:
+    route = route_deliver_gate_verdict(
+        _verdict(
+            accepted=False,
+            reasons=("semantic_miss: evidence text lacks behavior=admin_delete_denied",),
+        ),
+        rejection_count=1,
+        model_escalation_threshold=2,
+    )
+
+    assert route.action is RecoveryAction.REDISPATCH
+    assert route.reason == "deliver_gate_redispatch_required"
+
+
 def test_repeated_traceguard_rejections_route_to_model_escalation() -> None:
     route = route_deliver_gate_verdict(
         _verdict(accepted=False, reasons=("unsupported_fact_id: fact_1 is not present",)),

--- a/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
+++ b/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from ouroboros.harness.claim_term_guard import ClaimTermGuardFact, deterministic_claim_term_guard
 from ouroboros.orchestrator.traceguard_benchmark_capture import (
     LEGACY_SELF_REPORT_ROWS,
     build_traceguard_benchmark_capture,
@@ -33,6 +34,33 @@ def test_traceguard_benchmark_reports_required_ab_metrics() -> None:
         / capture.legacy_report.median_chars_per_ac
     ) <= 1.5
 
+
+
+def test_claim_term_guard_benchmark_semantic_miss_matches_guard_logic() -> None:
+    capture = build_traceguard_benchmark_capture()
+    semantic_miss_rows = [
+        row for row in capture.traceguard_rows if row.semantic_miss_incidents > 0
+    ]
+
+    assert [row.ac_id for row in semantic_miss_rows] == ["FH-AC-008"]
+    guard_verdict = deterministic_claim_term_guard(
+        ac_id="FH-AC-008",
+        facts=(
+            ClaimTermGuardFact(
+                fact_id="test_passed:admin_delete_denied",
+                evidence_handle="ev_retry_budget",
+                statement="test_passed behavior=admin_delete_denied",
+                evidence_text="pytest passed for user profile update",
+            ),
+        ),
+    )
+
+    assert guard_verdict.accepted is False
+    guarded_row = capture.claim_term_guard_rows[-1]
+    assert guarded_row.ac_id == "FH-AC-008"
+    assert guarded_row.accepted is False
+    assert guarded_row.semantic_miss_incidents == 0
+    assert guarded_row.source_ref == "fixture:claim-term-guard/rejected-semantic-miss"
 
 def test_traceguard_benchmark_delta_is_json_serializable() -> None:
     payload = build_traceguard_benchmark_capture().to_dict()

--- a/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
+++ b/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
@@ -35,12 +35,9 @@ def test_traceguard_benchmark_reports_required_ab_metrics() -> None:
     ) <= 1.5
 
 
-
 def test_claim_term_guard_benchmark_semantic_miss_matches_guard_logic() -> None:
     capture = build_traceguard_benchmark_capture()
-    semantic_miss_rows = [
-        row for row in capture.traceguard_rows if row.semantic_miss_incidents > 0
-    ]
+    semantic_miss_rows = [row for row in capture.traceguard_rows if row.semantic_miss_incidents > 0]
 
     assert [row.ac_id for row in semantic_miss_rows] == ["FH-AC-008"]
     guard_verdict = deterministic_claim_term_guard(
@@ -62,15 +59,16 @@ def test_claim_term_guard_benchmark_semantic_miss_matches_guard_logic() -> None:
     assert guarded_row.semantic_miss_incidents == 0
     assert guarded_row.source_ref == "fixture:claim-term-guard/rejected-semantic-miss"
 
+
 def test_traceguard_benchmark_delta_is_json_serializable() -> None:
     payload = build_traceguard_benchmark_capture().to_dict()
 
     assert payload["delta"]["fabrication_incidents_per_100_acs"] == pytest.approx(-25.0)
     assert payload["delta"]["semantic_miss_incidents_per_100_acs"] == pytest.approx(-12.5)
     assert payload["delta"]["median_chars_ratio"] <= 1.5
-    assert payload["delta"]["claim_term_guard_semantic_miss_incidents_per_100_acs"] == pytest.approx(
-        -12.5
-    )
+    assert payload["delta"][
+        "claim_term_guard_semantic_miss_incidents_per_100_acs"
+    ] == pytest.approx(-12.5)
     assert payload["delta"]["claim_term_guard_median_chars_ratio"] <= 1.5
     json.dumps(payload)
 

--- a/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
+++ b/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
@@ -23,8 +23,14 @@ def test_traceguard_benchmark_reports_required_ab_metrics() -> None:
     assert capture.traceguard_report.fabrication_incidents_per_100_acs == 0.0
     assert capture.legacy_report.semantic_miss_incidents_per_100_acs == pytest.approx(25.0)
     assert capture.traceguard_report.semantic_miss_incidents_per_100_acs == pytest.approx(12.5)
+    assert capture.claim_term_guard_report.fabrication_incidents_per_100_acs == 0.0
+    assert capture.claim_term_guard_report.semantic_miss_incidents_per_100_acs == 0.0
     assert (
         capture.traceguard_report.median_chars_per_ac / capture.legacy_report.median_chars_per_ac
+    ) <= 1.5
+    assert (
+        capture.claim_term_guard_report.median_chars_per_ac
+        / capture.legacy_report.median_chars_per_ac
     ) <= 1.5
 
 
@@ -34,6 +40,10 @@ def test_traceguard_benchmark_delta_is_json_serializable() -> None:
     assert payload["delta"]["fabrication_incidents_per_100_acs"] == pytest.approx(-25.0)
     assert payload["delta"]["semantic_miss_incidents_per_100_acs"] == pytest.approx(-12.5)
     assert payload["delta"]["median_chars_ratio"] <= 1.5
+    assert payload["delta"]["claim_term_guard_semantic_miss_incidents_per_100_acs"] == pytest.approx(
+        -12.5
+    )
+    assert payload["delta"]["claim_term_guard_median_chars_ratio"] <= 1.5
     json.dumps(payload)
 
 
@@ -44,3 +54,4 @@ def test_traceguard_benchmark_markdown_artifact_matches_renderer() -> None:
     assert artifact == expected
     assert "Fabrication incidents per 100 ACs" in artifact
     assert "Semantic-miss incidents per 100 ACs" in artifact
+    assert "TraceGuard + claim-term guard" in artifact


### PR DESCRIPTION
## Summary

- Add a deterministic claim-term guard that runs after TraceGuard accepts evidence-backed deliver claims.
- Reject structured claim statements when their required `key=value` term values are absent from the cited evidence text.
- Extend the fixture benchmark with a `TraceGuard + claim-term guard` arm that reduces semantic-miss incidents from 12.5/100 ACs to 0 without reintroducing fabrication.

## Changes

- Introduce `ouroboros.harness.claim_term_guard` with `ClaimTermGuardFact`, `ClaimTermGuardVerdict`, and `deterministic_claim_term_guard`.
- Add an optional `claim_term_guard` hook to `evaluate_deliver_claim` while preserving default TraceGuard-only behavior.
- Route `semantic_miss` rejections through the existing redispatch/escalation taxonomy.
- Update the TraceGuard benchmark renderer and artifact with the claim-term guard fixture profile.

## Notes

- This remains deterministic and fixture-only; it does not wire an LLM semantic evaluator or change live default behavior.
- This guard checks normalized structured term values, not full `key=value` pairs. The key identifies diagnostics; the value must appear in evidence text.
- Prose-only claims are intentionally not rejected by this guard. Richer semantic evaluation remains a later profile-specific layer.
- This PR is stacked on #1011.

## Verification

- uv run pytest tests/unit/harness -q
- uv run pytest tests/unit/orchestrator/test_traceguard_benchmark_capture.py tests/unit/orchestrator/test_baseline_metrics_capture.py -q
- uv run python -m ouroboros.orchestrator.traceguard_benchmark_capture >/tmp/traceguard-benchmark.out && diff -u docs/agentos/traceguard-vs-legacy-benchmark.md /tmp/traceguard-benchmark.out
- uv run ruff check src/ouroboros/harness src/ouroboros/orchestrator/traceguard_benchmark_capture.py tests/unit/harness tests/unit/orchestrator/test_traceguard_benchmark_capture.py
- uv run mypy src/ouroboros/harness/claim_term_guard.py src/ouroboros/harness/deliver_gate.py src/ouroboros/harness/deliver_routing.py src/ouroboros/orchestrator/traceguard_benchmark_capture.py

| Metric | Legacy | TraceGuard | TraceGuard + Claim-Term Guard |
|---|---:|---:|---:|
| one-shot pass rate | 0.8750 | 0.5000 | 0.5000 |
| K=2 recovery rate | 0.0000 | 0.7500 | 0.7500 |
| fabrication / 100 ACs | 25.0000 | 0.0000 | 0.0000 |
| semantic miss / 100 ACs | 25.0000 | 12.5000 | 0.0000 |
| median chars / AC | 1295 | 1820 | 1820 |
| median chars ratio | - | 1.4054x | 1.4054x |

## References

Refs #978
Refs #961
