### PR TITLE
fix(harness): harden projection query provenance after #990

### DIFF
--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -163,7 +163,12 @@ class ProjectionQueryHandler:
                         tool_name="ouroboros_query_projection",
                     )
                 )
-            seed_id = seed_id_override or _derive_seed_id(ordered_events, session_id, execution_id)
+            seed_id, seed_id_source = _resolve_seed_id(
+                ordered_events,
+                session_id,
+                execution_id,
+                override=seed_id_override,
+            )
             goal = _derive_goal(ordered_events)
             projection = build_projection(ordered_events, seed_id=seed_id, goal=goal)
 
@@ -181,6 +186,7 @@ class ProjectionQueryHandler:
                         session_id=session_id,
                         execution_id=execution_id,
                         seed_id=seed_id,
+                        seed_id_source=seed_id_source,
                         event_count=len(ordered_events),
                         limit=limit,
                     ),
@@ -232,6 +238,27 @@ async def _load_projection_events(
                     or _is_session_terminal_event(event, session_id)
                     or _event_links_execution(event, declared_execution_id)
                 ]
+            payload_execution_ids = _event_payload_execution_ids(events)
+            if len(payload_execution_ids) > 1:
+                msg = (
+                    f"session_id {session_id!r} references multiple executions; "
+                    "provide execution_id for an unambiguous projection"
+                )
+                raise ValueError(msg)
+            if len(payload_execution_ids) == 1:
+                payload_execution_id = next(iter(payload_execution_ids))
+                scoped_events = await store.query_session_related_events(
+                    session_id=session_id,
+                    execution_id=payload_execution_id,
+                    limit=None,
+                )
+                return [
+                    event
+                    for event in scoped_events
+                    if _is_session_metadata_event(event, session_id)
+                    or _is_session_terminal_event(event, session_id)
+                    or _event_links_execution(event, payload_execution_id)
+                ]
             return events
         if not _session_declares_execution(events, session_id, execution_id):
             msg = f"execution_id {execution_id!r} does not belong to session_id {session_id!r}"
@@ -257,6 +284,7 @@ def _projection_meta(
     session_id: str | None,
     execution_id: str | None,
     seed_id: str,
+    seed_id_source: str,
     event_count: int,
     limit: int | None,
 ) -> dict[str, Any]:
