### PR TITLE
fix(harness): resolve #978 typed evidence blocker

### DIFF
--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -31,6 +31,7 @@ Usage:
 from __future__ import annotations
 
 import ast
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import StrEnum
 import json
@@ -47,8 +48,11 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 # json.JSONDecoder.raw_decode — that's how we avoid every sentinel-
 # scanning class of bug (the closing ``` or any `}` may appear inside a
 # JSON string value, and only a real JSON parser knows string boundaries).
-_JSON_FENCE_RE = re.compile(r"```\s*json\b", re.IGNORECASE)
-_BARE_FENCE = "```"
+_FENCE_LINE_RE = re.compile(
+    r"^(?P<indent>[ \t]{0,3})(?P<fence>`{3,})(?P<info>[^`\n]*)$",
+    re.MULTILINE,
+)
+_CLOSING_FENCE_RE = re.compile(r"^[ \t]{0,3}`{3,}[ \t]*$", re.MULTILINE)
 _EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
 _DECODER = json.JSONDecoder()
 
@@ -131,31 +135,56 @@ class EvidenceRecord:
         return self.data.get(name, default)
 
 
+def _top_level_fence_body_starts(text: str) -> Iterator[tuple[str, int]]:
+    """Yield (info, body_start) for Markdown fences outside other fences."""
+    search_pos = 0
+    while True:
+        opener = _FENCE_LINE_RE.search(text, search_pos)
+        if opener is None:
+            return
+
+        info = opener.group("info").strip().lower()
+        body_start = opener.end()
+        if body_start < len(text) and text[body_start] == "\n":
+            body_start += 1
+
+        yield info, body_start
+
+        closer = _CLOSING_FENCE_RE.search(text, body_start)
+        if closer is None:
+            return
+        search_pos = closer.end()
+
+
+def _skip_json_whitespace(text: str, start: int) -> int:
+    """Move start to the first non-whitespace JSON character."""
+    while start < len(text) and text[start] in " \t\r\n":
+        start += 1
+    return start
+
+
 def _find_body_start(text: str) -> int:
     """Locate where the JSON body begins.
 
-    Prefer the first explicit JSON fence (```json / ```JSON), even if
-    an earlier prose/code fence exists. If no explicit JSON fence is
-    found, use the first bare fence. If no fence is found, treat the
-    whole input as a bare JSON body — the JSON decoder will skip leading
-    whitespace itself.
+    Prefer the first explicit top-level JSON fence (```json / ```JSON),
+    even if an earlier prose/code fence exists. Fence detection is itself
+    fence-aware: a literal ````json`` token printed inside an earlier
+    non-JSON code block is not treated as the evidence opener. If no
+    explicit JSON fence is found, use the first top-level fence. If no
+    fence is found, treat the whole input as a bare JSON body — the JSON
+    decoder will skip leading whitespace itself.
     """
-    match = _JSON_FENCE_RE.search(text)
-    if match is not None:
-        best_open = match.start()
-        best_open_len = match.end() - match.start()
-    else:
-        best_open = text.find(_BARE_FENCE)
-        best_open_len = len(_BARE_FENCE)
-    if best_open == -1:
-        return 0
-    body_start = best_open + best_open_len
-    # JSONDecoder tolerates leading whitespace but `raw_decode` requires
-    # the *first* non-whitespace character to start the value, so skip
-    # whitespace explicitly to give clean offsets in error messages.
-    while body_start < len(text) and text[body_start] in " \t\r\n":
-        body_start += 1
-    return body_start
+    first_fence_body_start: int | None = None
+
+    for info, body_start in _top_level_fence_body_starts(text):
+        if first_fence_body_start is None:
+            first_fence_body_start = body_start
+        if info.split(maxsplit=1)[0:1] == ["json"]:
+            return _skip_json_whitespace(text, body_start)
+
+    if first_fence_body_start is not None:
+        return _skip_json_whitespace(text, first_fence_body_start)
+    return 0
 
 
 def extract_evidence(text: str) -> EvidenceRecord:

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -150,7 +150,7 @@ def _top_level_fence_body_starts(text: str) -> Iterator[tuple[str, int]]:
 
         yield info, body_start
 
