### PR TITLE
fix(harness): harden Bash file evidence proof after #1010

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -239,7 +239,9 @@ def _runtime_message_supports_file_reference(reference: str, message: AgentMessa
     normalized_reference = reference.strip().lower()
     if not normalized_reference:
         return False
-    text = _runtime_message_search_text(message)
+    text = _runtime_message_file_proof_text(message)
+    if not text:
+        return False
     reference_pattern = re.compile(rf"(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-])")
     if not reference_pattern.search(text):
         return False
@@ -255,6 +257,25 @@ def _runtime_message_supports_file_reference(reference: str, message: AgentMessa
             text,
         )
     )
+
+
+def _runtime_message_file_proof_text(message: AgentMessage) -> str:
+    """Return text that can prove a file was touched by the current run.
+
+    For Bash tool invocations, command text is not proof by itself: read-only
+    commands such as ``grep updated src/app.py`` can contain both the claimed
+    path and mutation verbs. Trust Bash result/output fields instead. Dedicated
+    edit/write tools still expose their tool inputs because their tool identity
+    supplies the mutation semantics.
+    """
+    if message.tool_name == "Bash":
+        parts: list[str] = []
+        for key in ("result_preview", "output", "stdout", "stderr"):
+            value = message.data.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+        return "\n".join(parts).lower()
+    return _runtime_message_search_text(message)
 
 
 def _looks_like_test_command(command: str) -> bool:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -224,26 +224,37 @@ def _runtime_messages_support_file_claim(
         resolved.relative_to(base)
     except ValueError:
         return False
-    if any(_runtime_message_supports_file_reference(value, message) for message in messages):
+    if any(
+        _runtime_message_supports_file_reference(value, message, messages=messages, index=index)
+        for index, message in enumerate(messages)
+    ):
         return True
     if not resolved.exists():
         return False
     basename = candidate.name.strip().lower()
     return bool(basename) and any(
-        _runtime_message_supports_file_reference(basename, message) for message in messages
+        _runtime_message_supports_file_reference(basename, message, messages=messages, index=index)
+        for index, message in enumerate(messages)
     )
 
 
-def _runtime_message_supports_file_reference(reference: str, message: AgentMessage) -> bool:
+def _runtime_message_supports_file_reference(
+    reference: str,
+    message: AgentMessage,
+    *,
+    messages: tuple[AgentMessage, ...],
+    index: int,
+) -> bool:
     """Return True when one message plausibly reports touching a file reference."""
     normalized_reference = reference.strip().lower()
     if not normalized_reference:
         return False
     text = _runtime_message_file_proof_text(message)
     if message.tool_name == "Bash":
-        return _text_supports_file_mutation_reference(
-            text, normalized_reference
-        ) or _bash_command_mutates_file_reference(message, normalized_reference)
+        return _text_supports_file_mutation_reference(text, normalized_reference) or (
+            _bash_command_mutates_file_reference(message, normalized_reference)
+            and _runtime_message_has_following_success(messages, index)
+        )
     if message.tool_name in {"Edit", "Write", "NotebookEdit"}:
         return bool(text and _file_reference_pattern(normalized_reference).search(text))
     return _text_supports_file_mutation_reference(text, normalized_reference)
@@ -307,6 +318,33 @@ def _bash_command_mutates_file_reference(message: AgentMessage, normalized_refer
             normalized_command,
         )
     )
+
+
+def _runtime_message_has_following_success(messages: tuple[AgentMessage, ...], index: int) -> bool:
+    """Return True when a tool-call message is followed by a successful result."""
+    for candidate in messages[index + 1 :]:
+        if candidate.type == "tool":
+            return False
+        if candidate.is_error:
+            return False
+        exit_code = candidate.data.get("exit_code")
+        if isinstance(exit_code, int):
+            return exit_code == 0
+        if candidate.data.get("subtype") == "success":
+            return True
+        text = "\n".join(
+            str(part)
+            for part in (
+                candidate.content,
+                candidate.data.get("result_preview"),
+                candidate.data.get("output"),
+                candidate.data.get("stdout"),
+            )
+            if isinstance(part, str)
+        ).lower()
+        if re.search(r"\b(exit\s*code\s*0|completed|succeeded|success)\b", text):
+            return True
+    return False
 
 
 def _runtime_message_file_proof_text(message: AgentMessage) -> str:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -273,9 +273,7 @@ def _file_reference_pattern(normalized_reference: str) -> re.Pattern[str]:
     return re.compile(rf"(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-])")
 
 
