### PR TITLE
fix(plugin): align hook lifecycle scope SSOT

### DIFF
--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -318,10 +318,10 @@ the contract and keeps review scope small.
 |---|---|---|---|---|---|
 | `before_invocation` | After trust/confirmation, before `plugin.invoked` | Read-only inspection / policy | `fail_closed` for policy hooks, `fail_open` for observability-only hooks | `plugin:lifecycle:read` for read-only, stronger scope for policy decisions | **Included** |
 | `after_invocation` | After `plugin.completed` / `plugin.failed` is known, before the wrapper returns to the caller | Observability / summary emission | `fail_open` | `plugin:lifecycle:read` | **Included** |
-| `before_tool_call` | Before a plugin-mediated tool call is allowed to execute | Policy / possible mutation gate | `fail_closed` | tool-specific permission plus `plugin.tool.intercept` | Deferred |
-| `after_tool_call` | After a plugin-mediated tool call result is available | Observability or result annotation | `fail_open` unless it mutates returned evidence | `plugin.tool.observe` | Deferred |
+| `before_tool_call` | Before a plugin-mediated tool call is allowed to execute | Policy / possible mutation gate | `fail_closed` | tool-specific permission plus `plugin:tool:intercept` | Deferred |
+| `after_tool_call` | After a plugin-mediated tool call result is available | Observability or result annotation | `fail_open` unless it mutates returned evidence | `plugin:tool:observe` | Deferred |
 | `before_artifact_write` | Before artifact service writes plugin-provided output | Policy / mutation gate | `fail_closed` | artifact-specific write permission | Deferred |
-| `after_artifact_write` | After artifact write completes | Observability | `fail_open` | `plugin.artifact.observe` | Deferred |
+| `after_artifact_write` | After artifact write completes | Observability | `fail_open` | `plugin:artifact:observe` | Deferred |
 | `on_error` | When the wrapper sees a plugin/runtime error | Observability / recovery hint | `fail_open`; MUST NOT mask the original error | `plugin:lifecycle:read` | Deferred |
 | `on_cancel` | When a plugin invocation is cancelled | Observability / cleanup hint | `fail_open`; cleanup side effects require explicit permission | `plugin:lifecycle:read` or cleanup-specific scope | Deferred |
 

--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -316,14 +316,14 @@ the contract and keeps review scope small.
 
 | Hook | Phase | Side-effect class | Default failure policy | Required permission class | v1 status |
 |---|---|---|---|---|---|
-| `before_invocation` | After trust/confirmation, before `plugin.invoked` | Read-only inspection / policy | `fail_closed` for policy hooks, `fail_open` for observability-only hooks | `plugin.lifecycle.read` for read-only, stronger scope for policy decisions | **Included** |
-| `after_invocation` | After `plugin.completed` / `plugin.failed` is known, before the wrapper returns to the caller | Observability / summary emission | `fail_open` | `plugin.lifecycle.read` | **Included** |
+| `before_invocation` | After trust/confirmation, before `plugin.invoked` | Read-only inspection / policy | `fail_closed` for policy hooks, `fail_open` for observability-only hooks | `plugin:lifecycle:read` for read-only, stronger scope for policy decisions | **Included** |
+| `after_invocation` | After `plugin.completed` / `plugin.failed` is known, before the wrapper returns to the caller | Observability / summary emission | `fail_open` | `plugin:lifecycle:read` | **Included** |
 | `before_tool_call` | Before a plugin-mediated tool call is allowed to execute | Policy / possible mutation gate | `fail_closed` | tool-specific permission plus `plugin.tool.intercept` | Deferred |
 | `after_tool_call` | After a plugin-mediated tool call result is available | Observability or result annotation | `fail_open` unless it mutates returned evidence | `plugin.tool.observe` | Deferred |
 | `before_artifact_write` | Before artifact service writes plugin-provided output | Policy / mutation gate | `fail_closed` | artifact-specific write permission | Deferred |
 | `after_artifact_write` | After artifact write completes | Observability | `fail_open` | `plugin.artifact.observe` | Deferred |
-| `on_error` | When the wrapper sees a plugin/runtime error | Observability / recovery hint | `fail_open`; MUST NOT mask the original error | `plugin.lifecycle.read` | Deferred |
-| `on_cancel` | When a plugin invocation is cancelled | Observability / cleanup hint | `fail_open`; cleanup side effects require explicit permission | `plugin.lifecycle.read` or cleanup-specific scope | Deferred |
+| `on_error` | When the wrapper sees a plugin/runtime error | Observability / recovery hint | `fail_open`; MUST NOT mask the original error | `plugin:lifecycle:read` | Deferred |
+| `on_cancel` | When a plugin invocation is cancelled | Observability / cleanup hint | `fail_open`; cleanup side effects require explicit permission | `plugin:lifecycle:read` or cleanup-specific scope | Deferred |
 
 The following candidate hooks are intentionally **not** in the v1 hook
 vocabulary:
@@ -402,7 +402,10 @@ Hooks inherit the same trust model as commands: a required permission that is
 not trusted blocks before plugin-controlled code runs. Additional rules:
 
 1. Read-only lifecycle hooks require at least a read lifecycle scope such as
-   `plugin.lifecycle.read`.
+   `plugin:lifecycle:read`.
+   Lifecycle permission scopes use the same colon-delimited grammar as manifest
+   `permissions[].scope`; dot-delimited forms such as `plugin.lifecycle.read` are
+   invalid.
 2. Hooks that can block, authorize, rewrite, or mutate work require an explicit
    policy/mutation permission and default to `fail_closed`.
 3. Hooks MUST NOT directly edit `.omx`, EventStore rows, artifacts, or user

