### PR TITLE
fix(harness): stabilize projection identity across queries

### DIFF
--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -94,8 +94,8 @@ class ProjectionBuilder:
             raise ValueError(msg)
         self._seed_id = seed_id.strip()
         self._goal = goal
-        self._run_id = run_id
-        self._stage_id = stage_id
+        self._run_id_override = run_id.strip() if run_id and run_id.strip() else None
+        self._stage_id_override = stage_id.strip() if stage_id and stage_id.strip() else None
         self._source_key = source_key.strip() if source_key and source_key.strip() else None
         self._tool_started: OrderedDict[str, BaseEvent] = OrderedDict()
         self._llm_started: OrderedDict[str, BaseEvent] = OrderedDict()
@@ -163,19 +163,16 @@ class ProjectionBuilder:
     def build(self) -> ProjectionBuildResult:
         """Finalize the record bundle from ingested events.
 
-        Repeated calls return identical ``run_id`` / ``stage_id`` so
-        replayable projections stay stable.
+        Repeated calls derive ``run_id`` / ``stage_id`` from the current
+        source key so incremental builds converge with one-shot replays
+        over the same final event set.
         """
         source_key = self._source_key or _derive_projection_source_key(
             self._identity_events,
             seed_id=self._seed_id,
         )
-        if self._run_id is None:
-            self._run_id = _stable_run_id(source_key)
-        if self._stage_id is None:
-            self._stage_id = _stable_stage_id(self._run_id, StageKind.EXECUTE)
-        run_id = self._run_id
-        stage_id = self._stage_id
+        run_id = self._run_id_override or _stable_run_id(source_key)
+        stage_id = self._stage_id_override or _stable_stage_id(run_id, StageKind.EXECUTE)
 
         started_at = self._first_event_at or self._idle_started_at
         ended_at = self._last_event_at

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -87,6 +87,7 @@ class ProjectionBuilder:
         goal: str = "",
         run_id: str | None = None,
         stage_id: str | None = None,
+        source_key: str | None = None,
     ) -> None:
         if not seed_id.strip():
             msg = "ProjectionBuilder requires a non-blank seed_id"
@@ -95,9 +96,11 @@ class ProjectionBuilder:
         self._goal = goal
         self._run_id = run_id
         self._stage_id = stage_id
+        self._source_key = source_key.strip() if source_key and source_key.strip() else None
         self._tool_started: OrderedDict[str, BaseEvent] = OrderedDict()
         self._llm_started: OrderedDict[str, BaseEvent] = OrderedDict()
         self._steps: OrderedDict[str, StepRecord] = OrderedDict()
+        self._identity_events: list[BaseEvent] = []
         self._idle_started_at = datetime.now(UTC)
         self._first_event_at: datetime | None = None
         self._last_event_at: datetime | None = None
@@ -113,6 +116,7 @@ class ProjectionBuilder:
     def add_event(self, event: BaseEvent) -> ProjectionBuilder:
         """Ingest a single event. Returns self for chaining."""
         self._update_timestamps(event)
+        self._identity_events.append(event)
 
         if event.type == _TOOL_STARTED:
             call_id = _extract_call_id(event)
