### PR TITLE
docs(plugin): clarify v1 hook outcome audit contract (#939)

### DIFF
--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -425,6 +425,15 @@ implementation PRs should use these event names unless the vendored
 - `plugin.hook.failed`
 - `plugin.hook.blocked`
 
+The current v0.3 schema slice vendors only the v1 hook **outcome** events
+needed for blocked/failed hook paths: `plugin.hook.blocked` and
+`plugin.hook.failed`. In code, `HOOK_OUTCOME_AUDIT_EVENTS` is the canonical
+constant for that narrowed set, and `HOOK_AUDIT_EVENTS` remains only a
+backward-compatible alias for the original #984 export. Successful hook
+start/completion telemetry (`plugin.hook.invoked` / `plugin.hook.completed`)
+must land through a separate schema/runtime slice before core emits those
+events.
+
 Hook event payloads follow the same bounded-payload rules as command audit
 events:
 

--- a/src/ouroboros/plugin/hooks.py
+++ b/src/ouroboros/plugin/hooks.py
@@ -16,9 +16,11 @@ What this module owns:
   silently accepting them at manifest-validation time.
 * :class:`HookFailurePolicy` — the v1 failure policies (``fail_open``
   / ``fail_closed``).
-* :data:`HOOK_AUDIT_EVENTS` — the audit event names the wrapper emits
-  for hook execution outcomes (``plugin.hook.blocked`` /
-  ``plugin.hook.failed``).
+* :data:`HOOK_OUTCOME_AUDIT_EVENTS` — the v1 hook outcome event names
+  currently vendored in the manifest/audit schemas
+  (``plugin.hook.blocked`` / ``plugin.hook.failed``). These are not the
+  full future hook telemetry set; successful hook start/completion
+  events remain deferred until their schema/runtime slice lands.
 * :func:`is_v1_hook_kind` / :func:`is_v1_failure_policy` — helpers
   consumed by manifest validators in follow-up PRs. They live here so
   the contract is the single source of truth.
@@ -127,13 +129,28 @@ class HookFailurePolicy(StrEnum):
     FAIL_CLOSED = "fail_closed"
 
 
-#: Audit event names the wrapper emits for hook execution outcomes.
-#: These are exported as constants so manifest validators and audit
-#: consumers reference the same string set the wrapper will emit when
-#: dispatch lands in a follow-up PR.
+#: V1 hook outcome event names currently vendored in the
+#: manifest/audit schemas. These are exported as constants so manifest
+#: validators and audit consumers reference the same string set the
+#: wrapper will emit for hook block/failure outcomes when dispatch
+#: lands in a follow-up PR.
+#:
+#: This is deliberately narrower than the full future hook telemetry
+#: vocabulary in ``docs/rfc/userlevel-plugins.md``. Successful
+#: ``plugin.hook.invoked`` / ``plugin.hook.completed`` emission remains
+#: deferred until the upstream audit schema and core runtime wiring both
+#: support those events.
 HOOK_BLOCKED_EVENT: Final[str] = "plugin.hook.blocked"
 HOOK_FAILED_EVENT: Final[str] = "plugin.hook.failed"
-HOOK_AUDIT_EVENTS: Final[frozenset[str]] = frozenset({HOOK_BLOCKED_EVENT, HOOK_FAILED_EVENT})
+HOOK_OUTCOME_AUDIT_EVENTS: Final[frozenset[str]] = frozenset(
+    {HOOK_BLOCKED_EVENT, HOOK_FAILED_EVENT}
+)
+
+#: Backward-compatible alias for the original #984 export. Prefer
+#: :data:`HOOK_OUTCOME_AUDIT_EVENTS` in new call sites so the name does
+#: not imply that all future hook audit events are already schema-
+#: vendored or safe to emit.
+HOOK_AUDIT_EVENTS: Final[frozenset[str]] = HOOK_OUTCOME_AUDIT_EVENTS
 
 #: Hook permission scope reserved for read-only lifecycle observation
 #: (the v1 baseline used by ``before_invocation`` / ``after_invocation``
@@ -194,6 +211,7 @@ __all__ = [
     "HOOK_FAILED_EVENT",
     "HOOK_LIFECYCLE_READ_SCOPE",
     "HOOK_LIFECYCLE_SCOPES",
+    "HOOK_OUTCOME_AUDIT_EVENTS",
     "DeferredHookKind",
     "ExcludedHookKind",
     "HookFailurePolicy",

--- a/tests/unit/plugin/test_hooks_contract.py
+++ b/tests/unit/plugin/test_hooks_contract.py
@@ -6,8 +6,10 @@ Covers the v1 contract from issue #939 (first slice — types only):
 * ``DeferredHookKind`` and ``ExcludedHookKind`` enumerate the remaining
   candidate sets without overlapping ``HookKind``.
 * ``HookFailurePolicy`` exposes the two v1 policies the RFC defines.
-* ``HOOK_AUDIT_EVENTS`` matches the wrapper event names the RFC
-  references (``plugin.hook.blocked`` / ``plugin.hook.failed``).
+* ``HOOK_OUTCOME_AUDIT_EVENTS`` matches the v1 hook outcome event names
+  currently vendored in the schema (``plugin.hook.blocked`` /
+  ``plugin.hook.failed``), while ``HOOK_AUDIT_EVENTS`` remains a
+  compatibility alias for the original #984 export.
 * The ``is_*`` helpers route any candidate string to exactly one of
   v1 / deferred / excluded / unknown.
 """
@@ -18,6 +20,7 @@ from ouroboros.plugin.hooks import (
     HOOK_AUDIT_EVENTS,
     HOOK_BLOCKED_EVENT,
     HOOK_FAILED_EVENT,
+    HOOK_OUTCOME_AUDIT_EVENTS,
     DeferredHookKind,
     ExcludedHookKind,
     HookFailurePolicy,
@@ -81,16 +84,19 @@ class TestFailurePolicy:
 
 
 class TestAuditEventConstants:
-    def test_audit_event_set(self) -> None:
-        assert frozenset({"plugin.hook.blocked", "plugin.hook.failed"}) == HOOK_AUDIT_EVENTS
+    def test_hook_outcome_event_set(self) -> None:
+        assert frozenset({"plugin.hook.blocked", "plugin.hook.failed"}) == HOOK_OUTCOME_AUDIT_EVENTS
+
+    def test_legacy_audit_event_alias_points_to_outcome_events(self) -> None:
+        assert HOOK_AUDIT_EVENTS is HOOK_OUTCOME_AUDIT_EVENTS
 
     def test_blocked_event_constant(self) -> None:
         assert HOOK_BLOCKED_EVENT == "plugin.hook.blocked"
-        assert HOOK_BLOCKED_EVENT in HOOK_AUDIT_EVENTS
+        assert HOOK_BLOCKED_EVENT in HOOK_OUTCOME_AUDIT_EVENTS
 
     def test_failed_event_constant(self) -> None:
         assert HOOK_FAILED_EVENT == "plugin.hook.failed"
-        assert HOOK_FAILED_EVENT in HOOK_AUDIT_EVENTS
+        assert HOOK_FAILED_EVENT in HOOK_OUTCOME_AUDIT_EVENTS
 
 
 class TestRoutingHelpers:


### PR DESCRIPTION
## Scope

#939 contract-hygiene follow-up after the merged #984 / #985 / #986 / #987 stack.

This PR clarifies that the currently vendored v1 hook audit set is the **outcome** subset only:

- `plugin.hook.blocked`
- `plugin.hook.failed`

It adds `HOOK_OUTCOME_AUDIT_EVENTS` as the preferred constant and keeps the original `HOOK_AUDIT_EVENTS` export as a compatibility alias so existing imports do not break.

## SSOT / sequencing guardrails

- Routes only to #939, the canonical Plugin boundary in #961.
- Does not create a new AgentOS substrate surface.
- Does not touch #920 / #946 / #956 / #978 Tier 2 runtime sequencing.
- Does not wire runtime hook dispatch.
- Does not emit new audit events.
- Keeps `HOOK_AUDIT_EVENTS` as a compatibility alias.
- Leaves `plugin.hook.invoked` / `plugin.hook.completed` for a separate schema/runtime slice before core emits them.

## What changed

- `src/ouroboros/plugin/hooks.py`
  - Adds `HOOK_OUTCOME_AUDIT_EVENTS`.
  - Retains `HOOK_AUDIT_EVENTS` as a backward-compatible alias.
  - Documents that successful hook start/completion telemetry is deferred.
- `tests/unit/plugin/test_hooks_contract.py`
  - Covers the canonical outcome-event constant.
  - Pins alias identity for the legacy export.
- `docs/rfc/userlevel-plugins.md`
  - Records that v0.3 currently vendors only blocked/failed hook outcome events.
  - Clarifies that `plugin.hook.invoked` / `plugin.hook.completed` need a future schema/runtime slice.

## Verification

```bash
uv run ruff check src/ouroboros/plugin/hooks.py tests/unit/plugin/test_hooks_contract.py
uv run pytest tests/unit/plugin/test_hooks_contract.py \
  tests/unit/plugin/test_manifest_hook_validation.py \
  tests/unit/plugin/test_manifest_schema_0_3.py \
  tests/unit/plugin/test_hook_permission_scopes.py -q
uv run pytest tests/unit/plugin -q
git diff --check
```

Results:

- Ruff: passed
- Targeted hook/schema tests: `51 passed in 10.20s`
- Full plugin unit suite: `402 passed, 1 skipped in 13.55s`
- `git diff --check`: clean