-def _bash_command_mutates_file_reference(
-    message: AgentMessage, normalized_reference: str
-) -> bool:
+def _bash_command_mutates_file_reference(message: AgentMessage, normalized_reference: str) -> bool:
     """Return True for explicit shell writes to the referenced file.
 
     Bash command text is only trusted when the command itself carries mutation

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -240,13 +240,22 @@ def _runtime_message_supports_file_reference(reference: str, message: AgentMessa
     if not normalized_reference:
         return False
     text = _runtime_message_file_proof_text(message)
+    if message.tool_name == "Bash":
+        return _text_supports_file_mutation_reference(
+            text, normalized_reference
+        ) or _bash_command_mutates_file_reference(message, normalized_reference)
+    if message.tool_name in {"Edit", "Write", "NotebookEdit"}:
+        return bool(text and _file_reference_pattern(normalized_reference).search(text))
+    return _text_supports_file_mutation_reference(text, normalized_reference)
+
+
+def _text_supports_file_mutation_reference(text: str, normalized_reference: str) -> bool:
+    """Return True when text pairs a file reference with mutation language."""
     if not text:
         return False
-    reference_pattern = re.compile(rf"(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-])")
+    reference_pattern = _file_reference_pattern(normalized_reference)
     if not reference_pattern.search(text):
         return False
-    if message.tool_name in {"Edit", "Write", "NotebookEdit"}:
-        return True
     return bool(
         re.search(
             rf"(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-]).*\b("
@@ -255,6 +264,49 @@ def _runtime_message_supports_file_reference(reference: str, message: AgentMessa
             r"updated|modified|changed|created|generated|wrote|written|patched"
             rf")\b.*(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-])",
             text,
+        )
+    )
+
+
+def _file_reference_pattern(normalized_reference: str) -> re.Pattern[str]:
+    """Return a conservative token pattern for a workspace-relative file reference."""
+    return re.compile(rf"(?<![\w./-]){re.escape(normalized_reference)}(?![\w./-])")
+
+
+def _bash_command_mutates_file_reference(
+    message: AgentMessage, normalized_reference: str
+) -> bool:
+    """Return True for explicit shell writes to the referenced file.
+
+    Bash command text is only trusted when the command itself carries mutation
+    semantics for the claimed file. This preserves direct shell-edit evidence
+    such as ``touch src/generated.py`` or ``printf ... > src/generated.py``
+    without allowing read-only probes like ``grep updated src/generated.py`` to
+    prove ``files_touched`` merely by containing a path and a mutation word.
+    """
+    tool_input = message.data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return False
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return False
+    normalized_command = command.strip().lower()
+    if not normalized_command:
+        return False
+    if not _file_reference_pattern(normalized_reference).search(normalized_command):
+        return False
+    quoted_reference = rf"['\"]?{re.escape(normalized_reference)}['\"]?"
+    if re.search(rf"(^|[\s;&|])(?:\d?>|&>|>>|\d>>)\s*{quoted_reference}", normalized_command):
+        return True
+    return bool(
+        re.search(
+            rf"(^|[\s;&|])(touch|truncate|tee)\b[^;&|]*\s{quoted_reference}(?=$|[\s;&|])",
+            normalized_command,
+        )
+        or re.search(
+            rf"(^|[\s;&|])(sed|perl)\b[^;&|]*\s-[^\s;&|]*i[^;&|]*\s"
+            rf"{quoted_reference}(?=$|[\s;&|])",
+            normalized_command,
         )
     )
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -233,7 +233,13 @@ def _runtime_messages_support_file_claim(
         return False
     basename = candidate.name.strip().lower()
     return bool(basename) and any(
-        _runtime_message_supports_file_reference(basename, message, messages=messages, index=index)
+        _runtime_message_supports_file_reference(
+            basename,
+            message,
+            messages=messages,
+            index=index,
+            allow_bash_command_text=False,
+        )
         for index, message in enumerate(messages)
     )
 
@@ -244,6 +250,7 @@ def _runtime_message_supports_file_reference(
     *,
     messages: tuple[AgentMessage, ...],
     index: int,
+    allow_bash_command_text: bool = True,
 ) -> bool:
     """Return True when one message plausibly reports touching a file reference."""
     normalized_reference = reference.strip().lower()
@@ -252,7 +259,8 @@ def _runtime_message_supports_file_reference(
     text = _runtime_message_file_proof_text(message)
     if message.tool_name == "Bash":
         return _text_supports_file_mutation_reference(text, normalized_reference) or (
-            _bash_command_mutates_file_reference(message, normalized_reference)
+            allow_bash_command_text
+            and _bash_command_mutates_file_reference(message, normalized_reference)
             and _runtime_message_has_following_success(messages, index)
         )
     if message.tool_name in {"Edit", "Write", "NotebookEdit"}:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1997,6 +1997,80 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is False
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_bash_command_basename_fallback(
+        self, tmp_path
+    ) -> None:
+        """Bash command-text proof must not use basename fallback for another path."""
+        generated_file = tmp_path / "src" / "generated.py"
+        generated_file.parent.mkdir()
+        generated_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/generated.py"],'
+                '"commands_run":["touch generated.py","pytest tests/test_generated.py"],'
+                '"tests_passed":["tests/test_generated.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: touch generated.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "touch generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="command completed with exit code 0",
+                        data={"subtype": "success", "exit_code": 0},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_generated.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_generated.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "files_touched: src/generated.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_test_not_covered_by_success_chunk(
         self, tmp_path
     ) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1767,6 +1767,158 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is False
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "touch src/generated.py",
+            "printf 'VALUE = 1' > src/generated.py",
+            "sed -i '' 's/1/2/' src/generated.py",
+        ),
+    )
+    async def test_fat_harness_verifier_allows_explicit_bash_file_mutation_without_output(
+        self, tmp_path, command
+    ) -> None:
+        """Explicit shell writes can prove files_touched even without path-specific output."""
+        generated_file = tmp_path / "src" / "generated.py"
+        generated_file.parent.mkdir()
+        generated_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                f'{{"files_touched":["src/generated.py"],'
+                f'"commands_run":["{command}","pytest tests/test_generated.py"],'
+                '"tests_passed":["tests/test_generated.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content=f"Bash: {command}",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": command}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_generated.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_generated.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_bash_mutation_of_different_file(
+        self, tmp_path
+    ) -> None:
+        """A mutating Bash pipeline must not prove a separately read file was touched."""
+        preexisting_file = tmp_path / "src" / "preexisting.py"
+        generated_file = tmp_path / "src" / "generated.py"
+        preexisting_file.parent.mkdir()
+        preexisting_file.write_text("VALUE = 1\n", encoding="utf-8")
+        generated_file.write_text("VALUE = 2\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/preexisting.py"],'
+                '"commands_run":["cat src/preexisting.py | tee src/generated.py",'
+                '"pytest tests/test_generated.py"],'
+                '"tests_passed":["tests/test_generated.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: cat src/preexisting.py | tee src/generated.py",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {
+                                "command": "cat src/preexisting.py | tee src/generated.py"
+                            }
+                        },
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_generated.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_generated.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "files_touched: src/preexisting.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_test_not_covered_by_success_chunk(
         self, tmp_path
     ) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1801,6 +1801,11 @@ class TestParallelACExecutor:
                         data={"tool_input": {"command": command}},
                     ),
                     AgentMessage(
+                        type="result",
+                        content="command completed with exit code 0",
+                        data={"subtype": "success", "exit_code": 0},
+                    ),
+                    AgentMessage(
                         type="tool",
                         content="Bash: pytest tests/test_generated.py",
                         tool_name="Bash",
@@ -1911,6 +1916,79 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error is not None
         assert "files_touched: src/preexisting.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_failed_explicit_bash_file_mutation(
+        self, tmp_path
+    ) -> None:
+        """An explicit shell write command must also have a successful result."""
+        generated_file = tmp_path / "src" / "generated.py"
+        generated_file.parent.mkdir()
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/generated.py"],'
+                '"commands_run":["touch src/generated.py","pytest tests/test_generated.py"],'
+                '"tests_passed":["tests/test_generated.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: touch src/generated.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "touch src/generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="touch: src/generated.py: permission denied",
+                        data={"subtype": "error", "exit_code": 1},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_generated.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_generated.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "files_touched: src/generated.py" in result.error
         evidence_event = next(
             event
             for event in appended_events

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1698,6 +1698,75 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is False
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_read_only_bash_command_with_write_word(
+        self, tmp_path
+    ) -> None:
+        """Read-only Bash command text cannot prove files_touched via mutation words."""
+        preexisting_file = tmp_path / "src" / "preexisting.py"
+        preexisting_file.parent.mkdir()
+        preexisting_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/preexisting.py"],'
+                '"commands_run":["grep updated src/preexisting.py"],'
+                '"tests_passed":["tests/test_preexisting.py"]}\n'
+                "```",
+                native_session_id="opencode-session-evidence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: grep updated src/preexisting.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "grep updated src/preexisting.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest tests/test_preexisting.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_preexisting.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_preexisting.py passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "files_touched: src/preexisting.py" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_test_not_covered_by_success_chunk(
         self, tmp_path
     ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1010 / #1006 / #920.

This PR closes one remaining current-run proof gap in the default atomic verifier: a read-only Bash command such as `grep updated src/preexisting.py` could previously contain both a claimed file path and a mutation verb, causing `files_touched` to pass even though the command only read an existing file.

Changes:

- split file-proof search text from generic claim search text
- for Bash tool invocations, ignore command text as file mutation proof and trust only result/output fields
- keep dedicated mutation tools (`Edit`, `Write`, `NotebookEdit`) as valid file proof through their tool inputs
- add a regression test for read-only Bash command text containing a write verb

## Scope

- Narrow hardening follow-up to #1010
- No #978 P5 legacy self-report removal
- No default behavior flip
- No new verifier architecture or shell-command ontology

## Validation

- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q` → 75 passed
- Targeted regression/positive checks:
  - `test_fat_harness_verifier_rejects_read_only_bash_command_with_write_word`
  - `test_fat_harness_verifier_allows_bash_generated_file_and_whole_suite_test`
  - `test_fat_harness_verifier_rejects_read_only_file_reference`
  → 3 passed
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py` → passed
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` → passed

Refs #920
Refs #961
Follow-up to #1010