-        closing_fence_re = re.compile(rf"^[ \t]{{0,3}}`{{{fence_len},}}[ \t]*$", re.MULTILINE)
+        closing_fence_re = re.compile(rf"^[ \t]{{0,3}}`{{{fence_len},}}[ \t]*\r?$", re.MULTILINE)
         closer = closing_fence_re.search(text, body_start)
         if closer is None:
             return

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -39,12 +39,16 @@ from typing import Any
 
 from ouroboros.orchestrator.profile_loader import ExecutionProfile
 
-# Fence openers signal where the JSON evidence body starts. Once we've
-# located the opener, parsing the body is delegated to JSON itself via
+# Fence openers signal where the JSON evidence body starts. Prefer
+# language-tagged JSON fences over bare fences anywhere in the output:
+# leaf results commonly include earlier non-JSON code fences before the
+# final "Validation evidence" block. Once we've located the opener,
+# parsing the body is delegated to JSON itself via
 # json.JSONDecoder.raw_decode — that's how we avoid every sentinel-
 # scanning class of bug (the closing ``` or any `}` may appear inside a
 # JSON string value, and only a real JSON parser knows string boundaries).
-_FENCE_OPENERS: tuple[str, ...] = ("```json", "```JSON", "```")
+_JSON_FENCE_RE = re.compile(r"```\s*json\b", re.IGNORECASE)
+_BARE_FENCE = "```"
 _EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
 _DECODER = json.JSONDecoder()
 
@@ -130,19 +134,19 @@ class EvidenceRecord:
 def _find_body_start(text: str) -> int:
     """Locate where the JSON body begins.
 
-    Scans for the earliest fence opener (```json / ```JSON / ```). If
-    none is found we treat the whole input as a bare JSON body — the
-    JSON decoder will skip leading whitespace itself.
+    Prefer the first explicit JSON fence (```json / ```JSON), even if
+    an earlier prose/code fence exists. If no explicit JSON fence is
+    found, use the first bare fence. If no fence is found, treat the
+    whole input as a bare JSON body — the JSON decoder will skip leading
+    whitespace itself.
     """
-    best_open = -1
-    best_open_len = 0
-    for opener in _FENCE_OPENERS:
-        idx = text.find(opener)
-        if idx == -1:
-            continue
-        if best_open == -1 or idx < best_open:
-            best_open = idx
-            best_open_len = len(opener)
+    match = _JSON_FENCE_RE.search(text)
+    if match is not None:
+        best_open = match.start()
+        best_open_len = match.end() - match.start()
+    else:
+        best_open = text.find(_BARE_FENCE)
+        best_open_len = len(_BARE_FENCE)
     if best_open == -1:
         return 0
     body_start = best_open + best_open_len

--- a/src/ouroboros/orchestrator/evidence_schema.py
+++ b/src/ouroboros/orchestrator/evidence_schema.py
@@ -52,7 +52,6 @@ _FENCE_LINE_RE = re.compile(
     r"^(?P<indent>[ \t]{0,3})(?P<fence>`{3,})(?P<info>[^`\n]*)$",
     re.MULTILINE,
 )
-_CLOSING_FENCE_RE = re.compile(r"^[ \t]{0,3}`{3,}[ \t]*$", re.MULTILINE)
 _EXPR_RE = re.compile(r"^\s*(?P<field>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<lit>.+?)\s*$")
 _DECODER = json.JSONDecoder()
 
@@ -143,6 +142,7 @@ def _top_level_fence_body_starts(text: str) -> Iterator[tuple[str, int]]:
         if opener is None:
             return
 
+        fence_len = len(opener.group("fence"))
         info = opener.group("info").strip().lower()
         body_start = opener.end()
         if body_start < len(text) and text[body_start] == "\n":
