### PR TITLE
fix(orchestrator): normalize governed parent context headings

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -416,6 +416,27 @@ _SIBLING_HEADLINE_CHARS = 80
 _SiblingACRef = tuple[int | None, str]
 
 
+def _normalize_governed_parent_summary(parent_summary: str) -> str:
+    """Render legacy level context inside the governor without nested H2 headings.
+
+    ``build_context_prompt()`` is also used by the legacy prompt path, where its
+    top-level ``##`` sections are appropriate.  Governed dispatch already wraps
+    that text in ``## Parent context`` via ``compose_context()``, so preserving
+    those headings creates a hard-to-scan nested hierarchy.  Convert only the
+    known top-level headings to compact labels; leave indented or embedded
+    markdown from AC outputs untouched.
+    """
+    lines: list[str] = []
+    for line in parent_summary.strip().splitlines():
+        if line.startswith("## "):
+            heading = line[3:].strip()
+            if heading:
+                lines.append(f"{heading}:")
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
 def _get_available_memory_gb() -> float | None:
     """Get available memory in GB. Returns None if check fails."""
     system = platform.system()
@@ -2986,7 +3007,9 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         try:
             composed = compose_context(
                 ac=ac_content,
-                parent_summary=build_context_prompt(level_contexts or []),
+                parent_summary=_normalize_governed_parent_summary(
+                    build_context_prompt(level_contexts or [])
+                ),
                 siblings=sibling_statuses,
             )
         except ValueError as exc:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -414,6 +414,7 @@ _MEMORY_WAIT_MAX_SECONDS = 120.0
 _MAX_LEAF_RESULT_CHARS = 1200
 _SIBLING_HEADLINE_CHARS = 80
 _SiblingACRef = tuple[int | None, str]
+_GOVERNED_COORDINATOR_REVIEW_HEADING_RE = re.compile(r"^## Coordinator Review \(Level (\d+)\)$")
 
 
 def _normalize_governed_parent_summary(parent_summary: str) -> str:
@@ -428,10 +429,12 @@ def _normalize_governed_parent_summary(parent_summary: str) -> str:
     """
     lines: list[str] = []
     for line in parent_summary.strip().splitlines():
-        if line.startswith("## "):
-            heading = line[3:].strip()
-            if heading:
-                lines.append(f"{heading}:")
+        if line == "## Previous Work Context":
+            lines.append("Previous Work Context:")
+            continue
+        coordinator_review = _GOVERNED_COORDINATOR_REVIEW_HEADING_RE.fullmatch(line)
+        if coordinator_review:
+            lines.append(f"Coordinator Review (Level {coordinator_review.group(1)}):")
             continue
         lines.append(line)
     return "\n".join(lines).strip()

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -414,29 +414,66 @@ _MEMORY_WAIT_MAX_SECONDS = 120.0
 _MAX_LEAF_RESULT_CHARS = 1200
 _SIBLING_HEADLINE_CHARS = 80
 _SiblingACRef = tuple[int | None, str]
-_GOVERNED_COORDINATOR_REVIEW_HEADING_RE = re.compile(r"^## Coordinator Review \(Level (\d+)\)$")
 
 
-def _normalize_governed_parent_summary(parent_summary: str) -> str:
-    """Render legacy level context inside the governor without nested H2 headings.
+def _build_governed_parent_summary(level_contexts: list[LevelContext] | None) -> str:
+    """Render level context for governed dispatch without nested H2 headings.
 
     ``build_context_prompt()`` is also used by the legacy prompt path, where its
     top-level ``##`` sections are appropriate.  Governed dispatch already wraps
     that text in ``## Parent context`` via ``compose_context()``, so preserving
-    those headings creates a hard-to-scan nested hierarchy.  Convert only the
-    known top-level headings to compact labels; leave indented or embedded
-    markdown from AC outputs untouched.
+    those headings creates a hard-to-scan nested hierarchy.  Build the governed
+    variant from structured ``LevelContext`` data so only orchestrator-owned
+    section wrappers become compact labels; embedded markdown from AC outputs
+    remains byte-for-byte content inside its original summary text.
     """