--- a/src/ouroboros/plugin/schemas/0.3/_source.json
+++ b/src/ouroboros/plugin/schemas/0.3/_source.json
@@ -5,7 +5,8 @@
   "local_extensions": {
     "plugin.schema.json": [
       "Bumped $id/title/schema_version const from 0.2 to 0.3.",
-      "Narrowed hooks[].name enum to the v1 HookKind set: 'before_invocation' and 'after_invocation'. Deferred candidates (before_tool_call, after_tool_call, before_artifact_write, after_artifact_write, on_error, on_cancel) and excluded candidates (before_runtime_start, after_runtime_start, before_state_commit, after_state_commit, on_event, on_rewind) are no longer accepted at the schema layer; refer to src/ouroboros/plugin/hooks.py for the routing helpers and follow-up RFC slices."
+      "Narrowed hooks[].name enum to the v1 HookKind set: 'before_invocation' and 'after_invocation'. Deferred candidates (before_tool_call, after_tool_call, before_artifact_write, after_artifact_write, on_error, on_cancel) and excluded candidates (before_runtime_start, after_runtime_start, before_state_commit, after_state_commit, on_event, on_rewind) are no longer accepted at the schema layer; refer to src/ouroboros/plugin/hooks.py for the routing helpers and follow-up RFC slices.",
+      "Allows plugin.hook.blocked / plugin.hook.failed in explicit audit.events declarations while preserving the four-event default used by the Python manifest loader until runtime hook dispatch lands."
     ],
     "audit-event.schema.json": [
       "Vendored audit-event.schema.json with local 0.3 $id/title/schema_version alignment and added plugin.hook.blocked / plugin.hook.failed to match the v1 hook wrapper event constants."

--- a/src/ouroboros/plugin/schemas/0.3/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.3/plugin.schema.json
@@ -209,9 +209,7 @@
           "plugin.invoked",
           "plugin.permission_used",
           "plugin.completed",
-          "plugin.failed",
-          "plugin.hook.blocked",
-          "plugin.hook.failed"
+          "plugin.failed"
         ]
       },
       "properties": {

--- a/tests/unit/plugin/test_hook_permission_scopes.py
+++ b/tests/unit/plugin/test_hook_permission_scopes.py
@@ -44,6 +44,7 @@ class TestRoutingHelper:
     def test_rejects_unrelated_scope(self) -> None:
         assert not is_hook_lifecycle_scope("github:read")
         assert not is_hook_lifecycle_scope("plugin.tool.intercept")
+        assert not is_hook_lifecycle_scope("plugin.lifecycle.read")
 
     def test_rejects_case_variant(self) -> None:
         # The scope set is exact-match by design; capability resolvers

--- a/tests/unit/plugin/test_manifest_schema_0_3.py
+++ b/tests/unit/plugin/test_manifest_schema_0_3.py
@@ -159,6 +159,17 @@ class TestV02Compatibility:
 
 
 class TestV03HookAuditEvents:
+    def test_manifest_audit_default_matches_loader_standard_events(self, tmp_path: Path) -> None:
+        payload = _v03_manifest()
+        payload.pop("audit", None)
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.audit.events == (
+            "plugin.invoked",
+            "plugin.permission_used",
+            "plugin.completed",
+            "plugin.failed",
+        )
+
     def test_manifest_audit_events_accept_hook_wrapper_events(self, tmp_path: Path) -> None:
         payload = _v03_manifest()
         payload["audit"] = {"events": ["plugin.hook.blocked", "plugin.hook.failed"]}


### PR DESCRIPTION
## Scope

Narrow #987 follow-up for #939 / #961 SSOT alignment. This PR keeps the hook lifecycle permission scope and v0.3 audit defaults consistent across the RFC, JSON Schema, and Python manifest loader before the next #939 validator slice.

## What changed

- Updates `docs/rfc/userlevel-plugins.md` to use the canonical colon-delimited lifecycle scope: `plugin:lifecycle:read`.
- Documents that dot-delimited lifecycle scopes such as `plugin.lifecycle.read` are invalid because manifest permissions use the existing colon-delimited grammar.
- Keeps `plugin.hook.blocked` / `plugin.hook.failed` available for explicit v0.3 `audit.events` declarations, but removes them from the schema default so the JSON Schema default matches the Python loader's standard four command events.
- Adds regression coverage for rejecting the dot-delimited scope and preserving the v0.3 loader default.

## Non-goals

- No runtime hook dispatch.
- No `plugin.permission_used` hook-specific emission change.
- No new hook event emission or ordering contract.
- No #920 / #946 / #956 / #978 Tier 2 work.

## Verification

```bash
python -m json.tool src/ouroboros/plugin/schemas/0.3/_source.json >/dev/null
python -m json.tool src/ouroboros/plugin/schemas/0.3/plugin.schema.json >/dev/null
uv run pytest tests/unit/plugin/test_hook_permission_scopes.py tests/unit/plugin/test_manifest_schema_0_3.py tests/unit/plugin/test_manifest.py -q
uv run pytest tests/unit/plugin -q
uv run ruff check src/ouroboros/plugin tests/unit/plugin
```

Observed locally:

- targeted plugin tests: `79 passed`
- full plugin unit suite: `402 passed, 1 skipped`
- Ruff: `All checks passed!`

Refs #939. Follow-up to #987 under #961's Tier 1 plugin track.