@@ -150,7 +150,8 @@ def _top_level_fence_body_starts(text: str) -> Iterator[tuple[str, int]]:
 
         yield info, body_start
 
-        closer = _CLOSING_FENCE_RE.search(text, body_start)
+        closing_fence_re = re.compile(rf"^[ \t]{{0,3}}`{{{fence_len},}}[ \t]*$", re.MULTILINE)
+        closer = closing_fence_re.search(text, body_start)
         if closer is None:
             return
         search_pos = closer.end()

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2932,7 +2932,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
 
         The metadata is intentionally descriptive only. It lets projections,
         tests, and reviewers prove which profile shaped decomposition without
-        changing dispatch behavior or flipping the fat-harness default path.
+        changing dispatch behavior or the CLI fat-harness default path.
         """
         profile = self._execution_profile
         if profile is None:
@@ -3404,6 +3404,23 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         except OSError:
             file_listing = "(unable to list)"
 
+        if self._fat_harness_mode and self._execution_profile is not None:
+            required_fields = ", ".join(self._execution_profile.evidence_schema.required)
+            completion_instruction = (
+                "Use the available tools to accomplish this task. Report progress through "
+                "tool-visible work, not a prose-only completion claim.\n"
+                "When complete, emit exactly ONE fenced JSON evidence record as the "
+                "final response and then stop. Populate the active profile fields "
+                f"directly ({required_fields}); do not emit a generic command_result "
+                "wrapper. Do not prefix it with [TASK_COMPLETE] or any prose; the "
+                "harness decides success from typed evidence plus the verifier PASS."
+            )
+        else:
+            completion_instruction = (
+                "Use the available tools to accomplish this task. Report your progress "
+                "clearly.\nWhen complete, explicitly state: [TASK_COMPLETE]"
+            )
+
         prompt = f"""Execute the following task:
 
 ## Working Directory
@@ -3419,8 +3436,7 @@ Files present:
 
 {task_section}
 {legacy_context_section}{retry_section}{parallel_section}