+    if not level_contexts:
+        return ""
+
+    sections: list[str] = []
+    for ctx in level_contexts:
+        text = ctx.to_prompt_text()
+        if text:
+            sections.append(text)
+
+    has_reviews = any(ctx.coordinator_review for ctx in level_contexts)
+    if not sections and not has_reviews:
+        return ""
+
     lines: list[str] = []
-    for line in parent_summary.strip().splitlines():
-        if line == "## Previous Work Context":
-            lines.append("Previous Work Context:")
-            continue
-        coordinator_review = _GOVERNED_COORDINATOR_REVIEW_HEADING_RE.fullmatch(line)
-        if coordinator_review:
-            lines.append(f"Coordinator Review (Level {coordinator_review.group(1)}):")
-            continue
-        lines.append(line)
+    if sections:
+        lines.extend(
+            (
+                "Previous Work Context:",
+                "The following ACs have already been completed. "
+                "Use this context to inform your work.",
+                "",
+                "\n\n".join(sections),
+            )
+        )
+
+    for ctx in level_contexts:
+        if ctx.coordinator_review:
+            review = ctx.coordinator_review
+            review_lines: list[str] = []
+
+            if review.review_summary:
+                review_lines.append(f"**Review**: {review.review_summary}")
+
+            if review.fixes_applied:
+                fixes = "; ".join(review.fixes_applied)
+                review_lines.append(f"**Fixes applied**: {fixes}")
+
+            if review.warnings_for_next_level:
+                for warning in review.warnings_for_next_level:
+                    review_lines.append(f"- WARNING: {warning}")
+
+            if review_lines:
+                if lines:
+                    lines.append("")
+                lines.append(f"Coordinator Review (Level {review.level_number}):")
+                lines.extend(review_lines)
+
     return "\n".join(lines).strip()
 
 
@@ -3010,9 +3047,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         try:
             composed = compose_context(
                 ac=ac_content,
-                parent_summary=_normalize_governed_parent_summary(
-                    build_context_prompt(level_contexts or [])
-                ),
+                parent_summary=_build_governed_parent_summary(level_contexts),
                 siblings=sibling_statuses,
             )
         except ValueError as exc:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -28,6 +28,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ParallelExecutionResult,
     StageExecutionOutcome,
     _message_contains_test_success,
+    _normalize_governed_parent_summary,
     render_parallel_completion_message,
     render_parallel_verification_report,
 )