@@ -264,6 +292,7 @@ def _projection_meta(
         "session_id": session_id,
         "execution_id": execution_id,
         "seed_id": seed_id,
+        "seed_id_source": seed_id_source,
         "event_count": event_count,
         "limit": limit,
         "run": projection.run.model_dump(mode="json"),
@@ -293,17 +322,30 @@ def _format_projection_text(projection: ProjectionBuildResult, event_count: int)
     return "\n".join(lines)
 
 
-def _derive_seed_id(
+def _resolve_seed_id(
     events: Sequence[BaseEvent],
     session_id: str | None,
     execution_id: str | None,
-) -> str:
+    *,
+    override: str | None,
+) -> tuple[str, str]:
+    if override is not None:
+        return override, "argument"
+    seed_id = _derive_seed_id(events)
+    if seed_id is not None:
+        return seed_id, "event"
+    fallback = execution_id or session_id or "projection"
+    return fallback.strip() or "projection", "fallback"
+
+
+def _derive_seed_id(
+    events: Sequence[BaseEvent],
+) -> str | None:
     for event in events:
         value = event.data.get("seed_id") if isinstance(event.data, dict) else None
         if isinstance(value, str) and value.strip():
             return value.strip()
-    fallback = execution_id or session_id or "projection"
-    return fallback.strip() or "projection"
+    return None
 
 
 def _ensure_aware_timestamp(event: BaseEvent) -> BaseEvent:
@@ -331,6 +373,18 @@ def _session_execution_ids(events: Sequence[BaseEvent], session_id: str) -> froz
         value = event.data.get("execution_id") if isinstance(event.data, dict) else None
         if isinstance(value, str) and value.strip():
             execution_ids.add(value.strip())
+    return frozenset(execution_ids)
+
+
+def _event_payload_execution_ids(events: Sequence[BaseEvent]) -> frozenset[str]:
+    execution_ids: set[str] = set()
+    for event in events:
+        if not isinstance(event.data, dict):
+            continue
+        for key in ("execution_id", "parent_execution_id"):
+            value = event.data.get(key)
+            if isinstance(value, str) and value.strip():
+                execution_ids.add(value.strip())
     return frozenset(execution_ids)
 
 

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -640,6 +640,7 @@ class TestProjectionQueryHandler:
         assert "Run Projection" in result.value.text_content
         assert result.value.meta["execution_id"] == "exec_projection_123"
         assert result.value.meta["seed_id"] == "seed_projection_123"
+        assert result.value.meta["seed_id_source"] == "event"
         assert result.value.meta["event_count"] == 3
         assert result.value.meta["run"]["goal"] == "Inspect projection"
         assert len(result.value.meta["stages"]) == 1
@@ -719,6 +720,7 @@ class TestProjectionQueryHandler:
         assert result.is_ok
         assert result.value.meta["session_id"] == "orch_projection_123"
         assert result.value.meta["seed_id"] == "seed_projection_456"
+        assert result.value.meta["seed_id_source"] == "event"
         assert result.value.meta["run"]["goal"] == "Project session"
         assert result.value.meta["event_count"] == 3
         assert result.value.meta["run"]["ended_at"] == "2026-01-01T00:00:00.100000Z"
@@ -848,6 +850,7 @@ class TestProjectionQueryHandler:
 
         assert result.is_ok
         assert result.value.meta["seed_id"] == "seed_projection_b"
+        assert result.value.meta["seed_id_source"] == "event"
         assert result.value.meta["run"]["goal"] == "Requested execution"
         assert result.value.meta["event_count"] == 3
         assert [step["name"] for step in result.value.meta["steps"]] == ["Bash", "Read"]
@@ -883,6 +886,156 @@ class TestProjectionQueryHandler:
 
         assert result.is_err
         assert "declares multiple executions" in str(result.error)
+
+    async def test_handle_rejects_metadata_less_session_only_multi_execution_payloads(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Session-only queries must fail closed when payloads imply multiple runs."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_exec_a",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_payload_a",
+                data={
+                    "session_id": "orch_projection_payload_only",
+                    "execution_id": "exec_payload_a",
+                    "call_id": "payload_a",
+                    "tool_name": "Bash",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_exec_b",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_payload_b",
+                data={
+                    "session_id": "orch_projection_payload_only",
+                    "execution_id": "exec_payload_b",
+                    "call_id": "payload_b",
+                    "tool_name": "Read",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"session_id": "orch_projection_payload_only"})
+
+        assert result.is_err
+        assert "references multiple executions" in str(result.error)
+
+    async def test_handle_narrows_metadata_less_session_only_single_execution_payload(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """A metadata-less session projection may use one payload execution candidate."""
+        from datetime import UTC, datetime, timedelta
+
+        from ouroboros.events.base import BaseEvent
+
+        t0 = datetime(2026, 1, 1, tzinfo=UTC)
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_session_metadata",
+                type="orchestrator.session.started",
+                timestamp=t0,
+                aggregate_type="session",
+                aggregate_id="orch_projection_payload_single",
+                data={
+                    "seed_id": "seed_payload_single",
+                    "seed_goal": "Project metadata-less session",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_single",
+                type="tool.call.started",
+                timestamp=t0 + timedelta(milliseconds=10),
+                aggregate_type="execution",
+                aggregate_id="exec_payload_single",
+                data={
+                    "session_id": "orch_projection_payload_single",
+                    "execution_id": "exec_payload_single",
+                    "call_id": "payload_single",
+                    "tool_name": "Bash",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_child",
+                type="tool.call.started",
+                timestamp=t0 + timedelta(milliseconds=20),
+                aggregate_type="execution",
+                aggregate_id="exec_payload_single_child",
+                data={
+                    "parent_execution_id": "exec_payload_single",
+                    "call_id": "payload_child",
+                    "tool_name": "Read",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_payload_foreign_family",
+                type="tool.call.started",
+                timestamp=t0 + timedelta(milliseconds=30),
+                aggregate_type="lineage",
+                aggregate_id="lineage_payload_single",
+                data={
+                    "session_id": "orch_projection_payload_single",
+                    "execution_id": "exec_payload_single",
+                    "call_id": "payload_foreign",
+                    "tool_name": "Read",
+                },
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle({"session_id": "orch_projection_payload_single"})
+
+        assert result.is_ok
+        assert result.value.meta["event_count"] == 3
+        assert result.value.meta["seed_id"] == "seed_payload_single"
+        assert result.value.meta["seed_id_source"] == "event"
+        assert result.value.meta["run"]["goal"] == "Project metadata-less session"
+        assert result.value.meta["run"]["started_at"] == "2026-01-01T00:00:00Z"
+        assert [step["name"] for step in result.value.meta["steps"]] == ["Bash", "Read"]
+
+    async def test_handle_records_argument_seed_id_provenance(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Caller-provided seed IDs remain visible as argument-sourced labels."""
+        from ouroboros.events.base import BaseEvent
+
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_seed_argument",
+                type="tool.call.started",
+                aggregate_type="execution",
+                aggregate_id="exec_seed_argument",
+                data={"call_id": "seed_argument", "tool_name": "Bash"},
+            )
+        )
+
+        handler = ProjectionQueryHandler(event_store=memory_event_store)
+        result = await handler.handle(
+            {
+                "execution_id": "exec_seed_argument",
+                "seed_id": "seed_from_argument",
+            }
+        )
+
+        assert result.is_ok
+        assert result.value.meta["seed_id"] == "seed_from_argument"
+        assert result.value.meta["seed_id_source"] == "argument"
 
     async def test_handle_limit_is_fail_closed_safety_cap(
         self,


### PR DESCRIPTION
## Summary

Follow-up to #990 / #946 PR-2.

This PR hardens the read-only projection MCP query surface by:

- adding `seed_id_source` to distinguish event-derived, caller-provided, and fallback seed IDs
- failing closed for session-only projection queries when metadata-less payloads reference multiple executions
- narrowing metadata-less session-only projections when exactly one payload execution candidate exists

## Scope

- No recorder changes
- No projection caching
- No CLI surface
- No artifact/verdict mapping
- No #1006 verifier PASS changes
- No #978 P5 legacy self-report removal

## Validation

- `uv run pytest tests/unit/mcp/tools/test_definitions.py::TestProjectionQueryHandler -q` → 14 passed
- `uv run pytest tests/unit/persistence/test_event_store.py::TestSessionRelatedEvents -q` → 5 passed
- `uv run mypy src/ouroboros/mcp/tools/projection_handlers.py tests/unit/mcp/tools/test_definitions.py` → passed
- `uv run ruff check src/ouroboros/mcp/tools/projection_handlers.py tests/unit/mcp/tools/test_definitions.py` → passed