@@ -162,10 +166,14 @@ class ProjectionBuilder:
         Repeated calls return identical ``run_id`` / ``stage_id`` so
         replayable projections stay stable.
         """
+        source_key = self._source_key or _derive_projection_source_key(
+            self._identity_events,
+            seed_id=self._seed_id,
+        )
         if self._run_id is None:
-            self._run_id = RunRecord(seed_id=self._seed_id).run_id
+            self._run_id = _stable_run_id(source_key)
         if self._stage_id is None:
-            self._stage_id = StageRecord(run_id=self._run_id, kind=StageKind.EXECUTE).stage_id
+            self._stage_id = _stable_stage_id(self._run_id, StageKind.EXECUTE)
         run_id = self._run_id
         stage_id = self._stage_id
 
@@ -295,9 +303,14 @@ def build_projection(
     *,
     seed_id: str,
     goal: str = "",
+    source_key: str | None = None,
 ) -> ProjectionBuildResult:
     """One-shot projection from a sequence of events."""
-    return ProjectionBuilder(seed_id=seed_id, goal=goal).add_events(events).build()
+    return (
+        ProjectionBuilder(seed_id=seed_id, goal=goal, source_key=source_key)
+        .add_events(events)
+        .build()
+    )
 
 
 def _extract_call_id(event: BaseEvent) -> str | None:
@@ -347,6 +360,70 @@ def _safe_bool(value: Any) -> bool | None:
     if isinstance(value, bool):
         return value
     return None
+
+
+def _derive_projection_source_key(events: Sequence[BaseEvent], *, seed_id: str) -> str:
+    """Return the deterministic identity source for a projected run.
+
+    Projection records are rebuildable read-models over the journal, so
+    run/stage IDs must not depend on object construction time. Prefer an
+    explicit execution aggregate when the event slice has exactly one,
+    then a single session aggregate, then a stable digest of the event
+    slice. Empty synthetic projections fall back to the seed id.
+    """
+    execution_ids = _event_scope_ids(events, scope="execution")
+    if len(execution_ids) == 1:
+        return f"execution:{next(iter(execution_ids))}"
+
+    session_ids = _event_scope_ids(events, scope="session")
+    if len(session_ids) == 1:
+        return f"session:{next(iter(session_ids))}"
+
+    if events:
+        digest = uuid5(
+            NAMESPACE_URL,
+            "ouroboros:harness:projection:events:"
+            + "|".join(
+                _event_identity_part(event) for event in sorted(events, key=_event_sort_key)
+            ),
+        ).hex[:12]
+        return f"events:{digest}"
+
+    return f"seed:{seed_id}"
+
+
+def _event_scope_ids(events: Sequence[BaseEvent], *, scope: str) -> frozenset[str]:
+    values: set[str] = set()
+    data_key = f"{scope}_id"
+    for event in events:
+        if event.aggregate_type == scope and event.aggregate_id.strip():
+            values.add(event.aggregate_id.strip())
+        if isinstance(event.data, dict):
+            value = event.data.get(data_key)
+            if isinstance(value, str) and value.strip():
+                values.add(value.strip())
+    return frozenset(values)
+
+
+def _event_sort_key(event: BaseEvent) -> tuple[datetime, str]:
+    return (event.timestamp, event.id)
+
+
+def _event_identity_part(event: BaseEvent) -> str:
+    return (
+        f"{event.timestamp.isoformat()}::{event.id}::"
+        f"{event.aggregate_type}:{event.aggregate_id}::{event.type}"
+    )
+
+
+def _stable_run_id(source_key: str) -> str:
+    digest = uuid5(NAMESPACE_URL, f"ouroboros:harness:run:{source_key}").hex[:12]
+    return f"run_{digest}"
+
+
+def _stable_stage_id(run_id: str, kind: StageKind) -> str:
+    digest = uuid5(NAMESPACE_URL, f"ouroboros:harness:stage:{run_id}:{kind.value}").hex[:12]
+    return f"stage_{digest}"
 
 
 def _tool_step_metadata(

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -181,8 +181,13 @@ class ProjectionBuilder:
         ended_at = self._last_event_at
 
         steps_for_stage = tuple(
-            _rewrite_step_run_stage(step, run_id=run_id, stage_id=stage_id)
-            for step in self._steps.values()
+            _rewrite_step_identity(
+                step,
+                step_id=_stable_step_id(source_key, *_slot_parts(slot_key)),
+                run_id=run_id,
+                stage_id=stage_id,
+            )
+            for slot_key, step in self._steps.items()
         )
 
         stage = StageRecord(
@@ -242,7 +247,9 @@ class ProjectionBuilder:
         previous = self._steps.get(key)
         step = StepRecord(
             schema_version=PROJECTION_SCHEMA_VERSION,
-            step_id=previous.step_id if previous is not None else _stable_step_id("tool", call_id),
+            step_id=previous.step_id
+            if previous is not None
+            else _stable_step_id("pending", "tool", call_id),
             run_id="run_placeholder",  # rewritten in build()
             stage_id="stage_placeholder",
             kind=kind,
@@ -278,7 +285,9 @@ class ProjectionBuilder:
         previous = self._steps.get(key)
         step = StepRecord(
             schema_version=PROJECTION_SCHEMA_VERSION,
-            step_id=previous.step_id if previous is not None else _stable_step_id("llm", call_id),
+            step_id=previous.step_id
+            if previous is not None
+            else _stable_step_id("pending", "llm", call_id),
             run_id="run_placeholder",  # rewritten in build()
             stage_id="stage_placeholder",
             kind=StepKind.MODEL_CALL,
@@ -471,15 +480,29 @@ def _slot_key(family: str, call_id: str) -> str:
     return f"{family}:{call_id}"
 
 
-def _stable_step_id(family: str, call_id: str) -> str:
-    digest = uuid5(NAMESPACE_URL, f"ouroboros:harness:{family}:{call_id}").hex[:12]
+def _stable_step_id(source_key: str, family: str, call_id: str) -> str:
+    digest = uuid5(
+        NAMESPACE_URL,
+        f"ouroboros:harness:step:{source_key}:{family}:{call_id}",
+    ).hex[:12]
     return f"step_{family}_{digest}"
 
 
-def _rewrite_step_run_stage(step: StepRecord, *, run_id: str, stage_id: str) -> StepRecord:
+def _slot_parts(slot_key: str) -> tuple[str, str]:
+    family, call_id = slot_key.split(":", 1)
+    return family, call_id
+
+
+def _rewrite_step_identity(
+    step: StepRecord,
+    *,
+    step_id: str,
+    run_id: str,
+    stage_id: str,
+) -> StepRecord:
     return StepRecord(
         schema_version=step.schema_version,
-        step_id=step.step_id,
+        step_id=step_id,
         run_id=run_id,
         stage_id=stage_id,
         kind=step.kind,
@@ -516,7 +539,7 @@ def _step_from_start_only(
             metadata["args_preview"] = preview
     return StepRecord(
         schema_version=PROJECTION_SCHEMA_VERSION,
-        step_id=_stable_step_id(family, call_id),
+        step_id=_stable_step_id("pending", family, call_id),
         run_id=run_id,
         stage_id=stage_id,
         kind=kind,

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -269,7 +269,15 @@ async def _load_projection_events(
                     or _event_links_execution(event, payload_execution_id)
                 ]
             return events
-        if not _session_declares_execution(events, session_id, execution_id):
+        if not _session_declares_execution(
+            events,
+            session_id,
+            execution_id,
+        ) and not _session_payload_links_execution(
+            events,
+            session_id,
+            execution_id,
+        ):
             msg = f"execution_id {execution_id!r} does not belong to session_id {session_id!r}"
             raise ValueError(msg)
         return [
@@ -383,6 +391,24 @@ def _session_execution_ids(events: Sequence[BaseEvent], session_id: str) -> froz
         if isinstance(value, str) and value.strip():
             execution_ids.add(value.strip())
     return frozenset(execution_ids)
+
+
+def _session_payload_links_execution(
+    events: Sequence[BaseEvent],
+    session_id: str,
+    execution_id: str,
+) -> bool:
+    for event in events:
+        if not isinstance(event.data, dict):
+            continue
+        payload_session_id = event.data.get("session_id")
+        if not isinstance(payload_session_id, str) or payload_session_id.strip() != session_id:
+            continue
+        for key in ("execution_id", "parent_execution_id"):
+            value = event.data.get(key)
+            if isinstance(value, str) and value.strip() == execution_id:
+                return True
+    return False
 
 
 def _event_payload_execution_ids(events: Sequence[BaseEvent]) -> frozenset[str]:

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -268,7 +268,12 @@ async def _load_projection_events(
                     or _is_session_terminal_event(event, session_id)
                     or _event_links_execution(event, payload_execution_id)
                 ]
-            return events
+            return [
+                event
+                for event in events
+                if _is_session_metadata_event(event, session_id)
+                or _is_session_terminal_event(event, session_id)
+            ]
         if not _session_declares_execution(
             events,
             session_id,

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -247,7 +247,7 @@ async def _load_projection_events(
                     or _is_session_terminal_event(event, session_id)
                     or _event_links_execution(event, declared_execution_id)
                 ]
-            payload_execution_ids = _event_payload_execution_ids(events)
+            payload_execution_ids = _event_payload_execution_ids(events, session_id)
             if len(payload_execution_ids) > 1:
                 msg = (
                     f"session_id {session_id!r} references multiple executions; "
@@ -398,29 +398,40 @@ def _session_payload_links_execution(
     session_id: str,
     execution_id: str,
 ) -> bool:
-    for event in events:
-        if not isinstance(event.data, dict):
-            continue
-        payload_session_id = event.data.get("session_id")
-        if not isinstance(payload_session_id, str) or payload_session_id.strip() != session_id:
-            continue
-        for key in ("execution_id", "parent_execution_id"):
-            value = event.data.get(key)
-            if isinstance(value, str) and value.strip() == execution_id:
-                return True
-    return False
+    return any(
+        _event_payload_links_session_execution(event, session_id, execution_id) for event in events
+    )
 
 
-def _event_payload_execution_ids(events: Sequence[BaseEvent]) -> frozenset[str]:
+def _event_payload_execution_ids(
+    events: Sequence[BaseEvent],
+    session_id: str,
+) -> frozenset[str]:
     execution_ids: set[str] = set()
     for event in events:
         if not isinstance(event.data, dict):
             continue
         for key in ("execution_id", "parent_execution_id"):
             value = event.data.get(key)
-            if isinstance(value, str) and value.strip():
-                execution_ids.add(value.strip())
+            if not isinstance(value, str) or not value.strip():
+                continue
+            execution_id = value.strip()
+            if _event_payload_links_session_execution(event, session_id, execution_id):
+                execution_ids.add(execution_id)
     return frozenset(execution_ids)
+
+
+def _event_payload_links_session_execution(
+    event: BaseEvent,
+    session_id: str,
+    execution_id: str,
+) -> bool:
+    if not isinstance(event.data, dict):
+        return False
+    payload_session_id = event.data.get("session_id")
+    if not isinstance(payload_session_id, str) or payload_session_id.strip() != session_id:
+        return False
+    return _event_links_execution(event, execution_id)
 
 
 def _is_session_metadata_event(
@@ -484,7 +495,7 @@ def _query_projection_source_key(
         execution_ids = _session_execution_ids(events, session_id)
         if len(execution_ids) == 1:
             return f"execution:{next(iter(execution_ids))}"
-        payload_execution_ids = _event_payload_execution_ids(events)
+        payload_execution_ids = _event_payload_execution_ids(events, session_id)
         if len(payload_execution_ids) == 1:
             return f"execution:{next(iter(payload_execution_ids))}"
     if session_id is not None:

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -170,7 +170,16 @@ class ProjectionQueryHandler:
                 override=seed_id_override,
             )
             goal = _derive_goal(ordered_events)
-            projection = build_projection(ordered_events, seed_id=seed_id, goal=goal)
+            projection = build_projection(
+                ordered_events,
+                seed_id=seed_id,
+                goal=goal,
+                source_key=_query_projection_source_key(
+                    ordered_events,
+                    session_id=session_id,
+                    execution_id=execution_id,
+                ),
+            )
 
             return Result.ok(
                 MCPToolResult(
@@ -435,6 +444,26 @@ def _derive_goal(events: Sequence[BaseEvent]) -> str:
             if isinstance(value, str) and value.strip():
                 return value.strip()
     return ""
+
+
+def _query_projection_source_key(
+    events: Sequence[BaseEvent],
+    *,
+    session_id: str | None,
+    execution_id: str | None,
+) -> str | None:
+    if execution_id is not None:
+        return f"execution:{execution_id}"
+    if session_id is not None:
+        execution_ids = _session_execution_ids(events, session_id)
+        if len(execution_ids) == 1:
+            return f"execution:{next(iter(execution_ids))}"
+        payload_execution_ids = _event_payload_execution_ids(events)
+        if len(payload_execution_ids) == 1:
+            return f"execution:{next(iter(payload_execution_ids))}"
+    if session_id is not None:
+        return f"session:{session_id}"
+    return None
 
 
 def _string_argument(arguments: dict[str, Any], name: str) -> str | None:

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -343,6 +343,28 @@ class TestIncrementalIngestion:
         assert first.stages[0].stage_id != different.stages[0].stage_id
         assert first.steps[0].step_id != different.steps[0].step_id
 
+    def test_incremental_build_after_empty_build_converges_with_one_shot(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            _tool_started(
+                call_id="late",
+                tool_name="Bash",
+                when=t0,
+                event_id="evt_late_start",
+            )
+        ]
+        builder = ProjectionBuilder(seed_id="seed_abc")
+
+        empty = builder.build()
+        builder.add_events(events)
+        incremental = builder.build()
+        one_shot = build_projection(events, seed_id="seed_abc")
+
+        assert empty.run.run_id != incremental.run.run_id
+        assert incremental.run.run_id == one_shot.run.run_id
+        assert incremental.stages[0].stage_id == one_shot.stages[0].stage_id
+        assert incremental.steps[0].step_id == one_shot.steps[0].step_id
+
     def test_in_flight_step_id_stays_stable_across_builds_and_completion(self) -> None:
         t0 = datetime.now(UTC)
         builder = ProjectionBuilder(seed_id="seed_abc")

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -310,6 +310,37 @@ class TestIncrementalIngestion:
         assert first.run.run_id == second.run.run_id
         assert first.steps[0].step_id == second.steps[0].step_id
 
+    def test_one_shot_projection_ids_are_stable_across_replays(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            _tool_started(call_id="c1", tool_name="Bash", when=t0, event_id="evt_a"),
+            _tool_returned(
+                call_id="c1",
+                tool_name="Bash",
+                when=t0 + timedelta(milliseconds=10),
+                event_id="evt_b",
+            ),
+        ]
+
+        first = build_projection(events, seed_id="seed_abc")
+        second = build_projection(events, seed_id="seed_abc")
+
+        assert first.run.run_id == second.run.run_id
+        assert first.stages[0].stage_id == second.stages[0].stage_id
+        assert first.steps[0].step_id == second.steps[0].step_id
+
+    def test_projection_source_key_controls_run_identity(self) -> None:
+        events = [_tool_started(call_id="c1", tool_name="Bash")]
+
+        first = build_projection(events, seed_id="seed_abc", source_key="execution:exec_a")
+        second = build_projection(events, seed_id="seed_abc", source_key="execution:exec_a")
+        different = build_projection(events, seed_id="seed_abc", source_key="execution:exec_b")
+
+        assert first.run.run_id == second.run.run_id
+        assert first.stages[0].stage_id == second.stages[0].stage_id
+        assert first.run.run_id != different.run.run_id
+        assert first.stages[0].stage_id != different.stages[0].stage_id
+
     def test_in_flight_step_id_stays_stable_across_builds_and_completion(self) -> None:
         t0 = datetime.now(UTC)
         builder = ProjectionBuilder(seed_id="seed_abc")

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -338,8 +338,10 @@ class TestIncrementalIngestion:
 
         assert first.run.run_id == second.run.run_id
         assert first.stages[0].stage_id == second.stages[0].stage_id
+        assert first.steps[0].step_id == second.steps[0].step_id
         assert first.run.run_id != different.run.run_id
         assert first.stages[0].stage_id != different.stages[0].stage_id
+        assert first.steps[0].step_id != different.steps[0].step_id
 
     def test_in_flight_step_id_stays_stable_across_builds_and_completion(self) -> None:
         t0 = datetime.now(UTC)

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -635,8 +635,10 @@ class TestProjectionQueryHandler:
 
         handler = ProjectionQueryHandler(event_store=memory_event_store)
         result = await handler.handle({"execution_id": "exec_projection_123"})
+        second_result = await handler.handle({"execution_id": "exec_projection_123"})
 
         assert result.is_ok
+        assert second_result.is_ok
         assert "Run Projection" in result.value.text_content
         assert result.value.meta["execution_id"] == "exec_projection_123"
         assert result.value.meta["seed_id"] == "seed_projection_123"
@@ -650,6 +652,14 @@ class TestProjectionQueryHandler:
         assert step["ok"] is True
         assert step["source_event_ids"] == ["evt_proj_start", "evt_proj_return"]
         assert result.value.meta["steps"][1]["name"] == "Read"
+        assert result.value.meta["run"]["run_id"] == second_result.value.meta["run"]["run_id"]
+        assert (
+            result.value.meta["stages"][0]["stage_id"]
+            == second_result.value.meta["stages"][0]["stage_id"]
+        )
+        assert [step["step_id"] for step in result.value.meta["steps"]] == [
+            step["step_id"] for step in second_result.value.meta["steps"]
+        ]
 
     async def test_handle_projects_session_related_events(
         self,
@@ -716,8 +726,10 @@ class TestProjectionQueryHandler:
 
         handler = ProjectionQueryHandler(event_store=memory_event_store)
         result = await handler.handle({"session_id": "orch_projection_123"})
+        second_result = await handler.handle({"session_id": "orch_projection_123"})
 
         assert result.is_ok
+        assert second_result.is_ok
         assert result.value.meta["session_id"] == "orch_projection_123"
         assert result.value.meta["seed_id"] == "seed_projection_456"
         assert result.value.meta["seed_id_source"] == "event"
@@ -725,6 +737,11 @@ class TestProjectionQueryHandler:
         assert result.value.meta["event_count"] == 3
         assert result.value.meta["run"]["ended_at"] == "2026-01-01T00:00:00.100000Z"
         assert result.value.meta["steps"][0]["name"] == "Read"
+        assert result.value.meta["run"]["run_id"] == second_result.value.meta["run"]["run_id"]
+        assert (
+            result.value.meta["stages"][0]["stage_id"]
+            == second_result.value.meta["stages"][0]["stage_id"]
+        )
 
     async def test_handle_rejects_mismatched_session_execution(
         self,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -946,6 +946,56 @@ class TestProjectionQueryHandler:
         assert result.is_err
         assert "references multiple executions" in str(result.error)
 
+    async def test_handle_disambiguates_metadata_less_session_with_execution_id(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Explicit execution_id can disambiguate payload-only session links."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_exec_a",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_payload_a",
+                data={
+                    "session_id": "orch_projection_payload_multi",
+                    "execution_id": "exec_payload_a",
+                    "call_id": "payload_a",
+                    "tool_name": "Bash",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_exec_b",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_payload_b",
+                data={
+                    "session_id": "orch_projection_payload_multi",
+                    "execution_id": "exec_payload_b",
+                    "call_id": "payload_b",
+                    "tool_name": "Read",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle(
+            {
+                "session_id": "orch_projection_payload_multi",
+                "execution_id": "exec_payload_a",
+            }
+        )
+
+        assert result.is_ok
+        assert result.value.meta["event_count"] == 1
+        assert result.value.meta["seed_id"] == "exec_payload_a"
+        assert result.value.meta["seed_id_source"] == "fallback"
+        assert [step["name"] for step in result.value.meta["steps"]] == ["Bash"]
+
     async def test_handle_narrows_metadata_less_session_only_single_execution_payload(
         self,
         memory_event_store: EventStore,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -946,6 +946,84 @@ class TestProjectionQueryHandler:
         assert result.is_err
         assert "references multiple executions" in str(result.error)
 
+    async def test_handle_ignores_foreign_payload_execution_candidates(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Foreign aggregates must not establish session execution membership."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_real_exec",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_payload_real",
+                data={
+                    "session_id": "orch_projection_foreign_payload",
+                    "execution_id": "exec_payload_real",
+                    "call_id": "payload_real",
+                    "tool_name": "Bash",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_foreign_exec",
+                type="tool.call.started",
+                aggregate_type="lineage",
+                aggregate_id="lineage_payload_foreign",
+                data={
+                    "session_id": "orch_projection_foreign_payload",
+                    "execution_id": "exec_payload_foreign",
+                    "call_id": "payload_foreign",
+                    "tool_name": "Read",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"session_id": "orch_projection_foreign_payload"})
+
+        assert result.is_ok
+        assert result.value.meta["event_count"] == 1
+        assert result.value.meta["seed_id"] == "orch_projection_foreign_payload"
+        assert result.value.meta["seed_id_source"] == "fallback"
+        assert [step["name"] for step in result.value.meta["steps"]] == ["Bash"]
+
+    async def test_handle_rejects_foreign_only_payload_session_execution(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Explicit session/execution selectors cannot be proven by foreign aggregates."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_foreign_only_exec",
+                type="tool.call.started",
+                aggregate_type="lineage",
+                aggregate_id="lineage_payload_foreign_only",
+                data={
+                    "session_id": "orch_projection_foreign_only",
+                    "execution_id": "exec_payload_foreign_only",
+                    "call_id": "payload_foreign_only",
+                    "tool_name": "Read",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle(
+            {
+                "session_id": "orch_projection_foreign_only",
+                "execution_id": "exec_payload_foreign_only",
+            }
+        )
+
+        assert result.is_err
+        assert "does not belong" in str(result.error)
+
     async def test_handle_disambiguates_metadata_less_session_with_execution_id(
         self,
         memory_event_store: EventStore,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -991,6 +991,34 @@ class TestProjectionQueryHandler:
         assert result.value.meta["seed_id_source"] == "fallback"
         assert [step["name"] for step in result.value.meta["steps"]] == ["Bash"]
 
+    async def test_handle_rejects_foreign_only_payload_session_query(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Session-only projections must not project foreign payload-only aggregates."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_foreign_only_session",
+                type="tool.call.started",
+                aggregate_type="lineage",
+                aggregate_id="lineage_payload_foreign_only_session",
+                data={
+                    "session_id": "orch_projection_foreign_only_session",
+                    "execution_id": "exec_payload_foreign_only_session",
+                    "call_id": "payload_foreign_only_session",
+                    "tool_name": "Read",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"session_id": "orch_projection_foreign_only_session"})
+
+        assert result.is_err
+        assert "No events found" in str(result.error)
+
     async def test_handle_rejects_foreign_only_payload_session_execution(
         self,
         memory_event_store: EventStore,


### PR DESCRIPTION
## Summary

Refs #946 and #961. Follow-up to the #946 projection foundation/query slices (#983 / #990).

This PR hardens projection identity without expanding the projection surface:

- anchors `ProjectionBuilder` run/default-stage IDs to deterministic source keys instead of construction-time generated IDs;
- lets `build_projection(..., source_key=...)` carry a query/selector identity into the read model;
- makes `ouroboros_query_projection` use execution/session selectors as the projection identity source;
- records `seed_id_source` in MCP meta (`argument` / `event` / `fallback`) so fallback labels are explicit;
- fails session-only projection queries closed when payloads imply multiple executions and no `execution_id` disambiguates them;
- adds regressions proving repeated builder and MCP queries return stable `run_id`, `stage_id`, and `step_id` values.

## SSOT alignment

This is not a new AgentOS surface and does not change default execution behavior. It keeps #946 projections as read-only EventStore-derived records while making the already-merged #983/#990 line safe for downstream RunSnapshot, capsule, plugin, and inspector consumers.

## Non-goals

- No artifact mapping.
- No verdict mapping.
- No CLI surface.
- No multi-stage inference.
- No EventStore schema change.
- No projection caching or persistence.

## Verification

```bash
uv run pytest tests/unit/harness/test_projection_builder.py tests/unit/harness/test_projection_records.py tests/unit/mcp/tools/test_definitions.py tests/unit/persistence/test_event_store.py -q
# 236 passed in 15.38s

uv run mypy src/ouroboros/harness/projection_builder.py src/ouroboros/mcp/tools/projection_handlers.py tests/unit/harness/test_projection_builder.py tests/unit/mcp/tools/test_definitions.py
# Success: no issues found in 4 source files

uv run ruff check src/ouroboros/harness/projection_builder.py src/ouroboros/mcp/tools/projection_handlers.py tests/unit/harness/test_projection_builder.py tests/unit/mcp/tools/test_definitions.py
# All checks passed!

uv run ruff format --check src/ouroboros/harness/projection_builder.py src/ouroboros/mcp/tools/projection_handlers.py tests/unit/harness/test_projection_builder.py tests/unit/mcp/tools/test_definitions.py
# 4 files already formatted
```