@@ -105,6 +106,36 @@ def test_message_contains_test_success_handles_zero_failure_summaries(
     """Verifier accepts explicit zero-failure summaries without allowing failures."""
     message = AgentMessage(type="result", content=content, data={})
     assert _message_contains_test_success(message) is expected
+
+
+def test_normalize_governed_parent_summary_preserves_embedded_result_headings() -> None:
+    """Only framework wrapper H2 headings are normalized for governed dispatch."""
+    parent_summary = (
+        "\n## Previous Work Context\n"
+        "- AC 1: Prepare helper\n"
+        "  Result: Helper is ready\n"
+        "## User Heading\n"
+        "Prior result detail\n\n"
+        "## Coordinator Review (Level 12)\n"
+        "**Review**: No conflicts remain\n"
+        "## Coordinator Review (Level N)\n"
+        "## Previous Work Context appendix\n"
+    )
+
+    normalized = _normalize_governed_parent_summary(parent_summary)
+
+    assert normalized.splitlines() == [
+        "Previous Work Context:",
+        "- AC 1: Prepare helper",
+        "  Result: Helper is ready",
+        "## User Heading",
+        "Prior result detail",
+        "",
+        "Coordinator Review (Level 12):",
+        "**Review**: No conflicts remain",
+        "## Coordinator Review (Level N)",
+        "## Previous Work Context appendix",
+    ]
 
 
 class _FinalMessageRuntime:
@@ -274,7 +305,7 @@ class TestProfileAwareContextGovernance:
                     ac_index=0,
                     ac_content="Prepare helper",
                     success=True,
-                    key_output="Helper is ready",
+                    key_output=("Helper is ready\n## User Heading\nPrior result detail"),
                 ),
             ),
             coordinator_review=CoordinatorReview(
@@ -307,6 +338,9 @@ class TestProfileAwareContextGovernance:
         assert "Previous Work Context:" in prompt
         assert "Coordinator Review (Level 1):" in prompt
         assert "Helper is ready" in prompt
+        assert "## User Heading" in prompt
+        assert "User Heading:" not in prompt
+        assert "Prior result detail" in prompt
         assert "No conflicts remain" in prompt
         assert "Keep edits localized" in prompt
         assert "## Sibling status" in prompt

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -27,8 +27,8 @@ from ouroboros.orchestrator.parallel_executor import (
     ParallelACExecutor,
     ParallelExecutionResult,
     StageExecutionOutcome,
+    _build_governed_parent_summary,
     _message_contains_test_success,
-    _normalize_governed_parent_summary,
     render_parallel_completion_message,
     render_parallel_verification_report,
 )
@@ -108,33 +108,49 @@ def test_message_contains_test_success_handles_zero_failure_summaries(
     assert _message_contains_test_success(message) is expected
 
 
-def test_normalize_governed_parent_summary_preserves_embedded_result_headings() -> None:
-    """Only framework wrapper H2 headings are normalized for governed dispatch."""
-    parent_summary = (
-        "\n## Previous Work Context\n"
-        "- AC 1: Prepare helper\n"
-        "  Result: Helper is ready\n"
-        "## User Heading\n"
-        "Prior result detail\n\n"
-        "## Coordinator Review (Level 12)\n"
-        "**Review**: No conflicts remain\n"
-        "## Coordinator Review (Level N)\n"
-        "## Previous Work Context appendix\n"
+def test_build_governed_parent_summary_preserves_embedded_wrapper_headings() -> None:
+    """Only orchestrator-owned wrappers are normalized for governed dispatch."""
+    level_context = LevelContext(
+        level_number=0,
+        completed_acs=(
+            ACContextSummary(
+                ac_index=0,
+                ac_content="Prepare helper",
+                success=True,
+                key_output=(
+                    "Helper is ready\n"
+                    "## User Heading\n"
+                    "## Previous Work Context\n"
+                    "## Coordinator Review (Level 12)\n"
+                    "Prior result detail"
+                ),
+            ),
+        ),
+        coordinator_review=CoordinatorReview(
+            level_number=12,
+            review_summary=(
+                "No conflicts remain\n## Previous Work Context\n## Coordinator Review (Level 12)"
+            ),
+        ),
     )
 
-    normalized = _normalize_governed_parent_summary(parent_summary)
+    normalized = _build_governed_parent_summary([level_context])
 
     assert normalized.splitlines() == [
         "Previous Work Context:",
+        "The following ACs have already been completed. Use this context to inform your work.",
+        "",
         "- AC 1: Prepare helper",
         "  Result: Helper is ready",
         "## User Heading",
+        "## Previous Work Context",
+        "## Coordinator Review (Level 12)",
         "Prior result detail",
         "",
         "Coordinator Review (Level 12):",
         "**Review**: No conflicts remain",
-        "## Coordinator Review (Level N)",
-        "## Previous Work Context appendix",
+        "## Previous Work Context",
+        "## Coordinator Review (Level 12)",
     ]
 
 
@@ -305,12 +321,18 @@ class TestProfileAwareContextGovernance:
                     ac_index=0,
                     ac_content="Prepare helper",
                     success=True,
-                    key_output=("Helper is ready\n## User Heading\nPrior result detail"),
+                    key_output=(
+                        "Helper is ready\n"
+                        "## User Heading\n"
+                        "## Previous Work Context\n"
+                        "## Coordinator Review (Level 1)\n"
+                        "Prior result detail"
+                    ),
                 ),
             ),
             coordinator_review=CoordinatorReview(
                 level_number=1,
-                review_summary="No conflicts remain",
+                review_summary="No conflicts remain\n## Previous Work Context",
                 warnings_for_next_level=("Keep edits localized",),
             ),
         )
