### PR TITLE
fix(harness): accept zero-failure verifier summaries

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -281,15 +281,15 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
         if isinstance(value, str):
             parts.append(value)
     text = "\n".join(parts).lower()
-    failure_scan_text = re.sub(r"\b0\s+(failed|failures|error|errors)\b", "", text)
+    zero_failure_pattern = (
+        r"\b(0\s+(failed|failures?|errors?)|no\s+(tests?\s+)?(failed|failures?|errors?))\b"
+    )
+    failure_scan_text = re.sub(zero_failure_pattern, "", text)
     if re.search(
-        r"\b[1-9]\d*\s+failed\b|\b(failure|error|errors)\b|exit\s*code\s*[1-9]",
+        r"\b[1-9]\d*\s+(failed|failures?|errors?)\b|"
+        r"\b(failure|failures?|error|errors)\b|"
+        r"exit\s*code\s*[1-9]",
         failure_scan_text,
-    ):
-        return False
-    if re.search(r"\bfailed\b", text) and not re.search(
-        r"\b0\s+failed\b|\bno\s+tests?\s+failed\b",
-        text,
     ):
         return False
     if re.search(r"\b0\s+passed\b", text) and not re.search(r"\b[1-9]\d*\s+passed\b", text):

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -27,6 +27,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ParallelACExecutor,
     ParallelExecutionResult,
     StageExecutionOutcome,
+    _message_contains_test_success,
     render_parallel_completion_message,
     render_parallel_verification_report,
 )
@@ -82,6 +83,28 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
     event_store.append.side_effect = _append
     event_store.replay.side_effect = _replay
     return event_store, appended_events
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    (
+        ("3 passed in 1.2s", True),
+        ("0 failed, 3 passed", True),
+        ("0 failed, 0 errors, 1 passed", True),
+        ("no errors, 3 passed", True),
+        ("no tests failed, 3 passed", True),
+        ("exit code 0", True),
+        ("1 failed, 3 passed", False),
+        ("2 errors, 1 passed", False),
+    ),
+)
+def test_message_contains_test_success_handles_zero_failure_summaries(
+    content: str,
+    expected: bool,
+) -> None:
+    """Verifier accepts explicit zero-failure summaries without allowing failures."""
+    message = AgentMessage(type="result", content=content, data={})
+    assert _message_contains_test_success(message) is expected
 
 
 class _FinalMessageRuntime:


### PR DESCRIPTION
## Summary

Narrow follow-up after #1006/#1010. The fat-harness verifier should not reject common successful test summaries solely because they contain explicit zero-failure text.

## What changed

- Accepts explicit zero-failure summaries such as:
  - `0 failed, 3 passed`
  - `0 failed, 0 errors, 1 passed`
  - `no errors, 3 passed`
  - `no tests failed, 3 passed`
- Continues rejecting non-zero failure/error output such as:
  - `1 failed, 3 passed`
  - `2 errors, 1 passed`
- Adds direct regression coverage for the success parser.

## Boundary

- Does not change the #920/#961 acceptance invariant.
- Does not start #978 P5.
- Keeps legacy self-report fallback untouched.
- Complements #1010 current-run file-proof hardening by removing the remaining verifier false-negative in test-output parsing.

## Validation

- `uv run pytest -q tests/unit/orchestrator/test_parallel_executor.py -k 'zero_failure_summaries or fat_harness or observe_only or typed_evidence'` → 24 passed
- `uv run pytest -q tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_verifier.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py` → 245 passed, 1 skipped
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` → passed
- `uv run mypy src/ouroboros/orchestrator/verifier.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py` → passed

Refs #961, #920, #1006, #1010.