### PR TITLE
fix(harness): preserve execution evidence without session payload

### DIFF
--- a/src/ouroboros/harness/deliver_gate.py
+++ b/src/ouroboros/harness/deliver_gate.py
@@ -326,14 +326,27 @@ def _event_matches_required_anchors(
         keys=("execution_id", "parent_execution_id"),
     ):
         return False
-    return not (
-        session_id is not None
-        and not _event_matches_anchor(
-            event,
-            session_id,
-            keys=("session_id",),
-        )
-    )
+    return session_id is None or _event_matches_optional_session_anchor(event, session_id)
+
+
+def _event_matches_optional_session_anchor(event: BaseEvent, session_id: str) -> bool:
+    """Return True when an event does not contradict the optional session anchor.
+
+    The I/O journal recorder allows execution-scoped tool/LLM events to carry
+    ``execution_id`` without also carrying ``session_id``. Once an execution
+    anchor has matched, those rows are valid evidence and must not be pruned
+    merely because the optional session correlation field is absent. Explicit
+    session-scoped rows, or rows that do carry a ``session_id`` payload, still
+    have to match the requested session so broad EventStore OR queries cannot
+    splice another session's evidence into the manifest.
+    """
+    if event.aggregate_type == "session":
+        return event.aggregate_id == session_id
+    if isinstance(event.data, dict):
+        value = event.data.get("session_id")
+        if isinstance(value, str) and value.strip():
+            return value.strip() == session_id
+    return True
 
 
 def _event_matches_anchor(event: BaseEvent, anchor: str, *, keys: tuple[str, ...]) -> bool:

--- a/tests/unit/harness/test_deliver_gate.py
+++ b/tests/unit/harness/test_deliver_gate.py
@@ -350,6 +350,85 @@ class TestLoadAcEvidenceManifest:
         assert manifest.entries[0].source_event_ids == ("evt_started_target",)
 
     @pytest.mark.asyncio
+    async def test_execution_scoped_events_without_session_payload_are_retained(
+        self,
+    ) -> None:
+        now = datetime.now(UTC)
+        store = _FakeEventStore(
+            [
+                _tool_started(
+                    call_id="target",
+                    session_id=None,
+                    execution_id="exec_1",
+                    when=now,
+                ),
+                _tool_returned(
+                    call_id="target",
+                    session_id=None,
+                    execution_id="exec_1",
+                    when=now + timedelta(seconds=1),
+                ),
+            ]
+        )
+
+        manifest = await load_ac_evidence_manifest(
+            store,
+            ac_id="ac_1",
+            session_id="sess_1",
+            execution_id="exec_1",
+        )
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == (
+            "evt_started_target",
+            "evt_returned_target",
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_aggregate_events_must_match_requested_session(self) -> None:
+        now = datetime.now(UTC)
+        store = _FakeEventStore(
+            [
+                BaseEvent(
+                    id="evt_started_wrong_session_aggregate",
+                    type="tool.call.started",
+                    timestamp=now,
+                    aggregate_type="session",
+                    aggregate_id="other_sess",
+                    data={
+                        "call_id": "wrong_session_aggregate",
+                        "tool_name": "Bash",
+                        "ac_id": "ac_1",
+                        "execution_id": "exec_1",
+                    },
+                ),
+                BaseEvent(
+                    id="evt_started_target_session_aggregate",
+                    type="tool.call.started",
+                    timestamp=now + timedelta(seconds=1),
+                    aggregate_type="session",
+                    aggregate_id="sess_1",
+                    data={
+                        "call_id": "target_session_aggregate",
+                        "tool_name": "Bash",
+                        "ac_id": "ac_1",
+                        "execution_id": "exec_1",
+                    },
+                ),
+            ]
+        )
+
+        manifest = await load_ac_evidence_manifest(
+            store,
+            ac_id="ac_1",
+            session_id="sess_1",
+            execution_id="exec_1",
+        )
+
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].source_event_ids == ("evt_started_target_session_aggregate",)
+
+    @pytest.mark.asyncio
     async def test_scope_id_filters_production_shaped_events_without_ac_payload(self) -> None:
         now = datetime.now(UTC)
         store = _FakeEventStore(


### PR DESCRIPTION
## Summary

Follow-up to merged #993's late review finding. The deliver-gate EventStore loader now treats `execution_id` as the hard ownership anchor and treats `session_id` as an optional contradiction guard instead of requiring every execution-scoped I/O event to carry a `session_id` payload.

This preserves valid recorder-shaped tool/LLM events that carry `execution_id` but omit optional `session_id`, while still rejecting:

- explicit `data["session_id"]` mismatches;
- `session` aggregate rows from a different session;
- execution mismatches via the existing hard execution anchor.

## Scope controls

- No default-path behavior change outside the read-only deliver-gate loader.
- No TraceGuard enforcement change.
- No legacy self-report removal.
- No schema or new AgentOS surface.

## Verification

- `uv run pytest tests/unit/harness/test_deliver_gate.py tests/unit/harness/test_deliver_routing.py tests/unit/harness/test_journal_normalizer.py tests/unit/orchestrator/test_parallel_executor.py -q`
- `uv run ruff check src/ouroboros/harness/deliver_gate.py tests/unit/harness/test_deliver_gate.py`
- `uv run mypy src/ouroboros/harness/deliver_gate.py tests/unit/harness/test_deliver_gate.py`

Resolves late #993 review debt before #978 P5 / legacy fallback removal readiness.