@@ -333,13 +355,15 @@ class TestProfileAwareContextGovernance:
         prompt = runtime.calls[0]["prompt"]
         assert "## Governed Dispatch Context (AC 2)" in prompt
         assert "## Parent context" in prompt
-        assert "## Previous Work Context" not in prompt
-        assert "## Coordinator Review" not in prompt
+        assert "## Previous Work Context\nThe following ACs" not in prompt
+        assert "## Coordinator Review (Level 1)\n**Review**" not in prompt
         assert "Previous Work Context:" in prompt
         assert "Coordinator Review (Level 1):" in prompt
         assert "Helper is ready" in prompt
         assert "## User Heading" in prompt
         assert "User Heading:" not in prompt
+        assert "## Previous Work Context" in prompt
+        assert "## Coordinator Review (Level 1)" in prompt
         assert "Prior result detail" in prompt
         assert "No conflicts remain" in prompt
         assert "Keep edits localized" in prompt

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -277,6 +277,11 @@ class TestProfileAwareContextGovernance:
                     key_output="Helper is ready",
                 ),
             ),
+            coordinator_review=CoordinatorReview(
+                level_number=1,
+                review_summary="No conflicts remain",
+                warnings_for_next_level=("Keep edits localized",),
+            ),
         )
 
         result = await executor._execute_atomic_ac(
@@ -297,7 +302,13 @@ class TestProfileAwareContextGovernance:
         prompt = runtime.calls[0]["prompt"]
         assert "## Governed Dispatch Context (AC 2)" in prompt
         assert "## Parent context" in prompt
+        assert "## Previous Work Context" not in prompt
+        assert "## Coordinator Review" not in prompt
+        assert "Previous Work Context:" in prompt
+        assert "Coordinator Review (Level 1):" in prompt
         assert "Helper is ready" in prompt
+        assert "No conflicts remain" in prompt
+        assert "Keep edits localized" in prompt
         assert "## Sibling status" in prompt
         assert "… sibling-1: Implement duplicate leaf" in prompt
         assert "## AC\nImplement duplicate leaf" in prompt


### PR DESCRIPTION
## Scope

Narrow follow-up to the non-blocking `ouroboros-agent` readability note on merged PR #998.

#998 correctly wired profile-backed atomic AC dispatch through the context governor, but the approved review noted that governed `## Parent context` could contain nested legacy H2 headings such as `## Previous Work Context` and `## Coordinator Review`. This PR normalizes those generated top-level headings into compact labels only for the governed parent-summary path.

## What changed

- Adds `_normalize_governed_parent_summary()` in `parallel_executor.py`.
- Converts generated top-level legacy headings inside governed parent context:
  - `## Previous Work Context` → `Previous Work Context:`
  - `## Coordinator Review (Level N)` → `Coordinator Review (Level N):`
- Leaves legacy non-profile prompt rendering untouched.
- Leaves embedded/indented markdown from AC outputs untouched.
- Extends the #998 governed dispatch regression to cover coordinator review text and the absence of nested H2 headings.

## Boundary

- No change to context governance enforcement/default behavior.
- No budget/acceptance gate change.
- No #978 P5 / legacy fallback removal.
- `context_acceptance_enforced=false` and `context_default_flipped=false` remain the #961 milestone boundary.

## Verification

```bash
uv run pytest tests/unit/orchestrator/test_context_governor.py tests/unit/orchestrator/test_parallel_executor.py -q
uv run ruff check src/ouroboros/orchestrator/context_governor.py src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_context_governor.py tests/unit/orchestrator/test_parallel_executor.py
uv run ruff format --check src/ouroboros/orchestrator/context_governor.py src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_context_governor.py tests/unit/orchestrator/test_parallel_executor.py
uv run mypy src/ouroboros/orchestrator/context_governor.py src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_context_governor.py tests/unit/orchestrator/test_parallel_executor.py
```

Observed locally:

- targeted tests: `106 passed`
- Ruff check: passed
- Ruff format check: passed
- MyPy: success

Refs #998, #961, #920.