-Use the available tools to accomplish this task. Report your progress clearly.
-When complete, explicitly state: [TASK_COMPLETE]
+{completion_instruction}
 """
 
         messages: list[AgentMessage] = []

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -88,6 +88,7 @@ from ouroboros.orchestrator.policy import (
     evaluate_capability_policy,
 )
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, ProfileError, load_profile
+from ouroboros.orchestrator.profile_strategy import ProfileBackedStrategy
 from ouroboros.orchestrator.runtime_message_projection import (
     message_tool_input,
     message_tool_name,
@@ -267,6 +268,15 @@ def _execution_profile_for_seed(seed: Seed) -> ExecutionProfile | None:
         return None
 
 
+def _strategy_for_seed(seed: Seed, *, fat_harness_mode: bool = False) -> ExecutionStrategy:
+    """Resolve the prompt/tool strategy for the active execution mode."""
+    if fat_harness_mode:
+        profile = _execution_profile_for_seed(seed)
+        if profile is not None:
+            return ProfileBackedStrategy(profile)
+    return get_strategy(seed.task_type)
+
+
 def build_system_prompt(
     seed: Seed,
     strategy: ExecutionStrategy | None = None,
@@ -440,9 +450,10 @@ class OrchestratorRunner:
                         and recovery. When provided, enables per-level state snapshots.
             max_decomposition_depth: Maximum recursive AC decomposition depth.
             max_parallel_workers: Maximum concurrent AC workers for parallel execution.
-            fat_harness_mode: Temporary opt-in path that enforces profile
-                typed-evidence validation at atomic AC acceptance before the
-                #920 PR-5 default flip removes the opt-in selection.
+            fat_harness_mode: Enforce profile typed-evidence validation plus
+                verifier PASS at atomic AC acceptance. CLI `ooo run` enables
+                this by default after #920 PR-5; the constructor default stays
+                False as the internal legacy fallback until #978 P5 removes it.
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -2080,8 +2091,10 @@ class OrchestratorRunner:
                     start_time=start_time,
                 )
 
-            # Build prompts with strategy
-            strategy = get_strategy(seed.task_type)
+            # Build prompts with strategy. The fat-harness default path must use
+            # the profile-backed prompt contract so leaf agents are told to emit
+            # schema-valid evidence before the acceptance gate parses it.
+            strategy = _strategy_for_seed(seed, fat_harness_mode=self._fat_harness_mode)
             system_prompt = build_system_prompt(seed, strategy=strategy)
             task_prompt = build_task_prompt(seed, strategy=strategy)
 
@@ -2109,7 +2122,7 @@ class OrchestratorRunner:
 
             # Check for fat-harness / parallel execution mode. Fat-harness
             # uses the AC executor even for single-AC or --sequential runs so
-            # the opt-in evidence gate is never silently bypassed.
+            # the evidence gate is never silently bypassed.
             if (
                 self._fat_harness_mode
                 or force_sequential_levels
@@ -2985,6 +2998,28 @@ class OrchestratorRunner:
                 OrchestratorError(
                     message=f"Session is in terminal state {tracker.status.value}, cannot resume",
                     details={"session_id": session_id, "status": tracker.status.value},
+                )
+            )
+
+        if self._fat_harness_mode:
+            self._cleanup_pre_execution_state(
+                tracker.execution_id,
+                session_id,
+                session_registered=False,
+            )
+            return Result.err(
+                OrchestratorError(
+                    message=(
+                        "Fat-harness resume is blocked because the legacy resume path "
+                        "cannot enforce typed evidence plus verifier PASS; restart the "
+                        "run so each AC goes through the fat-harness acceptance gate."
+                    ),
+                    details={
+                        "session_id": session_id,
+                        "execution_id": tracker.execution_id,
+                        "fat_harness_mode": True,
+                        "resume_blocked": "typed_evidence_gate_required",
+                    },
                 )
             )
 

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -89,6 +89,33 @@ class TestExtractEvidence:
             "tests_passed": ["tests/test_emitter.py::test_example"],
         }
 
+    def test_matches_closing_fence_length_before_later_json_evidence(self) -> None:
+        text = (
+            "Documented an embedded markdown example:\n\n"
+            "````markdown\n"
+            "Example evidence shape:\n"
+            "```json\n"
+            '{"not": "top-level evidence"}\n'
+            "```\n"
+            "````\n\n"
+            "Validation evidence:\n\n"
+            "```json\n"
+            "{\n"
+            '  "files_touched": ["docs/example.md"],\n'
+            '  "commands_run": ["pytest tests/test_docs.py"],\n'
+            '  "tests_passed": ["tests/test_docs.py::test_example"]\n'
+            "}\n"
+            "```\n"
+        )
+
+        record = extract_evidence(text)
+
+        assert record.data == {
+            "files_touched": ["docs/example.md"],
+            "commands_run": ["pytest tests/test_docs.py"],
+            "tests_passed": ["tests/test_docs.py::test_example"],
+        }
+
     def test_fenced_block_without_lang_tag(self) -> None:
         record = extract_evidence('prelude\n```\n{"y": 2}\n```\n')
         assert record.data == {"y": 2}

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -64,6 +64,31 @@ class TestExtractEvidence:
             "tests_passed": ["test_hello.py::test_hello"],
         }
 
+    def test_ignores_json_fence_literal_inside_earlier_code_block(self) -> None:
+        text = (
+            "Implemented markdown emitter:\n\n"
+            "```python\n"
+            "def example():\n"
+            '    return "```json"\n'
+            "```\n\n"
+            "Validation evidence:\n\n"
+            "```json\n"
+            "{\n"
+            '  "files_touched": ["emitter.py"],\n'
+            '  "commands_run": ["pytest tests/test_emitter.py"],\n'
+            '  "tests_passed": ["tests/test_emitter.py::test_example"]\n'
+            "}\n"
+            "```\n"
+        )
+
+        record = extract_evidence(text)
+
+        assert record.data == {
+            "files_touched": ["emitter.py"],
+            "commands_run": ["pytest tests/test_emitter.py"],
+            "tests_passed": ["tests/test_emitter.py::test_example"],
+        }
+
     def test_fenced_block_without_lang_tag(self) -> None:
         record = extract_evidence('prelude\n```\n{"y": 2}\n```\n')
         assert record.data == {"y": 2}

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -116,6 +116,30 @@ class TestExtractEvidence:
             "tests_passed": ["tests/test_docs.py::test_example"],
         }
 
+    def test_accepts_crlf_closing_fence_before_later_json_evidence(self) -> None:
+        text = (
+            "Implemented Windows output:\r\n\r\n"
+            "```python\r\n"
+            "print('hello')\r\n"
+            "```\r\n\r\n"
+            "Validation evidence:\r\n\r\n"
+            "```json\r\n"
+            "{\r\n"
+            '  "files_touched": ["windows.py"],\r\n'
+            '  "commands_run": ["pytest tests/test_windows.py"],\r\n'
+            '  "tests_passed": ["tests/test_windows.py::test_example"]\r\n'
+            "}\r\n"
+            "```\r\n"
+        )
+
+        record = extract_evidence(text)
+
+        assert record.data == {
+            "files_touched": ["windows.py"],
+            "commands_run": ["pytest tests/test_windows.py"],
+            "tests_passed": ["tests/test_windows.py::test_example"],
+        }
+
     def test_fenced_block_without_lang_tag(self) -> None:
         record = extract_evidence('prelude\n```\n{"y": 2}\n```\n')
         assert record.data == {"y": 2}

--- a/tests/unit/orchestrator/test_evidence_schema.py
+++ b/tests/unit/orchestrator/test_evidence_schema.py
@@ -39,9 +39,40 @@ class TestExtractEvidence:
         record = extract_evidence(text)
         assert record.data == {"x": 1}
 
+    def test_prefers_json_evidence_fence_after_non_json_code_fence(self) -> None:
+        text = (
+            "Implemented `hello.py`:\n\n"
+            "```python\n"
+            "def hello():\n"
+            '    return "hello"\n'
+            "```\n\n"
+            "Validation evidence:\n\n"
+            "```json\n"
+            "{\n"
+            '  "files_touched": ["hello.py", "test_hello.py"],\n'
+            '  "commands_run": ["pytest test_hello.py"],\n'
+            '  "tests_passed": ["test_hello.py::test_hello"]\n'
+            "}\n"
+            "```\n"
+        )
+
+        record = extract_evidence(text)
+
+        assert record.data == {
+            "files_touched": ["hello.py", "test_hello.py"],
+            "commands_run": ["pytest test_hello.py"],
+            "tests_passed": ["test_hello.py::test_hello"],
+        }
+
     def test_fenced_block_without_lang_tag(self) -> None:
         record = extract_evidence('prelude\n```\n{"y": 2}\n```\n')
         assert record.data == {"y": 2}
+
+    def test_bare_non_json_fence_still_rejected_without_later_json_fence(self) -> None:
+        text = 'summary\n```python\ndef hello():\n    return "hello"\n```\n'
+
+        with pytest.raises(EvidenceError, match="not valid JSON"):
+            extract_evidence(text)
 
     def test_empty_text_rejected(self) -> None:
         with pytest.raises(EvidenceError, match="empty"):

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -128,6 +128,8 @@ class _FinalMessageRuntime:
         self._native_session_id = native_session_id
         self._support_messages = support_messages
         self._cwd = cwd
+        self.last_prompt: str | None = None
+        self.last_system_prompt: str | None = None
 
     @property
     def runtime_backend(self) -> str:
@@ -149,7 +151,9 @@ class _FinalMessageRuntime:
         resume_handle: RuntimeHandle | None = None,
         resume_session_id: str | None = None,
     ):
-        del prompt, tools, system_prompt, resume_session_id
+        del tools, resume_session_id
+        self.last_prompt = prompt
+        self.last_system_prompt = system_prompt
         for message in self._support_messages:
             yield message
         yield AgentMessage(
@@ -1240,8 +1244,227 @@ class TestParallelACExecutor:
         assert "Evidence is not valid JSON" in evidence_event.data["typed_evidence_error"]
 
     @pytest.mark.asyncio
+    async def test_fat_harness_atomic_prompt_requests_json_evidence_without_task_complete(
+        self,
+    ) -> None:
+        """Fat-harness atomic prompts must not ask for prose [TASK_COMPLETE]."""
+        event_store, _ = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            "```json\n"
+            '{"files_touched":["src/app.py"],"commands_run":["pytest"],"tests_passed":["pytest"]}'
+            "\n```",
+            native_session_id="opencode-session-prompt",
+            support_messages=(
+                AgentMessage(
+                    type="tool",
+                    content="Edit src/app.py",
+                    tool_name="Edit",
+                    data={"input": {"file_path": "src/app.py"}},
+                ),
+                AgentMessage(
+                    type="tool",
+                    content="pytest passed",
+                    tool_name="Bash",
+                    data={"input": {"command": "pytest"}},
+                ),
+            ),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert runtime.last_prompt is not None
+        assert "emit exactly ONE fenced JSON evidence record" in runtime.last_prompt
+        assert "files_touched, commands_run, tests_passed" in runtime.last_prompt
+        assert "do not emit a generic command_result wrapper" in runtime.last_prompt
+        assert "Do not prefix it with [TASK_COMPLETE]" in runtime.last_prompt
+        assert "explicitly state: [TASK_COMPLETE]" not in runtime.last_prompt
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_accepts_validation_evidence_after_code_fence(self) -> None:
+        """Regression for #978 batch 2b: parser must skip earlier code fences."""
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "[AC_COMPLETE: 1]\n\n"
+                "`hello.py` contains:\n\n"
+                "```python\n"
+                "def hello():\n"
+                '    return "hello"\n'
+                "```\n\n"
+                "Validation evidence:\n\n"
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["hello.py", "test_hello.py"],\n'
+                '  "commands_run": ["pytest test_hello.py"],\n'
+                '  "tests_passed": ["test_hello.py::test_hello"]\n'
+                "}\n"
+                "```",
+                native_session_id="opencode-session-evidence-code-fence",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Write: hello.py created",
+                        tool_name="Write",
+                        data={"tool_input": {"file_path": "hello.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Write: test_hello.py created",
+                        tool_name="Write",
+                        data={"tool_input": {"file_path": "test_hello.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest test_hello.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest test_hello.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="test_hello.py::test_hello passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content='Create hello.py with hello() returning "hello".',
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        assert result.typed_evidence is not None
+        assert result.typed_evidence.data["files_touched"] == ["hello.py", "test_hello.py"]
+        assert result.typed_evidence_validation is not None
+        assert result.typed_evidence_validation.ok is True
+        assert result.atomic_verifier_verdict is not None
+        assert result.atomic_verifier_verdict.passed is True
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["typed_evidence_present"] is True
+        assert evidence_event.data["typed_evidence_valid"] is True
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_rejects_command_result_wrapper_after_parsing_json_fence(
+        self,
+    ) -> None:
+        """Actual #978 failing shape parses, then fails schema without verifier."""
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "[AC_COMPLETE: 1]\n\n"
+                "```python\n"
+                "def hello():\n"
+                '    return "hello"\n'
+                "```\n\n"
+                "Validation evidence:\n\n"
+                "```json\n"
+                "{\n"
+                '  "type": "command_result",\n'
+                '  "command": "pytest test_hello.py",\n'
+                '  "cwd": "/Users/jh0927/character-chat",\n'
+                '  "exit_code": 0,\n'
+                '  "result": "1 passed in 0.01s"\n'
+                "}\n"
+                "```",
+                native_session_id="opencode-session-command-result-wrapper",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: pytest test_hello.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest test_hello.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="1 passed in 0.01s",
+                        data={"subtype": "success"},
+                    ),
+                ),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content='Create hello.py with hello() returning "hello".',
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.typed_evidence is not None
+        assert result.typed_evidence.data["type"] == "command_result"
+        assert result.typed_evidence_validation is not None
+        assert result.typed_evidence_validation.ok is False
+        assert result.typed_evidence_error is None
+        assert "Fat-harness typed evidence validation failed" in (result.error or "")
+        assert result.atomic_verifier_verdict is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["typed_evidence_present"] is True
+        assert evidence_event.data["typed_evidence_valid"] is False
+        assert evidence_event.data["typed_evidence_error"] is None
+        assert evidence_event.data["missing_fields"] == [
+            "files_touched",
+            "commands_run",
+            "tests_passed",
+        ]
+        assert evidence_event.data["verifier_ran"] is False
+
+    @pytest.mark.asyncio
     async def test_fat_harness_mode_rejects_missing_typed_evidence(self) -> None:
-        """Temporary opt-in mode gates atomic success on profile evidence."""
+        """Fat-harness mode gates atomic success on profile evidence."""
         event_store, appended_events = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=_FinalMessageRuntime(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -29,6 +29,7 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 # TODO: uncomment when OpenCode runtime is shipped
 # from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 from ouroboros.orchestrator.parallel_executor import ACExecutionResult, ParallelExecutionResult
+from ouroboros.orchestrator.profile_strategy import ProfileBackedStrategy
 from ouroboros.orchestrator.runner import (
     OrchestratorError,
     OrchestratorResult,
@@ -1211,6 +1212,47 @@ class TestOrchestratorRunner:
         release_lock_mock.assert_called_once_with("/tmp/worktree/.locks/repo/orch_test.json")
 
     @pytest.mark.asyncio
+    async def test_fat_harness_resume_is_blocked_before_legacy_direct_execution(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Fat-harness resume must not bypass typed evidence acceptance."""
+        from ouroboros.core.types import Result
+
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            fat_harness_mode=True,
+            task_workspace=_task_workspace(),
+        )
+        running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
+            SessionStatus.RUNNING
+        )
+
+        with (
+            patch.object(
+                runner._session_repo,
+                "reconstruct_session",
+                return_value=Result.ok(running_tracker),
+            ),
+            patch.object(runner, "_get_merged_tools", AsyncMock()) as get_merged_tools,
+            patch.object(mock_adapter, "execute_task", AsyncMock()) as execute_task,
+            patch("ouroboros.orchestrator.runner.release_lock") as release_lock_mock,
+        ):
+            result = await runner.resume_session("sess_resume", sample_seed)
+
+        assert result.is_err
+        assert "Fat-harness resume is blocked" in result.error.message
+        assert result.error.details["resume_blocked"] == "typed_evidence_gate_required"
+        get_merged_tools.assert_not_called()
+        execute_task.assert_not_called()
+        release_lock_mock.assert_called_once_with("/tmp/worktree/.locks/repo/orch_test.json")
+
+    @pytest.mark.asyncio
     async def test_resume_session_tool_setup_failure_cleans_up_workspace_lock(
         self,
         mock_adapter: MagicMock,
@@ -2114,7 +2156,7 @@ class TestOrchestratorRunner:
         mock_console: MagicMock,
         sample_seed: Seed,
     ) -> None:
-        """Runner opt-in should reach the atomic executor without changing defaults."""
+        """Runner fat-harness mode should reach the atomic executor."""
         from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 
         runner = OrchestratorRunner(
@@ -2178,6 +2220,57 @@ class TestOrchestratorRunner:
 
         assert result.is_ok
         assert captured_init["fat_harness_mode"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_uses_profile_backed_prompt_contract(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        sample_seed: Seed,
+    ) -> None:
+        """Default fat-harness leaves must be prompted to emit typed JSON evidence."""
+        from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            fat_harness_mode=True,
+        )
+        tracker = SessionTracker.create("exec_profile_prompt", sample_seed.metadata.seed_id)
+        expected = Result.ok(
+            OrchestratorResult(
+                success=True,
+                session_id=tracker.session_id,
+                execution_id=tracker.execution_id,
+            )
+        )
+        captured_strategy: Any = None
+
+        async def _capture_tools(**kwargs: Any) -> tuple[list[str], None, tuple[Any, ...]]:
+            nonlocal captured_strategy
+            captured_strategy = kwargs["strategy"]
+            return ["Read"], None, assemble_session_tool_catalog(["Read"])
+
+        with (
+            patch.object(runner, "_check_startup_cancellation", AsyncMock(return_value=False)),
+            patch.object(runner, "_get_merged_tools", AsyncMock(side_effect=_capture_tools)),
+            patch.object(runner, "_execute_parallel", AsyncMock(return_value=expected)) as execute,
+        ):
+            result = await runner.execute_precreated_session(
+                sample_seed,
+                tracker,
+                parallel=True,
+            )
+
+        assert result is expected
+        assert isinstance(captured_strategy, ProfileBackedStrategy)
+        system_prompt = execute.await_args.kwargs["system_prompt"]
+        assert "consolidated evidence contract" in system_prompt
+        assert "files_touched" in system_prompt
+        assert "commands_run" in system_prompt
+        assert "tests_passed" in system_prompt
 
     @pytest.mark.asyncio
     async def test_fat_harness_single_ac_uses_ac_executor_path(


### PR DESCRIPTION
## Summary

Fixes the #978 blocker observed in batch 2b by keeping fat-harness prompt wiring, typed-evidence parsing, and acceptance-gate routing aligned:

- route fat-harness fresh runs through the profile-backed strategy so leaves see the active evidence contract
- remove the atomic prose/[TASK_COMPLETE] completion instruction when fat-harness evidence gating is active
- parse the explicit `json` evidence fence even when final output contains earlier prose/code fences
- reject the observed `{ "type": "command_result", ... }` wrapper as schema-invalid instead of treating it as parse failure
- fail closed on fat-harness resume before the legacy direct adapter path can bypass typed evidence + verifier PASS

## Root cause addressed

The observed final message contained prose plus a Python code fence before `Validation evidence:`. `extract_evidence()` selected the earliest fence, so it tried to parse `def hello():` as JSON and reported `Evidence is not valid JSON: Expecting value (line 1, col 1)`. The actual JSON fence was later in the same final message.

## Tests

- `uv run pytest -q tests/unit/orchestrator/test_evidence_schema.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_verifier.py tests/unit/orchestrator/test_runner.py` — 273 passed, 1 skipped
- `uv run pytest -q tests/unit/orchestrator/test_runner.py::TestOrchestratorRunner::test_fat_harness_resume_is_blocked_before_legacy_direct_execution tests/unit/orchestrator/test_runner.py::TestOrchestratorRunner::test_fat_harness_uses_profile_backed_prompt_contract tests/unit/orchestrator/test_evidence_schema.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_verifier.py` — 161 passed
- `uv run mypy src/ouroboros/orchestrator/evidence_schema.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/runner.py`
- `uv run ruff check src/ouroboros/orchestrator/evidence_schema.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_evidence_schema.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_runner.py`
- `uv run ruff format --check src/ouroboros/orchestrator/evidence_schema.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_evidence_schema.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_runner.py`
- `git diff --check`

## Follow-up after merge

Rerun the controlled #978 seed and verify EventStore reports:

- `typed_evidence_present=true`
- `typed_evidence_valid=true`
- `verifier_ran=true`
- `verifier_passed=true`
