### PR TITLE
fix(harness): reject standalone failed verifier output

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -287,7 +287,7 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
     failure_scan_text = re.sub(zero_failure_pattern, "", text)
     if re.search(
         r"\b[1-9]\d*\s+(failed|failures?|errors?)\b|"
-        r"\b(failure|failures?|error|errors)\b|"
+        r"\b(failed|failure|failures?|error|errors)\b|"
         r"exit\s*code\s*[1-9]",
         failure_scan_text,
     ):

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -96,6 +96,8 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
         ("exit code 0", True),
         ("1 failed, 3 passed", False),
         ("2 errors, 1 passed", False),
+        ("FAILED tests/test_app.py::test_auth", False),
+        ("tests failed", False),
     ),
 )
 def test_message_contains_test_success_handles_zero_failure_summaries(


### PR DESCRIPTION
## Summary

Follow-up to merged #1018's review finding. #1018 correctly allowed explicit zero-failure summaries (`0 failed`, `no tests failed`, `no errors`) but accidentally stopped treating standalone `failed` output as a negative signal.

This PR restores that rejection while preserving the zero-failure allowlist.

## What changed

- Re-adds `failed` to the verifier failure regex after zero-failure phrases are stripped.
- Adds regression coverage for raw/generic failure output:
  - `FAILED tests/test_app.py::test_auth`
  - `tests failed`

## Scope controls

- Does not revert #1018 zero-failure success handling.
- Does not change #920/#961 acceptance invariants.
- Does not start #978 P5 or remove legacy self-report fallback.
- No new AgentOS surface, schema, or dependency.

## Verification

- `uv run pytest -q tests/unit/orchestrator/test_parallel_executor.py -k 'zero_failure_summaries or fat_harness or observe_only or typed_evidence'`
- `uv run pytest -q tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_verifier.py tests/unit/orchestrator/test_runner.py tests/unit/cli/test_run_qa.py`
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run mypy src/ouroboros/orchestrator/verifier.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/parallel_executor_models.py`

Resolves late #1018 review debt before any #978 P5 / legacy fallback removal readiness claim.
