### PR TITLE
fix(run): align fat-harness prompts with evidence enforcement

### DIFF
--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -88,6 +88,7 @@ from ouroboros.orchestrator.policy import (
     evaluate_capability_policy,
 )
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, ProfileError, load_profile
+from ouroboros.orchestrator.profile_strategy import ProfileBackedStrategy
 from ouroboros.orchestrator.runtime_message_projection import (
     message_tool_input,
     message_tool_name,
@@ -265,6 +266,30 @@ def _execution_profile_for_seed(seed: Seed) -> ExecutionProfile | None:
             task_type=seed.task_type,
         )
         return None
+
+
+def _execution_strategy_for_seed(
+    seed: Seed,
+    *,
+    fat_harness_mode: bool = False,
+) -> ExecutionStrategy:
+    """Return the prompt/tool strategy for a seed execution.
+
+    Fat-harness mode enforces profile-shaped typed evidence at atomic
+    acceptance. Use the profile-backed strategy there as well, otherwise
+    the runner can enforce evidence that the leaf prompt never requested.
+    If a profile is unavailable, fall back to the legacy strategy so the
+    existing task_type error/compatibility behavior is preserved.
+    """
+    if fat_harness_mode:
+        try:
+            return ProfileBackedStrategy(load_profile(seed.task_type))
+        except ProfileError:
+            log.warning(
+                "orchestrator.runner.profile_strategy_unavailable",
+                task_type=seed.task_type,
+            )
+    return get_strategy(seed.task_type)
 
 
 def build_system_prompt(
@@ -2081,7 +2106,10 @@ class OrchestratorRunner:
                 )
 
             # Build prompts with strategy
-            strategy = get_strategy(seed.task_type)
+            strategy = _execution_strategy_for_seed(
+                seed,
+                fat_harness_mode=self._fat_harness_mode,
+            )
             system_prompt = build_system_prompt(seed, strategy=strategy)
             task_prompt = build_task_prompt(seed, strategy=strategy)
 
@@ -3001,10 +3029,14 @@ class OrchestratorRunner:
             )
 
             # Build resume prompt
-            system_prompt = build_system_prompt(seed)
+            resume_strategy = _execution_strategy_for_seed(
+                seed,
+                fat_harness_mode=self._fat_harness_mode,
+            )
+            system_prompt = build_system_prompt(seed, strategy=resume_strategy)
             resume_prompt = f"""Continue executing the task from where you left off.
 
-{build_task_prompt(seed)}
+{build_task_prompt(seed, strategy=resume_strategy)}
 
 Note: This is a resumed session. Please continue from where execution was interrupted.
 """
@@ -3020,6 +3052,7 @@ Note: This is a resumed session. Please continue from where execution was interr
             merged_tools, mcp_provider, tool_catalog = await self._get_merged_tools(
                 session_id=session_id,
                 tool_prefix=self._mcp_tool_prefix,
+                strategy=resume_strategy,
             )
             runtime_handle = self._seed_runtime_handle(runtime_handle, tool_catalog=tool_catalog)
 
@@ -3032,7 +3065,6 @@ Note: This is a resumed session. Please continue from where execution was interr
             # Create workflow state tracker for progress display
             from ouroboros.orchestrator.workflow_state import WorkflowStateTracker
 
-            resume_strategy = get_strategy(seed.task_type)
             state_tracker = WorkflowStateTracker(
                 acceptance_criteria=seed.acceptance_criteria,
                 goal=seed.goal,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2200,7 +2200,7 @@ class TestOrchestratorRunner:
             mock_console,
             fat_harness_mode=True,
         )
-        expected = Result.ok(
+        expected: Result[OrchestratorResult, OrchestratorError] = Result.ok(
             OrchestratorResult(
                 success=True,
                 session_id=tracker.session_id,
@@ -2214,7 +2214,7 @@ class TestOrchestratorRunner:
                 runner,
                 "_get_merged_tools",
                 AsyncMock(return_value=(["Read"], None, assemble_session_tool_catalog(["Read"]))),
-            ),
+            ) as get_merged_tools,
             patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
         ):
             result = await runner.execute_precreated_session(
@@ -2226,6 +2226,13 @@ class TestOrchestratorRunner:
         assert result is expected
         assert execute.await_args.kwargs["seed"] is single_ac_seed
         assert "force_sequential_levels" not in execute.await_args.kwargs
+        system_prompt = execute.await_args.kwargs["system_prompt"]
+        assert "[POST" in system_prompt
+        assert "files_touched" in system_prompt
+        assert "commands_run" in system_prompt
+        assert "tests_passed" in system_prompt
+        strategy = get_merged_tools.await_args.kwargs["strategy"]
+        assert "[POST" in strategy.get_system_prompt_fragment()
 
     @pytest.mark.asyncio
     async def test_fat_harness_sequential_run_uses_sequential_ac_executor_plan(
@@ -2245,7 +2252,7 @@ class TestOrchestratorRunner:
             mock_console,
             fat_harness_mode=True,
         )
-        expected = Result.ok(
+        expected: Result[OrchestratorResult, OrchestratorError] = Result.ok(
             OrchestratorResult(
                 success=True,
                 session_id=tracker.session_id,
@@ -2280,7 +2287,7 @@ class TestOrchestratorRunner:
 
         tracker = SessionTracker.create("exec_forced", sample_seed.metadata.seed_id)
         runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
-        expected = Result.ok(
+        expected: Result[OrchestratorResult, OrchestratorError] = Result.ok(
             OrchestratorResult(
                 success=True,
                 session_id=tracker.session_id,


### PR DESCRIPTION
## Summary

Follow-up from the #1001/#961/#978 review and the first post-#1006 observation batch.

#1001 itself was a valid fixture-only C.4 benchmark slice, but the later live observation showed a separate wiring gap: fat-harness mode now enforces profile-shaped typed evidence, while the runner still built leaf prompts from the legacy `get_strategy()` text that does not include the profile-backed evidence contract.

This PR routes fat-harness seed execution and resume prompts through `ProfileBackedStrategy`, so the leaf receives the same `evidence_schema` fields that the atomic acceptance gate enforces.

## What changed

- Adds a runner-local strategy resolver that uses `ProfileBackedStrategy(load_profile(seed.task_type))` only when `fat_harness_mode` is active.
- Keeps legacy strategy behavior for non-fat-harness runs and for profile-load fallback.
- Applies the same strategy selection to resume prompt/tool construction.
- Extends the single-AC fat-harness runner test to prove the generated system prompt includes the evidence POST block and required code-profile fields.

## Boundary

- Does not remove the legacy self-report fallback.
- Does not start #978 P5.
- Does not weaken typed-evidence or verifier-PASS enforcement.
- Does not change #1001's benchmark artifact.

## Validation

```bash
uv run pytest tests/unit/orchestrator/test_runner.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_profile_strategy.py -q
uv run mypy src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_runner.py
uv run ruff check src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_runner.py
uv run ruff format --check src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_runner.py
```

Observed locally:

- Targeted orchestrator/profile tests: `228 passed, 1 skipped`
- MyPy: success
- Ruff: all checks passed
- Ruff format check: already formatted

Refs #961 and #978. Follow-up analysis from merged #1001 and the post-#1006 observation blocker.
