### PR TITLE
fix(agentos): surface typed evidence schema to fat-harness leaves

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3014,6 +3014,72 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         }
         return f"## Governed Dispatch Context ({label})\n{rendered}", audit
 
+    def _build_typed_evidence_prompt_section(self) -> str:
+        """Return profile evidence-output instructions for atomic leaf prompts.
+
+        Legacy dispatch has no active profile and keeps its historical prompt
+        shape.  Profile-backed dispatch must teach the leaf what the harness
+        will parse at completion; otherwise fat-harness enforcement can fail
+        every leaf before the verifier sees valid typed evidence.
+        """
+        profile = self._execution_profile
+        if profile is None:
+            return ""
+
+        required = list(profile.evidence_schema.required)
+        must_produce = list(profile.must_produce)
+        rejected_if = list(profile.evidence_schema.rejected_if)
+        example: dict[str, Any] = {}
+        for field_name in required:
+            if field_name == "files_touched":
+                example[field_name] = ["relative/path.py"]
+            elif field_name == "commands_run":
+                example[field_name] = ["pytest path/to/test.py"]
+            elif field_name == "tests_passed":
+                example[field_name] = ["path/to/test.py"]
+            else:
+                example[field_name] = ["evidence value"]
+
+        lines = [
+            "",
+            "## Required Typed Evidence",
+            "The active execution profile requires machine-readable evidence at completion.",
+            "After [TASK_COMPLETE], include exactly one fenced `json` object that the harness can parse.",
+        ]
+        if required:
+            lines.append("Required fields: " + ", ".join(required) + ".")
+        if must_produce:
+            lines.append("Must produce evidence for: " + ", ".join(must_produce) + ".")
+        if rejected_if:
+            lines.append("Rejected if: " + "; ".join(rejected_if) + ".")
+        lines.extend(
+            [
+                "Use relative paths from the working directory and list only tools/tests you actually ran.",
+                "If blocked by a legitimate precondition, return a blocked evidence object instead of prose-only status.",
+                "Completion template:",
+                "[TASK_COMPLETE]",
+                "```json",
+                json.dumps(example, indent=2, sort_keys=True),
+                "```",
+                "Blocked template:",
+                "```json",
+                json.dumps(
+                    {
+                        "status": "blocked",
+                        "blocker": {
+                            "code": "MISSING_AUTHORITY",
+                            "reason": "Explain the unmet precondition.",
+                            "required_by": "Name the required approval, credential, or tool.",
+                        },
+                    },
+                    indent=2,
+                    sort_keys=True,
+                ),
+                "```",
+            ]
+        )
+        return "\n".join(lines) + "\n"
+
     async def _emit_atomic_context_governed_event(
         self,
         *,
@@ -3392,6 +3458,8 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     f"{other_list}\n"
                 )
 
+        typed_evidence_section = self._build_typed_evidence_prompt_section()
+
         # Scan the requested runtime workspace so prompts stay aligned with the actual task cwd.
         import os
 
@@ -3418,7 +3486,7 @@ Files present:
 {seed_goal}
 
 {task_section}
-{legacy_context_section}{retry_section}{parallel_section}
+{legacy_context_section}{retry_section}{parallel_section}{typed_evidence_section}
 Use the available tools to accomplish this task. Report your progress clearly.
 When complete, explicitly state: [TASK_COMPLETE]
 """

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -304,6 +304,14 @@ class TestProfileAwareContextGovernance:
         assert "## Parallel Execution Notice" in prompt
         assert "Avoid modifying files that other agents are likely editing." in prompt
         assert "summarized in the governed sibling-status section above" in prompt
+        assert "## Required Typed Evidence" in prompt
+        assert "Required fields: files_touched, commands_run, tests_passed." in prompt
+        assert "Must produce evidence for: tests_passed, files_touched." in prompt
+        assert "Rejected if: tests_passed == []." in prompt
+        assert '"files_touched": [' in prompt
+        assert '"commands_run": [' in prompt
+        assert '"tests_passed": [' in prompt
+        assert "Blocked template:" in prompt
 
         context_events = [
             event for event in appended_events if event.type == "execution.ac.context_governed"
@@ -400,6 +408,7 @@ class TestProfileAwareContextGovernance:
         assert "## Previous Work Context" in prompt
         assert "## Parallel Execution Notice" in prompt
         assert "## Governed Dispatch Context" not in prompt
+        assert "## Required Typed Evidence" not in prompt
         assert not any(event.type == "execution.ac.context_governed" for event in appended_events)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to the #961/#978 AgentOS observation gate after reviewing #1000's semantic-miss baseline direction.

#1000 itself remains the right narrow precondition: it samples/reports `semantic_miss_incidents_per_100_acs` beside fabrication without changing live enforcement. The current observation blocker is later in the stack: profile/fat-harness leaves can be enforced for typed evidence, but the atomic dispatch prompt does not tell the leaf which JSON evidence schema to emit.

This PR adds a narrow prompt-surface fix:

- profile-backed atomic leaves now receive a `Required Typed Evidence` section;
- the section lists required fields, `must_produce`, and `rejected_if` rules from the active execution profile;
- it gives a fenced JSON completion template plus a typed blocked template;
- legacy/no-profile atomic dispatch keeps the old prompt shape.

## Why this direction

The #978 observation batch showed `typed_evidence_present=true` at 0/24 and verifier never ran because leaf outputs were prose-only/malformed JSON. Loosening extraction or verifier acceptance would move against the AgentOS evidence-gated direction. Teaching the active profile schema to the leaf is the smallest corrective action that preserves the gate.

## Boundaries

- Does not change #1000 baseline metric semantics.
- Does not weaken typed-evidence validation.
- Does not bypass verifier PASS.
- Does not remove legacy fallback.
- Does not change legacy/no-profile prompt shape.

## Validation

- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py::TestProfileAwareContextGovernance -q` → 3 passed
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py::TestProfileAwareContextGovernance tests/unit/orchestrator/test_parallel_executor.py::TestParallelACExecutor -q` → 64 passed
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` → passed
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` → passed

## Next observation after merge

Rerun a small controlled #978 observation seed in a git repo and require at least one path with `typed_evidence_present=true`, `typed_evidence_valid=true`, `verifier_ran=true`, and `verifier_passed=true` before any #978 P5 fallback-removal claim.
